### PR TITLE
feat: support IP allocation policies for expected interfaces

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -52,6 +52,16 @@ Add a host whose DPU should be treated as a plain NIC:
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
     --dpu-policy nic
 
+Add a host interface with a fixed IP:
+    $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
+    --host_nics '[{\"mac_address\":\"02:00:00:00:10:01\",\"role\":\"host\",\"ip_allocation\":\"fixed\",\"fixed_ip\":\"192.0.2.21\"}]'
+
+Add a DPU OS interface that retains its DHCP address:
+    $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
+    --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
+    --host_nics '[{\"mac_address\":\"02:00:00:00:20:01\",\"role\":\"dpu_os\",\"ip_allocation\":\"retained\"}]'
+
 Retain the BMC's auto-allocated DHCP address as a static one (never expires):
     $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
@@ -123,7 +133,7 @@ pub struct Args {
     #[clap(
         long = "host_nics",
         value_name = "HOST_NICS",
-        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type)",
+        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc and ip_allocation=dynamic|fixed|retained. An omitted role defaults to host. When ip_allocation is omitted, fixed_ip implies fixed; otherwise it defaults to dynamic.",
         action = clap::ArgAction::Append
     )]
     pub host_nics: Option<String>,

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -208,7 +208,7 @@ pub struct Args {
         long = "host_nics",
         value_name = "HOST_NICS",
         group = "group",
-        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Replaces the machine's full host NIC list."
+        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc|unspecified and ip_allocation=dynamic|fixed|retained|unspecified. Replaces the machine's full host NIC list. For a matching stored MAC, omitting role preserves the stored role; role=unspecified resets it to host. Omitting ip_allocation preserves the stored policy when the presence of fixed_ip is unchanged; ip_allocation=unspecified resets it to fixed_ip inference."
     )]
     pub host_nics: Option<String>,
 

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -932,8 +932,7 @@ impl ApiClient {
         Ok(self.0.update_expected_machine(request).await?)
     }
 
-    /// Replaces the entire expected-machine table from JSON. Entries with `bmc_ip_address` trigger
-    /// the same static BMC `machine_interface` setup as a single create.
+    /// Replaces the entire expected-machine table from JSON.
     pub async fn replace_all_expected_machines(
         &self,
         expected_machine_list: Vec<ExpectedMachineJson>,

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -480,12 +480,11 @@ pub async fn discover_dhcp(
     )?;
     let is_v6_observation = address_family == IpAddressFamily::Ipv6
         && message_kind == Some(DhcpMessageKind::V6InfoRequest);
-    let mut host_nic: Option<ExpectedHostNic> = None;
-    // `is_primary_nic` reflects the matched ExpectedHostNic's `primary` flag.
-    // - `Some(true)` -- the operator flagged this NIC as the host's boot interface.
-    // - `Some(false)` -- another NIC on this host is the declared primary.
-    // - `None` -- no declaration, use the default at interface creation time.
-    let mut is_primary_nic: Option<bool> = None;
+    let mut expected_interface: Option<ExpectedHostNic> = None;
+    // `host_primary_declaration` is intentionally Host-only. A DPU OS
+    // interface is always primary and a DPU BMC interface is never primary;
+    // api-db derives those values from the matched interface role.
+    let mut host_primary_declaration: Option<bool> = None;
 
     let parsed_mac: MacAddress = mac_address.parse()?;
     let mut predicted_interface_for_observation = None;
@@ -500,23 +499,23 @@ pub async fn discover_dhcp(
         match db::machine::find_existing_machine(&mut txn, parsed_mac, parsed_relay).await? {
             Some(existing_machine) => Some(existing_machine),
             None => {
-                if let Some(expected_interface) =
+                if let Some(predicted_interface) =
                     db::predicted_machine_interface::find_by_mac_address(&mut txn, parsed_mac)
                         .await?
                 {
                     if is_v6_observation {
-                        predicted_interface_for_observation = Some(expected_interface);
+                        predicted_interface_for_observation = Some(predicted_interface);
                         None
                     } else {
                         // remember expected machine id for later rack update
                         machine_interface::move_predicted_machine_interface_to_machine(
                             &mut txn,
-                            &expected_interface,
+                            &predicted_interface,
                             parsed_relay,
                             api.runtime_config.retained_boot_interface_window,
                         )
                         .await?;
-                        Some(expected_interface.machine_id)
+                        Some(predicted_interface.machine_id)
                     }
                 } else {
                     // DPA allocation is currently IPv4-only. The overlay
@@ -537,50 +536,48 @@ pub async fn discover_dhcp(
                         return Ok(resp);
                     }
 
-                    // Now lets check expected machine data to see if there's any
-                    // useful configuration we need to address, such as primary NIC
-                    // assignment and/or static DHCP reservation allocations.
+                    // ExpectedMachine is the ingestion template for an unknown
+                    // interface, so this is where its role, segment guard, Host
+                    // primary declaration, and allocation policy join the normal
+                    // DHCP path.
                     //
-                    // For static DHCP reservations, we do this here for the simple
-                    // reason that it's a good place to put it. If an operator force
-                    // deletes a machine and its interfaces, how would we put them
-                    // back? The answer is the same way they would be put back in a
-                    // dynamic allocation -- during DHCPDISCOVER/DHCPREQUEST. We see
-                    // that a static DHCP reservation is configured per expected
-                    // machine data, so we make an idempotent call to ensure that
-                    // allocation exists, and if not, is created.
+                    // Why also materialize a fixed reservation here? An operator
+                    // may force-delete a machine and all of its interfaces. The
+                    // next DHCP request is then the first point where we see that
+                    // MAC again, so the idempotent preallocation rebuilds the
+                    // reservation before the common find-or-create path runs.
                     if let Some(m) =
                         expected_machine::find_by_host_mac_address(&mut txn, parsed_mac)
                             .await
                             .map_err(CarbideError::from)?
                     {
-                        // The host's declared primary NIC (if any) decides whether this
-                        // MAC is its boot interface; the matched NIC also carries any
-                        // static reservation need handled below.
-                        if let Some(declared_primary_mac) = m.data.declared_primary_mac() {
-                            is_primary_nic = Some(declared_primary_mac == parsed_mac);
-                        }
-                        host_nic = m
+                        expected_interface = m
                             .data
                             .host_nics
                             .iter()
-                            .find(|nic| nic.mac_address == parsed_mac)
+                            .find(|interface| interface.mac_address == parsed_mac)
                             .cloned();
-                        if let Some(ref nic) = host_nic
-                            && let Some(fixed_ip) = nic.fixed_ip
-                            && fixed_ip.is_address_family(address_family)
-                        {
-                            // It looks like there's a DHCP reservation for this address,
-                            // so make an idempotent call to ensure we have a preallocated
-                            // machine interface (and machine interface address) for it,
-                            // creating one if needed.
-                            db::machine_interface::preallocate_machine_interface(
-                                &mut txn,
-                                parsed_mac,
-                                fixed_ip,
-                                api.runtime_config.retained_boot_interface_window,
-                            )
-                            .await?;
+                        if let Some(interface) = expected_interface.as_ref() {
+                            if interface.role.is_host()
+                                && let Some(declared_primary_mac) = m.data.declared_primary_mac()
+                            {
+                                host_primary_declaration = Some(declared_primary_mac == parsed_mac);
+                            }
+                            if interface
+                                .fixed_ip
+                                .is_some_and(|fixed_ip| fixed_ip.is_address_family(address_family))
+                            {
+                                // The fixed reservation must exist before the common
+                                // path looks up this MAC. This call also applies the
+                                // interface's role and segment guard while the row is
+                                // still unassociated.
+                                db::machine_interface::preallocate_expected_machine_interface(
+                                    &mut txn,
+                                    interface,
+                                    api.runtime_config.retained_boot_interface_window,
+                                )
+                                .await?;
+                            }
                         }
                     } else if let Some(m) =
                         expected_machine::find_by_bmc_mac_address(&mut txn, parsed_mac)
@@ -633,7 +630,7 @@ pub async fn discover_dhcp(
         let network_segments = db::machine_interface::network_segments_for_dhcp_relays(
             &mut txn,
             std::slice::from_ref(&parsed_relay),
-            host_nic.as_ref(),
+            expected_interface.as_ref(),
         )
         .await?;
         let exact_link_address_match = |segment: &NetworkSegment| {
@@ -693,9 +690,10 @@ pub async fn discover_dhcp(
             && interfaces.is_empty()
             && predicted_interface_for_observation.is_none()
         {
-            // Anonymous reserved requests can receive segment options without
-            // creating observed rows. Known or predicted interfaces must
-            // continue through common safety checks and DHCP bookkeeping.
+            // Reserved requests without an existing or predicted interface can
+            // receive segment options without creating an observed row. Known
+            // or predicted interfaces must continue through common safety
+            // checks and DHCP bookkeeping.
             let record = options_only_dhcpv6_record_from_segment(
                 &mut txn,
                 parsed_mac,
@@ -733,8 +731,8 @@ pub async fn discover_dhcp(
             existing_machine_id,
             parsed_mac,
             std::slice::from_ref(&parsed_relay),
-            host_nic,
-            is_primary_nic,
+            expected_interface,
+            host_primary_declaration,
             api.runtime_config.retained_boot_interface_window,
         )
         .await?
@@ -747,8 +745,8 @@ pub async fn discover_dhcp(
             parsed_mac,
             std::slice::from_ref(&parsed_relay),
             machine_interface::FindOrCreateMachineInterfaceOptions {
-                host_nic,
-                is_primary: is_primary_nic,
+                host_nic: expected_interface,
+                is_primary: host_primary_declaration,
                 retained_window: api.runtime_config.retained_boot_interface_window,
             },
             address_family,

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::collections::HashSet;
+
 use ::rpc::forge as rpc;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
@@ -25,7 +27,9 @@ use uuid::Uuid;
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
-use crate::handlers::machine_interface_address::update_preallocated_machine_interface;
+use crate::handlers::machine_interface_address::{
+    update_preallocated_expected_machine_interface, update_preallocated_machine_interface,
+};
 
 lazy_static! {
     // Verify what serial is alphanumeric string with, allows dashes '-' and underscores '_'
@@ -69,19 +73,35 @@ pub(crate) async fn add(
 ) -> Result<tonic::Response<()>, tonic::Status> {
     log_request_data(&request);
 
-    let request = request.into_inner();
+    let machine = parse_expected_machine_for_insert(request.into_inner())?;
+
+    let mut txn = api.txn_begin().await?;
+    db::expected_machine::create(&mut txn, machine).await?;
+
+    txn.commit().await?;
+
+    Ok(tonic::Response::new(()))
+}
+
+/// `parse_expected_machine_for_insert` converts an RPC request and runs every
+/// validation required before creating an `ExpectedMachine`.
+///
+/// Keeping parsing separate from [`add`] lets [`replace_all`] reject every bad
+/// replacement before it clears the current inventory.
+fn parse_expected_machine_for_insert(
+    request: rpc::ExpectedMachine,
+) -> Result<ExpectedMachine, CarbideError> {
     if carbide_utils::has_duplicates(&request.fallback_dpu_serial_numbers) {
-        return Err(
-            CarbideError::InvalidArgument("duplicate dpu serial number found".to_string()).into(),
-        );
+        return Err(CarbideError::InvalidArgument(
+            "duplicate dpu serial number found".to_string(),
+        ));
     }
 
     if !CHASSIS_SERIAL_REGEX.is_match(&request.chassis_serial_number) {
         return Err(CarbideError::InvalidArgument(format!(
             "chassis serial is not formatted properly {}",
             request.chassis_serial_number
-        ))
-        .into());
+        )));
     }
 
     let parsed_mac: MacAddress = request
@@ -107,22 +127,15 @@ pub(crate) async fn add(
     };
 
     validate_expected_machine_for_insert(&machine)?;
-
-    let mut txn = api.txn_begin().await?;
-    db::expected_machine::create(&mut txn, machine).await?;
-
-    txn.commit().await?;
-
-    Ok(tonic::Response::new(()))
+    Ok(machine)
 }
 
-/// Validate the ExpectedMachine payload prior to insert.
-/// Shared between the `add` gRPC handler and the
-/// `expected_machines.json` import flow.
+/// `validate_expected_machine_for_insert` applies the validation shared by the
+/// `add` handler and the `expected_machines.json` import flow.
 pub(crate) fn validate_expected_machine_for_insert(
     machine: &ExpectedMachine,
 ) -> Result<(), CarbideError> {
-    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
+    validate_expected_interfaces(&machine.data.host_nics)?;
     machine
         .data
         .bmc_ip_allocation
@@ -141,12 +154,11 @@ pub(crate) async fn create_missing_from(
     txn: &mut sqlx::PgConnection,
     expected_machines: &[ExpectedMachine],
 ) -> Result<(), CarbideError> {
-    let existing_macs: std::collections::HashSet<String> =
-        db::expected_machine::find_all(&mut *txn)
-            .await?
-            .into_iter()
-            .map(|m| m.bmc_mac_address.to_string())
-            .collect();
+    let existing_macs: HashSet<String> = db::expected_machine::find_all(&mut *txn)
+        .await?
+        .into_iter()
+        .map(|m| m.bmc_mac_address.to_string())
+        .collect();
 
     for expected_machine in expected_machines {
         if existing_macs.contains(&expected_machine.bmc_mac_address.to_string()) {
@@ -186,16 +198,16 @@ pub(crate) async fn delete(
     Ok(tonic::Response::new(()))
 }
 
-/// Updates an expected machine row and, when `bmc_ip_address` is set, reconciles the pre-allocated
-/// `machine_interface` via [`update_preallocated_machine_interface`] (no-op for interfaces that
-/// already have addresses—operators use `machine-interfaces assign-address` for those).
+/// Updates an expected machine row and reconciles configured fixed BMC and
+/// nested-interface addresses. Existing addressed interfaces remain unchanged;
+/// operators use `machine-interfaces assign-address` to update those rows.
 pub(crate) async fn update(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachine>,
 ) -> Result<tonic::Response<()>, tonic::Status> {
     log_request_data(&request);
 
-    let request = request.into_inner();
+    let mut request = request.into_inner();
     if carbide_utils::has_duplicates(&request.fallback_dpu_serial_numbers) {
         return Err(
             CarbideError::InvalidArgument("duplicate dpu serial number found".to_string()).into(),
@@ -215,6 +227,16 @@ pub(crate) async fn update(
         .bmc_mac_address
         .parse::<MacAddress>()
         .map_err(CarbideError::from)?;
+    let mut txn = api.txn_begin().await?;
+    let existing = db::expected_machine::find_for_update(
+        &mut txn,
+        &ExpectedMachineRequest {
+            id,
+            bmc_mac_address: Some(parsed_mac),
+        },
+    )
+    .await?;
+    preserve_omitted_rpc_role_and_allocation(&mut request, existing.as_ref());
     let data: ExpectedMachineData = request.try_into()?;
 
     let machine = ExpectedMachine {
@@ -222,39 +244,14 @@ pub(crate) async fn update(
         bmc_mac_address: parsed_mac,
         data,
     };
+    validate_expected_machine_for_insert(&machine)?;
 
-    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
-    machine
-        .data
-        .bmc_ip_allocation
-        .validate(machine.data.bmc_ip_address.is_some())
-        .map_err(|msg| CarbideError::InvalidArgument(msg.to_string()))?;
-
-    let mut txn = api.txn_begin().await?;
-
-    // Update BMC interface if bmc_ip_address is set.
-    if let Some(bmc_ip) = machine.data.bmc_ip_address {
-        update_preallocated_machine_interface(
-            &mut txn,
-            machine.bmc_mac_address,
-            bmc_ip,
-            api.runtime_config.retained_boot_interface_window,
-        )
-        .await?;
-    }
-
-    // Update/create machine interfaces for host NICs with fixed IPs.
-    for nic in &machine.data.host_nics {
-        if let Some(ip) = nic.fixed_ip {
-            update_preallocated_machine_interface(
-                &mut txn,
-                nic.mac_address,
-                ip,
-                api.runtime_config.retained_boot_interface_window,
-            )
-            .await?;
-        }
-    }
+    update_preallocated_interfaces(
+        &mut txn,
+        &machine,
+        api.runtime_config.retained_boot_interface_window,
+    )
+    .await?;
 
     db::expected_machine::update(&mut txn, &machine)
         .await
@@ -265,8 +262,11 @@ pub(crate) async fn update(
     Ok(tonic::Response::new(()))
 }
 
-/// Clears all expected machines, then creates each entry via [`add`]. Optional `bmc_ip_address` on
-/// each RPC message runs the same `machine_interface` pre-allocation as a single create.
+/// Replace the complete expected-machine inventory in one transaction.
+///
+/// Every entry is parsed and validated before the current inventory is
+/// cleared. The clear and replacement inserts then commit together, so any
+/// database failure also leaves the previous inventory intact.
 pub(crate) async fn replace_all(
     api: &Api,
     request: tonic::Request<rpc::ExpectedMachineList>,
@@ -275,14 +275,42 @@ pub(crate) async fn replace_all(
     let request = request.into_inner();
 
     let mut txn = api.txn_begin().await?;
+    let previous = db::expected_machine::find_all_for_replace(&mut txn).await?;
+    let mut replacements = request.expected_machines;
+    for replacement in &mut replacements {
+        let existing = find_previous_expected_machine(&previous, replacement);
+        preserve_omitted_rpc_role_and_allocation(replacement, existing);
+    }
+
+    let mut seen_bmc_macs = HashSet::with_capacity(replacements.len());
+    let mut seen_ids = HashSet::with_capacity(replacements.len());
+    let mut parsed_replacements = Vec::with_capacity(replacements.len());
+    for replacement in replacements {
+        let parsed = parse_expected_machine_for_insert(replacement)?;
+        if !seen_bmc_macs.insert(parsed.bmc_mac_address) {
+            return Err(CarbideError::InvalidArgument(format!(
+                "duplicate expected machine BMC MAC address {} in replacement list",
+                parsed.bmc_mac_address,
+            ))
+            .into());
+        }
+        if let Some(id) = parsed.id
+            && !seen_ids.insert(id)
+        {
+            return Err(CarbideError::InvalidArgument(format!(
+                "duplicate expected machine id {id} in replacement list",
+            ))
+            .into());
+        }
+        parsed_replacements.push(parsed);
+    }
 
     db::expected_machine::clear(&mut txn).await?;
-
+    for expected_machine in parsed_replacements {
+        db::expected_machine::create(&mut txn, expected_machine).await?;
+    }
     txn.commit().await?;
 
-    for expected_machine in request.expected_machines {
-        add(api, tonic::Request::new(expected_machine)).await?;
-    }
     Ok(tonic::Response::new(()))
 }
 
@@ -351,8 +379,42 @@ pub(crate) async fn delete_all(
     Ok(tonic::Response::new(()))
 }
 
-/// Rejects an ExpectedMachine payload that declares more than one host NIC
-/// with `primary: true`, returning an InvalidArgument if found.
+/// Reject invalid expected-interface allocation and primary declarations.
+fn validate_expected_interfaces(host_nics: &[ExpectedHostNic]) -> Result<(), CarbideError> {
+    validate_expected_interface_role_and_allocation(host_nics)?;
+    validate_at_most_one_primary_host_nic(host_nics)
+}
+
+/// `validate_expected_interface_role_and_allocation` checks only the role and
+/// allocation fields added to expected interfaces.
+///
+/// Batch update historically did not apply the older Expected Machine
+/// validators, so it uses this narrower check to avoid changing legacy batch
+/// behavior.
+fn validate_expected_interface_role_and_allocation(
+    host_nics: &[ExpectedHostNic],
+) -> Result<(), CarbideError> {
+    for interface in host_nics {
+        interface.validate_ip_allocation().map_err(|message| {
+            CarbideError::InvalidArgument(format!(
+                "host_nics interface {}: {message}",
+                interface.mac_address,
+            ))
+        })?;
+        if interface.primary.is_some() && !interface.role.is_host() {
+            return Err(CarbideError::InvalidArgument(format!(
+                "only a role=host interface may set primary; {} has role {}",
+                interface.mac_address, interface.role,
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// `validate_at_most_one_primary_host_nic` rejects competing machine-wide Host
+/// primary declarations. DPU roles define their own primary behavior and may
+/// not set this field.
 fn validate_at_most_one_primary_host_nic(
     host_nics: &[ExpectedHostNic],
 ) -> Result<(), CarbideError> {
@@ -369,6 +431,144 @@ fn validate_at_most_one_primary_host_nic(
         )));
     }
     Ok(())
+}
+
+/// `find_previous_expected_machine` finds the stored row whose newly-added
+/// interface fields may need to survive a replacement request.
+///
+/// Prefer the stable ID so a BMC MAC change still matches the same row. Older
+/// clients may omit the ID, so the BMC MAC remains the compatibility fallback.
+fn find_previous_expected_machine<'a>(
+    previous: &'a [ExpectedMachine],
+    replacement: &rpc::ExpectedMachine,
+) -> Option<&'a ExpectedMachine> {
+    replacement
+        .id
+        .as_ref()
+        .and_then(|id| Uuid::parse_str(&id.value).ok())
+        .and_then(|id| previous.iter().find(|machine| machine.id == Some(id)))
+        .or_else(|| {
+            replacement
+                .bmc_mac_address
+                .parse::<MacAddress>()
+                .ok()
+                .and_then(|mac_address| {
+                    previous
+                        .iter()
+                        .find(|machine| machine.bmc_mac_address == mac_address)
+                })
+        })
+}
+
+/// Preserve omitted role and allocation fields unknown to older RPC clients.
+///
+/// `None` means the field was absent, while an explicit `Unspecified` asks to
+/// restore legacy defaults. Match each interface at the same list index first
+/// so duplicate legacy MAC entries retain independent settings, then fall back
+/// to MAC for clients that reorder the list.
+///
+/// Other optional fields keep their existing full-replacement behavior. For
+/// example, omitting `network_segment_type` removes that guard.
+fn preserve_omitted_rpc_role_and_allocation(
+    replacement: &mut rpc::ExpectedMachine,
+    existing: Option<&ExpectedMachine>,
+) {
+    let Some(existing) = existing else {
+        return;
+    };
+
+    for (index, interface) in replacement.host_nics.iter_mut().enumerate() {
+        let Ok(mac_address) = interface.mac_address.parse::<MacAddress>() else {
+            continue;
+        };
+        let Some(existing_interface) = existing
+            .data
+            .host_nics
+            .get(index)
+            .filter(|candidate| candidate.mac_address == mac_address)
+            .or_else(|| {
+                existing
+                    .data
+                    .host_nics
+                    .iter()
+                    .find(|candidate| candidate.mac_address == mac_address)
+            })
+        else {
+            // A new interface has no stored value to preserve. Missing fields
+            // retain their normal inference/default behavior.
+            continue;
+        };
+
+        let preserve_role = interface.role.is_none();
+        let preserve_ip_allocation = interface.ip_allocation.is_none();
+        if preserve_role {
+            interface.role = (!existing_interface.role.is_host())
+                .then(|| rpc::ExpectedInterfaceRole::from(existing_interface.role) as i32);
+            if !existing_interface.role.is_host() && interface.primary == Some(false) {
+                // Older clients commonly send primary=false for every entry.
+                // Once the stored DPU role is restored, that legacy field no
+                // longer applies and must not make the payload invalid.
+                interface.primary = None;
+            }
+        }
+        if preserve_ip_allocation
+            // An old client still controls legacy fixed/dynamic intent through
+            // `fixed_ip`. Preserve a newer explicit policy only while that
+            // legacy signal remains unchanged.
+            && existing_interface.fixed_ip.is_some()
+                == interface
+                    .fixed_ip
+                    .as_deref()
+                    .is_some_and(|ip| !ip.is_empty())
+        {
+            interface.ip_allocation = existing_interface
+                .ip_allocation
+                .map(|policy| rpc::ExpectedInterfaceIpAllocation::from(policy) as i32);
+        }
+    }
+}
+
+/// `update_preallocated_interfaces` applies the update-time fixed-address
+/// behavior shared by the single and batch APIs.
+///
+/// The lower-level helpers create a missing reservation or fill an addressless
+/// row, but leave existing addresses alone. An associated row may receive its
+/// configured fixed address, but its role-derived type and primary setting
+/// remain managed state. Operators still use the machine-interface address APIs
+/// to replace a live address.
+async fn update_preallocated_interfaces(
+    txn: &mut sqlx::PgConnection,
+    machine: &ExpectedMachine,
+    retained_window: Option<chrono::Duration>,
+) -> Result<(), CarbideError> {
+    if let Some(bmc_ip) = machine.data.bmc_ip_address {
+        update_preallocated_machine_interface(
+            &mut *txn,
+            machine.bmc_mac_address,
+            bmc_ip,
+            retained_window,
+        )
+        .await?;
+    }
+
+    for interface in &machine.data.host_nics {
+        if interface.fixed_ip.is_some() {
+            update_preallocated_expected_machine_interface(&mut *txn, interface, retained_window)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Preserve the request representation used by batch results and replace only
+/// the ID with its parsed value. Older clients expect their payload back rather
+/// than a model-normalized copy.
+fn batch_result_with_id(mut machine: rpc::ExpectedMachine, id: Uuid) -> rpc::ExpectedMachine {
+    machine.id = Some(::rpc::common::Uuid {
+        value: id.to_string(),
+    });
+    machine
 }
 
 /// Helper function to sanitize expected machine and return parsed IDs (ID+MAC)
@@ -419,14 +619,14 @@ fn sanitize_expected_machine_and_get_ids(
     Ok((id, parsed_mac))
 }
 
-/// Creates one expected machine inside an existing transaction (batch API). Applies the same static
-/// BMC pre-allocation rules as [`add`].
+/// Creates one expected machine inside an existing transaction (batch API).
 async fn create_expected_machine(
     txn: &mut sqlx::PgConnection,
     machine: rpc::ExpectedMachine,
     id: Uuid,
     parsed_mac: MacAddress,
-) -> Result<(), CarbideError> {
+) -> Result<rpc::ExpectedMachine, CarbideError> {
+    let result_machine = batch_result_with_id(machine.clone(), id);
     let db_data: ExpectedMachineData = machine.try_into()?;
 
     let expected_machine = ExpectedMachine {
@@ -438,18 +638,30 @@ async fn create_expected_machine(
     validate_expected_machine_for_insert(&expected_machine)?;
     db::expected_machine::create(txn, expected_machine).await?;
 
-    Ok(())
+    Ok(result_machine)
 }
 
-/// Updates one expected machine inside an existing transaction (batch API). Applies the same
-/// static BMC reconciliation as [`update`].
+/// Updates one expected machine inside an existing transaction (batch API).
+///
+/// Fixed BMC and nested-interface addresses use the same safe reconciliation
+/// as [`update`].
 async fn update_expected_machine(
     txn: &mut sqlx::PgConnection,
-    machine: rpc::ExpectedMachine,
+    mut machine: rpc::ExpectedMachine,
     id: Uuid,
     parsed_mac: MacAddress,
     retained_window: Option<chrono::Duration>,
-) -> Result<(), CarbideError> {
+) -> Result<rpc::ExpectedMachine, CarbideError> {
+    let result_machine = batch_result_with_id(machine.clone(), id);
+    let existing = db::expected_machine::find_for_update(
+        &mut *txn,
+        &ExpectedMachineRequest {
+            id: Some(id),
+            bmc_mac_address: Some(parsed_mac),
+        },
+    )
+    .await?;
+    preserve_omitted_rpc_role_and_allocation(&mut machine, existing.as_ref());
     let data: ExpectedMachineData = machine.try_into()?;
 
     let expected_machine = ExpectedMachine {
@@ -457,20 +669,12 @@ async fn update_expected_machine(
         bmc_mac_address: parsed_mac,
         data,
     };
-
-    if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
-        update_preallocated_machine_interface(
-            txn,
-            expected_machine.bmc_mac_address,
-            bmc_ip,
-            retained_window,
-        )
-        .await?;
-    }
+    validate_expected_interface_role_and_allocation(&expected_machine.data.host_nics)?;
+    update_preallocated_interfaces(txn, &expected_machine, retained_window).await?;
 
     db::expected_machine::update(txn, &expected_machine).await?;
 
-    Ok(())
+    Ok(result_machine)
 }
 
 #[derive(Copy, Clone)]
@@ -520,7 +724,7 @@ async fn apply_operation(
     id: Uuid,
     parsed_mac: MacAddress,
     retained_window: Option<chrono::Duration>,
-) -> Result<(), CarbideError> {
+) -> Result<rpc::ExpectedMachine, CarbideError> {
     match op {
         BatchOperation::Create => create_expected_machine(txn, machine, id, parsed_mac).await,
         BatchOperation::Update => {
@@ -557,11 +761,6 @@ async fn process_batch_operations(
                     }
                 };
 
-            let mut machine_for_result = machine.clone();
-            machine_for_result.id = Some(::rpc::common::Uuid {
-                value: id.to_string(),
-            });
-
             let mut txn = match api.txn_begin().await {
                 Ok(txn) => txn,
                 Err(e) => {
@@ -583,8 +782,8 @@ async fn process_batch_operations(
             )
             .await
             {
-                Ok(_) => match txn.commit().await {
-                    Ok(_) => results.push(build_success_result(machine_for_result)),
+                Ok(result_machine) => match txn.commit().await {
+                    Ok(_) => results.push(build_success_result(result_machine)),
                     Err(e) => {
                         results.push(build_failure_result(id, format!("Failed to commit: {}", e)))
                     }
@@ -601,21 +800,23 @@ async fn process_batch_operations(
     }
 
     let mut prepared = Vec::with_capacity(machines.len());
-    for machine in machines {
+    for (request_index, machine) in machines.into_iter().enumerate() {
         let (id, parsed_mac) =
             sanitize_expected_machine_and_get_ids(api, machine.clone(), op.is_update())?;
-        prepared.push((machine, id, parsed_mac));
+        prepared.push((request_index, machine, id, parsed_mac));
+    }
+    if op.is_update() {
+        // Every update locks its stored row before preserving fields omitted by
+        // older clients. A stable order keeps overlapping all-or-nothing
+        // batches from taking those row locks in opposite directions.
+        prepared.sort_by_key(|(_, _, id, _)| *id);
     }
 
     let mut txn = api.txn_begin().await?;
+    let mut ordered_results = Vec::with_capacity(prepared.len());
 
-    for (machine, id, parsed_mac) in prepared {
-        let mut machine_for_result = machine.clone();
-        machine_for_result.id = Some(::rpc::common::Uuid {
-            value: id.to_string(),
-        });
-
-        if let Err(e) = apply_operation(
+    for (request_index, machine, id, parsed_mac) in prepared {
+        let result_machine = match apply_operation(
             op,
             txn.as_pgconn(),
             machine,
@@ -625,19 +826,26 @@ async fn process_batch_operations(
         )
         .await
         {
-            txn.rollback_or_log("expected-machine write after operation failure")
-                .await;
-            return Err(e);
-        }
-        results.push(build_success_result(machine_for_result));
+            Ok(machine) => machine,
+            Err(error) => {
+                txn.rollback_or_log("expected-machine write after operation failure")
+                    .await;
+                return Err(error);
+            }
+        };
+        ordered_results.push((request_index, build_success_result(result_machine)));
     }
 
     txn.commit().await?;
 
-    Ok(results)
+    ordered_results.sort_by_key(|(request_index, _)| *request_index);
+    Ok(ordered_results
+        .into_iter()
+        .map(|(_, result)| result)
+        .collect())
 }
 
-/// Batch-create expected machines. Static BMC IP handling matches single [`add`] for each row.
+/// Batch-create expected machines.
 pub(crate) async fn create_expected_machines(
     api: &Api,
     request: tonic::Request<rpc::BatchExpectedMachineOperationRequest>,
@@ -697,6 +905,8 @@ pub(crate) async fn query(
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     #[test]
@@ -714,5 +924,168 @@ mod tests {
 
         let too_long = "A".repeat(65);
         assert!(!CHASSIS_SERIAL_REGEX.is_match(&too_long));
+    }
+
+    #[test]
+    fn expected_interface_primary_is_host_only() {
+        check_values(
+            [
+                Check {
+                    scenario: "Host may be primary",
+                    input: (
+                        model::expected_machine::ExpectedInterfaceRole::Host,
+                        Some(true),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "Host may be secondary",
+                    input: (
+                        model::expected_machine::ExpectedInterfaceRole::Host,
+                        Some(false),
+                    ),
+                    expect: true,
+                },
+                Check {
+                    scenario: "DPU OS derives primary behavior from its role",
+                    input: (model::expected_machine::ExpectedInterfaceRole::DpuOs, None),
+                    expect: true,
+                },
+                Check {
+                    scenario: "DPU BMC derives primary behavior from its role",
+                    input: (model::expected_machine::ExpectedInterfaceRole::DpuBmc, None),
+                    expect: true,
+                },
+                Check {
+                    scenario: "DPU OS cannot override primary behavior",
+                    input: (
+                        model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        Some(false),
+                    ),
+                    expect: false,
+                },
+                Check {
+                    scenario: "DPU BMC cannot override primary behavior",
+                    input: (
+                        model::expected_machine::ExpectedInterfaceRole::DpuBmc,
+                        Some(true),
+                    ),
+                    expect: false,
+                },
+            ],
+            |(role, primary)| {
+                validate_expected_interface_role_and_allocation(&[ExpectedHostNic {
+                    role,
+                    primary,
+                    ..Default::default()
+                }])
+                .is_ok()
+            },
+        );
+    }
+
+    #[test]
+    fn omitted_role_and_allocation_are_preserved_per_list_entry() {
+        let mac_address: MacAddress = "7A:7B:7C:7D:7E:91".parse().unwrap();
+        let existing = ExpectedMachine {
+            id: Some(Uuid::new_v4()),
+            bmc_mac_address: "7A:7B:7C:7D:7E:90".parse().unwrap(),
+            data: ExpectedMachineData {
+                host_nics: vec![
+                    ExpectedHostNic {
+                        mac_address,
+                        role: model::expected_machine::ExpectedInterfaceRole::DpuBmc,
+                        ip_allocation: Some(
+                            model::expected_machine::ExpectedInterfaceIpAllocation::Retained,
+                        ),
+                        network_segment_type: Some(
+                            model::network_segment::NetworkSegmentType::Underlay,
+                        ),
+                        ..Default::default()
+                    },
+                    ExpectedHostNic {
+                        mac_address,
+                        role: model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        ip_allocation: Some(
+                            model::expected_machine::ExpectedInterfaceIpAllocation::Dynamic,
+                        ),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+        };
+        let mut replacement = rpc::ExpectedMachine {
+            host_nics: vec![
+                rpc::ExpectedHostNic {
+                    mac_address: mac_address.to_string(),
+                    primary: Some(false),
+                    ..Default::default()
+                },
+                rpc::ExpectedHostNic {
+                    mac_address: mac_address.to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        preserve_omitted_rpc_role_and_allocation(&mut replacement, Some(&existing));
+
+        assert_eq!(
+            replacement.host_nics[0].role,
+            Some(rpc::ExpectedInterfaceRole::DpuBmc as i32),
+        );
+        assert_eq!(
+            replacement.host_nics[0].ip_allocation,
+            Some(rpc::ExpectedInterfaceIpAllocation::Retained as i32),
+        );
+        assert_eq!(replacement.host_nics[0].primary, None);
+        assert_eq!(replacement.host_nics[0].network_segment_type, None);
+        assert_eq!(
+            replacement.host_nics[1].role,
+            Some(rpc::ExpectedInterfaceRole::DpuOs as i32),
+        );
+        assert_eq!(
+            replacement.host_nics[1].ip_allocation,
+            Some(rpc::ExpectedInterfaceIpAllocation::Dynamic as i32),
+        );
+        let parsed: ExpectedMachineData = replacement.try_into().unwrap();
+        assert!(validate_expected_interface_role_and_allocation(&parsed.host_nics).is_ok());
+    }
+
+    #[test]
+    fn omitted_dpu_role_does_not_hide_primary_true() {
+        let mac_address: MacAddress = "7A:7B:7C:7D:7E:93".parse().unwrap();
+        let existing = ExpectedMachine {
+            id: Some(Uuid::new_v4()),
+            bmc_mac_address: "7A:7B:7C:7D:7E:92".parse().unwrap(),
+            data: ExpectedMachineData {
+                host_nics: vec![ExpectedHostNic {
+                    mac_address,
+                    role: model::expected_machine::ExpectedInterfaceRole::DpuBmc,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        };
+        let mut replacement = rpc::ExpectedMachine {
+            host_nics: vec![rpc::ExpectedHostNic {
+                mac_address: mac_address.to_string(),
+                primary: Some(true),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        preserve_omitted_rpc_role_and_allocation(&mut replacement, Some(&existing));
+
+        assert_eq!(
+            replacement.host_nics[0].role,
+            Some(rpc::ExpectedInterfaceRole::DpuBmc as i32),
+        );
+        assert_eq!(replacement.host_nics[0].primary, Some(true));
+        let parsed: ExpectedMachineData = replacement.try_into().unwrap();
+        assert!(validate_expected_interface_role_and_allocation(&parsed.host_nics).is_err());
     }
 }

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -18,24 +18,14 @@
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::allocation_type::AllocationType;
+use model::expected_machine::ExpectedHostNic;
+use model::machine_interface::InterfaceType;
+use model::network_segment::NetworkSegmentType;
 use rpc::forge as rpc;
 use tonic::{Request, Response, Status};
 
 use crate::api::Api;
 use crate::errors::CarbideError;
-
-/// Resolve the correct segment for a static IP. If the IP is within a
-/// managed network prefix, use that segment. Otherwise use the
-/// static-assignments anchor segment.
-async fn resolve_segment_for_static_ip(
-    txn: &mut sqlx::PgConnection,
-    ip: std::net::IpAddr,
-) -> Result<model::network_segment::NetworkSegment, CarbideError> {
-    match db::network_segment::for_prefix_containing_address(txn, ip).await? {
-        Some(seg) => Ok(seg),
-        None => Ok(db::network_segment::static_assignments(txn).await?),
-    }
-}
 
 /// Update or create a machine_interface with a static address.
 ///
@@ -54,14 +44,101 @@ pub async fn update_preallocated_machine_interface(
     bmc_ip: std::net::IpAddr,
     retained_window: Option<chrono::Duration>,
 ) -> Result<(), CarbideError> {
-    let existing = db::machine_interface::find_by_mac_address(&mut *txn, bmc_mac_address).await?;
+    update_preallocated_machine_interface_with_settings(
+        txn,
+        bmc_mac_address,
+        bmc_ip,
+        None,
+        retained_window,
+    )
+    .await
+}
+
+/// Apply the existing safe update behavior to a fixed expected interface.
+///
+/// An addressed interface remains unchanged. A missing row is created with
+/// the declared interface settings. Any addressless row receives the fixed IP,
+/// but only an unassociated row also receives the role-derived settings.
+pub async fn update_preallocated_expected_machine_interface(
+    txn: &mut sqlx::PgConnection,
+    expected_interface: &ExpectedHostNic,
+    retained_window: Option<chrono::Duration>,
+) -> Result<(), CarbideError> {
+    let fixed_ip = expected_interface
+        .fixed_reservation_ip()
+        .map_err(|message| {
+            CarbideError::InvalidArgument(format!(
+                "expected interface {}: {message}",
+                expected_interface.mac_address,
+            ))
+        })?;
+
+    update_preallocated_machine_interface_with_settings(
+        txn,
+        expected_interface.mac_address,
+        fixed_ip,
+        Some(ExpectedInterfaceSettings {
+            interface_type: expected_interface.role.interface_type(),
+            primary_interface: expected_interface.role.primary_interface_override(),
+            segment_type_guard: expected_interface.segment_type_guard(),
+        }),
+        retained_window,
+    )
+    .await
+}
+
+/// ExpectedInterface settings that may be applied with a fixed-address
+/// reservation.
+///
+/// These settings configure a new row, but only update an existing row while
+/// it is still unassociated. ExpectedMachine is an ingestion template and must
+/// not reclassify an interface after another resource owns it.
+#[derive(Clone, Copy)]
+struct ExpectedInterfaceSettings {
+    /// Database interface type represented by the configured role.
+    interface_type: InterfaceType,
+    /// Role-specific primary-interface value, when the role declares one.
+    primary_interface: Option<bool>,
+    /// Segment type that the fixed address must resolve to.
+    segment_type_guard: Option<NetworkSegmentType>,
+}
+
+/// Create or safely update a fixed-address reservation.
+///
+/// Existing addressed rows remain unchanged. Addressless rows receive the
+/// fixed address, but ExpectedInterface settings are applied only while the row
+/// is unassociated. Passing no settings preserves the existing Host BMC update
+/// behavior.
+async fn update_preallocated_machine_interface_with_settings(
+    txn: &mut sqlx::PgConnection,
+    mac_address: MacAddress,
+    ip_address: std::net::IpAddr,
+    settings: Option<ExpectedInterfaceSettings>,
+    retained_window: Option<chrono::Duration>,
+) -> Result<(), CarbideError> {
+    let segment_type_guard = settings.and_then(|settings| settings.segment_type_guard);
+    // An explicit segment type is a configuration guard, so validate it even
+    // when an addressed interface will otherwise remain unchanged. Legacy
+    // callers resolve lazily to preserve that addressed-row no-op.
+    let guarded_segment = if let Some(segment_type_guard) = segment_type_guard {
+        Some(
+            db::network_segment::for_static_address(txn, ip_address, Some(segment_type_guard))
+                .await?,
+        )
+    } else {
+        None
+    };
+    let existing = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
 
     if let Some(iface) = existing.first() {
         if iface.addresses.is_empty() {
             // No addresses -- safe to assign the static IP.
-            db::machine_interface_address::assign_static(txn, iface.id, bmc_ip).await?;
+            db::machine_interface_address::assign_static(txn, iface.id, ip_address).await?;
 
-            let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
+            let segment = match guarded_segment {
+                Some(segment) => segment,
+                None => db::network_segment::for_static_address(txn, ip_address, None).await?,
+            };
             if iface.segment_id != segment.id {
                 db::machine_interface::update_segment_id(
                     txn,
@@ -71,10 +148,29 @@ pub async fn update_preallocated_machine_interface(
                 )
                 .await?;
             }
+            // Address reconciliation is independent from these settings. A
+            // configured fixed address is still assigned above when an
+            // associated row has no addresses; ownership only prevents role
+            // and primary-interface changes.
+            if let Some(settings) = settings {
+                db::machine_interface::update_unassociated_expected_interface_settings(
+                    txn,
+                    iface.id,
+                    Some(settings.interface_type),
+                    settings.primary_interface,
+                )
+                .await?;
+            }
+            db::machine_interface::sync_hostname_after_address_assignment(
+                txn,
+                iface.id,
+                segment.config.subdomain_id,
+            )
+            .await?;
 
             tracing::info!(
-                %bmc_mac_address,
-                bmc_ip_address = %bmc_ip,
+                %mac_address,
+                ip_address = %ip_address,
                 machine_interface_id = %iface.id,
                 "Assigned static address to existing interface without addresses"
             );
@@ -83,29 +179,38 @@ pub async fn update_preallocated_machine_interface(
             // expected data updates are decoupled from managed state.
             // The caller updates the expected data table; we just log.
             tracing::info!(
-                %bmc_mac_address,
-                bmc_ip_address = %bmc_ip,
+                %mac_address,
+                ip_address = %ip_address,
                 existing_addresses = ?iface.addresses,
                 "Interface already has addresses, updated expected data only"
             );
         }
     } else {
         // No interface yet -- create a new one.
-        let segment = resolve_segment_for_static_ip(txn, bmc_ip).await?;
-
-        db::machine_interface::create(
+        let segment = match guarded_segment {
+            Some(segment) => segment,
+            None => db::network_segment::for_static_address(txn, ip_address, None).await?,
+        };
+        let interface_type = settings
+            .map(|settings| settings.interface_type)
+            .unwrap_or(InterfaceType::Data);
+        let primary_interface = settings
+            .and_then(|settings| settings.primary_interface)
+            .unwrap_or(true);
+        db::machine_interface::create_with_type(
             txn,
             std::slice::from_ref(&segment),
-            &bmc_mac_address,
-            true,
-            AddressSelectionStrategy::StaticAddress(bmc_ip),
+            &mac_address,
+            primary_interface,
+            AddressSelectionStrategy::StaticAddress(ip_address),
+            interface_type,
             retained_window,
         )
         .await?;
 
         tracing::info!(
-            %bmc_mac_address,
-            bmc_ip_address = %bmc_ip,
+            %mac_address,
+            ip_address = %ip_address,
             network_segment_id = %segment.id,
             "Pre-allocated static machine interface"
         );
@@ -131,7 +236,8 @@ pub async fn assign_static_address(
     // Resolve the correct segment for this IP and update the interface
     // if needed. IPs within a managed prefix go on that prefix's segment.
     // External IPs go on the static-assignments anchor segment.
-    let target_segment = resolve_segment_for_static_ip(txn.as_pgconn(), ip_address).await?;
+    let target_segment =
+        db::network_segment::for_static_address(txn.as_pgconn(), ip_address, None).await?;
 
     let current_iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
     if current_iface.segment_id != target_segment.id {

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -21,7 +21,9 @@ use common::api_fixtures::{
 };
 use db::{self};
 use mac_address::MacAddress;
-use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
+use model::expected_machine::{
+    ExpectedInterfaceIpAllocation, ExpectedInterfaceRole, ExpectedMachine, ExpectedMachineData,
+};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{ExpectedMachineList, ExpectedMachineRequest};
 use uuid::Uuid;
@@ -492,6 +494,100 @@ async fn test_replace_all_expected_machines(pool: sqlx::PgPool) {
     assert_eq!(expected_machine_1, resulting_machine_1);
     assert_eq!(expected_machine_2, resulting_machine_2);
     assert_eq!(expected_machine_3_clone, resulting_machine_3);
+}
+
+#[crate::sqlx_test]
+async fn test_replace_all_prevalidates_batch_before_clearing_existing_machines(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    fn replacement(
+        bmc_mac_address: &str,
+        chassis_serial_number: &str,
+    ) -> rpc::forge::ExpectedMachine {
+        rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac_address.into(),
+            bmc_username: "ADMIN_NEW".into(),
+            bmc_password: "PASS_NEW".into(),
+            chassis_serial_number: chassis_serial_number.into(),
+            ..Default::default()
+        }
+    }
+
+    create_fixture_expected_machines(&pool).await;
+    let env = create_test_env(pool).await;
+    let mut original = env
+        .api
+        .get_all_expected_machines(tonic::Request::new(()))
+        .await?
+        .into_inner()
+        .expected_machines;
+    original.sort_by_key(|machine| machine.bmc_mac_address.clone());
+
+    let mut invalid_policy = replacement("6A:6B:6C:6D:6E:71", "SERIAL-FIXED");
+    invalid_policy.host_nics = vec![rpc::forge::ExpectedHostNic {
+        mac_address: "6A:6B:6C:6D:6E:72".into(),
+        ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+        ..Default::default()
+    }];
+
+    let duplicate_id = Uuid::new_v4().to_string();
+    let mut duplicate_id_a = replacement("6A:6B:6C:6D:6E:74", "SERIAL-DUP-ID-A");
+    duplicate_id_a.id = Some(::rpc::common::Uuid {
+        value: duplicate_id.clone(),
+    });
+    let mut duplicate_id_b = replacement("6A:6B:6C:6D:6E:75", "SERIAL-DUP-ID-B");
+    duplicate_id_b.id = Some(::rpc::common::Uuid {
+        value: duplicate_id,
+    });
+
+    for (case, replacements, expected_error) in [
+        (
+            "invalid interface policy",
+            vec![
+                replacement("6A:6B:6C:6D:6E:70", "SERIAL-VALID"),
+                invalid_policy,
+            ],
+            "ip_allocation=fixed requires fixed_ip",
+        ),
+        (
+            "duplicate BMC MAC",
+            vec![
+                replacement("6A:6B:6C:6D:6E:73", "SERIAL-DUP-MAC-A"),
+                replacement("6A:6B:6C:6D:6E:73", "SERIAL-DUP-MAC-B"),
+            ],
+            "duplicate expected machine BMC MAC address",
+        ),
+        (
+            "duplicate id",
+            vec![duplicate_id_a, duplicate_id_b],
+            "duplicate expected machine id",
+        ),
+    ] {
+        let error = env
+            .api
+            .replace_all_expected_machines(tonic::Request::new(ExpectedMachineList {
+                expected_machines: replacements,
+            }))
+            .await
+            .expect_err("invalid replacement should be rejected");
+        assert_eq!(error.code(), tonic::Code::InvalidArgument, "case: {case}");
+        assert!(
+            error.message().contains(expected_error),
+            "case: {case}; unexpected rejection reason: {}",
+            error.message(),
+        );
+
+        let mut remaining = env
+            .api
+            .get_all_expected_machines(tonic::Request::new(()))
+            .await?
+            .into_inner()
+            .expected_machines;
+        remaining.sort_by_key(|machine| machine.bmc_mac_address.clone());
+        assert_eq!(remaining, original, "case: {case}");
+    }
+
+    Ok(())
 }
 
 #[crate::sqlx_test()]
@@ -1308,8 +1404,15 @@ async fn test_batch_create_missing_id(pool: sqlx::PgPool) {
 async fn test_batch_update_expected_machines_all_or_nothing_success(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
 
-    let id1 = Uuid::new_v4();
-    let id2 = Uuid::new_v4();
+    // Send the larger ID first so the update path must reorder its row locks
+    // and then restore the request order in its response.
+    let first_id = Uuid::new_v4();
+    let second_id = Uuid::new_v4();
+    let (id1, id2) = if first_id > second_id {
+        (first_id, second_id)
+    } else {
+        (second_id, first_id)
+    };
 
     // Create initial machines
     let create_req = rpc::forge::BatchExpectedMachineOperationRequest {
@@ -1388,6 +1491,8 @@ async fn test_batch_update_expected_machines_all_or_nothing_success(pool: sqlx::
     assert_eq!(results.len(), 2);
     assert!(results[0].success);
     assert!(results[1].success);
+    assert_eq!(results[0].id.as_ref().unwrap().value, id1.to_string());
+    assert_eq!(results[1].id.as_ref().unwrap().value, id2.to_string());
 
     // Verify both machines were updated
     let get_req1 = rpc::forge::ExpectedMachineRequest {
@@ -1645,6 +1750,561 @@ async fn test_batch_update_expected_machines_partial_results(pool: sqlx::PgPool)
     assert_eq!(machine3.into_inner().bmc_username, "admin3_updated");
 }
 
+/// Older clients omit newly-added expected-interface fields. Single and batch
+/// updates preserve stored values, while explicit Unspecified values reset
+/// those fields to their legacy defaults.
+#[crate::sqlx_test]
+async fn test_update_expected_machine_preserves_interface_fields_omitted_by_older_client(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    struct Case {
+        scenario: &'static str,
+        suffix: u8,
+        role: Option<i32>,
+        allocation: Option<i32>,
+        use_batch: bool,
+        expected_role: Option<i32>,
+        expected_allocation: Option<i32>,
+    }
+
+    for Case {
+        scenario,
+        suffix,
+        role,
+        allocation,
+        use_batch,
+        expected_role,
+        expected_allocation,
+    } in [
+        Case {
+            scenario: "single update, omitted",
+            suffix: 0x63,
+            role: None,
+            allocation: None,
+            use_batch: false,
+            expected_role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+            expected_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+        },
+        Case {
+            scenario: "single update, unspecified",
+            suffix: 0x66,
+            role: Some(rpc::forge::ExpectedInterfaceRole::Unspecified as i32),
+            allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32),
+            use_batch: false,
+            expected_role: None,
+            expected_allocation: None,
+        },
+        Case {
+            scenario: "batch update, omitted",
+            suffix: 0x69,
+            role: None,
+            allocation: None,
+            use_batch: true,
+            expected_role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+            expected_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+        },
+        Case {
+            scenario: "batch update, unspecified",
+            suffix: 0x6c,
+            role: Some(rpc::forge::ExpectedInterfaceRole::Unspecified as i32),
+            allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32),
+            use_batch: true,
+            expected_role: None,
+            expected_allocation: None,
+        },
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac: MacAddress = format!("7A:7B:7C:7D:7E:{suffix:02X}").parse()?;
+        let dpu_bmc_mac: MacAddress = format!("7A:7B:7C:7D:7E:{:02X}", suffix + 1).parse()?;
+        let new_dpu_os_mac: MacAddress = format!("7A:7B:7C:7D:7E:{:02X}", suffix + 2).parse()?;
+        let serial = format!("EM-COMPAT-{suffix:02X}");
+
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.to_string(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    mac_address: dpu_bmc_mac.to_string(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .await?;
+
+        let update = rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "UPDATED_ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial,
+            host_nics: vec![
+                rpc::forge::ExpectedHostNic {
+                    mac_address: dpu_bmc_mac.to_string(),
+                    role,
+                    ip_allocation: allocation,
+                    ..Default::default()
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: new_dpu_os_mac.to_string(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32),
+                    ip_allocation: allocation,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        if use_batch {
+            let response = env
+                .api
+                .update_expected_machines(tonic::Request::new(
+                    rpc::forge::BatchExpectedMachineOperationRequest {
+                        expected_machines: Some(rpc::forge::ExpectedMachineList {
+                            expected_machines: vec![update],
+                        }),
+                        accept_partial_results: false,
+                    },
+                ))
+                .await?
+                .into_inner();
+            assert!(response.results[0].success, "case: {scenario}");
+            let returned = response.results[0]
+                .expected_machine
+                .as_ref()
+                .expect("successful batch update should return the request representation");
+            let returned_interface = returned
+                .host_nics
+                .iter()
+                .find(|interface| interface.mac_address == dpu_bmc_mac.to_string())
+                .expect("batch result should include the stored interface");
+            assert!(
+                returned.metadata.is_none(),
+                "case {scenario}: batch results should preserve the request representation",
+            );
+            #[allow(deprecated)]
+            {
+                assert!(
+                    !returned.dpf_enabled,
+                    "case {scenario}: batch results should not normalize legacy defaults",
+                );
+            }
+            assert_eq!(returned_interface.role, role, "case: {scenario}",);
+            assert_eq!(
+                returned_interface.ip_allocation, allocation,
+                "case: {scenario}",
+            );
+        } else {
+            env.api
+                .update_expected_machine(tonic::Request::new(update))
+                .await?;
+        }
+
+        let retrieved = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: String::new(),
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+            }))
+            .await?
+            .into_inner();
+
+        assert_eq!(retrieved.bmc_username, "UPDATED_ADMIN", "case: {scenario}");
+        let retained = retrieved
+            .host_nics
+            .iter()
+            .find(|interface| interface.mac_address == dpu_bmc_mac.to_string())
+            .expect("stored interface should remain present");
+        assert_eq!(
+            retained.role, expected_role,
+            "case {scenario}: role should match the requested update semantics",
+        );
+        assert_eq!(
+            retained.ip_allocation, expected_allocation,
+            "case {scenario}: allocation should match the requested update semantics",
+        );
+
+        let added = retrieved
+            .host_nics
+            .iter()
+            .find(|interface| interface.mac_address == new_dpu_os_mac.to_string())
+            .expect("new interface should be added");
+        assert_eq!(
+            added.ip_allocation, None,
+            "case {scenario}: a new interface should keep allocation inference",
+        );
+    }
+
+    Ok(())
+}
+
+/// Wait until an expected-machine writer is blocked by the test transaction.
+async fn wait_until_expected_machine_write_is_blocked(pool: &sqlx::PgPool, blocker_pid: i32) {
+    for _ in 0..300 {
+        let blocked: bool = sqlx::query_scalar(
+            r#"
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_stat_activity AS activity
+                    WHERE activity.datname = current_database()
+                      AND activity.wait_event_type = 'Lock'
+                      AND $1 = ANY(pg_blocking_pids(activity.pid))
+                      AND activity.query ILIKE '%' || $2 || '%'
+                )
+            "#,
+        )
+        .bind(blocker_pid)
+        .bind("expected_machines")
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        if blocked {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    panic!("expected-machine write never waited for the database lock");
+}
+
+#[crate::sqlx_test]
+async fn test_concurrent_older_client_update_preserves_interface_fields(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    for (case, suffix, use_batch) in [
+        ("single update by MAC", 0x78, false),
+        ("batch update by ID", 0x7a, true),
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac_address = format!("7A:7B:7C:7D:81:{suffix:02X}");
+        let interface_mac_address = format!("7A:7B:7C:7D:81:{:02X}", suffix + 1);
+        let chassis_serial_number = format!("EM-LOCK-{suffix:02X}");
+
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac_address.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: chassis_serial_number.clone(),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    mac_address: interface_mac_address.clone(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .await?;
+
+        let mut blocker = env.pool.begin().await?;
+        let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *blocker)
+            .await?;
+        let mut newer = db::expected_machine::find_by_id(&mut *blocker, id)
+            .await?
+            .expect("expected machine should exist");
+        newer.data.host_nics[0].role = ExpectedInterfaceRole::DpuBmc;
+        newer.data.host_nics[0].ip_allocation = Some(ExpectedInterfaceIpAllocation::Retained);
+        db::expected_machine::update(&mut blocker, &newer).await?;
+
+        let update = rpc::forge::ExpectedMachine {
+            id: use_batch.then(|| ::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac_address.clone(),
+            bmc_username: "UPDATED_ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number,
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: interface_mac_address,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let api = env.api.clone();
+        let update_task = tokio::spawn(async move {
+            if use_batch {
+                let response = api
+                    .update_expected_machines(tonic::Request::new(
+                        rpc::forge::BatchExpectedMachineOperationRequest {
+                            expected_machines: Some(ExpectedMachineList {
+                                expected_machines: vec![update],
+                            }),
+                            accept_partial_results: false,
+                        },
+                    ))
+                    .await?
+                    .into_inner();
+                assert!(
+                    response.results[0].success,
+                    "batch update failed: {:?}",
+                    response.results[0].error_message
+                );
+            } else {
+                api.update_expected_machine(tonic::Request::new(update))
+                    .await?;
+            }
+            Ok::<(), tonic::Status>(())
+        });
+
+        wait_until_expected_machine_write_is_blocked(&env.pool, blocker_pid).await;
+        blocker.commit().await?;
+        let update_result =
+            tokio::time::timeout(std::time::Duration::from_secs(10), update_task).await?;
+        update_result??;
+
+        let stored = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: String::new(),
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(stored.bmc_username, "UPDATED_ADMIN", "case: {case}");
+        assert_eq!(
+            stored.host_nics[0].role,
+            Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+            "case: {case}"
+        );
+        assert_eq!(
+            stored.host_nics[0].ip_allocation,
+            Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+            "case: {case}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Replace-all must preserve the latest interface fields when an older client
+/// races with a single-machine update.
+#[crate::sqlx_test]
+async fn test_concurrent_replace_all_preserves_latest_interface_fields(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let id = Uuid::new_v4();
+    let bmc_mac_address = "7A:7B:7C:7D:81:7C".to_string();
+    let interface_mac_address = "7A:7B:7C:7D:81:7D".to_string();
+    let chassis_serial_number = "EM-REPLACE-LOCK-7C".to_string();
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac_address.clone(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: chassis_serial_number.clone(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: interface_mac_address.clone(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut blocker = env.pool.begin().await?;
+    let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *blocker)
+        .await?;
+    let mut newer = db::expected_machine::find_for_update(
+        &mut blocker,
+        &model::expected_machine::ExpectedMachineRequest {
+            id: Some(id),
+            bmc_mac_address: None,
+        },
+    )
+    .await?
+    .expect("expected machine should exist");
+    newer.data.host_nics[0].role = ExpectedInterfaceRole::DpuBmc;
+    newer.data.host_nics[0].ip_allocation = Some(ExpectedInterfaceIpAllocation::Retained);
+
+    let replacement = rpc::forge::ExpectedMachine {
+        id: Some(::rpc::common::Uuid {
+            value: id.to_string(),
+        }),
+        bmc_mac_address: bmc_mac_address.clone(),
+        bmc_username: "OLDER_CLIENT".into(),
+        bmc_password: "PASS".into(),
+        chassis_serial_number,
+        host_nics: vec![rpc::forge::ExpectedHostNic {
+            mac_address: interface_mac_address,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let api = env.api.clone();
+    let replace_task = tokio::spawn(async move {
+        api.replace_all_expected_machines(tonic::Request::new(ExpectedMachineList {
+            expected_machines: vec![replacement],
+        }))
+        .await?;
+        Ok::<(), tonic::Status>(())
+    });
+
+    wait_until_expected_machine_write_is_blocked(&env.pool, blocker_pid).await;
+    db::expected_machine::update(&mut blocker, &newer).await?;
+    blocker.commit().await?;
+    let replace_result =
+        tokio::time::timeout(std::time::Duration::from_secs(10), replace_task).await?;
+    replace_result??;
+
+    let stored = env
+        .api
+        .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+            bmc_mac_address: String::new(),
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(stored.bmc_username, "OLDER_CLIENT");
+    assert_eq!(
+        stored.host_nics[0].role,
+        Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+    );
+    assert_eq!(
+        stored.host_nics[0].ip_allocation,
+        Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_replace_all_preserves_interface_fields_omitted_by_older_client(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    struct Case {
+        scenario: &'static str,
+        suffix: u8,
+        role: Option<i32>,
+        allocation: Option<i32>,
+        omit_id: bool,
+        expected_role: Option<i32>,
+        expected_allocation: Option<i32>,
+    }
+
+    for Case {
+        scenario,
+        suffix,
+        role,
+        allocation,
+        omit_id,
+        expected_role,
+        expected_allocation,
+    } in [
+        Case {
+            scenario: "omitted fields and id",
+            suffix: 0x72,
+            role: None,
+            allocation: None,
+            omit_id: true,
+            expected_role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+            expected_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+        },
+        Case {
+            scenario: "Unspecified fields",
+            suffix: 0x74,
+            role: Some(rpc::forge::ExpectedInterfaceRole::Unspecified as i32),
+            allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32),
+            omit_id: false,
+            expected_role: None,
+            expected_allocation: None,
+        },
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac = format!("7A:7B:7C:7D:80:{suffix:02X}");
+        let interface_mac = format!("7A:7B:7C:7D:80:{:02X}", suffix + 1);
+        let serial = format!("EM-REPLACE-COMPAT-{suffix:02X}");
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    mac_address: interface_mac.clone(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .await?;
+
+        env.api
+            .replace_all_expected_machines(tonic::Request::new(ExpectedMachineList {
+                expected_machines: vec![rpc::forge::ExpectedMachine {
+                    id: (!omit_id).then(|| ::rpc::common::Uuid {
+                        value: id.to_string(),
+                    }),
+                    bmc_mac_address: bmc_mac.clone(),
+                    bmc_username: "UPDATED".into(),
+                    bmc_password: "PASS".into(),
+                    chassis_serial_number: serial,
+                    host_nics: vec![rpc::forge::ExpectedHostNic {
+                        mac_address: interface_mac,
+                        role,
+                        ip_allocation: allocation,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+            }))
+            .await?;
+
+        let stored = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: if omit_id { bmc_mac } else { String::new() },
+                id: (!omit_id).then(|| ::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(stored.bmc_username, "UPDATED", "case: {scenario}");
+        assert_eq!(stored.host_nics[0].role, expected_role, "case: {scenario}",);
+        assert_eq!(
+            stored.host_nics[0].ip_allocation, expected_allocation,
+            "case: {scenario}",
+        );
+    }
+
+    Ok(())
+}
+
 // test_patch_dpf_enabled_none_to_true verifies that when an expected machine is
 // added with is_dpf_enabled: None, the value defaults to true on insert, and a
 // subsequent update with is_dpf_enabled: None preserves that value.
@@ -1859,6 +2519,211 @@ async fn test_update_expected_machine_add_static_ip(pool: sqlx::PgPool) {
     );
 }
 
+/// Single and batch updates use the same fixed expected-interface
+/// reconciliation, including the role-derived interface settings.
+#[crate::sqlx_test]
+async fn test_expected_machine_update_fixed_interface_single_batch_parity(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    for (case, suffix, fixed_ip, use_batch) in [
+        ("single update", 0x70, "192.0.2.220", false),
+        ("batch update", 0x72, "192.0.2.221", true),
+    ] {
+        let fixed_ip: std::net::IpAddr = fixed_ip.parse()?;
+        let id = Uuid::new_v4();
+        let bmc_mac: MacAddress = format!("5A:5B:5C:5D:60:{suffix:02X}").parse()?;
+        let interface_mac: MacAddress = format!("5A:5B:5C:5D:60:{:02X}", suffix + 1).parse()?;
+        let serial = format!("FIXED-INTERFACE-{suffix:02X}");
+
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.to_string(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                ..Default::default()
+            }))
+            .await?;
+
+        let update = rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial,
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: interface_mac.to_string(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+                fixed_ip: Some(fixed_ip.to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        if use_batch {
+            let response = env
+                .api
+                .update_expected_machines(tonic::Request::new(
+                    rpc::forge::BatchExpectedMachineOperationRequest {
+                        expected_machines: Some(ExpectedMachineList {
+                            expected_machines: vec![update],
+                        }),
+                        accept_partial_results: false,
+                    },
+                ))
+                .await?
+                .into_inner();
+            assert!(response.results[0].success, "case: {case}");
+        } else {
+            env.api
+                .update_expected_machine(tonic::Request::new(update))
+                .await?;
+        }
+
+        let mut txn = env.pool.begin().await?;
+        let interfaces =
+            db::machine_interface::find_by_mac_address(&mut *txn, interface_mac).await?;
+        assert_eq!(interfaces.len(), 1, "case: {case}");
+        assert_eq!(
+            interfaces[0].interface_type,
+            model::machine_interface::InterfaceType::Bmc,
+            "case: {case}",
+        );
+        assert!(!interfaces[0].primary_interface, "case: {case}");
+        assert_eq!(interfaces[0].addresses, vec![fixed_ip], "case: {case}",);
+
+        let addresses =
+            db::machine_interface_address::find_for_interface(&mut txn, interfaces[0].id).await?;
+        assert_eq!(addresses.len(), 1, "case: {case}");
+        assert_eq!(
+            addresses[0].allocation_type,
+            model::allocation_type::AllocationType::Static,
+            "case: {case}",
+        );
+        txn.rollback().await?;
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_legacy_bmc_update_preserves_interface_behavior_and_restores_naming(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let bmc_mac: MacAddress = "5A:5B:5C:5D:5E:61".parse()?;
+    let initial_ip: std::net::IpAddr = "192.0.2.210".parse()?;
+    let configured_ip: std::net::IpAddr = "192.0.2.211".parse()?;
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "root".into(),
+            bmc_password: "testpass".into(),
+            chassis_serial_number: "UPDATE-ADDRESSLESS-BMC".into(),
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    db::machine_interface::preallocate_bmc_machine_interface(&mut txn, bmc_mac, initial_ip, None)
+        .await?;
+    let interface = db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac)
+        .await?
+        .pop()
+        .expect("BMC preallocation should create an interface");
+    db::machine_interface_address::delete(&mut txn, &interface.id).await?;
+    db::machine_interface::sync_hostname_after_address_change(&mut txn, interface.id).await?;
+    let addressless = db::machine_interface::find_one(txn.as_mut(), interface.id).await?;
+    assert_eq!(
+        addressless.interface_type,
+        model::machine_interface::InterfaceType::Bmc,
+    );
+    assert!(!addressless.primary_interface);
+    assert!(addressless.hostname.starts_with("noip-"));
+    assert!(addressless.domain_id.is_none());
+    txn.commit().await?;
+
+    let mut update = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            id: None,
+        }))
+        .await?
+        .into_inner();
+    update.id = None;
+    update.bmc_ip_address = Some(configured_ip.to_string());
+    env.api
+        .update_expected_machine(tonic::Request::new(update))
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    let updated = db::machine_interface::find_one(txn.as_mut(), interface.id).await?;
+    txn.rollback().await?;
+    assert_eq!(
+        updated.interface_type,
+        model::machine_interface::InterfaceType::Bmc,
+    );
+    assert!(!updated.primary_interface);
+    assert_eq!(updated.addresses, vec![configured_ip]);
+    assert!(!updated.hostname.starts_with("noip-"));
+    assert_eq!(updated.domain_id, Some(env.domain.into()));
+
+    // Once addressed, legacy BMC updates remain decoupled from the managed
+    // interface. This also needs to hold on upgraded sites that do not have
+    // the newer static-assignments anchor.
+    let external_ip: std::net::IpAddr = "203.0.113.211".parse()?;
+    let mut txn = env.pool.begin().await?;
+    let static_assignments = db::network_segment::static_assignments(txn.as_mut()).await?;
+    db::network_segment::final_delete(static_assignments.id, txn.as_mut()).await?;
+    assert!(
+        db::network_segment::for_prefix_containing_address(txn.as_mut(), external_ip)
+            .await?
+            .is_none(),
+    );
+    txn.commit().await?;
+
+    let mut update = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            id: None,
+        }))
+        .await?
+        .into_inner();
+    update.id = None;
+    update.bmc_ip_address = Some(external_ip.to_string());
+    env.api
+        .update_expected_machine(tonic::Request::new(update))
+        .await?;
+
+    let expected = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: bmc_mac.to_string(),
+            id: None,
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(expected.bmc_ip_address, Some(external_ip.to_string()));
+
+    let mut txn = env.pool.begin().await?;
+    let unchanged = db::machine_interface::find_one(txn.as_mut(), interface.id).await?;
+    txn.rollback().await?;
+    assert_eq!(unchanged.addresses, vec![configured_ip]);
+
+    Ok(())
+}
+
 #[crate::sqlx_test()]
 async fn test_update_expected_machine_change_static_ip(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
@@ -1956,7 +2821,13 @@ async fn test_add_with_host_nic_fixed_ip_creates_interface(
     let env = create_test_env(pool).await;
     let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:01".parse().unwrap();
     let nic_mac: MacAddress = "7A:7B:7C:7D:7E:02".parse().unwrap();
-    let fixed_ip = "192.0.2.230";
+    let fixed_ip: std::net::IpAddr = "192.0.2.230".parse()?;
+    let expected_interface = model::expected_machine::ExpectedHostNic {
+        mac_address: nic_mac,
+        nic_type: Some("onboard".into()),
+        fixed_ip: Some(fixed_ip),
+        ..Default::default()
+    };
 
     env.api
         .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
@@ -1966,29 +2837,18 @@ async fn test_add_with_host_nic_fixed_ip_creates_interface(
             bmc_password: "PASS".into(),
             chassis_serial_number: "EM-FIXEDIP-001".into(),
             host_nics: vec![rpc::forge::ExpectedHostNic {
-                network_segment_type: None,
                 mac_address: nic_mac.to_string(),
                 nic_type: Some("onboard".into()),
-                fixed_ip: Some(fixed_ip.into()),
-                fixed_mask: None,
-                fixed_gateway: None,
-                primary: None,
+                fixed_ip: Some(fixed_ip.to_string()),
+                ..Default::default()
             }],
             ..Default::default()
         }))
         .await?;
 
-    // Add doesn't preallocate inline; mimic what site-explorer does on the next iteration --
-    // materialize the host NIC's static fixed_ip.
-    carbide_site_explorer::try_preallocate_one(
-        &env.pool,
-        nic_mac,
-        fixed_ip.parse().unwrap(),
-        model::machine_interface::InterfaceType::Data,
-        "expected_machine host NIC",
-        None,
-    )
-    .await;
+    // Add doesn't preallocate inline; run the same allocation-policy helper
+    // that Site Explorer uses on its next iteration.
+    carbide_site_explorer::try_apply_expected_interface(&env.pool, &expected_interface, None).await;
 
     let mut txn = env.pool.begin().await?;
     let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, nic_mac).await?;
@@ -1998,7 +2858,7 @@ async fn test_add_with_host_nic_fixed_ip_creates_interface(
         "should have one interface for the host NIC MAC"
     );
     assert!(
-        interfaces[0].addresses.contains(&fixed_ip.parse().unwrap()),
+        interfaces[0].addresses.contains(&fixed_ip),
         "interface should have the fixed IP"
     );
 
@@ -2040,6 +2900,7 @@ async fn test_dhcp_discover_uses_fixed_ip_from_host_nics(
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: None,
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -2163,6 +3024,7 @@ async fn test_dhcp_discover_preallocates_host_nic_fixed_ip_for_unknown_mac(
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: None,
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -2336,6 +3198,7 @@ async fn test_dhcp_honors_primary_host_nic(
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: Some(true),
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -2400,6 +3263,7 @@ async fn test_dhcp_marks_non_primary_mac_as_non_primary(
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: Some(true),
+                    ..Default::default()
                 },
                 rpc::forge::ExpectedHostNic {
                     network_segment_type: None,
@@ -2409,6 +3273,7 @@ async fn test_dhcp_marks_non_primary_mac_as_non_primary(
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: None,
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -2468,6 +3333,7 @@ async fn test_add_rejects_multiple_primary_host_nics(
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: Some(true),
+                    ..Default::default()
                 },
                 rpc::forge::ExpectedHostNic {
                     network_segment_type: None,
@@ -2477,6 +3343,7 @@ async fn test_add_rejects_multiple_primary_host_nics(
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: Some(true),
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -2521,6 +3388,7 @@ async fn test_declared_primary_survives_dhcp_arrival_order(
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: Some(true),
+                    ..Default::default()
                 },
                 rpc::forge::ExpectedHostNic {
                     network_segment_type: None,
@@ -2530,6 +3398,7 @@ async fn test_declared_primary_survives_dhcp_arrival_order(
                     fixed_mask: None,
                     fixed_gateway: None,
                     primary: None,
+                    ..Default::default()
                 },
             ],
             ..Default::default()
@@ -3064,6 +3933,7 @@ async fn test_create_missing_from_preallocates_interfaces(
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: Some(true),
+                ..Default::default()
             }],
             ..Default::default()
         },
@@ -3077,8 +3947,7 @@ async fn test_create_missing_from_preallocates_interfaces(
     .await?;
     txn.commit().await?;
 
-    // Mimic site-explorer's per-row materialization: one preallocate per static IP on the
-    // entity we just inserted.
+    // Run the same per-row materialization helpers as Site Explorer.
     carbide_site_explorer::try_preallocate_one(
         &env.pool,
         bmc_mac,
@@ -3088,12 +3957,9 @@ async fn test_create_missing_from_preallocates_interfaces(
         None,
     )
     .await;
-    carbide_site_explorer::try_preallocate_one(
+    carbide_site_explorer::try_apply_expected_interface(
         &env.pool,
-        nic_mac,
-        host_ip,
-        model::machine_interface::InterfaceType::Data,
-        "expected_machine host NIC",
+        &machine.data.host_nics[0],
         None,
     )
     .await;

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -23,7 +23,8 @@ use carbide_uuid::machine::MachineInterfaceId;
 use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    create_host_inband_network_segment, create_network_segment,
+    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_host_inband_network_segment,
+    create_network_segment,
 };
 use common::api_fixtures::{
     FIXTURE_DHCP_RELAY_ADDRESS, TestEnv, TestEnvOverrides, create_managed_host,
@@ -36,6 +37,9 @@ use ipnetwork::IpNetwork;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::allocation_type::AllocationType;
+use model::expected_machine::{
+    ExpectedHostNic, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole,
+};
 use model::machine_interface::InterfaceType;
 use model::network_segment::NetworkSegmentType;
 use model::test_support::ManagedHostConfig;
@@ -523,6 +527,7 @@ async fn test_machine_dhcp_declared_admin_nic_allocates_from_relay_admin_segment
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: Some(true),
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -619,6 +624,159 @@ async fn test_machine_dhcp_declared_segment_type_allocates_from_relay_admin_segm
     let persisted_interface = db::machine_interface::find_one(txn.as_mut(), interface_id).await?;
     assert_eq!(persisted_interface.segment_id, second_admin_segment);
     assert_eq!(persisted_interface.mac_address, admin_nic_mac);
+
+    Ok(())
+}
+
+/// Every expected-interface role uses the same DHCP and allocation-policy
+/// path, while the role supplies only its interface type and primary setting.
+#[crate::sqlx_test]
+async fn test_expected_interface_roles_and_policies_flow_through_dhcp_and_site_explorer(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let expected_bmc_mac: MacAddress = "7A:7B:7C:7D:7E:31".parse()?;
+    let host_mac: MacAddress = "7A:7B:7C:7D:7E:34".parse()?;
+    let dpu_os_mac: MacAddress = "7A:7B:7C:7D:7E:32".parse()?;
+    let dpu_bmc_mac: MacAddress = "7A:7B:7C:7D:7E:33".parse()?;
+    let underlay_segment = env
+        .underlay_segment
+        .expect("test environment should have an underlay segment");
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: expected_bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-DPU-EXPECTED-INTERFACES-001".into(),
+            host_nics: vec![
+                rpc::forge::ExpectedHostNic {
+                    mac_address: host_mac.to_string(),
+                    network_segment_type: Some(rpc::forge::NetworkSegmentType::Underlay as i32),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::Host as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                    primary: Some(true),
+                    ..Default::default()
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: dpu_os_mac.to_string(),
+                    network_segment_type: Some(rpc::forge::NetworkSegmentType::Underlay as i32),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                    ..Default::default()
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: dpu_bmc_mac.to_string(),
+                    network_segment_type: Some(rpc::forge::NetworkSegmentType::Underlay as i32),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }))
+        .await?;
+
+    // The machine-wide primary declaration belongs only to the Host role. DPU
+    // OS and DPU BMC still derive their primary settings from their roles even
+    // when the same ExpectedMachine also declares a primary Host interface.
+    struct Case {
+        name: &'static str,
+        mac_address: MacAddress,
+        role: ExpectedInterfaceRole,
+        policy: ExpectedInterfaceIpAllocation,
+        interface_type: InterfaceType,
+        primary: bool,
+    }
+
+    for Case {
+        name,
+        mac_address,
+        role,
+        policy,
+        interface_type,
+        primary,
+    } in [
+        Case {
+            name: "Host dynamic",
+            mac_address: host_mac,
+            role: ExpectedInterfaceRole::Host,
+            policy: ExpectedInterfaceIpAllocation::Dynamic,
+            interface_type: InterfaceType::Data,
+            primary: true,
+        },
+        Case {
+            name: "DPU OS dynamic",
+            mac_address: dpu_os_mac,
+            role: ExpectedInterfaceRole::DpuOs,
+            policy: ExpectedInterfaceIpAllocation::Dynamic,
+            interface_type: InterfaceType::Data,
+            primary: true,
+        },
+        Case {
+            name: "DPU BMC retained",
+            mac_address: dpu_bmc_mac,
+            role: ExpectedInterfaceRole::DpuBmc,
+            policy: ExpectedInterfaceIpAllocation::Retained,
+            interface_type: InterfaceType::Bmc,
+            primary: false,
+        },
+    ] {
+        let response = env
+            .api
+            .discover_dhcp(
+                DhcpDiscovery::builder(mac_address, FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.ip())
+                    .tonic_request(),
+            )
+            .await?
+            .into_inner();
+        let interface_id = response
+            .machine_interface_id
+            .expect("DHCP response should identify the interface");
+
+        let mut txn = pool.begin().await?;
+        let interface = db::machine_interface::find_one(txn.as_mut(), interface_id).await?;
+        let before =
+            db::machine_interface_address::find_for_interface(&mut txn, interface_id).await?;
+        txn.rollback().await?;
+        assert_eq!(interface.segment_id, underlay_segment, "case: {name}");
+        assert_eq!(interface.interface_type, interface_type, "case: {name}");
+        assert_eq!(interface.primary_interface, primary, "case: {name}");
+        assert_eq!(before.len(), 1, "case: {name}");
+        assert_eq!(
+            before[0].allocation_type,
+            AllocationType::Dhcp,
+            "case: {name}",
+        );
+
+        carbide_site_explorer::try_apply_expected_interface(
+            &pool,
+            &ExpectedHostNic {
+                mac_address,
+                role,
+                ip_allocation: Some(policy),
+                network_segment_type: Some(NetworkSegmentType::Underlay),
+                ..Default::default()
+            },
+            None,
+        )
+        .await;
+
+        let mut txn = pool.begin().await?;
+        let after =
+            db::machine_interface_address::find_for_interface(&mut txn, interface_id).await?;
+        txn.rollback().await?;
+        let expected_allocation = if policy == ExpectedInterfaceIpAllocation::Retained {
+            AllocationType::Static
+        } else {
+            AllocationType::Dhcp
+        };
+        assert_eq!(after.len(), 1, "case: {name}");
+        assert_eq!(
+            after[0].allocation_type, expected_allocation,
+            "case: {name}",
+        );
+    }
 
     Ok(())
 }
@@ -1401,10 +1559,11 @@ async fn test_dhcp_v6_solicit_exact_link_precedes_reserved_prefix_candidate(
     Ok(())
 }
 
-// Exact DHCPv6 link-address routing is authoritative even when expected host
-// NIC metadata declares a different segment type.
+// A legacy Host declaration that omits the new allocation policy keeps its
+// typed segment field as a first-lease selector, so an exact DHCPv6
+// link-address remains authoritative.
 #[crate::sqlx_test]
-async fn test_dhcp_v6_solicit_exact_link_precedes_expected_host_nic_type_filter(
+async fn test_dhcp_v6_solicit_exact_link_preserves_legacy_typed_segment_behavior(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool.clone()).await;
@@ -1426,7 +1585,8 @@ async fn test_dhcp_v6_solicit_exact_link_precedes_expected_host_nic_type_filter(
     .await;
     add_ipv6_prefix(&pool, exact_segment, "2001:db8:91::/64", Some(relay)).await?;
 
-    // Declare the host NIC as Admin; the exact link-address must still win.
+    // The typed field selects Admin for prefix matching, but omission of the
+    // new policy keeps it from guarding the authoritative exact link-address.
     env.api
         .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
             id: None,
@@ -1470,10 +1630,10 @@ async fn test_dhcp_v6_solicit_exact_link_precedes_expected_host_nic_type_filter(
     Ok(())
 }
 
-// INFORMATION-REQUEST uses the same exact-link authority before expected NIC
-// type narrowing, so SLAAC observation lands on the exact segment.
+// INFORMATION-REQUEST uses the same legacy Host compatibility rule, so its
+// SLAAC observation follows the authoritative exact link-address segment.
 #[crate::sqlx_test]
-async fn test_dhcp_v6_info_request_exact_link_precedes_expected_host_nic_type_filter(
+async fn test_dhcp_v6_info_request_exact_link_preserves_legacy_typed_segment_behavior(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool.clone()).await;
@@ -1495,7 +1655,8 @@ async fn test_dhcp_v6_info_request_exact_link_precedes_expected_host_nic_type_fi
     .await;
     add_ipv6_prefix(&pool, exact_segment, "2001:db8:93::/64", Some(relay)).await?;
 
-    // Declare the host NIC as Admin; the exact link-address must still win.
+    // Omission of the new policy keeps the typed Admin field from guarding the
+    // authoritative Underlay link-address.
     env.api
         .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
             id: None,
@@ -1538,6 +1699,128 @@ async fn test_dhcp_v6_info_request_exact_link_precedes_expected_host_nic_type_fi
         addresses[0].address,
         expected_slaac_address("2001:db8:93::".parse()?, host_mac)
     );
+
+    Ok(())
+}
+
+// A typed segment guard rejects an exact DHCPv6 link-address from a different
+// segment type for every allocation-bearing DHCPv6 message.
+#[crate::sqlx_test]
+async fn test_dhcp_v6_exact_link_honors_expected_segment_type_guard(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+
+    struct Case {
+        name: &'static str,
+        message_kind: i32,
+        relay: &'static str,
+        fallback_prefix: &'static str,
+        fallback_ipv4_prefix: &'static str,
+        fallback_ipv4_gateway: &'static str,
+        exact_prefix: &'static str,
+        exact_ipv4_prefix: &'static str,
+        exact_ipv4_gateway: &'static str,
+        bmc_mac: &'static str,
+        host_mac: &'static str,
+    }
+
+    for case in [
+        Case {
+            name: "SOLICIT",
+            message_kind: RPC_MESSAGE_KIND_V6_SOLICIT,
+            relay: "2001:db8:92::1",
+            fallback_prefix: "2001:db8:92::/64",
+            fallback_ipv4_prefix: "192.0.92.0/24",
+            fallback_ipv4_gateway: "192.0.92.1",
+            exact_prefix: "2001:db8:93::/64",
+            exact_ipv4_prefix: "192.0.93.0/24",
+            exact_ipv4_gateway: "192.0.93.1",
+            bmc_mac: "02:00:00:00:00:29",
+            host_mac: "02:00:00:00:00:2a",
+        },
+        Case {
+            name: "INFO_REQUEST",
+            message_kind: RPC_MESSAGE_KIND_V6_INFO_REQUEST,
+            relay: "2001:db8:94::1",
+            fallback_prefix: "2001:db8:94::/64",
+            fallback_ipv4_prefix: "192.0.94.0/24",
+            fallback_ipv4_gateway: "192.0.94.1",
+            exact_prefix: "2001:db8:95::/64",
+            exact_ipv4_prefix: "192.0.95.0/24",
+            exact_ipv4_gateway: "192.0.95.1",
+            bmc_mac: "02:00:00:00:00:2b",
+            host_mac: "02:00:00:00:00:2c",
+        },
+    ] {
+        let bmc_mac: MacAddress = case.bmc_mac.parse()?;
+        let host_mac: MacAddress = case.host_mac.parse()?;
+
+        // Create a declared-type prefix fallback and a different-type exact match.
+        let fallback_segment_name = format!("ADMIN_V6_{}_EXPECTED_FALLBACK", case.name);
+        let fallback_segment = create_network_segment(
+            &env.api,
+            &fallback_segment_name,
+            case.fallback_ipv4_prefix,
+            case.fallback_ipv4_gateway,
+            rpc::forge::NetworkSegmentType::Admin,
+            None,
+            true,
+        )
+        .await;
+        add_ipv6_prefix(&pool, fallback_segment, case.fallback_prefix, None).await?;
+        let exact_segment_name = format!("UNDERLAY_V6_{}_EXACT_BEATS_EXPECTED_ADMIN", case.name);
+        let exact_segment = create_network_segment(
+            &env.api,
+            &exact_segment_name,
+            case.exact_ipv4_prefix,
+            case.exact_ipv4_gateway,
+            rpc::forge::NetworkSegmentType::Underlay,
+            None,
+            true,
+        )
+        .await;
+        add_ipv6_prefix(&pool, exact_segment, case.exact_prefix, Some(case.relay)).await?;
+
+        // Declare the host NIC as Admin; the exact Underlay link-address must be
+        // rejected.
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: None,
+                bmc_mac_address: bmc_mac.to_string(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: format!("DHCP6-{}-GUARD", case.name),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    mac_address: host_mac.to_string(),
+                    network_segment_type: Some(rpc::forge::NetworkSegmentType::Admin as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                    primary: Some(true),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .await?;
+
+        let status = env
+            .api
+            .discover_dhcp(dhcpv6_discovery(host_mac, case.relay, case.message_kind))
+            .await
+            .expect_err("the typed segment guard should reject a different exact-link segment");
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        assert!(
+            status
+                .message()
+                .contains("do not identify the expected admin network segment type"),
+            "{status}",
+        );
+
+        // A rejected discover must not create an observed interface.
+        let mut txn = pool.begin().await?;
+        let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, host_mac).await?;
+        txn.rollback().await?;
+        assert!(interfaces.is_empty(), "case: {}", case.name);
+    }
 
     Ok(())
 }
@@ -1771,6 +2054,7 @@ async fn test_dhcp_v6_info_request_materializes_fixed_reservation(
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: None,
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -1854,6 +2138,7 @@ async fn test_dhcp_v6_fixed_reservation_restores_domain_after_v4_expiration(
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: None,
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -1917,6 +2202,7 @@ async fn test_dhcp_v6_info_request_materializes_fixed_reservation_on_reserved_no
                 fixed_mask: None,
                 fixed_gateway: None,
                 primary: None,
+                ..Default::default()
             }],
             ..Default::default()
         }))
@@ -1955,41 +2241,76 @@ async fn test_dhcp_v6_info_request_materializes_fixed_reservation_on_reserved_no
     Ok(())
 }
 
-// Reserved IPv6-enabled segments still deliver DHCPv6 options, but they must
-// not create an observed interface row or SLAAC address without a reservation.
+// Reserved IPv6-enabled segments still deliver DHCPv6 options to anonymous and
+// legacy expected interfaces, but they must not create an observed interface
+// row or SLAAC address without a reservation.
 #[crate::sqlx_test]
 async fn test_dhcp_v6_info_request_on_reserved_segment_returns_options_only_without_observation(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool.clone()).await;
-    let mac = MacAddress::from_str("02:00:00:00:00:11").unwrap();
+    let anonymous_mac = MacAddress::from_str("02:00:00:00:00:11").unwrap();
+    let expected_mac = MacAddress::from_str("02:00:00:00:00:30").unwrap();
+    let bmc_mac = MacAddress::from_str("02:00:00:00:00:31").unwrap();
 
     // Make the admin segment v6-enabled and reserved-only before first contact.
     add_ipv6_prefix(&pool, env.admin_segment(), "2001:db8:12::/64", None).await?;
     set_segment_reserved(&pool, env.admin_segment()).await?;
-    let response = env
-        .api
-        .discover_dhcp(dhcpv6_discovery(
-            mac,
-            "2001:db8:12::1",
-            RPC_MESSAGE_KIND_V6_INFO_REQUEST,
-        ))
-        .await?
-        .into_inner();
-    assert_eq!(response.address, "");
-    assert_eq!(response.prefix, "");
-    assert!(response.gateway.is_none());
-    assert_eq!(response.mac_address, mac.to_string());
-    assert_eq!(response.machine_id, None);
-    assert_eq!(response.machine_interface_id, None);
-    assert_eq!(response.segment_id, Some(env.admin_segment()));
-    assert_eq!(response.subdomain_id, Some(env.domain.into()));
-    assert!(response.last_invalidation_time.is_some());
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-DHCPV6-RESERVED-OPTIONS-001".into(),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: expected_mac.to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    for (case, mac) in [
+        ("anonymous interface", anonymous_mac),
+        ("legacy expected interface", expected_mac),
+    ] {
+        let response = env
+            .api
+            .discover_dhcp(dhcpv6_discovery(
+                mac,
+                "2001:db8:12::1",
+                RPC_MESSAGE_KIND_V6_INFO_REQUEST,
+            ))
+            .await?
+            .into_inner();
+        assert_eq!(response.address, "", "case: {case}");
+        assert_eq!(response.prefix, "", "case: {case}");
+        assert!(response.gateway.is_none(), "case: {case}");
+        assert_eq!(response.mac_address, mac.to_string(), "case: {case}");
+        assert_eq!(response.machine_id, None, "case: {case}");
+        assert_eq!(response.machine_interface_id, None, "case: {case}");
+        assert_eq!(
+            response.segment_id,
+            Some(env.admin_segment()),
+            "case: {case}",
+        );
+        assert_eq!(
+            response.subdomain_id,
+            Some(env.domain.into()),
+            "case: {case}",
+        );
+        assert!(response.last_invalidation_time.is_some(), "case: {case}");
+    }
 
     // Verify the options request did not persist an observed interface.
     let mut txn = pool.begin().await?;
-    let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
-    assert!(interfaces.is_empty());
+    for (case, mac) in [
+        ("anonymous interface", anonymous_mac),
+        ("legacy expected interface", expected_mac),
+    ] {
+        let interfaces = db::machine_interface::find_by_mac_address(&mut *txn, mac).await?;
+        assert!(interfaces.is_empty(), "case: {case}");
+    }
     txn.rollback().await?;
 
     Ok(())

--- a/crates/api-db/src/expected_machine.rs
+++ b/crates/api-db/src/expected_machine.rs
@@ -138,6 +138,27 @@ pub async fn find_all(txn: impl DbReader<'_>) -> DatabaseResult<Vec<ExpectedMach
         .map_err(|err| DatabaseError::query(sql, err))
 }
 
+/// Lock expected-machine writes and return the inventory being replaced.
+///
+/// Older clients omit interface fields they do not know about. Replace-all
+/// reads those values before clearing the table, so the read must exclude
+/// concurrent inserts, updates, and deletes until the replacement transaction
+/// commits. Replace-all is rare, so a table-level writer lock keeps the complete
+/// inventory operation easy to reason about.
+pub async fn find_all_for_replace(txn: &mut PgConnection) -> DatabaseResult<Vec<ExpectedMachine>> {
+    let lock = "LOCK TABLE expected_machines IN SHARE ROW EXCLUSIVE MODE";
+    sqlx::query(lock)
+        .execute(&mut *txn)
+        .await
+        .map_err(|error| DatabaseError::query(lock, error))?;
+
+    let query = "SELECT * FROM expected_machines ORDER BY id";
+    sqlx::query_as(query)
+        .fetch_all(txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))
+}
+
 /// find_all_by_rack_id returns all expected machines for a given rack_id.
 pub async fn find_all_by_rack_id(
     txn: &mut PgConnection,
@@ -315,6 +336,58 @@ pub async fn find(
         Err(DatabaseError::InvalidArgument(
             "either id or bmc_mac_address must be provided".into(),
         ))
+    }
+}
+
+/// Returns the selected expected machine while locking it for the current
+/// transaction.
+///
+/// Acquire the table lock an eventual update needs before taking the row lock.
+/// Replace-all takes a stronger writer lock, so this order prevents each path
+/// from holding one lock while waiting to upgrade to the other.
+pub async fn find_for_update(
+    txn: &mut PgConnection,
+    req: &ExpectedMachineRequest,
+) -> DatabaseResult<Option<ExpectedMachine>> {
+    // Resolve the selector before taking a table lock so an invalid request
+    // cannot delay a real writer.
+    enum Selector {
+        Id(Uuid),
+        BmcMacAddress(MacAddress),
+    }
+    let selector = if let Some(id) = req.id {
+        Selector::Id(id)
+    } else if let Some(mac_address) = req.bmc_mac_address {
+        Selector::BmcMacAddress(mac_address)
+    } else {
+        return Err(DatabaseError::InvalidArgument(
+            "either id or bmc_mac_address must be provided".into(),
+        ));
+    };
+
+    let lock = "LOCK TABLE expected_machines IN ROW EXCLUSIVE MODE";
+    sqlx::query(lock)
+        .execute(&mut *txn)
+        .await
+        .map_err(|error| DatabaseError::query(lock, error))?;
+
+    match selector {
+        Selector::Id(id) => {
+            let query = "SELECT * FROM expected_machines WHERE id=$1 FOR UPDATE";
+            sqlx::query_as(query)
+                .bind(id)
+                .fetch_optional(txn)
+                .await
+                .map_err(|err| DatabaseError::query(query, err))
+        }
+        Selector::BmcMacAddress(mac_address) => {
+            let query = "SELECT * FROM expected_machines WHERE bmc_mac_address=$1 FOR UPDATE";
+            sqlx::query_as(query)
+                .bind(mac_address)
+                .fetch_optional(txn)
+                .await
+                .map_err(|err| DatabaseError::query(query, err))
+        }
     }
 }
 

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -31,11 +31,11 @@ use itertools::Itertools;
 use mac_address::MacAddress;
 use model::address_selection_strategy::AddressSelectionStrategy;
 use model::allocation_type::AllocationType;
-use model::expected_machine::ExpectedHostNic;
+use model::expected_machine::{ExpectedHostNic, ExpectedInterfaceIpAllocation};
 use model::hardware_info::HardwareInfo;
 use model::machine::MachineInterfaceSnapshot;
 use model::machine_interface::InterfaceType;
-use model::machine_interface_address::MachineInterfaceAssociation;
+use model::machine_interface_address::{InterfaceAssociationType, MachineInterfaceAssociation};
 use model::network_prefix::NetworkPrefix;
 use model::network_segment::{AllocationStrategy, NetworkSegment, NetworkSegmentType};
 use model::predicted_machine_interface::PredictedMachineInterface;
@@ -519,26 +519,23 @@ pub async fn find_one(
     }
 }
 
-// Returns (MachineInterface, newly_created_interface).
-// newly_created_interface indicates that we couldn't find a
-// MachineInterface, so created new one.
-//
-// DHCPv4 and DHCPv6 for the same NIC intentionally converge on the same
-// machine_interfaces row through the `(segment_id, mac_address)` invariant.
-//
-// `is_primary` carries the declared `ExpectedHostNic.primary` for this MAC:
-// `Some(true)` -- this NIC is the host's declared boot interface, `Some(false)`
-// -- a different NIC is, `None` -- nothing was declared. On a newly created (and
-// thus still machine-less) row we make that declaration stick, promoting to or
-// demoting from the creation default as needed, so the boot interface is right
-// from the first lease. `None` keeps the creation default.
-//
-// If we're not making a new interface, then existing interfaces
-// are returned untouched.
 /// Optional metadata used while finding or creating a DHCP machine interface.
+///
+/// DHCPv4 and DHCPv6 for the same NIC intentionally converge on one
+/// `machine_interfaces` row through the `(segment_id, mac_address)` invariant.
+/// ExpectedInterface settings and the host-level primary declaration are
+/// applied only while an existing row is unassociated. DHCP may still reconcile
+/// its segment and addresses independently of those settings.
 pub struct FindOrCreateMachineInterfaceOptions {
+    /// ExpectedInterface declaration matched by the observed MAC address.
     pub host_nic: Option<ExpectedHostNic>,
+    /// Host-level primary-interface declaration supplied by the caller.
+    ///
+    /// `Some(true)` selects this Host interface, `Some(false)` records that
+    /// another Host interface was selected, and `None` leaves the
+    /// role-specific or creation default unchanged.
     pub is_primary: Option<bool>,
+    /// Time that an unused allocation remains eligible for reuse.
     pub retained_window: Option<chrono::Duration>,
 }
 
@@ -659,6 +656,11 @@ pub async fn find_or_create_observed_machine_interface(
     is_primary: Option<bool>,
     retained_window: Option<chrono::Duration>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
+    let expected_interface_type = host_nic.as_ref().map(|nic| nic.role.interface_type());
+    let expected_primary_interface = host_nic
+        .as_ref()
+        .and_then(|nic| nic.role.primary_interface_override());
+    let interface_type = expected_interface_type.unwrap_or(InterfaceType::Data);
     let relaystr = relays
         .iter()
         .map(|v| v.to_string())
@@ -704,8 +706,15 @@ pub async fn find_or_create_observed_machine_interface(
                         )));
                     }
 
-                    create_without_addresses(txn, segment, &mac_address, true, retained_window)
-                        .await?
+                    create_without_addresses(
+                        txn,
+                        segment,
+                        &mac_address,
+                        expected_primary_interface.unwrap_or(true),
+                        interface_type,
+                        retained_window,
+                    )
+                    .await?
                 }
                 1 => {
                     tracing::debug!(
@@ -713,7 +722,20 @@ pub async fn find_or_create_observed_machine_interface(
                         "Mac address exists, validating the relay and returning it",
                     );
                     let mut existing_interface = interface_snapshot.remove(0);
-                    reconcile_interface_segment(txn, &mut existing_interface, relays).await?;
+                    reconcile_interface_segment(
+                        txn,
+                        &mut existing_interface,
+                        relays,
+                        host_nic.as_ref(),
+                    )
+                    .await?;
+                    reconcile_unassociated_expected_interface_settings(
+                        txn,
+                        &mut existing_interface,
+                        expected_interface_type,
+                        expected_primary_interface,
+                    )
+                    .await?;
                     existing_interface
                 }
                 n => {
@@ -753,61 +775,168 @@ pub async fn find_or_create_observed_machine_interface(
     }
 }
 
-/// Apply the expected-host primary declaration to an anonymous interface row.
+/// Update ExpectedInterface settings only while the interface remains
+/// unassociated.
+///
+/// The ownership predicate is part of the database update so an association
+/// racing with ExpectedMachine reconciliation cannot be overwritten by stale
+/// snapshot data. Returns `true` only when at least one setting changed;
+/// already-matching or associated rows return `false`.
+pub async fn update_unassociated_expected_interface_settings(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+    interface_type: Option<InterfaceType>,
+    primary_interface: Option<bool>,
+) -> DatabaseResult<bool> {
+    if interface_type.is_none() && primary_interface.is_none() {
+        return Ok(false);
+    }
+
+    let query = r#"
+UPDATE machine_interfaces
+SET interface_type = COALESCE($1::interface_type, interface_type),
+    primary_interface = COALESCE($2::boolean, primary_interface)
+WHERE id = $3::uuid
+  AND association_type = 'None'::association_type
+  AND machine_id IS NULL
+  AND attached_dpu_machine_id IS NULL
+  AND switch_id IS NULL
+  AND power_shelf_id IS NULL
+  AND (
+      ($1::interface_type IS NOT NULL AND interface_type IS DISTINCT FROM $1::interface_type)
+      OR ($2::boolean IS NOT NULL AND primary_interface IS DISTINCT FROM $2::boolean)
+  )
+"#;
+    sqlx::query(query)
+        .bind(interface_type)
+        .bind(primary_interface)
+        .bind(interface_id)
+        .execute(txn)
+        .await
+        .map(|result| result.rows_affected() == 1)
+        .map_err(|error| DatabaseError::query(query, error))
+}
+
+/// Reconcile role-derived ExpectedInterface settings on an unassociated row.
+///
+/// ExpectedMachine is an ingestion template. Once a machine, DPU, switch, or
+/// power shelf owns the row, its interface type and primary-interface setting
+/// belong to managed state and are left unchanged.
+async fn reconcile_unassociated_expected_interface_settings(
+    txn: &mut PgConnection,
+    interface: &mut MachineInterfaceSnapshot,
+    interface_type: Option<InterfaceType>,
+    primary_interface: Option<bool>,
+) -> DatabaseResult<()> {
+    if !interface_is_unassociated(interface) {
+        return Ok(());
+    }
+
+    let interface_type =
+        interface_type.filter(|interface_type| interface.interface_type != *interface_type);
+    let primary_interface =
+        primary_interface.filter(|primary| interface.primary_interface != *primary);
+    if interface_type.is_none() && primary_interface.is_none() {
+        return Ok(());
+    }
+
+    if update_unassociated_expected_interface_settings(
+        txn,
+        interface.id,
+        interface_type,
+        primary_interface,
+    )
+    .await?
+    {
+        if let Some(interface_type) = interface_type {
+            interface.interface_type = interface_type;
+        }
+        if let Some(primary_interface) = primary_interface {
+            interface.primary_interface = primary_interface;
+        }
+    } else {
+        // Another transaction may have associated or already reconciled the
+        // row after this snapshot was read. Return current state to the DHCP
+        // caller instead of leaking the stale ownership fields.
+        *interface = find_one(&mut *txn, interface.id).await?;
+    }
+    Ok(())
+}
+
+/// Return whether no machine, DPU, switch, or power shelf owns an interface.
+///
+/// `association_type` is checked together with every ownership column because
+/// this predicate protects ExpectedMachine reconciliation from changing
+/// already-managed interface settings.
+fn interface_is_unassociated(interface: &MachineInterfaceSnapshot) -> bool {
+    matches!(
+        interface.association_type,
+        Some(InterfaceAssociationType::None)
+    ) && interface.machine_id.is_none()
+        && interface.attached_dpu_machine_id.is_none()
+        && interface.switch_id.is_none()
+        && interface.power_shelf_id.is_none()
+}
+
+/// Apply the host-level primary declaration to an unassociated interface row.
+///
+/// Role-specific defaults are established before this function runs. The
+/// caller may override that value for a Host interface, but ExpectedMachine
+/// must not alter primary-interface state after another resource owns the row.
 async fn apply_primary_declaration(
     txn: &mut PgConnection,
     interface: &mut MachineInterfaceSnapshot,
     is_primary: Option<bool>,
 ) -> DatabaseResult<()> {
-    // The declaration is safe on NULL-machine rows because the primary-interface
-    // uniqueness index does not constrain them.
-    match is_primary {
-        Some(false) if interface.primary_interface => {
-            set_primary_interface(&interface.id, false, &mut *txn).await?;
-            interface.primary_interface = false;
-        }
-        Some(true) if !interface.primary_interface => {
-            set_primary_interface(&interface.id, true, &mut *txn).await?;
-            interface.primary_interface = true;
-        }
-        _ => {}
+    if !interface_is_unassociated(interface) {
+        return Ok(());
+    }
+
+    // The primary-interface uniqueness index is machine-scoped. The ownership
+    // guard keeps this declaration from changing an attached DPU, switch, or
+    // power-shelf interface that also has no machine_id.
+    let Some(is_primary) = is_primary.filter(|primary| interface.primary_interface != *primary)
+    else {
+        return Ok(());
+    };
+    if update_unassociated_expected_interface_settings(txn, interface.id, None, Some(is_primary))
+        .await?
+    {
+        interface.primary_interface = is_primary;
+    } else {
+        *interface = find_one(&mut *txn, interface.id).await?;
     }
     Ok(())
 }
 
-/// Resolve DHCP candidate network segments for a relay list and optional NIC type.
+/// Resolve DHCP candidate network segments for a relay list and optional
+/// expected-interface declaration.
 pub async fn network_segments_for_dhcp_relays(
     txn: &mut PgConnection,
     relays: &[IpAddr],
     host_nic: Option<&ExpectedHostNic>,
 ) -> DatabaseResult<Vec<NetworkSegment>> {
-    let expected_network_segment_type =
+    let selected_network_segment_type =
         host_nic.and_then(ExpectedHostNic::resolved_network_segment_type);
+    let guarded_network_segment_type = host_nic.and_then(ExpectedHostNic::segment_type_guard);
     let network_segments = db_network_segment::for_relay_all(txn, relays).await?;
     let exact_segment_ids = exact_dhcpv6_link_address_segment_ids(&network_segments, relays);
     if !exact_segment_ids.is_empty() {
-        // DHCPv6 link-address is authoritative relay metadata, so exact
-        // matches win even when ExpectedHostNic suggests a different type.
-        let exact_segments = network_segments
+        // DHCPv6 link-address is authoritative relay metadata. A configured
+        // segment type remains a guard on that exact match.
+        let mut exact_segments = network_segments
             .into_iter()
             .filter(|segment| exact_segment_ids.contains(&segment.id))
             .collect::<Vec<_>>();
 
-        if let Some(network_segment_type) = expected_network_segment_type
-            && exact_segments
-                .iter()
-                .any(|segment| segment.config.segment_type != network_segment_type)
-        {
-            tracing::warn!(
-                relay_ip_addresses = %relays.iter().join(", "),
-                expected_network_segment_type = %network_segment_type,
-                exact_segment_ids = %exact_segments.iter().map(|segment| segment.id.to_string()).join(", "),
-                exact_segment_types = %exact_segments
-                    .iter()
-                    .map(|segment| segment.config.segment_type.to_string())
-                    .join(", "),
-                "DHCPv6 exact link-address segment type differs from ExpectedHostNic segment type; using authoritative exact link-address segment"
-            );
+        if let Some(network_segment_type) = guarded_network_segment_type {
+            exact_segments.retain(|segment| segment.config.segment_type == network_segment_type);
+            if exact_segments.is_empty() {
+                return Err(DatabaseError::FailedPrecondition(format!(
+                    "DHCPv6 relay addresses {} do not identify the expected {network_segment_type} network segment type",
+                    relays.iter().join(", "),
+                )));
+            }
         }
 
         return Ok(exact_segments);
@@ -815,11 +944,18 @@ pub async fn network_segments_for_dhcp_relays(
 
     // With no exact link-address match, a declared NIC may narrow prefix-based
     // candidates to the expected segment type.
-    if let Some(network_segment_type) = expected_network_segment_type {
-        Ok(network_segments
+    if let Some(network_segment_type) = selected_network_segment_type {
+        let matching_segments = network_segments
             .into_iter()
             .filter(|segment| segment.config.segment_type == network_segment_type)
-            .collect())
+            .collect::<Vec<_>>();
+        if guarded_network_segment_type.is_some() && matching_segments.is_empty() {
+            return Err(DatabaseError::FailedPrecondition(format!(
+                "DHCP relay addresses {} do not identify the expected {network_segment_type} network segment type",
+                relays.iter().join(", "),
+            )));
+        }
+        Ok(matching_segments)
     } else {
         Ok(network_segments)
     }
@@ -877,6 +1013,11 @@ async fn validate_existing_mac_and_create_inner(
     retained_window: Option<chrono::Duration>,
     address_family: Option<IpAddressFamily>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
+    let expected_interface_type = host_nic.as_ref().map(|nic| nic.role.interface_type());
+    let expected_primary_interface = host_nic
+        .as_ref()
+        .and_then(|nic| nic.role.primary_interface_override());
+    let interface_type = expected_interface_type.unwrap_or(InterfaceType::Data);
     let mut interface_snapshot = find_by_mac_address(&mut *txn, mac_address).await?;
     match &interface_snapshot.len() {
         0 => {
@@ -952,14 +1093,16 @@ async fn validate_existing_mac_and_create_inner(
 
                 // Dynamic-pool allocation.
                 // Any AddressSelectionStrategy::StaticIp flows will have happened as part of
-                // preallocate_machine_interface or preallocate_bmc_machine_interface.
+                // preallocate_machine_interface, preallocate_bmc_machine_interface, or
+                // preallocate_expected_machine_interface.
                 // (`create` recovers any retained boot interface id onto the new row.)
-                let v = create(
+                let v = create_with_type(
                     txn,
                     &network_segments,
                     &mac_address,
-                    true,
+                    expected_primary_interface.unwrap_or(true),
                     AddressSelectionStrategy::NextAvailableIp,
+                    interface_type,
                     retained_window,
                 )
                 .await?;
@@ -982,7 +1125,15 @@ async fn validate_existing_mac_and_create_inner(
             // not update the interface. Consider having reconcile_interface_segment
             // just return the interface, which would probably look a lot better.
             let mut existing_interface = interface_snapshot.remove(0);
-            reconcile_interface_segment(txn, &mut existing_interface, relays).await?;
+            reconcile_interface_segment(txn, &mut existing_interface, relays, host_nic.as_ref())
+                .await?;
+            reconcile_unassociated_expected_interface_settings(
+                txn,
+                &mut existing_interface,
+                expected_interface_type,
+                expected_primary_interface,
+            )
+            .await?;
             Ok(existing_interface)
         }
         n => {
@@ -1021,11 +1172,16 @@ pub async fn preallocate_machine_interface(
     static_ip: IpAddr,
     retained_window: Option<chrono::Duration>,
 ) -> DatabaseResult<()> {
-    preallocate_machine_interface_with_type(
+    preallocate_machine_interface_with_options(
         txn,
         mac_address,
         static_ip,
-        InterfaceType::Data,
+        PreallocationOptions {
+            interface_type: InterfaceType::Data,
+            primary_interface: None,
+            segment_type_guard: None,
+            allow_associated_interface_settings_update: true,
+        },
         retained_window,
     )
     .await
@@ -1037,11 +1193,50 @@ pub async fn preallocate_bmc_machine_interface(
     static_ip: IpAddr,
     retained_window: Option<chrono::Duration>,
 ) -> DatabaseResult<()> {
-    preallocate_machine_interface_with_type(
+    preallocate_machine_interface_with_options(
         txn,
         mac_address,
         static_ip,
-        InterfaceType::Bmc,
+        PreallocationOptions {
+            interface_type: InterfaceType::Bmc,
+            primary_interface: Some(false),
+            segment_type_guard: None,
+            allow_associated_interface_settings_update: true,
+        },
+        retained_window,
+    )
+    .await
+}
+
+/// Create or reconcile a fixed ExpectedInterface reservation.
+///
+/// The fixed address is reconciled whenever it is safe to do so. Role-derived
+/// interface settings apply to a new or unassociated row, but ExpectedMachine
+/// does not reclassify an already-associated interface.
+pub async fn preallocate_expected_machine_interface(
+    txn: &mut PgConnection,
+    expected_interface: &ExpectedHostNic,
+    retained_window: Option<chrono::Duration>,
+) -> DatabaseResult<()> {
+    let static_ip = expected_interface
+        .fixed_reservation_ip()
+        .map_err(|message| {
+            DatabaseError::InvalidArgument(format!(
+                "expected interface {}: {message}",
+                expected_interface.mac_address,
+            ))
+        })?;
+
+    preallocate_machine_interface_with_options(
+        txn,
+        expected_interface.mac_address,
+        static_ip,
+        PreallocationOptions {
+            interface_type: expected_interface.role.interface_type(),
+            primary_interface: expected_interface.role.primary_interface_override(),
+            segment_type_guard: expected_interface.segment_type_guard(),
+            allow_associated_interface_settings_update: false,
+        },
         retained_window,
     )
     .await
@@ -1054,35 +1249,145 @@ pub async fn retain_bmc_address_by_mac(
     txn: &mut PgConnection,
     bmc_mac: MacAddress,
 ) -> DatabaseResult<()> {
+    retain_address_by_mac_and_type(txn, bmc_mac, InterfaceType::Bmc, None).await
+}
+
+/// Pin DHCP addresses for an expected interface whose allocation policy is
+/// `Retained`. `ExpectedMachine` keeps the policy; matching DHCP address rows
+/// become `Static`, matching the existing Host BMC behavior.
+pub async fn retain_expected_machine_interface_address(
+    txn: &mut PgConnection,
+    expected_interface: &ExpectedHostNic,
+) -> DatabaseResult<()> {
+    expected_interface
+        .require_ip_allocation(ExpectedInterfaceIpAllocation::Retained)
+        .map_err(|message| {
+            DatabaseError::InvalidArgument(format!(
+                "expected interface {}: {message}",
+                expected_interface.mac_address,
+            ))
+        })?;
+    retain_address_by_mac_and_type(
+        txn,
+        expected_interface.mac_address,
+        expected_interface.role.interface_type(),
+        expected_interface.segment_type_guard(),
+    )
+    .await
+}
+
+/// Convert matching DHCP addresses to `Static` for the current interface
+/// lifetime.
+///
+/// The interface type prevents a shared MAC from selecting the wrong row. When
+/// `segment_type_guard` is configured, every matching DHCP address must already
+/// belong to that segment type before any address is retained.
+async fn retain_address_by_mac_and_type(
+    txn: &mut PgConnection,
+    mac_address: MacAddress,
+    interface_type: InterfaceType,
+    segment_type_guard: Option<NetworkSegmentType>,
+) -> DatabaseResult<()> {
+    if let Some(segment_type_guard) = segment_type_guard {
+        let query = "SELECT ns.network_segment_type
+            FROM machine_interfaces mi
+            JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+            JOIN network_segments ns ON ns.id = mi.segment_id
+            WHERE mi.mac_address = $1
+              AND mi.interface_type = $2
+              AND mia.allocation_type = 'dhcp'
+              AND ns.network_segment_type != $3
+            LIMIT 1";
+        let mismatched_segment_type: Option<NetworkSegmentType> = sqlx::query_scalar(query)
+            .bind(mac_address)
+            .bind(interface_type)
+            .bind(segment_type_guard)
+            .fetch_optional(&mut *txn)
+            .await
+            .map_err(|err| DatabaseError::query(query, err))?;
+        if let Some(mismatched_segment_type) = mismatched_segment_type {
+            return Err(DatabaseError::FailedPrecondition(format!(
+                "expected interface {mac_address} has a DHCP address on a {mismatched_segment_type} network segment, not the expected {segment_type_guard} segment type",
+            )));
+        }
+
+        let query = "UPDATE machine_interface_addresses
+            SET allocation_type = 'static'
+            WHERE allocation_type = 'dhcp'
+              AND interface_id IN (
+                  SELECT mi.id
+                  FROM machine_interfaces mi
+                  JOIN network_segments ns ON ns.id = mi.segment_id
+                  WHERE mi.mac_address = $1
+                    AND mi.interface_type = $2
+                    AND ns.network_segment_type = $3
+              )";
+        return sqlx::query(query)
+            .bind(mac_address)
+            .bind(interface_type)
+            .bind(segment_type_guard)
+            .execute(txn)
+            .await
+            .map(|_| ())
+            .map_err(|err| DatabaseError::query(query, err));
+    }
+
     let query = "UPDATE machine_interface_addresses
         SET allocation_type = 'static'
         WHERE allocation_type = 'dhcp'
           AND interface_id IN (
               SELECT id FROM machine_interfaces
-              WHERE mac_address = $1 AND interface_type = 'Bmc'
+              WHERE mac_address = $1 AND interface_type = $2
           )";
     sqlx::query(query)
-        .bind(bmc_mac)
+        .bind(mac_address)
+        .bind(interface_type)
         .execute(txn)
         .await
         .map(|_| ())
         .map_err(|err| DatabaseError::query(query, err))
 }
 
-/// If a machine interface row already exists for `mac_address`, reconcile it against the
-/// requested (`static_ip`, `interface_type`):
-///   - Returns `Ok(true)` when an existing row can carry `static_ip`. Promotes
-///     `interface_type` (and clears `primary_interface` for Bmc) if those don't already match.
-///     Existing DHCP/SLAAC rows for the same address family are replaced by the static
-///     reservation.
-///   - Returns `Ok(false)` when no row exists for `mac_address` — caller should create.
-///   - Returns `Err(InvalidArgument)` when a row exists but carries a different static address
+/// Settings used to create or reconcile a fixed-address reservation.
+///
+/// Address reconciliation always runs when it is safe. The associated-row
+/// option controls only whether `interface_type` and `primary_interface` may be
+/// changed after another resource owns the row.
+#[derive(Clone, Copy)]
+struct PreallocationOptions {
+    /// Interface type used for new rows and eligible existing rows.
+    interface_type: InterfaceType,
+    /// Explicit primary-interface value, or `None` to keep the existing/default
+    /// value.
+    primary_interface: Option<bool>,
+    /// Segment type that the fixed address must resolve to.
+    segment_type_guard: Option<NetworkSegmentType>,
+    /// Allow requested interface settings to change an already-associated row.
+    ///
+    /// This does not disable fixed-address reconciliation. ExpectedInterface
+    /// callers set this to `false` so expected configuration cannot reclassify
+    /// managed state, while legacy generic and Host BMC callers preserve their
+    /// existing setting-update behavior.
+    allow_associated_interface_settings_update: bool,
+}
+
+/// If a machine interface row already exists for `mac_address`, reconcile it
+/// against the requested static IP and interface settings:
+///   - Returns `Ok(true)` when an existing row can use `static_ip`. Updates
+///     its interface settings when allowed. Existing DHCP/SLAAC rows for the
+///     same address family are replaced by the static reservation.
+///   - Returns `Ok(false)` when no row exists for `mac_address` -- caller should create.
+///   - Returns `Err(InvalidArgument)` when a row exists but has a different `Static` address
 ///     for the requested address family.
+///
+/// `allow_associated_interface_settings_update` affects only `interface_type`
+/// and `primary_interface`; it never disables fixed-address reconciliation.
 async fn reconcile_existing_preallocation(
     txn: &mut PgConnection,
     mac_address: MacAddress,
     static_ip: IpAddr,
-    interface_type: InterfaceType,
+    options: PreallocationOptions,
+    known_target_segment: Option<&NetworkSegment>,
 ) -> DatabaseResult<bool> {
     let existing = find_by_mac_address(&mut *txn, mac_address).await?;
     let Some(iface) = existing.first() else {
@@ -1125,13 +1430,15 @@ async fn reconcile_existing_preallocation(
                     existing_addr.id, existing_addr.name,
                 )));
             }
-            let target_segment =
-                match db_network_segment::for_prefix_containing_address(&mut *txn, static_ip)
-                    .await?
-                {
-                    Some(segment) => segment,
-                    None => db_network_segment::static_assignments(&mut *txn).await?,
-                };
+            let derived_segment;
+            let target_segment = match known_target_segment {
+                Some(segment) => segment,
+                None => {
+                    derived_segment =
+                        db_network_segment::for_static_address(&mut *txn, static_ip, None).await?;
+                    &derived_segment
+                }
+            };
             // Do not silently move an existing preallocated interface; changing
             // segment ownership is an explicit update operation.
             if iface.segment_id != target_segment.id {
@@ -1152,26 +1459,65 @@ async fn reconcile_existing_preallocation(
         }
     }
 
-    if iface.interface_type != interface_type {
-        set_interface_type(&iface.id, interface_type, txn).await?;
-    }
-    if interface_type == InterfaceType::Bmc && iface.primary_interface {
-        set_primary_interface(&iface.id, false, txn).await?;
+    // Fixed-address reconciliation has already completed above. Ownership only
+    // decides whether this caller may also change the requested interface settings.
+    if options.allow_associated_interface_settings_update {
+        if iface.interface_type != options.interface_type {
+            set_interface_type(&iface.id, options.interface_type, txn).await?;
+        }
+        if let Some(primary_interface) = options.primary_interface
+            && iface.primary_interface != primary_interface
+        {
+            set_primary_interface(&iface.id, primary_interface, txn).await?;
+        }
+    } else {
+        update_unassociated_expected_interface_settings(
+            txn,
+            iface.id,
+            Some(options.interface_type),
+            options.primary_interface,
+        )
+        .await?;
     }
     Ok(true)
 }
 
-async fn preallocate_machine_interface_with_type(
+/// Create a fixed-address reservation or reconcile an existing row.
+///
+/// `segment_type_guard` validates configured intent before either path runs.
+/// Associated-row policy affects only role-derived interface settings; it
+/// never suppresses safe fixed-address reconciliation.
+async fn preallocate_machine_interface_with_options(
     txn: &mut PgConnection,
     mac_address: MacAddress,
     static_ip: IpAddr,
-    interface_type: InterfaceType,
+    options: PreallocationOptions,
     retained_window: Option<chrono::Duration>,
 ) -> DatabaseResult<()> {
+    // An explicit segment type is a configuration guard, so validate it even
+    // when the reservation already exists. Legacy callers resolve lazily to
+    // preserve their exact-(MAC, IP) idempotent path.
+    let guarded_segment = if let Some(segment_type_guard) = options.segment_type_guard {
+        Some(
+            db_network_segment::for_static_address(&mut *txn, static_ip, Some(segment_type_guard))
+                .await?,
+        )
+    } else {
+        None
+    };
+
     // If there's already a matching record for (ip, mac), just return Ok,
     // instead of attempting to insert, getting a duplicate error, and then
     // handling.
-    if reconcile_existing_preallocation(txn, mac_address, static_ip, interface_type).await? {
+    if reconcile_existing_preallocation(
+        txn,
+        mac_address,
+        static_ip,
+        options,
+        guarded_segment.as_ref(),
+    )
+    .await?
+    {
         return Ok(());
     }
 
@@ -1184,19 +1530,19 @@ async fn preallocate_machine_interface_with_type(
         )));
     }
 
-    let segment =
-        match db_network_segment::for_prefix_containing_address(&mut *txn, static_ip).await? {
-            Some(seg) => seg,
-            None => db_network_segment::static_assignments(&mut *txn).await?,
-        };
-
+    let segment = match guarded_segment {
+        Some(segment) => segment,
+        None => db_network_segment::for_static_address(&mut *txn, static_ip, None).await?,
+    };
     match create_with_type(
         txn,
         std::slice::from_ref(&segment),
         &mac_address,
-        interface_type != InterfaceType::Bmc,
+        options
+            .primary_interface
+            .unwrap_or(options.interface_type != InterfaceType::Bmc),
         AddressSelectionStrategy::StaticAddress(static_ip),
-        interface_type,
+        options.interface_type,
         retained_window,
     )
     .await
@@ -1211,11 +1557,18 @@ async fn preallocate_machine_interface_with_type(
             Ok(())
         }
         Err(DatabaseError::NetworkSegmentDuplicateMacAddress(_)) => {
-            // Looks like we might have lost a race with anohter inserter. Try to
+            // Looks like we might have lost a race with another inserter. Try to
             // uphold our idempotency by re-fetching to reconcile. If the conflicting
             // row carries our `static_ip`, our work is already done!
             // Otherwise return an error.
-            if reconcile_existing_preallocation(txn, mac_address, static_ip, interface_type).await?
+            if reconcile_existing_preallocation(
+                txn,
+                mac_address,
+                static_ip,
+                options,
+                Some(&segment),
+            )
+            .await?
             {
                 Ok(())
             } else {
@@ -1660,6 +2013,7 @@ async fn create_without_addresses(
     segment: &NetworkSegment,
     macaddr: &MacAddress,
     primary_interface: bool,
+    interface_type: InterfaceType,
     retained_window: Option<chrono::Duration>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     // A brand-new observed row has no address yet, so naming uses the dormant placeholder.
@@ -1669,7 +2023,7 @@ async fn create_without_addresses(
         current_hostname: None,
         machine_id: None,
         is_primary: primary_interface,
-        interface_type: InterfaceType::Data,
+        interface_type,
         interface_id: None,
         domain_id: segment.config.subdomain_id,
     };
@@ -1683,7 +2037,7 @@ async fn create_without_addresses(
         hostname,
         segment.config.subdomain_id,
         primary_interface,
-        InterfaceType::Data,
+        interface_type,
     )
     .await?;
 
@@ -2194,6 +2548,7 @@ pub async fn move_predicted_machine_interface_to_machine(
                     &network_segment,
                     &predicted_machine_interface.mac_address,
                     predicted_machine_interface.primary_interface,
+                    InterfaceType::Data,
                     retained_window,
                 )
                 .await?;
@@ -2954,8 +3309,19 @@ async fn reconcile_interface_segment(
     txn: &mut PgConnection,
     existing_interface: &mut MachineInterfaceSnapshot,
     relays: &[IpAddr],
+    host_nic: Option<&ExpectedHostNic>,
 ) -> DatabaseResult<()> {
-    let relay_segments = crate::network_segment::for_relay_all(txn, relays).await?;
+    // An explicit typed declaration guards an existing row. Legacy `nic_type`
+    // only narrowed initial DHCP selection, so it must not invalidate a row
+    // that earlier versions already placed on a different segment type.
+    let relay_segments = if host_nic
+        .and_then(ExpectedHostNic::segment_type_guard)
+        .is_some()
+    {
+        network_segments_for_dhcp_relays(txn, relays, host_nic).await?
+    } else {
+        db_network_segment::for_relay_all(txn, relays).await?
+    };
 
     if relay_segments.is_empty() {
         return Err(DatabaseError::internal(format!(

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
+use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
 use carbide_uuid::network::NetworkSegmentId;
+use model::allocation_type::AllocationType;
+use model::expected_machine::{
+    ExpectedHostNic, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole,
+};
 use model::machine_interface::InterfaceType;
 use model::network_prefix::NewNetworkPrefix;
 use model::network_segment::{
@@ -76,6 +81,43 @@ async fn create_test_segment(
             segment_type: NetworkSegmentType::HostInband,
             can_stretch: Some(false),
             allocation_strategy: AllocationStrategy::Reserved,
+        },
+        txn.as_pgconn(),
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    txn.commit().await?;
+
+    Ok(segment_id)
+}
+
+async fn create_managed_segment(
+    pool: &sqlx::PgPool,
+    name: &str,
+    prefix: &str,
+    segment_type: NetworkSegmentType,
+    allocation_strategy: AllocationStrategy,
+) -> Result<NetworkSegmentId, Box<dyn std::error::Error>> {
+    let segment_id = NetworkSegmentId::new();
+    let mut txn = db::Transaction::begin(pool).await?;
+    db::network_segment::persist(
+        NewNetworkSegment {
+            id: segment_id,
+            name: name.to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: vec![NewNetworkPrefix {
+                prefix: prefix.parse()?,
+                gateway: None,
+                dhcpv6_link_address: None,
+                num_reserved: 0,
+            }],
+            vlan_id: None,
+            vni: None,
+            segment_type,
+            can_stretch: Some(false),
+            allocation_strategy,
         },
         txn.as_pgconn(),
         NetworkSegmentControllerState::Ready,
@@ -175,6 +217,192 @@ async fn test_preallocate_machine_interface_is_idempotent(
         interfaces[0].addresses.contains(&ip),
         "interface should still carry the static IP"
     );
+
+    Ok(())
+}
+
+/// Legacy installations can have an external static reservation on an
+/// ordinary segment without the newer static-assignments anchor. Reapplying
+/// that exact reservation remains an idempotent no-op.
+#[crate::sqlx_test]
+async fn test_preallocate_machine_interface_is_idempotent_without_static_assignments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_id = create_test_segment(&pool, "legacy-external-static").await?;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:30".parse()?;
+    let ip: IpAddr = "203.0.113.230".parse()?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    let interface_id: MachineInterfaceId = sqlx::query_scalar(
+        "INSERT INTO machine_interfaces
+            (segment_id, mac_address, primary_interface, hostname)
+         VALUES ($1, $2, true, 'legacy-external-static')
+         RETURNING id",
+    )
+    .bind(segment_id)
+    .bind(mac)
+    .fetch_one(txn.as_pgconn())
+    .await?;
+    crate::machine_interface_address::insert(
+        txn.as_pgconn(),
+        interface_id,
+        ip,
+        AllocationType::Static,
+    )
+    .await?;
+
+    preallocate_machine_interface(txn.as_pgconn(), mac, ip, None).await?;
+    let interfaces = find_by_mac_address(txn.as_pgconn(), mac).await?;
+    txn.commit().await?;
+
+    assert_eq!(interfaces.len(), 1);
+    assert_eq!(interfaces[0].segment_id, segment_id);
+    assert_eq!(interfaces[0].addresses, vec![ip]);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expected_declaration_does_not_reclassify_attached_dpu_interface(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_name = "attached-dpu-interface";
+    create_managed_segment(
+        &pool,
+        segment_name,
+        "192.0.2.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let dpu_id = MachineId::new(
+        MachineIdSource::ProductBoardChassisSerial,
+        [0x43; 32],
+        MachineType::Dpu,
+    );
+    let mac: MacAddress = "7A:7B:7C:7D:7E:2F".parse()?;
+    let relay: IpAddr = "192.0.2.1".parse()?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    sqlx::query("INSERT INTO machines (id, dpf) VALUES ($1, '{}'::jsonb)")
+        .bind(dpu_id)
+        .execute(txn.as_pgconn())
+        .await?;
+    let segment = db::network_segment::find_by_name(txn.as_pgconn(), segment_name).await?;
+    let interface = create_without_addresses(
+        txn.as_pgconn(),
+        &segment,
+        &mac,
+        true,
+        InterfaceType::Data,
+        None,
+    )
+    .await?;
+    associate_interface_with_dpu_machine(&interface.id, &dpu_id, txn.as_pgconn()).await?;
+
+    let expected_interface = ExpectedHostNic {
+        mac_address: mac,
+        role: ExpectedInterfaceRole::DpuBmc,
+        ..Default::default()
+    };
+    let reconciled = find_or_create_machine_interface(
+        txn.as_pgconn(),
+        None,
+        mac,
+        &[relay],
+        Some(expected_interface),
+        Some(false),
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+
+    assert_eq!(reconciled.attached_dpu_machine_id, Some(dpu_id));
+    assert_eq!(reconciled.interface_type, InterfaceType::Data);
+    assert!(reconciled.primary_interface);
+
+    Ok(())
+}
+
+/// An association that commits after DHCP reads an interface must still win
+/// over ExpectedMachine settings derived from that stale snapshot.
+#[crate::sqlx_test]
+async fn test_expected_interface_settings_do_not_overwrite_concurrent_dpu_association(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_name = "concurrently-attached-dpu-interface";
+    create_managed_segment(
+        &pool,
+        segment_name,
+        "198.51.100.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let dpu_id = MachineId::new(
+        MachineIdSource::ProductBoardChassisSerial,
+        [0x44; 32],
+        MachineType::Dpu,
+    );
+    let mac: MacAddress = "7A:7B:7C:7D:7E:2E".parse()?;
+
+    let mut setup_txn = db::Transaction::begin(&pool).await?;
+    sqlx::query("INSERT INTO machines (id, dpf) VALUES ($1, '{}'::jsonb)")
+        .bind(dpu_id)
+        .execute(setup_txn.as_pgconn())
+        .await?;
+    let segment = db::network_segment::find_by_name(setup_txn.as_pgconn(), segment_name).await?;
+    let interface = create_without_addresses(
+        setup_txn.as_pgconn(),
+        &segment,
+        &mac,
+        true,
+        InterfaceType::Data,
+        None,
+    )
+    .await?;
+    setup_txn.commit().await?;
+
+    let mut snapshot_txn = db::Transaction::begin(&pool).await?;
+    let mut stale_interface = find_one(snapshot_txn.as_pgconn(), interface.id).await?;
+    let updated = update_unassociated_expected_interface_settings(
+        snapshot_txn.as_pgconn(),
+        interface.id,
+        Some(InterfaceType::Data),
+        Some(true),
+    )
+    .await?;
+    assert!(
+        !updated,
+        "steady-state ExpectedInterface settings should not write a new row version",
+    );
+    snapshot_txn.commit().await?;
+
+    let mut association_txn = db::Transaction::begin(&pool).await?;
+    associate_interface_with_dpu_machine(&interface.id, &dpu_id, association_txn.as_pgconn())
+        .await?;
+    association_txn.commit().await?;
+
+    let mut expected_txn = db::Transaction::begin(&pool).await?;
+    reconcile_unassociated_expected_interface_settings(
+        expected_txn.as_pgconn(),
+        &mut stale_interface,
+        Some(InterfaceType::Bmc),
+        Some(false),
+    )
+    .await?;
+    assert_eq!(stale_interface.attached_dpu_machine_id, Some(dpu_id));
+    assert_eq!(stale_interface.interface_type, InterfaceType::Data);
+    assert!(stale_interface.primary_interface);
+    expected_txn.commit().await?;
+
+    let mut verify_txn = db::Transaction::begin(&pool).await?;
+    let reconciled = find_one(verify_txn.as_pgconn(), interface.id).await?;
+    verify_txn.commit().await?;
+
+    assert_eq!(reconciled.attached_dpu_machine_id, Some(dpu_id));
+    assert_eq!(reconciled.interface_type, InterfaceType::Data);
+    assert!(reconciled.primary_interface);
 
     Ok(())
 }
@@ -398,6 +626,522 @@ async fn test_retain_bmc_address_pins_dhcp_and_survives_expiry(
         "the retained Static address should survive DHCP lease expiry"
     );
     assert_eq!(addrs[0].allocation_type, AllocationType::Static);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expected_interface_role_controls_fixed_preallocation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    create_static_assignments_segment(&pool).await?;
+    let segment_id = create_managed_segment(
+        &pool,
+        "expected-interface-underlay",
+        "192.0.2.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Reserved,
+    )
+    .await?;
+
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        role: ExpectedInterfaceRole,
+        primary: Option<bool>,
+        expected_type: InterfaceType,
+        expected_primary: bool,
+    }
+
+    for Case {
+        name,
+        suffix,
+        role,
+        primary,
+        expected_type,
+        expected_primary,
+    } in [
+        Case {
+            name: "host default",
+            suffix: 0x51,
+            role: ExpectedInterfaceRole::Host,
+            primary: None,
+            expected_type: InterfaceType::Data,
+            expected_primary: true,
+        },
+        Case {
+            name: "Host false retains legacy creation default",
+            suffix: 0x52,
+            role: ExpectedInterfaceRole::Host,
+            primary: Some(false),
+            expected_type: InterfaceType::Data,
+            expected_primary: true,
+        },
+        Case {
+            name: "DPU OS",
+            suffix: 0x53,
+            role: ExpectedInterfaceRole::DpuOs,
+            primary: None,
+            expected_type: InterfaceType::Data,
+            expected_primary: true,
+        },
+        Case {
+            name: "DPU BMC",
+            suffix: 0x54,
+            role: ExpectedInterfaceRole::DpuBmc,
+            primary: None,
+            expected_type: InterfaceType::Bmc,
+            expected_primary: false,
+        },
+    ] {
+        let expected_interface = ExpectedHostNic {
+            mac_address: MacAddress::new([0x7a, 0x7b, 0x7c, 0x7d, 0x7e, suffix]),
+            role,
+            ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+            network_segment_type: Some(NetworkSegmentType::Underlay),
+            fixed_ip: Some(format!("192.0.2.{suffix}").parse()?),
+            primary,
+            ..Default::default()
+        };
+
+        let mut txn = db::Transaction::begin(&pool).await?;
+        preallocate_expected_machine_interface(txn.as_pgconn(), &expected_interface, None).await?;
+        let interfaces =
+            find_by_mac_address(txn.as_pgconn(), expected_interface.mac_address).await?;
+        txn.commit().await?;
+
+        assert_eq!(interfaces.len(), 1, "case: {name}");
+        assert_eq!(interfaces[0].interface_type, expected_type, "case: {name}");
+        assert_eq!(
+            interfaces[0].primary_interface, expected_primary,
+            "case: {name}",
+        );
+        assert_eq!(interfaces[0].segment_id, segment_id, "case: {name}");
+        assert_eq!(
+            interfaces[0].addresses,
+            vec![expected_interface.fixed_ip.unwrap()],
+            "case: {name}",
+        );
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_fixed_host_preallocation_does_not_override_machine_wide_primary_selection(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    create_static_assignments_segment(&pool).await?;
+    create_managed_segment(
+        &pool,
+        "fixed-host-primary",
+        "192.0.2.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Reserved,
+    )
+    .await?;
+    let expected_interface = ExpectedHostNic {
+        mac_address: "7A:7B:7C:7D:7E:59".parse()?,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        fixed_ip: Some("192.0.2.59".parse()?),
+        ..Default::default()
+    };
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    preallocate_expected_machine_interface(txn.as_pgconn(), &expected_interface, None).await?;
+    let interface_id = find_by_mac_address(txn.as_pgconn(), expected_interface.mac_address)
+        .await?
+        .pop()
+        .expect("fixed Host preallocation should create an interface")
+        .id;
+
+    // DHCP applies the ExpectedMachine-wide primary declaration. A later Site
+    // Explorer pass must not replace it with the Host creation default.
+    set_primary_interface(&interface_id, false, txn.as_pgconn()).await?;
+    preallocate_expected_machine_interface(txn.as_pgconn(), &expected_interface, None).await?;
+    let interface = find_one(txn.as_pgconn(), interface_id).await?;
+    txn.commit().await?;
+
+    assert!(!interface.primary_interface);
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_fixed_preallocation_derives_segment_before_applying_typed_guard(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    create_static_assignments_segment(&pool).await?;
+    let underlay_segment = create_managed_segment(
+        &pool,
+        "fixed-address-underlay",
+        "198.51.100.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Reserved,
+    )
+    .await?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    let legacy_hint = ExpectedHostNic {
+        mac_address: "7A:7B:7C:7D:7E:61".parse()?,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        nic_type: Some("onboard".to_string()),
+        fixed_ip: Some("198.51.100.61".parse()?),
+        ..Default::default()
+    };
+    preallocate_expected_machine_interface(txn.as_pgconn(), &legacy_hint, None).await?;
+    let interface = find_by_mac_address(txn.as_pgconn(), legacy_hint.mac_address)
+        .await?
+        .pop()
+        .expect("legacy fixed interface should be preallocated");
+    assert_eq!(interface.segment_id, underlay_segment);
+    let reconciled = validate_existing_mac_and_create(
+        txn.as_pgconn(),
+        legacy_hint.mac_address,
+        &["198.51.100.1".parse()?],
+        Some(legacy_hint.clone()),
+        None,
+    )
+    .await?;
+    assert_eq!(
+        reconciled.segment_id, underlay_segment,
+        "legacy nic_type must not reject an existing row whose fixed IP selected the segment",
+    );
+
+    let legacy_typed_segment = ExpectedHostNic {
+        mac_address: "7A:7B:7C:7D:7E:64".parse()?,
+        network_segment_type: Some(NetworkSegmentType::Underlay),
+        fixed_ip: Some("203.0.113.64".parse()?),
+        ..Default::default()
+    };
+    preallocate_expected_machine_interface(txn.as_pgconn(), &legacy_typed_segment, None).await?;
+    let legacy_interface = find_by_mac_address(txn.as_pgconn(), legacy_typed_segment.mac_address)
+        .await?
+        .pop()
+        .expect("legacy fixed interface should be preallocated");
+    let static_assignments = db::network_segment::static_assignments(txn.as_pgconn()).await?;
+    assert_eq!(
+        legacy_interface.segment_id, static_assignments.id,
+        "a legacy Host declaration must not turn its DHCP selector into a fixed-address guard",
+    );
+
+    let wrong_guard = ExpectedHostNic {
+        mac_address: "7A:7B:7C:7D:7E:62".parse()?,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        network_segment_type: Some(NetworkSegmentType::Admin),
+        fixed_ip: Some("198.51.100.62".parse()?),
+        ..Default::default()
+    };
+    let error = preallocate_expected_machine_interface(txn.as_pgconn(), &wrong_guard, None)
+        .await
+        .expect_err("the typed segment guard should reject a different segment type");
+    assert!(matches!(error, DatabaseError::InvalidArgument(_)));
+
+    let outside_guard = ExpectedHostNic {
+        mac_address: "7A:7B:7C:7D:7E:63".parse()?,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        network_segment_type: Some(NetworkSegmentType::Underlay),
+        fixed_ip: Some("203.0.113.63".parse()?),
+        ..Default::default()
+    };
+    let error = preallocate_expected_machine_interface(txn.as_pgconn(), &outside_guard, None)
+        .await
+        .expect_err("a guarded fixed IP should belong to a configured segment");
+    assert!(matches!(error, DatabaseError::InvalidArgument(_)));
+    txn.rollback().await?;
+
+    Ok(())
+}
+
+/// Existing Host declarations used `network_segment_type` only to narrow the
+/// first DHCP segment choice. An explicit allocation policy turns that same
+/// field into a guard for later DHCP reconciliation.
+#[crate::sqlx_test]
+async fn test_explicit_policy_opts_existing_host_interface_into_segment_guard(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    create_static_assignments_segment(&pool).await?;
+    let segment_id = create_managed_segment(
+        &pool,
+        "legacy-host-segment-selector",
+        "198.51.100.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let mac_address: MacAddress = "7A:7B:7C:7D:7E:65".parse()?;
+    let fixed_ip = "198.51.100.65".parse()?;
+    let relay = "198.51.100.1".parse()?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    preallocate_machine_interface(txn.as_pgconn(), mac_address, fixed_ip, None).await?;
+
+    let legacy_interface = ExpectedHostNic {
+        mac_address,
+        network_segment_type: Some(NetworkSegmentType::Admin),
+        ..Default::default()
+    };
+    let reconciled = validate_existing_mac_and_create(
+        txn.as_pgconn(),
+        mac_address,
+        &[relay],
+        Some(legacy_interface.clone()),
+        None,
+    )
+    .await?;
+    assert_eq!(reconciled.segment_id, segment_id);
+
+    let explicit_policy = ExpectedHostNic {
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Dynamic),
+        ..legacy_interface
+    };
+    let error = validate_existing_mac_and_create(
+        txn.as_pgconn(),
+        mac_address,
+        &[relay],
+        Some(explicit_policy),
+        None,
+    )
+    .await
+    .expect_err("an explicit policy should enforce the typed segment guard");
+    assert!(matches!(error, DatabaseError::FailedPrecondition(_)));
+    assert!(
+        error
+            .to_string()
+            .contains("do not identify the expected admin network segment type"),
+        "{error}",
+    );
+    txn.rollback().await?;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expected_interface_retained_policy_pins_all_dhcp_address_families(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    create_static_assignments_segment(&pool).await?;
+    create_managed_segment(
+        &pool,
+        "retained-wrong-interface-type",
+        "203.0.113.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    create_managed_segment(
+        &pool,
+        "retained-wrong-segment-type",
+        "198.51.100.0/24",
+        NetworkSegmentType::Admin,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let mac_address: MacAddress = "7A:7B:7C:7D:7E:71".parse()?;
+    let wrong_segment_mac: MacAddress = "7A:7B:7C:7D:7E:72".parse()?;
+    let addresses = ["192.0.2.71".parse()?, "2001:db8::71".parse()?];
+    let bmc_address = "203.0.113.71".parse()?;
+    let wrong_segment_address = "198.51.100.72".parse()?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    preallocate_machine_interface(txn.as_pgconn(), mac_address, addresses[0], None).await?;
+    let interface_id = find_by_mac_address(txn.as_pgconn(), mac_address)
+        .await?
+        .pop()
+        .expect("preallocation should create an interface")
+        .id;
+    crate::machine_interface_address::delete(txn.as_pgconn(), &interface_id).await?;
+    for address in addresses {
+        crate::machine_interface_address::insert(
+            txn.as_pgconn(),
+            interface_id,
+            address,
+            AllocationType::Dhcp,
+        )
+        .await?;
+    }
+
+    let bmc_segment =
+        crate::network_segment::for_prefix_containing_address(txn.as_pgconn(), bmc_address)
+            .await?
+            .expect("BMC test address should belong to the managed segment");
+    let bmc_interface = create_with_type(
+        txn.as_pgconn(),
+        &[bmc_segment],
+        &mac_address,
+        false,
+        AddressSelectionStrategy::StaticAddress(bmc_address),
+        InterfaceType::Bmc,
+        None,
+    )
+    .await?;
+    crate::machine_interface_address::delete(txn.as_pgconn(), &bmc_interface.id).await?;
+    crate::machine_interface_address::insert(
+        txn.as_pgconn(),
+        bmc_interface.id,
+        bmc_address,
+        AllocationType::Dhcp,
+    )
+    .await?;
+
+    preallocate_machine_interface(
+        txn.as_pgconn(),
+        wrong_segment_mac,
+        wrong_segment_address,
+        None,
+    )
+    .await?;
+    let wrong_segment_interface_id = find_by_mac_address(txn.as_pgconn(), wrong_segment_mac)
+        .await?
+        .pop()
+        .expect("wrong-segment preallocation should create an interface")
+        .id;
+    crate::machine_interface_address::delete(txn.as_pgconn(), &wrong_segment_interface_id).await?;
+    crate::machine_interface_address::insert(
+        txn.as_pgconn(),
+        wrong_segment_interface_id,
+        wrong_segment_address,
+        AllocationType::Dhcp,
+    )
+    .await?;
+
+    let expected_interface = ExpectedHostNic {
+        mac_address,
+        role: ExpectedInterfaceRole::DpuOs,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Retained),
+        ..Default::default()
+    };
+    retain_expected_machine_interface_address(txn.as_pgconn(), &expected_interface).await?;
+    retain_expected_machine_interface_address(txn.as_pgconn(), &expected_interface).await?;
+    let retained =
+        crate::machine_interface_address::find_for_interface(txn.as_pgconn(), interface_id).await?;
+    let bmc_addresses =
+        crate::machine_interface_address::find_for_interface(txn.as_pgconn(), bmc_interface.id)
+            .await?;
+
+    let wrong_segment_expected_interface = ExpectedHostNic {
+        mac_address: wrong_segment_mac,
+        role: ExpectedInterfaceRole::DpuOs,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Retained),
+        network_segment_type: Some(NetworkSegmentType::Underlay),
+        ..Default::default()
+    };
+    let error = retain_expected_machine_interface_address(
+        txn.as_pgconn(),
+        &wrong_segment_expected_interface,
+    )
+    .await
+    .expect_err("the typed segment guard should reject a DHCP address on another segment type");
+    assert!(matches!(error, DatabaseError::FailedPrecondition(_)));
+    let wrong_segment_addresses = crate::machine_interface_address::find_for_interface(
+        txn.as_pgconn(),
+        wrong_segment_interface_id,
+    )
+    .await?;
+    txn.commit().await?;
+
+    assert_eq!(retained.len(), 2);
+    assert!(
+        retained
+            .iter()
+            .all(|address| address.allocation_type == AllocationType::Static),
+    );
+    assert_eq!(bmc_addresses.len(), 1);
+    assert_eq!(bmc_addresses[0].allocation_type, AllocationType::Dhcp);
+    assert_eq!(wrong_segment_addresses.len(), 1);
+    assert_eq!(
+        wrong_segment_addresses[0].allocation_type,
+        AllocationType::Dhcp,
+    );
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_expected_interface_role_controls_observed_interface_creation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_id = create_managed_segment(
+        &pool,
+        "observed-interface-underlay",
+        "203.0.113.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let relay = "203.0.113.1".parse()?;
+
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        role: ExpectedInterfaceRole,
+        primary: Option<bool>,
+        expected_type: InterfaceType,
+        expected_primary: bool,
+    }
+
+    for Case {
+        name,
+        suffix,
+        role,
+        primary,
+        expected_type,
+        expected_primary,
+    } in [
+        Case {
+            name: "Host false retains legacy creation default",
+            suffix: 0x81,
+            role: ExpectedInterfaceRole::Host,
+            primary: Some(false),
+            expected_type: InterfaceType::Data,
+            expected_primary: true,
+        },
+        Case {
+            name: "DPU OS",
+            suffix: 0x82,
+            role: ExpectedInterfaceRole::DpuOs,
+            primary: None,
+            expected_type: InterfaceType::Data,
+            expected_primary: true,
+        },
+        Case {
+            name: "DPU BMC",
+            suffix: 0x83,
+            role: ExpectedInterfaceRole::DpuBmc,
+            primary: None,
+            expected_type: InterfaceType::Bmc,
+            expected_primary: false,
+        },
+    ] {
+        let expected_interface = ExpectedHostNic {
+            mac_address: MacAddress::new([0x7a, 0x7b, 0x7c, 0x7d, 0x7e, suffix]),
+            role,
+            ip_allocation: Some(ExpectedInterfaceIpAllocation::Dynamic),
+            network_segment_type: Some(NetworkSegmentType::Underlay),
+            primary,
+            ..Default::default()
+        };
+        let mut txn = db::Transaction::begin(&pool).await?;
+        let interface = find_or_create_observed_machine_interface(
+            txn.as_pgconn(),
+            None,
+            expected_interface.mac_address,
+            &[relay],
+            Some(expected_interface),
+            None,
+            None,
+        )
+        .await?;
+        txn.commit().await?;
+
+        assert_eq!(interface.segment_id, segment_id, "case: {name}");
+        assert_eq!(interface.interface_type, expected_type, "case: {name}");
+        assert_eq!(
+            interface.primary_interface, expected_primary,
+            "case: {name}",
+        );
+        assert!(interface.addresses.is_empty(), "case: {name}");
+    }
 
     Ok(())
 }

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -256,6 +256,37 @@ pub async fn for_prefix_containing_address(
     }
 }
 
+/// Resolve the segment that owns a configured static address.
+///
+/// A segment type is a guard: the address must already fall within a managed
+/// prefix of that type. Without a guard, addresses outside managed prefixes
+/// continue to use `static-assignments`.
+pub async fn for_static_address(
+    txn: &mut PgConnection,
+    address: IpAddr,
+    expected_segment_type: Option<NetworkSegmentType>,
+) -> DatabaseResult<NetworkSegment> {
+    match for_prefix_containing_address(&mut *txn, address).await? {
+        Some(segment) => {
+            if let Some(expected_segment_type) = expected_segment_type
+                && segment.config.segment_type != expected_segment_type
+            {
+                return Err(DatabaseError::InvalidArgument(format!(
+                    "fixed IP {address} belongs to {} network segment {}, not the expected {expected_segment_type} segment type",
+                    segment.config.segment_type, segment.config.name,
+                )));
+            }
+            Ok(segment)
+        }
+        None => match expected_segment_type {
+            Some(expected_segment_type) => Err(DatabaseError::InvalidArgument(format!(
+                "fixed IP {address} is not within a configured {expected_segment_type} network segment",
+            ))),
+            None => static_assignments(&mut *txn).await,
+        },
+    }
+}
+
 /// Returns all network segments that contain at least one relay/gateway IP.
 pub async fn for_relay_all(
     txn: &mut PgConnection,

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -25,6 +25,7 @@ use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 use uuid::Uuid;
 
+use crate::machine_interface::InterfaceType;
 use crate::metadata::Metadata;
 use crate::network_segment::NetworkSegmentType;
 
@@ -145,17 +146,153 @@ pub struct ExpectedMachineRequest {
     pub bmc_mac_address: Option<MacAddress>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct ExpectedHostNic {
-    pub mac_address: MacAddress,
-    /// The network segment type this NIC's first DHCP lease should come from.
+/// Identifies which machine endpoint an expected interface belongs to.
+///
+/// The role determines the resulting [`InterfaceType`] and whether the
+/// interface has a role-defined primary state. It does not choose a network
+/// segment or change the allocation policy available to that interface.
+///
+/// Host BMC identity remains on [`ExpectedMachine::bmc_mac_address`].
+/// [NVIDIA/infra-controller#4103](https://github.com/NVIDIA/infra-controller/issues/4103)
+/// tracks representing its network settings with the same interface model.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpectedInterfaceRole {
+    /// A host operating-system interface. This preserves the behavior of
+    /// declarations created before interface roles were introduced.
+    #[default]
+    Host,
+    /// The DPU operating-system interface.
+    DpuOs,
+    /// The DPU's Redfish/BMC interface.
+    DpuBmc,
+}
+
+impl std::fmt::Display for ExpectedInterfaceRole {
+    /// Write the canonical TOML/JSON spelling used for this role.
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Host => "host",
+            Self::DpuOs => "dpu_os",
+            Self::DpuBmc => "dpu_bmc",
+        })
+    }
+}
+
+impl ExpectedInterfaceRole {
+    /// Return whether this role participates in machine-wide Host primary
+    /// selection.
     ///
-    /// A NIC's segment is normally determined by its DHCP relay -- the segment
-    /// whose prefix contains the relay address. Where segment prefixes nest or
-    /// overlap, one relay can match several segments; declaring this narrows the
-    /// choice to the segment of this type. `None` (with no legacy
-    /// [`Self::nic_type`]) leaves the relay's match as-is. Resolved via
-    /// [`Self::resolved_network_segment_type`].
+    /// Serde also uses this predicate to omit the default Host role from stored
+    /// JSON, keeping legacy Host declarations free of a new role field.
+    pub fn is_host(&self) -> bool {
+        matches!(self, Self::Host)
+    }
+
+    /// Return the database interface type produced by this endpoint role.
+    ///
+    /// Host and DPU OS endpoints both exchange operating-system data. A DPU
+    /// BMC endpoint uses the BMC interface type so the existing BMC-specific
+    /// routing and address behavior still applies.
+    pub fn interface_type(self) -> InterfaceType {
+        match self {
+            Self::Host | Self::DpuOs => InterfaceType::Data,
+            Self::DpuBmc => InterfaceType::Bmc,
+        }
+    }
+
+    /// Return the primary-interface value fixed by this endpoint role.
+    ///
+    /// Host primary selection needs all Host declarations on the
+    /// `ExpectedMachine`, so `None` tells the caller to use that machine-wide
+    /// result. A DPU OS interface is always its DPU's primary data interface,
+    /// while a DPU BMC interface is never primary.
+    pub fn primary_interface_override(self) -> Option<bool> {
+        match self {
+            Self::Host => None,
+            Self::DpuOs => Some(true),
+            Self::DpuBmc => Some(false),
+        }
+    }
+}
+
+/// Controls how an expected interface receives and retains its IP address.
+///
+/// When the policy is omitted, [`ExpectedHostNic::resolved_ip_allocation`]
+/// preserves the legacy configuration contract: an interface with
+/// [`ExpectedHostNic::fixed_ip`] is fixed, and one without it is dynamic.
+/// Explicit `Dynamic` differs from omission because it rejects a simultaneous
+/// `fixed_ip` instead of inferring `Fixed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpectedInterfaceIpAllocation {
+    /// Allocate a normal DHCP lease that may expire and change. A configured
+    /// segment-type guard must match the segment selected by the DHCP relay.
+    Dynamic,
+    /// Reserve the operator-specified [`ExpectedHostNic::fixed_ip`]. Prefix
+    /// containment finds the segment, and a configured segment-type guard must
+    /// match it.
+    Fixed,
+    /// Allocate through DHCP, then change that address row to Static for the
+    /// lifetime of this interface row. The address is not saved in
+    /// `ExpectedMachine` for reuse after the interface is deleted and
+    /// re-ingested, and changing the policy later does not convert that row
+    /// back to DHCP. A configured segment-type guard must match the segment
+    /// selected by the DHCP relay.
+    Retained,
+}
+
+impl ExpectedInterfaceIpAllocation {
+    /// Validate whether this explicit or resolved policy may be paired with
+    /// the interface's `fixed_ip` declaration.
+    ///
+    /// Only `Fixed` accepts a configured address. `Dynamic` and `Retained`
+    /// require DHCP to select one.
+    pub fn validate(self, has_fixed_ip: bool) -> Result<(), &'static str> {
+        match self {
+            Self::Fixed if !has_fixed_ip => Err("ip_allocation=fixed requires fixed_ip"),
+            Self::Dynamic if has_fixed_ip => {
+                Err("ip_allocation=dynamic cannot be combined with fixed_ip")
+            }
+            Self::Retained if has_fixed_ip => {
+                Err("ip_allocation=retained cannot be combined with fixed_ip; use fixed")
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+/// Configures one interface that NICo may encounter while ingesting an
+/// `ExpectedMachine`.
+///
+/// Every role uses the same allocation and optional segment-guard fields. The
+/// role only supplies endpoint-specific interface type and primary behavior.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ExpectedHostNic {
+    /// MAC address used to match DHCP and discovered interface traffic to this
+    /// declaration.
+    pub mac_address: MacAddress,
+    /// Which machine endpoint owns this interface. Missing values retain the
+    /// legacy host-interface behavior.
+    #[serde(default, skip_serializing_if = "ExpectedInterfaceRole::is_host")]
+    pub role: ExpectedInterfaceRole,
+    /// Optional IP allocation policy. Missing declarations infer `Fixed` when
+    /// [`Self::fixed_ip`] is configured and `Dynamic` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ip_allocation: Option<ExpectedInterfaceIpAllocation>,
+    /// Optional guard for the interface's network segment type.
+    ///
+    /// For an explicit allocation policy or DPU role, Dynamic and Retained use
+    /// this as a guard on the segment selected by the DHCP relay, while Fixed
+    /// uses it as a guard on the segment containing the configured address.
+    ///
+    /// A legacy Host declaration that omits `ip_allocation` keeps the earlier
+    /// behavior where this field only narrows initial DHCP segment selection.
+    /// This compatibility rule is exposed by [`Self::segment_type_guard`].
+    /// `None` (with no legacy [`Self::nic_type`]) leaves DHCP selection
+    /// unconstrained; a fixed IP still derives its segment from the address.
+    /// Updates retain the existing full-replacement behavior, so omission
+    /// clears this field.
     #[serde(default)]
     pub network_segment_type: Option<NetworkSegmentType>,
     /// Legacy free-form NIC-type segment hint (`bf3`, `onboard`, `oob`, ...).
@@ -165,20 +302,90 @@ pub struct ExpectedHostNic {
     pub fixed_mask: Option<String>,
     #[serde(default, deserialize_with = "deserialize_optional_ip_addr_lossy")]
     pub fixed_gateway: Option<IpAddr>,
-    /// When true, `primary` flags this NIC as the host's boot (primary)
-    /// interface. At most one NIC per ExpectedMachine may be marked primary
-    /// (which is enforced in the API). This ultimately propagates into the
-    /// machine_interfaces table, but, in today's world, only really applies
-    /// to zero-DPU. A machine *with* a DPU will end up taking over when
-    /// site-explorer finds a DPU for the machine (and update the primary
-    /// interface accordingly).
+    /// Host-role interfaces may set `primary=true` to declare the host's boot
+    /// interface. When one Host interface is declared primary, the other Host
+    /// interfaces become non-primary. An explicit `false` remains accepted for
+    /// compatibility but does not replace that machine-wide selection. DPU OS
+    /// interfaces are primary data interfaces and DPU BMC interfaces are
+    /// non-primary; those roles must omit this field.
     #[serde(default)]
     pub primary: Option<bool>,
 }
 
 impl ExpectedHostNic {
-    /// The network segment type to narrow this NIC's DHCP segment selection to,
-    /// if the declaration names one. Prefers the typed
+    /// Return the configured allocation policy or infer the legacy policy from
+    /// whether this interface has a fixed IP.
+    ///
+    /// Omission must remain distinguishable from explicit `Dynamic`: old
+    /// declarations supplied only `fixed_ip`, while explicit `Dynamic` rejects
+    /// that same combination during validation. Inferring `Fixed` here does not
+    /// opt a legacy Host declaration into the newer segment-type guard; see
+    /// [`Self::segment_type_guard`].
+    pub fn resolved_ip_allocation(&self) -> ExpectedInterfaceIpAllocation {
+        self.ip_allocation.unwrap_or_else(|| {
+            if self.fixed_ip.is_some() {
+                ExpectedInterfaceIpAllocation::Fixed
+            } else {
+                ExpectedInterfaceIpAllocation::Dynamic
+            }
+        })
+    }
+
+    /// Validate the effective allocation policy against this interface's
+    /// fixed-IP declaration.
+    pub fn validate_ip_allocation(&self) -> Result<(), &'static str> {
+        self.resolved_ip_allocation()
+            .validate(self.fixed_ip.is_some())
+    }
+
+    /// Validate the declaration and require one resolved allocation policy.
+    ///
+    /// Callers that materialize Fixed or Retained state use this shared check
+    /// so policy validation cannot drift between API, DHCP, and Site Explorer
+    /// paths.
+    pub fn require_ip_allocation(
+        &self,
+        required: ExpectedInterfaceIpAllocation,
+    ) -> Result<(), &'static str> {
+        self.validate_ip_allocation()?;
+        if self.resolved_ip_allocation() == required {
+            return Ok(());
+        }
+
+        Err(match required {
+            ExpectedInterfaceIpAllocation::Dynamic => {
+                "expected interface does not use dynamic IP allocation"
+            }
+            ExpectedInterfaceIpAllocation::Fixed => {
+                "expected interface does not use fixed IP allocation"
+            }
+            ExpectedInterfaceIpAllocation::Retained => {
+                "expected interface does not use retained IP allocation"
+            }
+        })
+    }
+
+    /// Return the configured address after validating that this interface uses
+    /// Fixed allocation.
+    pub fn fixed_reservation_ip(&self) -> Result<IpAddr, &'static str> {
+        self.require_ip_allocation(ExpectedInterfaceIpAllocation::Fixed)?;
+        self.fixed_ip.ok_or("ip_allocation=fixed requires fixed_ip")
+    }
+
+    /// Return the typed segment guard for declarations using the generalized
+    /// ExpectedInterface policy contract.
+    ///
+    /// Before roles and allocation policies existed, a Host declaration could
+    /// use `network_segment_type` only to narrow initial DHCP selection. Keep
+    /// that behavior when both new fields are omitted. An explicit policy or a
+    /// DPU role opts into the same guard semantics for every allocation path.
+    pub fn segment_type_guard(&self) -> Option<NetworkSegmentType> {
+        self.network_segment_type
+            .filter(|_| self.ip_allocation.is_some() || !self.role.is_host())
+    }
+
+    /// Return the network segment type that narrows Dynamic or Retained DHCP
+    /// segment selection, if the declaration names one. Prefers the typed
     /// [`Self::network_segment_type`]; otherwise maps the legacy
     /// [`Self::nic_type`] string so machines declared before the typed field
     /// keep their segment. `None` -> selection stays with whatever segment(s)
@@ -278,7 +485,7 @@ impl ExpectedMachineData {
     pub fn declared_primary_mac(&self) -> Option<MacAddress> {
         self.host_nics
             .iter()
-            .find(|nic| nic.primary == Some(true))
+            .find(|nic| nic.role.is_host() && nic.primary == Some(true))
             .map(|nic| nic.mac_address)
     }
 }
@@ -719,6 +926,266 @@ mod tests {
     }
 
     #[test]
+    fn expected_interface_role_preserves_legacy_json_format() {
+        let legacy = r#"{
+            "mac_address": "AA:BB:CC:DD:EE:FF",
+            "nic_type": "dpu"
+        }"#;
+        let interface: ExpectedHostNic = serde_json::from_str(legacy).unwrap();
+
+        assert_eq!(interface.role, ExpectedInterfaceRole::Host);
+        assert_eq!(interface.ip_allocation, None);
+        let serialized = serde_json::to_value(interface).unwrap();
+        assert_eq!(serialized.get("role"), None);
+        assert_eq!(serialized.get("ip_allocation"), None);
+    }
+
+    #[test]
+    fn expected_interface_roles_use_canonical_names() {
+        check_values(
+            [
+                Check {
+                    scenario: "Host remains omitted from stored JSON",
+                    input: ExpectedInterfaceRole::Host,
+                    expect: ("host".to_string(), None),
+                },
+                Check {
+                    scenario: "DPU OS uses its canonical name",
+                    input: ExpectedInterfaceRole::DpuOs,
+                    expect: ("dpu_os".to_string(), Some(serde_json::json!("dpu_os"))),
+                },
+                Check {
+                    scenario: "DPU BMC uses its canonical name",
+                    input: ExpectedInterfaceRole::DpuBmc,
+                    expect: ("dpu_bmc".to_string(), Some(serde_json::json!("dpu_bmc"))),
+                },
+            ],
+            |role| {
+                let serialized = serde_json::to_value(ExpectedHostNic {
+                    role,
+                    ..Default::default()
+                })
+                .unwrap();
+                (role.to_string(), serialized.get("role").cloned())
+            },
+        );
+    }
+
+    #[test]
+    fn expected_interface_roles_map_to_interface_behavior() {
+        check_values(
+            [
+                Check {
+                    scenario: "legacy host",
+                    input: ExpectedInterfaceRole::Host,
+                    expect: (true, InterfaceType::Data),
+                },
+                Check {
+                    scenario: "DPU OS",
+                    input: ExpectedInterfaceRole::DpuOs,
+                    expect: (false, InterfaceType::Data),
+                },
+                Check {
+                    scenario: "DPU BMC",
+                    input: ExpectedInterfaceRole::DpuBmc,
+                    expect: (false, InterfaceType::Bmc),
+                },
+            ],
+            |role| (role.is_host(), role.interface_type()),
+        );
+    }
+
+    #[test]
+    fn expected_interface_roles_resolve_role_primary_state() {
+        check_values(
+            [
+                Check {
+                    scenario: "legacy Host keeps machine-wide selection",
+                    input: ExpectedInterfaceRole::Host,
+                    expect: None,
+                },
+                Check {
+                    scenario: "DPU OS is always primary",
+                    input: ExpectedInterfaceRole::DpuOs,
+                    expect: Some(true),
+                },
+                Check {
+                    scenario: "DPU BMC is never primary",
+                    input: ExpectedInterfaceRole::DpuBmc,
+                    expect: Some(false),
+                },
+            ],
+            ExpectedInterfaceRole::primary_interface_override,
+        );
+    }
+
+    #[test]
+    fn expected_interface_ip_allocation_infers_and_validates_policy() {
+        struct Declaration {
+            policy: Option<ExpectedInterfaceIpAllocation>,
+            fixed_ip: Option<IpAddr>,
+        }
+
+        let fixed_ip = Some("192.0.2.10".parse().unwrap());
+        check_values(
+            [
+                Check {
+                    scenario: "omitted policy without fixed IP infers dynamic",
+                    input: Declaration {
+                        policy: None,
+                        fixed_ip: None,
+                    },
+                    expect: (ExpectedInterfaceIpAllocation::Dynamic, None),
+                },
+                Check {
+                    scenario: "omitted policy with fixed IP infers fixed",
+                    input: Declaration {
+                        policy: None,
+                        fixed_ip,
+                    },
+                    expect: (ExpectedInterfaceIpAllocation::Fixed, None),
+                },
+                Check {
+                    scenario: "explicit dynamic without fixed IP is valid",
+                    input: Declaration {
+                        policy: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                        fixed_ip: None,
+                    },
+                    expect: (ExpectedInterfaceIpAllocation::Dynamic, None),
+                },
+                Check {
+                    scenario: "explicit dynamic with fixed IP is rejected",
+                    input: Declaration {
+                        policy: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                        fixed_ip,
+                    },
+                    expect: (
+                        ExpectedInterfaceIpAllocation::Dynamic,
+                        Some("ip_allocation=dynamic cannot be combined with fixed_ip"),
+                    ),
+                },
+                Check {
+                    scenario: "explicit fixed with fixed IP is valid",
+                    input: Declaration {
+                        policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                        fixed_ip,
+                    },
+                    expect: (ExpectedInterfaceIpAllocation::Fixed, None),
+                },
+                Check {
+                    scenario: "explicit fixed without fixed IP is rejected",
+                    input: Declaration {
+                        policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                        fixed_ip: None,
+                    },
+                    expect: (
+                        ExpectedInterfaceIpAllocation::Fixed,
+                        Some("ip_allocation=fixed requires fixed_ip"),
+                    ),
+                },
+                Check {
+                    scenario: "explicit retained without fixed IP is valid",
+                    input: Declaration {
+                        policy: Some(ExpectedInterfaceIpAllocation::Retained),
+                        fixed_ip: None,
+                    },
+                    expect: (ExpectedInterfaceIpAllocation::Retained, None),
+                },
+                Check {
+                    scenario: "explicit retained with fixed IP is rejected",
+                    input: Declaration {
+                        policy: Some(ExpectedInterfaceIpAllocation::Retained),
+                        fixed_ip,
+                    },
+                    expect: (
+                        ExpectedInterfaceIpAllocation::Retained,
+                        Some("ip_allocation=retained cannot be combined with fixed_ip; use fixed"),
+                    ),
+                },
+            ],
+            |declaration| {
+                let interface = ExpectedHostNic {
+                    mac_address: "AA:BB:CC:DD:EE:FF".parse().unwrap(),
+                    ip_allocation: declaration.policy,
+                    fixed_ip: declaration.fixed_ip,
+                    ..Default::default()
+                };
+                (
+                    interface.resolved_ip_allocation(),
+                    interface.validate_ip_allocation().err(),
+                )
+            },
+        );
+    }
+
+    /// Fixed reservation callers share one policy-and-address invariant.
+    #[test]
+    fn expected_interface_fixed_reservation_ip_validates_policy() {
+        let fixed_ip = "192.0.2.10".parse().unwrap();
+        check_values(
+            [
+                Check {
+                    scenario: "legacy fixed address",
+                    input: (None, Some(fixed_ip)),
+                    expect: Ok(fixed_ip),
+                },
+                Check {
+                    scenario: "explicit fixed address",
+                    input: (Some(ExpectedInterfaceIpAllocation::Fixed), Some(fixed_ip)),
+                    expect: Ok(fixed_ip),
+                },
+                Check {
+                    scenario: "dynamic policy",
+                    input: (Some(ExpectedInterfaceIpAllocation::Dynamic), None),
+                    expect: Err("expected interface does not use fixed IP allocation"),
+                },
+                Check {
+                    scenario: "fixed policy without an address",
+                    input: (Some(ExpectedInterfaceIpAllocation::Fixed), None),
+                    expect: Err("ip_allocation=fixed requires fixed_ip"),
+                },
+                Check {
+                    scenario: "retained policy",
+                    input: (Some(ExpectedInterfaceIpAllocation::Retained), None),
+                    expect: Err("expected interface does not use fixed IP allocation"),
+                },
+            ],
+            |(ip_allocation, fixed_ip)| {
+                ExpectedHostNic {
+                    ip_allocation,
+                    fixed_ip,
+                    ..Default::default()
+                }
+                .fixed_reservation_ip()
+            },
+        );
+    }
+
+    #[test]
+    fn expected_interface_ip_allocation_json_uses_canonical_names() {
+        check_values(
+            [
+                Check {
+                    scenario: "dynamic",
+                    input: ExpectedInterfaceIpAllocation::Dynamic,
+                    expect: r#""dynamic""#.to_string(),
+                },
+                Check {
+                    scenario: "fixed",
+                    input: ExpectedInterfaceIpAllocation::Fixed,
+                    expect: r#""fixed""#.to_string(),
+                },
+                Check {
+                    scenario: "retained",
+                    input: ExpectedInterfaceIpAllocation::Retained,
+                    expect: r#""retained""#.to_string(),
+                },
+            ],
+            |policy| serde_json::to_string(&policy).unwrap(),
+        );
+    }
+
+    #[test]
     fn host_lifecycle_profile_is_empty_when_all_fields_none() {
         let hlp = HostLifecycleProfile::default();
         assert!(hlp.is_empty());
@@ -896,17 +1363,26 @@ mod tests {
         let mac_a: MacAddress = "AA:BB:CC:00:00:01".parse().unwrap();
         let mac_b: MacAddress = "AA:BB:CC:00:00:02".parse().unwrap();
 
-        let nic = |mac: MacAddress, primary: Option<bool>| ExpectedHostNic {
-            mac_address: mac,
-            primary,
-            ..Default::default()
+        let nic = |mac: MacAddress,
+                   role: ExpectedInterfaceRole,
+                   primary: Option<bool>|
+         -> ExpectedHostNic {
+            ExpectedHostNic {
+                mac_address: mac,
+                role,
+                primary,
+                ..Default::default()
+            }
         };
 
         // Nothing declared -- empty, or only explicit non-primaries.
         assert_eq!(ExpectedMachineData::default().declared_primary_mac(), None);
         assert_eq!(
             ExpectedMachineData {
-                host_nics: vec![nic(mac_a, None), nic(mac_b, Some(false))],
+                host_nics: vec![
+                    nic(mac_a, ExpectedInterfaceRole::Host, None),
+                    nic(mac_b, ExpectedInterfaceRole::Host, Some(false)),
+                ],
                 ..Default::default()
             }
             .declared_primary_mac(),
@@ -916,11 +1392,23 @@ mod tests {
         // The declared NIC wins.
         assert_eq!(
             ExpectedMachineData {
-                host_nics: vec![nic(mac_a, Some(false)), nic(mac_b, Some(true))],
+                host_nics: vec![
+                    nic(mac_a, ExpectedInterfaceRole::Host, Some(false)),
+                    nic(mac_b, ExpectedInterfaceRole::Host, Some(true)),
+                ],
                 ..Default::default()
             }
             .declared_primary_mac(),
             Some(mac_b)
+        );
+
+        assert_eq!(
+            ExpectedMachineData {
+                host_nics: vec![nic(mac_a, ExpectedInterfaceRole::DpuBmc, Some(true))],
+                ..Default::default()
+            }
+            .declared_primary_mac(),
+            None
         );
     }
 
@@ -1011,6 +1499,101 @@ mod tests {
                 case.want,
                 "{}",
                 case.name
+            );
+        }
+    }
+
+    /// Explicit policies and DPU roles opt into universal segment guards,
+    /// while a legacy Host declaration keeps first-DHCP selection behavior.
+    #[test]
+    fn segment_type_guard_preserves_legacy_host_compatibility() {
+        struct Case {
+            name: &'static str,
+            role: ExpectedInterfaceRole,
+            ip_allocation: Option<ExpectedInterfaceIpAllocation>,
+            fixed_ip: Option<IpAddr>,
+            network_segment_type: Option<NetworkSegmentType>,
+            expected_guard: Option<NetworkSegmentType>,
+        }
+
+        for case in [
+            Case {
+                name: "legacy Host declaration",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: None,
+                fixed_ip: None,
+                network_segment_type: Some(NetworkSegmentType::Admin),
+                expected_guard: None,
+            },
+            Case {
+                name: "legacy Host fixed IP inference",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: None,
+                fixed_ip: Some("192.0.2.10".parse().unwrap()),
+                network_segment_type: Some(NetworkSegmentType::Admin),
+                expected_guard: None,
+            },
+            Case {
+                name: "explicit Host Dynamic policy",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                fixed_ip: None,
+                network_segment_type: Some(NetworkSegmentType::Admin),
+                expected_guard: Some(NetworkSegmentType::Admin),
+            },
+            Case {
+                name: "explicit Host Fixed policy",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+                fixed_ip: Some("192.0.2.10".parse().unwrap()),
+                network_segment_type: Some(NetworkSegmentType::Admin),
+                expected_guard: Some(NetworkSegmentType::Admin),
+            },
+            Case {
+                name: "explicit Host Retained policy",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: Some(ExpectedInterfaceIpAllocation::Retained),
+                fixed_ip: None,
+                network_segment_type: Some(NetworkSegmentType::Admin),
+                expected_guard: Some(NetworkSegmentType::Admin),
+            },
+            Case {
+                name: "DPU OS role",
+                role: ExpectedInterfaceRole::DpuOs,
+                ip_allocation: None,
+                fixed_ip: None,
+                network_segment_type: Some(NetworkSegmentType::Admin),
+                expected_guard: Some(NetworkSegmentType::Admin),
+            },
+            Case {
+                name: "DPU BMC role",
+                role: ExpectedInterfaceRole::DpuBmc,
+                ip_allocation: None,
+                fixed_ip: None,
+                network_segment_type: Some(NetworkSegmentType::Underlay),
+                expected_guard: Some(NetworkSegmentType::Underlay),
+            },
+            Case {
+                name: "no typed segment",
+                role: ExpectedInterfaceRole::DpuOs,
+                ip_allocation: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                fixed_ip: None,
+                network_segment_type: None,
+                expected_guard: None,
+            },
+        ] {
+            let interface = ExpectedHostNic {
+                role: case.role,
+                ip_allocation: case.ip_allocation,
+                fixed_ip: case.fixed_ip,
+                network_segment_type: case.network_segment_type,
+                ..Default::default()
+            };
+            assert_eq!(
+                interface.segment_type_guard(),
+                case.expected_guard,
+                "{}",
+                case.name,
             );
         }
     }

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -68,6 +68,7 @@ fn expected_host_nics(
             fixed_gateway: None,
             primary: Some(index == 0),
             network_segment_type: Some(NetworkSegmentType::HostInband as i32),
+            ..Default::default()
         })
         .collect()
 }
@@ -547,6 +548,7 @@ mod tests {
             fixed_gateway: None,
             primary: Some(primary),
             network_segment_type: Some(NetworkSegmentType::HostInband as i32),
+            ..Default::default()
         }
     }
 

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -621,6 +621,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("ExpectedHostNic", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedHostNic", "#[derive(serde::Deserialize)]")
+        .field_attribute(
+            "ExpectedHostNic.role",
+            "#[serde(default, skip_serializing_if = \"Option::is_none\", deserialize_with = \"ExpectedInterfaceRole::deserialize_optional\", serialize_with = \"ExpectedInterfaceRole::serialize_optional\")]",
+        )
+        .field_attribute(
+            "ExpectedHostNic.ip_allocation",
+            "#[serde(default, skip_serializing_if = \"Option::is_none\", deserialize_with = \"ExpectedInterfaceIpAllocation::deserialize_optional\", serialize_with = \"ExpectedInterfaceIpAllocation::serialize_optional\")]",
+        )
         .type_attribute("HostLifecycleProfile", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute("ExpectedMachine", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedPowerShelf", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6166,27 +6166,41 @@ message IpxeTemplateList {
 message ExpectedHostNic {
   string mac_address = 1;
   // Legacy free-form segment hint (bf3, onboard, oob, ...). Kept for backward
-  // compatibility; declare network_segment_type instead, which wins.
+  // compatibility; declare `network_segment_type` instead, which wins.
   optional string nic_type = 2;
   optional string fixed_ip = 3;
   optional string fixed_mask = 4;
   optional string fixed_gateway = 5;
-  // When true, this flags the given NIC as the host's primary (boot)
-  // interface (used in cases of zero DPU).
+  // Host-role interfaces may set this to true to declare the host's primary
+  // (boot) interface.
   //
-  // Up to one NIC per ExpectedMachine may be marked primary, if set at
-  // all. Propagates to `machine_interfaces.primary_interface` during DHCP
-  // when this NIC is first discovered.
-  //
-  // Some day this could be even possibly used to say "this dumb NIC
-  // *is* the primary interface, even though I know I have a DPU."
+  // At most one Host interface per `ExpectedMachine` may set it to true; the
+  // other Host interfaces then become non-primary. False remains accepted for
+  // compatibility but does not replace that machine-wide selection. DPU OS
+  // interfaces are primary data interfaces and DPU BMC interfaces are
+  // non-primary; those roles must omit this field.
   optional bool primary = 6;
-  // The network segment type this NIC's first DHCP lease should come from.
-  // A NIC's segment normally follows its DHCP relay; where segment prefixes
-  // nest or overlap and a relay matches several, this narrows the choice to
-  // the segment of this type. Supersedes nic_type; absent both, the relay's
-  // match stands.
+  // Optional guard for this interface's network segment type. An explicit
+  // allocation policy or DPU role applies the guard to DHCP-selected segments
+  // and fixed-address containment. A legacy Host declaration with an omitted
+  // policy keeps the earlier first-DHCP selection-only behavior. Supersedes
+  // `nic_type` for DHCP; absent both, relay selection remains unconstrained.
+  // On update, omission clears this guard.
   optional NetworkSegmentType network_segment_type = 7;
+  // Machine endpoint that owns this interface. The role selects interface type
+  // and primary behavior only; Host, DPU OS, and DPU BMC all accept the same
+  // allocation policies and optional segment guard. On create, missing and
+  // Unspecified mean Host. On update, omission preserves the stored role while
+  // explicit Unspecified resets it to Host.
+  optional ExpectedInterfaceRole role = 8;
+  // Optional allocation policy. On create, missing and Unspecified infer Fixed
+  // from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
+  // stored policy while explicit Unspecified resets to that inference.
+  // Explicit Dynamic rejects `fixed_ip`. For a legacy Host declaration,
+  // inferred Fixed still selects the segment by address-prefix containment but
+  // does not turn `network_segment_type` into a fixed-address guard; configure
+  // Fixed explicitly to request that check.
+  optional ExpectedInterfaceIpAllocation ip_allocation = 9;
 }
 
 // Forge RPC representation of the per-host policy for how NICo treats DPU
@@ -9130,6 +9144,46 @@ enum OperatingSystemType {
   OS_TYPE_UNSPECIFIED = 0;
   OS_TYPE_IPXE = 1;              // Raw inline iPXE script
   OS_TYPE_TEMPLATED_IPXE = 2; // iPXE OS using an iPXE template
+}
+
+// Identifies which machine endpoint owns an entry in `ExpectedMachine.host_nics`.
+// Each role accepts Dynamic, Fixed, and Retained allocation plus the optional
+// segment guard. The role only derives interface type and primary behavior.
+//
+// On create, missing and `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` mean Host. On
+// update, omission preserves the stored role, while explicit
+// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. Host BMC identity
+// remains on `ExpectedMachine.bmc_mac_address`. NVIDIA/infra-controller#4103
+// tracks adding its network settings to this same interface model.
+enum ExpectedInterfaceRole {
+  // Preserve the legacy Host role when the optional field is absent.
+  EXPECTED_INTERFACE_ROLE_UNSPECIFIED = 0;
+  // Host operating-system data interface. Primary selection is machine-wide.
+  EXPECTED_INTERFACE_ROLE_HOST = 1;
+  // DPU operating-system data interface. Always primary for its DPU.
+  EXPECTED_INTERFACE_ROLE_DPU_OS = 2;
+  // DPU Redfish/BMC interface. Never primary.
+  EXPECTED_INTERFACE_ROLE_DPU_BMC = 3;
+}
+
+// Controls how an expected interface receives and retains its IP address.
+// Missing and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` preserve legacy
+// behavior: `fixed_ip` implies `FIXED`, while its absence implies `DYNAMIC`.
+enum ExpectedInterfaceIpAllocation {
+  // Infer Fixed or Dynamic from whether `fixed_ip` is configured. For a legacy
+  // Host declaration, this does not opt into the fixed-address segment guard.
+  EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED = 0;
+  // Use an expiring DHCP lease. The segment guard must match the relay's
+  // selected segment when configured.
+  EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC = 1;
+  // Reserve `fixed_ip`. Its prefix selects the segment, and the segment guard
+  // must match that segment when configured.
+  EXPECTED_INTERFACE_IP_ALLOCATION_FIXED = 2;
+  // Allocate through DHCP, then make the address Static for this interface
+  // row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The
+  // address is not converted back to DHCP if the policy later changes. The
+  // segment guard must match the relay's selected segment when configured.
+  EXPECTED_INTERFACE_IP_ALLOCATION_RETAINED = 3;
 }
 
 message OperatingSystem {

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -577,6 +577,147 @@ impl FromStr for forge::InstanceSpxConfig {
     }
 }
 
+/// JSON input accepted for prost's optional integer-backed interface role.
+///
+/// Admin clients may use the short enum name while protobuf-compatible clients
+/// may continue to send its integer value.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum ExpectedInterfaceRoleInput {
+    Name(String),
+    Number(i32),
+}
+
+impl forge::ExpectedInterfaceRole {
+    /// Deserialize an optional role from its short name or protobuf integer.
+    ///
+    /// JSON `null` remains `None`. `unspecified` remains an explicit protobuf
+    /// value here and becomes the legacy Host role at the model boundary.
+    pub fn deserialize_optional<'de, D>(deserializer: D) -> Result<Option<i32>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value: Option<ExpectedInterfaceRoleInput> =
+            serde::Deserialize::deserialize(deserializer)?;
+        let Some(value) = value else {
+            return Ok(None);
+        };
+
+        let role = match value {
+            ExpectedInterfaceRoleInput::Number(value) => {
+                Self::try_from(value).map_err(serde::de::Error::custom)?
+            }
+            ExpectedInterfaceRoleInput::Name(name) => {
+                match name.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+                    "unspecified" | "expected_interface_role_unspecified" => Self::Unspecified,
+                    "host" | "expected_interface_role_host" => Self::Host,
+                    "dpu_os" | "dpuos" | "expected_interface_role_dpu_os" => Self::DpuOs,
+                    "dpu_bmc" | "dpubmc" | "expected_interface_role_dpu_bmc" => Self::DpuBmc,
+                    _ => {
+                        return Err(serde::de::Error::custom(format!(
+                            "unknown expected interface role {name:?}"
+                        )));
+                    }
+                }
+            }
+        };
+        Ok(Some(role as i32))
+    }
+
+    /// Serialize an optional prost role as its short JSON name.
+    ///
+    /// `None` stays absent so model conversion can preserve the representation
+    /// used by clients that predate interface roles.
+    pub fn serialize_optional<S>(value: &Option<i32>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = value else {
+            return serializer.serialize_none();
+        };
+        let role = Self::try_from(*value).map_err(Error::custom)?;
+        serializer.serialize_str(match role {
+            Self::Unspecified => "unspecified",
+            Self::Host => "host",
+            Self::DpuOs => "dpu_os",
+            Self::DpuBmc => "dpu_bmc",
+        })
+    }
+}
+
+/// JSON input accepted for prost's optional integer-backed IP allocation
+/// policy.
+///
+/// Admin clients may use the short enum name while protobuf-compatible clients
+/// may continue to send its integer value.
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum ExpectedInterfaceIpAllocationInput {
+    Name(String),
+    Number(i32),
+}
+
+impl forge::ExpectedInterfaceIpAllocation {
+    /// Deserialize an optional allocation policy from its short name or
+    /// protobuf integer.
+    ///
+    /// JSON `null` remains `None`. `unspecified` remains an explicit protobuf
+    /// value here and becomes an omitted policy at the model boundary, where
+    /// `fixed_ip` determines the legacy policy.
+    pub fn deserialize_optional<'de, D>(deserializer: D) -> Result<Option<i32>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value: Option<ExpectedInterfaceIpAllocationInput> =
+            serde::Deserialize::deserialize(deserializer)?;
+        let Some(value) = value else {
+            return Ok(None);
+        };
+
+        let policy = match value {
+            ExpectedInterfaceIpAllocationInput::Number(value) => {
+                Self::try_from(value).map_err(serde::de::Error::custom)?
+            }
+            ExpectedInterfaceIpAllocationInput::Name(name) => {
+                match name.trim().to_ascii_lowercase().replace('-', "_").as_str() {
+                    "unspecified" | "expected_interface_ip_allocation_unspecified" => {
+                        Self::Unspecified
+                    }
+                    "dynamic" | "expected_interface_ip_allocation_dynamic" => Self::Dynamic,
+                    "fixed" | "expected_interface_ip_allocation_fixed" => Self::Fixed,
+                    "retained" | "expected_interface_ip_allocation_retained" => Self::Retained,
+                    _ => {
+                        return Err(serde::de::Error::custom(format!(
+                            "unknown expected interface IP allocation {name:?}"
+                        )));
+                    }
+                }
+            }
+        };
+        Ok(Some(policy as i32))
+    }
+
+    /// Serialize an optional prost allocation policy as its short JSON name.
+    ///
+    /// `None` stays absent; it must not become explicit `Dynamic`
+    /// because an omitted policy plus `fixed_ip` resolves to `Fixed`.
+    pub fn serialize_optional<S>(value: &Option<i32>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Some(value) = value else {
+            return serializer.serialize_none();
+        };
+        let policy = Self::try_from(*value).map_err(Error::custom)?;
+        serializer.serialize_str(match policy {
+            Self::Unspecified => "unspecified",
+            Self::Dynamic => "dynamic",
+            Self::Fixed => "fixed",
+            Self::Retained => "retained",
+        })
+    }
+}
+
 /*  ****************************************************** */
 // Serialization/deserialization helpers for network
 // security group enums to let admin CLI callers describe

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -18,9 +18,9 @@ use std::net::IpAddr;
 
 use mac_address::MacAddress;
 use model::expected_machine::{
-    BmcIpAllocationType, ExpectedHostNic, ExpectedMachine, ExpectedMachineData,
-    ExpectedMachineRequest, HostDpuPolicy, HostLifecycleProfile, LinkedExpectedMachine,
-    UnexpectedMachine,
+    BmcIpAllocationType, ExpectedHostNic, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole,
+    ExpectedMachine, ExpectedMachineData, ExpectedMachineRequest, HostDpuPolicy,
+    HostLifecycleProfile, LinkedExpectedMachine, UnexpectedMachine,
 };
 use model::metadata::Metadata;
 use model::network_segment::NetworkSegmentType;
@@ -65,6 +65,128 @@ fn host_dpu_policy_to_rpc(policy: HostDpuPolicy) -> Option<i32> {
         HostDpuPolicy::Manage => None,
         policy => Some(rpc::forge::DpuMode::from(policy) as i32),
     }
+}
+
+/// Convert the model role to its concrete protobuf value.
+///
+/// Optional-field omission is handled separately so this conversion never
+/// needs to treat Host as an absent role.
+impl From<ExpectedInterfaceRole> for rpc::forge::ExpectedInterfaceRole {
+    fn from(role: ExpectedInterfaceRole) -> Self {
+        match role {
+            ExpectedInterfaceRole::Host => Self::Host,
+            ExpectedInterfaceRole::DpuOs => Self::DpuOs,
+            ExpectedInterfaceRole::DpuBmc => Self::DpuBmc,
+        }
+    }
+}
+
+/// Convert a concrete protobuf role to its model role.
+///
+/// `Unspecified` maps to Host for clients that predate the role field.
+impl From<rpc::forge::ExpectedInterfaceRole> for ExpectedInterfaceRole {
+    fn from(role: rpc::forge::ExpectedInterfaceRole) -> Self {
+        match role {
+            rpc::forge::ExpectedInterfaceRole::Unspecified
+            | rpc::forge::ExpectedInterfaceRole::Host => Self::Host,
+            rpc::forge::ExpectedInterfaceRole::DpuOs => Self::DpuOs,
+            rpc::forge::ExpectedInterfaceRole::DpuBmc => Self::DpuBmc,
+        }
+    }
+}
+
+/// Decode the optional role field while preserving its compatibility default.
+///
+/// Both a missing field and `Unspecified` become Host. Unknown protobuf values
+/// remain errors so a newer role is not silently treated as a Host interface.
+fn expected_interface_role_from_rpc(
+    role: Option<i32>,
+) -> Result<ExpectedInterfaceRole, RpcDataConversionError> {
+    let Some(role) = role else {
+        return Ok(ExpectedInterfaceRole::default());
+    };
+    rpc::forge::ExpectedInterfaceRole::try_from(role)
+        .map(Into::into)
+        .map_err(|_| {
+            RpcDataConversionError::InvalidArgument(format!(
+                "invalid expected interface role: {role}"
+            ))
+        })
+}
+
+/// Encode a role without adding the default Host field to legacy responses.
+///
+/// DPU roles must remain explicit because they select different endpoint
+/// behavior.
+fn expected_interface_role_to_rpc(role: ExpectedInterfaceRole) -> Option<i32> {
+    match role {
+        ExpectedInterfaceRole::Host => None,
+        role => Some(rpc::forge::ExpectedInterfaceRole::from(role) as i32),
+    }
+}
+
+/// Convert a resolved model allocation policy to its protobuf value.
+impl From<ExpectedInterfaceIpAllocation> for rpc::forge::ExpectedInterfaceIpAllocation {
+    fn from(policy: ExpectedInterfaceIpAllocation) -> Self {
+        match policy {
+            ExpectedInterfaceIpAllocation::Dynamic => Self::Dynamic,
+            ExpectedInterfaceIpAllocation::Fixed => Self::Fixed,
+            ExpectedInterfaceIpAllocation::Retained => Self::Retained,
+        }
+    }
+}
+
+/// Convert a concrete protobuf allocation policy to its resolved model value.
+///
+/// `Unspecified` has no resolved value on its own: the containing interface
+/// needs `fixed_ip` to infer whether the legacy policy is Fixed or Dynamic.
+impl TryFrom<rpc::forge::ExpectedInterfaceIpAllocation> for ExpectedInterfaceIpAllocation {
+    type Error = RpcDataConversionError;
+
+    fn try_from(policy: rpc::forge::ExpectedInterfaceIpAllocation) -> Result<Self, Self::Error> {
+        match policy {
+            rpc::forge::ExpectedInterfaceIpAllocation::Unspecified => {
+                Err(RpcDataConversionError::InvalidArgument(
+                    "expected interface IP allocation is unspecified".into(),
+                ))
+            }
+            rpc::forge::ExpectedInterfaceIpAllocation::Dynamic => Ok(Self::Dynamic),
+            rpc::forge::ExpectedInterfaceIpAllocation::Fixed => Ok(Self::Fixed),
+            rpc::forge::ExpectedInterfaceIpAllocation::Retained => Ok(Self::Retained),
+        }
+    }
+}
+
+/// Decode the optional allocation field without resolving an omitted policy.
+///
+/// Missing and `Unspecified` both remain `None`. That distinction matters
+/// because omission plus `fixed_ip` means Fixed, while explicit Dynamic rejects
+/// `fixed_ip`.
+fn expected_interface_ip_allocation_from_rpc(
+    policy: Option<i32>,
+) -> Result<Option<ExpectedInterfaceIpAllocation>, RpcDataConversionError> {
+    let Some(policy) = policy else {
+        return Ok(None);
+    };
+    let policy = rpc::forge::ExpectedInterfaceIpAllocation::try_from(policy).map_err(|_| {
+        RpcDataConversionError::InvalidArgument(format!(
+            "invalid expected interface IP allocation: {policy}"
+        ))
+    })?;
+    match policy {
+        rpc::forge::ExpectedInterfaceIpAllocation::Unspecified => Ok(None),
+        policy => ExpectedInterfaceIpAllocation::try_from(policy).map(Some),
+    }
+}
+
+/// Encode only explicitly configured allocation policies.
+///
+/// An omitted model policy stays absent so old `fixed_ip` declarations keep
+/// their Fixed inference instead of being rewritten as explicit Dynamic.
+fn expected_interface_ip_allocation_to_rpc(
+    policy: Option<ExpectedInterfaceIpAllocation>,
+) -> Option<i32> {
+    policy.map(|policy| rpc::forge::ExpectedInterfaceIpAllocation::from(policy) as i32)
 }
 
 impl From<BmcIpAllocationType> for rpc::forge::BmcIpAllocationType {
@@ -132,6 +254,8 @@ impl From<ExpectedHostNic> for rpc::forge::ExpectedHostNic {
             network_segment_type: expected_host_nic
                 .network_segment_type
                 .map(|segment_type| segment_type as i32),
+            role: expected_interface_role_to_rpc(expected_host_nic.role),
+            ip_allocation: expected_interface_ip_allocation_to_rpc(expected_host_nic.ip_allocation),
         }
     }
 }
@@ -165,6 +289,10 @@ impl TryFrom<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
                 .network_segment_type
                 .map(NetworkSegmentType::rpc_try_from)
                 .transpose()?,
+            role: expected_interface_role_from_rpc(expected_host_nic.role)?,
+            ip_allocation: expected_interface_ip_allocation_from_rpc(
+                expected_host_nic.ip_allocation,
+            )?,
         })
     }
 }
@@ -701,6 +829,347 @@ mod tests {
                 Err(error) => panic!("unexpected conversion error: {error}"),
             },
         );
+    }
+
+    #[test]
+    fn expected_interface_ip_allocation_uses_optional_wire_field() {
+        struct WireDeclaration {
+            policy: Option<i32>,
+            fixed_ip: Option<String>,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "missing policy without fixed IP infers dynamic and stays absent",
+                    input: WireDeclaration {
+                        policy: None,
+                        fixed_ip: None,
+                    },
+                    expect: (None, ExpectedInterfaceIpAllocation::Dynamic, None),
+                },
+                Check {
+                    scenario: "missing policy with fixed IP infers fixed and stays absent",
+                    input: WireDeclaration {
+                        policy: None,
+                        fixed_ip: Some("192.0.2.10".into()),
+                    },
+                    expect: (None, ExpectedInterfaceIpAllocation::Fixed, None),
+                },
+                Check {
+                    scenario: "unspecified policy becomes absent",
+                    input: WireDeclaration {
+                        policy: Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32),
+                        fixed_ip: None,
+                    },
+                    expect: (None, ExpectedInterfaceIpAllocation::Dynamic, None),
+                },
+                Check {
+                    scenario: "dynamic round trips",
+                    input: WireDeclaration {
+                        policy: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                        fixed_ip: None,
+                    },
+                    expect: (
+                        Some(ExpectedInterfaceIpAllocation::Dynamic),
+                        ExpectedInterfaceIpAllocation::Dynamic,
+                        Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                    ),
+                },
+                Check {
+                    scenario: "fixed round trips",
+                    input: WireDeclaration {
+                        policy: Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+                        fixed_ip: Some("192.0.2.10".into()),
+                    },
+                    expect: (
+                        Some(ExpectedInterfaceIpAllocation::Fixed),
+                        ExpectedInterfaceIpAllocation::Fixed,
+                        Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+                    ),
+                },
+                Check {
+                    scenario: "retained round trips",
+                    input: WireDeclaration {
+                        policy: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                        fixed_ip: None,
+                    },
+                    expect: (
+                        Some(ExpectedInterfaceIpAllocation::Retained),
+                        ExpectedInterfaceIpAllocation::Retained,
+                        Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ),
+                },
+            ],
+            |declaration| {
+                let model = ExpectedHostNic::try_from(rpc::forge::ExpectedHostNic {
+                    mac_address: "AA:BB:CC:DD:EE:FF".into(),
+                    fixed_ip: declaration.fixed_ip,
+                    ip_allocation: declaration.policy,
+                    ..Default::default()
+                })
+                .unwrap();
+                let resolved = model.resolved_ip_allocation();
+                let emitted = rpc::forge::ExpectedHostNic::from(model.clone());
+                (model.ip_allocation, resolved, emitted.ip_allocation)
+            },
+        );
+    }
+
+    #[test]
+    fn expected_interface_ip_allocation_json_accepts_names_and_numbers() {
+        scenarios!(
+            run = |value: serde_json::Value| {
+                serde_json::from_value::<rpc::forge::ExpectedHostNic>(serde_json::json!({
+                    "mac_address": "AA:BB:CC:DD:EE:FF",
+                    "ip_allocation": value,
+                }))
+                .map(|interface| {
+                    interface.ip_allocation.map(|value| {
+                        rpc::forge::ExpectedInterfaceIpAllocation::try_from(value).unwrap()
+                    })
+                })
+                .map_err(|error| error.to_string())
+            };
+            "short names" {
+                serde_json::json!("unspecified") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified)),
+                serde_json::json!("dynamic") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic)),
+                serde_json::json!("fixed") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed)),
+                serde_json::json!("retained") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained)),
+            }
+            "fully-qualified aliases" {
+                serde_json::json!("expected_interface_ip_allocation_unspecified") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified)),
+                serde_json::json!("expected_interface_ip_allocation_dynamic") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic)),
+                serde_json::json!("expected_interface_ip_allocation_fixed") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed)),
+                serde_json::json!("expected_interface_ip_allocation_retained") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained)),
+            }
+            "normalized and numeric values" {
+                serde_json::json!(" EXPECTED-INTERFACE-IP-ALLOCATION-RETAINED ") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained)),
+                serde_json::json!(2) =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed)),
+            }
+            "optional and invalid values" {
+                serde_json::Value::Null => Yields(None),
+                serde_json::json!("automatic") => FailsWith(
+                    "unknown expected interface IP allocation \"automatic\"".to_string()
+                ),
+            }
+        );
+
+        let interface = rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&interface).unwrap();
+        assert!(json.contains(r#""ip_allocation":"retained""#), "{json}");
+    }
+
+    #[test]
+    fn expected_interface_ip_allocation_rejects_unknown_rpc_value() {
+        let err = ExpectedHostNic::try_from(rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            ip_allocation: Some(i32::MAX),
+            ..Default::default()
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, RpcDataConversionError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn expected_interface_role_uses_optional_wire_field() {
+        scenarios!(
+            run = |role| {
+                let model = ExpectedHostNic::try_from(rpc::forge::ExpectedHostNic {
+                    mac_address: "AA:BB:CC:DD:EE:FF".into(),
+                    role,
+                    ..Default::default()
+                })
+                .map_err(drop)?;
+                let emitted = rpc::forge::ExpectedHostNic::from(model.clone());
+                Ok::<_, ()>((model.role, emitted.role))
+            };
+            "missing field is legacy Host and remains omitted" {
+                None => Yields((ExpectedInterfaceRole::Host, None)),
+            }
+            "Unspecified is legacy Host and remains omitted" {
+                Some(rpc::forge::ExpectedInterfaceRole::Unspecified as i32) =>
+                    Yields((ExpectedInterfaceRole::Host, None)),
+            }
+            "explicit Host remains wire-compatible" {
+                Some(rpc::forge::ExpectedInterfaceRole::Host as i32) =>
+                    Yields((ExpectedInterfaceRole::Host, None)),
+            }
+            "DPU OS round trips" {
+                Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32) => Yields((
+                    ExpectedInterfaceRole::DpuOs,
+                    Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32),
+                )),
+            }
+            "DPU BMC round trips" {
+                Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32) => Yields((
+                    ExpectedInterfaceRole::DpuBmc,
+                    Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                )),
+            }
+        );
+    }
+
+    #[test]
+    fn expected_interface_role_json_accepts_names_and_numbers() {
+        scenarios!(
+            run = |value: serde_json::Value| {
+                serde_json::from_value::<rpc::forge::ExpectedHostNic>(serde_json::json!({
+                    "mac_address": "AA:BB:CC:DD:EE:FF",
+                    "role": value,
+                }))
+                .map(|interface| {
+                    interface
+                        .role
+                        .map(|value| rpc::forge::ExpectedInterfaceRole::try_from(value).unwrap())
+                })
+                .map_err(|error| error.to_string())
+            };
+            "short names" {
+                serde_json::json!("unspecified") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::Unspecified)),
+                serde_json::json!("host") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::Host)),
+                serde_json::json!("dpu_os") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuOs)),
+                serde_json::json!("dpu_bmc") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuBmc)),
+            }
+            "fully-qualified aliases" {
+                serde_json::json!("expected_interface_role_unspecified") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::Unspecified)),
+                serde_json::json!("expected_interface_role_host") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::Host)),
+                serde_json::json!("expected_interface_role_dpu_os") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuOs)),
+                serde_json::json!("expected_interface_role_dpu_bmc") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuBmc)),
+            }
+            "normalized and numeric values" {
+                serde_json::json!(" DPU-OS ") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuOs)),
+                serde_json::json!("dpubmc") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuBmc)),
+                serde_json::json!(1) =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::Host)),
+            }
+            "optional and invalid values" {
+                serde_json::Value::Null => Yields(None),
+                serde_json::json!("sidecar") =>
+                    FailsWith("unknown expected interface role \"sidecar\"".to_string()),
+            }
+        );
+
+        let interface = rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&interface).unwrap();
+        assert!(json.contains(r#""role":"dpu_bmc""#), "{json}");
+
+        let legacy_interface = rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            role: None,
+            ..Default::default()
+        };
+        let legacy_json = serde_json::to_string(&legacy_interface).unwrap();
+        assert!(!legacy_json.contains(r#""role""#), "{legacy_json}");
+        assert!(!legacy_json.contains(r#""ip_allocation""#), "{legacy_json}");
+    }
+
+    #[test]
+    fn expected_interface_role_rejects_unknown_rpc_value() {
+        let err = ExpectedHostNic::try_from(rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            role: Some(i32::MAX),
+            ..Default::default()
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, RpcDataConversionError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn expected_interface_fields_are_additive() {
+        let descriptor_set =
+            prost_types::FileDescriptorSet::decode(rpc::REFLECTION_API_SERVICE_DESCRIPTOR).unwrap();
+        let forge = descriptor_set
+            .file
+            .iter()
+            .find(|file| file.package.as_deref() == Some("forge"))
+            .unwrap();
+        let expected_host_nic = forge
+            .message_type
+            .iter()
+            .find(|message| message.name.as_deref() == Some("ExpectedHostNic"))
+            .unwrap();
+        let field_numbers = expected_host_nic
+            .field
+            .iter()
+            .map(|field| (field.name.as_deref().unwrap(), field.number.unwrap()))
+            .collect::<Vec<_>>();
+
+        for expected in [
+            ("mac_address", 1),
+            ("nic_type", 2),
+            ("fixed_ip", 3),
+            ("fixed_mask", 4),
+            ("fixed_gateway", 5),
+            ("primary", 6),
+            ("network_segment_type", 7),
+            ("role", 8),
+            ("ip_allocation", 9),
+        ] {
+            assert!(field_numbers.contains(&expected));
+        }
+
+        let role_field = expected_host_nic
+            .field
+            .iter()
+            .find(|field| field.name.as_deref() == Some("role"))
+            .unwrap();
+        assert_eq!(
+            role_field.type_name.as_deref(),
+            Some(".forge.ExpectedInterfaceRole")
+        );
+
+        let allocation_field = expected_host_nic
+            .field
+            .iter()
+            .find(|field| field.name.as_deref() == Some("ip_allocation"))
+            .unwrap();
+        assert_eq!(
+            allocation_field.type_name.as_deref(),
+            Some(".forge.ExpectedInterfaceIpAllocation")
+        );
+
+        let expected_machine = forge
+            .message_type
+            .iter()
+            .find(|message| message.name.as_deref() == Some("ExpectedMachine"))
+            .unwrap();
+        let host_nics = expected_machine
+            .field
+            .iter()
+            .find(|field| field.name.as_deref() == Some("host_nics"))
+            .unwrap();
+        assert_eq!(host_nics.number, Some(9));
     }
 
     #[test]

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -87,7 +87,7 @@ use db::ObjectColumnFilter;
 use db::work_lock_manager::WorkLockManagerHandle;
 pub use managed_host::is_endpoint_in_managed_host;
 use model::DpuModel;
-use model::expected_machine::HostDpuPolicy;
+use model::expected_machine::{ExpectedHostNic, ExpectedInterfaceIpAllocation, HostDpuPolicy};
 use model::firmware::FirmwareComponentType;
 use model::network_segment::NetworkSegmentType;
 mod switch_creator;
@@ -111,6 +111,16 @@ use self::metrics::{
 };
 use crate::config::SiteExplorerExploreMode;
 use crate::explored_endpoint_index::ExploredEndpointIndex;
+
+/// Return whether an expected interface is explicitly a non-Redfish DPU OS
+/// endpoint.
+///
+/// Host is the compatibility default for existing `host_nics` entries, so
+/// those entries remain scannable even when they look like data interfaces.
+/// DPU BMC interfaces remain scannable too.
+fn should_skip_expected_interface_redfish_scan(interface: &ExpectedHostNic) -> bool {
+    interface.role == model::expected_machine::ExpectedInterfaceRole::DpuOs
+}
 
 pub fn new_bmc_explorer(
     redfish_client_pool: Arc<dyn RedfishClientPool>,
@@ -1995,12 +2005,13 @@ impl SiteExplorer {
             .map(|sku| (sku.id, sku.device_type))
             .collect();
 
-        // Record expected machine metrics and reconcile any configured static-IP reservations
-        // (bmc_ip_address, host_nics[].fixed_ip) into machine_interfaces. Idempotent on the
-        // api-db side -- steady-state runs are no-ops at the row level. This is the canonical
-        // path that materializes static reservations for IPs that don't reach
-        // `discover_dhcp` (devices on the static-assignments segment, devices not yet powered
-        // on, etc.), and a belt-and-suspenders for the in-network case too.
+        // Record Expected Machine metrics and apply configured address
+        // policies. Host, DPU OS, and DPU BMC declarations all use
+        // `try_apply_expected_interface`; their roles only determine the row's
+        // interface type and primary setting. Fixed addresses create rows when
+        // needed, while Retained changes a matching DHCP address to `Static`.
+        // The database helpers are idempotent, so steady-state passes do not
+        // change rows.
         let preallocate_start = Instant::now();
         for expected_machine in &expected_machines {
             let device_type = expected_machine
@@ -2035,15 +2046,9 @@ impl SiteExplorer {
                 try_retain_bmc(&self.database_connection, expected_machine.bmc_mac_address).await;
             }
             for nic in &expected_machine.data.host_nics {
-                let Some(ip) = nic.fixed_ip else {
-                    continue;
-                };
-                try_preallocate_one(
+                try_apply_expected_interface(
                     &self.database_connection,
-                    nic.mac_address,
-                    ip,
-                    InterfaceType::Data,
-                    "expected_machine host NIC",
+                    nic,
                     self.config.retained_boot_interface_window,
                 )
                 .await;
@@ -2110,18 +2115,20 @@ impl SiteExplorer {
         );
 
         let expected_count = expected_machines.len();
+        let expected_non_redfish_interface_macs = expected_machines
+            .iter()
+            .flat_map(|machine| &machine.data.host_nics)
+            .filter(|interface| should_skip_expected_interface_redfish_scan(interface))
+            .map(|interface| interface.mac_address)
+            .collect::<HashSet<_>>();
 
-        // We don't have to scan anything that is on the Tenant or Admin Segments,
-        // since we know what those Segments are used for (Forge allocated the IPs on the segments
-        // for a specific machine).
-        // We also can skip scanning IPs which are knowingly used as DPU OOB interfaces,
-        // since those will not speak redfish.
-        // Note: As a side effect of this, OOB interfaces might for a short time be scanned,
-        // until the machine is ingested. At that point in time this filter will remove them
-        // from the to-be-scanned list.
-        // Get all underlay interfaces from the database, which includes interfaces
-        // which have come from both DHCP and/or static assignments. Fetched here, after the
-        // preallocate loops above, so we see any freshly preallocated rows from this iteration.
+        // Tenant and Admin segments are never Redfish discovery networks. The
+        // Underlay may contain DPU OS data interfaces, so keep only explicitly
+        // declared DPU OS MACs out of the scan. Host remains the compatibility
+        // default for legacy entries, and DPU BMC interfaces remain eligible.
+        //
+        // Load interfaces after allocation reconciliation so this iteration
+        // also sees newly-created fixed reservations.
         let interface_load_start = Instant::now();
         let mut txn = self.txn_begin().await?;
         let interfaces = db::machine_interface::find_all(&mut txn).await?;
@@ -2139,7 +2146,9 @@ impl SiteExplorer {
                 // On Underlay an unadopted interface is a BMC to explore, and adopted BMCs
                 // stay visible too.
                 let underlay = underlay_segments.contains(&iface.segment_id)
-                    && (iface.machine_id.is_none() || is_bmc);
+                    && (is_bmc
+                        || (iface.machine_id.is_none()
+                            && !expected_non_redfish_interface_macs.contains(&iface.mac_address)));
                 // On HostInband only scan BMCs. The host in-band NIC also DHCPs here with no
                 // machine_id and is not a Redfish endpoint.
                 let host_inband = host_inband_segments.contains(&iface.segment_id) && is_bmc;
@@ -3572,13 +3581,14 @@ impl SiteExplorer {
     }
 }
 
-/// Reconcile a single static-IP reservation into `machine_interfaces` in its
-/// own transaction.
+/// `try_preallocate_one` reconciles one generic fixed-address reservation in
+/// its own transaction.
 ///
-/// Called once per configured static IP during the `update_explored_endpoints`
-/// walk over `expected_machine` / `expected_switch` / `expected_power_shelf`.
-/// Idempotent on the api-db side -- steady-state runs are noops. Per-entry
-/// errors are logged as warnings, and doesn't stop the wider iteration.
+/// Site Explorer uses this for flat BMC, switch NVOS, and power-shelf
+/// configuration. Nested expected interfaces use
+/// [`try_apply_expected_interface`] because their role and segment guard also
+/// need to be applied. Database operations are idempotent, and a failure is
+/// logged without stopping the wider reconciliation pass.
 ///
 /// This is `pub` so tests can drive a single (mac, ip, interface_type)
 /// preallocation directly without needing to create a full `SiteExplorer`.
@@ -3680,6 +3690,82 @@ pub async fn try_retain_bmc(pool: &PgPool, mac: MacAddress) {
                 %error,
                 bmc_mac_address = %mac,
                 "Site-explorer BMC retain skipped"
+            );
+        }
+    }
+}
+
+/// `try_apply_expected_interface` applies the allocation policy for one nested
+/// expected interface.
+///
+/// Every role follows this same policy path. Fixed reservations are
+/// materialized while expected configuration is reconciled. Retained follows
+/// the existing Host BMC behavior: a matching DHCP address becomes `Static`
+/// for this interface row's lifetime, but the selected address is not written
+/// back to `ExpectedMachine` for a later re-ingestion. Dynamic needs no
+/// reconciliation here.
+///
+/// Each interface gets its own transaction so one invalid reservation cannot
+/// stop Site Explorer from processing the remaining expected inventory.
+pub async fn try_apply_expected_interface(
+    pool: &PgPool,
+    expected_interface: &ExpectedHostNic,
+    retained_window: Option<chrono::Duration>,
+) {
+    let allocation = expected_interface.resolved_ip_allocation();
+    let mut txn = match allocation {
+        ExpectedInterfaceIpAllocation::Dynamic => return,
+        ExpectedInterfaceIpAllocation::Fixed | ExpectedInterfaceIpAllocation::Retained => {
+            match db::Transaction::begin(pool).await {
+                Ok(txn) => txn,
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        mac_address = %expected_interface.mac_address,
+                        "Site-explorer expected-interface allocation: txn_begin failed"
+                    );
+                    return;
+                }
+            }
+        }
+    };
+
+    let result = match allocation {
+        ExpectedInterfaceIpAllocation::Dynamic => {
+            unreachable!("dynamic allocation returns before opening a transaction")
+        }
+        ExpectedInterfaceIpAllocation::Fixed => {
+            db::machine_interface::preallocate_expected_machine_interface(
+                txn.as_pgconn(),
+                expected_interface,
+                retained_window,
+            )
+            .await
+        }
+        ExpectedInterfaceIpAllocation::Retained => {
+            db::machine_interface::retain_expected_machine_interface_address(
+                txn.as_pgconn(),
+                expected_interface,
+            )
+            .await
+        }
+    };
+
+    match result {
+        Ok(()) => {
+            if let Err(error) = txn.commit().await {
+                tracing::warn!(
+                    %error,
+                    mac_address = %expected_interface.mac_address,
+                    "Site-explorer expected-interface allocation: commit failed"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                mac_address = %expected_interface.mac_address,
+                "Site-explorer expected-interface allocation skipped"
             );
         }
     }
@@ -4162,6 +4248,7 @@ mod tests {
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, Check, check_cases, check_values, value_scenarios};
     use config_version::ConfigVersion;
+    use model::expected_machine::ExpectedInterfaceRole;
     use model::site_explorer::PreingestionState;
 
     use super::*;
@@ -4192,6 +4279,39 @@ mod tests {
                 },
             ],
             rms_location_value,
+        );
+    }
+
+    /// Only an explicit DPU OS role suppresses Redfish scanning.
+    ///
+    /// Host remains eligible because it is the default for legacy entries
+    /// that did not declare an interface role.
+    #[test]
+    fn expected_interface_role_controls_redfish_scan_classification() {
+        check_values(
+            [
+                Check {
+                    scenario: "legacy host entry",
+                    input: ExpectedInterfaceRole::Host,
+                    expect: false,
+                },
+                Check {
+                    scenario: "DPU OS interface",
+                    input: ExpectedInterfaceRole::DpuOs,
+                    expect: true,
+                },
+                Check {
+                    scenario: "DPU BMC interface",
+                    input: ExpectedInterfaceRole::DpuBmc,
+                    expect: false,
+                },
+            ],
+            |role| {
+                should_skip_expected_interface_redfish_scan(&ExpectedHostNic {
+                    role,
+                    ..Default::default()
+                })
+            },
         );
     }
 

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -1135,9 +1135,13 @@ impl MachineCreator {
     }
 }
 
-/// Host inband MACs used when minting `predicted_machine_interface` rows for zero-DPU hosts.
-/// Prefers Redfish-reported System EthernetInterfaces; falls back to `ExpectedMachine.host_nics`
-/// when the BMC omits them from Redfish.
+/// `host_mac_addresses_for_predicted_machine` finds the Host interfaces used to
+/// mint `predicted_machine_interface` rows for a zero-DPU host.
+///
+/// Redfish-reported System EthernetInterfaces remain authoritative. When the
+/// BMC omits that inventory, only Host-role ExpectedMachine declarations are a
+/// valid fallback; treating DPU OS or DPU BMC declarations as Host interfaces
+/// would attach those endpoints to the wrong machine.
 fn host_mac_addresses_for_predicted_machine(
     report: &EndpointExplorationReport,
     machine_data: Option<&ExpectedMachineData>,
@@ -1147,19 +1151,138 @@ fn host_mac_addresses_for_predicted_machine(
         [_, ..] => from_redfish,
         [] => machine_data
             .filter(|_| !(report.is_dpu() || report.is_switch() || report.is_power_shelf()))
-            .map(|data| data.host_nics.as_slice())
+            .map(|data| {
+                data.host_nics
+                    .iter()
+                    .filter(|interface| interface.role.is_host())
+                    .map(|interface| interface.mac_address)
+                    .dedup()
+                    .collect::<Vec<_>>()
+            })
             .none_if_empty()
-            .map(|host_nics| {
+            .inspect(|host_mac_addresses| {
                 tracing::info!(
-                    host_nic_count = host_nics.len(),
+                    host_nic_count = host_mac_addresses.len(),
                     "System EthernetInterfaces missing from Redfish; using ExpectedMachine.host_nics for predicted machine interfaces"
                 );
-                host_nics
-                    .iter()
-                    .map(|nic| nic.mac_address)
-                    .dedup()
-                    .collect()
             })
             .unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use model::expected_machine::{ExpectedHostNic, ExpectedInterfaceRole};
+    use model::site_explorer::{Chassis, ComputerSystem, EthernetInterface};
+
+    use super::*;
+
+    /// Redfish inventory stays authoritative, and the zero-DPU fallback uses
+    /// only Host declarations from a host ExpectedMachine.
+    #[test]
+    fn host_mac_addresses_for_predicted_machine_cases() {
+        let host_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        let dpu_os_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
+        let dpu_bmc_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x03]);
+        let redfish_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x04]);
+        let interface = |mac_address, role| ExpectedHostNic {
+            mac_address,
+            role,
+            ..Default::default()
+        };
+        let machine_data = |host_nics| ExpectedMachineData {
+            host_nics,
+            ..Default::default()
+        };
+        let all_roles = || {
+            machine_data(vec![
+                interface(host_mac, ExpectedInterfaceRole::Host),
+                interface(dpu_os_mac, ExpectedInterfaceRole::DpuOs),
+                interface(dpu_bmc_mac, ExpectedInterfaceRole::DpuBmc),
+            ])
+        };
+        let excluded_report = |chassis_id: &str| EndpointExplorationReport {
+            chassis: vec![Chassis {
+                id: chassis_id.to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "Redfish EthernetInterfaces are authoritative",
+                    input: (
+                        EndpointExplorationReport {
+                            systems: vec![ComputerSystem {
+                                ethernet_interfaces: vec![EthernetInterface {
+                                    mac_address: Some(redfish_mac),
+                                    ..Default::default()
+                                }],
+                                ..Default::default()
+                            }],
+                            ..Default::default()
+                        },
+                        Some(all_roles()),
+                    ),
+                    expect: vec![redfish_mac],
+                },
+                Check {
+                    scenario: "Host declarations provide the zero-DPU fallback",
+                    input: (EndpointExplorationReport::default(), Some(all_roles())),
+                    expect: vec![host_mac],
+                },
+                Check {
+                    scenario: "DPU-only declarations do not become Host predictions",
+                    input: (
+                        EndpointExplorationReport::default(),
+                        Some(machine_data(vec![
+                            interface(dpu_os_mac, ExpectedInterfaceRole::DpuOs),
+                            interface(dpu_bmc_mac, ExpectedInterfaceRole::DpuBmc),
+                        ])),
+                    ),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "missing ExpectedMachine data has no fallback",
+                    input: (EndpointExplorationReport::default(), None),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "DPU reports do not use Host declarations",
+                    input: (
+                        EndpointExplorationReport {
+                            systems: vec![ComputerSystem {
+                                id: "Bluefield".to_string(),
+                                ..Default::default()
+                            }],
+                            chassis: vec![Chassis {
+                                id: "Card1".to_string(),
+                                model: Some("BlueField 3 DPU".to_string()),
+                                ..Default::default()
+                            }],
+                            ..Default::default()
+                        },
+                        Some(all_roles()),
+                    ),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "switch reports do not use Host declarations",
+                    input: (excluded_report("MGX_NVSwitch_0"), Some(all_roles())),
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "power-shelf reports do not use Host declarations",
+                    input: (excluded_report("PowerShelf"), Some(all_roles())),
+                    expect: vec![],
+                },
+            ],
+            |(report, machine_data)| {
+                host_mac_addresses_for_predicted_machine(&report, machine_data.as_ref())
+            },
+        );
     }
 }

--- a/crates/site-explorer/tests/integration/reconcile.rs
+++ b/crates/site-explorer/tests/integration/reconcile.rs
@@ -17,6 +17,7 @@
 
 use std::net::IpAddr;
 
+use carbide_site_explorer::config::SiteExplorerConfig;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::network_segment::create_static_assignments_segment;
 use mac_address::MacAddress;
@@ -30,11 +31,12 @@ async fn init(pool: &PgPool) -> TestHarness {
     test_harness
 }
 
-/// Site-explorer reconciles every `expected_*` row's configured static IPs into
-/// `machine_interface` rows by calling `try_preallocate_one` per static IP during
-/// `update_explored_endpoints`. This test drives the same per-row materialization directly,
-/// covering the static-assignments-segment counterpart to the DHCP `discover()` recovery hook:
-/// devices whose IP lives outside any Carbide-managed network never reach `discover()`, so this
+/// Site-explorer reconciles configured BMC static IPs from every `expected_*`
+/// row into `machine_interface` rows by calling `try_preallocate_one` during
+/// `update_explored_endpoints`. This test drives the same per-row
+/// materialization directly, covering the static-assignments-segment
+/// counterpart to the DHCP `discover()` recovery hook: devices whose IP lives
+/// outside any Carbide-managed network never reach `discover()`, so this
 /// per-row preallocation is what gets their rows onto the books.
 #[sqlx_test]
 async fn test_site_explorer_reconcile_creates_missing_preallocations(
@@ -216,12 +218,18 @@ async fn test_site_explorer_reconcile_is_idempotent(
 async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    init(&pool).await;
+    let test_harness = init(&pool).await;
 
     let bmc_mac: MacAddress = "AA:BB:CC:DD:E1:01".parse().unwrap();
     let nic_mac: MacAddress = "AA:BB:CC:DD:E1:02".parse().unwrap();
     let fixed_ip = "10.99.0.20";
     let parsed_fixed_ip: IpAddr = fixed_ip.parse().unwrap();
+    let expected_interface = model::expected_machine::ExpectedHostNic {
+        mac_address: nic_mac,
+        nic_type: Some("onboard".into()),
+        fixed_ip: Some(parsed_fixed_ip),
+        ..Default::default()
+    };
 
     let mut txn = pool.begin().await?;
     db::expected_machine::create(
@@ -231,15 +239,7 @@ async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
             bmc_mac_address: bmc_mac,
             data: ExpectedMachineData {
                 serial_number: "reconcile-hostnic-001".to_string(),
-                host_nics: vec![model::expected_machine::ExpectedHostNic {
-                    network_segment_type: None,
-                    mac_address: nic_mac,
-                    nic_type: Some("onboard".into()),
-                    fixed_ip: Some(parsed_fixed_ip),
-                    fixed_mask: None,
-                    fixed_gateway: None,
-                    primary: None,
-                }],
+                host_nics: vec![expected_interface],
                 ..Default::default()
             },
         },
@@ -247,15 +247,16 @@ async fn test_site_explorer_reconcile_preallocates_host_nic_fixed_ip(
     .await?;
     txn.commit().await?;
 
-    carbide_site_explorer::try_preallocate_one(
-        &pool,
-        nic_mac,
-        parsed_fixed_ip,
-        model::machine_interface::InterfaceType::Data,
-        "expected_machine host NIC",
-        None,
-    )
-    .await;
+    // Drive the production reconciliation entry point so this covers loading
+    // `ExpectedMachineData.host_nics` as well as applying its policy.
+    let explorer = super::env::test_site_explorer(
+        &test_harness,
+        SiteExplorerConfig {
+            explorations_per_run: 0,
+            ..Default::default()
+        },
+    );
+    explorer.run_single_iteration().await?;
 
     let mut txn = pool.begin().await?;
     let nic_iface = db::machine_interface::find_by_mac_address(&mut *txn, nic_mac).await?;

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -4494,6 +4494,136 @@ func (OperatingSystemType) EnumDescriptor() ([]byte, []int) {
 	return file_nico_nico_proto_rawDescGZIP(), []int{81}
 }
 
+// Identifies which machine endpoint owns an entry in `ExpectedMachine.host_nics`.
+// Each role accepts Dynamic, Fixed, and Retained allocation plus the optional
+// segment guard. The role only derives interface type and primary behavior.
+//
+// On create, missing and `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` mean Host. On
+// update, omission preserves the stored role, while explicit
+// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. Host BMC identity
+// remains on `ExpectedMachine.bmc_mac_address`. NVIDIA/infra-controller#4103
+// tracks adding its network settings to this same interface model.
+type ExpectedInterfaceRole int32
+
+const (
+	// Preserve the legacy Host role when the optional field is absent.
+	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_UNSPECIFIED ExpectedInterfaceRole = 0
+	// Host operating-system data interface. Primary selection is machine-wide.
+	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_HOST ExpectedInterfaceRole = 1
+	// DPU operating-system data interface. Always primary for its DPU.
+	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_DPU_OS ExpectedInterfaceRole = 2
+	// DPU Redfish/BMC interface. Never primary.
+	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_DPU_BMC ExpectedInterfaceRole = 3
+)
+
+// Enum value maps for ExpectedInterfaceRole.
+var (
+	ExpectedInterfaceRole_name = map[int32]string{
+		0: "EXPECTED_INTERFACE_ROLE_UNSPECIFIED",
+		1: "EXPECTED_INTERFACE_ROLE_HOST",
+		2: "EXPECTED_INTERFACE_ROLE_DPU_OS",
+		3: "EXPECTED_INTERFACE_ROLE_DPU_BMC",
+	}
+	ExpectedInterfaceRole_value = map[string]int32{
+		"EXPECTED_INTERFACE_ROLE_UNSPECIFIED": 0,
+		"EXPECTED_INTERFACE_ROLE_HOST":        1,
+		"EXPECTED_INTERFACE_ROLE_DPU_OS":      2,
+		"EXPECTED_INTERFACE_ROLE_DPU_BMC":     3,
+	}
+)
+
+func (x ExpectedInterfaceRole) Enum() *ExpectedInterfaceRole {
+	p := new(ExpectedInterfaceRole)
+	*p = x
+	return p
+}
+
+func (x ExpectedInterfaceRole) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ExpectedInterfaceRole) Descriptor() protoreflect.EnumDescriptor {
+	return file_nico_nico_proto_enumTypes[82].Descriptor()
+}
+
+func (ExpectedInterfaceRole) Type() protoreflect.EnumType {
+	return &file_nico_nico_proto_enumTypes[82]
+}
+
+func (x ExpectedInterfaceRole) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ExpectedInterfaceRole.Descriptor instead.
+func (ExpectedInterfaceRole) EnumDescriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{82}
+}
+
+// Controls how an expected interface receives and retains its IP address.
+// Missing and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` preserve legacy
+// behavior: `fixed_ip` implies `FIXED`, while its absence implies `DYNAMIC`.
+type ExpectedInterfaceIpAllocation int32
+
+const (
+	// Infer Fixed or Dynamic from whether `fixed_ip` is configured. For a legacy
+	// Host declaration, this does not opt into the fixed-address segment guard.
+	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED ExpectedInterfaceIpAllocation = 0
+	// Use an expiring DHCP lease. The segment guard must match the relay's
+	// selected segment when configured.
+	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC ExpectedInterfaceIpAllocation = 1
+	// Reserve `fixed_ip`. Its prefix selects the segment, and the segment guard
+	// must match that segment when configured.
+	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_FIXED ExpectedInterfaceIpAllocation = 2
+	// Allocate through DHCP, then make the address Static for this interface
+	// row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The
+	// address is not converted back to DHCP if the policy later changes. The
+	// segment guard must match the relay's selected segment when configured.
+	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_RETAINED ExpectedInterfaceIpAllocation = 3
+)
+
+// Enum value maps for ExpectedInterfaceIpAllocation.
+var (
+	ExpectedInterfaceIpAllocation_name = map[int32]string{
+		0: "EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED",
+		1: "EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC",
+		2: "EXPECTED_INTERFACE_IP_ALLOCATION_FIXED",
+		3: "EXPECTED_INTERFACE_IP_ALLOCATION_RETAINED",
+	}
+	ExpectedInterfaceIpAllocation_value = map[string]int32{
+		"EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED": 0,
+		"EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC":     1,
+		"EXPECTED_INTERFACE_IP_ALLOCATION_FIXED":       2,
+		"EXPECTED_INTERFACE_IP_ALLOCATION_RETAINED":    3,
+	}
+)
+
+func (x ExpectedInterfaceIpAllocation) Enum() *ExpectedInterfaceIpAllocation {
+	p := new(ExpectedInterfaceIpAllocation)
+	*p = x
+	return p
+}
+
+func (x ExpectedInterfaceIpAllocation) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ExpectedInterfaceIpAllocation) Descriptor() protoreflect.EnumDescriptor {
+	return file_nico_nico_proto_enumTypes[83].Descriptor()
+}
+
+func (ExpectedInterfaceIpAllocation) Type() protoreflect.EnumType {
+	return &file_nico_nico_proto_enumTypes[83]
+}
+
+func (x ExpectedInterfaceIpAllocation) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ExpectedInterfaceIpAllocation.Descriptor instead.
+func (ExpectedInterfaceIpAllocation) EnumDescriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{83}
+}
+
 // Identifies the lifecycle authority responsible for a site prefix.
 type SitePrefixAuthority int32
 
@@ -4528,11 +4658,11 @@ func (x SitePrefixAuthority) String() string {
 }
 
 func (SitePrefixAuthority) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[82].Descriptor()
+	return file_nico_nico_proto_enumTypes[84].Descriptor()
 }
 
 func (SitePrefixAuthority) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[82]
+	return &file_nico_nico_proto_enumTypes[84]
 }
 
 func (x SitePrefixAuthority) Number() protoreflect.EnumNumber {
@@ -4541,7 +4671,7 @@ func (x SitePrefixAuthority) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SitePrefixAuthority.Descriptor instead.
 func (SitePrefixAuthority) EnumDescriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{82}
+	return file_nico_nico_proto_rawDescGZIP(), []int{84}
 }
 
 // Describes where a site prefix may be routed.
@@ -4575,11 +4705,11 @@ func (x SitePrefixRoutingScope) String() string {
 }
 
 func (SitePrefixRoutingScope) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[83].Descriptor()
+	return file_nico_nico_proto_enumTypes[85].Descriptor()
 }
 
 func (SitePrefixRoutingScope) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[83]
+	return &file_nico_nico_proto_enumTypes[85]
 }
 
 func (x SitePrefixRoutingScope) Number() protoreflect.EnumNumber {
@@ -4588,7 +4718,7 @@ func (x SitePrefixRoutingScope) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SitePrefixRoutingScope.Descriptor instead.
 func (SitePrefixRoutingScope) EnumDescriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{83}
+	return file_nico_nico_proto_rawDescGZIP(), []int{85}
 }
 
 // Describes the current lifecycle state of a site prefix.
@@ -4631,11 +4761,11 @@ func (x SitePrefixLifecycleState) String() string {
 }
 
 func (SitePrefixLifecycleState) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[84].Descriptor()
+	return file_nico_nico_proto_enumTypes[86].Descriptor()
 }
 
 func (SitePrefixLifecycleState) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[84]
+	return &file_nico_nico_proto_enumTypes[86]
 }
 
 func (x SitePrefixLifecycleState) Number() protoreflect.EnumNumber {
@@ -4644,7 +4774,7 @@ func (x SitePrefixLifecycleState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SitePrefixLifecycleState.Descriptor instead.
 func (SitePrefixLifecycleState) EnumDescriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{84}
+	return file_nico_nico_proto_rawDescGZIP(), []int{86}
 }
 
 type InstancePowerRequest_Operation int32
@@ -4674,11 +4804,11 @@ func (x InstancePowerRequest_Operation) String() string {
 }
 
 func (InstancePowerRequest_Operation) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[85].Descriptor()
+	return file_nico_nico_proto_enumTypes[87].Descriptor()
 }
 
 func (InstancePowerRequest_Operation) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[85]
+	return &file_nico_nico_proto_enumTypes[87]
 }
 
 func (x InstancePowerRequest_Operation) Number() protoreflect.EnumNumber {
@@ -4717,11 +4847,11 @@ func (x InstanceUpdateStatus_Module) String() string {
 }
 
 func (InstanceUpdateStatus_Module) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[86].Descriptor()
+	return file_nico_nico_proto_enumTypes[88].Descriptor()
 }
 
 func (InstanceUpdateStatus_Module) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[86]
+	return &file_nico_nico_proto_enumTypes[88]
 }
 
 func (x InstanceUpdateStatus_Module) Number() protoreflect.EnumNumber {
@@ -4763,11 +4893,11 @@ func (x MachineCredentialsUpdateRequest_CredentialPurpose) String() string {
 }
 
 func (MachineCredentialsUpdateRequest_CredentialPurpose) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[87].Descriptor()
+	return file_nico_nico_proto_enumTypes[89].Descriptor()
 }
 
 func (MachineCredentialsUpdateRequest_CredentialPurpose) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[87]
+	return &file_nico_nico_proto_enumTypes[89]
 }
 
 func (x MachineCredentialsUpdateRequest_CredentialPurpose) Number() protoreflect.EnumNumber {
@@ -4834,11 +4964,11 @@ func (x ForgeAgentControlResponse_LegacyAction) String() string {
 }
 
 func (ForgeAgentControlResponse_LegacyAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[88].Descriptor()
+	return file_nico_nico_proto_enumTypes[90].Descriptor()
 }
 
 func (ForgeAgentControlResponse_LegacyAction) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[88]
+	return &file_nico_nico_proto_enumTypes[90]
 }
 
 func (x ForgeAgentControlResponse_LegacyAction) Number() protoreflect.EnumNumber {
@@ -4880,11 +5010,11 @@ func (x MachineCleanupInfo_CleanupResult) String() string {
 }
 
 func (MachineCleanupInfo_CleanupResult) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[89].Descriptor()
+	return file_nico_nico_proto_enumTypes[91].Descriptor()
 }
 
 func (MachineCleanupInfo_CleanupResult) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[89]
+	return &file_nico_nico_proto_enumTypes[91]
 }
 
 func (x MachineCleanupInfo_CleanupResult) Number() protoreflect.EnumNumber {
@@ -4929,11 +5059,11 @@ func (x DpuReprovisioningRequest_Mode) String() string {
 }
 
 func (DpuReprovisioningRequest_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[90].Descriptor()
+	return file_nico_nico_proto_enumTypes[92].Descriptor()
 }
 
 func (DpuReprovisioningRequest_Mode) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[90]
+	return &file_nico_nico_proto_enumTypes[92]
 }
 
 func (x DpuReprovisioningRequest_Mode) Number() protoreflect.EnumNumber {
@@ -4975,11 +5105,11 @@ func (x HostReprovisioningRequest_Mode) String() string {
 }
 
 func (HostReprovisioningRequest_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[91].Descriptor()
+	return file_nico_nico_proto_enumTypes[93].Descriptor()
 }
 
 func (HostReprovisioningRequest_Mode) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[91]
+	return &file_nico_nico_proto_enumTypes[93]
 }
 
 func (x HostReprovisioningRequest_Mode) Number() protoreflect.EnumNumber {
@@ -5024,11 +5154,11 @@ func (x MachineSetAutoUpdateRequest_SetAutoupdateAction) String() string {
 }
 
 func (MachineSetAutoUpdateRequest_SetAutoupdateAction) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[92].Descriptor()
+	return file_nico_nico_proto_enumTypes[94].Descriptor()
 }
 
 func (MachineSetAutoUpdateRequest_SetAutoupdateAction) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[92]
+	return &file_nico_nico_proto_enumTypes[94]
 }
 
 func (x MachineSetAutoUpdateRequest_SetAutoupdateAction) Number() protoreflect.EnumNumber {
@@ -5070,11 +5200,11 @@ func (x MachineValidationOnDemandRequest_Action) String() string {
 }
 
 func (MachineValidationOnDemandRequest_Action) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[93].Descriptor()
+	return file_nico_nico_proto_enumTypes[95].Descriptor()
 }
 
 func (MachineValidationOnDemandRequest_Action) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[93]
+	return &file_nico_nico_proto_enumTypes[95]
 }
 
 func (x MachineValidationOnDemandRequest_Action) Number() protoreflect.EnumNumber {
@@ -5134,11 +5264,11 @@ func (x AdminPowerControlRequest_SystemPowerControl) String() string {
 }
 
 func (AdminPowerControlRequest_SystemPowerControl) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[94].Descriptor()
+	return file_nico_nico_proto_enumTypes[96].Descriptor()
 }
 
 func (AdminPowerControlRequest_SystemPowerControl) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[94]
+	return &file_nico_nico_proto_enumTypes[96]
 }
 
 func (x AdminPowerControlRequest_SystemPowerControl) Number() protoreflect.EnumNumber {
@@ -5189,11 +5319,11 @@ func (x GetRedfishJobStateResponse_RedfishJobState) String() string {
 }
 
 func (GetRedfishJobStateResponse_RedfishJobState) Descriptor() protoreflect.EnumDescriptor {
-	return file_nico_nico_proto_enumTypes[95].Descriptor()
+	return file_nico_nico_proto_enumTypes[97].Descriptor()
 }
 
 func (GetRedfishJobStateResponse_RedfishJobState) Type() protoreflect.EnumType {
-	return &file_nico_nico_proto_enumTypes[95]
+	return &file_nico_nico_proto_enumTypes[97]
 }
 
 func (x GetRedfishJobStateResponse_RedfishJobState) Number() protoreflect.EnumNumber {
@@ -35290,29 +35420,43 @@ type ExpectedHostNic struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	MacAddress string                 `protobuf:"bytes,1,opt,name=mac_address,json=macAddress,proto3" json:"mac_address,omitempty"`
 	// Legacy free-form segment hint (bf3, onboard, oob, ...). Kept for backward
-	// compatibility; declare network_segment_type instead, which wins.
+	// compatibility; declare `network_segment_type` instead, which wins.
 	NicType      *string `protobuf:"bytes,2,opt,name=nic_type,json=nicType,proto3,oneof" json:"nic_type,omitempty"`
 	FixedIp      *string `protobuf:"bytes,3,opt,name=fixed_ip,json=fixedIp,proto3,oneof" json:"fixed_ip,omitempty"`
 	FixedMask    *string `protobuf:"bytes,4,opt,name=fixed_mask,json=fixedMask,proto3,oneof" json:"fixed_mask,omitempty"`
 	FixedGateway *string `protobuf:"bytes,5,opt,name=fixed_gateway,json=fixedGateway,proto3,oneof" json:"fixed_gateway,omitempty"`
-	// When true, this flags the given NIC as the host's primary (boot)
-	// interface (used in cases of zero DPU).
+	// Host-role interfaces may set this to true to declare the host's primary
+	// (boot) interface.
 	//
-	// Up to one NIC per ExpectedMachine may be marked primary, if set at
-	// all. Propagates to `machine_interfaces.primary_interface` during DHCP
-	// when this NIC is first discovered.
-	//
-	// Some day this could be even possibly used to say "this dumb NIC
-	// *is* the primary interface, even though I know I have a DPU."
+	// At most one Host interface per `ExpectedMachine` may set it to true; the
+	// other Host interfaces then become non-primary. False remains accepted for
+	// compatibility but does not replace that machine-wide selection. DPU OS
+	// interfaces are primary data interfaces and DPU BMC interfaces are
+	// non-primary; those roles must omit this field.
 	Primary *bool `protobuf:"varint,6,opt,name=primary,proto3,oneof" json:"primary,omitempty"`
-	// The network segment type this NIC's first DHCP lease should come from.
-	// A NIC's segment normally follows its DHCP relay; where segment prefixes
-	// nest or overlap and a relay matches several, this narrows the choice to
-	// the segment of this type. Supersedes nic_type; absent both, the relay's
-	// match stands.
+	// Optional guard for this interface's network segment type. An explicit
+	// allocation policy or DPU role applies the guard to DHCP-selected segments
+	// and fixed-address containment. A legacy Host declaration with an omitted
+	// policy keeps the earlier first-DHCP selection-only behavior. Supersedes
+	// `nic_type` for DHCP; absent both, relay selection remains unconstrained.
+	// On update, omission clears this guard.
 	NetworkSegmentType *NetworkSegmentType `protobuf:"varint,7,opt,name=network_segment_type,json=networkSegmentType,proto3,enum=forge.NetworkSegmentType,oneof" json:"network_segment_type,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Machine endpoint that owns this interface. The role selects interface type
+	// and primary behavior only; Host, DPU OS, and DPU BMC all accept the same
+	// allocation policies and optional segment guard. On create, missing and
+	// Unspecified mean Host. On update, omission preserves the stored role while
+	// explicit Unspecified resets it to Host.
+	Role *ExpectedInterfaceRole `protobuf:"varint,8,opt,name=role,proto3,enum=forge.ExpectedInterfaceRole,oneof" json:"role,omitempty"`
+	// Optional allocation policy. On create, missing and Unspecified infer Fixed
+	// from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
+	// stored policy while explicit Unspecified resets to that inference.
+	// Explicit Dynamic rejects `fixed_ip`. For a legacy Host declaration,
+	// inferred Fixed still selects the segment by address-prefix containment but
+	// does not turn `network_segment_type` into a fixed-address guard; configure
+	// Fixed explicitly to request that check.
+	IpAllocation  *ExpectedInterfaceIpAllocation `protobuf:"varint,9,opt,name=ip_allocation,json=ipAllocation,proto3,enum=forge.ExpectedInterfaceIpAllocation,oneof" json:"ip_allocation,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExpectedHostNic) Reset() {
@@ -35392,6 +35536,20 @@ func (x *ExpectedHostNic) GetNetworkSegmentType() NetworkSegmentType {
 		return *x.NetworkSegmentType
 	}
 	return NetworkSegmentType_TENANT
+}
+
+func (x *ExpectedHostNic) GetRole() ExpectedInterfaceRole {
+	if x != nil && x.Role != nil {
+		return *x.Role
+	}
+	return ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_UNSPECIFIED
+}
+
+func (x *ExpectedHostNic) GetIpAllocation() ExpectedInterfaceIpAllocation {
+	if x != nil && x.IpAllocation != nil {
+		return *x.IpAllocation
+	}
+	return ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED
 }
 
 // Per-host lifecycle profile for settings that affect state-machine progression.
@@ -64853,7 +65011,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\v2\x16.common.IpxeTemplateIdR\x02id\"\x1a\n" +
 	"\x18ListIpxeTemplatesRequest\"E\n" +
 	"\x10IpxeTemplateList\x121\n" +
-	"\ttemplates\x18\x01 \x03(\v2\x13.forge.IpxeTemplateR\ttemplates\"\x91\x03\n" +
+	"\ttemplates\x18\x01 \x03(\v2\x13.forge.IpxeTemplateR\ttemplates\"\xb3\x04\n" +
 	"\x0fExpectedHostNic\x12\x1f\n" +
 	"\vmac_address\x18\x01 \x01(\tR\n" +
 	"macAddress\x12\x1e\n" +
@@ -64863,14 +65021,18 @@ const file_nico_nico_proto_rawDesc = "" +
 	"fixed_mask\x18\x04 \x01(\tH\x02R\tfixedMask\x88\x01\x01\x12(\n" +
 	"\rfixed_gateway\x18\x05 \x01(\tH\x03R\ffixedGateway\x88\x01\x01\x12\x1d\n" +
 	"\aprimary\x18\x06 \x01(\bH\x04R\aprimary\x88\x01\x01\x12P\n" +
-	"\x14network_segment_type\x18\a \x01(\x0e2\x19.forge.NetworkSegmentTypeH\x05R\x12networkSegmentType\x88\x01\x01B\v\n" +
+	"\x14network_segment_type\x18\a \x01(\x0e2\x19.forge.NetworkSegmentTypeH\x05R\x12networkSegmentType\x88\x01\x01\x125\n" +
+	"\x04role\x18\b \x01(\x0e2\x1c.forge.ExpectedInterfaceRoleH\x06R\x04role\x88\x01\x01\x12N\n" +
+	"\rip_allocation\x18\t \x01(\x0e2$.forge.ExpectedInterfaceIpAllocationH\aR\fipAllocation\x88\x01\x01B\v\n" +
 	"\t_nic_typeB\v\n" +
 	"\t_fixed_ipB\r\n" +
 	"\v_fixed_maskB\x10\n" +
 	"\x0e_fixed_gatewayB\n" +
 	"\n" +
 	"\b_primaryB\x17\n" +
-	"\x15_network_segment_type\"[\n" +
+	"\x15_network_segment_typeB\a\n" +
+	"\x05_roleB\x10\n" +
+	"\x0e_ip_allocation\"[\n" +
 	"\x14HostLifecycleProfile\x12.\n" +
 	"\x10disable_lockdown\x18\x01 \x01(\bH\x00R\x0fdisableLockdown\x88\x01\x01B\x13\n" +
 	"\x11_disable_lockdown\"\xe2\v\n" +
@@ -67516,7 +67678,17 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x13OperatingSystemType\x12\x17\n" +
 	"\x13OS_TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fOS_TYPE_IPXE\x10\x01\x12\x1a\n" +
-	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x02*\x8c\x01\n" +
+	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x02*\xab\x01\n" +
+	"\x15ExpectedInterfaceRole\x12'\n" +
+	"#EXPECTED_INTERFACE_ROLE_UNSPECIFIED\x10\x00\x12 \n" +
+	"\x1cEXPECTED_INTERFACE_ROLE_HOST\x10\x01\x12\"\n" +
+	"\x1eEXPECTED_INTERFACE_ROLE_DPU_OS\x10\x02\x12#\n" +
+	"\x1fEXPECTED_INTERFACE_ROLE_DPU_BMC\x10\x03*\xda\x01\n" +
+	"\x1dExpectedInterfaceIpAllocation\x120\n" +
+	",EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED\x10\x00\x12,\n" +
+	"(EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC\x10\x01\x12*\n" +
+	"&EXPECTED_INTERFACE_IP_ALLOCATION_FIXED\x10\x02\x12-\n" +
+	")EXPECTED_INTERFACE_IP_ALLOCATION_RETAINED\x10\x03*\x8c\x01\n" +
 	"\x13SitePrefixAuthority\x12%\n" +
 	"!SITE_PREFIX_AUTHORITY_UNSPECIFIED\x10\x00\x12$\n" +
 	" SITE_PREFIX_AUTHORITY_CONFIGURED\x10\x01\x12(\n" +
@@ -68023,7 +68195,7 @@ func file_nico_nico_proto_rawDescGZIP() []byte {
 	return file_nico_nico_proto_rawDescData
 }
 
-var file_nico_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 96)
+var file_nico_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 98)
 var file_nico_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 909)
 var file_nico_nico_proto_goTypes = []any{
 	(SpdmAttestationStatus)(0),                      // 0: forge.SpdmAttestationStatus
@@ -68108,3288 +68280,3292 @@ var file_nico_nico_proto_goTypes = []any{
 	(PowerShelfComponent)(0),                                                  // 79: forge.PowerShelfComponent
 	(ComputeTrayComponent)(0),                                                 // 80: forge.ComputeTrayComponent
 	(OperatingSystemType)(0),                                                  // 81: forge.OperatingSystemType
-	(SitePrefixAuthority)(0),                                                  // 82: forge.SitePrefixAuthority
-	(SitePrefixRoutingScope)(0),                                               // 83: forge.SitePrefixRoutingScope
-	(SitePrefixLifecycleState)(0),                                             // 84: forge.SitePrefixLifecycleState
-	(InstancePowerRequest_Operation)(0),                                       // 85: forge.InstancePowerRequest.Operation
-	(InstanceUpdateStatus_Module)(0),                                          // 86: forge.InstanceUpdateStatus.Module
-	(MachineCredentialsUpdateRequest_CredentialPurpose)(0),                    // 87: forge.MachineCredentialsUpdateRequest.CredentialPurpose
-	(ForgeAgentControlResponse_LegacyAction)(0),                               // 88: forge.ForgeAgentControlResponse.LegacyAction
-	(MachineCleanupInfo_CleanupResult)(0),                                     // 89: forge.MachineCleanupInfo.CleanupResult
-	(DpuReprovisioningRequest_Mode)(0),                                        // 90: forge.DpuReprovisioningRequest.Mode
-	(HostReprovisioningRequest_Mode)(0),                                       // 91: forge.HostReprovisioningRequest.Mode
-	(MachineSetAutoUpdateRequest_SetAutoupdateAction)(0),                      // 92: forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
-	(MachineValidationOnDemandRequest_Action)(0),                              // 93: forge.MachineValidationOnDemandRequest.Action
-	(AdminPowerControlRequest_SystemPowerControl)(0),                          // 94: forge.AdminPowerControlRequest.SystemPowerControl
-	(GetRedfishJobStateResponse_RedfishJobState)(0),                           // 95: forge.GetRedfishJobStateResponse.RedfishJobState
-	(*LifecycleStatus)(nil),                                                   // 96: forge.LifecycleStatus
-	(*SpdmMachineAttestationStatus)(nil),                                      // 97: forge.SpdmMachineAttestationStatus
-	(*SpdmMachineAttestationTriggerResponse)(nil),                             // 98: forge.SpdmMachineAttestationTriggerResponse
-	(*SpdmAttestationDetails)(nil),                                            // 99: forge.SpdmAttestationDetails
-	(*SpdmGetAttestationMachineResponse)(nil),                                 // 100: forge.SpdmGetAttestationMachineResponse
-	(*SpdmMachineAttestationTriggerRequest)(nil),                              // 101: forge.SpdmMachineAttestationTriggerRequest
-	(*SpdmListAttestationMachinesRequest)(nil),                                // 102: forge.SpdmListAttestationMachinesRequest
-	(*SpdmListAttestationMachinesResponse)(nil),                               // 103: forge.SpdmListAttestationMachinesResponse
-	(*MachineIdentityRequest)(nil),                                            // 104: forge.MachineIdentityRequest
-	(*MachineIdentityResponse)(nil),                                           // 105: forge.MachineIdentityResponse
-	(*GetTenantIdentityConfigRequest)(nil),                                    // 106: forge.GetTenantIdentityConfigRequest
-	(*TenantIdentitySigningKey)(nil),                                          // 107: forge.TenantIdentitySigningKey
-	(*TenantIdentityConfig)(nil),                                              // 108: forge.TenantIdentityConfig
-	(*SetTenantIdentityConfigRequest)(nil),                                    // 109: forge.SetTenantIdentityConfigRequest
-	(*TenantIdentityConfigResponse)(nil),                                      // 110: forge.TenantIdentityConfigResponse
-	(*ClientSecretBasic)(nil),                                                 // 111: forge.ClientSecretBasic
-	(*ClientSecretBasicResponse)(nil),                                         // 112: forge.ClientSecretBasicResponse
-	(*TokenDelegationResponse)(nil),                                           // 113: forge.TokenDelegationResponse
-	(*GetTokenDelegationRequest)(nil),                                         // 114: forge.GetTokenDelegationRequest
-	(*TokenDelegation)(nil),                                                   // 115: forge.TokenDelegation
-	(*TokenDelegationRequest)(nil),                                            // 116: forge.TokenDelegationRequest
-	(*ReencryptTenantIdentitySecretsRequest)(nil),                             // 117: forge.ReencryptTenantIdentitySecretsRequest
-	(*ReencryptTenantIdentityFailure)(nil),                                    // 118: forge.ReencryptTenantIdentityFailure
-	(*ReencryptTenantIdentitySecretsResponse)(nil),                            // 119: forge.ReencryptTenantIdentitySecretsResponse
-	(*Jwks)(nil),                                                              // 120: forge.Jwks
-	(*OpenIdConfiguration)(nil),                                               // 121: forge.OpenIdConfiguration
-	(*JwksRequest)(nil),                                                       // 122: forge.JwksRequest
-	(*OpenIdConfigRequest)(nil),                                               // 123: forge.OpenIdConfigRequest
-	(*MachineIngestionStateResponse)(nil),                                     // 124: forge.MachineIngestionStateResponse
-	(*TpmCaAddedCaStatus)(nil),                                                // 125: forge.TpmCaAddedCaStatus
-	(*TpmCaCertId)(nil),                                                       // 126: forge.TpmCaCertId
-	(*TpmEkCertStatus)(nil),                                                   // 127: forge.TpmEkCertStatus
-	(*TpmEkCertStatusCollection)(nil),                                         // 128: forge.TpmEkCertStatusCollection
-	(*TpmCaCert)(nil),                                                         // 129: forge.TpmCaCert
-	(*TpmCaCertDetail)(nil),                                                   // 130: forge.TpmCaCertDetail
-	(*TpmCaCertDetailCollection)(nil),                                         // 131: forge.TpmCaCertDetailCollection
-	(*AttestKeyBindChallenge)(nil),                                            // 132: forge.AttestKeyBindChallenge
-	(*AttestQuoteRequest)(nil),                                                // 133: forge.AttestQuoteRequest
-	(*AttestQuoteResponse)(nil),                                               // 134: forge.AttestQuoteResponse
-	(*CredentialCreationRequest)(nil),                                         // 135: forge.CredentialCreationRequest
-	(*CredentialDeletionRequest)(nil),                                         // 136: forge.CredentialDeletionRequest
-	(*CredentialCreationResult)(nil),                                          // 137: forge.CredentialCreationResult
-	(*CredentialDeletionResult)(nil),                                          // 138: forge.CredentialDeletionResult
-	(*RotateCredentialRequest)(nil),                                           // 139: forge.RotateCredentialRequest
-	(*RotateCredentialResult)(nil),                                            // 140: forge.RotateCredentialResult
-	(*CredentialRotationStatusRequest)(nil),                                   // 141: forge.CredentialRotationStatusRequest
-	(*DeviceCredentialRotationStatus)(nil),                                    // 142: forge.DeviceCredentialRotationStatus
-	(*CredentialRotationStatusResult)(nil),                                    // 143: forge.CredentialRotationStatusResult
-	(*VersionRequest)(nil),                                                    // 144: forge.VersionRequest
-	(*BuildInfo)(nil),                                                         // 145: forge.BuildInfo
-	(*RuntimeConfig)(nil),                                                     // 146: forge.RuntimeConfig
-	(*EchoRequest)(nil),                                                       // 147: forge.EchoRequest
-	(*EchoResponse)(nil),                                                      // 148: forge.EchoResponse
-	(*DNSMessage)(nil),                                                        // 149: forge.DNSMessage
-	(*DnsRequest)(nil),                                                        // 150: forge.DnsRequest
-	(*DnsReply)(nil),                                                          // 151: forge.DnsReply
-	(*ConsoleInput)(nil),                                                      // 152: forge.ConsoleInput
-	(*ConsoleOutput)(nil),                                                     // 153: forge.ConsoleOutput
-	(*InstanceEvent)(nil),                                                     // 154: forge.InstanceEvent
-	(*VpcSearchQuery)(nil),                                                    // 155: forge.VpcSearchQuery
-	(*VpcSearchFilter)(nil),                                                   // 156: forge.VpcSearchFilter
-	(*VpcIdList)(nil),                                                         // 157: forge.VpcIdList
-	(*VpcsByIdsRequest)(nil),                                                  // 158: forge.VpcsByIdsRequest
-	(*TenantSearchQuery)(nil),                                                 // 159: forge.TenantSearchQuery
-	(*VpcConfig)(nil),                                                         // 160: forge.VpcConfig
-	(*VpcStatus)(nil),                                                         // 161: forge.VpcStatus
-	(*Vpc)(nil),                                                               // 162: forge.Vpc
-	(*VpcCreationRequest)(nil),                                                // 163: forge.VpcCreationRequest
-	(*VpcUpdateRequest)(nil),                                                  // 164: forge.VpcUpdateRequest
-	(*VpcUpdateResult)(nil),                                                   // 165: forge.VpcUpdateResult
-	(*VpcUpdateVirtualizationRequest)(nil),                                    // 166: forge.VpcUpdateVirtualizationRequest
-	(*VpcUpdateVirtualizationResult)(nil),                                     // 167: forge.VpcUpdateVirtualizationResult
-	(*VpcDeletionRequest)(nil),                                                // 168: forge.VpcDeletionRequest
-	(*VpcDeletionResult)(nil),                                                 // 169: forge.VpcDeletionResult
-	(*VpcList)(nil),                                                           // 170: forge.VpcList
-	(*VpcPrefix)(nil),                                                         // 171: forge.VpcPrefix
-	(*VpcPrefixConfig)(nil),                                                   // 172: forge.VpcPrefixConfig
-	(*VpcPrefixStatus)(nil),                                                   // 173: forge.VpcPrefixStatus
-	(*VpcPrefixCreationRequest)(nil),                                          // 174: forge.VpcPrefixCreationRequest
-	(*VpcPrefixSearchQuery)(nil),                                              // 175: forge.VpcPrefixSearchQuery
-	(*VpcPrefixGetRequest)(nil),                                               // 176: forge.VpcPrefixGetRequest
-	(*VpcPrefixIdList)(nil),                                                   // 177: forge.VpcPrefixIdList
-	(*VpcPrefixList)(nil),                                                     // 178: forge.VpcPrefixList
-	(*VpcPrefixUpdateRequest)(nil),                                            // 179: forge.VpcPrefixUpdateRequest
-	(*VpcPrefixDeletionRequest)(nil),                                          // 180: forge.VpcPrefixDeletionRequest
-	(*VpcPrefixDeletionResult)(nil),                                           // 181: forge.VpcPrefixDeletionResult
-	(*VpcPrefixStateHistoriesRequest)(nil),                                    // 182: forge.VpcPrefixStateHistoriesRequest
-	(*VpcPeering)(nil),                                                        // 183: forge.VpcPeering
-	(*VpcPeeringIdList)(nil),                                                  // 184: forge.VpcPeeringIdList
-	(*VpcPeeringList)(nil),                                                    // 185: forge.VpcPeeringList
-	(*VpcPeeringCreationRequest)(nil),                                         // 186: forge.VpcPeeringCreationRequest
-	(*VpcPeeringSearchFilter)(nil),                                            // 187: forge.VpcPeeringSearchFilter
-	(*VpcPeeringsByIdsRequest)(nil),                                           // 188: forge.VpcPeeringsByIdsRequest
-	(*VpcPeeringDeletionRequest)(nil),                                         // 189: forge.VpcPeeringDeletionRequest
-	(*VpcPeeringDeletionResult)(nil),                                          // 190: forge.VpcPeeringDeletionResult
-	(*IBPartitionConfig)(nil),                                                 // 191: forge.IBPartitionConfig
-	(*IBPartitionStatus)(nil),                                                 // 192: forge.IBPartitionStatus
-	(*IBPartition)(nil),                                                       // 193: forge.IBPartition
-	(*IBPartitionList)(nil),                                                   // 194: forge.IBPartitionList
-	(*IBPartitionCreationRequest)(nil),                                        // 195: forge.IBPartitionCreationRequest
-	(*IBPartitionUpdateRequest)(nil),                                          // 196: forge.IBPartitionUpdateRequest
-	(*IBPartitionDeletionRequest)(nil),                                        // 197: forge.IBPartitionDeletionRequest
-	(*IBPartitionDeletionResult)(nil),                                         // 198: forge.IBPartitionDeletionResult
-	(*IBPartitionSearchFilter)(nil),                                           // 199: forge.IBPartitionSearchFilter
-	(*IBPartitionsByIdsRequest)(nil),                                          // 200: forge.IBPartitionsByIdsRequest
-	(*IBPartitionIdList)(nil),                                                 // 201: forge.IBPartitionIdList
-	(*PowerShelfConfig)(nil),                                                  // 202: forge.PowerShelfConfig
-	(*PowerShelfStatus)(nil),                                                  // 203: forge.PowerShelfStatus
-	(*PowerShelf)(nil),                                                        // 204: forge.PowerShelf
-	(*PowerShelfList)(nil),                                                    // 205: forge.PowerShelfList
-	(*PowerShelfCreationRequest)(nil),                                         // 206: forge.PowerShelfCreationRequest
-	(*PowerShelfDeletionRequest)(nil),                                         // 207: forge.PowerShelfDeletionRequest
-	(*PowerShelfDeletionResult)(nil),                                          // 208: forge.PowerShelfDeletionResult
-	(*PowerShelfMaintenanceRequest)(nil),                                      // 209: forge.PowerShelfMaintenanceRequest
-	(*PowerShelfStateHistoriesRequest)(nil),                                   // 210: forge.PowerShelfStateHistoriesRequest
-	(*PowerShelfQuery)(nil),                                                   // 211: forge.PowerShelfQuery
-	(*PowerShelfSearchFilter)(nil),                                            // 212: forge.PowerShelfSearchFilter
-	(*PowerShelvesByIdsRequest)(nil),                                          // 213: forge.PowerShelvesByIdsRequest
-	(*ExpectedPowerShelf)(nil),                                                // 214: forge.ExpectedPowerShelf
-	(*ExpectedPowerShelfRequest)(nil),                                         // 215: forge.ExpectedPowerShelfRequest
-	(*ExpectedPowerShelfList)(nil),                                            // 216: forge.ExpectedPowerShelfList
-	(*LinkedExpectedPowerShelfList)(nil),                                      // 217: forge.LinkedExpectedPowerShelfList
-	(*LinkedExpectedPowerShelf)(nil),                                          // 218: forge.LinkedExpectedPowerShelf
-	(*SwitchConfig)(nil),                                                      // 219: forge.SwitchConfig
-	(*FabricManagerConfig)(nil),                                               // 220: forge.FabricManagerConfig
-	(*FabricManagerStatus)(nil),                                               // 221: forge.FabricManagerStatus
-	(*SwitchStatus)(nil),                                                      // 222: forge.SwitchStatus
-	(*PlacementInRack)(nil),                                                   // 223: forge.PlacementInRack
-	(*Switch)(nil),                                                            // 224: forge.Switch
-	(*SwitchList)(nil),                                                        // 225: forge.SwitchList
-	(*SwitchCreationRequest)(nil),                                             // 226: forge.SwitchCreationRequest
-	(*SwitchDeletionRequest)(nil),                                             // 227: forge.SwitchDeletionRequest
-	(*SwitchDeletionResult)(nil),                                              // 228: forge.SwitchDeletionResult
-	(*StateHistoryRecord)(nil),                                                // 229: forge.StateHistoryRecord
-	(*StateHistoryRecords)(nil),                                               // 230: forge.StateHistoryRecords
-	(*SwitchStateHistoriesRequest)(nil),                                       // 231: forge.SwitchStateHistoriesRequest
-	(*StateHistories)(nil),                                                    // 232: forge.StateHistories
-	(*SwitchQuery)(nil),                                                       // 233: forge.SwitchQuery
-	(*SwitchSearchFilter)(nil),                                                // 234: forge.SwitchSearchFilter
-	(*SwitchesByIdsRequest)(nil),                                              // 235: forge.SwitchesByIdsRequest
-	(*ExpectedSwitch)(nil),                                                    // 236: forge.ExpectedSwitch
-	(*ExpectedSwitchRequest)(nil),                                             // 237: forge.ExpectedSwitchRequest
-	(*ExpectedSwitchList)(nil),                                                // 238: forge.ExpectedSwitchList
-	(*LinkedExpectedSwitchList)(nil),                                          // 239: forge.LinkedExpectedSwitchList
-	(*LinkedExpectedSwitch)(nil),                                              // 240: forge.LinkedExpectedSwitch
-	(*ExpectedRack)(nil),                                                      // 241: forge.ExpectedRack
-	(*ExpectedRackRequest)(nil),                                               // 242: forge.ExpectedRackRequest
-	(*ExpectedRackList)(nil),                                                  // 243: forge.ExpectedRackList
-	(*IBFabricSearchFilter)(nil),                                              // 244: forge.IBFabricSearchFilter
-	(*IBFabricIdList)(nil),                                                    // 245: forge.IBFabricIdList
-	(*NetworkSegmentStateHistory)(nil),                                        // 246: forge.NetworkSegmentStateHistory
-	(*NetworkSegmentConfig)(nil),                                              // 247: forge.NetworkSegmentConfig
-	(*NetworkSegmentStatus)(nil),                                              // 248: forge.NetworkSegmentStatus
-	(*NetworkSegment)(nil),                                                    // 249: forge.NetworkSegment
-	(*NetworkSegmentCreationRequest)(nil),                                     // 250: forge.NetworkSegmentCreationRequest
-	(*NetworkSegmentDeletionRequest)(nil),                                     // 251: forge.NetworkSegmentDeletionRequest
-	(*AttachNetworkSegmentToVpcRequest)(nil),                                  // 252: forge.AttachNetworkSegmentToVpcRequest
-	(*NetworkSegmentDeletionResult)(nil),                                      // 253: forge.NetworkSegmentDeletionResult
-	(*NetworkSegmentStateHistoriesRequest)(nil),                               // 254: forge.NetworkSegmentStateHistoriesRequest
-	(*NetworkSegmentSearchConfig)(nil),                                        // 255: forge.NetworkSegmentSearchConfig
-	(*NetworkSegmentSearchFilter)(nil),                                        // 256: forge.NetworkSegmentSearchFilter
-	(*NetworkSegmentIdList)(nil),                                              // 257: forge.NetworkSegmentIdList
-	(*NetworkSegmentsByIdsRequest)(nil),                                       // 258: forge.NetworkSegmentsByIdsRequest
-	(*NetworkPrefix)(nil),                                                     // 259: forge.NetworkPrefix
-	(*MachineState)(nil),                                                      // 260: forge.MachineState
-	(*InstancePowerRequest)(nil),                                              // 261: forge.InstancePowerRequest
-	(*InstancePowerResult)(nil),                                               // 262: forge.InstancePowerResult
-	(*InstanceList)(nil),                                                      // 263: forge.InstanceList
-	(*Label)(nil),                                                             // 264: forge.Label
-	(*Metadata)(nil),                                                          // 265: forge.Metadata
-	(*InstanceSearchFilter)(nil),                                              // 266: forge.InstanceSearchFilter
-	(*InstanceIdList)(nil),                                                    // 267: forge.InstanceIdList
-	(*InstancesByIdsRequest)(nil),                                             // 268: forge.InstancesByIdsRequest
-	(*InstanceAllocationRequest)(nil),                                         // 269: forge.InstanceAllocationRequest
-	(*BatchInstanceAllocationRequest)(nil),                                    // 270: forge.BatchInstanceAllocationRequest
-	(*BatchInstanceAllocationResponse)(nil),                                   // 271: forge.BatchInstanceAllocationResponse
-	(*IpxeTemplateParameter)(nil),                                             // 272: forge.IpxeTemplateParameter
-	(*IpxeTemplateArtifact)(nil),                                              // 273: forge.IpxeTemplateArtifact
-	(*IpxeTemplate)(nil),                                                      // 274: forge.IpxeTemplate
-	(*TenantConfig)(nil),                                                      // 275: forge.TenantConfig
-	(*InstanceOperatingSystemConfig)(nil),                                     // 276: forge.InstanceOperatingSystemConfig
-	(*InlineIpxe)(nil),                                                        // 277: forge.InlineIpxe
-	(*InstanceConfig)(nil),                                                    // 278: forge.InstanceConfig
-	(*InstanceNetworkConfig)(nil),                                             // 279: forge.InstanceNetworkConfig
-	(*InstanceNetworkAutoConfig)(nil),                                         // 280: forge.InstanceNetworkAutoConfig
-	(*InstanceInfinibandConfig)(nil),                                          // 281: forge.InstanceInfinibandConfig
-	(*InstanceDpuExtensionServiceConfig)(nil),                                 // 282: forge.InstanceDpuExtensionServiceConfig
-	(*InstanceDpuExtensionServicesConfig)(nil),                                // 283: forge.InstanceDpuExtensionServicesConfig
-	(*InstanceNVLinkConfig)(nil),                                              // 284: forge.InstanceNVLinkConfig
-	(*InstanceSpxConfig)(nil),                                                 // 285: forge.InstanceSpxConfig
-	(*InstanceSpxAttachment)(nil),                                             // 286: forge.InstanceSpxAttachment
-	(*InstanceOperatingSystemUpdateRequest)(nil),                              // 287: forge.InstanceOperatingSystemUpdateRequest
-	(*InstanceConfigUpdateRequest)(nil),                                       // 288: forge.InstanceConfigUpdateRequest
-	(*InstanceStatus)(nil),                                                    // 289: forge.InstanceStatus
-	(*InstanceSpxStatus)(nil),                                                 // 290: forge.InstanceSpxStatus
-	(*InstanceSpxAttachmentStatus)(nil),                                       // 291: forge.InstanceSpxAttachmentStatus
-	(*InstanceNetworkStatus)(nil),                                             // 292: forge.InstanceNetworkStatus
-	(*InstanceInfinibandStatus)(nil),                                          // 293: forge.InstanceInfinibandStatus
-	(*DpuExtensionServiceStatus)(nil),                                         // 294: forge.DpuExtensionServiceStatus
-	(*InstanceDpuExtensionServiceStatus)(nil),                                 // 295: forge.InstanceDpuExtensionServiceStatus
-	(*InstanceDpuExtensionServicesStatus)(nil),                                // 296: forge.InstanceDpuExtensionServicesStatus
-	(*InstanceNVLinkStatus)(nil),                                              // 297: forge.InstanceNVLinkStatus
-	(*Instance)(nil),                                                          // 298: forge.Instance
-	(*InstanceUpdateStatus)(nil),                                              // 299: forge.InstanceUpdateStatus
-	(*InstanceInterfaceConfig)(nil),                                           // 300: forge.InstanceInterfaceConfig
-	(*InstanceInterfaceVpcSelection)(nil),                                     // 301: forge.InstanceInterfaceVpcSelection
-	(*InstanceInterfaceIpv6Config)(nil),                                       // 302: forge.InstanceInterfaceIpv6Config
-	(*InstanceInterfaceRoutingProfile)(nil),                                   // 303: forge.InstanceInterfaceRoutingProfile
-	(*InstanceIBInterfaceConfig)(nil),                                         // 304: forge.InstanceIBInterfaceConfig
-	(*InstanceInterfaceResolvedVpcPrefixes)(nil),                              // 305: forge.InstanceInterfaceResolvedVpcPrefixes
-	(*InstanceInterfaceStatus)(nil),                                           // 306: forge.InstanceInterfaceStatus
-	(*InstanceIBInterfaceStatus)(nil),                                         // 307: forge.InstanceIBInterfaceStatus
-	(*InstanceNVLinkGpuStatus)(nil),                                           // 308: forge.InstanceNVLinkGpuStatus
-	(*InstanceNVLinkGpuConfig)(nil),                                           // 309: forge.InstanceNVLinkGpuConfig
-	(*InstancePhoneHomeLastContactRequest)(nil),                               // 310: forge.InstancePhoneHomeLastContactRequest
-	(*InstancePhoneHomeLastContactResponse)(nil),                              // 311: forge.InstancePhoneHomeLastContactResponse
-	(*Issue)(nil),                                                             // 312: forge.Issue
-	(*DeleteInitiatedBy)(nil),                                                 // 313: forge.DeleteInitiatedBy
-	(*DeleteAttribution)(nil),                                                 // 314: forge.DeleteAttribution
-	(*InstanceReleaseRequest)(nil),                                            // 315: forge.InstanceReleaseRequest
-	(*InstanceReleaseResult)(nil),                                             // 316: forge.InstanceReleaseResult
-	(*MachinesByIdsRequest)(nil),                                              // 317: forge.MachinesByIdsRequest
-	(*MachineSearchConfig)(nil),                                               // 318: forge.MachineSearchConfig
-	(*MachineStateHistoriesRequest)(nil),                                      // 319: forge.MachineStateHistoriesRequest
-	(*MachineStateHistories)(nil),                                             // 320: forge.MachineStateHistories
-	(*MachineStateHistoryRecords)(nil),                                        // 321: forge.MachineStateHistoryRecords
-	(*MachineHealthHistoriesRequest)(nil),                                     // 322: forge.MachineHealthHistoriesRequest
-	(*HealthHistories)(nil),                                                   // 323: forge.HealthHistories
-	(*HealthHistoryRecords)(nil),                                              // 324: forge.HealthHistoryRecords
-	(*HealthHistoryRecord)(nil),                                               // 325: forge.HealthHistoryRecord
-	(*TenantByOrganizationIdsRequest)(nil),                                    // 326: forge.TenantByOrganizationIdsRequest
-	(*TenantSearchFilter)(nil),                                                // 327: forge.TenantSearchFilter
-	(*TenantList)(nil),                                                        // 328: forge.TenantList
-	(*TenantOrganizationIdList)(nil),                                          // 329: forge.TenantOrganizationIdList
-	(*InterfaceList)(nil),                                                     // 330: forge.InterfaceList
-	(*MachineList)(nil),                                                       // 331: forge.MachineList
-	(*InterfaceDeleteQuery)(nil),                                              // 332: forge.InterfaceDeleteQuery
-	(*InterfaceSearchQuery)(nil),                                              // 333: forge.InterfaceSearchQuery
-	(*AssignStaticAddressRequest)(nil),                                        // 334: forge.AssignStaticAddressRequest
-	(*AssignStaticAddressResponse)(nil),                                       // 335: forge.AssignStaticAddressResponse
-	(*RemoveStaticAddressRequest)(nil),                                        // 336: forge.RemoveStaticAddressRequest
-	(*RemoveStaticAddressResponse)(nil),                                       // 337: forge.RemoveStaticAddressResponse
-	(*FindInterfaceAddressesRequest)(nil),                                     // 338: forge.FindInterfaceAddressesRequest
-	(*InterfaceAddress)(nil),                                                  // 339: forge.InterfaceAddress
-	(*FindInterfaceAddressesResponse)(nil),                                    // 340: forge.FindInterfaceAddressesResponse
-	(*BmcInfo)(nil),                                                           // 341: forge.BmcInfo
-	(*SwitchNvosInfo)(nil),                                                    // 342: forge.SwitchNvosInfo
-	(*MachineConfig)(nil),                                                     // 343: forge.MachineConfig
-	(*MachineStatus)(nil),                                                     // 344: forge.MachineStatus
-	(*Machine)(nil),                                                           // 345: forge.Machine
-	(*DpfMachineState)(nil),                                                   // 346: forge.DpfMachineState
-	(*InstanceNetworkRestrictions)(nil),                                       // 347: forge.InstanceNetworkRestrictions
-	(*MachineMetadataUpdateRequest)(nil),                                      // 348: forge.MachineMetadataUpdateRequest
-	(*RackMetadataUpdateRequest)(nil),                                         // 349: forge.RackMetadataUpdateRequest
-	(*SwitchMetadataUpdateRequest)(nil),                                       // 350: forge.SwitchMetadataUpdateRequest
-	(*PowerShelfMetadataUpdateRequest)(nil),                                   // 351: forge.PowerShelfMetadataUpdateRequest
-	(*DpuAgentInventoryReport)(nil),                                           // 352: forge.DpuAgentInventoryReport
-	(*MachineComponentInventory)(nil),                                         // 353: forge.MachineComponentInventory
-	(*MachineInventorySoftwareComponent)(nil),                                 // 354: forge.MachineInventorySoftwareComponent
-	(*HealthSourceOrigin)(nil),                                                // 355: forge.HealthSourceOrigin
-	(*ControllerStateReason)(nil),                                             // 356: forge.ControllerStateReason
-	(*ControllerStateSourceReference)(nil),                                    // 357: forge.ControllerStateSourceReference
-	(*StateSla)(nil),                                                          // 358: forge.StateSla
-	(*InstanceTenantStatus)(nil),                                              // 359: forge.InstanceTenantStatus
-	(*MachineEvent)(nil),                                                      // 360: forge.MachineEvent
-	(*MachineInterface)(nil),                                                  // 361: forge.MachineInterface
-	(*InfinibandStatusObservation)(nil),                                       // 362: forge.InfinibandStatusObservation
-	(*MachineIbInterface)(nil),                                                // 363: forge.MachineIbInterface
-	(*DhcpDiscovery)(nil),                                                     // 364: forge.DhcpDiscovery
-	(*ExpireDhcpLeaseRequest)(nil),                                            // 365: forge.ExpireDhcpLeaseRequest
-	(*ExpireDhcpLeaseResponse)(nil),                                           // 366: forge.ExpireDhcpLeaseResponse
-	(*DhcpRecord)(nil),                                                        // 367: forge.DhcpRecord
-	(*NetworkSegmentList)(nil),                                                // 368: forge.NetworkSegmentList
-	(*SSHKeyValidationRequest)(nil),                                           // 369: forge.SSHKeyValidationRequest
-	(*SSHKeyValidationResponse)(nil),                                          // 370: forge.SSHKeyValidationResponse
-	(*GetBmcCredentialsRequest)(nil),                                          // 371: forge.GetBmcCredentialsRequest
-	(*GetSwitchNvosCredentialsRequest)(nil),                                   // 372: forge.GetSwitchNvosCredentialsRequest
-	(*GetBmcCredentialsResponse)(nil),                                         // 373: forge.GetBmcCredentialsResponse
-	(*BmcCredentials)(nil),                                                    // 374: forge.BmcCredentials
-	(*GetSiteExplorationRequest)(nil),                                         // 375: forge.GetSiteExplorationRequest
-	(*ClearSiteExplorationErrorRequest)(nil),                                  // 376: forge.ClearSiteExplorationErrorRequest
-	(*ReExploreEndpointRequest)(nil),                                          // 377: forge.ReExploreEndpointRequest
-	(*RefreshEndpointReportRequest)(nil),                                      // 378: forge.RefreshEndpointReportRequest
-	(*DeleteExploredEndpointRequest)(nil),                                     // 379: forge.DeleteExploredEndpointRequest
-	(*PauseExploredEndpointRemediationRequest)(nil),                           // 380: forge.PauseExploredEndpointRemediationRequest
-	(*DeleteExploredEndpointResponse)(nil),                                    // 381: forge.DeleteExploredEndpointResponse
-	(*BmcEndpointRequest)(nil),                                                // 382: forge.BmcEndpointRequest
-	(*SshTimeoutConfig)(nil),                                                  // 383: forge.SshTimeoutConfig
-	(*SshRequest)(nil),                                                        // 384: forge.SshRequest
-	(*CopyBfbToDpuRshimRequest)(nil),                                          // 385: forge.CopyBfbToDpuRshimRequest
-	(*UpdateMachineHardwareInfoRequest)(nil),                                  // 386: forge.UpdateMachineHardwareInfoRequest
-	(*MachineHardwareInfo)(nil),                                               // 387: forge.MachineHardwareInfo
-	(*ManagedHostNetworkConfigRequest)(nil),                                   // 388: forge.ManagedHostNetworkConfigRequest
-	(*ManagedHostNetworkConfigResponse)(nil),                                  // 389: forge.ManagedHostNetworkConfigResponse
-	(*TrafficInterceptConfig)(nil),                                            // 390: forge.TrafficInterceptConfig
-	(*TrafficInterceptBridging)(nil),                                          // 391: forge.TrafficInterceptBridging
-	(*ManagedHostDpuExtensionServiceConfig)(nil),                              // 392: forge.ManagedHostDpuExtensionServiceConfig
-	(*ManagedHostQuarantineState)(nil),                                        // 393: forge.ManagedHostQuarantineState
-	(*GetManagedHostQuarantineStateRequest)(nil),                              // 394: forge.GetManagedHostQuarantineStateRequest
-	(*GetManagedHostQuarantineStateResponse)(nil),                             // 395: forge.GetManagedHostQuarantineStateResponse
-	(*SetManagedHostQuarantineStateRequest)(nil),                              // 396: forge.SetManagedHostQuarantineStateRequest
-	(*SetManagedHostQuarantineStateResponse)(nil),                             // 397: forge.SetManagedHostQuarantineStateResponse
-	(*ClearManagedHostQuarantineStateRequest)(nil),                            // 398: forge.ClearManagedHostQuarantineStateRequest
-	(*ClearManagedHostQuarantineStateResponse)(nil),                           // 399: forge.ClearManagedHostQuarantineStateResponse
-	(*ManagedHostNetworkConfig)(nil),                                          // 400: forge.ManagedHostNetworkConfig
-	(*FlatInterfaceConfig)(nil),                                               // 401: forge.FlatInterfaceConfig
-	(*FlatInterfaceRoutingProfile)(nil),                                       // 402: forge.FlatInterfaceRoutingProfile
-	(*FlatInterfaceIpv6Config)(nil),                                           // 403: forge.FlatInterfaceIpv6Config
-	(*FlatInterfaceNetworkSecurityGroupConfig)(nil),                           // 404: forge.FlatInterfaceNetworkSecurityGroupConfig
-	(*ManagedHostNetworkStatusRequest)(nil),                                   // 405: forge.ManagedHostNetworkStatusRequest
-	(*ManagedHostNetworkStatusResponse)(nil),                                  // 406: forge.ManagedHostNetworkStatusResponse
-	(*DpuAgentUpgradeCheckRequest)(nil),                                       // 407: forge.DpuAgentUpgradeCheckRequest
-	(*DpuAgentUpgradeCheckResponse)(nil),                                      // 408: forge.DpuAgentUpgradeCheckResponse
-	(*DpuAgentUpgradePolicyRequest)(nil),                                      // 409: forge.DpuAgentUpgradePolicyRequest
-	(*DpuAgentUpgradePolicyResponse)(nil),                                     // 410: forge.DpuAgentUpgradePolicyResponse
-	(*AdminForceDeleteMachineRequest)(nil),                                    // 411: forge.AdminForceDeleteMachineRequest
-	(*AdminForceDeleteMachineResponse)(nil),                                   // 412: forge.AdminForceDeleteMachineResponse
-	(*DisableSecureBootResponse)(nil),                                         // 413: forge.DisableSecureBootResponse
-	(*LockdownRequest)(nil),                                                   // 414: forge.LockdownRequest
-	(*LockdownResponse)(nil),                                                  // 415: forge.LockdownResponse
-	(*LockdownStatusRequest)(nil),                                             // 416: forge.LockdownStatusRequest
-	(*MachineSetupStatusRequest)(nil),                                         // 417: forge.MachineSetupStatusRequest
-	(*MachineSetupRequest)(nil),                                               // 418: forge.MachineSetupRequest
-	(*MachineSetupResponse)(nil),                                              // 419: forge.MachineSetupResponse
-	(*SetDpuFirstBootOrderRequest)(nil),                                       // 420: forge.SetDpuFirstBootOrderRequest
-	(*SetDpuFirstBootOrderResponse)(nil),                                      // 421: forge.SetDpuFirstBootOrderResponse
-	(*AdminRebootRequest)(nil),                                                // 422: forge.AdminRebootRequest
-	(*AdminRebootResponse)(nil),                                               // 423: forge.AdminRebootResponse
-	(*AdminBmcResetRequest)(nil),                                              // 424: forge.AdminBmcResetRequest
-	(*AdminBmcResetResponse)(nil),                                             // 425: forge.AdminBmcResetResponse
-	(*EnableInfiniteBootRequest)(nil),                                         // 426: forge.EnableInfiniteBootRequest
-	(*EnableInfiniteBootResponse)(nil),                                        // 427: forge.EnableInfiniteBootResponse
-	(*IsInfiniteBootEnabledRequest)(nil),                                      // 428: forge.IsInfiniteBootEnabledRequest
-	(*IsInfiniteBootEnabledResponse)(nil),                                     // 429: forge.IsInfiniteBootEnabledResponse
-	(*BMCMetaDataGetRequest)(nil),                                             // 430: forge.BMCMetaDataGetRequest
-	(*BMCMetaDataGetResponse)(nil),                                            // 431: forge.BMCMetaDataGetResponse
-	(*MachineCredentialsUpdateRequest)(nil),                                   // 432: forge.MachineCredentialsUpdateRequest
-	(*MachineCredentialsUpdateResponse)(nil),                                  // 433: forge.MachineCredentialsUpdateResponse
-	(*ForgeAgentControlRequest)(nil),                                          // 434: forge.ForgeAgentControlRequest
-	(*ForgeAgentControlResponse)(nil),                                         // 435: forge.ForgeAgentControlResponse
-	(*MachineDiscoveryInfo)(nil),                                              // 436: forge.MachineDiscoveryInfo
-	(*MachineDiscoveryCompletedRequest)(nil),                                  // 437: forge.MachineDiscoveryCompletedRequest
-	(*MachineCleanupInfo)(nil),                                                // 438: forge.MachineCleanupInfo
-	(*MachineCertificate)(nil),                                                // 439: forge.MachineCertificate
-	(*MachineCertificateRenewRequest)(nil),                                    // 440: forge.MachineCertificateRenewRequest
-	(*MachineCertificateResult)(nil),                                          // 441: forge.MachineCertificateResult
-	(*MachineDiscoveryResult)(nil),                                            // 442: forge.MachineDiscoveryResult
-	(*MachineDiscoveryCompletedResponse)(nil),                                 // 443: forge.MachineDiscoveryCompletedResponse
-	(*MachineCleanupResult)(nil),                                              // 444: forge.MachineCleanupResult
-	(*ForgeScoutErrorReport)(nil),                                             // 445: forge.ForgeScoutErrorReport
-	(*ForgeScoutErrorReportResult)(nil),                                       // 446: forge.ForgeScoutErrorReportResult
-	(*PxeInstructionRequest)(nil),                                             // 447: forge.PxeInstructionRequest
-	(*PxeInstructions)(nil),                                                   // 448: forge.PxeInstructions
-	(*CloudInitDiscoveryInstructions)(nil),                                    // 449: forge.CloudInitDiscoveryInstructions
-	(*CloudInitMetaData)(nil),                                                 // 450: forge.CloudInitMetaData
-	(*CloudInitInstructionsRequest)(nil),                                      // 451: forge.CloudInitInstructionsRequest
-	(*CloudInitInstructions)(nil),                                             // 452: forge.CloudInitInstructions
-	(*DpuNetworkStatus)(nil),                                                  // 453: forge.DpuNetworkStatus
-	(*LastDhcpRequest)(nil),                                                   // 454: forge.LastDhcpRequest
-	(*DpuExtensionServiceStatusObservation)(nil),                              // 455: forge.DpuExtensionServiceStatusObservation
-	(*DpuExtensionServiceComponent)(nil),                                      // 456: forge.DpuExtensionServiceComponent
-	(*OptionalHealthReport)(nil),                                              // 457: forge.OptionalHealthReport
-	(*HealthReportEntry)(nil),                                                 // 458: forge.HealthReportEntry
-	(*InsertMachineHealthReportRequest)(nil),                                  // 459: forge.InsertMachineHealthReportRequest
-	(*InsertRackHealthReportRequest)(nil),                                     // 460: forge.InsertRackHealthReportRequest
-	(*RemoveRackHealthReportRequest)(nil),                                     // 461: forge.RemoveRackHealthReportRequest
-	(*ListRackHealthReportsRequest)(nil),                                      // 462: forge.ListRackHealthReportsRequest
-	(*InsertSwitchHealthReportRequest)(nil),                                   // 463: forge.InsertSwitchHealthReportRequest
-	(*RemoveSwitchHealthReportRequest)(nil),                                   // 464: forge.RemoveSwitchHealthReportRequest
-	(*ListSwitchHealthReportsRequest)(nil),                                    // 465: forge.ListSwitchHealthReportsRequest
-	(*InsertPowerShelfHealthReportRequest)(nil),                               // 466: forge.InsertPowerShelfHealthReportRequest
-	(*RemovePowerShelfHealthReportRequest)(nil),                               // 467: forge.RemovePowerShelfHealthReportRequest
-	(*ListPowerShelfHealthReportsRequest)(nil),                                // 468: forge.ListPowerShelfHealthReportsRequest
-	(*ListHealthReportResponse)(nil),                                          // 469: forge.ListHealthReportResponse
-	(*RemoveMachineHealthReportRequest)(nil),                                  // 470: forge.RemoveMachineHealthReportRequest
-	(*ListNVLinkDomainHealthReportsRequest)(nil),                              // 471: forge.ListNVLinkDomainHealthReportsRequest
-	(*InsertNVLinkDomainHealthReportRequest)(nil),                             // 472: forge.InsertNVLinkDomainHealthReportRequest
-	(*RemoveNVLinkDomainHealthReportRequest)(nil),                             // 473: forge.RemoveNVLinkDomainHealthReportRequest
-	(*InstanceInterfaceStatusObservation)(nil),                                // 474: forge.InstanceInterfaceStatusObservation
-	(*FabricInterfaceData)(nil),                                               // 475: forge.FabricInterfaceData
-	(*LinkData)(nil),                                                          // 476: forge.LinkData
-	(*Tenant)(nil),                                                            // 477: forge.Tenant
-	(*CreateTenantRequest)(nil),                                               // 478: forge.CreateTenantRequest
-	(*CreateTenantResponse)(nil),                                              // 479: forge.CreateTenantResponse
-	(*UpdateTenantRequest)(nil),                                               // 480: forge.UpdateTenantRequest
-	(*UpdateTenantResponse)(nil),                                              // 481: forge.UpdateTenantResponse
-	(*FindTenantRequest)(nil),                                                 // 482: forge.FindTenantRequest
-	(*FindTenantResponse)(nil),                                                // 483: forge.FindTenantResponse
-	(*TenantKeysetIdentifier)(nil),                                            // 484: forge.TenantKeysetIdentifier
-	(*TenantPublicKey)(nil),                                                   // 485: forge.TenantPublicKey
-	(*TenantKeysetContent)(nil),                                               // 486: forge.TenantKeysetContent
-	(*TenantKeyset)(nil),                                                      // 487: forge.TenantKeyset
-	(*CreateTenantKeysetRequest)(nil),                                         // 488: forge.CreateTenantKeysetRequest
-	(*CreateTenantKeysetResponse)(nil),                                        // 489: forge.CreateTenantKeysetResponse
-	(*TenantKeySetList)(nil),                                                  // 490: forge.TenantKeySetList
-	(*UpdateTenantKeysetRequest)(nil),                                         // 491: forge.UpdateTenantKeysetRequest
-	(*UpdateTenantKeysetResponse)(nil),                                        // 492: forge.UpdateTenantKeysetResponse
-	(*DeleteTenantKeysetRequest)(nil),                                         // 493: forge.DeleteTenantKeysetRequest
-	(*DeleteTenantKeysetResponse)(nil),                                        // 494: forge.DeleteTenantKeysetResponse
-	(*TenantKeysetSearchFilter)(nil),                                          // 495: forge.TenantKeysetSearchFilter
-	(*TenantKeysetIdList)(nil),                                                // 496: forge.TenantKeysetIdList
-	(*TenantKeysetsByIdsRequest)(nil),                                         // 497: forge.TenantKeysetsByIdsRequest
-	(*ValidateTenantPublicKeyRequest)(nil),                                    // 498: forge.ValidateTenantPublicKeyRequest
-	(*ValidateTenantPublicKeyResponse)(nil),                                   // 499: forge.ValidateTenantPublicKeyResponse
-	(*ListResourcePoolsRequest)(nil),                                          // 500: forge.ListResourcePoolsRequest
-	(*ResourcePools)(nil),                                                     // 501: forge.ResourcePools
-	(*ResourcePool)(nil),                                                      // 502: forge.ResourcePool
-	(*GrowResourcePoolRequest)(nil),                                           // 503: forge.GrowResourcePoolRequest
-	(*GrowResourcePoolResponse)(nil),                                          // 504: forge.GrowResourcePoolResponse
-	(*Range)(nil),                                                             // 505: forge.Range
-	(*MigrateVpcVniResponse)(nil),                                             // 506: forge.MigrateVpcVniResponse
-	(*MaintenanceRequest)(nil),                                                // 507: forge.MaintenanceRequest
-	(*SetDynamicConfigRequest)(nil),                                           // 508: forge.SetDynamicConfigRequest
-	(*FindIpAddressRequest)(nil),                                              // 509: forge.FindIpAddressRequest
-	(*FindIpAddressResponse)(nil),                                             // 510: forge.FindIpAddressResponse
-	(*IdentifyUuidRequest)(nil),                                               // 511: forge.IdentifyUuidRequest
-	(*IdentifyUuidResponse)(nil),                                              // 512: forge.IdentifyUuidResponse
-	(*FindBmcIpsRequest)(nil),                                                 // 513: forge.FindBmcIpsRequest
-	(*IdentifyMacRequest)(nil),                                                // 514: forge.IdentifyMacRequest
-	(*IdentifyMacResponse)(nil),                                               // 515: forge.IdentifyMacResponse
-	(*IdentifySerialRequest)(nil),                                             // 516: forge.IdentifySerialRequest
-	(*IdentifySerialResponse)(nil),                                            // 517: forge.IdentifySerialResponse
-	(*DpuReprovisioningRequest)(nil),                                          // 518: forge.DpuReprovisioningRequest
-	(*DpuReprovisioningListRequest)(nil),                                      // 519: forge.DpuReprovisioningListRequest
-	(*DpuReprovisioningListResponse)(nil),                                     // 520: forge.DpuReprovisioningListResponse
-	(*HostReprovisioningRequest)(nil),                                         // 521: forge.HostReprovisioningRequest
-	(*HostReprovisioningListRequest)(nil),                                     // 522: forge.HostReprovisioningListRequest
-	(*HostReprovisioningListResponse)(nil),                                    // 523: forge.HostReprovisioningListResponse
-	(*DpuOsOperationalState)(nil),                                             // 524: forge.DpuOsOperationalState
-	(*DpuRepresentorStatus)(nil),                                              // 525: forge.DpuRepresentorStatus
-	(*DpuInfoStatusObservation)(nil),                                          // 526: forge.DpuInfoStatusObservation
-	(*DpuInfo)(nil),                                                           // 527: forge.DpuInfo
-	(*GetDpuInfoListRequest)(nil),                                             // 528: forge.GetDpuInfoListRequest
-	(*GetDpuInfoListResponse)(nil),                                            // 529: forge.GetDpuInfoListResponse
-	(*IpAddressMatch)(nil),                                                    // 530: forge.IpAddressMatch
-	(*MachineBootOverride)(nil),                                               // 531: forge.MachineBootOverride
-	(*ConnectedDevice)(nil),                                                   // 532: forge.ConnectedDevice
-	(*ConnectedDeviceList)(nil),                                               // 533: forge.ConnectedDeviceList
-	(*BmcIpList)(nil),                                                         // 534: forge.BmcIpList
-	(*BmcIp)(nil),                                                             // 535: forge.BmcIp
-	(*MacAddressBmcIp)(nil),                                                   // 536: forge.MacAddressBmcIp
-	(*MachineIdBmcIpPairs)(nil),                                               // 537: forge.MachineIdBmcIpPairs
-	(*MachineIdBmcIp)(nil),                                                    // 538: forge.MachineIdBmcIp
-	(*NetworkDevice)(nil),                                                     // 539: forge.NetworkDevice
-	(*NetworkTopologyRequest)(nil),                                            // 540: forge.NetworkTopologyRequest
-	(*NetworkDeviceIdList)(nil),                                               // 541: forge.NetworkDeviceIdList
-	(*NetworkTopologyData)(nil),                                               // 542: forge.NetworkTopologyData
-	(*RouteServers)(nil),                                                      // 543: forge.RouteServers
-	(*RouteServerEntries)(nil),                                                // 544: forge.RouteServerEntries
-	(*RouteServer)(nil),                                                       // 545: forge.RouteServer
-	(*SetHostUefiPasswordRequest)(nil),                                        // 546: forge.SetHostUefiPasswordRequest
-	(*SetHostUefiPasswordResponse)(nil),                                       // 547: forge.SetHostUefiPasswordResponse
-	(*ClearHostUefiPasswordRequest)(nil),                                      // 548: forge.ClearHostUefiPasswordRequest
-	(*ClearHostUefiPasswordResponse)(nil),                                     // 549: forge.ClearHostUefiPasswordResponse
-	(*OsImageAttributes)(nil),                                                 // 550: forge.OsImageAttributes
-	(*OsImage)(nil),                                                           // 551: forge.OsImage
-	(*ListOsImageRequest)(nil),                                                // 552: forge.ListOsImageRequest
-	(*ListOsImageResponse)(nil),                                               // 553: forge.ListOsImageResponse
-	(*DeleteOsImageRequest)(nil),                                              // 554: forge.DeleteOsImageRequest
-	(*DeleteOsImageResponse)(nil),                                             // 555: forge.DeleteOsImageResponse
-	(*GetIpxeTemplateRequest)(nil),                                            // 556: forge.GetIpxeTemplateRequest
-	(*ListIpxeTemplatesRequest)(nil),                                          // 557: forge.ListIpxeTemplatesRequest
-	(*IpxeTemplateList)(nil),                                                  // 558: forge.IpxeTemplateList
-	(*ExpectedHostNic)(nil),                                                   // 559: forge.ExpectedHostNic
-	(*HostLifecycleProfile)(nil),                                              // 560: forge.HostLifecycleProfile
-	(*ExpectedMachine)(nil),                                                   // 561: forge.ExpectedMachine
-	(*ExpectedMachineRequest)(nil),                                            // 562: forge.ExpectedMachineRequest
-	(*ExpectedMachineList)(nil),                                               // 563: forge.ExpectedMachineList
-	(*LinkedExpectedMachineList)(nil),                                         // 564: forge.LinkedExpectedMachineList
-	(*LinkedExpectedMachine)(nil),                                             // 565: forge.LinkedExpectedMachine
-	(*UnexpectedMachineList)(nil),                                             // 566: forge.UnexpectedMachineList
-	(*UnexpectedMachine)(nil),                                                 // 567: forge.UnexpectedMachine
-	(*BatchExpectedMachineOperationRequest)(nil),                              // 568: forge.BatchExpectedMachineOperationRequest
-	(*ExpectedMachineOperationResult)(nil),                                    // 569: forge.ExpectedMachineOperationResult
-	(*BatchExpectedMachineOperationResponse)(nil),                             // 570: forge.BatchExpectedMachineOperationResponse
-	(*MachineRebootCompletedResponse)(nil),                                    // 571: forge.MachineRebootCompletedResponse
-	(*MachineRebootCompletedRequest)(nil),                                     // 572: forge.MachineRebootCompletedRequest
-	(*ScoutFirmwareUpgradeStatusRequest)(nil),                                 // 573: forge.ScoutFirmwareUpgradeStatusRequest
-	(*MachineValidationCompletedRequest)(nil),                                 // 574: forge.MachineValidationCompletedRequest
-	(*MachineValidationCompletedResponse)(nil),                                // 575: forge.MachineValidationCompletedResponse
-	(*MachineValidationResult)(nil),                                           // 576: forge.MachineValidationResult
-	(*MachineValidationResultPostRequest)(nil),                                // 577: forge.MachineValidationResultPostRequest
-	(*MachineValidationResultList)(nil),                                       // 578: forge.MachineValidationResultList
-	(*MachineValidationGetRequest)(nil),                                       // 579: forge.MachineValidationGetRequest
-	(*MachineValidationStatus)(nil),                                           // 580: forge.MachineValidationStatus
-	(*MachineValidationRun)(nil),                                              // 581: forge.MachineValidationRun
-	(*MachineSetAutoUpdateRequest)(nil),                                       // 582: forge.MachineSetAutoUpdateRequest
-	(*MachineSetAutoUpdateResponse)(nil),                                      // 583: forge.MachineSetAutoUpdateResponse
-	(*GetMachineValidationExternalConfigRequest)(nil),                         // 584: forge.GetMachineValidationExternalConfigRequest
-	(*MachineValidationExternalConfig)(nil),                                   // 585: forge.MachineValidationExternalConfig
-	(*GetMachineValidationExternalConfigResponse)(nil),                        // 586: forge.GetMachineValidationExternalConfigResponse
-	(*GetMachineValidationExternalConfigsRequest)(nil),                        // 587: forge.GetMachineValidationExternalConfigsRequest
-	(*GetMachineValidationExternalConfigsResponse)(nil),                       // 588: forge.GetMachineValidationExternalConfigsResponse
-	(*AddUpdateMachineValidationExternalConfigRequest)(nil),                   // 589: forge.AddUpdateMachineValidationExternalConfigRequest
-	(*RemoveMachineValidationExternalConfigRequest)(nil),                      // 590: forge.RemoveMachineValidationExternalConfigRequest
-	(*MachineValidationOnDemandRequest)(nil),                                  // 591: forge.MachineValidationOnDemandRequest
-	(*MachineValidationOnDemandResponse)(nil),                                 // 592: forge.MachineValidationOnDemandResponse
-	(*FirmwareUpgradeActivity)(nil),                                           // 593: forge.FirmwareUpgradeActivity
-	(*NvosUpdateActivity)(nil),                                                // 594: forge.NvosUpdateActivity
-	(*ConfigureNmxClusterActivity)(nil),                                       // 595: forge.ConfigureNmxClusterActivity
-	(*PowerSequenceActivity)(nil),                                             // 596: forge.PowerSequenceActivity
-	(*MaintenanceActivityConfig)(nil),                                         // 597: forge.MaintenanceActivityConfig
-	(*RackMaintenanceScope)(nil),                                              // 598: forge.RackMaintenanceScope
-	(*RackMaintenanceOnDemandRequest)(nil),                                    // 599: forge.RackMaintenanceOnDemandRequest
-	(*RackMaintenanceOnDemandResponse)(nil),                                   // 600: forge.RackMaintenanceOnDemandResponse
-	(*AdminPowerControlRequest)(nil),                                          // 601: forge.AdminPowerControlRequest
-	(*AdminPowerControlResponse)(nil),                                         // 602: forge.AdminPowerControlResponse
-	(*GetRedfishJobStateRequest)(nil),                                         // 603: forge.GetRedfishJobStateRequest
-	(*GetRedfishJobStateResponse)(nil),                                        // 604: forge.GetRedfishJobStateResponse
-	(*MachineValidationRunList)(nil),                                          // 605: forge.MachineValidationRunList
-	(*MachineValidationRunListGetRequest)(nil),                                // 606: forge.MachineValidationRunListGetRequest
-	(*MachineValidationRunItemSearchFilter)(nil),                              // 607: forge.MachineValidationRunItemSearchFilter
-	(*MachineValidationRunItemIdList)(nil),                                    // 608: forge.MachineValidationRunItemIdList
-	(*MachineValidationRunItemsByIdsRequest)(nil),                             // 609: forge.MachineValidationRunItemsByIdsRequest
-	(*MachineValidationRunItemList)(nil),                                      // 610: forge.MachineValidationRunItemList
-	(*MachineValidationRunItem)(nil),                                          // 611: forge.MachineValidationRunItem
-	(*MachineValidationAttemptGetRequest)(nil),                                // 612: forge.MachineValidationAttemptGetRequest
-	(*MachineValidationAttempt)(nil),                                          // 613: forge.MachineValidationAttempt
-	(*MachineValidationHeartbeatRequest)(nil),                                 // 614: forge.MachineValidationHeartbeatRequest
-	(*MachineValidationHeartbeatResponse)(nil),                                // 615: forge.MachineValidationHeartbeatResponse
-	(*IsBmcInManagedHostResponse)(nil),                                        // 616: forge.IsBmcInManagedHostResponse
-	(*BmcCredentialStatusResponse)(nil),                                       // 617: forge.BmcCredentialStatusResponse
-	(*MachineValidationTestsGetRequest)(nil),                                  // 618: forge.MachineValidationTestsGetRequest
-	(*MachineValidationTestUpdateRequest)(nil),                                // 619: forge.MachineValidationTestUpdateRequest
-	(*MachineValidationTestAddRequest)(nil),                                   // 620: forge.MachineValidationTestAddRequest
-	(*MachineValidationTestAddUpdateResponse)(nil),                            // 621: forge.MachineValidationTestAddUpdateResponse
-	(*MachineValidationTestsGetResponse)(nil),                                 // 622: forge.MachineValidationTestsGetResponse
-	(*MachineValidationTestVerfiedRequest)(nil),                               // 623: forge.MachineValidationTestVerfiedRequest
-	(*MachineValidationTestVerfiedResponse)(nil),                              // 624: forge.MachineValidationTestVerfiedResponse
-	(*MachineValidationTest)(nil),                                             // 625: forge.MachineValidationTest
-	(*MachineValidationTestNextVersionResponse)(nil),                          // 626: forge.MachineValidationTestNextVersionResponse
-	(*MachineValidationTestNextVersionRequest)(nil),                           // 627: forge.MachineValidationTestNextVersionRequest
-	(*MachineValidationTestEnableDisableTestRequest)(nil),                     // 628: forge.MachineValidationTestEnableDisableTestRequest
-	(*MachineValidationTestEnableDisableTestResponse)(nil),                    // 629: forge.MachineValidationTestEnableDisableTestResponse
-	(*MachineValidationRunRequest)(nil),                                       // 630: forge.MachineValidationRunRequest
-	(*MachineValidationRunResponse)(nil),                                      // 631: forge.MachineValidationRunResponse
-	(*MachineCapabilityAttributesCpu)(nil),                                    // 632: forge.MachineCapabilityAttributesCpu
-	(*MachineCapabilityAttributesGpu)(nil),                                    // 633: forge.MachineCapabilityAttributesGpu
-	(*MachineCapabilityAttributesMemory)(nil),                                 // 634: forge.MachineCapabilityAttributesMemory
-	(*MachineCapabilityAttributesStorage)(nil),                                // 635: forge.MachineCapabilityAttributesStorage
-	(*MachineCapabilityAttributesNetwork)(nil),                                // 636: forge.MachineCapabilityAttributesNetwork
-	(*MachineCapabilityAttributesInfiniband)(nil),                             // 637: forge.MachineCapabilityAttributesInfiniband
-	(*MachineCapabilityAttributesDpu)(nil),                                    // 638: forge.MachineCapabilityAttributesDpu
-	(*MachineCapabilitiesSet)(nil),                                            // 639: forge.MachineCapabilitiesSet
-	(*InstanceTypeAttributes)(nil),                                            // 640: forge.InstanceTypeAttributes
-	(*InstanceType)(nil),                                                      // 641: forge.InstanceType
-	(*InstanceTypeMachineCapabilityFilterAttributes)(nil),                     // 642: forge.InstanceTypeMachineCapabilityFilterAttributes
-	(*CreateInstanceTypeRequest)(nil),                                         // 643: forge.CreateInstanceTypeRequest
-	(*CreateInstanceTypeResponse)(nil),                                        // 644: forge.CreateInstanceTypeResponse
-	(*FindInstanceTypeIdsRequest)(nil),                                        // 645: forge.FindInstanceTypeIdsRequest
-	(*FindInstanceTypeIdsResponse)(nil),                                       // 646: forge.FindInstanceTypeIdsResponse
-	(*FindInstanceTypesByIdsRequest)(nil),                                     // 647: forge.FindInstanceTypesByIdsRequest
-	(*FindInstanceTypesByIdsResponse)(nil),                                    // 648: forge.FindInstanceTypesByIdsResponse
-	(*DeleteInstanceTypeRequest)(nil),                                         // 649: forge.DeleteInstanceTypeRequest
-	(*DeleteInstanceTypeResponse)(nil),                                        // 650: forge.DeleteInstanceTypeResponse
-	(*UpdateInstanceTypeResponse)(nil),                                        // 651: forge.UpdateInstanceTypeResponse
-	(*UpdateInstanceTypeRequest)(nil),                                         // 652: forge.UpdateInstanceTypeRequest
-	(*AssociateMachinesWithInstanceTypeRequest)(nil),                          // 653: forge.AssociateMachinesWithInstanceTypeRequest
-	(*AssociateMachinesWithInstanceTypeResponse)(nil),                         // 654: forge.AssociateMachinesWithInstanceTypeResponse
-	(*RemoveMachineInstanceTypeAssociationRequest)(nil),                       // 655: forge.RemoveMachineInstanceTypeAssociationRequest
-	(*RemoveMachineInstanceTypeAssociationResponse)(nil),                      // 656: forge.RemoveMachineInstanceTypeAssociationResponse
-	(*RedfishBrowseRequest)(nil),                                              // 657: forge.RedfishBrowseRequest
-	(*RedfishBrowseResponse)(nil),                                             // 658: forge.RedfishBrowseResponse
-	(*RedfishListActionsRequest)(nil),                                         // 659: forge.RedfishListActionsRequest
-	(*RedfishListActionsResponse)(nil),                                        // 660: forge.RedfishListActionsResponse
-	(*RedfishAction)(nil),                                                     // 661: forge.RedfishAction
-	(*OptionalRedfishActionResult)(nil),                                       // 662: forge.OptionalRedfishActionResult
-	(*RedfishActionResult)(nil),                                               // 663: forge.RedfishActionResult
-	(*RedfishCreateActionRequest)(nil),                                        // 664: forge.RedfishCreateActionRequest
-	(*RedfishCreateActionResponse)(nil),                                       // 665: forge.RedfishCreateActionResponse
-	(*RedfishActionID)(nil),                                                   // 666: forge.RedfishActionID
-	(*RedfishApproveActionResponse)(nil),                                      // 667: forge.RedfishApproveActionResponse
-	(*RedfishApplyActionResponse)(nil),                                        // 668: forge.RedfishApplyActionResponse
-	(*RedfishCancelActionResponse)(nil),                                       // 669: forge.RedfishCancelActionResponse
-	(*UfmBrowseRequest)(nil),                                                  // 670: forge.UfmBrowseRequest
-	(*UfmBrowseResponse)(nil),                                                 // 671: forge.UfmBrowseResponse
-	(*NetworkSecurityGroupAttributes)(nil),                                    // 672: forge.NetworkSecurityGroupAttributes
-	(*NetworkSecurityGroup)(nil),                                              // 673: forge.NetworkSecurityGroup
-	(*CreateNetworkSecurityGroupRequest)(nil),                                 // 674: forge.CreateNetworkSecurityGroupRequest
-	(*CreateNetworkSecurityGroupResponse)(nil),                                // 675: forge.CreateNetworkSecurityGroupResponse
-	(*FindNetworkSecurityGroupIdsRequest)(nil),                                // 676: forge.FindNetworkSecurityGroupIdsRequest
-	(*FindNetworkSecurityGroupIdsResponse)(nil),                               // 677: forge.FindNetworkSecurityGroupIdsResponse
-	(*FindNetworkSecurityGroupsByIdsRequest)(nil),                             // 678: forge.FindNetworkSecurityGroupsByIdsRequest
-	(*FindNetworkSecurityGroupsByIdsResponse)(nil),                            // 679: forge.FindNetworkSecurityGroupsByIdsResponse
-	(*UpdateNetworkSecurityGroupResponse)(nil),                                // 680: forge.UpdateNetworkSecurityGroupResponse
-	(*UpdateNetworkSecurityGroupRequest)(nil),                                 // 681: forge.UpdateNetworkSecurityGroupRequest
-	(*DeleteNetworkSecurityGroupRequest)(nil),                                 // 682: forge.DeleteNetworkSecurityGroupRequest
-	(*DeleteNetworkSecurityGroupResponse)(nil),                                // 683: forge.DeleteNetworkSecurityGroupResponse
-	(*NetworkSecurityGroupStatus)(nil),                                        // 684: forge.NetworkSecurityGroupStatus
-	(*NetworkSecurityGroupPropagationObjectStatus)(nil),                       // 685: forge.NetworkSecurityGroupPropagationObjectStatus
-	(*GetNetworkSecurityGroupPropagationStatusResponse)(nil),                  // 686: forge.GetNetworkSecurityGroupPropagationStatusResponse
-	(*NetworkSecurityGroupIdList)(nil),                                        // 687: forge.NetworkSecurityGroupIdList
-	(*GetNetworkSecurityGroupPropagationStatusRequest)(nil),                   // 688: forge.GetNetworkSecurityGroupPropagationStatusRequest
-	(*NetworkSecurityGroupRuleAttributes)(nil),                                // 689: forge.NetworkSecurityGroupRuleAttributes
-	(*ResolvedNetworkSecurityGroupRule)(nil),                                  // 690: forge.ResolvedNetworkSecurityGroupRule
-	(*GetNetworkSecurityGroupAttachmentsRequest)(nil),                         // 691: forge.GetNetworkSecurityGroupAttachmentsRequest
-	(*NetworkSecurityGroupAttachments)(nil),                                   // 692: forge.NetworkSecurityGroupAttachments
-	(*GetNetworkSecurityGroupAttachmentsResponse)(nil),                        // 693: forge.GetNetworkSecurityGroupAttachmentsResponse
-	(*GetDesiredFirmwareVersionsRequest)(nil),                                 // 694: forge.GetDesiredFirmwareVersionsRequest
-	(*GetDesiredFirmwareVersionsResponse)(nil),                                // 695: forge.GetDesiredFirmwareVersionsResponse
-	(*DesiredFirmwareVersionEntry)(nil),                                       // 696: forge.DesiredFirmwareVersionEntry
-	(*SkuComponentChassis)(nil),                                               // 697: forge.SkuComponentChassis
-	(*SkuComponentCpu)(nil),                                                   // 698: forge.SkuComponentCpu
-	(*SkuComponentGpu)(nil),                                                   // 699: forge.SkuComponentGpu
-	(*SkuComponentEthernetDevices)(nil),                                       // 700: forge.SkuComponentEthernetDevices
-	(*SkuComponentInfinibandDevices)(nil),                                     // 701: forge.SkuComponentInfinibandDevices
-	(*SkuComponentStorage)(nil),                                               // 702: forge.SkuComponentStorage
-	(*SkuComponentStorageController)(nil),                                     // 703: forge.SkuComponentStorageController
-	(*SkuComponentMemory)(nil),                                                // 704: forge.SkuComponentMemory
-	(*SkuComponentTpm)(nil),                                                   // 705: forge.SkuComponentTpm
-	(*SkuComponents)(nil),                                                     // 706: forge.SkuComponents
-	(*Sku)(nil),                                                               // 707: forge.Sku
-	(*SkuMachinePair)(nil),                                                    // 708: forge.SkuMachinePair
-	(*RemoveSkuRequest)(nil),                                                  // 709: forge.RemoveSkuRequest
-	(*SkuList)(nil),                                                           // 710: forge.SkuList
-	(*SkuIdList)(nil),                                                         // 711: forge.SkuIdList
-	(*SkuStatus)(nil),                                                         // 712: forge.SkuStatus
-	(*SkusByIdsRequest)(nil),                                                  // 713: forge.SkusByIdsRequest
-	(*SkuSearchFilter)(nil),                                                   // 714: forge.SkuSearchFilter
-	(*DpaInterface)(nil),                                                      // 715: forge.DpaInterface
-	(*DpaInterfaceCreationRequest)(nil),                                       // 716: forge.DpaInterfaceCreationRequest
-	(*DpaInterfaceIdList)(nil),                                                // 717: forge.DpaInterfaceIdList
-	(*DpaInterfacesByIdsRequest)(nil),                                         // 718: forge.DpaInterfacesByIdsRequest
-	(*DpaInterfaceList)(nil),                                                  // 719: forge.DpaInterfaceList
-	(*DpaNetworkObservationSetRequest)(nil),                                   // 720: forge.DpaNetworkObservationSetRequest
-	(*DpaInterfaceDeletionRequest)(nil),                                       // 721: forge.DpaInterfaceDeletionRequest
-	(*DpaInterfaceDeletionResult)(nil),                                        // 722: forge.DpaInterfaceDeletionResult
-	(*SkuUpdateMetadataRequest)(nil),                                          // 723: forge.SkuUpdateMetadataRequest
-	(*PowerOptionRequest)(nil),                                                // 724: forge.PowerOptionRequest
-	(*PowerOptionUpdateRequest)(nil),                                          // 725: forge.PowerOptionUpdateRequest
-	(*PowerOptions)(nil),                                                      // 726: forge.PowerOptions
-	(*PowerOptionResponse)(nil),                                               // 727: forge.PowerOptionResponse
-	(*ComputeAllocationAttributes)(nil),                                       // 728: forge.ComputeAllocationAttributes
-	(*ComputeAllocation)(nil),                                                 // 729: forge.ComputeAllocation
-	(*CreateComputeAllocationRequest)(nil),                                    // 730: forge.CreateComputeAllocationRequest
-	(*CreateComputeAllocationResponse)(nil),                                   // 731: forge.CreateComputeAllocationResponse
-	(*FindComputeAllocationIdsRequest)(nil),                                   // 732: forge.FindComputeAllocationIdsRequest
-	(*FindComputeAllocationIdsResponse)(nil),                                  // 733: forge.FindComputeAllocationIdsResponse
-	(*FindComputeAllocationsByIdsRequest)(nil),                                // 734: forge.FindComputeAllocationsByIdsRequest
-	(*FindComputeAllocationsByIdsResponse)(nil),                               // 735: forge.FindComputeAllocationsByIdsResponse
-	(*UpdateComputeAllocationResponse)(nil),                                   // 736: forge.UpdateComputeAllocationResponse
-	(*UpdateComputeAllocationRequest)(nil),                                    // 737: forge.UpdateComputeAllocationRequest
-	(*DeleteComputeAllocationRequest)(nil),                                    // 738: forge.DeleteComputeAllocationRequest
-	(*DeleteComputeAllocationResponse)(nil),                                   // 739: forge.DeleteComputeAllocationResponse
-	(*InstanceTypeAllocationStats)(nil),                                       // 740: forge.InstanceTypeAllocationStats
-	(*GetRackRequest)(nil),                                                    // 741: forge.GetRackRequest
-	(*GetRackResponse)(nil),                                                   // 742: forge.GetRackResponse
-	(*RackList)(nil),                                                          // 743: forge.RackList
-	(*RackSearchFilter)(nil),                                                  // 744: forge.RackSearchFilter
-	(*RackIdList)(nil),                                                        // 745: forge.RackIdList
-	(*RacksByIdsRequest)(nil),                                                 // 746: forge.RacksByIdsRequest
-	(*Rack)(nil),                                                              // 747: forge.Rack
-	(*RackConfig)(nil),                                                        // 748: forge.RackConfig
-	(*RackStatus)(nil),                                                        // 749: forge.RackStatus
-	(*RackStateHistoriesRequest)(nil),                                         // 750: forge.RackStateHistoriesRequest
-	(*DeleteRackRequest)(nil),                                                 // 751: forge.DeleteRackRequest
-	(*AdminForceDeleteRackRequest)(nil),                                       // 752: forge.AdminForceDeleteRackRequest
-	(*AdminForceDeleteRackResponse)(nil),                                      // 753: forge.AdminForceDeleteRackResponse
-	(*RackCapabilityCompute)(nil),                                             // 754: forge.RackCapabilityCompute
-	(*RackCapabilitySwitch)(nil),                                              // 755: forge.RackCapabilitySwitch
-	(*RackCapabilityPowerShelf)(nil),                                          // 756: forge.RackCapabilityPowerShelf
-	(*RackCapabilitiesSet)(nil),                                               // 757: forge.RackCapabilitiesSet
-	(*RackProfile)(nil),                                                       // 758: forge.RackProfile
-	(*GetRackProfileRequest)(nil),                                             // 759: forge.GetRackProfileRequest
-	(*GetRackProfileResponse)(nil),                                            // 760: forge.GetRackProfileResponse
-	(*RackManagerForgeRequest)(nil),                                           // 761: forge.RackManagerForgeRequest
-	(*RackManagerForgeResponse)(nil),                                          // 762: forge.RackManagerForgeResponse
-	(*MachineNVLinkInfo)(nil),                                                 // 763: forge.MachineNVLinkInfo
-	(*UpdateMachineNvLinkInfoRequest)(nil),                                    // 764: forge.UpdateMachineNvLinkInfoRequest
-	(*MachineSpxStatusObservation)(nil),                                       // 765: forge.MachineSpxStatusObservation
-	(*MachineSpxAttachmentStatusObservation)(nil),                             // 766: forge.MachineSpxAttachmentStatusObservation
-	(*AstraConfig)(nil),                                                       // 767: forge.AstraConfig
-	(*AstraAttachment)(nil),                                                   // 768: forge.AstraAttachment
-	(*AstraConfigStatus)(nil),                                                 // 769: forge.AstraConfigStatus
-	(*AstraAttachmentStatus)(nil),                                             // 770: forge.AstraAttachmentStatus
-	(*AstraStatus)(nil),                                                       // 771: forge.AstraStatus
-	(*NVLinkGpu)(nil),                                                         // 772: forge.NVLinkGpu
-	(*MachineNVLinkStatusObservation)(nil),                                    // 773: forge.MachineNVLinkStatusObservation
-	(*MachineNVLinkGpuStatusObservation)(nil),                                 // 774: forge.MachineNVLinkGpuStatusObservation
-	(*NmxcBrowseRequest)(nil),                                                 // 775: forge.NmxcBrowseRequest
-	(*NmxcBrowseResponse)(nil),                                                // 776: forge.NmxcBrowseResponse
-	(*NVLinkPartition)(nil),                                                   // 777: forge.NVLinkPartition
-	(*NVLinkPartitionList)(nil),                                               // 778: forge.NVLinkPartitionList
-	(*NVLinkPartitionSearchConfig)(nil),                                       // 779: forge.NVLinkPartitionSearchConfig
-	(*NVLinkPartitionQuery)(nil),                                              // 780: forge.NVLinkPartitionQuery
-	(*NVLinkPartitionSearchFilter)(nil),                                       // 781: forge.NVLinkPartitionSearchFilter
-	(*NVLinkPartitionsByIdsRequest)(nil),                                      // 782: forge.NVLinkPartitionsByIdsRequest
-	(*NVLinkPartitionIdList)(nil),                                             // 783: forge.NVLinkPartitionIdList
-	(*NVLinkFabricSearchFilter)(nil),                                          // 784: forge.NVLinkFabricSearchFilter
-	(*NVLinkLogicalPartitionConfig)(nil),                                      // 785: forge.NVLinkLogicalPartitionConfig
-	(*NVLinkLogicalPartitionStatus)(nil),                                      // 786: forge.NVLinkLogicalPartitionStatus
-	(*NVLinkLogicalPartition)(nil),                                            // 787: forge.NVLinkLogicalPartition
-	(*NVLinkLogicalPartitionList)(nil),                                        // 788: forge.NVLinkLogicalPartitionList
-	(*NVLinkLogicalPartitionCreationRequest)(nil),                             // 789: forge.NVLinkLogicalPartitionCreationRequest
-	(*NVLinkLogicalPartitionDeletionRequest)(nil),                             // 790: forge.NVLinkLogicalPartitionDeletionRequest
-	(*NVLinkLogicalPartitionDeletionResult)(nil),                              // 791: forge.NVLinkLogicalPartitionDeletionResult
-	(*NVLinkLogicalPartitionSearchFilter)(nil),                                // 792: forge.NVLinkLogicalPartitionSearchFilter
-	(*NVLinkLogicalPartitionsByIdsRequest)(nil),                               // 793: forge.NVLinkLogicalPartitionsByIdsRequest
-	(*NVLinkLogicalPartitionIdList)(nil),                                      // 794: forge.NVLinkLogicalPartitionIdList
-	(*NVLinkLogicalPartitionUpdateRequest)(nil),                               // 795: forge.NVLinkLogicalPartitionUpdateRequest
-	(*NVLinkLogicalPartitionUpdateResult)(nil),                                // 796: forge.NVLinkLogicalPartitionUpdateResult
-	(*CreateBmcUserRequest)(nil),                                              // 797: forge.CreateBmcUserRequest
-	(*CreateBmcUserResponse)(nil),                                             // 798: forge.CreateBmcUserResponse
-	(*DeleteBmcUserRequest)(nil),                                              // 799: forge.DeleteBmcUserRequest
-	(*DeleteBmcUserResponse)(nil),                                             // 800: forge.DeleteBmcUserResponse
-	(*SetBmcRootPasswordRequest)(nil),                                         // 801: forge.SetBmcRootPasswordRequest
-	(*SetBmcRootPasswordResponse)(nil),                                        // 802: forge.SetBmcRootPasswordResponse
-	(*ProbeBmcVendorRequest)(nil),                                             // 803: forge.ProbeBmcVendorRequest
-	(*ProbeBmcVendorResponse)(nil),                                            // 804: forge.ProbeBmcVendorResponse
-	(*SetFirmwareUpdateTimeWindowRequest)(nil),                                // 805: forge.SetFirmwareUpdateTimeWindowRequest
-	(*SetFirmwareUpdateTimeWindowResponse)(nil),                               // 806: forge.SetFirmwareUpdateTimeWindowResponse
-	(*UpsertHostFirmwareConfigRequest)(nil),                                   // 807: forge.UpsertHostFirmwareConfigRequest
-	(*DeleteHostFirmwareConfigRequest)(nil),                                   // 808: forge.DeleteHostFirmwareConfigRequest
-	(*UpsertHostFirmwareComponentConfig)(nil),                                 // 809: forge.UpsertHostFirmwareComponentConfig
-	(*HostFirmwareComponentConfigResponse)(nil),                               // 810: forge.HostFirmwareComponentConfigResponse
-	(*HostFirmwareVersionConfig)(nil),                                         // 811: forge.HostFirmwareVersionConfig
-	(*HostFirmwareArtifact)(nil),                                              // 812: forge.HostFirmwareArtifact
-	(*HostFirmwareConfigResponse)(nil),                                        // 813: forge.HostFirmwareConfigResponse
-	(*ListHostFirmwareRequest)(nil),                                           // 814: forge.ListHostFirmwareRequest
-	(*ListHostFirmwareResponse)(nil),                                          // 815: forge.ListHostFirmwareResponse
-	(*AvailableHostFirmware)(nil),                                             // 816: forge.AvailableHostFirmware
-	(*TrimTableRequest)(nil),                                                  // 817: forge.TrimTableRequest
-	(*TrimTableResponse)(nil),                                                 // 818: forge.TrimTableResponse
-	(*NvlinkNmxcEndpoint)(nil),                                                // 819: forge.NvlinkNmxcEndpoint
-	(*NvlinkNmxcEndpointList)(nil),                                            // 820: forge.NvlinkNmxcEndpointList
-	(*DeleteNvlinkNmxcEndpointRequest)(nil),                                   // 821: forge.DeleteNvlinkNmxcEndpointRequest
-	(*CreateRemediationRequest)(nil),                                          // 822: forge.CreateRemediationRequest
-	(*CreateRemediationResponse)(nil),                                         // 823: forge.CreateRemediationResponse
-	(*RemediationIdList)(nil),                                                 // 824: forge.RemediationIdList
-	(*RemediationList)(nil),                                                   // 825: forge.RemediationList
-	(*Remediation)(nil),                                                       // 826: forge.Remediation
-	(*ApproveRemediationRequest)(nil),                                         // 827: forge.ApproveRemediationRequest
-	(*RevokeRemediationRequest)(nil),                                          // 828: forge.RevokeRemediationRequest
-	(*EnableRemediationRequest)(nil),                                          // 829: forge.EnableRemediationRequest
-	(*DisableRemediationRequest)(nil),                                         // 830: forge.DisableRemediationRequest
-	(*FindAppliedRemediationIdsRequest)(nil),                                  // 831: forge.FindAppliedRemediationIdsRequest
-	(*AppliedRemediationIdList)(nil),                                          // 832: forge.AppliedRemediationIdList
-	(*FindAppliedRemediationsRequest)(nil),                                    // 833: forge.FindAppliedRemediationsRequest
-	(*AppliedRemediation)(nil),                                                // 834: forge.AppliedRemediation
-	(*AppliedRemediationList)(nil),                                            // 835: forge.AppliedRemediationList
-	(*GetNextRemediationForMachineRequest)(nil),                               // 836: forge.GetNextRemediationForMachineRequest
-	(*GetNextRemediationForMachineResponse)(nil),                              // 837: forge.GetNextRemediationForMachineResponse
-	(*RemediationAppliedRequest)(nil),                                         // 838: forge.RemediationAppliedRequest
-	(*RemediationApplicationStatus)(nil),                                      // 839: forge.RemediationApplicationStatus
-	(*SetPrimaryDpuRequest)(nil),                                              // 840: forge.SetPrimaryDpuRequest
-	(*SetPrimaryInterfaceRequest)(nil),                                        // 841: forge.SetPrimaryInterfaceRequest
-	(*UsernamePassword)(nil),                                                  // 842: forge.UsernamePassword
-	(*SessionToken)(nil),                                                      // 843: forge.SessionToken
-	(*DpuExtensionServiceCredential)(nil),                                     // 844: forge.DpuExtensionServiceCredential
-	(*DpuExtensionServiceVersionInfo)(nil),                                    // 845: forge.DpuExtensionServiceVersionInfo
-	(*DpuExtensionService)(nil),                                               // 846: forge.DpuExtensionService
-	(*CreateDpuExtensionServiceRequest)(nil),                                  // 847: forge.CreateDpuExtensionServiceRequest
-	(*UpdateDpuExtensionServiceRequest)(nil),                                  // 848: forge.UpdateDpuExtensionServiceRequest
-	(*DeleteDpuExtensionServiceRequest)(nil),                                  // 849: forge.DeleteDpuExtensionServiceRequest
-	(*DeleteDpuExtensionServiceResponse)(nil),                                 // 850: forge.DeleteDpuExtensionServiceResponse
-	(*DpuExtensionServiceSearchFilter)(nil),                                   // 851: forge.DpuExtensionServiceSearchFilter
-	(*DpuExtensionServiceIdList)(nil),                                         // 852: forge.DpuExtensionServiceIdList
-	(*DpuExtensionServicesByIdsRequest)(nil),                                  // 853: forge.DpuExtensionServicesByIdsRequest
-	(*DpuExtensionServiceList)(nil),                                           // 854: forge.DpuExtensionServiceList
-	(*GetDpuExtensionServiceVersionsInfoRequest)(nil),                         // 855: forge.GetDpuExtensionServiceVersionsInfoRequest
-	(*DpuExtensionServiceVersionInfoList)(nil),                                // 856: forge.DpuExtensionServiceVersionInfoList
-	(*FindInstancesByDpuExtensionServiceRequest)(nil),                         // 857: forge.FindInstancesByDpuExtensionServiceRequest
-	(*FindInstancesByDpuExtensionServiceResponse)(nil),                        // 858: forge.FindInstancesByDpuExtensionServiceResponse
-	(*InstanceDpuExtensionServiceInfo)(nil),                                   // 859: forge.InstanceDpuExtensionServiceInfo
-	(*DpuExtensionServiceObservabilityConfigPrometheus)(nil),                  // 860: forge.DpuExtensionServiceObservabilityConfigPrometheus
-	(*DpuExtensionServiceObservabilityConfigLogging)(nil),                     // 861: forge.DpuExtensionServiceObservabilityConfigLogging
-	(*DpuExtensionServiceObservabilityConfig)(nil),                            // 862: forge.DpuExtensionServiceObservabilityConfig
-	(*DpuExtensionServiceObservability)(nil),                                  // 863: forge.DpuExtensionServiceObservability
-	(*ScoutStreamApiBoundMessage)(nil),                                        // 864: forge.ScoutStreamApiBoundMessage
-	(*ScoutStreamScoutBoundMessage)(nil),                                      // 865: forge.ScoutStreamScoutBoundMessage
-	(*ScoutStreamInitRequest)(nil),                                            // 866: forge.ScoutStreamInitRequest
-	(*ScoutStreamShowConnectionsRequest)(nil),                                 // 867: forge.ScoutStreamShowConnectionsRequest
-	(*ScoutStreamShowConnectionsResponse)(nil),                                // 868: forge.ScoutStreamShowConnectionsResponse
-	(*ScoutStreamDisconnectRequest)(nil),                                      // 869: forge.ScoutStreamDisconnectRequest
-	(*ScoutStreamDisconnectResponse)(nil),                                     // 870: forge.ScoutStreamDisconnectResponse
-	(*ScoutStreamAdminPingRequest)(nil),                                       // 871: forge.ScoutStreamAdminPingRequest
-	(*ScoutStreamAdminPingResponse)(nil),                                      // 872: forge.ScoutStreamAdminPingResponse
-	(*ScoutStreamAgentPingRequest)(nil),                                       // 873: forge.ScoutStreamAgentPingRequest
-	(*ScoutStreamAgentPingResponse)(nil),                                      // 874: forge.ScoutStreamAgentPingResponse
-	(*ScoutStreamConnectionInfo)(nil),                                         // 875: forge.ScoutStreamConnectionInfo
-	(*ScoutStreamError)(nil),                                                  // 876: forge.ScoutStreamError
-	(*PrefixFilterPolicyEntry)(nil),                                           // 877: forge.PrefixFilterPolicyEntry
-	(*RoutingProfile)(nil),                                                    // 878: forge.RoutingProfile
-	(*DomainLegacy)(nil),                                                      // 879: forge.DomainLegacy
-	(*DomainListLegacy)(nil),                                                  // 880: forge.DomainListLegacy
-	(*DomainDeletionLegacy)(nil),                                              // 881: forge.DomainDeletionLegacy
-	(*DomainDeletionResultLegacy)(nil),                                        // 882: forge.DomainDeletionResultLegacy
-	(*DomainSearchQueryLegacy)(nil),                                           // 883: forge.DomainSearchQueryLegacy
-	(*PxeDomain)(nil),                                                         // 884: forge.PxeDomain
-	(*MachinePositionQuery)(nil),                                              // 885: forge.MachinePositionQuery
-	(*MachinePositionInfoList)(nil),                                           // 886: forge.MachinePositionInfoList
-	(*MachinePositionInfo)(nil),                                               // 887: forge.MachinePositionInfo
-	(*ModifyDPFStateRequest)(nil),                                             // 888: forge.ModifyDPFStateRequest
-	(*DPFStateResponse)(nil),                                                  // 889: forge.DPFStateResponse
-	(*GetDPFStateRequest)(nil),                                                // 890: forge.GetDPFStateRequest
-	(*GetDPFHostSnapshotRequest)(nil),                                         // 891: forge.GetDPFHostSnapshotRequest
-	(*DPFHostSnapshotResponse)(nil),                                           // 892: forge.DPFHostSnapshotResponse
-	(*GetDPFServiceVersionsRequest)(nil),                                      // 893: forge.GetDPFServiceVersionsRequest
-	(*DPFServiceVersion)(nil),                                                 // 894: forge.DPFServiceVersion
-	(*DPFServiceVersionsResponse)(nil),                                        // 895: forge.DPFServiceVersionsResponse
-	(*ComponentResult)(nil),                                                   // 896: forge.ComponentResult
-	(*SwitchIdList)(nil),                                                      // 897: forge.SwitchIdList
-	(*PowerShelfIdList)(nil),                                                  // 898: forge.PowerShelfIdList
-	(*GetComponentInventoryRequest)(nil),                                      // 899: forge.GetComponentInventoryRequest
-	(*ComponentInventoryEntry)(nil),                                           // 900: forge.ComponentInventoryEntry
-	(*GetComponentInventoryResponse)(nil),                                     // 901: forge.GetComponentInventoryResponse
-	(*ComponentPowerControlRequest)(nil),                                      // 902: forge.ComponentPowerControlRequest
-	(*ComponentPowerControlResponse)(nil),                                     // 903: forge.ComponentPowerControlResponse
-	(*ComponentConfigureSwitchCertificateRequest)(nil),                        // 904: forge.ComponentConfigureSwitchCertificateRequest
-	(*ComponentConfigureSwitchCertificateResponse)(nil),                       // 905: forge.ComponentConfigureSwitchCertificateResponse
-	(*FirmwareUpdateStatus)(nil),                                              // 906: forge.FirmwareUpdateStatus
-	(*UpdateComputeTrayFirmwareTarget)(nil),                                   // 907: forge.UpdateComputeTrayFirmwareTarget
-	(*UpdateSwitchFirmwareTarget)(nil),                                        // 908: forge.UpdateSwitchFirmwareTarget
-	(*UpdatePowerShelfFirmwareTarget)(nil),                                    // 909: forge.UpdatePowerShelfFirmwareTarget
-	(*UpdateFirmwareObjectTarget)(nil),                                        // 910: forge.UpdateFirmwareObjectTarget
-	(*UpdateComponentFirmwareRequest)(nil),                                    // 911: forge.UpdateComponentFirmwareRequest
-	(*UpdateComponentFirmwareResponse)(nil),                                   // 912: forge.UpdateComponentFirmwareResponse
-	(*GetComponentFirmwareStatusRequest)(nil),                                 // 913: forge.GetComponentFirmwareStatusRequest
-	(*GetComponentFirmwareStatusResponse)(nil),                                // 914: forge.GetComponentFirmwareStatusResponse
-	(*ListComponentFirmwareVersionsRequest)(nil),                              // 915: forge.ListComponentFirmwareVersionsRequest
-	(*ComputeTrayFirmwareVersions)(nil),                                       // 916: forge.ComputeTrayFirmwareVersions
-	(*DeviceFirmwareVersions)(nil),                                            // 917: forge.DeviceFirmwareVersions
-	(*ListComponentFirmwareVersionsResponse)(nil),                             // 918: forge.ListComponentFirmwareVersionsResponse
-	(*SpxPartitionCreationRequest)(nil),                                       // 919: forge.SpxPartitionCreationRequest
-	(*SpxPartition)(nil),                                                      // 920: forge.SpxPartition
-	(*SpxPartitionIdList)(nil),                                                // 921: forge.SpxPartitionIdList
-	(*SpxPartitionDeletionRequest)(nil),                                       // 922: forge.SpxPartitionDeletionRequest
-	(*SpxPartitionDeletionResult)(nil),                                        // 923: forge.SpxPartitionDeletionResult
-	(*SpxPartitionSearchFilter)(nil),                                          // 924: forge.SpxPartitionSearchFilter
-	(*SpxPartitionList)(nil),                                                  // 925: forge.SpxPartitionList
-	(*SpxPartitionsByIdsRequest)(nil),                                         // 926: forge.SpxPartitionsByIdsRequest
-	(*AdminForceDeleteSwitchRequest)(nil),                                     // 927: forge.AdminForceDeleteSwitchRequest
-	(*AdminForceDeleteSwitchResponse)(nil),                                    // 928: forge.AdminForceDeleteSwitchResponse
-	(*AdminForceDeletePowerShelfRequest)(nil),                                 // 929: forge.AdminForceDeletePowerShelfRequest
-	(*AdminForceDeletePowerShelfResponse)(nil),                                // 930: forge.AdminForceDeletePowerShelfResponse
-	(*OperatingSystem)(nil),                                                   // 931: forge.OperatingSystem
-	(*CreateOperatingSystemRequest)(nil),                                      // 932: forge.CreateOperatingSystemRequest
-	(*IpxeTemplateParameters)(nil),                                            // 933: forge.IpxeTemplateParameters
-	(*IpxeTemplateArtifacts)(nil),                                             // 934: forge.IpxeTemplateArtifacts
-	(*UpdateOperatingSystemRequest)(nil),                                      // 935: forge.UpdateOperatingSystemRequest
-	(*DeleteOperatingSystemRequest)(nil),                                      // 936: forge.DeleteOperatingSystemRequest
-	(*DeleteOperatingSystemResponse)(nil),                                     // 937: forge.DeleteOperatingSystemResponse
-	(*OperatingSystemSearchFilter)(nil),                                       // 938: forge.OperatingSystemSearchFilter
-	(*OperatingSystemIdList)(nil),                                             // 939: forge.OperatingSystemIdList
-	(*OperatingSystemsByIdsRequest)(nil),                                      // 940: forge.OperatingSystemsByIdsRequest
-	(*OperatingSystemList)(nil),                                               // 941: forge.OperatingSystemList
-	(*GetOperatingSystemCachableIpxeTemplateArtifactsRequest)(nil),            // 942: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	(*IpxeTemplateArtifactList)(nil),                                          // 943: forge.IpxeTemplateArtifactList
-	(*IpxeTemplateArtifactUpdateRequest)(nil),                                 // 944: forge.IpxeTemplateArtifactUpdateRequest
-	(*UpdateOperatingSystemIpxeTemplateArtifactRequest)(nil),                  // 945: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	(*HostRepresentorInterceptBridging)(nil),                                  // 946: forge.HostRepresentorInterceptBridging
-	(*ReWrapSecretsRequest)(nil),                                              // 947: forge.ReWrapSecretsRequest
-	(*ReWrapSecretsResponse)(nil),                                             // 948: forge.ReWrapSecretsResponse
-	(*GetMachineBootInterfacesRequest)(nil),                                   // 949: forge.GetMachineBootInterfacesRequest
-	(*MachineBootInterface)(nil),                                              // 950: forge.MachineBootInterface
-	(*MachineInterfaceBootInterface)(nil),                                     // 951: forge.MachineInterfaceBootInterface
-	(*PredictedBootInterface)(nil),                                            // 952: forge.PredictedBootInterface
-	(*ExploredBootInterface)(nil),                                             // 953: forge.ExploredBootInterface
-	(*RetainedBootInterface)(nil),                                             // 954: forge.RetainedBootInterface
-	(*GetMachineBootInterfacesResponse)(nil),                                  // 955: forge.GetMachineBootInterfacesResponse
-	(*GetContainerRegistryCredentialRequest)(nil),                             // 956: forge.GetContainerRegistryCredentialRequest
-	(*GetContainerRegistryCredentialResponse)(nil),                            // 957: forge.GetContainerRegistryCredentialResponse
-	(*SetContainerRegistryCredentialRequest)(nil),                             // 958: forge.SetContainerRegistryCredentialRequest
-	(*SitePrefix)(nil),                                                        // 959: forge.SitePrefix
-	(*SitePrefixConfig)(nil),                                                  // 960: forge.SitePrefixConfig
-	(*SitePrefixStatus)(nil),                                                  // 961: forge.SitePrefixStatus
-	(*SitePrefixSearchFilter)(nil),                                            // 962: forge.SitePrefixSearchFilter
-	(*SitePrefixesByIdsRequest)(nil),                                          // 963: forge.SitePrefixesByIdsRequest
-	(*SitePrefixIdList)(nil),                                                  // 964: forge.SitePrefixIdList
-	(*SitePrefixList)(nil),                                                    // 965: forge.SitePrefixList
-	nil,                                                                       // 966: forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
-	(*DNSMessage_DNSQuestion)(nil),                                            // 967: forge.DNSMessage.DNSQuestion
-	(*DNSMessage_DNSResponse)(nil),                                            // 968: forge.DNSMessage.DNSResponse
-	(*DNSMessage_DNSResponse_DNSRR)(nil),                                      // 969: forge.DNSMessage.DNSResponse.DNSRR
-	nil,                                                                       // 970: forge.FabricManagerConfig.ConfigMapEntry
-	nil,                                                                       // 971: forge.StateHistories.HistoriesEntry
-	nil,                                                                       // 972: forge.MachineStateHistories.HistoriesEntry
-	nil,                                                                       // 973: forge.HealthHistories.HistoriesEntry
-	nil,                                                                       // 974: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
-	(*MachineCredentialsUpdateRequest_Credentials)(nil),                       // 975: forge.MachineCredentialsUpdateRequest.Credentials
-	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo)(nil),              // 976: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
-	(*ForgeAgentControlResponse_Noop)(nil),                                    // 977: forge.ForgeAgentControlResponse.Noop
-	(*ForgeAgentControlResponse_Reset)(nil),                                   // 978: forge.ForgeAgentControlResponse.Reset
-	(*ForgeAgentControlResponse_Discovery)(nil),                               // 979: forge.ForgeAgentControlResponse.Discovery
-	(*ForgeAgentControlResponse_Rebuild)(nil),                                 // 980: forge.ForgeAgentControlResponse.Rebuild
-	(*ForgeAgentControlResponse_Retry)(nil),                                   // 981: forge.ForgeAgentControlResponse.Retry
-	(*ForgeAgentControlResponse_Measure)(nil),                                 // 982: forge.ForgeAgentControlResponse.Measure
-	(*ForgeAgentControlResponse_LogError)(nil),                                // 983: forge.ForgeAgentControlResponse.LogError
-	(*ForgeAgentControlResponse_MachineValidation)(nil),                       // 984: forge.ForgeAgentControlResponse.MachineValidation
-	(*ForgeAgentControlResponse_MachineValidationFilter)(nil),                 // 985: forge.ForgeAgentControlResponse.MachineValidationFilter
-	(*ForgeAgentControlResponse_MlxAction)(nil),                               // 986: forge.ForgeAgentControlResponse.MlxAction
-	(*ForgeAgentControlResponse_MlxDeviceAction)(nil),                         // 987: forge.ForgeAgentControlResponse.MlxDeviceAction
-	(*ForgeAgentControlResponse_MlxDeviceNoop)(nil),                           // 988: forge.ForgeAgentControlResponse.MlxDeviceNoop
-	(*ForgeAgentControlResponse_MlxDeviceLock)(nil),                           // 989: forge.ForgeAgentControlResponse.MlxDeviceLock
-	(*ForgeAgentControlResponse_MlxDeviceUnlock)(nil),                         // 990: forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	(*ForgeAgentControlResponse_MlxDeviceApplyProfile)(nil),                   // 991: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	(*ForgeAgentControlResponse_MlxDeviceApplyFirmware)(nil),                  // 992: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	(*ForgeAgentControlResponse_FirmwareUpgrade)(nil),                         // 993: forge.ForgeAgentControlResponse.FirmwareUpgrade
-	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair)(nil), // 994: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	(*MachineCleanupInfo_CleanupStepResult)(nil),                              // 995: forge.MachineCleanupInfo.CleanupStepResult
-	(*DpuReprovisioningListResponse_DpuReprovisioningListItem)(nil),           // 996: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
-	(*HostReprovisioningListResponse_HostReprovisioningListItem)(nil),         // 997: forge.HostReprovisioningListResponse.HostReprovisioningListItem
-	(*MachineValidationTestUpdateRequest_Payload)(nil),                        // 998: forge.MachineValidationTestUpdateRequest.Payload
-	nil,                                                  // 999: forge.RedfishBrowseResponse.HeadersEntry
-	nil,                                                  // 1000: forge.RedfishActionResult.HeadersEntry
-	nil,                                                  // 1001: forge.UfmBrowseResponse.HeadersEntry
-	nil,                                                  // 1002: forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
-	nil,                                                  // 1003: forge.NmxcBrowseResponse.HeadersEntry
-	(*DPFStateResponse_DPFState)(nil),                    // 1004: forge.DPFStateResponse.DPFState
-	(*MachineId)(nil),                                    // 1005: common.MachineId
-	(*timestamppb.Timestamp)(nil),                        // 1006: google.protobuf.Timestamp
-	(*VpcId)(nil),                                        // 1007: common.VpcId
-	(*NVLinkLogicalPartitionId)(nil),                     // 1008: common.NVLinkLogicalPartitionId
-	(*VpcPrefixId)(nil),                                  // 1009: common.VpcPrefixId
-	(*VpcPeeringId)(nil),                                 // 1010: common.VpcPeeringId
-	(*IBPartitionId)(nil),                                // 1011: common.IBPartitionId
-	(*HealthReport)(nil),                                 // 1012: health.HealthReport
-	(*PowerShelfId)(nil),                                 // 1013: common.PowerShelfId
-	(*RackId)(nil),                                       // 1014: common.RackId
-	(*UUID)(nil),                                         // 1015: common.UUID
-	(*SwitchId)(nil),                                     // 1016: common.SwitchId
-	(*RackProfileId)(nil),                                // 1017: common.RackProfileId
-	(*DomainId)(nil),                                     // 1018: common.DomainId
-	(*NetworkSegmentId)(nil),                             // 1019: common.NetworkSegmentId
-	(*NetworkPrefixId)(nil),                              // 1020: common.NetworkPrefixId
-	(*InstanceId)(nil),                                   // 1021: common.InstanceId
-	(*IpxeTemplateId)(nil),                               // 1022: common.IpxeTemplateId
-	(*OperatingSystemId)(nil),                            // 1023: common.OperatingSystemId
-	(*SpxPartitionId)(nil),                               // 1024: common.SpxPartitionId
-	(*NVLinkDomainId)(nil),                               // 1025: common.NVLinkDomainId
-	(*MachineInterfaceId)(nil),                           // 1026: common.MachineInterfaceId
-	(*DiscoveryInfo)(nil),                                // 1027: machine_discovery.DiscoveryInfo
-	(*durationpb.Duration)(nil),                          // 1028: google.protobuf.Duration
-	(*StringList)(nil),                                   // 1029: common.StringList
-	(*Gpu)(nil),                                          // 1030: machine_discovery.Gpu
-	(*RouteTarget)(nil),                                  // 1031: common.RouteTarget
-	(*MachineValidationId)(nil),                          // 1032: common.MachineValidationId
-	(*Uint32List)(nil),                                   // 1033: common.Uint32List
-	(*DpaInterfaceId)(nil),                               // 1034: common.DpaInterfaceId
-	(*ComputeAllocationId)(nil),                          // 1035: common.ComputeAllocationId
-	(*RackHardwareType)(nil),                             // 1036: common.RackHardwareType
-	(*NVLinkPartitionId)(nil),                            // 1037: common.NVLinkPartitionId
-	(*RemediationId)(nil),                                // 1038: common.RemediationId
-	(*MlxDeviceLockdownResponse)(nil),                    // 1039: mlx_device.MlxDeviceLockdownResponse
-	(*MlxDeviceProfileSyncResponse)(nil),                 // 1040: mlx_device.MlxDeviceProfileSyncResponse
-	(*MlxDeviceProfileCompareResponse)(nil),              // 1041: mlx_device.MlxDeviceProfileCompareResponse
-	(*MlxDeviceInfoDeviceResponse)(nil),                  // 1042: mlx_device.MlxDeviceInfoDeviceResponse
-	(*MlxDeviceInfoReportResponse)(nil),                  // 1043: mlx_device.MlxDeviceInfoReportResponse
-	(*MlxDeviceRegistryListResponse)(nil),                // 1044: mlx_device.MlxDeviceRegistryListResponse
-	(*MlxDeviceRegistryShowResponse)(nil),                // 1045: mlx_device.MlxDeviceRegistryShowResponse
-	(*MlxDeviceConfigQueryResponse)(nil),                 // 1046: mlx_device.MlxDeviceConfigQueryResponse
-	(*MlxDeviceConfigSetResponse)(nil),                   // 1047: mlx_device.MlxDeviceConfigSetResponse
-	(*MlxDeviceConfigSyncResponse)(nil),                  // 1048: mlx_device.MlxDeviceConfigSyncResponse
-	(*MlxDeviceConfigCompareResponse)(nil),               // 1049: mlx_device.MlxDeviceConfigCompareResponse
-	(*MlxDeviceLockdownLockRequest)(nil),                 // 1050: mlx_device.MlxDeviceLockdownLockRequest
-	(*MlxDeviceLockdownUnlockRequest)(nil),               // 1051: mlx_device.MlxDeviceLockdownUnlockRequest
-	(*MlxDeviceLockdownStatusRequest)(nil),               // 1052: mlx_device.MlxDeviceLockdownStatusRequest
-	(*MlxDeviceProfileSyncRequest)(nil),                  // 1053: mlx_device.MlxDeviceProfileSyncRequest
-	(*MlxDeviceProfileCompareRequest)(nil),               // 1054: mlx_device.MlxDeviceProfileCompareRequest
-	(*MlxDeviceInfoDeviceRequest)(nil),                   // 1055: mlx_device.MlxDeviceInfoDeviceRequest
-	(*MlxDeviceInfoReportRequest)(nil),                   // 1056: mlx_device.MlxDeviceInfoReportRequest
-	(*MlxDeviceRegistryListRequest)(nil),                 // 1057: mlx_device.MlxDeviceRegistryListRequest
-	(*MlxDeviceRegistryShowRequest)(nil),                 // 1058: mlx_device.MlxDeviceRegistryShowRequest
-	(*MlxDeviceConfigQueryRequest)(nil),                  // 1059: mlx_device.MlxDeviceConfigQueryRequest
-	(*MlxDeviceConfigSetRequest)(nil),                    // 1060: mlx_device.MlxDeviceConfigSetRequest
-	(*MlxDeviceConfigSyncRequest)(nil),                   // 1061: mlx_device.MlxDeviceConfigSyncRequest
-	(*MlxDeviceConfigCompareRequest)(nil),                // 1062: mlx_device.MlxDeviceConfigCompareRequest
-	(*Domain)(nil),                                       // 1063: dns.Domain
-	(*MachineIdList)(nil),                                // 1064: common.MachineIdList
-	(*EndpointExplorationReport)(nil),                    // 1065: site_explorer.EndpointExplorationReport
-	(SystemPowerControl)(0),                              // 1066: common.SystemPowerControl
-	(*SitePrefixId)(nil),                                 // 1067: common.SitePrefixId
-	(*SerializableMlxConfigProfile)(nil),                 // 1068: mlx_device.SerializableMlxConfigProfile
-	(*FirmwareFlasherProfile)(nil),                       // 1069: mlx_device.FirmwareFlasherProfile
-	(*ScoutFirmwareUpgradeTask)(nil),                     // 1070: scout_firmware_upgrade.ScoutFirmwareUpgradeTask
-	(*CreateDomainRequest)(nil),                          // 1071: dns.CreateDomainRequest
-	(*UpdateDomainRequest)(nil),                          // 1072: dns.UpdateDomainRequest
-	(*DomainDeletionRequest)(nil),                        // 1073: dns.DomainDeletionRequest
-	(*DomainSearchQuery)(nil),                            // 1074: dns.DomainSearchQuery
-	(*DnsResourceRecordLookupRequest)(nil),               // 1075: dns.DnsResourceRecordLookupRequest
-	(*GetAllDomainsRequest)(nil),                         // 1076: dns.GetAllDomainsRequest
-	(*DomainMetadataRequest)(nil),                        // 1077: dns.DomainMetadataRequest
-	(*emptypb.Empty)(nil),                                // 1078: google.protobuf.Empty
-	(*ExploredEndpointSearchFilter)(nil),                 // 1079: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointsByIdsRequest)(nil),                // 1080: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredManagedHostSearchFilter)(nil),              // 1081: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostsByIdsRequest)(nil),             // 1082: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1083: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1084: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*CreateMeasurementBundleRequest)(nil),               // 1085: measured_boot.CreateMeasurementBundleRequest
-	(*DeleteMeasurementBundleRequest)(nil),               // 1086: measured_boot.DeleteMeasurementBundleRequest
-	(*RenameMeasurementBundleRequest)(nil),               // 1087: measured_boot.RenameMeasurementBundleRequest
-	(*UpdateMeasurementBundleRequest)(nil),               // 1088: measured_boot.UpdateMeasurementBundleRequest
-	(*ShowMeasurementBundleRequest)(nil),                 // 1089: measured_boot.ShowMeasurementBundleRequest
-	(*ShowMeasurementBundlesRequest)(nil),                // 1090: measured_boot.ShowMeasurementBundlesRequest
-	(*ListMeasurementBundlesRequest)(nil),                // 1091: measured_boot.ListMeasurementBundlesRequest
-	(*ListMeasurementBundleMachinesRequest)(nil),         // 1092: measured_boot.ListMeasurementBundleMachinesRequest
-	(*FindClosestBundleMatchRequest)(nil),                // 1093: measured_boot.FindClosestBundleMatchRequest
-	(*DeleteMeasurementJournalRequest)(nil),              // 1094: measured_boot.DeleteMeasurementJournalRequest
-	(*ShowMeasurementJournalRequest)(nil),                // 1095: measured_boot.ShowMeasurementJournalRequest
-	(*ShowMeasurementJournalsRequest)(nil),               // 1096: measured_boot.ShowMeasurementJournalsRequest
-	(*ListMeasurementJournalRequest)(nil),                // 1097: measured_boot.ListMeasurementJournalRequest
-	(*AttestCandidateMachineRequest)(nil),                // 1098: measured_boot.AttestCandidateMachineRequest
-	(*ShowCandidateMachineRequest)(nil),                  // 1099: measured_boot.ShowCandidateMachineRequest
-	(*ShowCandidateMachinesRequest)(nil),                 // 1100: measured_boot.ShowCandidateMachinesRequest
-	(*ListCandidateMachinesRequest)(nil),                 // 1101: measured_boot.ListCandidateMachinesRequest
-	(*CreateMeasurementSystemProfileRequest)(nil),        // 1102: measured_boot.CreateMeasurementSystemProfileRequest
-	(*DeleteMeasurementSystemProfileRequest)(nil),        // 1103: measured_boot.DeleteMeasurementSystemProfileRequest
-	(*RenameMeasurementSystemProfileRequest)(nil),        // 1104: measured_boot.RenameMeasurementSystemProfileRequest
-	(*ShowMeasurementSystemProfileRequest)(nil),          // 1105: measured_boot.ShowMeasurementSystemProfileRequest
-	(*ShowMeasurementSystemProfilesRequest)(nil),         // 1106: measured_boot.ShowMeasurementSystemProfilesRequest
-	(*ListMeasurementSystemProfilesRequest)(nil),         // 1107: measured_boot.ListMeasurementSystemProfilesRequest
-	(*ListMeasurementSystemProfileBundlesRequest)(nil),   // 1108: measured_boot.ListMeasurementSystemProfileBundlesRequest
-	(*ListMeasurementSystemProfileMachinesRequest)(nil),  // 1109: measured_boot.ListMeasurementSystemProfileMachinesRequest
-	(*CreateMeasurementReportRequest)(nil),               // 1110: measured_boot.CreateMeasurementReportRequest
-	(*DeleteMeasurementReportRequest)(nil),               // 1111: measured_boot.DeleteMeasurementReportRequest
-	(*PromoteMeasurementReportRequest)(nil),              // 1112: measured_boot.PromoteMeasurementReportRequest
-	(*RevokeMeasurementReportRequest)(nil),               // 1113: measured_boot.RevokeMeasurementReportRequest
-	(*ShowMeasurementReportForIdRequest)(nil),            // 1114: measured_boot.ShowMeasurementReportForIdRequest
-	(*ShowMeasurementReportsForMachineRequest)(nil),      // 1115: measured_boot.ShowMeasurementReportsForMachineRequest
-	(*ShowMeasurementReportsRequest)(nil),                // 1116: measured_boot.ShowMeasurementReportsRequest
-	(*ListMeasurementReportRequest)(nil),                 // 1117: measured_boot.ListMeasurementReportRequest
-	(*MatchMeasurementReportRequest)(nil),                // 1118: measured_boot.MatchMeasurementReportRequest
-	(*ImportSiteMeasurementsRequest)(nil),                // 1119: measured_boot.ImportSiteMeasurementsRequest
-	(*ExportSiteMeasurementsRequest)(nil),                // 1120: measured_boot.ExportSiteMeasurementsRequest
-	(*AddMeasurementTrustedMachineRequest)(nil),          // 1121: measured_boot.AddMeasurementTrustedMachineRequest
-	(*RemoveMeasurementTrustedMachineRequest)(nil),       // 1122: measured_boot.RemoveMeasurementTrustedMachineRequest
-	(*AddMeasurementTrustedProfileRequest)(nil),          // 1123: measured_boot.AddMeasurementTrustedProfileRequest
-	(*RemoveMeasurementTrustedProfileRequest)(nil),       // 1124: measured_boot.RemoveMeasurementTrustedProfileRequest
-	(*ListMeasurementTrustedMachinesRequest)(nil),        // 1125: measured_boot.ListMeasurementTrustedMachinesRequest
-	(*ListMeasurementTrustedProfilesRequest)(nil),        // 1126: measured_boot.ListMeasurementTrustedProfilesRequest
-	(*ListAttestationSummaryRequest)(nil),                // 1127: measured_boot.ListAttestationSummaryRequest
-	(*PublishMlxDeviceReportRequest)(nil),                // 1128: mlx_device.PublishMlxDeviceReportRequest
-	(*PublishMlxObservationReportRequest)(nil),           // 1129: mlx_device.PublishMlxObservationReportRequest
-	(*MlxAdminProfileSyncRequest)(nil),                   // 1130: mlx_device.MlxAdminProfileSyncRequest
-	(*MlxAdminProfileShowRequest)(nil),                   // 1131: mlx_device.MlxAdminProfileShowRequest
-	(*MlxAdminProfileCompareRequest)(nil),                // 1132: mlx_device.MlxAdminProfileCompareRequest
-	(*MlxAdminProfileListRequest)(nil),                   // 1133: mlx_device.MlxAdminProfileListRequest
-	(*MlxAdminLockdownLockRequest)(nil),                  // 1134: mlx_device.MlxAdminLockdownLockRequest
-	(*MlxAdminLockdownUnlockRequest)(nil),                // 1135: mlx_device.MlxAdminLockdownUnlockRequest
-	(*MlxAdminLockdownStatusRequest)(nil),                // 1136: mlx_device.MlxAdminLockdownStatusRequest
-	(*MlxAdminDeviceInfoRequest)(nil),                    // 1137: mlx_device.MlxAdminDeviceInfoRequest
-	(*MlxAdminDeviceReportRequest)(nil),                  // 1138: mlx_device.MlxAdminDeviceReportRequest
-	(*MlxAdminRegistryListRequest)(nil),                  // 1139: mlx_device.MlxAdminRegistryListRequest
-	(*MlxAdminRegistryShowRequest)(nil),                  // 1140: mlx_device.MlxAdminRegistryShowRequest
-	(*MlxAdminConfigQueryRequest)(nil),                   // 1141: mlx_device.MlxAdminConfigQueryRequest
-	(*MlxAdminConfigSetRequest)(nil),                     // 1142: mlx_device.MlxAdminConfigSetRequest
-	(*MlxAdminConfigSyncRequest)(nil),                    // 1143: mlx_device.MlxAdminConfigSyncRequest
-	(*MlxAdminConfigCompareRequest)(nil),                 // 1144: mlx_device.MlxAdminConfigCompareRequest
-	(*DomainDeletionResult)(nil),                         // 1145: dns.DomainDeletionResult
-	(*DomainList)(nil),                                   // 1146: dns.DomainList
-	(*DnsResourceRecordLookupResponse)(nil),              // 1147: dns.DnsResourceRecordLookupResponse
-	(*GetAllDomainsResponse)(nil),                        // 1148: dns.GetAllDomainsResponse
-	(*DomainMetadataResponse)(nil),                       // 1149: dns.DomainMetadataResponse
-	(*SiteExplorationReport)(nil),                        // 1150: site_explorer.SiteExplorationReport
-	(*SiteExplorerLastRunResponse)(nil),                  // 1151: site_explorer.SiteExplorerLastRunResponse
-	(*ExploredEndpoint)(nil),                             // 1152: site_explorer.ExploredEndpoint
-	(*ExploredEndpointIdList)(nil),                       // 1153: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointList)(nil),                         // 1154: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostIdList)(nil),                    // 1155: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostList)(nil),                      // 1156: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDeviceHostIdList)(nil),                  // 1157: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDeviceList)(nil),                        // 1158: site_explorer.ExploredMlxDeviceList
-	(*CreateMeasurementBundleResponse)(nil),              // 1159: measured_boot.CreateMeasurementBundleResponse
-	(*DeleteMeasurementBundleResponse)(nil),              // 1160: measured_boot.DeleteMeasurementBundleResponse
-	(*RenameMeasurementBundleResponse)(nil),              // 1161: measured_boot.RenameMeasurementBundleResponse
-	(*UpdateMeasurementBundleResponse)(nil),              // 1162: measured_boot.UpdateMeasurementBundleResponse
-	(*ShowMeasurementBundleResponse)(nil),                // 1163: measured_boot.ShowMeasurementBundleResponse
-	(*ShowMeasurementBundlesResponse)(nil),               // 1164: measured_boot.ShowMeasurementBundlesResponse
-	(*ListMeasurementBundlesResponse)(nil),               // 1165: measured_boot.ListMeasurementBundlesResponse
-	(*ListMeasurementBundleMachinesResponse)(nil),        // 1166: measured_boot.ListMeasurementBundleMachinesResponse
-	(*DeleteMeasurementJournalResponse)(nil),             // 1167: measured_boot.DeleteMeasurementJournalResponse
-	(*ShowMeasurementJournalResponse)(nil),               // 1168: measured_boot.ShowMeasurementJournalResponse
-	(*ShowMeasurementJournalsResponse)(nil),              // 1169: measured_boot.ShowMeasurementJournalsResponse
-	(*ListMeasurementJournalResponse)(nil),               // 1170: measured_boot.ListMeasurementJournalResponse
-	(*AttestCandidateMachineResponse)(nil),               // 1171: measured_boot.AttestCandidateMachineResponse
-	(*ShowCandidateMachineResponse)(nil),                 // 1172: measured_boot.ShowCandidateMachineResponse
-	(*ShowCandidateMachinesResponse)(nil),                // 1173: measured_boot.ShowCandidateMachinesResponse
-	(*ListCandidateMachinesResponse)(nil),                // 1174: measured_boot.ListCandidateMachinesResponse
-	(*CreateMeasurementSystemProfileResponse)(nil),       // 1175: measured_boot.CreateMeasurementSystemProfileResponse
-	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1176: measured_boot.DeleteMeasurementSystemProfileResponse
-	(*RenameMeasurementSystemProfileResponse)(nil),       // 1177: measured_boot.RenameMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfileResponse)(nil),         // 1178: measured_boot.ShowMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1179: measured_boot.ShowMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfilesResponse)(nil),        // 1180: measured_boot.ListMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1181: measured_boot.ListMeasurementSystemProfileBundlesResponse
-	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1182: measured_boot.ListMeasurementSystemProfileMachinesResponse
-	(*CreateMeasurementReportResponse)(nil),              // 1183: measured_boot.CreateMeasurementReportResponse
-	(*DeleteMeasurementReportResponse)(nil),              // 1184: measured_boot.DeleteMeasurementReportResponse
-	(*PromoteMeasurementReportResponse)(nil),             // 1185: measured_boot.PromoteMeasurementReportResponse
-	(*RevokeMeasurementReportResponse)(nil),              // 1186: measured_boot.RevokeMeasurementReportResponse
-	(*ShowMeasurementReportForIdResponse)(nil),           // 1187: measured_boot.ShowMeasurementReportForIdResponse
-	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1188: measured_boot.ShowMeasurementReportsForMachineResponse
-	(*ShowMeasurementReportsResponse)(nil),               // 1189: measured_boot.ShowMeasurementReportsResponse
-	(*ListMeasurementReportResponse)(nil),                // 1190: measured_boot.ListMeasurementReportResponse
-	(*MatchMeasurementReportResponse)(nil),               // 1191: measured_boot.MatchMeasurementReportResponse
-	(*ImportSiteMeasurementsResponse)(nil),               // 1192: measured_boot.ImportSiteMeasurementsResponse
-	(*ExportSiteMeasurementsResponse)(nil),               // 1193: measured_boot.ExportSiteMeasurementsResponse
-	(*AddMeasurementTrustedMachineResponse)(nil),         // 1194: measured_boot.AddMeasurementTrustedMachineResponse
-	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1195: measured_boot.RemoveMeasurementTrustedMachineResponse
-	(*AddMeasurementTrustedProfileResponse)(nil),         // 1196: measured_boot.AddMeasurementTrustedProfileResponse
-	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1197: measured_boot.RemoveMeasurementTrustedProfileResponse
-	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1198: measured_boot.ListMeasurementTrustedMachinesResponse
-	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1199: measured_boot.ListMeasurementTrustedProfilesResponse
-	(*ListAttestationSummaryResponse)(nil),               // 1200: measured_boot.ListAttestationSummaryResponse
-	(*LockdownStatus)(nil),                               // 1201: site_explorer.LockdownStatus
-	(*PublishMlxDeviceReportResponse)(nil),               // 1202: mlx_device.PublishMlxDeviceReportResponse
-	(*PublishMlxObservationReportResponse)(nil),          // 1203: mlx_device.PublishMlxObservationReportResponse
-	(*MlxAdminProfileSyncResponse)(nil),                  // 1204: mlx_device.MlxAdminProfileSyncResponse
-	(*MlxAdminProfileShowResponse)(nil),                  // 1205: mlx_device.MlxAdminProfileShowResponse
-	(*MlxAdminProfileCompareResponse)(nil),               // 1206: mlx_device.MlxAdminProfileCompareResponse
-	(*MlxAdminProfileListResponse)(nil),                  // 1207: mlx_device.MlxAdminProfileListResponse
-	(*MlxAdminLockdownLockResponse)(nil),                 // 1208: mlx_device.MlxAdminLockdownLockResponse
-	(*MlxAdminLockdownUnlockResponse)(nil),               // 1209: mlx_device.MlxAdminLockdownUnlockResponse
-	(*MlxAdminLockdownStatusResponse)(nil),               // 1210: mlx_device.MlxAdminLockdownStatusResponse
-	(*MlxAdminDeviceInfoResponse)(nil),                   // 1211: mlx_device.MlxAdminDeviceInfoResponse
-	(*MlxAdminDeviceReportResponse)(nil),                 // 1212: mlx_device.MlxAdminDeviceReportResponse
-	(*MlxAdminRegistryListResponse)(nil),                 // 1213: mlx_device.MlxAdminRegistryListResponse
-	(*MlxAdminRegistryShowResponse)(nil),                 // 1214: mlx_device.MlxAdminRegistryShowResponse
-	(*MlxAdminConfigQueryResponse)(nil),                  // 1215: mlx_device.MlxAdminConfigQueryResponse
-	(*MlxAdminConfigSetResponse)(nil),                    // 1216: mlx_device.MlxAdminConfigSetResponse
-	(*MlxAdminConfigSyncResponse)(nil),                   // 1217: mlx_device.MlxAdminConfigSyncResponse
-	(*MlxAdminConfigCompareResponse)(nil),                // 1218: mlx_device.MlxAdminConfigCompareResponse
+	(ExpectedInterfaceRole)(0),                                                // 82: forge.ExpectedInterfaceRole
+	(ExpectedInterfaceIpAllocation)(0),                                        // 83: forge.ExpectedInterfaceIpAllocation
+	(SitePrefixAuthority)(0),                                                  // 84: forge.SitePrefixAuthority
+	(SitePrefixRoutingScope)(0),                                               // 85: forge.SitePrefixRoutingScope
+	(SitePrefixLifecycleState)(0),                                             // 86: forge.SitePrefixLifecycleState
+	(InstancePowerRequest_Operation)(0),                                       // 87: forge.InstancePowerRequest.Operation
+	(InstanceUpdateStatus_Module)(0),                                          // 88: forge.InstanceUpdateStatus.Module
+	(MachineCredentialsUpdateRequest_CredentialPurpose)(0),                    // 89: forge.MachineCredentialsUpdateRequest.CredentialPurpose
+	(ForgeAgentControlResponse_LegacyAction)(0),                               // 90: forge.ForgeAgentControlResponse.LegacyAction
+	(MachineCleanupInfo_CleanupResult)(0),                                     // 91: forge.MachineCleanupInfo.CleanupResult
+	(DpuReprovisioningRequest_Mode)(0),                                        // 92: forge.DpuReprovisioningRequest.Mode
+	(HostReprovisioningRequest_Mode)(0),                                       // 93: forge.HostReprovisioningRequest.Mode
+	(MachineSetAutoUpdateRequest_SetAutoupdateAction)(0),                      // 94: forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
+	(MachineValidationOnDemandRequest_Action)(0),                              // 95: forge.MachineValidationOnDemandRequest.Action
+	(AdminPowerControlRequest_SystemPowerControl)(0),                          // 96: forge.AdminPowerControlRequest.SystemPowerControl
+	(GetRedfishJobStateResponse_RedfishJobState)(0),                           // 97: forge.GetRedfishJobStateResponse.RedfishJobState
+	(*LifecycleStatus)(nil),                                                   // 98: forge.LifecycleStatus
+	(*SpdmMachineAttestationStatus)(nil),                                      // 99: forge.SpdmMachineAttestationStatus
+	(*SpdmMachineAttestationTriggerResponse)(nil),                             // 100: forge.SpdmMachineAttestationTriggerResponse
+	(*SpdmAttestationDetails)(nil),                                            // 101: forge.SpdmAttestationDetails
+	(*SpdmGetAttestationMachineResponse)(nil),                                 // 102: forge.SpdmGetAttestationMachineResponse
+	(*SpdmMachineAttestationTriggerRequest)(nil),                              // 103: forge.SpdmMachineAttestationTriggerRequest
+	(*SpdmListAttestationMachinesRequest)(nil),                                // 104: forge.SpdmListAttestationMachinesRequest
+	(*SpdmListAttestationMachinesResponse)(nil),                               // 105: forge.SpdmListAttestationMachinesResponse
+	(*MachineIdentityRequest)(nil),                                            // 106: forge.MachineIdentityRequest
+	(*MachineIdentityResponse)(nil),                                           // 107: forge.MachineIdentityResponse
+	(*GetTenantIdentityConfigRequest)(nil),                                    // 108: forge.GetTenantIdentityConfigRequest
+	(*TenantIdentitySigningKey)(nil),                                          // 109: forge.TenantIdentitySigningKey
+	(*TenantIdentityConfig)(nil),                                              // 110: forge.TenantIdentityConfig
+	(*SetTenantIdentityConfigRequest)(nil),                                    // 111: forge.SetTenantIdentityConfigRequest
+	(*TenantIdentityConfigResponse)(nil),                                      // 112: forge.TenantIdentityConfigResponse
+	(*ClientSecretBasic)(nil),                                                 // 113: forge.ClientSecretBasic
+	(*ClientSecretBasicResponse)(nil),                                         // 114: forge.ClientSecretBasicResponse
+	(*TokenDelegationResponse)(nil),                                           // 115: forge.TokenDelegationResponse
+	(*GetTokenDelegationRequest)(nil),                                         // 116: forge.GetTokenDelegationRequest
+	(*TokenDelegation)(nil),                                                   // 117: forge.TokenDelegation
+	(*TokenDelegationRequest)(nil),                                            // 118: forge.TokenDelegationRequest
+	(*ReencryptTenantIdentitySecretsRequest)(nil),                             // 119: forge.ReencryptTenantIdentitySecretsRequest
+	(*ReencryptTenantIdentityFailure)(nil),                                    // 120: forge.ReencryptTenantIdentityFailure
+	(*ReencryptTenantIdentitySecretsResponse)(nil),                            // 121: forge.ReencryptTenantIdentitySecretsResponse
+	(*Jwks)(nil),                                                              // 122: forge.Jwks
+	(*OpenIdConfiguration)(nil),                                               // 123: forge.OpenIdConfiguration
+	(*JwksRequest)(nil),                                                       // 124: forge.JwksRequest
+	(*OpenIdConfigRequest)(nil),                                               // 125: forge.OpenIdConfigRequest
+	(*MachineIngestionStateResponse)(nil),                                     // 126: forge.MachineIngestionStateResponse
+	(*TpmCaAddedCaStatus)(nil),                                                // 127: forge.TpmCaAddedCaStatus
+	(*TpmCaCertId)(nil),                                                       // 128: forge.TpmCaCertId
+	(*TpmEkCertStatus)(nil),                                                   // 129: forge.TpmEkCertStatus
+	(*TpmEkCertStatusCollection)(nil),                                         // 130: forge.TpmEkCertStatusCollection
+	(*TpmCaCert)(nil),                                                         // 131: forge.TpmCaCert
+	(*TpmCaCertDetail)(nil),                                                   // 132: forge.TpmCaCertDetail
+	(*TpmCaCertDetailCollection)(nil),                                         // 133: forge.TpmCaCertDetailCollection
+	(*AttestKeyBindChallenge)(nil),                                            // 134: forge.AttestKeyBindChallenge
+	(*AttestQuoteRequest)(nil),                                                // 135: forge.AttestQuoteRequest
+	(*AttestQuoteResponse)(nil),                                               // 136: forge.AttestQuoteResponse
+	(*CredentialCreationRequest)(nil),                                         // 137: forge.CredentialCreationRequest
+	(*CredentialDeletionRequest)(nil),                                         // 138: forge.CredentialDeletionRequest
+	(*CredentialCreationResult)(nil),                                          // 139: forge.CredentialCreationResult
+	(*CredentialDeletionResult)(nil),                                          // 140: forge.CredentialDeletionResult
+	(*RotateCredentialRequest)(nil),                                           // 141: forge.RotateCredentialRequest
+	(*RotateCredentialResult)(nil),                                            // 142: forge.RotateCredentialResult
+	(*CredentialRotationStatusRequest)(nil),                                   // 143: forge.CredentialRotationStatusRequest
+	(*DeviceCredentialRotationStatus)(nil),                                    // 144: forge.DeviceCredentialRotationStatus
+	(*CredentialRotationStatusResult)(nil),                                    // 145: forge.CredentialRotationStatusResult
+	(*VersionRequest)(nil),                                                    // 146: forge.VersionRequest
+	(*BuildInfo)(nil),                                                         // 147: forge.BuildInfo
+	(*RuntimeConfig)(nil),                                                     // 148: forge.RuntimeConfig
+	(*EchoRequest)(nil),                                                       // 149: forge.EchoRequest
+	(*EchoResponse)(nil),                                                      // 150: forge.EchoResponse
+	(*DNSMessage)(nil),                                                        // 151: forge.DNSMessage
+	(*DnsRequest)(nil),                                                        // 152: forge.DnsRequest
+	(*DnsReply)(nil),                                                          // 153: forge.DnsReply
+	(*ConsoleInput)(nil),                                                      // 154: forge.ConsoleInput
+	(*ConsoleOutput)(nil),                                                     // 155: forge.ConsoleOutput
+	(*InstanceEvent)(nil),                                                     // 156: forge.InstanceEvent
+	(*VpcSearchQuery)(nil),                                                    // 157: forge.VpcSearchQuery
+	(*VpcSearchFilter)(nil),                                                   // 158: forge.VpcSearchFilter
+	(*VpcIdList)(nil),                                                         // 159: forge.VpcIdList
+	(*VpcsByIdsRequest)(nil),                                                  // 160: forge.VpcsByIdsRequest
+	(*TenantSearchQuery)(nil),                                                 // 161: forge.TenantSearchQuery
+	(*VpcConfig)(nil),                                                         // 162: forge.VpcConfig
+	(*VpcStatus)(nil),                                                         // 163: forge.VpcStatus
+	(*Vpc)(nil),                                                               // 164: forge.Vpc
+	(*VpcCreationRequest)(nil),                                                // 165: forge.VpcCreationRequest
+	(*VpcUpdateRequest)(nil),                                                  // 166: forge.VpcUpdateRequest
+	(*VpcUpdateResult)(nil),                                                   // 167: forge.VpcUpdateResult
+	(*VpcUpdateVirtualizationRequest)(nil),                                    // 168: forge.VpcUpdateVirtualizationRequest
+	(*VpcUpdateVirtualizationResult)(nil),                                     // 169: forge.VpcUpdateVirtualizationResult
+	(*VpcDeletionRequest)(nil),                                                // 170: forge.VpcDeletionRequest
+	(*VpcDeletionResult)(nil),                                                 // 171: forge.VpcDeletionResult
+	(*VpcList)(nil),                                                           // 172: forge.VpcList
+	(*VpcPrefix)(nil),                                                         // 173: forge.VpcPrefix
+	(*VpcPrefixConfig)(nil),                                                   // 174: forge.VpcPrefixConfig
+	(*VpcPrefixStatus)(nil),                                                   // 175: forge.VpcPrefixStatus
+	(*VpcPrefixCreationRequest)(nil),                                          // 176: forge.VpcPrefixCreationRequest
+	(*VpcPrefixSearchQuery)(nil),                                              // 177: forge.VpcPrefixSearchQuery
+	(*VpcPrefixGetRequest)(nil),                                               // 178: forge.VpcPrefixGetRequest
+	(*VpcPrefixIdList)(nil),                                                   // 179: forge.VpcPrefixIdList
+	(*VpcPrefixList)(nil),                                                     // 180: forge.VpcPrefixList
+	(*VpcPrefixUpdateRequest)(nil),                                            // 181: forge.VpcPrefixUpdateRequest
+	(*VpcPrefixDeletionRequest)(nil),                                          // 182: forge.VpcPrefixDeletionRequest
+	(*VpcPrefixDeletionResult)(nil),                                           // 183: forge.VpcPrefixDeletionResult
+	(*VpcPrefixStateHistoriesRequest)(nil),                                    // 184: forge.VpcPrefixStateHistoriesRequest
+	(*VpcPeering)(nil),                                                        // 185: forge.VpcPeering
+	(*VpcPeeringIdList)(nil),                                                  // 186: forge.VpcPeeringIdList
+	(*VpcPeeringList)(nil),                                                    // 187: forge.VpcPeeringList
+	(*VpcPeeringCreationRequest)(nil),                                         // 188: forge.VpcPeeringCreationRequest
+	(*VpcPeeringSearchFilter)(nil),                                            // 189: forge.VpcPeeringSearchFilter
+	(*VpcPeeringsByIdsRequest)(nil),                                           // 190: forge.VpcPeeringsByIdsRequest
+	(*VpcPeeringDeletionRequest)(nil),                                         // 191: forge.VpcPeeringDeletionRequest
+	(*VpcPeeringDeletionResult)(nil),                                          // 192: forge.VpcPeeringDeletionResult
+	(*IBPartitionConfig)(nil),                                                 // 193: forge.IBPartitionConfig
+	(*IBPartitionStatus)(nil),                                                 // 194: forge.IBPartitionStatus
+	(*IBPartition)(nil),                                                       // 195: forge.IBPartition
+	(*IBPartitionList)(nil),                                                   // 196: forge.IBPartitionList
+	(*IBPartitionCreationRequest)(nil),                                        // 197: forge.IBPartitionCreationRequest
+	(*IBPartitionUpdateRequest)(nil),                                          // 198: forge.IBPartitionUpdateRequest
+	(*IBPartitionDeletionRequest)(nil),                                        // 199: forge.IBPartitionDeletionRequest
+	(*IBPartitionDeletionResult)(nil),                                         // 200: forge.IBPartitionDeletionResult
+	(*IBPartitionSearchFilter)(nil),                                           // 201: forge.IBPartitionSearchFilter
+	(*IBPartitionsByIdsRequest)(nil),                                          // 202: forge.IBPartitionsByIdsRequest
+	(*IBPartitionIdList)(nil),                                                 // 203: forge.IBPartitionIdList
+	(*PowerShelfConfig)(nil),                                                  // 204: forge.PowerShelfConfig
+	(*PowerShelfStatus)(nil),                                                  // 205: forge.PowerShelfStatus
+	(*PowerShelf)(nil),                                                        // 206: forge.PowerShelf
+	(*PowerShelfList)(nil),                                                    // 207: forge.PowerShelfList
+	(*PowerShelfCreationRequest)(nil),                                         // 208: forge.PowerShelfCreationRequest
+	(*PowerShelfDeletionRequest)(nil),                                         // 209: forge.PowerShelfDeletionRequest
+	(*PowerShelfDeletionResult)(nil),                                          // 210: forge.PowerShelfDeletionResult
+	(*PowerShelfMaintenanceRequest)(nil),                                      // 211: forge.PowerShelfMaintenanceRequest
+	(*PowerShelfStateHistoriesRequest)(nil),                                   // 212: forge.PowerShelfStateHistoriesRequest
+	(*PowerShelfQuery)(nil),                                                   // 213: forge.PowerShelfQuery
+	(*PowerShelfSearchFilter)(nil),                                            // 214: forge.PowerShelfSearchFilter
+	(*PowerShelvesByIdsRequest)(nil),                                          // 215: forge.PowerShelvesByIdsRequest
+	(*ExpectedPowerShelf)(nil),                                                // 216: forge.ExpectedPowerShelf
+	(*ExpectedPowerShelfRequest)(nil),                                         // 217: forge.ExpectedPowerShelfRequest
+	(*ExpectedPowerShelfList)(nil),                                            // 218: forge.ExpectedPowerShelfList
+	(*LinkedExpectedPowerShelfList)(nil),                                      // 219: forge.LinkedExpectedPowerShelfList
+	(*LinkedExpectedPowerShelf)(nil),                                          // 220: forge.LinkedExpectedPowerShelf
+	(*SwitchConfig)(nil),                                                      // 221: forge.SwitchConfig
+	(*FabricManagerConfig)(nil),                                               // 222: forge.FabricManagerConfig
+	(*FabricManagerStatus)(nil),                                               // 223: forge.FabricManagerStatus
+	(*SwitchStatus)(nil),                                                      // 224: forge.SwitchStatus
+	(*PlacementInRack)(nil),                                                   // 225: forge.PlacementInRack
+	(*Switch)(nil),                                                            // 226: forge.Switch
+	(*SwitchList)(nil),                                                        // 227: forge.SwitchList
+	(*SwitchCreationRequest)(nil),                                             // 228: forge.SwitchCreationRequest
+	(*SwitchDeletionRequest)(nil),                                             // 229: forge.SwitchDeletionRequest
+	(*SwitchDeletionResult)(nil),                                              // 230: forge.SwitchDeletionResult
+	(*StateHistoryRecord)(nil),                                                // 231: forge.StateHistoryRecord
+	(*StateHistoryRecords)(nil),                                               // 232: forge.StateHistoryRecords
+	(*SwitchStateHistoriesRequest)(nil),                                       // 233: forge.SwitchStateHistoriesRequest
+	(*StateHistories)(nil),                                                    // 234: forge.StateHistories
+	(*SwitchQuery)(nil),                                                       // 235: forge.SwitchQuery
+	(*SwitchSearchFilter)(nil),                                                // 236: forge.SwitchSearchFilter
+	(*SwitchesByIdsRequest)(nil),                                              // 237: forge.SwitchesByIdsRequest
+	(*ExpectedSwitch)(nil),                                                    // 238: forge.ExpectedSwitch
+	(*ExpectedSwitchRequest)(nil),                                             // 239: forge.ExpectedSwitchRequest
+	(*ExpectedSwitchList)(nil),                                                // 240: forge.ExpectedSwitchList
+	(*LinkedExpectedSwitchList)(nil),                                          // 241: forge.LinkedExpectedSwitchList
+	(*LinkedExpectedSwitch)(nil),                                              // 242: forge.LinkedExpectedSwitch
+	(*ExpectedRack)(nil),                                                      // 243: forge.ExpectedRack
+	(*ExpectedRackRequest)(nil),                                               // 244: forge.ExpectedRackRequest
+	(*ExpectedRackList)(nil),                                                  // 245: forge.ExpectedRackList
+	(*IBFabricSearchFilter)(nil),                                              // 246: forge.IBFabricSearchFilter
+	(*IBFabricIdList)(nil),                                                    // 247: forge.IBFabricIdList
+	(*NetworkSegmentStateHistory)(nil),                                        // 248: forge.NetworkSegmentStateHistory
+	(*NetworkSegmentConfig)(nil),                                              // 249: forge.NetworkSegmentConfig
+	(*NetworkSegmentStatus)(nil),                                              // 250: forge.NetworkSegmentStatus
+	(*NetworkSegment)(nil),                                                    // 251: forge.NetworkSegment
+	(*NetworkSegmentCreationRequest)(nil),                                     // 252: forge.NetworkSegmentCreationRequest
+	(*NetworkSegmentDeletionRequest)(nil),                                     // 253: forge.NetworkSegmentDeletionRequest
+	(*AttachNetworkSegmentToVpcRequest)(nil),                                  // 254: forge.AttachNetworkSegmentToVpcRequest
+	(*NetworkSegmentDeletionResult)(nil),                                      // 255: forge.NetworkSegmentDeletionResult
+	(*NetworkSegmentStateHistoriesRequest)(nil),                               // 256: forge.NetworkSegmentStateHistoriesRequest
+	(*NetworkSegmentSearchConfig)(nil),                                        // 257: forge.NetworkSegmentSearchConfig
+	(*NetworkSegmentSearchFilter)(nil),                                        // 258: forge.NetworkSegmentSearchFilter
+	(*NetworkSegmentIdList)(nil),                                              // 259: forge.NetworkSegmentIdList
+	(*NetworkSegmentsByIdsRequest)(nil),                                       // 260: forge.NetworkSegmentsByIdsRequest
+	(*NetworkPrefix)(nil),                                                     // 261: forge.NetworkPrefix
+	(*MachineState)(nil),                                                      // 262: forge.MachineState
+	(*InstancePowerRequest)(nil),                                              // 263: forge.InstancePowerRequest
+	(*InstancePowerResult)(nil),                                               // 264: forge.InstancePowerResult
+	(*InstanceList)(nil),                                                      // 265: forge.InstanceList
+	(*Label)(nil),                                                             // 266: forge.Label
+	(*Metadata)(nil),                                                          // 267: forge.Metadata
+	(*InstanceSearchFilter)(nil),                                              // 268: forge.InstanceSearchFilter
+	(*InstanceIdList)(nil),                                                    // 269: forge.InstanceIdList
+	(*InstancesByIdsRequest)(nil),                                             // 270: forge.InstancesByIdsRequest
+	(*InstanceAllocationRequest)(nil),                                         // 271: forge.InstanceAllocationRequest
+	(*BatchInstanceAllocationRequest)(nil),                                    // 272: forge.BatchInstanceAllocationRequest
+	(*BatchInstanceAllocationResponse)(nil),                                   // 273: forge.BatchInstanceAllocationResponse
+	(*IpxeTemplateParameter)(nil),                                             // 274: forge.IpxeTemplateParameter
+	(*IpxeTemplateArtifact)(nil),                                              // 275: forge.IpxeTemplateArtifact
+	(*IpxeTemplate)(nil),                                                      // 276: forge.IpxeTemplate
+	(*TenantConfig)(nil),                                                      // 277: forge.TenantConfig
+	(*InstanceOperatingSystemConfig)(nil),                                     // 278: forge.InstanceOperatingSystemConfig
+	(*InlineIpxe)(nil),                                                        // 279: forge.InlineIpxe
+	(*InstanceConfig)(nil),                                                    // 280: forge.InstanceConfig
+	(*InstanceNetworkConfig)(nil),                                             // 281: forge.InstanceNetworkConfig
+	(*InstanceNetworkAutoConfig)(nil),                                         // 282: forge.InstanceNetworkAutoConfig
+	(*InstanceInfinibandConfig)(nil),                                          // 283: forge.InstanceInfinibandConfig
+	(*InstanceDpuExtensionServiceConfig)(nil),                                 // 284: forge.InstanceDpuExtensionServiceConfig
+	(*InstanceDpuExtensionServicesConfig)(nil),                                // 285: forge.InstanceDpuExtensionServicesConfig
+	(*InstanceNVLinkConfig)(nil),                                              // 286: forge.InstanceNVLinkConfig
+	(*InstanceSpxConfig)(nil),                                                 // 287: forge.InstanceSpxConfig
+	(*InstanceSpxAttachment)(nil),                                             // 288: forge.InstanceSpxAttachment
+	(*InstanceOperatingSystemUpdateRequest)(nil),                              // 289: forge.InstanceOperatingSystemUpdateRequest
+	(*InstanceConfigUpdateRequest)(nil),                                       // 290: forge.InstanceConfigUpdateRequest
+	(*InstanceStatus)(nil),                                                    // 291: forge.InstanceStatus
+	(*InstanceSpxStatus)(nil),                                                 // 292: forge.InstanceSpxStatus
+	(*InstanceSpxAttachmentStatus)(nil),                                       // 293: forge.InstanceSpxAttachmentStatus
+	(*InstanceNetworkStatus)(nil),                                             // 294: forge.InstanceNetworkStatus
+	(*InstanceInfinibandStatus)(nil),                                          // 295: forge.InstanceInfinibandStatus
+	(*DpuExtensionServiceStatus)(nil),                                         // 296: forge.DpuExtensionServiceStatus
+	(*InstanceDpuExtensionServiceStatus)(nil),                                 // 297: forge.InstanceDpuExtensionServiceStatus
+	(*InstanceDpuExtensionServicesStatus)(nil),                                // 298: forge.InstanceDpuExtensionServicesStatus
+	(*InstanceNVLinkStatus)(nil),                                              // 299: forge.InstanceNVLinkStatus
+	(*Instance)(nil),                                                          // 300: forge.Instance
+	(*InstanceUpdateStatus)(nil),                                              // 301: forge.InstanceUpdateStatus
+	(*InstanceInterfaceConfig)(nil),                                           // 302: forge.InstanceInterfaceConfig
+	(*InstanceInterfaceVpcSelection)(nil),                                     // 303: forge.InstanceInterfaceVpcSelection
+	(*InstanceInterfaceIpv6Config)(nil),                                       // 304: forge.InstanceInterfaceIpv6Config
+	(*InstanceInterfaceRoutingProfile)(nil),                                   // 305: forge.InstanceInterfaceRoutingProfile
+	(*InstanceIBInterfaceConfig)(nil),                                         // 306: forge.InstanceIBInterfaceConfig
+	(*InstanceInterfaceResolvedVpcPrefixes)(nil),                              // 307: forge.InstanceInterfaceResolvedVpcPrefixes
+	(*InstanceInterfaceStatus)(nil),                                           // 308: forge.InstanceInterfaceStatus
+	(*InstanceIBInterfaceStatus)(nil),                                         // 309: forge.InstanceIBInterfaceStatus
+	(*InstanceNVLinkGpuStatus)(nil),                                           // 310: forge.InstanceNVLinkGpuStatus
+	(*InstanceNVLinkGpuConfig)(nil),                                           // 311: forge.InstanceNVLinkGpuConfig
+	(*InstancePhoneHomeLastContactRequest)(nil),                               // 312: forge.InstancePhoneHomeLastContactRequest
+	(*InstancePhoneHomeLastContactResponse)(nil),                              // 313: forge.InstancePhoneHomeLastContactResponse
+	(*Issue)(nil),                                                             // 314: forge.Issue
+	(*DeleteInitiatedBy)(nil),                                                 // 315: forge.DeleteInitiatedBy
+	(*DeleteAttribution)(nil),                                                 // 316: forge.DeleteAttribution
+	(*InstanceReleaseRequest)(nil),                                            // 317: forge.InstanceReleaseRequest
+	(*InstanceReleaseResult)(nil),                                             // 318: forge.InstanceReleaseResult
+	(*MachinesByIdsRequest)(nil),                                              // 319: forge.MachinesByIdsRequest
+	(*MachineSearchConfig)(nil),                                               // 320: forge.MachineSearchConfig
+	(*MachineStateHistoriesRequest)(nil),                                      // 321: forge.MachineStateHistoriesRequest
+	(*MachineStateHistories)(nil),                                             // 322: forge.MachineStateHistories
+	(*MachineStateHistoryRecords)(nil),                                        // 323: forge.MachineStateHistoryRecords
+	(*MachineHealthHistoriesRequest)(nil),                                     // 324: forge.MachineHealthHistoriesRequest
+	(*HealthHistories)(nil),                                                   // 325: forge.HealthHistories
+	(*HealthHistoryRecords)(nil),                                              // 326: forge.HealthHistoryRecords
+	(*HealthHistoryRecord)(nil),                                               // 327: forge.HealthHistoryRecord
+	(*TenantByOrganizationIdsRequest)(nil),                                    // 328: forge.TenantByOrganizationIdsRequest
+	(*TenantSearchFilter)(nil),                                                // 329: forge.TenantSearchFilter
+	(*TenantList)(nil),                                                        // 330: forge.TenantList
+	(*TenantOrganizationIdList)(nil),                                          // 331: forge.TenantOrganizationIdList
+	(*InterfaceList)(nil),                                                     // 332: forge.InterfaceList
+	(*MachineList)(nil),                                                       // 333: forge.MachineList
+	(*InterfaceDeleteQuery)(nil),                                              // 334: forge.InterfaceDeleteQuery
+	(*InterfaceSearchQuery)(nil),                                              // 335: forge.InterfaceSearchQuery
+	(*AssignStaticAddressRequest)(nil),                                        // 336: forge.AssignStaticAddressRequest
+	(*AssignStaticAddressResponse)(nil),                                       // 337: forge.AssignStaticAddressResponse
+	(*RemoveStaticAddressRequest)(nil),                                        // 338: forge.RemoveStaticAddressRequest
+	(*RemoveStaticAddressResponse)(nil),                                       // 339: forge.RemoveStaticAddressResponse
+	(*FindInterfaceAddressesRequest)(nil),                                     // 340: forge.FindInterfaceAddressesRequest
+	(*InterfaceAddress)(nil),                                                  // 341: forge.InterfaceAddress
+	(*FindInterfaceAddressesResponse)(nil),                                    // 342: forge.FindInterfaceAddressesResponse
+	(*BmcInfo)(nil),                                                           // 343: forge.BmcInfo
+	(*SwitchNvosInfo)(nil),                                                    // 344: forge.SwitchNvosInfo
+	(*MachineConfig)(nil),                                                     // 345: forge.MachineConfig
+	(*MachineStatus)(nil),                                                     // 346: forge.MachineStatus
+	(*Machine)(nil),                                                           // 347: forge.Machine
+	(*DpfMachineState)(nil),                                                   // 348: forge.DpfMachineState
+	(*InstanceNetworkRestrictions)(nil),                                       // 349: forge.InstanceNetworkRestrictions
+	(*MachineMetadataUpdateRequest)(nil),                                      // 350: forge.MachineMetadataUpdateRequest
+	(*RackMetadataUpdateRequest)(nil),                                         // 351: forge.RackMetadataUpdateRequest
+	(*SwitchMetadataUpdateRequest)(nil),                                       // 352: forge.SwitchMetadataUpdateRequest
+	(*PowerShelfMetadataUpdateRequest)(nil),                                   // 353: forge.PowerShelfMetadataUpdateRequest
+	(*DpuAgentInventoryReport)(nil),                                           // 354: forge.DpuAgentInventoryReport
+	(*MachineComponentInventory)(nil),                                         // 355: forge.MachineComponentInventory
+	(*MachineInventorySoftwareComponent)(nil),                                 // 356: forge.MachineInventorySoftwareComponent
+	(*HealthSourceOrigin)(nil),                                                // 357: forge.HealthSourceOrigin
+	(*ControllerStateReason)(nil),                                             // 358: forge.ControllerStateReason
+	(*ControllerStateSourceReference)(nil),                                    // 359: forge.ControllerStateSourceReference
+	(*StateSla)(nil),                                                          // 360: forge.StateSla
+	(*InstanceTenantStatus)(nil),                                              // 361: forge.InstanceTenantStatus
+	(*MachineEvent)(nil),                                                      // 362: forge.MachineEvent
+	(*MachineInterface)(nil),                                                  // 363: forge.MachineInterface
+	(*InfinibandStatusObservation)(nil),                                       // 364: forge.InfinibandStatusObservation
+	(*MachineIbInterface)(nil),                                                // 365: forge.MachineIbInterface
+	(*DhcpDiscovery)(nil),                                                     // 366: forge.DhcpDiscovery
+	(*ExpireDhcpLeaseRequest)(nil),                                            // 367: forge.ExpireDhcpLeaseRequest
+	(*ExpireDhcpLeaseResponse)(nil),                                           // 368: forge.ExpireDhcpLeaseResponse
+	(*DhcpRecord)(nil),                                                        // 369: forge.DhcpRecord
+	(*NetworkSegmentList)(nil),                                                // 370: forge.NetworkSegmentList
+	(*SSHKeyValidationRequest)(nil),                                           // 371: forge.SSHKeyValidationRequest
+	(*SSHKeyValidationResponse)(nil),                                          // 372: forge.SSHKeyValidationResponse
+	(*GetBmcCredentialsRequest)(nil),                                          // 373: forge.GetBmcCredentialsRequest
+	(*GetSwitchNvosCredentialsRequest)(nil),                                   // 374: forge.GetSwitchNvosCredentialsRequest
+	(*GetBmcCredentialsResponse)(nil),                                         // 375: forge.GetBmcCredentialsResponse
+	(*BmcCredentials)(nil),                                                    // 376: forge.BmcCredentials
+	(*GetSiteExplorationRequest)(nil),                                         // 377: forge.GetSiteExplorationRequest
+	(*ClearSiteExplorationErrorRequest)(nil),                                  // 378: forge.ClearSiteExplorationErrorRequest
+	(*ReExploreEndpointRequest)(nil),                                          // 379: forge.ReExploreEndpointRequest
+	(*RefreshEndpointReportRequest)(nil),                                      // 380: forge.RefreshEndpointReportRequest
+	(*DeleteExploredEndpointRequest)(nil),                                     // 381: forge.DeleteExploredEndpointRequest
+	(*PauseExploredEndpointRemediationRequest)(nil),                           // 382: forge.PauseExploredEndpointRemediationRequest
+	(*DeleteExploredEndpointResponse)(nil),                                    // 383: forge.DeleteExploredEndpointResponse
+	(*BmcEndpointRequest)(nil),                                                // 384: forge.BmcEndpointRequest
+	(*SshTimeoutConfig)(nil),                                                  // 385: forge.SshTimeoutConfig
+	(*SshRequest)(nil),                                                        // 386: forge.SshRequest
+	(*CopyBfbToDpuRshimRequest)(nil),                                          // 387: forge.CopyBfbToDpuRshimRequest
+	(*UpdateMachineHardwareInfoRequest)(nil),                                  // 388: forge.UpdateMachineHardwareInfoRequest
+	(*MachineHardwareInfo)(nil),                                               // 389: forge.MachineHardwareInfo
+	(*ManagedHostNetworkConfigRequest)(nil),                                   // 390: forge.ManagedHostNetworkConfigRequest
+	(*ManagedHostNetworkConfigResponse)(nil),                                  // 391: forge.ManagedHostNetworkConfigResponse
+	(*TrafficInterceptConfig)(nil),                                            // 392: forge.TrafficInterceptConfig
+	(*TrafficInterceptBridging)(nil),                                          // 393: forge.TrafficInterceptBridging
+	(*ManagedHostDpuExtensionServiceConfig)(nil),                              // 394: forge.ManagedHostDpuExtensionServiceConfig
+	(*ManagedHostQuarantineState)(nil),                                        // 395: forge.ManagedHostQuarantineState
+	(*GetManagedHostQuarantineStateRequest)(nil),                              // 396: forge.GetManagedHostQuarantineStateRequest
+	(*GetManagedHostQuarantineStateResponse)(nil),                             // 397: forge.GetManagedHostQuarantineStateResponse
+	(*SetManagedHostQuarantineStateRequest)(nil),                              // 398: forge.SetManagedHostQuarantineStateRequest
+	(*SetManagedHostQuarantineStateResponse)(nil),                             // 399: forge.SetManagedHostQuarantineStateResponse
+	(*ClearManagedHostQuarantineStateRequest)(nil),                            // 400: forge.ClearManagedHostQuarantineStateRequest
+	(*ClearManagedHostQuarantineStateResponse)(nil),                           // 401: forge.ClearManagedHostQuarantineStateResponse
+	(*ManagedHostNetworkConfig)(nil),                                          // 402: forge.ManagedHostNetworkConfig
+	(*FlatInterfaceConfig)(nil),                                               // 403: forge.FlatInterfaceConfig
+	(*FlatInterfaceRoutingProfile)(nil),                                       // 404: forge.FlatInterfaceRoutingProfile
+	(*FlatInterfaceIpv6Config)(nil),                                           // 405: forge.FlatInterfaceIpv6Config
+	(*FlatInterfaceNetworkSecurityGroupConfig)(nil),                           // 406: forge.FlatInterfaceNetworkSecurityGroupConfig
+	(*ManagedHostNetworkStatusRequest)(nil),                                   // 407: forge.ManagedHostNetworkStatusRequest
+	(*ManagedHostNetworkStatusResponse)(nil),                                  // 408: forge.ManagedHostNetworkStatusResponse
+	(*DpuAgentUpgradeCheckRequest)(nil),                                       // 409: forge.DpuAgentUpgradeCheckRequest
+	(*DpuAgentUpgradeCheckResponse)(nil),                                      // 410: forge.DpuAgentUpgradeCheckResponse
+	(*DpuAgentUpgradePolicyRequest)(nil),                                      // 411: forge.DpuAgentUpgradePolicyRequest
+	(*DpuAgentUpgradePolicyResponse)(nil),                                     // 412: forge.DpuAgentUpgradePolicyResponse
+	(*AdminForceDeleteMachineRequest)(nil),                                    // 413: forge.AdminForceDeleteMachineRequest
+	(*AdminForceDeleteMachineResponse)(nil),                                   // 414: forge.AdminForceDeleteMachineResponse
+	(*DisableSecureBootResponse)(nil),                                         // 415: forge.DisableSecureBootResponse
+	(*LockdownRequest)(nil),                                                   // 416: forge.LockdownRequest
+	(*LockdownResponse)(nil),                                                  // 417: forge.LockdownResponse
+	(*LockdownStatusRequest)(nil),                                             // 418: forge.LockdownStatusRequest
+	(*MachineSetupStatusRequest)(nil),                                         // 419: forge.MachineSetupStatusRequest
+	(*MachineSetupRequest)(nil),                                               // 420: forge.MachineSetupRequest
+	(*MachineSetupResponse)(nil),                                              // 421: forge.MachineSetupResponse
+	(*SetDpuFirstBootOrderRequest)(nil),                                       // 422: forge.SetDpuFirstBootOrderRequest
+	(*SetDpuFirstBootOrderResponse)(nil),                                      // 423: forge.SetDpuFirstBootOrderResponse
+	(*AdminRebootRequest)(nil),                                                // 424: forge.AdminRebootRequest
+	(*AdminRebootResponse)(nil),                                               // 425: forge.AdminRebootResponse
+	(*AdminBmcResetRequest)(nil),                                              // 426: forge.AdminBmcResetRequest
+	(*AdminBmcResetResponse)(nil),                                             // 427: forge.AdminBmcResetResponse
+	(*EnableInfiniteBootRequest)(nil),                                         // 428: forge.EnableInfiniteBootRequest
+	(*EnableInfiniteBootResponse)(nil),                                        // 429: forge.EnableInfiniteBootResponse
+	(*IsInfiniteBootEnabledRequest)(nil),                                      // 430: forge.IsInfiniteBootEnabledRequest
+	(*IsInfiniteBootEnabledResponse)(nil),                                     // 431: forge.IsInfiniteBootEnabledResponse
+	(*BMCMetaDataGetRequest)(nil),                                             // 432: forge.BMCMetaDataGetRequest
+	(*BMCMetaDataGetResponse)(nil),                                            // 433: forge.BMCMetaDataGetResponse
+	(*MachineCredentialsUpdateRequest)(nil),                                   // 434: forge.MachineCredentialsUpdateRequest
+	(*MachineCredentialsUpdateResponse)(nil),                                  // 435: forge.MachineCredentialsUpdateResponse
+	(*ForgeAgentControlRequest)(nil),                                          // 436: forge.ForgeAgentControlRequest
+	(*ForgeAgentControlResponse)(nil),                                         // 437: forge.ForgeAgentControlResponse
+	(*MachineDiscoveryInfo)(nil),                                              // 438: forge.MachineDiscoveryInfo
+	(*MachineDiscoveryCompletedRequest)(nil),                                  // 439: forge.MachineDiscoveryCompletedRequest
+	(*MachineCleanupInfo)(nil),                                                // 440: forge.MachineCleanupInfo
+	(*MachineCertificate)(nil),                                                // 441: forge.MachineCertificate
+	(*MachineCertificateRenewRequest)(nil),                                    // 442: forge.MachineCertificateRenewRequest
+	(*MachineCertificateResult)(nil),                                          // 443: forge.MachineCertificateResult
+	(*MachineDiscoveryResult)(nil),                                            // 444: forge.MachineDiscoveryResult
+	(*MachineDiscoveryCompletedResponse)(nil),                                 // 445: forge.MachineDiscoveryCompletedResponse
+	(*MachineCleanupResult)(nil),                                              // 446: forge.MachineCleanupResult
+	(*ForgeScoutErrorReport)(nil),                                             // 447: forge.ForgeScoutErrorReport
+	(*ForgeScoutErrorReportResult)(nil),                                       // 448: forge.ForgeScoutErrorReportResult
+	(*PxeInstructionRequest)(nil),                                             // 449: forge.PxeInstructionRequest
+	(*PxeInstructions)(nil),                                                   // 450: forge.PxeInstructions
+	(*CloudInitDiscoveryInstructions)(nil),                                    // 451: forge.CloudInitDiscoveryInstructions
+	(*CloudInitMetaData)(nil),                                                 // 452: forge.CloudInitMetaData
+	(*CloudInitInstructionsRequest)(nil),                                      // 453: forge.CloudInitInstructionsRequest
+	(*CloudInitInstructions)(nil),                                             // 454: forge.CloudInitInstructions
+	(*DpuNetworkStatus)(nil),                                                  // 455: forge.DpuNetworkStatus
+	(*LastDhcpRequest)(nil),                                                   // 456: forge.LastDhcpRequest
+	(*DpuExtensionServiceStatusObservation)(nil),                              // 457: forge.DpuExtensionServiceStatusObservation
+	(*DpuExtensionServiceComponent)(nil),                                      // 458: forge.DpuExtensionServiceComponent
+	(*OptionalHealthReport)(nil),                                              // 459: forge.OptionalHealthReport
+	(*HealthReportEntry)(nil),                                                 // 460: forge.HealthReportEntry
+	(*InsertMachineHealthReportRequest)(nil),                                  // 461: forge.InsertMachineHealthReportRequest
+	(*InsertRackHealthReportRequest)(nil),                                     // 462: forge.InsertRackHealthReportRequest
+	(*RemoveRackHealthReportRequest)(nil),                                     // 463: forge.RemoveRackHealthReportRequest
+	(*ListRackHealthReportsRequest)(nil),                                      // 464: forge.ListRackHealthReportsRequest
+	(*InsertSwitchHealthReportRequest)(nil),                                   // 465: forge.InsertSwitchHealthReportRequest
+	(*RemoveSwitchHealthReportRequest)(nil),                                   // 466: forge.RemoveSwitchHealthReportRequest
+	(*ListSwitchHealthReportsRequest)(nil),                                    // 467: forge.ListSwitchHealthReportsRequest
+	(*InsertPowerShelfHealthReportRequest)(nil),                               // 468: forge.InsertPowerShelfHealthReportRequest
+	(*RemovePowerShelfHealthReportRequest)(nil),                               // 469: forge.RemovePowerShelfHealthReportRequest
+	(*ListPowerShelfHealthReportsRequest)(nil),                                // 470: forge.ListPowerShelfHealthReportsRequest
+	(*ListHealthReportResponse)(nil),                                          // 471: forge.ListHealthReportResponse
+	(*RemoveMachineHealthReportRequest)(nil),                                  // 472: forge.RemoveMachineHealthReportRequest
+	(*ListNVLinkDomainHealthReportsRequest)(nil),                              // 473: forge.ListNVLinkDomainHealthReportsRequest
+	(*InsertNVLinkDomainHealthReportRequest)(nil),                             // 474: forge.InsertNVLinkDomainHealthReportRequest
+	(*RemoveNVLinkDomainHealthReportRequest)(nil),                             // 475: forge.RemoveNVLinkDomainHealthReportRequest
+	(*InstanceInterfaceStatusObservation)(nil),                                // 476: forge.InstanceInterfaceStatusObservation
+	(*FabricInterfaceData)(nil),                                               // 477: forge.FabricInterfaceData
+	(*LinkData)(nil),                                                          // 478: forge.LinkData
+	(*Tenant)(nil),                                                            // 479: forge.Tenant
+	(*CreateTenantRequest)(nil),                                               // 480: forge.CreateTenantRequest
+	(*CreateTenantResponse)(nil),                                              // 481: forge.CreateTenantResponse
+	(*UpdateTenantRequest)(nil),                                               // 482: forge.UpdateTenantRequest
+	(*UpdateTenantResponse)(nil),                                              // 483: forge.UpdateTenantResponse
+	(*FindTenantRequest)(nil),                                                 // 484: forge.FindTenantRequest
+	(*FindTenantResponse)(nil),                                                // 485: forge.FindTenantResponse
+	(*TenantKeysetIdentifier)(nil),                                            // 486: forge.TenantKeysetIdentifier
+	(*TenantPublicKey)(nil),                                                   // 487: forge.TenantPublicKey
+	(*TenantKeysetContent)(nil),                                               // 488: forge.TenantKeysetContent
+	(*TenantKeyset)(nil),                                                      // 489: forge.TenantKeyset
+	(*CreateTenantKeysetRequest)(nil),                                         // 490: forge.CreateTenantKeysetRequest
+	(*CreateTenantKeysetResponse)(nil),                                        // 491: forge.CreateTenantKeysetResponse
+	(*TenantKeySetList)(nil),                                                  // 492: forge.TenantKeySetList
+	(*UpdateTenantKeysetRequest)(nil),                                         // 493: forge.UpdateTenantKeysetRequest
+	(*UpdateTenantKeysetResponse)(nil),                                        // 494: forge.UpdateTenantKeysetResponse
+	(*DeleteTenantKeysetRequest)(nil),                                         // 495: forge.DeleteTenantKeysetRequest
+	(*DeleteTenantKeysetResponse)(nil),                                        // 496: forge.DeleteTenantKeysetResponse
+	(*TenantKeysetSearchFilter)(nil),                                          // 497: forge.TenantKeysetSearchFilter
+	(*TenantKeysetIdList)(nil),                                                // 498: forge.TenantKeysetIdList
+	(*TenantKeysetsByIdsRequest)(nil),                                         // 499: forge.TenantKeysetsByIdsRequest
+	(*ValidateTenantPublicKeyRequest)(nil),                                    // 500: forge.ValidateTenantPublicKeyRequest
+	(*ValidateTenantPublicKeyResponse)(nil),                                   // 501: forge.ValidateTenantPublicKeyResponse
+	(*ListResourcePoolsRequest)(nil),                                          // 502: forge.ListResourcePoolsRequest
+	(*ResourcePools)(nil),                                                     // 503: forge.ResourcePools
+	(*ResourcePool)(nil),                                                      // 504: forge.ResourcePool
+	(*GrowResourcePoolRequest)(nil),                                           // 505: forge.GrowResourcePoolRequest
+	(*GrowResourcePoolResponse)(nil),                                          // 506: forge.GrowResourcePoolResponse
+	(*Range)(nil),                                                             // 507: forge.Range
+	(*MigrateVpcVniResponse)(nil),                                             // 508: forge.MigrateVpcVniResponse
+	(*MaintenanceRequest)(nil),                                                // 509: forge.MaintenanceRequest
+	(*SetDynamicConfigRequest)(nil),                                           // 510: forge.SetDynamicConfigRequest
+	(*FindIpAddressRequest)(nil),                                              // 511: forge.FindIpAddressRequest
+	(*FindIpAddressResponse)(nil),                                             // 512: forge.FindIpAddressResponse
+	(*IdentifyUuidRequest)(nil),                                               // 513: forge.IdentifyUuidRequest
+	(*IdentifyUuidResponse)(nil),                                              // 514: forge.IdentifyUuidResponse
+	(*FindBmcIpsRequest)(nil),                                                 // 515: forge.FindBmcIpsRequest
+	(*IdentifyMacRequest)(nil),                                                // 516: forge.IdentifyMacRequest
+	(*IdentifyMacResponse)(nil),                                               // 517: forge.IdentifyMacResponse
+	(*IdentifySerialRequest)(nil),                                             // 518: forge.IdentifySerialRequest
+	(*IdentifySerialResponse)(nil),                                            // 519: forge.IdentifySerialResponse
+	(*DpuReprovisioningRequest)(nil),                                          // 520: forge.DpuReprovisioningRequest
+	(*DpuReprovisioningListRequest)(nil),                                      // 521: forge.DpuReprovisioningListRequest
+	(*DpuReprovisioningListResponse)(nil),                                     // 522: forge.DpuReprovisioningListResponse
+	(*HostReprovisioningRequest)(nil),                                         // 523: forge.HostReprovisioningRequest
+	(*HostReprovisioningListRequest)(nil),                                     // 524: forge.HostReprovisioningListRequest
+	(*HostReprovisioningListResponse)(nil),                                    // 525: forge.HostReprovisioningListResponse
+	(*DpuOsOperationalState)(nil),                                             // 526: forge.DpuOsOperationalState
+	(*DpuRepresentorStatus)(nil),                                              // 527: forge.DpuRepresentorStatus
+	(*DpuInfoStatusObservation)(nil),                                          // 528: forge.DpuInfoStatusObservation
+	(*DpuInfo)(nil),                                                           // 529: forge.DpuInfo
+	(*GetDpuInfoListRequest)(nil),                                             // 530: forge.GetDpuInfoListRequest
+	(*GetDpuInfoListResponse)(nil),                                            // 531: forge.GetDpuInfoListResponse
+	(*IpAddressMatch)(nil),                                                    // 532: forge.IpAddressMatch
+	(*MachineBootOverride)(nil),                                               // 533: forge.MachineBootOverride
+	(*ConnectedDevice)(nil),                                                   // 534: forge.ConnectedDevice
+	(*ConnectedDeviceList)(nil),                                               // 535: forge.ConnectedDeviceList
+	(*BmcIpList)(nil),                                                         // 536: forge.BmcIpList
+	(*BmcIp)(nil),                                                             // 537: forge.BmcIp
+	(*MacAddressBmcIp)(nil),                                                   // 538: forge.MacAddressBmcIp
+	(*MachineIdBmcIpPairs)(nil),                                               // 539: forge.MachineIdBmcIpPairs
+	(*MachineIdBmcIp)(nil),                                                    // 540: forge.MachineIdBmcIp
+	(*NetworkDevice)(nil),                                                     // 541: forge.NetworkDevice
+	(*NetworkTopologyRequest)(nil),                                            // 542: forge.NetworkTopologyRequest
+	(*NetworkDeviceIdList)(nil),                                               // 543: forge.NetworkDeviceIdList
+	(*NetworkTopologyData)(nil),                                               // 544: forge.NetworkTopologyData
+	(*RouteServers)(nil),                                                      // 545: forge.RouteServers
+	(*RouteServerEntries)(nil),                                                // 546: forge.RouteServerEntries
+	(*RouteServer)(nil),                                                       // 547: forge.RouteServer
+	(*SetHostUefiPasswordRequest)(nil),                                        // 548: forge.SetHostUefiPasswordRequest
+	(*SetHostUefiPasswordResponse)(nil),                                       // 549: forge.SetHostUefiPasswordResponse
+	(*ClearHostUefiPasswordRequest)(nil),                                      // 550: forge.ClearHostUefiPasswordRequest
+	(*ClearHostUefiPasswordResponse)(nil),                                     // 551: forge.ClearHostUefiPasswordResponse
+	(*OsImageAttributes)(nil),                                                 // 552: forge.OsImageAttributes
+	(*OsImage)(nil),                                                           // 553: forge.OsImage
+	(*ListOsImageRequest)(nil),                                                // 554: forge.ListOsImageRequest
+	(*ListOsImageResponse)(nil),                                               // 555: forge.ListOsImageResponse
+	(*DeleteOsImageRequest)(nil),                                              // 556: forge.DeleteOsImageRequest
+	(*DeleteOsImageResponse)(nil),                                             // 557: forge.DeleteOsImageResponse
+	(*GetIpxeTemplateRequest)(nil),                                            // 558: forge.GetIpxeTemplateRequest
+	(*ListIpxeTemplatesRequest)(nil),                                          // 559: forge.ListIpxeTemplatesRequest
+	(*IpxeTemplateList)(nil),                                                  // 560: forge.IpxeTemplateList
+	(*ExpectedHostNic)(nil),                                                   // 561: forge.ExpectedHostNic
+	(*HostLifecycleProfile)(nil),                                              // 562: forge.HostLifecycleProfile
+	(*ExpectedMachine)(nil),                                                   // 563: forge.ExpectedMachine
+	(*ExpectedMachineRequest)(nil),                                            // 564: forge.ExpectedMachineRequest
+	(*ExpectedMachineList)(nil),                                               // 565: forge.ExpectedMachineList
+	(*LinkedExpectedMachineList)(nil),                                         // 566: forge.LinkedExpectedMachineList
+	(*LinkedExpectedMachine)(nil),                                             // 567: forge.LinkedExpectedMachine
+	(*UnexpectedMachineList)(nil),                                             // 568: forge.UnexpectedMachineList
+	(*UnexpectedMachine)(nil),                                                 // 569: forge.UnexpectedMachine
+	(*BatchExpectedMachineOperationRequest)(nil),                              // 570: forge.BatchExpectedMachineOperationRequest
+	(*ExpectedMachineOperationResult)(nil),                                    // 571: forge.ExpectedMachineOperationResult
+	(*BatchExpectedMachineOperationResponse)(nil),                             // 572: forge.BatchExpectedMachineOperationResponse
+	(*MachineRebootCompletedResponse)(nil),                                    // 573: forge.MachineRebootCompletedResponse
+	(*MachineRebootCompletedRequest)(nil),                                     // 574: forge.MachineRebootCompletedRequest
+	(*ScoutFirmwareUpgradeStatusRequest)(nil),                                 // 575: forge.ScoutFirmwareUpgradeStatusRequest
+	(*MachineValidationCompletedRequest)(nil),                                 // 576: forge.MachineValidationCompletedRequest
+	(*MachineValidationCompletedResponse)(nil),                                // 577: forge.MachineValidationCompletedResponse
+	(*MachineValidationResult)(nil),                                           // 578: forge.MachineValidationResult
+	(*MachineValidationResultPostRequest)(nil),                                // 579: forge.MachineValidationResultPostRequest
+	(*MachineValidationResultList)(nil),                                       // 580: forge.MachineValidationResultList
+	(*MachineValidationGetRequest)(nil),                                       // 581: forge.MachineValidationGetRequest
+	(*MachineValidationStatus)(nil),                                           // 582: forge.MachineValidationStatus
+	(*MachineValidationRun)(nil),                                              // 583: forge.MachineValidationRun
+	(*MachineSetAutoUpdateRequest)(nil),                                       // 584: forge.MachineSetAutoUpdateRequest
+	(*MachineSetAutoUpdateResponse)(nil),                                      // 585: forge.MachineSetAutoUpdateResponse
+	(*GetMachineValidationExternalConfigRequest)(nil),                         // 586: forge.GetMachineValidationExternalConfigRequest
+	(*MachineValidationExternalConfig)(nil),                                   // 587: forge.MachineValidationExternalConfig
+	(*GetMachineValidationExternalConfigResponse)(nil),                        // 588: forge.GetMachineValidationExternalConfigResponse
+	(*GetMachineValidationExternalConfigsRequest)(nil),                        // 589: forge.GetMachineValidationExternalConfigsRequest
+	(*GetMachineValidationExternalConfigsResponse)(nil),                       // 590: forge.GetMachineValidationExternalConfigsResponse
+	(*AddUpdateMachineValidationExternalConfigRequest)(nil),                   // 591: forge.AddUpdateMachineValidationExternalConfigRequest
+	(*RemoveMachineValidationExternalConfigRequest)(nil),                      // 592: forge.RemoveMachineValidationExternalConfigRequest
+	(*MachineValidationOnDemandRequest)(nil),                                  // 593: forge.MachineValidationOnDemandRequest
+	(*MachineValidationOnDemandResponse)(nil),                                 // 594: forge.MachineValidationOnDemandResponse
+	(*FirmwareUpgradeActivity)(nil),                                           // 595: forge.FirmwareUpgradeActivity
+	(*NvosUpdateActivity)(nil),                                                // 596: forge.NvosUpdateActivity
+	(*ConfigureNmxClusterActivity)(nil),                                       // 597: forge.ConfigureNmxClusterActivity
+	(*PowerSequenceActivity)(nil),                                             // 598: forge.PowerSequenceActivity
+	(*MaintenanceActivityConfig)(nil),                                         // 599: forge.MaintenanceActivityConfig
+	(*RackMaintenanceScope)(nil),                                              // 600: forge.RackMaintenanceScope
+	(*RackMaintenanceOnDemandRequest)(nil),                                    // 601: forge.RackMaintenanceOnDemandRequest
+	(*RackMaintenanceOnDemandResponse)(nil),                                   // 602: forge.RackMaintenanceOnDemandResponse
+	(*AdminPowerControlRequest)(nil),                                          // 603: forge.AdminPowerControlRequest
+	(*AdminPowerControlResponse)(nil),                                         // 604: forge.AdminPowerControlResponse
+	(*GetRedfishJobStateRequest)(nil),                                         // 605: forge.GetRedfishJobStateRequest
+	(*GetRedfishJobStateResponse)(nil),                                        // 606: forge.GetRedfishJobStateResponse
+	(*MachineValidationRunList)(nil),                                          // 607: forge.MachineValidationRunList
+	(*MachineValidationRunListGetRequest)(nil),                                // 608: forge.MachineValidationRunListGetRequest
+	(*MachineValidationRunItemSearchFilter)(nil),                              // 609: forge.MachineValidationRunItemSearchFilter
+	(*MachineValidationRunItemIdList)(nil),                                    // 610: forge.MachineValidationRunItemIdList
+	(*MachineValidationRunItemsByIdsRequest)(nil),                             // 611: forge.MachineValidationRunItemsByIdsRequest
+	(*MachineValidationRunItemList)(nil),                                      // 612: forge.MachineValidationRunItemList
+	(*MachineValidationRunItem)(nil),                                          // 613: forge.MachineValidationRunItem
+	(*MachineValidationAttemptGetRequest)(nil),                                // 614: forge.MachineValidationAttemptGetRequest
+	(*MachineValidationAttempt)(nil),                                          // 615: forge.MachineValidationAttempt
+	(*MachineValidationHeartbeatRequest)(nil),                                 // 616: forge.MachineValidationHeartbeatRequest
+	(*MachineValidationHeartbeatResponse)(nil),                                // 617: forge.MachineValidationHeartbeatResponse
+	(*IsBmcInManagedHostResponse)(nil),                                        // 618: forge.IsBmcInManagedHostResponse
+	(*BmcCredentialStatusResponse)(nil),                                       // 619: forge.BmcCredentialStatusResponse
+	(*MachineValidationTestsGetRequest)(nil),                                  // 620: forge.MachineValidationTestsGetRequest
+	(*MachineValidationTestUpdateRequest)(nil),                                // 621: forge.MachineValidationTestUpdateRequest
+	(*MachineValidationTestAddRequest)(nil),                                   // 622: forge.MachineValidationTestAddRequest
+	(*MachineValidationTestAddUpdateResponse)(nil),                            // 623: forge.MachineValidationTestAddUpdateResponse
+	(*MachineValidationTestsGetResponse)(nil),                                 // 624: forge.MachineValidationTestsGetResponse
+	(*MachineValidationTestVerfiedRequest)(nil),                               // 625: forge.MachineValidationTestVerfiedRequest
+	(*MachineValidationTestVerfiedResponse)(nil),                              // 626: forge.MachineValidationTestVerfiedResponse
+	(*MachineValidationTest)(nil),                                             // 627: forge.MachineValidationTest
+	(*MachineValidationTestNextVersionResponse)(nil),                          // 628: forge.MachineValidationTestNextVersionResponse
+	(*MachineValidationTestNextVersionRequest)(nil),                           // 629: forge.MachineValidationTestNextVersionRequest
+	(*MachineValidationTestEnableDisableTestRequest)(nil),                     // 630: forge.MachineValidationTestEnableDisableTestRequest
+	(*MachineValidationTestEnableDisableTestResponse)(nil),                    // 631: forge.MachineValidationTestEnableDisableTestResponse
+	(*MachineValidationRunRequest)(nil),                                       // 632: forge.MachineValidationRunRequest
+	(*MachineValidationRunResponse)(nil),                                      // 633: forge.MachineValidationRunResponse
+	(*MachineCapabilityAttributesCpu)(nil),                                    // 634: forge.MachineCapabilityAttributesCpu
+	(*MachineCapabilityAttributesGpu)(nil),                                    // 635: forge.MachineCapabilityAttributesGpu
+	(*MachineCapabilityAttributesMemory)(nil),                                 // 636: forge.MachineCapabilityAttributesMemory
+	(*MachineCapabilityAttributesStorage)(nil),                                // 637: forge.MachineCapabilityAttributesStorage
+	(*MachineCapabilityAttributesNetwork)(nil),                                // 638: forge.MachineCapabilityAttributesNetwork
+	(*MachineCapabilityAttributesInfiniband)(nil),                             // 639: forge.MachineCapabilityAttributesInfiniband
+	(*MachineCapabilityAttributesDpu)(nil),                                    // 640: forge.MachineCapabilityAttributesDpu
+	(*MachineCapabilitiesSet)(nil),                                            // 641: forge.MachineCapabilitiesSet
+	(*InstanceTypeAttributes)(nil),                                            // 642: forge.InstanceTypeAttributes
+	(*InstanceType)(nil),                                                      // 643: forge.InstanceType
+	(*InstanceTypeMachineCapabilityFilterAttributes)(nil),                     // 644: forge.InstanceTypeMachineCapabilityFilterAttributes
+	(*CreateInstanceTypeRequest)(nil),                                         // 645: forge.CreateInstanceTypeRequest
+	(*CreateInstanceTypeResponse)(nil),                                        // 646: forge.CreateInstanceTypeResponse
+	(*FindInstanceTypeIdsRequest)(nil),                                        // 647: forge.FindInstanceTypeIdsRequest
+	(*FindInstanceTypeIdsResponse)(nil),                                       // 648: forge.FindInstanceTypeIdsResponse
+	(*FindInstanceTypesByIdsRequest)(nil),                                     // 649: forge.FindInstanceTypesByIdsRequest
+	(*FindInstanceTypesByIdsResponse)(nil),                                    // 650: forge.FindInstanceTypesByIdsResponse
+	(*DeleteInstanceTypeRequest)(nil),                                         // 651: forge.DeleteInstanceTypeRequest
+	(*DeleteInstanceTypeResponse)(nil),                                        // 652: forge.DeleteInstanceTypeResponse
+	(*UpdateInstanceTypeResponse)(nil),                                        // 653: forge.UpdateInstanceTypeResponse
+	(*UpdateInstanceTypeRequest)(nil),                                         // 654: forge.UpdateInstanceTypeRequest
+	(*AssociateMachinesWithInstanceTypeRequest)(nil),                          // 655: forge.AssociateMachinesWithInstanceTypeRequest
+	(*AssociateMachinesWithInstanceTypeResponse)(nil),                         // 656: forge.AssociateMachinesWithInstanceTypeResponse
+	(*RemoveMachineInstanceTypeAssociationRequest)(nil),                       // 657: forge.RemoveMachineInstanceTypeAssociationRequest
+	(*RemoveMachineInstanceTypeAssociationResponse)(nil),                      // 658: forge.RemoveMachineInstanceTypeAssociationResponse
+	(*RedfishBrowseRequest)(nil),                                              // 659: forge.RedfishBrowseRequest
+	(*RedfishBrowseResponse)(nil),                                             // 660: forge.RedfishBrowseResponse
+	(*RedfishListActionsRequest)(nil),                                         // 661: forge.RedfishListActionsRequest
+	(*RedfishListActionsResponse)(nil),                                        // 662: forge.RedfishListActionsResponse
+	(*RedfishAction)(nil),                                                     // 663: forge.RedfishAction
+	(*OptionalRedfishActionResult)(nil),                                       // 664: forge.OptionalRedfishActionResult
+	(*RedfishActionResult)(nil),                                               // 665: forge.RedfishActionResult
+	(*RedfishCreateActionRequest)(nil),                                        // 666: forge.RedfishCreateActionRequest
+	(*RedfishCreateActionResponse)(nil),                                       // 667: forge.RedfishCreateActionResponse
+	(*RedfishActionID)(nil),                                                   // 668: forge.RedfishActionID
+	(*RedfishApproveActionResponse)(nil),                                      // 669: forge.RedfishApproveActionResponse
+	(*RedfishApplyActionResponse)(nil),                                        // 670: forge.RedfishApplyActionResponse
+	(*RedfishCancelActionResponse)(nil),                                       // 671: forge.RedfishCancelActionResponse
+	(*UfmBrowseRequest)(nil),                                                  // 672: forge.UfmBrowseRequest
+	(*UfmBrowseResponse)(nil),                                                 // 673: forge.UfmBrowseResponse
+	(*NetworkSecurityGroupAttributes)(nil),                                    // 674: forge.NetworkSecurityGroupAttributes
+	(*NetworkSecurityGroup)(nil),                                              // 675: forge.NetworkSecurityGroup
+	(*CreateNetworkSecurityGroupRequest)(nil),                                 // 676: forge.CreateNetworkSecurityGroupRequest
+	(*CreateNetworkSecurityGroupResponse)(nil),                                // 677: forge.CreateNetworkSecurityGroupResponse
+	(*FindNetworkSecurityGroupIdsRequest)(nil),                                // 678: forge.FindNetworkSecurityGroupIdsRequest
+	(*FindNetworkSecurityGroupIdsResponse)(nil),                               // 679: forge.FindNetworkSecurityGroupIdsResponse
+	(*FindNetworkSecurityGroupsByIdsRequest)(nil),                             // 680: forge.FindNetworkSecurityGroupsByIdsRequest
+	(*FindNetworkSecurityGroupsByIdsResponse)(nil),                            // 681: forge.FindNetworkSecurityGroupsByIdsResponse
+	(*UpdateNetworkSecurityGroupResponse)(nil),                                // 682: forge.UpdateNetworkSecurityGroupResponse
+	(*UpdateNetworkSecurityGroupRequest)(nil),                                 // 683: forge.UpdateNetworkSecurityGroupRequest
+	(*DeleteNetworkSecurityGroupRequest)(nil),                                 // 684: forge.DeleteNetworkSecurityGroupRequest
+	(*DeleteNetworkSecurityGroupResponse)(nil),                                // 685: forge.DeleteNetworkSecurityGroupResponse
+	(*NetworkSecurityGroupStatus)(nil),                                        // 686: forge.NetworkSecurityGroupStatus
+	(*NetworkSecurityGroupPropagationObjectStatus)(nil),                       // 687: forge.NetworkSecurityGroupPropagationObjectStatus
+	(*GetNetworkSecurityGroupPropagationStatusResponse)(nil),                  // 688: forge.GetNetworkSecurityGroupPropagationStatusResponse
+	(*NetworkSecurityGroupIdList)(nil),                                        // 689: forge.NetworkSecurityGroupIdList
+	(*GetNetworkSecurityGroupPropagationStatusRequest)(nil),                   // 690: forge.GetNetworkSecurityGroupPropagationStatusRequest
+	(*NetworkSecurityGroupRuleAttributes)(nil),                                // 691: forge.NetworkSecurityGroupRuleAttributes
+	(*ResolvedNetworkSecurityGroupRule)(nil),                                  // 692: forge.ResolvedNetworkSecurityGroupRule
+	(*GetNetworkSecurityGroupAttachmentsRequest)(nil),                         // 693: forge.GetNetworkSecurityGroupAttachmentsRequest
+	(*NetworkSecurityGroupAttachments)(nil),                                   // 694: forge.NetworkSecurityGroupAttachments
+	(*GetNetworkSecurityGroupAttachmentsResponse)(nil),                        // 695: forge.GetNetworkSecurityGroupAttachmentsResponse
+	(*GetDesiredFirmwareVersionsRequest)(nil),                                 // 696: forge.GetDesiredFirmwareVersionsRequest
+	(*GetDesiredFirmwareVersionsResponse)(nil),                                // 697: forge.GetDesiredFirmwareVersionsResponse
+	(*DesiredFirmwareVersionEntry)(nil),                                       // 698: forge.DesiredFirmwareVersionEntry
+	(*SkuComponentChassis)(nil),                                               // 699: forge.SkuComponentChassis
+	(*SkuComponentCpu)(nil),                                                   // 700: forge.SkuComponentCpu
+	(*SkuComponentGpu)(nil),                                                   // 701: forge.SkuComponentGpu
+	(*SkuComponentEthernetDevices)(nil),                                       // 702: forge.SkuComponentEthernetDevices
+	(*SkuComponentInfinibandDevices)(nil),                                     // 703: forge.SkuComponentInfinibandDevices
+	(*SkuComponentStorage)(nil),                                               // 704: forge.SkuComponentStorage
+	(*SkuComponentStorageController)(nil),                                     // 705: forge.SkuComponentStorageController
+	(*SkuComponentMemory)(nil),                                                // 706: forge.SkuComponentMemory
+	(*SkuComponentTpm)(nil),                                                   // 707: forge.SkuComponentTpm
+	(*SkuComponents)(nil),                                                     // 708: forge.SkuComponents
+	(*Sku)(nil),                                                               // 709: forge.Sku
+	(*SkuMachinePair)(nil),                                                    // 710: forge.SkuMachinePair
+	(*RemoveSkuRequest)(nil),                                                  // 711: forge.RemoveSkuRequest
+	(*SkuList)(nil),                                                           // 712: forge.SkuList
+	(*SkuIdList)(nil),                                                         // 713: forge.SkuIdList
+	(*SkuStatus)(nil),                                                         // 714: forge.SkuStatus
+	(*SkusByIdsRequest)(nil),                                                  // 715: forge.SkusByIdsRequest
+	(*SkuSearchFilter)(nil),                                                   // 716: forge.SkuSearchFilter
+	(*DpaInterface)(nil),                                                      // 717: forge.DpaInterface
+	(*DpaInterfaceCreationRequest)(nil),                                       // 718: forge.DpaInterfaceCreationRequest
+	(*DpaInterfaceIdList)(nil),                                                // 719: forge.DpaInterfaceIdList
+	(*DpaInterfacesByIdsRequest)(nil),                                         // 720: forge.DpaInterfacesByIdsRequest
+	(*DpaInterfaceList)(nil),                                                  // 721: forge.DpaInterfaceList
+	(*DpaNetworkObservationSetRequest)(nil),                                   // 722: forge.DpaNetworkObservationSetRequest
+	(*DpaInterfaceDeletionRequest)(nil),                                       // 723: forge.DpaInterfaceDeletionRequest
+	(*DpaInterfaceDeletionResult)(nil),                                        // 724: forge.DpaInterfaceDeletionResult
+	(*SkuUpdateMetadataRequest)(nil),                                          // 725: forge.SkuUpdateMetadataRequest
+	(*PowerOptionRequest)(nil),                                                // 726: forge.PowerOptionRequest
+	(*PowerOptionUpdateRequest)(nil),                                          // 727: forge.PowerOptionUpdateRequest
+	(*PowerOptions)(nil),                                                      // 728: forge.PowerOptions
+	(*PowerOptionResponse)(nil),                                               // 729: forge.PowerOptionResponse
+	(*ComputeAllocationAttributes)(nil),                                       // 730: forge.ComputeAllocationAttributes
+	(*ComputeAllocation)(nil),                                                 // 731: forge.ComputeAllocation
+	(*CreateComputeAllocationRequest)(nil),                                    // 732: forge.CreateComputeAllocationRequest
+	(*CreateComputeAllocationResponse)(nil),                                   // 733: forge.CreateComputeAllocationResponse
+	(*FindComputeAllocationIdsRequest)(nil),                                   // 734: forge.FindComputeAllocationIdsRequest
+	(*FindComputeAllocationIdsResponse)(nil),                                  // 735: forge.FindComputeAllocationIdsResponse
+	(*FindComputeAllocationsByIdsRequest)(nil),                                // 736: forge.FindComputeAllocationsByIdsRequest
+	(*FindComputeAllocationsByIdsResponse)(nil),                               // 737: forge.FindComputeAllocationsByIdsResponse
+	(*UpdateComputeAllocationResponse)(nil),                                   // 738: forge.UpdateComputeAllocationResponse
+	(*UpdateComputeAllocationRequest)(nil),                                    // 739: forge.UpdateComputeAllocationRequest
+	(*DeleteComputeAllocationRequest)(nil),                                    // 740: forge.DeleteComputeAllocationRequest
+	(*DeleteComputeAllocationResponse)(nil),                                   // 741: forge.DeleteComputeAllocationResponse
+	(*InstanceTypeAllocationStats)(nil),                                       // 742: forge.InstanceTypeAllocationStats
+	(*GetRackRequest)(nil),                                                    // 743: forge.GetRackRequest
+	(*GetRackResponse)(nil),                                                   // 744: forge.GetRackResponse
+	(*RackList)(nil),                                                          // 745: forge.RackList
+	(*RackSearchFilter)(nil),                                                  // 746: forge.RackSearchFilter
+	(*RackIdList)(nil),                                                        // 747: forge.RackIdList
+	(*RacksByIdsRequest)(nil),                                                 // 748: forge.RacksByIdsRequest
+	(*Rack)(nil),                                                              // 749: forge.Rack
+	(*RackConfig)(nil),                                                        // 750: forge.RackConfig
+	(*RackStatus)(nil),                                                        // 751: forge.RackStatus
+	(*RackStateHistoriesRequest)(nil),                                         // 752: forge.RackStateHistoriesRequest
+	(*DeleteRackRequest)(nil),                                                 // 753: forge.DeleteRackRequest
+	(*AdminForceDeleteRackRequest)(nil),                                       // 754: forge.AdminForceDeleteRackRequest
+	(*AdminForceDeleteRackResponse)(nil),                                      // 755: forge.AdminForceDeleteRackResponse
+	(*RackCapabilityCompute)(nil),                                             // 756: forge.RackCapabilityCompute
+	(*RackCapabilitySwitch)(nil),                                              // 757: forge.RackCapabilitySwitch
+	(*RackCapabilityPowerShelf)(nil),                                          // 758: forge.RackCapabilityPowerShelf
+	(*RackCapabilitiesSet)(nil),                                               // 759: forge.RackCapabilitiesSet
+	(*RackProfile)(nil),                                                       // 760: forge.RackProfile
+	(*GetRackProfileRequest)(nil),                                             // 761: forge.GetRackProfileRequest
+	(*GetRackProfileResponse)(nil),                                            // 762: forge.GetRackProfileResponse
+	(*RackManagerForgeRequest)(nil),                                           // 763: forge.RackManagerForgeRequest
+	(*RackManagerForgeResponse)(nil),                                          // 764: forge.RackManagerForgeResponse
+	(*MachineNVLinkInfo)(nil),                                                 // 765: forge.MachineNVLinkInfo
+	(*UpdateMachineNvLinkInfoRequest)(nil),                                    // 766: forge.UpdateMachineNvLinkInfoRequest
+	(*MachineSpxStatusObservation)(nil),                                       // 767: forge.MachineSpxStatusObservation
+	(*MachineSpxAttachmentStatusObservation)(nil),                             // 768: forge.MachineSpxAttachmentStatusObservation
+	(*AstraConfig)(nil),                                                       // 769: forge.AstraConfig
+	(*AstraAttachment)(nil),                                                   // 770: forge.AstraAttachment
+	(*AstraConfigStatus)(nil),                                                 // 771: forge.AstraConfigStatus
+	(*AstraAttachmentStatus)(nil),                                             // 772: forge.AstraAttachmentStatus
+	(*AstraStatus)(nil),                                                       // 773: forge.AstraStatus
+	(*NVLinkGpu)(nil),                                                         // 774: forge.NVLinkGpu
+	(*MachineNVLinkStatusObservation)(nil),                                    // 775: forge.MachineNVLinkStatusObservation
+	(*MachineNVLinkGpuStatusObservation)(nil),                                 // 776: forge.MachineNVLinkGpuStatusObservation
+	(*NmxcBrowseRequest)(nil),                                                 // 777: forge.NmxcBrowseRequest
+	(*NmxcBrowseResponse)(nil),                                                // 778: forge.NmxcBrowseResponse
+	(*NVLinkPartition)(nil),                                                   // 779: forge.NVLinkPartition
+	(*NVLinkPartitionList)(nil),                                               // 780: forge.NVLinkPartitionList
+	(*NVLinkPartitionSearchConfig)(nil),                                       // 781: forge.NVLinkPartitionSearchConfig
+	(*NVLinkPartitionQuery)(nil),                                              // 782: forge.NVLinkPartitionQuery
+	(*NVLinkPartitionSearchFilter)(nil),                                       // 783: forge.NVLinkPartitionSearchFilter
+	(*NVLinkPartitionsByIdsRequest)(nil),                                      // 784: forge.NVLinkPartitionsByIdsRequest
+	(*NVLinkPartitionIdList)(nil),                                             // 785: forge.NVLinkPartitionIdList
+	(*NVLinkFabricSearchFilter)(nil),                                          // 786: forge.NVLinkFabricSearchFilter
+	(*NVLinkLogicalPartitionConfig)(nil),                                      // 787: forge.NVLinkLogicalPartitionConfig
+	(*NVLinkLogicalPartitionStatus)(nil),                                      // 788: forge.NVLinkLogicalPartitionStatus
+	(*NVLinkLogicalPartition)(nil),                                            // 789: forge.NVLinkLogicalPartition
+	(*NVLinkLogicalPartitionList)(nil),                                        // 790: forge.NVLinkLogicalPartitionList
+	(*NVLinkLogicalPartitionCreationRequest)(nil),                             // 791: forge.NVLinkLogicalPartitionCreationRequest
+	(*NVLinkLogicalPartitionDeletionRequest)(nil),                             // 792: forge.NVLinkLogicalPartitionDeletionRequest
+	(*NVLinkLogicalPartitionDeletionResult)(nil),                              // 793: forge.NVLinkLogicalPartitionDeletionResult
+	(*NVLinkLogicalPartitionSearchFilter)(nil),                                // 794: forge.NVLinkLogicalPartitionSearchFilter
+	(*NVLinkLogicalPartitionsByIdsRequest)(nil),                               // 795: forge.NVLinkLogicalPartitionsByIdsRequest
+	(*NVLinkLogicalPartitionIdList)(nil),                                      // 796: forge.NVLinkLogicalPartitionIdList
+	(*NVLinkLogicalPartitionUpdateRequest)(nil),                               // 797: forge.NVLinkLogicalPartitionUpdateRequest
+	(*NVLinkLogicalPartitionUpdateResult)(nil),                                // 798: forge.NVLinkLogicalPartitionUpdateResult
+	(*CreateBmcUserRequest)(nil),                                              // 799: forge.CreateBmcUserRequest
+	(*CreateBmcUserResponse)(nil),                                             // 800: forge.CreateBmcUserResponse
+	(*DeleteBmcUserRequest)(nil),                                              // 801: forge.DeleteBmcUserRequest
+	(*DeleteBmcUserResponse)(nil),                                             // 802: forge.DeleteBmcUserResponse
+	(*SetBmcRootPasswordRequest)(nil),                                         // 803: forge.SetBmcRootPasswordRequest
+	(*SetBmcRootPasswordResponse)(nil),                                        // 804: forge.SetBmcRootPasswordResponse
+	(*ProbeBmcVendorRequest)(nil),                                             // 805: forge.ProbeBmcVendorRequest
+	(*ProbeBmcVendorResponse)(nil),                                            // 806: forge.ProbeBmcVendorResponse
+	(*SetFirmwareUpdateTimeWindowRequest)(nil),                                // 807: forge.SetFirmwareUpdateTimeWindowRequest
+	(*SetFirmwareUpdateTimeWindowResponse)(nil),                               // 808: forge.SetFirmwareUpdateTimeWindowResponse
+	(*UpsertHostFirmwareConfigRequest)(nil),                                   // 809: forge.UpsertHostFirmwareConfigRequest
+	(*DeleteHostFirmwareConfigRequest)(nil),                                   // 810: forge.DeleteHostFirmwareConfigRequest
+	(*UpsertHostFirmwareComponentConfig)(nil),                                 // 811: forge.UpsertHostFirmwareComponentConfig
+	(*HostFirmwareComponentConfigResponse)(nil),                               // 812: forge.HostFirmwareComponentConfigResponse
+	(*HostFirmwareVersionConfig)(nil),                                         // 813: forge.HostFirmwareVersionConfig
+	(*HostFirmwareArtifact)(nil),                                              // 814: forge.HostFirmwareArtifact
+	(*HostFirmwareConfigResponse)(nil),                                        // 815: forge.HostFirmwareConfigResponse
+	(*ListHostFirmwareRequest)(nil),                                           // 816: forge.ListHostFirmwareRequest
+	(*ListHostFirmwareResponse)(nil),                                          // 817: forge.ListHostFirmwareResponse
+	(*AvailableHostFirmware)(nil),                                             // 818: forge.AvailableHostFirmware
+	(*TrimTableRequest)(nil),                                                  // 819: forge.TrimTableRequest
+	(*TrimTableResponse)(nil),                                                 // 820: forge.TrimTableResponse
+	(*NvlinkNmxcEndpoint)(nil),                                                // 821: forge.NvlinkNmxcEndpoint
+	(*NvlinkNmxcEndpointList)(nil),                                            // 822: forge.NvlinkNmxcEndpointList
+	(*DeleteNvlinkNmxcEndpointRequest)(nil),                                   // 823: forge.DeleteNvlinkNmxcEndpointRequest
+	(*CreateRemediationRequest)(nil),                                          // 824: forge.CreateRemediationRequest
+	(*CreateRemediationResponse)(nil),                                         // 825: forge.CreateRemediationResponse
+	(*RemediationIdList)(nil),                                                 // 826: forge.RemediationIdList
+	(*RemediationList)(nil),                                                   // 827: forge.RemediationList
+	(*Remediation)(nil),                                                       // 828: forge.Remediation
+	(*ApproveRemediationRequest)(nil),                                         // 829: forge.ApproveRemediationRequest
+	(*RevokeRemediationRequest)(nil),                                          // 830: forge.RevokeRemediationRequest
+	(*EnableRemediationRequest)(nil),                                          // 831: forge.EnableRemediationRequest
+	(*DisableRemediationRequest)(nil),                                         // 832: forge.DisableRemediationRequest
+	(*FindAppliedRemediationIdsRequest)(nil),                                  // 833: forge.FindAppliedRemediationIdsRequest
+	(*AppliedRemediationIdList)(nil),                                          // 834: forge.AppliedRemediationIdList
+	(*FindAppliedRemediationsRequest)(nil),                                    // 835: forge.FindAppliedRemediationsRequest
+	(*AppliedRemediation)(nil),                                                // 836: forge.AppliedRemediation
+	(*AppliedRemediationList)(nil),                                            // 837: forge.AppliedRemediationList
+	(*GetNextRemediationForMachineRequest)(nil),                               // 838: forge.GetNextRemediationForMachineRequest
+	(*GetNextRemediationForMachineResponse)(nil),                              // 839: forge.GetNextRemediationForMachineResponse
+	(*RemediationAppliedRequest)(nil),                                         // 840: forge.RemediationAppliedRequest
+	(*RemediationApplicationStatus)(nil),                                      // 841: forge.RemediationApplicationStatus
+	(*SetPrimaryDpuRequest)(nil),                                              // 842: forge.SetPrimaryDpuRequest
+	(*SetPrimaryInterfaceRequest)(nil),                                        // 843: forge.SetPrimaryInterfaceRequest
+	(*UsernamePassword)(nil),                                                  // 844: forge.UsernamePassword
+	(*SessionToken)(nil),                                                      // 845: forge.SessionToken
+	(*DpuExtensionServiceCredential)(nil),                                     // 846: forge.DpuExtensionServiceCredential
+	(*DpuExtensionServiceVersionInfo)(nil),                                    // 847: forge.DpuExtensionServiceVersionInfo
+	(*DpuExtensionService)(nil),                                               // 848: forge.DpuExtensionService
+	(*CreateDpuExtensionServiceRequest)(nil),                                  // 849: forge.CreateDpuExtensionServiceRequest
+	(*UpdateDpuExtensionServiceRequest)(nil),                                  // 850: forge.UpdateDpuExtensionServiceRequest
+	(*DeleteDpuExtensionServiceRequest)(nil),                                  // 851: forge.DeleteDpuExtensionServiceRequest
+	(*DeleteDpuExtensionServiceResponse)(nil),                                 // 852: forge.DeleteDpuExtensionServiceResponse
+	(*DpuExtensionServiceSearchFilter)(nil),                                   // 853: forge.DpuExtensionServiceSearchFilter
+	(*DpuExtensionServiceIdList)(nil),                                         // 854: forge.DpuExtensionServiceIdList
+	(*DpuExtensionServicesByIdsRequest)(nil),                                  // 855: forge.DpuExtensionServicesByIdsRequest
+	(*DpuExtensionServiceList)(nil),                                           // 856: forge.DpuExtensionServiceList
+	(*GetDpuExtensionServiceVersionsInfoRequest)(nil),                         // 857: forge.GetDpuExtensionServiceVersionsInfoRequest
+	(*DpuExtensionServiceVersionInfoList)(nil),                                // 858: forge.DpuExtensionServiceVersionInfoList
+	(*FindInstancesByDpuExtensionServiceRequest)(nil),                         // 859: forge.FindInstancesByDpuExtensionServiceRequest
+	(*FindInstancesByDpuExtensionServiceResponse)(nil),                        // 860: forge.FindInstancesByDpuExtensionServiceResponse
+	(*InstanceDpuExtensionServiceInfo)(nil),                                   // 861: forge.InstanceDpuExtensionServiceInfo
+	(*DpuExtensionServiceObservabilityConfigPrometheus)(nil),                  // 862: forge.DpuExtensionServiceObservabilityConfigPrometheus
+	(*DpuExtensionServiceObservabilityConfigLogging)(nil),                     // 863: forge.DpuExtensionServiceObservabilityConfigLogging
+	(*DpuExtensionServiceObservabilityConfig)(nil),                            // 864: forge.DpuExtensionServiceObservabilityConfig
+	(*DpuExtensionServiceObservability)(nil),                                  // 865: forge.DpuExtensionServiceObservability
+	(*ScoutStreamApiBoundMessage)(nil),                                        // 866: forge.ScoutStreamApiBoundMessage
+	(*ScoutStreamScoutBoundMessage)(nil),                                      // 867: forge.ScoutStreamScoutBoundMessage
+	(*ScoutStreamInitRequest)(nil),                                            // 868: forge.ScoutStreamInitRequest
+	(*ScoutStreamShowConnectionsRequest)(nil),                                 // 869: forge.ScoutStreamShowConnectionsRequest
+	(*ScoutStreamShowConnectionsResponse)(nil),                                // 870: forge.ScoutStreamShowConnectionsResponse
+	(*ScoutStreamDisconnectRequest)(nil),                                      // 871: forge.ScoutStreamDisconnectRequest
+	(*ScoutStreamDisconnectResponse)(nil),                                     // 872: forge.ScoutStreamDisconnectResponse
+	(*ScoutStreamAdminPingRequest)(nil),                                       // 873: forge.ScoutStreamAdminPingRequest
+	(*ScoutStreamAdminPingResponse)(nil),                                      // 874: forge.ScoutStreamAdminPingResponse
+	(*ScoutStreamAgentPingRequest)(nil),                                       // 875: forge.ScoutStreamAgentPingRequest
+	(*ScoutStreamAgentPingResponse)(nil),                                      // 876: forge.ScoutStreamAgentPingResponse
+	(*ScoutStreamConnectionInfo)(nil),                                         // 877: forge.ScoutStreamConnectionInfo
+	(*ScoutStreamError)(nil),                                                  // 878: forge.ScoutStreamError
+	(*PrefixFilterPolicyEntry)(nil),                                           // 879: forge.PrefixFilterPolicyEntry
+	(*RoutingProfile)(nil),                                                    // 880: forge.RoutingProfile
+	(*DomainLegacy)(nil),                                                      // 881: forge.DomainLegacy
+	(*DomainListLegacy)(nil),                                                  // 882: forge.DomainListLegacy
+	(*DomainDeletionLegacy)(nil),                                              // 883: forge.DomainDeletionLegacy
+	(*DomainDeletionResultLegacy)(nil),                                        // 884: forge.DomainDeletionResultLegacy
+	(*DomainSearchQueryLegacy)(nil),                                           // 885: forge.DomainSearchQueryLegacy
+	(*PxeDomain)(nil),                                                         // 886: forge.PxeDomain
+	(*MachinePositionQuery)(nil),                                              // 887: forge.MachinePositionQuery
+	(*MachinePositionInfoList)(nil),                                           // 888: forge.MachinePositionInfoList
+	(*MachinePositionInfo)(nil),                                               // 889: forge.MachinePositionInfo
+	(*ModifyDPFStateRequest)(nil),                                             // 890: forge.ModifyDPFStateRequest
+	(*DPFStateResponse)(nil),                                                  // 891: forge.DPFStateResponse
+	(*GetDPFStateRequest)(nil),                                                // 892: forge.GetDPFStateRequest
+	(*GetDPFHostSnapshotRequest)(nil),                                         // 893: forge.GetDPFHostSnapshotRequest
+	(*DPFHostSnapshotResponse)(nil),                                           // 894: forge.DPFHostSnapshotResponse
+	(*GetDPFServiceVersionsRequest)(nil),                                      // 895: forge.GetDPFServiceVersionsRequest
+	(*DPFServiceVersion)(nil),                                                 // 896: forge.DPFServiceVersion
+	(*DPFServiceVersionsResponse)(nil),                                        // 897: forge.DPFServiceVersionsResponse
+	(*ComponentResult)(nil),                                                   // 898: forge.ComponentResult
+	(*SwitchIdList)(nil),                                                      // 899: forge.SwitchIdList
+	(*PowerShelfIdList)(nil),                                                  // 900: forge.PowerShelfIdList
+	(*GetComponentInventoryRequest)(nil),                                      // 901: forge.GetComponentInventoryRequest
+	(*ComponentInventoryEntry)(nil),                                           // 902: forge.ComponentInventoryEntry
+	(*GetComponentInventoryResponse)(nil),                                     // 903: forge.GetComponentInventoryResponse
+	(*ComponentPowerControlRequest)(nil),                                      // 904: forge.ComponentPowerControlRequest
+	(*ComponentPowerControlResponse)(nil),                                     // 905: forge.ComponentPowerControlResponse
+	(*ComponentConfigureSwitchCertificateRequest)(nil),                        // 906: forge.ComponentConfigureSwitchCertificateRequest
+	(*ComponentConfigureSwitchCertificateResponse)(nil),                       // 907: forge.ComponentConfigureSwitchCertificateResponse
+	(*FirmwareUpdateStatus)(nil),                                              // 908: forge.FirmwareUpdateStatus
+	(*UpdateComputeTrayFirmwareTarget)(nil),                                   // 909: forge.UpdateComputeTrayFirmwareTarget
+	(*UpdateSwitchFirmwareTarget)(nil),                                        // 910: forge.UpdateSwitchFirmwareTarget
+	(*UpdatePowerShelfFirmwareTarget)(nil),                                    // 911: forge.UpdatePowerShelfFirmwareTarget
+	(*UpdateFirmwareObjectTarget)(nil),                                        // 912: forge.UpdateFirmwareObjectTarget
+	(*UpdateComponentFirmwareRequest)(nil),                                    // 913: forge.UpdateComponentFirmwareRequest
+	(*UpdateComponentFirmwareResponse)(nil),                                   // 914: forge.UpdateComponentFirmwareResponse
+	(*GetComponentFirmwareStatusRequest)(nil),                                 // 915: forge.GetComponentFirmwareStatusRequest
+	(*GetComponentFirmwareStatusResponse)(nil),                                // 916: forge.GetComponentFirmwareStatusResponse
+	(*ListComponentFirmwareVersionsRequest)(nil),                              // 917: forge.ListComponentFirmwareVersionsRequest
+	(*ComputeTrayFirmwareVersions)(nil),                                       // 918: forge.ComputeTrayFirmwareVersions
+	(*DeviceFirmwareVersions)(nil),                                            // 919: forge.DeviceFirmwareVersions
+	(*ListComponentFirmwareVersionsResponse)(nil),                             // 920: forge.ListComponentFirmwareVersionsResponse
+	(*SpxPartitionCreationRequest)(nil),                                       // 921: forge.SpxPartitionCreationRequest
+	(*SpxPartition)(nil),                                                      // 922: forge.SpxPartition
+	(*SpxPartitionIdList)(nil),                                                // 923: forge.SpxPartitionIdList
+	(*SpxPartitionDeletionRequest)(nil),                                       // 924: forge.SpxPartitionDeletionRequest
+	(*SpxPartitionDeletionResult)(nil),                                        // 925: forge.SpxPartitionDeletionResult
+	(*SpxPartitionSearchFilter)(nil),                                          // 926: forge.SpxPartitionSearchFilter
+	(*SpxPartitionList)(nil),                                                  // 927: forge.SpxPartitionList
+	(*SpxPartitionsByIdsRequest)(nil),                                         // 928: forge.SpxPartitionsByIdsRequest
+	(*AdminForceDeleteSwitchRequest)(nil),                                     // 929: forge.AdminForceDeleteSwitchRequest
+	(*AdminForceDeleteSwitchResponse)(nil),                                    // 930: forge.AdminForceDeleteSwitchResponse
+	(*AdminForceDeletePowerShelfRequest)(nil),                                 // 931: forge.AdminForceDeletePowerShelfRequest
+	(*AdminForceDeletePowerShelfResponse)(nil),                                // 932: forge.AdminForceDeletePowerShelfResponse
+	(*OperatingSystem)(nil),                                                   // 933: forge.OperatingSystem
+	(*CreateOperatingSystemRequest)(nil),                                      // 934: forge.CreateOperatingSystemRequest
+	(*IpxeTemplateParameters)(nil),                                            // 935: forge.IpxeTemplateParameters
+	(*IpxeTemplateArtifacts)(nil),                                             // 936: forge.IpxeTemplateArtifacts
+	(*UpdateOperatingSystemRequest)(nil),                                      // 937: forge.UpdateOperatingSystemRequest
+	(*DeleteOperatingSystemRequest)(nil),                                      // 938: forge.DeleteOperatingSystemRequest
+	(*DeleteOperatingSystemResponse)(nil),                                     // 939: forge.DeleteOperatingSystemResponse
+	(*OperatingSystemSearchFilter)(nil),                                       // 940: forge.OperatingSystemSearchFilter
+	(*OperatingSystemIdList)(nil),                                             // 941: forge.OperatingSystemIdList
+	(*OperatingSystemsByIdsRequest)(nil),                                      // 942: forge.OperatingSystemsByIdsRequest
+	(*OperatingSystemList)(nil),                                               // 943: forge.OperatingSystemList
+	(*GetOperatingSystemCachableIpxeTemplateArtifactsRequest)(nil),            // 944: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	(*IpxeTemplateArtifactList)(nil),                                          // 945: forge.IpxeTemplateArtifactList
+	(*IpxeTemplateArtifactUpdateRequest)(nil),                                 // 946: forge.IpxeTemplateArtifactUpdateRequest
+	(*UpdateOperatingSystemIpxeTemplateArtifactRequest)(nil),                  // 947: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	(*HostRepresentorInterceptBridging)(nil),                                  // 948: forge.HostRepresentorInterceptBridging
+	(*ReWrapSecretsRequest)(nil),                                              // 949: forge.ReWrapSecretsRequest
+	(*ReWrapSecretsResponse)(nil),                                             // 950: forge.ReWrapSecretsResponse
+	(*GetMachineBootInterfacesRequest)(nil),                                   // 951: forge.GetMachineBootInterfacesRequest
+	(*MachineBootInterface)(nil),                                              // 952: forge.MachineBootInterface
+	(*MachineInterfaceBootInterface)(nil),                                     // 953: forge.MachineInterfaceBootInterface
+	(*PredictedBootInterface)(nil),                                            // 954: forge.PredictedBootInterface
+	(*ExploredBootInterface)(nil),                                             // 955: forge.ExploredBootInterface
+	(*RetainedBootInterface)(nil),                                             // 956: forge.RetainedBootInterface
+	(*GetMachineBootInterfacesResponse)(nil),                                  // 957: forge.GetMachineBootInterfacesResponse
+	(*GetContainerRegistryCredentialRequest)(nil),                             // 958: forge.GetContainerRegistryCredentialRequest
+	(*GetContainerRegistryCredentialResponse)(nil),                            // 959: forge.GetContainerRegistryCredentialResponse
+	(*SetContainerRegistryCredentialRequest)(nil),                             // 960: forge.SetContainerRegistryCredentialRequest
+	(*SitePrefix)(nil),                                                        // 961: forge.SitePrefix
+	(*SitePrefixConfig)(nil),                                                  // 962: forge.SitePrefixConfig
+	(*SitePrefixStatus)(nil),                                                  // 963: forge.SitePrefixStatus
+	(*SitePrefixSearchFilter)(nil),                                            // 964: forge.SitePrefixSearchFilter
+	(*SitePrefixesByIdsRequest)(nil),                                          // 965: forge.SitePrefixesByIdsRequest
+	(*SitePrefixIdList)(nil),                                                  // 966: forge.SitePrefixIdList
+	(*SitePrefixList)(nil),                                                    // 967: forge.SitePrefixList
+	nil,                                                                       // 968: forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
+	(*DNSMessage_DNSQuestion)(nil),                                            // 969: forge.DNSMessage.DNSQuestion
+	(*DNSMessage_DNSResponse)(nil),                                            // 970: forge.DNSMessage.DNSResponse
+	(*DNSMessage_DNSResponse_DNSRR)(nil),                                      // 971: forge.DNSMessage.DNSResponse.DNSRR
+	nil,                                                                       // 972: forge.FabricManagerConfig.ConfigMapEntry
+	nil,                                                                       // 973: forge.StateHistories.HistoriesEntry
+	nil,                                                                       // 974: forge.MachineStateHistories.HistoriesEntry
+	nil,                                                                       // 975: forge.HealthHistories.HistoriesEntry
+	nil,                                                                       // 976: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
+	(*MachineCredentialsUpdateRequest_Credentials)(nil),                       // 977: forge.MachineCredentialsUpdateRequest.Credentials
+	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo)(nil),              // 978: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
+	(*ForgeAgentControlResponse_Noop)(nil),                                    // 979: forge.ForgeAgentControlResponse.Noop
+	(*ForgeAgentControlResponse_Reset)(nil),                                   // 980: forge.ForgeAgentControlResponse.Reset
+	(*ForgeAgentControlResponse_Discovery)(nil),                               // 981: forge.ForgeAgentControlResponse.Discovery
+	(*ForgeAgentControlResponse_Rebuild)(nil),                                 // 982: forge.ForgeAgentControlResponse.Rebuild
+	(*ForgeAgentControlResponse_Retry)(nil),                                   // 983: forge.ForgeAgentControlResponse.Retry
+	(*ForgeAgentControlResponse_Measure)(nil),                                 // 984: forge.ForgeAgentControlResponse.Measure
+	(*ForgeAgentControlResponse_LogError)(nil),                                // 985: forge.ForgeAgentControlResponse.LogError
+	(*ForgeAgentControlResponse_MachineValidation)(nil),                       // 986: forge.ForgeAgentControlResponse.MachineValidation
+	(*ForgeAgentControlResponse_MachineValidationFilter)(nil),                 // 987: forge.ForgeAgentControlResponse.MachineValidationFilter
+	(*ForgeAgentControlResponse_MlxAction)(nil),                               // 988: forge.ForgeAgentControlResponse.MlxAction
+	(*ForgeAgentControlResponse_MlxDeviceAction)(nil),                         // 989: forge.ForgeAgentControlResponse.MlxDeviceAction
+	(*ForgeAgentControlResponse_MlxDeviceNoop)(nil),                           // 990: forge.ForgeAgentControlResponse.MlxDeviceNoop
+	(*ForgeAgentControlResponse_MlxDeviceLock)(nil),                           // 991: forge.ForgeAgentControlResponse.MlxDeviceLock
+	(*ForgeAgentControlResponse_MlxDeviceUnlock)(nil),                         // 992: forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	(*ForgeAgentControlResponse_MlxDeviceApplyProfile)(nil),                   // 993: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	(*ForgeAgentControlResponse_MlxDeviceApplyFirmware)(nil),                  // 994: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	(*ForgeAgentControlResponse_FirmwareUpgrade)(nil),                         // 995: forge.ForgeAgentControlResponse.FirmwareUpgrade
+	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair)(nil), // 996: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	(*MachineCleanupInfo_CleanupStepResult)(nil),                              // 997: forge.MachineCleanupInfo.CleanupStepResult
+	(*DpuReprovisioningListResponse_DpuReprovisioningListItem)(nil),           // 998: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
+	(*HostReprovisioningListResponse_HostReprovisioningListItem)(nil),         // 999: forge.HostReprovisioningListResponse.HostReprovisioningListItem
+	(*MachineValidationTestUpdateRequest_Payload)(nil),                        // 1000: forge.MachineValidationTestUpdateRequest.Payload
+	nil,                                                  // 1001: forge.RedfishBrowseResponse.HeadersEntry
+	nil,                                                  // 1002: forge.RedfishActionResult.HeadersEntry
+	nil,                                                  // 1003: forge.UfmBrowseResponse.HeadersEntry
+	nil,                                                  // 1004: forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
+	nil,                                                  // 1005: forge.NmxcBrowseResponse.HeadersEntry
+	(*DPFStateResponse_DPFState)(nil),                    // 1006: forge.DPFStateResponse.DPFState
+	(*MachineId)(nil),                                    // 1007: common.MachineId
+	(*timestamppb.Timestamp)(nil),                        // 1008: google.protobuf.Timestamp
+	(*VpcId)(nil),                                        // 1009: common.VpcId
+	(*NVLinkLogicalPartitionId)(nil),                     // 1010: common.NVLinkLogicalPartitionId
+	(*VpcPrefixId)(nil),                                  // 1011: common.VpcPrefixId
+	(*VpcPeeringId)(nil),                                 // 1012: common.VpcPeeringId
+	(*IBPartitionId)(nil),                                // 1013: common.IBPartitionId
+	(*HealthReport)(nil),                                 // 1014: health.HealthReport
+	(*PowerShelfId)(nil),                                 // 1015: common.PowerShelfId
+	(*RackId)(nil),                                       // 1016: common.RackId
+	(*UUID)(nil),                                         // 1017: common.UUID
+	(*SwitchId)(nil),                                     // 1018: common.SwitchId
+	(*RackProfileId)(nil),                                // 1019: common.RackProfileId
+	(*DomainId)(nil),                                     // 1020: common.DomainId
+	(*NetworkSegmentId)(nil),                             // 1021: common.NetworkSegmentId
+	(*NetworkPrefixId)(nil),                              // 1022: common.NetworkPrefixId
+	(*InstanceId)(nil),                                   // 1023: common.InstanceId
+	(*IpxeTemplateId)(nil),                               // 1024: common.IpxeTemplateId
+	(*OperatingSystemId)(nil),                            // 1025: common.OperatingSystemId
+	(*SpxPartitionId)(nil),                               // 1026: common.SpxPartitionId
+	(*NVLinkDomainId)(nil),                               // 1027: common.NVLinkDomainId
+	(*MachineInterfaceId)(nil),                           // 1028: common.MachineInterfaceId
+	(*DiscoveryInfo)(nil),                                // 1029: machine_discovery.DiscoveryInfo
+	(*durationpb.Duration)(nil),                          // 1030: google.protobuf.Duration
+	(*StringList)(nil),                                   // 1031: common.StringList
+	(*Gpu)(nil),                                          // 1032: machine_discovery.Gpu
+	(*RouteTarget)(nil),                                  // 1033: common.RouteTarget
+	(*MachineValidationId)(nil),                          // 1034: common.MachineValidationId
+	(*Uint32List)(nil),                                   // 1035: common.Uint32List
+	(*DpaInterfaceId)(nil),                               // 1036: common.DpaInterfaceId
+	(*ComputeAllocationId)(nil),                          // 1037: common.ComputeAllocationId
+	(*RackHardwareType)(nil),                             // 1038: common.RackHardwareType
+	(*NVLinkPartitionId)(nil),                            // 1039: common.NVLinkPartitionId
+	(*RemediationId)(nil),                                // 1040: common.RemediationId
+	(*MlxDeviceLockdownResponse)(nil),                    // 1041: mlx_device.MlxDeviceLockdownResponse
+	(*MlxDeviceProfileSyncResponse)(nil),                 // 1042: mlx_device.MlxDeviceProfileSyncResponse
+	(*MlxDeviceProfileCompareResponse)(nil),              // 1043: mlx_device.MlxDeviceProfileCompareResponse
+	(*MlxDeviceInfoDeviceResponse)(nil),                  // 1044: mlx_device.MlxDeviceInfoDeviceResponse
+	(*MlxDeviceInfoReportResponse)(nil),                  // 1045: mlx_device.MlxDeviceInfoReportResponse
+	(*MlxDeviceRegistryListResponse)(nil),                // 1046: mlx_device.MlxDeviceRegistryListResponse
+	(*MlxDeviceRegistryShowResponse)(nil),                // 1047: mlx_device.MlxDeviceRegistryShowResponse
+	(*MlxDeviceConfigQueryResponse)(nil),                 // 1048: mlx_device.MlxDeviceConfigQueryResponse
+	(*MlxDeviceConfigSetResponse)(nil),                   // 1049: mlx_device.MlxDeviceConfigSetResponse
+	(*MlxDeviceConfigSyncResponse)(nil),                  // 1050: mlx_device.MlxDeviceConfigSyncResponse
+	(*MlxDeviceConfigCompareResponse)(nil),               // 1051: mlx_device.MlxDeviceConfigCompareResponse
+	(*MlxDeviceLockdownLockRequest)(nil),                 // 1052: mlx_device.MlxDeviceLockdownLockRequest
+	(*MlxDeviceLockdownUnlockRequest)(nil),               // 1053: mlx_device.MlxDeviceLockdownUnlockRequest
+	(*MlxDeviceLockdownStatusRequest)(nil),               // 1054: mlx_device.MlxDeviceLockdownStatusRequest
+	(*MlxDeviceProfileSyncRequest)(nil),                  // 1055: mlx_device.MlxDeviceProfileSyncRequest
+	(*MlxDeviceProfileCompareRequest)(nil),               // 1056: mlx_device.MlxDeviceProfileCompareRequest
+	(*MlxDeviceInfoDeviceRequest)(nil),                   // 1057: mlx_device.MlxDeviceInfoDeviceRequest
+	(*MlxDeviceInfoReportRequest)(nil),                   // 1058: mlx_device.MlxDeviceInfoReportRequest
+	(*MlxDeviceRegistryListRequest)(nil),                 // 1059: mlx_device.MlxDeviceRegistryListRequest
+	(*MlxDeviceRegistryShowRequest)(nil),                 // 1060: mlx_device.MlxDeviceRegistryShowRequest
+	(*MlxDeviceConfigQueryRequest)(nil),                  // 1061: mlx_device.MlxDeviceConfigQueryRequest
+	(*MlxDeviceConfigSetRequest)(nil),                    // 1062: mlx_device.MlxDeviceConfigSetRequest
+	(*MlxDeviceConfigSyncRequest)(nil),                   // 1063: mlx_device.MlxDeviceConfigSyncRequest
+	(*MlxDeviceConfigCompareRequest)(nil),                // 1064: mlx_device.MlxDeviceConfigCompareRequest
+	(*Domain)(nil),                                       // 1065: dns.Domain
+	(*MachineIdList)(nil),                                // 1066: common.MachineIdList
+	(*EndpointExplorationReport)(nil),                    // 1067: site_explorer.EndpointExplorationReport
+	(SystemPowerControl)(0),                              // 1068: common.SystemPowerControl
+	(*SitePrefixId)(nil),                                 // 1069: common.SitePrefixId
+	(*SerializableMlxConfigProfile)(nil),                 // 1070: mlx_device.SerializableMlxConfigProfile
+	(*FirmwareFlasherProfile)(nil),                       // 1071: mlx_device.FirmwareFlasherProfile
+	(*ScoutFirmwareUpgradeTask)(nil),                     // 1072: scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	(*CreateDomainRequest)(nil),                          // 1073: dns.CreateDomainRequest
+	(*UpdateDomainRequest)(nil),                          // 1074: dns.UpdateDomainRequest
+	(*DomainDeletionRequest)(nil),                        // 1075: dns.DomainDeletionRequest
+	(*DomainSearchQuery)(nil),                            // 1076: dns.DomainSearchQuery
+	(*DnsResourceRecordLookupRequest)(nil),               // 1077: dns.DnsResourceRecordLookupRequest
+	(*GetAllDomainsRequest)(nil),                         // 1078: dns.GetAllDomainsRequest
+	(*DomainMetadataRequest)(nil),                        // 1079: dns.DomainMetadataRequest
+	(*emptypb.Empty)(nil),                                // 1080: google.protobuf.Empty
+	(*ExploredEndpointSearchFilter)(nil),                 // 1081: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointsByIdsRequest)(nil),                // 1082: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredManagedHostSearchFilter)(nil),              // 1083: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostsByIdsRequest)(nil),             // 1084: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1085: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1086: site_explorer.ExploredMlxDevicesByIdsRequest
+	(*CreateMeasurementBundleRequest)(nil),               // 1087: measured_boot.CreateMeasurementBundleRequest
+	(*DeleteMeasurementBundleRequest)(nil),               // 1088: measured_boot.DeleteMeasurementBundleRequest
+	(*RenameMeasurementBundleRequest)(nil),               // 1089: measured_boot.RenameMeasurementBundleRequest
+	(*UpdateMeasurementBundleRequest)(nil),               // 1090: measured_boot.UpdateMeasurementBundleRequest
+	(*ShowMeasurementBundleRequest)(nil),                 // 1091: measured_boot.ShowMeasurementBundleRequest
+	(*ShowMeasurementBundlesRequest)(nil),                // 1092: measured_boot.ShowMeasurementBundlesRequest
+	(*ListMeasurementBundlesRequest)(nil),                // 1093: measured_boot.ListMeasurementBundlesRequest
+	(*ListMeasurementBundleMachinesRequest)(nil),         // 1094: measured_boot.ListMeasurementBundleMachinesRequest
+	(*FindClosestBundleMatchRequest)(nil),                // 1095: measured_boot.FindClosestBundleMatchRequest
+	(*DeleteMeasurementJournalRequest)(nil),              // 1096: measured_boot.DeleteMeasurementJournalRequest
+	(*ShowMeasurementJournalRequest)(nil),                // 1097: measured_boot.ShowMeasurementJournalRequest
+	(*ShowMeasurementJournalsRequest)(nil),               // 1098: measured_boot.ShowMeasurementJournalsRequest
+	(*ListMeasurementJournalRequest)(nil),                // 1099: measured_boot.ListMeasurementJournalRequest
+	(*AttestCandidateMachineRequest)(nil),                // 1100: measured_boot.AttestCandidateMachineRequest
+	(*ShowCandidateMachineRequest)(nil),                  // 1101: measured_boot.ShowCandidateMachineRequest
+	(*ShowCandidateMachinesRequest)(nil),                 // 1102: measured_boot.ShowCandidateMachinesRequest
+	(*ListCandidateMachinesRequest)(nil),                 // 1103: measured_boot.ListCandidateMachinesRequest
+	(*CreateMeasurementSystemProfileRequest)(nil),        // 1104: measured_boot.CreateMeasurementSystemProfileRequest
+	(*DeleteMeasurementSystemProfileRequest)(nil),        // 1105: measured_boot.DeleteMeasurementSystemProfileRequest
+	(*RenameMeasurementSystemProfileRequest)(nil),        // 1106: measured_boot.RenameMeasurementSystemProfileRequest
+	(*ShowMeasurementSystemProfileRequest)(nil),          // 1107: measured_boot.ShowMeasurementSystemProfileRequest
+	(*ShowMeasurementSystemProfilesRequest)(nil),         // 1108: measured_boot.ShowMeasurementSystemProfilesRequest
+	(*ListMeasurementSystemProfilesRequest)(nil),         // 1109: measured_boot.ListMeasurementSystemProfilesRequest
+	(*ListMeasurementSystemProfileBundlesRequest)(nil),   // 1110: measured_boot.ListMeasurementSystemProfileBundlesRequest
+	(*ListMeasurementSystemProfileMachinesRequest)(nil),  // 1111: measured_boot.ListMeasurementSystemProfileMachinesRequest
+	(*CreateMeasurementReportRequest)(nil),               // 1112: measured_boot.CreateMeasurementReportRequest
+	(*DeleteMeasurementReportRequest)(nil),               // 1113: measured_boot.DeleteMeasurementReportRequest
+	(*PromoteMeasurementReportRequest)(nil),              // 1114: measured_boot.PromoteMeasurementReportRequest
+	(*RevokeMeasurementReportRequest)(nil),               // 1115: measured_boot.RevokeMeasurementReportRequest
+	(*ShowMeasurementReportForIdRequest)(nil),            // 1116: measured_boot.ShowMeasurementReportForIdRequest
+	(*ShowMeasurementReportsForMachineRequest)(nil),      // 1117: measured_boot.ShowMeasurementReportsForMachineRequest
+	(*ShowMeasurementReportsRequest)(nil),                // 1118: measured_boot.ShowMeasurementReportsRequest
+	(*ListMeasurementReportRequest)(nil),                 // 1119: measured_boot.ListMeasurementReportRequest
+	(*MatchMeasurementReportRequest)(nil),                // 1120: measured_boot.MatchMeasurementReportRequest
+	(*ImportSiteMeasurementsRequest)(nil),                // 1121: measured_boot.ImportSiteMeasurementsRequest
+	(*ExportSiteMeasurementsRequest)(nil),                // 1122: measured_boot.ExportSiteMeasurementsRequest
+	(*AddMeasurementTrustedMachineRequest)(nil),          // 1123: measured_boot.AddMeasurementTrustedMachineRequest
+	(*RemoveMeasurementTrustedMachineRequest)(nil),       // 1124: measured_boot.RemoveMeasurementTrustedMachineRequest
+	(*AddMeasurementTrustedProfileRequest)(nil),          // 1125: measured_boot.AddMeasurementTrustedProfileRequest
+	(*RemoveMeasurementTrustedProfileRequest)(nil),       // 1126: measured_boot.RemoveMeasurementTrustedProfileRequest
+	(*ListMeasurementTrustedMachinesRequest)(nil),        // 1127: measured_boot.ListMeasurementTrustedMachinesRequest
+	(*ListMeasurementTrustedProfilesRequest)(nil),        // 1128: measured_boot.ListMeasurementTrustedProfilesRequest
+	(*ListAttestationSummaryRequest)(nil),                // 1129: measured_boot.ListAttestationSummaryRequest
+	(*PublishMlxDeviceReportRequest)(nil),                // 1130: mlx_device.PublishMlxDeviceReportRequest
+	(*PublishMlxObservationReportRequest)(nil),           // 1131: mlx_device.PublishMlxObservationReportRequest
+	(*MlxAdminProfileSyncRequest)(nil),                   // 1132: mlx_device.MlxAdminProfileSyncRequest
+	(*MlxAdminProfileShowRequest)(nil),                   // 1133: mlx_device.MlxAdminProfileShowRequest
+	(*MlxAdminProfileCompareRequest)(nil),                // 1134: mlx_device.MlxAdminProfileCompareRequest
+	(*MlxAdminProfileListRequest)(nil),                   // 1135: mlx_device.MlxAdminProfileListRequest
+	(*MlxAdminLockdownLockRequest)(nil),                  // 1136: mlx_device.MlxAdminLockdownLockRequest
+	(*MlxAdminLockdownUnlockRequest)(nil),                // 1137: mlx_device.MlxAdminLockdownUnlockRequest
+	(*MlxAdminLockdownStatusRequest)(nil),                // 1138: mlx_device.MlxAdminLockdownStatusRequest
+	(*MlxAdminDeviceInfoRequest)(nil),                    // 1139: mlx_device.MlxAdminDeviceInfoRequest
+	(*MlxAdminDeviceReportRequest)(nil),                  // 1140: mlx_device.MlxAdminDeviceReportRequest
+	(*MlxAdminRegistryListRequest)(nil),                  // 1141: mlx_device.MlxAdminRegistryListRequest
+	(*MlxAdminRegistryShowRequest)(nil),                  // 1142: mlx_device.MlxAdminRegistryShowRequest
+	(*MlxAdminConfigQueryRequest)(nil),                   // 1143: mlx_device.MlxAdminConfigQueryRequest
+	(*MlxAdminConfigSetRequest)(nil),                     // 1144: mlx_device.MlxAdminConfigSetRequest
+	(*MlxAdminConfigSyncRequest)(nil),                    // 1145: mlx_device.MlxAdminConfigSyncRequest
+	(*MlxAdminConfigCompareRequest)(nil),                 // 1146: mlx_device.MlxAdminConfigCompareRequest
+	(*DomainDeletionResult)(nil),                         // 1147: dns.DomainDeletionResult
+	(*DomainList)(nil),                                   // 1148: dns.DomainList
+	(*DnsResourceRecordLookupResponse)(nil),              // 1149: dns.DnsResourceRecordLookupResponse
+	(*GetAllDomainsResponse)(nil),                        // 1150: dns.GetAllDomainsResponse
+	(*DomainMetadataResponse)(nil),                       // 1151: dns.DomainMetadataResponse
+	(*SiteExplorationReport)(nil),                        // 1152: site_explorer.SiteExplorationReport
+	(*SiteExplorerLastRunResponse)(nil),                  // 1153: site_explorer.SiteExplorerLastRunResponse
+	(*ExploredEndpoint)(nil),                             // 1154: site_explorer.ExploredEndpoint
+	(*ExploredEndpointIdList)(nil),                       // 1155: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointList)(nil),                         // 1156: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostIdList)(nil),                    // 1157: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostList)(nil),                      // 1158: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDeviceHostIdList)(nil),                  // 1159: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDeviceList)(nil),                        // 1160: site_explorer.ExploredMlxDeviceList
+	(*CreateMeasurementBundleResponse)(nil),              // 1161: measured_boot.CreateMeasurementBundleResponse
+	(*DeleteMeasurementBundleResponse)(nil),              // 1162: measured_boot.DeleteMeasurementBundleResponse
+	(*RenameMeasurementBundleResponse)(nil),              // 1163: measured_boot.RenameMeasurementBundleResponse
+	(*UpdateMeasurementBundleResponse)(nil),              // 1164: measured_boot.UpdateMeasurementBundleResponse
+	(*ShowMeasurementBundleResponse)(nil),                // 1165: measured_boot.ShowMeasurementBundleResponse
+	(*ShowMeasurementBundlesResponse)(nil),               // 1166: measured_boot.ShowMeasurementBundlesResponse
+	(*ListMeasurementBundlesResponse)(nil),               // 1167: measured_boot.ListMeasurementBundlesResponse
+	(*ListMeasurementBundleMachinesResponse)(nil),        // 1168: measured_boot.ListMeasurementBundleMachinesResponse
+	(*DeleteMeasurementJournalResponse)(nil),             // 1169: measured_boot.DeleteMeasurementJournalResponse
+	(*ShowMeasurementJournalResponse)(nil),               // 1170: measured_boot.ShowMeasurementJournalResponse
+	(*ShowMeasurementJournalsResponse)(nil),              // 1171: measured_boot.ShowMeasurementJournalsResponse
+	(*ListMeasurementJournalResponse)(nil),               // 1172: measured_boot.ListMeasurementJournalResponse
+	(*AttestCandidateMachineResponse)(nil),               // 1173: measured_boot.AttestCandidateMachineResponse
+	(*ShowCandidateMachineResponse)(nil),                 // 1174: measured_boot.ShowCandidateMachineResponse
+	(*ShowCandidateMachinesResponse)(nil),                // 1175: measured_boot.ShowCandidateMachinesResponse
+	(*ListCandidateMachinesResponse)(nil),                // 1176: measured_boot.ListCandidateMachinesResponse
+	(*CreateMeasurementSystemProfileResponse)(nil),       // 1177: measured_boot.CreateMeasurementSystemProfileResponse
+	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1178: measured_boot.DeleteMeasurementSystemProfileResponse
+	(*RenameMeasurementSystemProfileResponse)(nil),       // 1179: measured_boot.RenameMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfileResponse)(nil),         // 1180: measured_boot.ShowMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1181: measured_boot.ShowMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfilesResponse)(nil),        // 1182: measured_boot.ListMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1183: measured_boot.ListMeasurementSystemProfileBundlesResponse
+	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1184: measured_boot.ListMeasurementSystemProfileMachinesResponse
+	(*CreateMeasurementReportResponse)(nil),              // 1185: measured_boot.CreateMeasurementReportResponse
+	(*DeleteMeasurementReportResponse)(nil),              // 1186: measured_boot.DeleteMeasurementReportResponse
+	(*PromoteMeasurementReportResponse)(nil),             // 1187: measured_boot.PromoteMeasurementReportResponse
+	(*RevokeMeasurementReportResponse)(nil),              // 1188: measured_boot.RevokeMeasurementReportResponse
+	(*ShowMeasurementReportForIdResponse)(nil),           // 1189: measured_boot.ShowMeasurementReportForIdResponse
+	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1190: measured_boot.ShowMeasurementReportsForMachineResponse
+	(*ShowMeasurementReportsResponse)(nil),               // 1191: measured_boot.ShowMeasurementReportsResponse
+	(*ListMeasurementReportResponse)(nil),                // 1192: measured_boot.ListMeasurementReportResponse
+	(*MatchMeasurementReportResponse)(nil),               // 1193: measured_boot.MatchMeasurementReportResponse
+	(*ImportSiteMeasurementsResponse)(nil),               // 1194: measured_boot.ImportSiteMeasurementsResponse
+	(*ExportSiteMeasurementsResponse)(nil),               // 1195: measured_boot.ExportSiteMeasurementsResponse
+	(*AddMeasurementTrustedMachineResponse)(nil),         // 1196: measured_boot.AddMeasurementTrustedMachineResponse
+	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1197: measured_boot.RemoveMeasurementTrustedMachineResponse
+	(*AddMeasurementTrustedProfileResponse)(nil),         // 1198: measured_boot.AddMeasurementTrustedProfileResponse
+	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1199: measured_boot.RemoveMeasurementTrustedProfileResponse
+	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1200: measured_boot.ListMeasurementTrustedMachinesResponse
+	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1201: measured_boot.ListMeasurementTrustedProfilesResponse
+	(*ListAttestationSummaryResponse)(nil),               // 1202: measured_boot.ListAttestationSummaryResponse
+	(*LockdownStatus)(nil),                               // 1203: site_explorer.LockdownStatus
+	(*PublishMlxDeviceReportResponse)(nil),               // 1204: mlx_device.PublishMlxDeviceReportResponse
+	(*PublishMlxObservationReportResponse)(nil),          // 1205: mlx_device.PublishMlxObservationReportResponse
+	(*MlxAdminProfileSyncResponse)(nil),                  // 1206: mlx_device.MlxAdminProfileSyncResponse
+	(*MlxAdminProfileShowResponse)(nil),                  // 1207: mlx_device.MlxAdminProfileShowResponse
+	(*MlxAdminProfileCompareResponse)(nil),               // 1208: mlx_device.MlxAdminProfileCompareResponse
+	(*MlxAdminProfileListResponse)(nil),                  // 1209: mlx_device.MlxAdminProfileListResponse
+	(*MlxAdminLockdownLockResponse)(nil),                 // 1210: mlx_device.MlxAdminLockdownLockResponse
+	(*MlxAdminLockdownUnlockResponse)(nil),               // 1211: mlx_device.MlxAdminLockdownUnlockResponse
+	(*MlxAdminLockdownStatusResponse)(nil),               // 1212: mlx_device.MlxAdminLockdownStatusResponse
+	(*MlxAdminDeviceInfoResponse)(nil),                   // 1213: mlx_device.MlxAdminDeviceInfoResponse
+	(*MlxAdminDeviceReportResponse)(nil),                 // 1214: mlx_device.MlxAdminDeviceReportResponse
+	(*MlxAdminRegistryListResponse)(nil),                 // 1215: mlx_device.MlxAdminRegistryListResponse
+	(*MlxAdminRegistryShowResponse)(nil),                 // 1216: mlx_device.MlxAdminRegistryShowResponse
+	(*MlxAdminConfigQueryResponse)(nil),                  // 1217: mlx_device.MlxAdminConfigQueryResponse
+	(*MlxAdminConfigSetResponse)(nil),                    // 1218: mlx_device.MlxAdminConfigSetResponse
+	(*MlxAdminConfigSyncResponse)(nil),                   // 1219: mlx_device.MlxAdminConfigSyncResponse
+	(*MlxAdminConfigCompareResponse)(nil),                // 1220: mlx_device.MlxAdminConfigCompareResponse
 }
 var file_nico_nico_proto_depIdxs = []int32{
-	356,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
-	358,  // 1: forge.LifecycleStatus.sla:type_name -> forge.StateSla
-	1005, // 2: forge.SpdmMachineAttestationStatus.machine_id:type_name -> common.MachineId
+	358,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
+	360,  // 1: forge.LifecycleStatus.sla:type_name -> forge.StateSla
+	1007, // 2: forge.SpdmMachineAttestationStatus.machine_id:type_name -> common.MachineId
 	0,    // 3: forge.SpdmMachineAttestationStatus.attestation_status:type_name -> forge.SpdmAttestationStatus
-	1005, // 4: forge.SpdmMachineAttestationTriggerResponse.machine_id:type_name -> common.MachineId
-	1005, // 5: forge.SpdmAttestationDetails.machine_id:type_name -> common.MachineId
-	1006, // 6: forge.SpdmAttestationDetails.started_at:type_name -> google.protobuf.Timestamp
-	1006, // 7: forge.SpdmAttestationDetails.cancelled_at:type_name -> google.protobuf.Timestamp
-	1006, // 8: forge.SpdmAttestationDetails.completed_at:type_name -> google.protobuf.Timestamp
-	99,   // 9: forge.SpdmGetAttestationMachineResponse.attestations_details:type_name -> forge.SpdmAttestationDetails
-	1005, // 10: forge.SpdmMachineAttestationTriggerRequest.machine_id:type_name -> common.MachineId
-	1005, // 11: forge.SpdmListAttestationMachinesRequest.machine_id:type_name -> common.MachineId
+	1007, // 4: forge.SpdmMachineAttestationTriggerResponse.machine_id:type_name -> common.MachineId
+	1007, // 5: forge.SpdmAttestationDetails.machine_id:type_name -> common.MachineId
+	1008, // 6: forge.SpdmAttestationDetails.started_at:type_name -> google.protobuf.Timestamp
+	1008, // 7: forge.SpdmAttestationDetails.cancelled_at:type_name -> google.protobuf.Timestamp
+	1008, // 8: forge.SpdmAttestationDetails.completed_at:type_name -> google.protobuf.Timestamp
+	101,  // 9: forge.SpdmGetAttestationMachineResponse.attestations_details:type_name -> forge.SpdmAttestationDetails
+	1007, // 10: forge.SpdmMachineAttestationTriggerRequest.machine_id:type_name -> common.MachineId
+	1007, // 11: forge.SpdmListAttestationMachinesRequest.machine_id:type_name -> common.MachineId
 	1,    // 12: forge.SpdmListAttestationMachinesRequest.selector:type_name -> forge.SpdmListAttestationMachinesRequestSelector
-	97,   // 13: forge.SpdmListAttestationMachinesResponse.statuses:type_name -> forge.SpdmMachineAttestationStatus
-	1006, // 14: forge.TenantIdentitySigningKey.expire_at:type_name -> google.protobuf.Timestamp
-	108,  // 15: forge.SetTenantIdentityConfigRequest.config:type_name -> forge.TenantIdentityConfig
-	108,  // 16: forge.TenantIdentityConfigResponse.config:type_name -> forge.TenantIdentityConfig
-	1006, // 17: forge.TenantIdentityConfigResponse.created_at:type_name -> google.protobuf.Timestamp
-	1006, // 18: forge.TenantIdentityConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
-	107,  // 19: forge.TenantIdentityConfigResponse.signing_keys:type_name -> forge.TenantIdentitySigningKey
-	112,  // 20: forge.TokenDelegationResponse.client_secret_basic:type_name -> forge.ClientSecretBasicResponse
-	1006, // 21: forge.TokenDelegationResponse.created_at:type_name -> google.protobuf.Timestamp
-	1006, // 22: forge.TokenDelegationResponse.updated_at:type_name -> google.protobuf.Timestamp
-	111,  // 23: forge.TokenDelegation.client_secret_basic:type_name -> forge.ClientSecretBasic
-	115,  // 24: forge.TokenDelegationRequest.config:type_name -> forge.TokenDelegation
-	118,  // 25: forge.ReencryptTenantIdentitySecretsResponse.failures:type_name -> forge.ReencryptTenantIdentityFailure
+	99,   // 13: forge.SpdmListAttestationMachinesResponse.statuses:type_name -> forge.SpdmMachineAttestationStatus
+	1008, // 14: forge.TenantIdentitySigningKey.expire_at:type_name -> google.protobuf.Timestamp
+	110,  // 15: forge.SetTenantIdentityConfigRequest.config:type_name -> forge.TenantIdentityConfig
+	110,  // 16: forge.TenantIdentityConfigResponse.config:type_name -> forge.TenantIdentityConfig
+	1008, // 17: forge.TenantIdentityConfigResponse.created_at:type_name -> google.protobuf.Timestamp
+	1008, // 18: forge.TenantIdentityConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
+	109,  // 19: forge.TenantIdentityConfigResponse.signing_keys:type_name -> forge.TenantIdentitySigningKey
+	114,  // 20: forge.TokenDelegationResponse.client_secret_basic:type_name -> forge.ClientSecretBasicResponse
+	1008, // 21: forge.TokenDelegationResponse.created_at:type_name -> google.protobuf.Timestamp
+	1008, // 22: forge.TokenDelegationResponse.updated_at:type_name -> google.protobuf.Timestamp
+	113,  // 23: forge.TokenDelegation.client_secret_basic:type_name -> forge.ClientSecretBasic
+	117,  // 24: forge.TokenDelegationRequest.config:type_name -> forge.TokenDelegation
+	120,  // 25: forge.ReencryptTenantIdentitySecretsResponse.failures:type_name -> forge.ReencryptTenantIdentityFailure
 	2,    // 26: forge.JwksRequest.kind:type_name -> forge.JwksKind
 	3,    // 27: forge.MachineIngestionStateResponse.machine_ingestion_state:type_name -> forge.MachineIngestionState
-	126,  // 28: forge.TpmCaAddedCaStatus.id:type_name -> forge.TpmCaCertId
-	1005, // 29: forge.TpmEkCertStatus.machine_id:type_name -> common.MachineId
-	127,  // 30: forge.TpmEkCertStatusCollection.tpm_ek_cert_statuses:type_name -> forge.TpmEkCertStatus
-	130,  // 31: forge.TpmCaCertDetailCollection.tpm_ca_cert_details:type_name -> forge.TpmCaCertDetail
-	1005, // 32: forge.AttestQuoteRequest.machine_id:type_name -> common.MachineId
-	439,  // 33: forge.AttestQuoteResponse.machine_certificate:type_name -> forge.MachineCertificate
+	128,  // 28: forge.TpmCaAddedCaStatus.id:type_name -> forge.TpmCaCertId
+	1007, // 29: forge.TpmEkCertStatus.machine_id:type_name -> common.MachineId
+	129,  // 30: forge.TpmEkCertStatusCollection.tpm_ek_cert_statuses:type_name -> forge.TpmEkCertStatus
+	132,  // 31: forge.TpmCaCertDetailCollection.tpm_ca_cert_details:type_name -> forge.TpmCaCertDetail
+	1007, // 32: forge.AttestQuoteRequest.machine_id:type_name -> common.MachineId
+	441,  // 33: forge.AttestQuoteResponse.machine_certificate:type_name -> forge.MachineCertificate
 	4,    // 34: forge.CredentialCreationRequest.credential_type:type_name -> forge.CredentialType
 	4,    // 35: forge.CredentialDeletionRequest.credential_type:type_name -> forge.CredentialType
 	5,    // 36: forge.RotateCredentialRequest.credential_type:type_name -> forge.RotationCredentialType
 	5,    // 37: forge.RotateCredentialResult.credential_type:type_name -> forge.RotationCredentialType
-	1006, // 38: forge.RotateCredentialResult.started_at:type_name -> google.protobuf.Timestamp
+	1008, // 38: forge.RotateCredentialResult.started_at:type_name -> google.protobuf.Timestamp
 	5,    // 39: forge.CredentialRotationStatusRequest.credential_type:type_name -> forge.RotationCredentialType
-	1006, // 40: forge.DeviceCredentialRotationStatus.quarantined_until:type_name -> google.protobuf.Timestamp
-	1006, // 41: forge.DeviceCredentialRotationStatus.last_attempt_at:type_name -> google.protobuf.Timestamp
-	1006, // 42: forge.CredentialRotationStatusResult.started_at:type_name -> google.protobuf.Timestamp
-	142,  // 43: forge.CredentialRotationStatusResult.device:type_name -> forge.DeviceCredentialRotationStatus
-	146,  // 44: forge.BuildInfo.runtime_config:type_name -> forge.RuntimeConfig
-	966,  // 45: forge.RuntimeConfig.dpu_nic_firmware_update_version:type_name -> forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
-	967,  // 46: forge.DNSMessage.question:type_name -> forge.DNSMessage.DNSQuestion
-	968,  // 47: forge.DNSMessage.response:type_name -> forge.DNSMessage.DNSResponse
-	1007, // 48: forge.VpcSearchQuery.id:type_name -> common.VpcId
-	264,  // 49: forge.VpcSearchFilter.label:type_name -> forge.Label
-	1007, // 50: forge.VpcIdList.vpc_ids:type_name -> common.VpcId
-	1007, // 51: forge.VpcsByIdsRequest.vpc_ids:type_name -> common.VpcId
+	1008, // 40: forge.DeviceCredentialRotationStatus.quarantined_until:type_name -> google.protobuf.Timestamp
+	1008, // 41: forge.DeviceCredentialRotationStatus.last_attempt_at:type_name -> google.protobuf.Timestamp
+	1008, // 42: forge.CredentialRotationStatusResult.started_at:type_name -> google.protobuf.Timestamp
+	144,  // 43: forge.CredentialRotationStatusResult.device:type_name -> forge.DeviceCredentialRotationStatus
+	148,  // 44: forge.BuildInfo.runtime_config:type_name -> forge.RuntimeConfig
+	968,  // 45: forge.RuntimeConfig.dpu_nic_firmware_update_version:type_name -> forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
+	969,  // 46: forge.DNSMessage.question:type_name -> forge.DNSMessage.DNSQuestion
+	970,  // 47: forge.DNSMessage.response:type_name -> forge.DNSMessage.DNSResponse
+	1009, // 48: forge.VpcSearchQuery.id:type_name -> common.VpcId
+	266,  // 49: forge.VpcSearchFilter.label:type_name -> forge.Label
+	1009, // 50: forge.VpcIdList.vpc_ids:type_name -> common.VpcId
+	1009, // 51: forge.VpcsByIdsRequest.vpc_ids:type_name -> common.VpcId
 	6,    // 52: forge.VpcConfig.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1008, // 53: forge.VpcConfig.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1007, // 54: forge.Vpc.id:type_name -> common.VpcId
-	1006, // 55: forge.Vpc.created:type_name -> google.protobuf.Timestamp
-	1006, // 56: forge.Vpc.updated:type_name -> google.protobuf.Timestamp
-	1006, // 57: forge.Vpc.deleted:type_name -> google.protobuf.Timestamp
+	1010, // 53: forge.VpcConfig.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1009, // 54: forge.Vpc.id:type_name -> common.VpcId
+	1008, // 55: forge.Vpc.created:type_name -> google.protobuf.Timestamp
+	1008, // 56: forge.Vpc.updated:type_name -> google.protobuf.Timestamp
+	1008, // 57: forge.Vpc.deleted:type_name -> google.protobuf.Timestamp
 	6,    // 58: forge.Vpc.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	265,  // 59: forge.Vpc.metadata:type_name -> forge.Metadata
-	1008, // 60: forge.Vpc.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	161,  // 61: forge.Vpc.status:type_name -> forge.VpcStatus
-	160,  // 62: forge.Vpc.config:type_name -> forge.VpcConfig
+	267,  // 59: forge.Vpc.metadata:type_name -> forge.Metadata
+	1010, // 60: forge.Vpc.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	163,  // 61: forge.Vpc.status:type_name -> forge.VpcStatus
+	162,  // 62: forge.Vpc.config:type_name -> forge.VpcConfig
 	6,    // 63: forge.VpcCreationRequest.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1007, // 64: forge.VpcCreationRequest.id:type_name -> common.VpcId
-	265,  // 65: forge.VpcCreationRequest.metadata:type_name -> forge.Metadata
-	1008, // 66: forge.VpcCreationRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1007, // 67: forge.VpcUpdateRequest.id:type_name -> common.VpcId
-	265,  // 68: forge.VpcUpdateRequest.metadata:type_name -> forge.Metadata
-	1008, // 69: forge.VpcUpdateRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	162,  // 70: forge.VpcUpdateResult.vpc:type_name -> forge.Vpc
-	1007, // 71: forge.VpcUpdateVirtualizationRequest.id:type_name -> common.VpcId
+	1009, // 64: forge.VpcCreationRequest.id:type_name -> common.VpcId
+	267,  // 65: forge.VpcCreationRequest.metadata:type_name -> forge.Metadata
+	1010, // 66: forge.VpcCreationRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1009, // 67: forge.VpcUpdateRequest.id:type_name -> common.VpcId
+	267,  // 68: forge.VpcUpdateRequest.metadata:type_name -> forge.Metadata
+	1010, // 69: forge.VpcUpdateRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	164,  // 70: forge.VpcUpdateResult.vpc:type_name -> forge.Vpc
+	1009, // 71: forge.VpcUpdateVirtualizationRequest.id:type_name -> common.VpcId
 	6,    // 72: forge.VpcUpdateVirtualizationRequest.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1007, // 73: forge.VpcDeletionRequest.id:type_name -> common.VpcId
-	162,  // 74: forge.VpcList.vpcs:type_name -> forge.Vpc
-	1009, // 75: forge.VpcPrefix.id:type_name -> common.VpcPrefixId
-	1007, // 76: forge.VpcPrefix.vpc_id:type_name -> common.VpcId
-	172,  // 77: forge.VpcPrefix.config:type_name -> forge.VpcPrefixConfig
-	173,  // 78: forge.VpcPrefix.status:type_name -> forge.VpcPrefixStatus
-	265,  // 79: forge.VpcPrefix.metadata:type_name -> forge.Metadata
-	96,   // 80: forge.VpcPrefixStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1009, // 73: forge.VpcDeletionRequest.id:type_name -> common.VpcId
+	164,  // 74: forge.VpcList.vpcs:type_name -> forge.Vpc
+	1011, // 75: forge.VpcPrefix.id:type_name -> common.VpcPrefixId
+	1009, // 76: forge.VpcPrefix.vpc_id:type_name -> common.VpcId
+	174,  // 77: forge.VpcPrefix.config:type_name -> forge.VpcPrefixConfig
+	175,  // 78: forge.VpcPrefix.status:type_name -> forge.VpcPrefixStatus
+	267,  // 79: forge.VpcPrefix.metadata:type_name -> forge.Metadata
+	98,   // 80: forge.VpcPrefixStatus.lifecycle:type_name -> forge.LifecycleStatus
 	8,    // 81: forge.VpcPrefixStatus.tenant_state:type_name -> forge.TenantState
-	1009, // 82: forge.VpcPrefixCreationRequest.id:type_name -> common.VpcPrefixId
-	1007, // 83: forge.VpcPrefixCreationRequest.vpc_id:type_name -> common.VpcId
-	172,  // 84: forge.VpcPrefixCreationRequest.config:type_name -> forge.VpcPrefixConfig
-	265,  // 85: forge.VpcPrefixCreationRequest.metadata:type_name -> forge.Metadata
-	1007, // 86: forge.VpcPrefixSearchQuery.vpc_id:type_name -> common.VpcId
-	1009, // 87: forge.VpcPrefixSearchQuery.tenant_prefix_id:type_name -> common.VpcPrefixId
+	1011, // 82: forge.VpcPrefixCreationRequest.id:type_name -> common.VpcPrefixId
+	1009, // 83: forge.VpcPrefixCreationRequest.vpc_id:type_name -> common.VpcId
+	174,  // 84: forge.VpcPrefixCreationRequest.config:type_name -> forge.VpcPrefixConfig
+	267,  // 85: forge.VpcPrefixCreationRequest.metadata:type_name -> forge.Metadata
+	1009, // 86: forge.VpcPrefixSearchQuery.vpc_id:type_name -> common.VpcId
+	1011, // 87: forge.VpcPrefixSearchQuery.tenant_prefix_id:type_name -> common.VpcPrefixId
 	7,    // 88: forge.VpcPrefixSearchQuery.prefix_match_type:type_name -> forge.PrefixMatchType
 	10,   // 89: forge.VpcPrefixSearchQuery.deleted:type_name -> forge.DeletedFilter
-	1009, // 90: forge.VpcPrefixGetRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1011, // 90: forge.VpcPrefixGetRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
 	10,   // 91: forge.VpcPrefixGetRequest.deleted:type_name -> forge.DeletedFilter
-	1009, // 92: forge.VpcPrefixIdList.vpc_prefix_ids:type_name -> common.VpcPrefixId
-	171,  // 93: forge.VpcPrefixList.vpc_prefixes:type_name -> forge.VpcPrefix
-	1009, // 94: forge.VpcPrefixUpdateRequest.id:type_name -> common.VpcPrefixId
-	172,  // 95: forge.VpcPrefixUpdateRequest.config:type_name -> forge.VpcPrefixConfig
-	265,  // 96: forge.VpcPrefixUpdateRequest.metadata:type_name -> forge.Metadata
-	1009, // 97: forge.VpcPrefixDeletionRequest.id:type_name -> common.VpcPrefixId
-	1009, // 98: forge.VpcPrefixStateHistoriesRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
-	1010, // 99: forge.VpcPeering.id:type_name -> common.VpcPeeringId
-	1007, // 100: forge.VpcPeering.vpc_id:type_name -> common.VpcId
-	1007, // 101: forge.VpcPeering.peer_vpc_id:type_name -> common.VpcId
-	1010, // 102: forge.VpcPeeringIdList.vpc_peering_ids:type_name -> common.VpcPeeringId
-	183,  // 103: forge.VpcPeeringList.vpc_peerings:type_name -> forge.VpcPeering
-	1007, // 104: forge.VpcPeeringCreationRequest.vpc_id:type_name -> common.VpcId
-	1007, // 105: forge.VpcPeeringCreationRequest.peer_vpc_id:type_name -> common.VpcId
-	1010, // 106: forge.VpcPeeringCreationRequest.id:type_name -> common.VpcPeeringId
-	1007, // 107: forge.VpcPeeringSearchFilter.vpc_id:type_name -> common.VpcId
-	1010, // 108: forge.VpcPeeringsByIdsRequest.vpc_peering_ids:type_name -> common.VpcPeeringId
-	1010, // 109: forge.VpcPeeringDeletionRequest.id:type_name -> common.VpcPeeringId
+	1011, // 92: forge.VpcPrefixIdList.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	173,  // 93: forge.VpcPrefixList.vpc_prefixes:type_name -> forge.VpcPrefix
+	1011, // 94: forge.VpcPrefixUpdateRequest.id:type_name -> common.VpcPrefixId
+	174,  // 95: forge.VpcPrefixUpdateRequest.config:type_name -> forge.VpcPrefixConfig
+	267,  // 96: forge.VpcPrefixUpdateRequest.metadata:type_name -> forge.Metadata
+	1011, // 97: forge.VpcPrefixDeletionRequest.id:type_name -> common.VpcPrefixId
+	1011, // 98: forge.VpcPrefixStateHistoriesRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1012, // 99: forge.VpcPeering.id:type_name -> common.VpcPeeringId
+	1009, // 100: forge.VpcPeering.vpc_id:type_name -> common.VpcId
+	1009, // 101: forge.VpcPeering.peer_vpc_id:type_name -> common.VpcId
+	1012, // 102: forge.VpcPeeringIdList.vpc_peering_ids:type_name -> common.VpcPeeringId
+	185,  // 103: forge.VpcPeeringList.vpc_peerings:type_name -> forge.VpcPeering
+	1009, // 104: forge.VpcPeeringCreationRequest.vpc_id:type_name -> common.VpcId
+	1009, // 105: forge.VpcPeeringCreationRequest.peer_vpc_id:type_name -> common.VpcId
+	1012, // 106: forge.VpcPeeringCreationRequest.id:type_name -> common.VpcPeeringId
+	1009, // 107: forge.VpcPeeringSearchFilter.vpc_id:type_name -> common.VpcId
+	1012, // 108: forge.VpcPeeringsByIdsRequest.vpc_peering_ids:type_name -> common.VpcPeeringId
+	1012, // 109: forge.VpcPeeringDeletionRequest.id:type_name -> common.VpcPeeringId
 	8,    // 110: forge.IBPartitionStatus.state:type_name -> forge.TenantState
-	356,  // 111: forge.IBPartitionStatus.state_reason:type_name -> forge.ControllerStateReason
-	358,  // 112: forge.IBPartitionStatus.state_sla:type_name -> forge.StateSla
-	1011, // 113: forge.IBPartition.id:type_name -> common.IBPartitionId
-	191,  // 114: forge.IBPartition.config:type_name -> forge.IBPartitionConfig
-	192,  // 115: forge.IBPartition.status:type_name -> forge.IBPartitionStatus
-	265,  // 116: forge.IBPartition.metadata:type_name -> forge.Metadata
-	193,  // 117: forge.IBPartitionList.ib_partitions:type_name -> forge.IBPartition
-	191,  // 118: forge.IBPartitionCreationRequest.config:type_name -> forge.IBPartitionConfig
-	1011, // 119: forge.IBPartitionCreationRequest.id:type_name -> common.IBPartitionId
-	265,  // 120: forge.IBPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1011, // 121: forge.IBPartitionUpdateRequest.id:type_name -> common.IBPartitionId
-	191,  // 122: forge.IBPartitionUpdateRequest.config:type_name -> forge.IBPartitionConfig
-	265,  // 123: forge.IBPartitionUpdateRequest.metadata:type_name -> forge.Metadata
-	1011, // 124: forge.IBPartitionDeletionRequest.id:type_name -> common.IBPartitionId
-	1011, // 125: forge.IBPartitionsByIdsRequest.ib_partition_ids:type_name -> common.IBPartitionId
-	1011, // 126: forge.IBPartitionIdList.ib_partition_ids:type_name -> common.IBPartitionId
-	356,  // 127: forge.PowerShelfStatus.state_reason:type_name -> forge.ControllerStateReason
-	358,  // 128: forge.PowerShelfStatus.state_sla:type_name -> forge.StateSla
-	1012, // 129: forge.PowerShelfStatus.health:type_name -> health.HealthReport
-	355,  // 130: forge.PowerShelfStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	96,   // 131: forge.PowerShelfStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1013, // 132: forge.PowerShelf.id:type_name -> common.PowerShelfId
-	202,  // 133: forge.PowerShelf.config:type_name -> forge.PowerShelfConfig
-	203,  // 134: forge.PowerShelf.status:type_name -> forge.PowerShelfStatus
-	1006, // 135: forge.PowerShelf.deleted:type_name -> google.protobuf.Timestamp
-	265,  // 136: forge.PowerShelf.metadata:type_name -> forge.Metadata
-	341,  // 137: forge.PowerShelf.bmc_info:type_name -> forge.BmcInfo
-	1014, // 138: forge.PowerShelf.rack_id:type_name -> common.RackId
-	204,  // 139: forge.PowerShelfList.power_shelves:type_name -> forge.PowerShelf
-	202,  // 140: forge.PowerShelfCreationRequest.config:type_name -> forge.PowerShelfConfig
-	1013, // 141: forge.PowerShelfCreationRequest.id:type_name -> common.PowerShelfId
-	1013, // 142: forge.PowerShelfDeletionRequest.id:type_name -> common.PowerShelfId
-	1013, // 143: forge.PowerShelfMaintenanceRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	358,  // 111: forge.IBPartitionStatus.state_reason:type_name -> forge.ControllerStateReason
+	360,  // 112: forge.IBPartitionStatus.state_sla:type_name -> forge.StateSla
+	1013, // 113: forge.IBPartition.id:type_name -> common.IBPartitionId
+	193,  // 114: forge.IBPartition.config:type_name -> forge.IBPartitionConfig
+	194,  // 115: forge.IBPartition.status:type_name -> forge.IBPartitionStatus
+	267,  // 116: forge.IBPartition.metadata:type_name -> forge.Metadata
+	195,  // 117: forge.IBPartitionList.ib_partitions:type_name -> forge.IBPartition
+	193,  // 118: forge.IBPartitionCreationRequest.config:type_name -> forge.IBPartitionConfig
+	1013, // 119: forge.IBPartitionCreationRequest.id:type_name -> common.IBPartitionId
+	267,  // 120: forge.IBPartitionCreationRequest.metadata:type_name -> forge.Metadata
+	1013, // 121: forge.IBPartitionUpdateRequest.id:type_name -> common.IBPartitionId
+	193,  // 122: forge.IBPartitionUpdateRequest.config:type_name -> forge.IBPartitionConfig
+	267,  // 123: forge.IBPartitionUpdateRequest.metadata:type_name -> forge.Metadata
+	1013, // 124: forge.IBPartitionDeletionRequest.id:type_name -> common.IBPartitionId
+	1013, // 125: forge.IBPartitionsByIdsRequest.ib_partition_ids:type_name -> common.IBPartitionId
+	1013, // 126: forge.IBPartitionIdList.ib_partition_ids:type_name -> common.IBPartitionId
+	358,  // 127: forge.PowerShelfStatus.state_reason:type_name -> forge.ControllerStateReason
+	360,  // 128: forge.PowerShelfStatus.state_sla:type_name -> forge.StateSla
+	1014, // 129: forge.PowerShelfStatus.health:type_name -> health.HealthReport
+	357,  // 130: forge.PowerShelfStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	98,   // 131: forge.PowerShelfStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1015, // 132: forge.PowerShelf.id:type_name -> common.PowerShelfId
+	204,  // 133: forge.PowerShelf.config:type_name -> forge.PowerShelfConfig
+	205,  // 134: forge.PowerShelf.status:type_name -> forge.PowerShelfStatus
+	1008, // 135: forge.PowerShelf.deleted:type_name -> google.protobuf.Timestamp
+	267,  // 136: forge.PowerShelf.metadata:type_name -> forge.Metadata
+	343,  // 137: forge.PowerShelf.bmc_info:type_name -> forge.BmcInfo
+	1016, // 138: forge.PowerShelf.rack_id:type_name -> common.RackId
+	206,  // 139: forge.PowerShelfList.power_shelves:type_name -> forge.PowerShelf
+	204,  // 140: forge.PowerShelfCreationRequest.config:type_name -> forge.PowerShelfConfig
+	1015, // 141: forge.PowerShelfCreationRequest.id:type_name -> common.PowerShelfId
+	1015, // 142: forge.PowerShelfDeletionRequest.id:type_name -> common.PowerShelfId
+	1015, // 143: forge.PowerShelfMaintenanceRequest.power_shelf_ids:type_name -> common.PowerShelfId
 	9,    // 144: forge.PowerShelfMaintenanceRequest.operation:type_name -> forge.PowerShelfMaintenanceOperation
-	1013, // 145: forge.PowerShelfStateHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
-	1013, // 146: forge.PowerShelfQuery.power_shelf_id:type_name -> common.PowerShelfId
-	1014, // 147: forge.PowerShelfSearchFilter.rack_id:type_name -> common.RackId
+	1015, // 145: forge.PowerShelfStateHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	1015, // 146: forge.PowerShelfQuery.power_shelf_id:type_name -> common.PowerShelfId
+	1016, // 147: forge.PowerShelfSearchFilter.rack_id:type_name -> common.RackId
 	10,   // 148: forge.PowerShelfSearchFilter.deleted:type_name -> forge.DeletedFilter
-	1013, // 149: forge.PowerShelvesByIdsRequest.power_shelf_ids:type_name -> common.PowerShelfId
-	265,  // 150: forge.ExpectedPowerShelf.metadata:type_name -> forge.Metadata
-	1014, // 151: forge.ExpectedPowerShelf.rack_id:type_name -> common.RackId
-	1015, // 152: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
-	1015, // 153: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
-	214,  // 154: forge.ExpectedPowerShelfList.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
-	218,  // 155: forge.LinkedExpectedPowerShelfList.expected_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
-	1013, // 156: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
-	1015, // 157: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
-	1014, // 158: forge.LinkedExpectedPowerShelf.rack_id:type_name -> common.RackId
-	220,  // 159: forge.SwitchConfig.fabric_manager_config:type_name -> forge.FabricManagerConfig
-	970,  // 160: forge.FabricManagerConfig.config_map:type_name -> forge.FabricManagerConfig.ConfigMapEntry
+	1015, // 149: forge.PowerShelvesByIdsRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	267,  // 150: forge.ExpectedPowerShelf.metadata:type_name -> forge.Metadata
+	1016, // 151: forge.ExpectedPowerShelf.rack_id:type_name -> common.RackId
+	1017, // 152: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	1017, // 153: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
+	216,  // 154: forge.ExpectedPowerShelfList.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
+	220,  // 155: forge.LinkedExpectedPowerShelfList.expected_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
+	1015, // 156: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
+	1017, // 157: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	1016, // 158: forge.LinkedExpectedPowerShelf.rack_id:type_name -> common.RackId
+	222,  // 159: forge.SwitchConfig.fabric_manager_config:type_name -> forge.FabricManagerConfig
+	972,  // 160: forge.FabricManagerConfig.config_map:type_name -> forge.FabricManagerConfig.ConfigMapEntry
 	11,   // 161: forge.FabricManagerStatus.fabric_manager_state:type_name -> forge.FabricManagerState
-	356,  // 162: forge.SwitchStatus.state_reason:type_name -> forge.ControllerStateReason
-	358,  // 163: forge.SwitchStatus.state_sla:type_name -> forge.StateSla
-	1012, // 164: forge.SwitchStatus.health:type_name -> health.HealthReport
-	355,  // 165: forge.SwitchStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	96,   // 166: forge.SwitchStatus.lifecycle:type_name -> forge.LifecycleStatus
-	221,  // 167: forge.SwitchStatus.fabric_manager_status_details:type_name -> forge.FabricManagerStatus
-	1016, // 168: forge.Switch.id:type_name -> common.SwitchId
-	219,  // 169: forge.Switch.config:type_name -> forge.SwitchConfig
-	222,  // 170: forge.Switch.status:type_name -> forge.SwitchStatus
-	1006, // 171: forge.Switch.deleted:type_name -> google.protobuf.Timestamp
-	341,  // 172: forge.Switch.bmc_info:type_name -> forge.BmcInfo
-	265,  // 173: forge.Switch.metadata:type_name -> forge.Metadata
-	1014, // 174: forge.Switch.rack_id:type_name -> common.RackId
-	223,  // 175: forge.Switch.placement_in_rack:type_name -> forge.PlacementInRack
-	342,  // 176: forge.Switch.nvos_info:type_name -> forge.SwitchNvosInfo
-	224,  // 177: forge.SwitchList.switches:type_name -> forge.Switch
-	219,  // 178: forge.SwitchCreationRequest.config:type_name -> forge.SwitchConfig
-	1015, // 179: forge.SwitchCreationRequest.id:type_name -> common.UUID
-	223,  // 180: forge.SwitchCreationRequest.placement_in_rack:type_name -> forge.PlacementInRack
-	1016, // 181: forge.SwitchDeletionRequest.id:type_name -> common.SwitchId
-	1006, // 182: forge.StateHistoryRecord.time:type_name -> google.protobuf.Timestamp
-	229,  // 183: forge.StateHistoryRecords.records:type_name -> forge.StateHistoryRecord
-	1016, // 184: forge.SwitchStateHistoriesRequest.switch_ids:type_name -> common.SwitchId
-	971,  // 185: forge.StateHistories.histories:type_name -> forge.StateHistories.HistoriesEntry
-	1016, // 186: forge.SwitchQuery.switch_id:type_name -> common.SwitchId
-	1014, // 187: forge.SwitchSearchFilter.rack_id:type_name -> common.RackId
+	358,  // 162: forge.SwitchStatus.state_reason:type_name -> forge.ControllerStateReason
+	360,  // 163: forge.SwitchStatus.state_sla:type_name -> forge.StateSla
+	1014, // 164: forge.SwitchStatus.health:type_name -> health.HealthReport
+	357,  // 165: forge.SwitchStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	98,   // 166: forge.SwitchStatus.lifecycle:type_name -> forge.LifecycleStatus
+	223,  // 167: forge.SwitchStatus.fabric_manager_status_details:type_name -> forge.FabricManagerStatus
+	1018, // 168: forge.Switch.id:type_name -> common.SwitchId
+	221,  // 169: forge.Switch.config:type_name -> forge.SwitchConfig
+	224,  // 170: forge.Switch.status:type_name -> forge.SwitchStatus
+	1008, // 171: forge.Switch.deleted:type_name -> google.protobuf.Timestamp
+	343,  // 172: forge.Switch.bmc_info:type_name -> forge.BmcInfo
+	267,  // 173: forge.Switch.metadata:type_name -> forge.Metadata
+	1016, // 174: forge.Switch.rack_id:type_name -> common.RackId
+	225,  // 175: forge.Switch.placement_in_rack:type_name -> forge.PlacementInRack
+	344,  // 176: forge.Switch.nvos_info:type_name -> forge.SwitchNvosInfo
+	226,  // 177: forge.SwitchList.switches:type_name -> forge.Switch
+	221,  // 178: forge.SwitchCreationRequest.config:type_name -> forge.SwitchConfig
+	1017, // 179: forge.SwitchCreationRequest.id:type_name -> common.UUID
+	225,  // 180: forge.SwitchCreationRequest.placement_in_rack:type_name -> forge.PlacementInRack
+	1018, // 181: forge.SwitchDeletionRequest.id:type_name -> common.SwitchId
+	1008, // 182: forge.StateHistoryRecord.time:type_name -> google.protobuf.Timestamp
+	231,  // 183: forge.StateHistoryRecords.records:type_name -> forge.StateHistoryRecord
+	1018, // 184: forge.SwitchStateHistoriesRequest.switch_ids:type_name -> common.SwitchId
+	973,  // 185: forge.StateHistories.histories:type_name -> forge.StateHistories.HistoriesEntry
+	1018, // 186: forge.SwitchQuery.switch_id:type_name -> common.SwitchId
+	1016, // 187: forge.SwitchSearchFilter.rack_id:type_name -> common.RackId
 	10,   // 188: forge.SwitchSearchFilter.deleted:type_name -> forge.DeletedFilter
-	1016, // 189: forge.SwitchesByIdsRequest.switch_ids:type_name -> common.SwitchId
-	265,  // 190: forge.ExpectedSwitch.metadata:type_name -> forge.Metadata
-	1014, // 191: forge.ExpectedSwitch.rack_id:type_name -> common.RackId
-	1015, // 192: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
-	1015, // 193: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
-	236,  // 194: forge.ExpectedSwitchList.expected_switches:type_name -> forge.ExpectedSwitch
-	240,  // 195: forge.LinkedExpectedSwitchList.expected_switches:type_name -> forge.LinkedExpectedSwitch
-	1016, // 196: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId
-	1015, // 197: forge.LinkedExpectedSwitch.expected_switch_id:type_name -> common.UUID
-	1014, // 198: forge.LinkedExpectedSwitch.rack_id:type_name -> common.RackId
-	1014, // 199: forge.ExpectedRack.rack_id:type_name -> common.RackId
-	1017, // 200: forge.ExpectedRack.rack_profile_id:type_name -> common.RackProfileId
-	265,  // 201: forge.ExpectedRack.metadata:type_name -> forge.Metadata
-	241,  // 202: forge.ExpectedRackList.expected_racks:type_name -> forge.ExpectedRack
-	1006, // 203: forge.NetworkSegmentStateHistory.time:type_name -> google.protobuf.Timestamp
-	1007, // 204: forge.NetworkSegmentConfig.vpc_id:type_name -> common.VpcId
-	1018, // 205: forge.NetworkSegmentConfig.subdomain_id:type_name -> common.DomainId
+	1018, // 189: forge.SwitchesByIdsRequest.switch_ids:type_name -> common.SwitchId
+	267,  // 190: forge.ExpectedSwitch.metadata:type_name -> forge.Metadata
+	1016, // 191: forge.ExpectedSwitch.rack_id:type_name -> common.RackId
+	1017, // 192: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	1017, // 193: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
+	238,  // 194: forge.ExpectedSwitchList.expected_switches:type_name -> forge.ExpectedSwitch
+	242,  // 195: forge.LinkedExpectedSwitchList.expected_switches:type_name -> forge.LinkedExpectedSwitch
+	1018, // 196: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId
+	1017, // 197: forge.LinkedExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	1016, // 198: forge.LinkedExpectedSwitch.rack_id:type_name -> common.RackId
+	1016, // 199: forge.ExpectedRack.rack_id:type_name -> common.RackId
+	1019, // 200: forge.ExpectedRack.rack_profile_id:type_name -> common.RackProfileId
+	267,  // 201: forge.ExpectedRack.metadata:type_name -> forge.Metadata
+	243,  // 202: forge.ExpectedRackList.expected_racks:type_name -> forge.ExpectedRack
+	1008, // 203: forge.NetworkSegmentStateHistory.time:type_name -> google.protobuf.Timestamp
+	1009, // 204: forge.NetworkSegmentConfig.vpc_id:type_name -> common.VpcId
+	1020, // 205: forge.NetworkSegmentConfig.subdomain_id:type_name -> common.DomainId
 	12,   // 206: forge.NetworkSegmentConfig.segment_type:type_name -> forge.NetworkSegmentType
-	259,  // 207: forge.NetworkSegmentConfig.prefixes:type_name -> forge.NetworkPrefix
+	261,  // 207: forge.NetworkSegmentConfig.prefixes:type_name -> forge.NetworkPrefix
 	13,   // 208: forge.NetworkSegmentStatus.flags:type_name -> forge.NetworkSegmentFlag
-	96,   // 209: forge.NetworkSegmentStatus.lifecycle:type_name -> forge.LifecycleStatus
+	98,   // 209: forge.NetworkSegmentStatus.lifecycle:type_name -> forge.LifecycleStatus
 	8,    // 210: forge.NetworkSegmentStatus.tenant_state:type_name -> forge.TenantState
-	1019, // 211: forge.NetworkSegment.id:type_name -> common.NetworkSegmentId
-	1007, // 212: forge.NetworkSegment.vpc_id:type_name -> common.VpcId
-	1018, // 213: forge.NetworkSegment.subdomain_id:type_name -> common.DomainId
-	259,  // 214: forge.NetworkSegment.prefixes:type_name -> forge.NetworkPrefix
-	1006, // 215: forge.NetworkSegment.created:type_name -> google.protobuf.Timestamp
-	1006, // 216: forge.NetworkSegment.updated:type_name -> google.protobuf.Timestamp
-	1006, // 217: forge.NetworkSegment.deleted:type_name -> google.protobuf.Timestamp
+	1021, // 211: forge.NetworkSegment.id:type_name -> common.NetworkSegmentId
+	1009, // 212: forge.NetworkSegment.vpc_id:type_name -> common.VpcId
+	1020, // 213: forge.NetworkSegment.subdomain_id:type_name -> common.DomainId
+	261,  // 214: forge.NetworkSegment.prefixes:type_name -> forge.NetworkPrefix
+	1008, // 215: forge.NetworkSegment.created:type_name -> google.protobuf.Timestamp
+	1008, // 216: forge.NetworkSegment.updated:type_name -> google.protobuf.Timestamp
+	1008, // 217: forge.NetworkSegment.deleted:type_name -> google.protobuf.Timestamp
 	12,   // 218: forge.NetworkSegment.segment_type:type_name -> forge.NetworkSegmentType
 	13,   // 219: forge.NetworkSegment.flags:type_name -> forge.NetworkSegmentFlag
-	247,  // 220: forge.NetworkSegment.config:type_name -> forge.NetworkSegmentConfig
-	248,  // 221: forge.NetworkSegment.status:type_name -> forge.NetworkSegmentStatus
-	265,  // 222: forge.NetworkSegment.metadata:type_name -> forge.Metadata
+	249,  // 220: forge.NetworkSegment.config:type_name -> forge.NetworkSegmentConfig
+	250,  // 221: forge.NetworkSegment.status:type_name -> forge.NetworkSegmentStatus
+	267,  // 222: forge.NetworkSegment.metadata:type_name -> forge.Metadata
 	8,    // 223: forge.NetworkSegment.state:type_name -> forge.TenantState
-	246,  // 224: forge.NetworkSegment.history:type_name -> forge.NetworkSegmentStateHistory
-	356,  // 225: forge.NetworkSegment.state_reason:type_name -> forge.ControllerStateReason
-	358,  // 226: forge.NetworkSegment.state_sla:type_name -> forge.StateSla
-	1007, // 227: forge.NetworkSegmentCreationRequest.vpc_id:type_name -> common.VpcId
-	1018, // 228: forge.NetworkSegmentCreationRequest.subdomain_id:type_name -> common.DomainId
-	259,  // 229: forge.NetworkSegmentCreationRequest.prefixes:type_name -> forge.NetworkPrefix
+	248,  // 224: forge.NetworkSegment.history:type_name -> forge.NetworkSegmentStateHistory
+	358,  // 225: forge.NetworkSegment.state_reason:type_name -> forge.ControllerStateReason
+	360,  // 226: forge.NetworkSegment.state_sla:type_name -> forge.StateSla
+	1009, // 227: forge.NetworkSegmentCreationRequest.vpc_id:type_name -> common.VpcId
+	1020, // 228: forge.NetworkSegmentCreationRequest.subdomain_id:type_name -> common.DomainId
+	261,  // 229: forge.NetworkSegmentCreationRequest.prefixes:type_name -> forge.NetworkPrefix
 	12,   // 230: forge.NetworkSegmentCreationRequest.segment_type:type_name -> forge.NetworkSegmentType
-	1019, // 231: forge.NetworkSegmentCreationRequest.id:type_name -> common.NetworkSegmentId
-	1019, // 232: forge.NetworkSegmentDeletionRequest.id:type_name -> common.NetworkSegmentId
-	1019, // 233: forge.AttachNetworkSegmentToVpcRequest.network_segment_id:type_name -> common.NetworkSegmentId
-	1007, // 234: forge.AttachNetworkSegmentToVpcRequest.vpc_id:type_name -> common.VpcId
-	1019, // 235: forge.NetworkSegmentStateHistoriesRequest.network_segment_ids:type_name -> common.NetworkSegmentId
-	1019, // 236: forge.NetworkSegmentIdList.network_segments_ids:type_name -> common.NetworkSegmentId
-	1019, // 237: forge.NetworkSegmentsByIdsRequest.network_segments_ids:type_name -> common.NetworkSegmentId
-	1020, // 238: forge.NetworkPrefix.id:type_name -> common.NetworkPrefixId
-	85,   // 239: forge.InstancePowerRequest.operation:type_name -> forge.InstancePowerRequest.Operation
-	1021, // 240: forge.InstancePowerRequest.instance_id:type_name -> common.InstanceId
-	298,  // 241: forge.InstanceList.instances:type_name -> forge.Instance
-	264,  // 242: forge.Metadata.labels:type_name -> forge.Label
-	264,  // 243: forge.InstanceSearchFilter.label:type_name -> forge.Label
-	1021, // 244: forge.InstanceIdList.instance_ids:type_name -> common.InstanceId
-	1021, // 245: forge.InstancesByIdsRequest.instance_ids:type_name -> common.InstanceId
-	1005, // 246: forge.InstanceAllocationRequest.machine_id:type_name -> common.MachineId
-	278,  // 247: forge.InstanceAllocationRequest.config:type_name -> forge.InstanceConfig
-	1021, // 248: forge.InstanceAllocationRequest.instance_id:type_name -> common.InstanceId
-	265,  // 249: forge.InstanceAllocationRequest.metadata:type_name -> forge.Metadata
-	269,  // 250: forge.BatchInstanceAllocationRequest.instance_requests:type_name -> forge.InstanceAllocationRequest
-	298,  // 251: forge.BatchInstanceAllocationResponse.instances:type_name -> forge.Instance
+	1021, // 231: forge.NetworkSegmentCreationRequest.id:type_name -> common.NetworkSegmentId
+	1021, // 232: forge.NetworkSegmentDeletionRequest.id:type_name -> common.NetworkSegmentId
+	1021, // 233: forge.AttachNetworkSegmentToVpcRequest.network_segment_id:type_name -> common.NetworkSegmentId
+	1009, // 234: forge.AttachNetworkSegmentToVpcRequest.vpc_id:type_name -> common.VpcId
+	1021, // 235: forge.NetworkSegmentStateHistoriesRequest.network_segment_ids:type_name -> common.NetworkSegmentId
+	1021, // 236: forge.NetworkSegmentIdList.network_segments_ids:type_name -> common.NetworkSegmentId
+	1021, // 237: forge.NetworkSegmentsByIdsRequest.network_segments_ids:type_name -> common.NetworkSegmentId
+	1022, // 238: forge.NetworkPrefix.id:type_name -> common.NetworkPrefixId
+	87,   // 239: forge.InstancePowerRequest.operation:type_name -> forge.InstancePowerRequest.Operation
+	1023, // 240: forge.InstancePowerRequest.instance_id:type_name -> common.InstanceId
+	300,  // 241: forge.InstanceList.instances:type_name -> forge.Instance
+	266,  // 242: forge.Metadata.labels:type_name -> forge.Label
+	266,  // 243: forge.InstanceSearchFilter.label:type_name -> forge.Label
+	1023, // 244: forge.InstanceIdList.instance_ids:type_name -> common.InstanceId
+	1023, // 245: forge.InstancesByIdsRequest.instance_ids:type_name -> common.InstanceId
+	1007, // 246: forge.InstanceAllocationRequest.machine_id:type_name -> common.MachineId
+	280,  // 247: forge.InstanceAllocationRequest.config:type_name -> forge.InstanceConfig
+	1023, // 248: forge.InstanceAllocationRequest.instance_id:type_name -> common.InstanceId
+	267,  // 249: forge.InstanceAllocationRequest.metadata:type_name -> forge.Metadata
+	271,  // 250: forge.BatchInstanceAllocationRequest.instance_requests:type_name -> forge.InstanceAllocationRequest
+	300,  // 251: forge.BatchInstanceAllocationResponse.instances:type_name -> forge.Instance
 	14,   // 252: forge.IpxeTemplateArtifact.cache_strategy:type_name -> forge.IpxeTemplateArtifactCacheStrategy
-	1022, // 253: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
+	1024, // 253: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
 	15,   // 254: forge.IpxeTemplate.visibility:type_name -> forge.IpxeTemplateVisibility
-	277,  // 255: forge.InstanceOperatingSystemConfig.ipxe:type_name -> forge.InlineIpxe
-	1015, // 256: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
-	1023, // 257: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId
-	275,  // 258: forge.InstanceConfig.tenant:type_name -> forge.TenantConfig
-	276,  // 259: forge.InstanceConfig.os:type_name -> forge.InstanceOperatingSystemConfig
-	279,  // 260: forge.InstanceConfig.network:type_name -> forge.InstanceNetworkConfig
-	281,  // 261: forge.InstanceConfig.infiniband:type_name -> forge.InstanceInfinibandConfig
-	283,  // 262: forge.InstanceConfig.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesConfig
-	284,  // 263: forge.InstanceConfig.nvlink:type_name -> forge.InstanceNVLinkConfig
-	285,  // 264: forge.InstanceConfig.spxconfig:type_name -> forge.InstanceSpxConfig
-	300,  // 265: forge.InstanceNetworkConfig.interfaces:type_name -> forge.InstanceInterfaceConfig
-	280,  // 266: forge.InstanceNetworkConfig.auto_config:type_name -> forge.InstanceNetworkAutoConfig
-	1007, // 267: forge.InstanceNetworkAutoConfig.vpc_id:type_name -> common.VpcId
-	304,  // 268: forge.InstanceInfinibandConfig.ib_interfaces:type_name -> forge.InstanceIBInterfaceConfig
-	282,  // 269: forge.InstanceDpuExtensionServicesConfig.service_configs:type_name -> forge.InstanceDpuExtensionServiceConfig
-	309,  // 270: forge.InstanceNVLinkConfig.gpu_configs:type_name -> forge.InstanceNVLinkGpuConfig
-	286,  // 271: forge.InstanceSpxConfig.spx_attachments:type_name -> forge.InstanceSpxAttachment
-	1024, // 272: forge.InstanceSpxAttachment.spx_partition_id:type_name -> common.SpxPartitionId
+	279,  // 255: forge.InstanceOperatingSystemConfig.ipxe:type_name -> forge.InlineIpxe
+	1017, // 256: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
+	1025, // 257: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId
+	277,  // 258: forge.InstanceConfig.tenant:type_name -> forge.TenantConfig
+	278,  // 259: forge.InstanceConfig.os:type_name -> forge.InstanceOperatingSystemConfig
+	281,  // 260: forge.InstanceConfig.network:type_name -> forge.InstanceNetworkConfig
+	283,  // 261: forge.InstanceConfig.infiniband:type_name -> forge.InstanceInfinibandConfig
+	285,  // 262: forge.InstanceConfig.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesConfig
+	286,  // 263: forge.InstanceConfig.nvlink:type_name -> forge.InstanceNVLinkConfig
+	287,  // 264: forge.InstanceConfig.spxconfig:type_name -> forge.InstanceSpxConfig
+	302,  // 265: forge.InstanceNetworkConfig.interfaces:type_name -> forge.InstanceInterfaceConfig
+	282,  // 266: forge.InstanceNetworkConfig.auto_config:type_name -> forge.InstanceNetworkAutoConfig
+	1009, // 267: forge.InstanceNetworkAutoConfig.vpc_id:type_name -> common.VpcId
+	306,  // 268: forge.InstanceInfinibandConfig.ib_interfaces:type_name -> forge.InstanceIBInterfaceConfig
+	284,  // 269: forge.InstanceDpuExtensionServicesConfig.service_configs:type_name -> forge.InstanceDpuExtensionServiceConfig
+	311,  // 270: forge.InstanceNVLinkConfig.gpu_configs:type_name -> forge.InstanceNVLinkGpuConfig
+	288,  // 271: forge.InstanceSpxConfig.spx_attachments:type_name -> forge.InstanceSpxAttachment
+	1026, // 272: forge.InstanceSpxAttachment.spx_partition_id:type_name -> common.SpxPartitionId
 	16,   // 273: forge.InstanceSpxAttachment.attachment_type:type_name -> forge.SpxAttachmentType
-	1021, // 274: forge.InstanceOperatingSystemUpdateRequest.instance_id:type_name -> common.InstanceId
-	276,  // 275: forge.InstanceOperatingSystemUpdateRequest.os:type_name -> forge.InstanceOperatingSystemConfig
-	1021, // 276: forge.InstanceConfigUpdateRequest.instance_id:type_name -> common.InstanceId
-	278,  // 277: forge.InstanceConfigUpdateRequest.config:type_name -> forge.InstanceConfig
-	265,  // 278: forge.InstanceConfigUpdateRequest.metadata:type_name -> forge.Metadata
-	359,  // 279: forge.InstanceStatus.tenant:type_name -> forge.InstanceTenantStatus
-	292,  // 280: forge.InstanceStatus.network:type_name -> forge.InstanceNetworkStatus
-	293,  // 281: forge.InstanceStatus.infiniband:type_name -> forge.InstanceInfinibandStatus
-	296,  // 282: forge.InstanceStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesStatus
+	1023, // 274: forge.InstanceOperatingSystemUpdateRequest.instance_id:type_name -> common.InstanceId
+	278,  // 275: forge.InstanceOperatingSystemUpdateRequest.os:type_name -> forge.InstanceOperatingSystemConfig
+	1023, // 276: forge.InstanceConfigUpdateRequest.instance_id:type_name -> common.InstanceId
+	280,  // 277: forge.InstanceConfigUpdateRequest.config:type_name -> forge.InstanceConfig
+	267,  // 278: forge.InstanceConfigUpdateRequest.metadata:type_name -> forge.Metadata
+	361,  // 279: forge.InstanceStatus.tenant:type_name -> forge.InstanceTenantStatus
+	294,  // 280: forge.InstanceStatus.network:type_name -> forge.InstanceNetworkStatus
+	295,  // 281: forge.InstanceStatus.infiniband:type_name -> forge.InstanceInfinibandStatus
+	298,  // 282: forge.InstanceStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesStatus
 	24,   // 283: forge.InstanceStatus.configs_synced:type_name -> forge.SyncState
-	299,  // 284: forge.InstanceStatus.update:type_name -> forge.InstanceUpdateStatus
-	297,  // 285: forge.InstanceStatus.nvlink:type_name -> forge.InstanceNVLinkStatus
-	290,  // 286: forge.InstanceStatus.spx_status:type_name -> forge.InstanceSpxStatus
-	291,  // 287: forge.InstanceSpxStatus.attachment_statuses:type_name -> forge.InstanceSpxAttachmentStatus
+	301,  // 284: forge.InstanceStatus.update:type_name -> forge.InstanceUpdateStatus
+	299,  // 285: forge.InstanceStatus.nvlink:type_name -> forge.InstanceNVLinkStatus
+	292,  // 286: forge.InstanceStatus.spx_status:type_name -> forge.InstanceSpxStatus
+	293,  // 287: forge.InstanceSpxStatus.attachment_statuses:type_name -> forge.InstanceSpxAttachmentStatus
 	24,   // 288: forge.InstanceSpxStatus.configs_synced:type_name -> forge.SyncState
 	16,   // 289: forge.InstanceSpxAttachmentStatus.attachment_type:type_name -> forge.SpxAttachmentType
-	1024, // 290: forge.InstanceSpxAttachmentStatus.spx_partition_id:type_name -> common.SpxPartitionId
-	306,  // 291: forge.InstanceNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatus
+	1026, // 290: forge.InstanceSpxAttachmentStatus.spx_partition_id:type_name -> common.SpxPartitionId
+	308,  // 291: forge.InstanceNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatus
 	24,   // 292: forge.InstanceNetworkStatus.configs_synced:type_name -> forge.SyncState
-	307,  // 293: forge.InstanceInfinibandStatus.ib_interfaces:type_name -> forge.InstanceIBInterfaceStatus
+	309,  // 293: forge.InstanceInfinibandStatus.ib_interfaces:type_name -> forge.InstanceIBInterfaceStatus
 	24,   // 294: forge.InstanceInfinibandStatus.configs_synced:type_name -> forge.SyncState
-	1005, // 295: forge.DpuExtensionServiceStatus.dpu_machine_id:type_name -> common.MachineId
+	1007, // 295: forge.DpuExtensionServiceStatus.dpu_machine_id:type_name -> common.MachineId
 	74,   // 296: forge.DpuExtensionServiceStatus.status:type_name -> forge.DpuExtensionServiceDeploymentStatus
-	456,  // 297: forge.DpuExtensionServiceStatus.components:type_name -> forge.DpuExtensionServiceComponent
+	458,  // 297: forge.DpuExtensionServiceStatus.components:type_name -> forge.DpuExtensionServiceComponent
 	74,   // 298: forge.InstanceDpuExtensionServiceStatus.deployment_status:type_name -> forge.DpuExtensionServiceDeploymentStatus
-	294,  // 299: forge.InstanceDpuExtensionServiceStatus.dpu_statuses:type_name -> forge.DpuExtensionServiceStatus
-	295,  // 300: forge.InstanceDpuExtensionServicesStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServiceStatus
+	296,  // 299: forge.InstanceDpuExtensionServiceStatus.dpu_statuses:type_name -> forge.DpuExtensionServiceStatus
+	297,  // 300: forge.InstanceDpuExtensionServicesStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServiceStatus
 	24,   // 301: forge.InstanceDpuExtensionServicesStatus.configs_synced:type_name -> forge.SyncState
-	308,  // 302: forge.InstanceNVLinkStatus.gpu_statuses:type_name -> forge.InstanceNVLinkGpuStatus
+	310,  // 302: forge.InstanceNVLinkStatus.gpu_statuses:type_name -> forge.InstanceNVLinkGpuStatus
 	24,   // 303: forge.InstanceNVLinkStatus.configs_synced:type_name -> forge.SyncState
-	1021, // 304: forge.Instance.id:type_name -> common.InstanceId
-	1005, // 305: forge.Instance.machine_id:type_name -> common.MachineId
-	265,  // 306: forge.Instance.metadata:type_name -> forge.Metadata
-	278,  // 307: forge.Instance.config:type_name -> forge.InstanceConfig
-	289,  // 308: forge.Instance.status:type_name -> forge.InstanceStatus
-	86,   // 309: forge.InstanceUpdateStatus.module:type_name -> forge.InstanceUpdateStatus.Module
-	1006, // 310: forge.InstanceUpdateStatus.trigger_received_at:type_name -> google.protobuf.Timestamp
-	1006, // 311: forge.InstanceUpdateStatus.update_triggered_at:type_name -> google.protobuf.Timestamp
+	1023, // 304: forge.Instance.id:type_name -> common.InstanceId
+	1007, // 305: forge.Instance.machine_id:type_name -> common.MachineId
+	267,  // 306: forge.Instance.metadata:type_name -> forge.Metadata
+	280,  // 307: forge.Instance.config:type_name -> forge.InstanceConfig
+	291,  // 308: forge.Instance.status:type_name -> forge.InstanceStatus
+	88,   // 309: forge.InstanceUpdateStatus.module:type_name -> forge.InstanceUpdateStatus.Module
+	1008, // 310: forge.InstanceUpdateStatus.trigger_received_at:type_name -> google.protobuf.Timestamp
+	1008, // 311: forge.InstanceUpdateStatus.update_triggered_at:type_name -> google.protobuf.Timestamp
 	40,   // 312: forge.InstanceInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	1019, // 313: forge.InstanceInterfaceConfig.network_segment_id:type_name -> common.NetworkSegmentId
-	1019, // 314: forge.InstanceInterfaceConfig.segment_id:type_name -> common.NetworkSegmentId
-	1009, // 315: forge.InstanceInterfaceConfig.vpc_prefix_id:type_name -> common.VpcPrefixId
-	301,  // 316: forge.InstanceInterfaceConfig.vpc:type_name -> forge.InstanceInterfaceVpcSelection
-	302,  // 317: forge.InstanceInterfaceConfig.ipv6_interface_config:type_name -> forge.InstanceInterfaceIpv6Config
-	303,  // 318: forge.InstanceInterfaceConfig.routing_profile:type_name -> forge.InstanceInterfaceRoutingProfile
-	1007, // 319: forge.InstanceInterfaceVpcSelection.vpc_id:type_name -> common.VpcId
+	1021, // 313: forge.InstanceInterfaceConfig.network_segment_id:type_name -> common.NetworkSegmentId
+	1021, // 314: forge.InstanceInterfaceConfig.segment_id:type_name -> common.NetworkSegmentId
+	1011, // 315: forge.InstanceInterfaceConfig.vpc_prefix_id:type_name -> common.VpcPrefixId
+	303,  // 316: forge.InstanceInterfaceConfig.vpc:type_name -> forge.InstanceInterfaceVpcSelection
+	304,  // 317: forge.InstanceInterfaceConfig.ipv6_interface_config:type_name -> forge.InstanceInterfaceIpv6Config
+	305,  // 318: forge.InstanceInterfaceConfig.routing_profile:type_name -> forge.InstanceInterfaceRoutingProfile
+	1009, // 319: forge.InstanceInterfaceVpcSelection.vpc_id:type_name -> common.VpcId
 	17,   // 320: forge.InstanceInterfaceVpcSelection.family_mode:type_name -> forge.InstanceInterfaceIpFamilyMode
-	1009, // 321: forge.InstanceInterfaceIpv6Config.vpc_prefix_id:type_name -> common.VpcPrefixId
-	877,  // 322: forge.InstanceInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	1011, // 321: forge.InstanceInterfaceIpv6Config.vpc_prefix_id:type_name -> common.VpcPrefixId
+	879,  // 322: forge.InstanceInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	40,   // 323: forge.InstanceIBInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	1011, // 324: forge.InstanceIBInterfaceConfig.ib_partition_id:type_name -> common.IBPartitionId
-	1009, // 325: forge.InstanceInterfaceResolvedVpcPrefixes.ipv4_vpc_prefix_id:type_name -> common.VpcPrefixId
-	1009, // 326: forge.InstanceInterfaceResolvedVpcPrefixes.ipv6_vpc_prefix_id:type_name -> common.VpcPrefixId
-	1007, // 327: forge.InstanceInterfaceStatus.vpc_id:type_name -> common.VpcId
-	305,  // 328: forge.InstanceInterfaceStatus.resolved_vpc_prefixes:type_name -> forge.InstanceInterfaceResolvedVpcPrefixes
-	1025, // 329: forge.InstanceNVLinkGpuStatus.domain_id:type_name -> common.NVLinkDomainId
-	1008, // 330: forge.InstanceNVLinkGpuStatus.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1008, // 331: forge.InstanceNVLinkGpuConfig.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1021, // 332: forge.InstancePhoneHomeLastContactRequest.instance_id:type_name -> common.InstanceId
-	1006, // 333: forge.InstancePhoneHomeLastContactResponse.timestamp:type_name -> google.protobuf.Timestamp
+	1013, // 324: forge.InstanceIBInterfaceConfig.ib_partition_id:type_name -> common.IBPartitionId
+	1011, // 325: forge.InstanceInterfaceResolvedVpcPrefixes.ipv4_vpc_prefix_id:type_name -> common.VpcPrefixId
+	1011, // 326: forge.InstanceInterfaceResolvedVpcPrefixes.ipv6_vpc_prefix_id:type_name -> common.VpcPrefixId
+	1009, // 327: forge.InstanceInterfaceStatus.vpc_id:type_name -> common.VpcId
+	307,  // 328: forge.InstanceInterfaceStatus.resolved_vpc_prefixes:type_name -> forge.InstanceInterfaceResolvedVpcPrefixes
+	1027, // 329: forge.InstanceNVLinkGpuStatus.domain_id:type_name -> common.NVLinkDomainId
+	1010, // 330: forge.InstanceNVLinkGpuStatus.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1010, // 331: forge.InstanceNVLinkGpuConfig.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1023, // 332: forge.InstancePhoneHomeLastContactRequest.instance_id:type_name -> common.InstanceId
+	1008, // 333: forge.InstancePhoneHomeLastContactResponse.timestamp:type_name -> google.protobuf.Timestamp
 	18,   // 334: forge.Issue.category:type_name -> forge.IssueCategory
-	313,  // 335: forge.DeleteAttribution.initiated_by:type_name -> forge.DeleteInitiatedBy
-	1021, // 336: forge.InstanceReleaseRequest.id:type_name -> common.InstanceId
-	312,  // 337: forge.InstanceReleaseRequest.issue:type_name -> forge.Issue
-	314,  // 338: forge.InstanceReleaseRequest.delete_attribution:type_name -> forge.DeleteAttribution
-	1005, // 339: forge.MachinesByIdsRequest.machine_ids:type_name -> common.MachineId
-	1014, // 340: forge.MachineSearchConfig.rack_id:type_name -> common.RackId
-	1005, // 341: forge.MachineStateHistoriesRequest.machine_ids:type_name -> common.MachineId
-	972,  // 342: forge.MachineStateHistories.histories:type_name -> forge.MachineStateHistories.HistoriesEntry
-	360,  // 343: forge.MachineStateHistoryRecords.records:type_name -> forge.MachineEvent
-	1005, // 344: forge.MachineHealthHistoriesRequest.machine_ids:type_name -> common.MachineId
-	1006, // 345: forge.MachineHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	1006, // 346: forge.MachineHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	973,  // 347: forge.HealthHistories.histories:type_name -> forge.HealthHistories.HistoriesEntry
-	325,  // 348: forge.HealthHistoryRecords.records:type_name -> forge.HealthHistoryRecord
-	1012, // 349: forge.HealthHistoryRecord.health:type_name -> health.HealthReport
-	1006, // 350: forge.HealthHistoryRecord.time:type_name -> google.protobuf.Timestamp
-	477,  // 351: forge.TenantList.tenants:type_name -> forge.Tenant
-	361,  // 352: forge.InterfaceList.interfaces:type_name -> forge.MachineInterface
-	345,  // 353: forge.MachineList.machines:type_name -> forge.Machine
-	1026, // 354: forge.InterfaceDeleteQuery.id:type_name -> common.MachineInterfaceId
-	1026, // 355: forge.InterfaceSearchQuery.id:type_name -> common.MachineInterfaceId
-	1026, // 356: forge.AssignStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
-	1026, // 357: forge.AssignStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
+	315,  // 335: forge.DeleteAttribution.initiated_by:type_name -> forge.DeleteInitiatedBy
+	1023, // 336: forge.InstanceReleaseRequest.id:type_name -> common.InstanceId
+	314,  // 337: forge.InstanceReleaseRequest.issue:type_name -> forge.Issue
+	316,  // 338: forge.InstanceReleaseRequest.delete_attribution:type_name -> forge.DeleteAttribution
+	1007, // 339: forge.MachinesByIdsRequest.machine_ids:type_name -> common.MachineId
+	1016, // 340: forge.MachineSearchConfig.rack_id:type_name -> common.RackId
+	1007, // 341: forge.MachineStateHistoriesRequest.machine_ids:type_name -> common.MachineId
+	974,  // 342: forge.MachineStateHistories.histories:type_name -> forge.MachineStateHistories.HistoriesEntry
+	362,  // 343: forge.MachineStateHistoryRecords.records:type_name -> forge.MachineEvent
+	1007, // 344: forge.MachineHealthHistoriesRequest.machine_ids:type_name -> common.MachineId
+	1008, // 345: forge.MachineHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	1008, // 346: forge.MachineHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	975,  // 347: forge.HealthHistories.histories:type_name -> forge.HealthHistories.HistoriesEntry
+	327,  // 348: forge.HealthHistoryRecords.records:type_name -> forge.HealthHistoryRecord
+	1014, // 349: forge.HealthHistoryRecord.health:type_name -> health.HealthReport
+	1008, // 350: forge.HealthHistoryRecord.time:type_name -> google.protobuf.Timestamp
+	479,  // 351: forge.TenantList.tenants:type_name -> forge.Tenant
+	363,  // 352: forge.InterfaceList.interfaces:type_name -> forge.MachineInterface
+	347,  // 353: forge.MachineList.machines:type_name -> forge.Machine
+	1028, // 354: forge.InterfaceDeleteQuery.id:type_name -> common.MachineInterfaceId
+	1028, // 355: forge.InterfaceSearchQuery.id:type_name -> common.MachineInterfaceId
+	1028, // 356: forge.AssignStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
+	1028, // 357: forge.AssignStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
 	19,   // 358: forge.AssignStaticAddressResponse.status:type_name -> forge.AssignStaticAddressStatus
-	1026, // 359: forge.RemoveStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
-	1026, // 360: forge.RemoveStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
+	1028, // 359: forge.RemoveStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
+	1028, // 360: forge.RemoveStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
 	20,   // 361: forge.RemoveStaticAddressResponse.status:type_name -> forge.RemoveStaticAddressStatus
-	1026, // 362: forge.FindInterfaceAddressesRequest.interface_id:type_name -> common.MachineInterfaceId
-	1026, // 363: forge.FindInterfaceAddressesResponse.interface_id:type_name -> common.MachineInterfaceId
-	339,  // 364: forge.FindInterfaceAddressesResponse.addresses:type_name -> forge.InterfaceAddress
-	1026, // 365: forge.BmcInfo.machine_interface_id:type_name -> common.MachineInterfaceId
-	1006, // 366: forge.MachineConfig.maintenance_start_time:type_name -> google.protobuf.Timestamp
-	346,  // 367: forge.MachineConfig.dpf:type_name -> forge.DpfMachineState
-	361,  // 368: forge.MachineStatus.interfaces:type_name -> forge.MachineInterface
-	1027, // 369: forge.MachineStatus.discovery_info:type_name -> machine_discovery.DiscoveryInfo
-	1006, // 370: forge.MachineStatus.last_reboot_time:type_name -> google.protobuf.Timestamp
-	1006, // 371: forge.MachineStatus.last_observation_time:type_name -> google.protobuf.Timestamp
-	1005, // 372: forge.MachineStatus.associated_host_machine_id:type_name -> common.MachineId
-	1005, // 373: forge.MachineStatus.associated_dpu_machine_ids:type_name -> common.MachineId
-	1006, // 374: forge.MachineStatus.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
-	1012, // 375: forge.MachineStatus.health:type_name -> health.HealthReport
-	355,  // 376: forge.MachineStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	362,  // 377: forge.MachineStatus.infiniband:type_name -> forge.InfinibandStatusObservation
-	639,  // 378: forge.MachineStatus.capabilities:type_name -> forge.MachineCapabilitiesSet
-	712,  // 379: forge.MachineStatus.hw_sku:type_name -> forge.SkuStatus
-	393,  // 380: forge.MachineStatus.quarantine:type_name -> forge.ManagedHostQuarantineState
-	763,  // 381: forge.MachineStatus.nvlink_info:type_name -> forge.MachineNVLinkInfo
-	773,  // 382: forge.MachineStatus.nvlink:type_name -> forge.MachineNVLinkStatusObservation
-	765,  // 383: forge.MachineStatus.spx:type_name -> forge.MachineSpxStatusObservation
-	347,  // 384: forge.MachineStatus.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
-	96,   // 385: forge.MachineStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1005, // 386: forge.Machine.id:type_name -> common.MachineId
-	356,  // 387: forge.Machine.state_reason:type_name -> forge.ControllerStateReason
-	358,  // 388: forge.Machine.state_sla:type_name -> forge.StateSla
-	360,  // 389: forge.Machine.events:type_name -> forge.MachineEvent
-	361,  // 390: forge.Machine.interfaces:type_name -> forge.MachineInterface
-	1027, // 391: forge.Machine.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	1028, // 362: forge.FindInterfaceAddressesRequest.interface_id:type_name -> common.MachineInterfaceId
+	1028, // 363: forge.FindInterfaceAddressesResponse.interface_id:type_name -> common.MachineInterfaceId
+	341,  // 364: forge.FindInterfaceAddressesResponse.addresses:type_name -> forge.InterfaceAddress
+	1028, // 365: forge.BmcInfo.machine_interface_id:type_name -> common.MachineInterfaceId
+	1008, // 366: forge.MachineConfig.maintenance_start_time:type_name -> google.protobuf.Timestamp
+	348,  // 367: forge.MachineConfig.dpf:type_name -> forge.DpfMachineState
+	363,  // 368: forge.MachineStatus.interfaces:type_name -> forge.MachineInterface
+	1029, // 369: forge.MachineStatus.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	1008, // 370: forge.MachineStatus.last_reboot_time:type_name -> google.protobuf.Timestamp
+	1008, // 371: forge.MachineStatus.last_observation_time:type_name -> google.protobuf.Timestamp
+	1007, // 372: forge.MachineStatus.associated_host_machine_id:type_name -> common.MachineId
+	1007, // 373: forge.MachineStatus.associated_dpu_machine_ids:type_name -> common.MachineId
+	1008, // 374: forge.MachineStatus.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
+	1014, // 375: forge.MachineStatus.health:type_name -> health.HealthReport
+	357,  // 376: forge.MachineStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	364,  // 377: forge.MachineStatus.infiniband:type_name -> forge.InfinibandStatusObservation
+	641,  // 378: forge.MachineStatus.capabilities:type_name -> forge.MachineCapabilitiesSet
+	714,  // 379: forge.MachineStatus.hw_sku:type_name -> forge.SkuStatus
+	395,  // 380: forge.MachineStatus.quarantine:type_name -> forge.ManagedHostQuarantineState
+	765,  // 381: forge.MachineStatus.nvlink_info:type_name -> forge.MachineNVLinkInfo
+	775,  // 382: forge.MachineStatus.nvlink:type_name -> forge.MachineNVLinkStatusObservation
+	767,  // 383: forge.MachineStatus.spx:type_name -> forge.MachineSpxStatusObservation
+	349,  // 384: forge.MachineStatus.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
+	98,   // 385: forge.MachineStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1007, // 386: forge.Machine.id:type_name -> common.MachineId
+	358,  // 387: forge.Machine.state_reason:type_name -> forge.ControllerStateReason
+	360,  // 388: forge.Machine.state_sla:type_name -> forge.StateSla
+	362,  // 389: forge.Machine.events:type_name -> forge.MachineEvent
+	363,  // 390: forge.Machine.interfaces:type_name -> forge.MachineInterface
+	1029, // 391: forge.Machine.discovery_info:type_name -> machine_discovery.DiscoveryInfo
 	21,   // 392: forge.Machine.machine_type:type_name -> forge.MachineType
-	341,  // 393: forge.Machine.bmc_info:type_name -> forge.BmcInfo
-	1006, // 394: forge.Machine.last_reboot_time:type_name -> google.protobuf.Timestamp
-	1006, // 395: forge.Machine.last_observation_time:type_name -> google.protobuf.Timestamp
-	1006, // 396: forge.Machine.maintenance_start_time:type_name -> google.protobuf.Timestamp
-	1005, // 397: forge.Machine.associated_host_machine_id:type_name -> common.MachineId
-	353,  // 398: forge.Machine.inventory:type_name -> forge.MachineComponentInventory
-	1006, // 399: forge.Machine.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
-	1005, // 400: forge.Machine.associated_dpu_machine_ids:type_name -> common.MachineId
-	1012, // 401: forge.Machine.health:type_name -> health.HealthReport
-	355,  // 402: forge.Machine.health_sources:type_name -> forge.HealthSourceOrigin
-	362,  // 403: forge.Machine.ib_status:type_name -> forge.InfinibandStatusObservation
-	265,  // 404: forge.Machine.metadata:type_name -> forge.Metadata
-	347,  // 405: forge.Machine.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
-	639,  // 406: forge.Machine.capabilities:type_name -> forge.MachineCapabilitiesSet
-	712,  // 407: forge.Machine.hw_sku_status:type_name -> forge.SkuStatus
-	393,  // 408: forge.Machine.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	763,  // 409: forge.Machine.nvlink_info:type_name -> forge.MachineNVLinkInfo
-	773,  // 410: forge.Machine.nvlink_status_observation:type_name -> forge.MachineNVLinkStatusObservation
-	1014, // 411: forge.Machine.rack_id:type_name -> common.RackId
-	223,  // 412: forge.Machine.placement_in_rack:type_name -> forge.PlacementInRack
-	765,  // 413: forge.Machine.spx_status_observation:type_name -> forge.MachineSpxStatusObservation
-	346,  // 414: forge.Machine.dpf:type_name -> forge.DpfMachineState
-	343,  // 415: forge.Machine.config:type_name -> forge.MachineConfig
-	344,  // 416: forge.Machine.status:type_name -> forge.MachineStatus
+	343,  // 393: forge.Machine.bmc_info:type_name -> forge.BmcInfo
+	1008, // 394: forge.Machine.last_reboot_time:type_name -> google.protobuf.Timestamp
+	1008, // 395: forge.Machine.last_observation_time:type_name -> google.protobuf.Timestamp
+	1008, // 396: forge.Machine.maintenance_start_time:type_name -> google.protobuf.Timestamp
+	1007, // 397: forge.Machine.associated_host_machine_id:type_name -> common.MachineId
+	355,  // 398: forge.Machine.inventory:type_name -> forge.MachineComponentInventory
+	1008, // 399: forge.Machine.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
+	1007, // 400: forge.Machine.associated_dpu_machine_ids:type_name -> common.MachineId
+	1014, // 401: forge.Machine.health:type_name -> health.HealthReport
+	357,  // 402: forge.Machine.health_sources:type_name -> forge.HealthSourceOrigin
+	364,  // 403: forge.Machine.ib_status:type_name -> forge.InfinibandStatusObservation
+	267,  // 404: forge.Machine.metadata:type_name -> forge.Metadata
+	349,  // 405: forge.Machine.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
+	641,  // 406: forge.Machine.capabilities:type_name -> forge.MachineCapabilitiesSet
+	714,  // 407: forge.Machine.hw_sku_status:type_name -> forge.SkuStatus
+	395,  // 408: forge.Machine.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	765,  // 409: forge.Machine.nvlink_info:type_name -> forge.MachineNVLinkInfo
+	775,  // 410: forge.Machine.nvlink_status_observation:type_name -> forge.MachineNVLinkStatusObservation
+	1016, // 411: forge.Machine.rack_id:type_name -> common.RackId
+	225,  // 412: forge.Machine.placement_in_rack:type_name -> forge.PlacementInRack
+	767,  // 413: forge.Machine.spx_status_observation:type_name -> forge.MachineSpxStatusObservation
+	348,  // 414: forge.Machine.dpf:type_name -> forge.DpfMachineState
+	345,  // 415: forge.Machine.config:type_name -> forge.MachineConfig
+	346,  // 416: forge.Machine.status:type_name -> forge.MachineStatus
 	22,   // 417: forge.InstanceNetworkRestrictions.network_segment_membership_type:type_name -> forge.InstanceNetworkSegmentMembershipType
-	1019, // 418: forge.InstanceNetworkRestrictions.network_segment_ids:type_name -> common.NetworkSegmentId
-	1005, // 419: forge.MachineMetadataUpdateRequest.machine_id:type_name -> common.MachineId
-	265,  // 420: forge.MachineMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1014, // 421: forge.RackMetadataUpdateRequest.rack_id:type_name -> common.RackId
-	265,  // 422: forge.RackMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1016, // 423: forge.SwitchMetadataUpdateRequest.switch_id:type_name -> common.SwitchId
-	265,  // 424: forge.SwitchMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1013, // 425: forge.PowerShelfMetadataUpdateRequest.power_shelf_id:type_name -> common.PowerShelfId
-	265,  // 426: forge.PowerShelfMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1005, // 427: forge.DpuAgentInventoryReport.machine_id:type_name -> common.MachineId
-	353,  // 428: forge.DpuAgentInventoryReport.inventory:type_name -> forge.MachineComponentInventory
-	354,  // 429: forge.MachineComponentInventory.components:type_name -> forge.MachineInventorySoftwareComponent
+	1021, // 418: forge.InstanceNetworkRestrictions.network_segment_ids:type_name -> common.NetworkSegmentId
+	1007, // 419: forge.MachineMetadataUpdateRequest.machine_id:type_name -> common.MachineId
+	267,  // 420: forge.MachineMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1016, // 421: forge.RackMetadataUpdateRequest.rack_id:type_name -> common.RackId
+	267,  // 422: forge.RackMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1018, // 423: forge.SwitchMetadataUpdateRequest.switch_id:type_name -> common.SwitchId
+	267,  // 424: forge.SwitchMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1015, // 425: forge.PowerShelfMetadataUpdateRequest.power_shelf_id:type_name -> common.PowerShelfId
+	267,  // 426: forge.PowerShelfMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1007, // 427: forge.DpuAgentInventoryReport.machine_id:type_name -> common.MachineId
+	355,  // 428: forge.DpuAgentInventoryReport.inventory:type_name -> forge.MachineComponentInventory
+	356,  // 429: forge.MachineComponentInventory.components:type_name -> forge.MachineInventorySoftwareComponent
 	41,   // 430: forge.HealthSourceOrigin.mode:type_name -> forge.HealthReportApplyMode
 	23,   // 431: forge.ControllerStateReason.outcome:type_name -> forge.ControllerStateOutcome
-	357,  // 432: forge.ControllerStateReason.source_ref:type_name -> forge.ControllerStateSourceReference
-	1028, // 433: forge.StateSla.sla:type_name -> google.protobuf.Duration
+	359,  // 432: forge.ControllerStateReason.source_ref:type_name -> forge.ControllerStateSourceReference
+	1030, // 433: forge.StateSla.sla:type_name -> google.protobuf.Duration
 	8,    // 434: forge.InstanceTenantStatus.state:type_name -> forge.TenantState
-	1006, // 435: forge.MachineEvent.time:type_name -> google.protobuf.Timestamp
-	1026, // 436: forge.MachineInterface.id:type_name -> common.MachineInterfaceId
-	1005, // 437: forge.MachineInterface.attached_dpu_machine_id:type_name -> common.MachineId
-	1005, // 438: forge.MachineInterface.machine_id:type_name -> common.MachineId
-	1019, // 439: forge.MachineInterface.segment_id:type_name -> common.NetworkSegmentId
-	1018, // 440: forge.MachineInterface.domain_id:type_name -> common.DomainId
-	1006, // 441: forge.MachineInterface.created:type_name -> google.protobuf.Timestamp
-	1006, // 442: forge.MachineInterface.last_dhcp:type_name -> google.protobuf.Timestamp
-	1013, // 443: forge.MachineInterface.power_shelf_id:type_name -> common.PowerShelfId
-	1016, // 444: forge.MachineInterface.switch_id:type_name -> common.SwitchId
+	1008, // 435: forge.MachineEvent.time:type_name -> google.protobuf.Timestamp
+	1028, // 436: forge.MachineInterface.id:type_name -> common.MachineInterfaceId
+	1007, // 437: forge.MachineInterface.attached_dpu_machine_id:type_name -> common.MachineId
+	1007, // 438: forge.MachineInterface.machine_id:type_name -> common.MachineId
+	1021, // 439: forge.MachineInterface.segment_id:type_name -> common.NetworkSegmentId
+	1020, // 440: forge.MachineInterface.domain_id:type_name -> common.DomainId
+	1008, // 441: forge.MachineInterface.created:type_name -> google.protobuf.Timestamp
+	1008, // 442: forge.MachineInterface.last_dhcp:type_name -> google.protobuf.Timestamp
+	1015, // 443: forge.MachineInterface.power_shelf_id:type_name -> common.PowerShelfId
+	1018, // 444: forge.MachineInterface.switch_id:type_name -> common.SwitchId
 	26,   // 445: forge.MachineInterface.association_type:type_name -> forge.InterfaceAssociationType
 	27,   // 446: forge.MachineInterface.interface_type:type_name -> forge.InterfaceType
-	363,  // 447: forge.InfinibandStatusObservation.ib_interfaces:type_name -> forge.MachineIbInterface
-	1006, // 448: forge.InfinibandStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	1029, // 449: forge.MachineIbInterface.associated_pkeys:type_name -> common.StringList
-	1029, // 450: forge.MachineIbInterface.associated_partition_ids:type_name -> common.StringList
+	365,  // 447: forge.InfinibandStatusObservation.ib_interfaces:type_name -> forge.MachineIbInterface
+	1008, // 448: forge.InfinibandStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1031, // 449: forge.MachineIbInterface.associated_pkeys:type_name -> common.StringList
+	1031, // 450: forge.MachineIbInterface.associated_partition_ids:type_name -> common.StringList
 	28,   // 451: forge.DhcpDiscovery.address_family:type_name -> forge.AddressFamily
 	29,   // 452: forge.DhcpDiscovery.message_kind:type_name -> forge.MessageKind
 	30,   // 453: forge.ExpireDhcpLeaseResponse.status:type_name -> forge.ExpireDhcpLeaseStatus
-	1005, // 454: forge.DhcpRecord.machine_id:type_name -> common.MachineId
-	1026, // 455: forge.DhcpRecord.machine_interface_id:type_name -> common.MachineInterfaceId
-	1019, // 456: forge.DhcpRecord.segment_id:type_name -> common.NetworkSegmentId
-	1018, // 457: forge.DhcpRecord.subdomain_id:type_name -> common.DomainId
-	1006, // 458: forge.DhcpRecord.last_invalidation_time:type_name -> google.protobuf.Timestamp
-	249,  // 459: forge.NetworkSegmentList.network_segments:type_name -> forge.NetworkSegment
+	1007, // 454: forge.DhcpRecord.machine_id:type_name -> common.MachineId
+	1028, // 455: forge.DhcpRecord.machine_interface_id:type_name -> common.MachineInterfaceId
+	1021, // 456: forge.DhcpRecord.segment_id:type_name -> common.NetworkSegmentId
+	1020, // 457: forge.DhcpRecord.subdomain_id:type_name -> common.DomainId
+	1008, // 458: forge.DhcpRecord.last_invalidation_time:type_name -> google.protobuf.Timestamp
+	251,  // 459: forge.NetworkSegmentList.network_segments:type_name -> forge.NetworkSegment
 	31,   // 460: forge.SSHKeyValidationResponse.role:type_name -> forge.UserRoles
-	1016, // 461: forge.GetSwitchNvosCredentialsRequest.switch_id:type_name -> common.SwitchId
-	374,  // 462: forge.GetBmcCredentialsResponse.credentials:type_name -> forge.BmcCredentials
-	842,  // 463: forge.BmcCredentials.username_password:type_name -> forge.UsernamePassword
-	843,  // 464: forge.BmcCredentials.session_token:type_name -> forge.SessionToken
-	382,  // 465: forge.SshRequest.endpoint_request:type_name -> forge.BmcEndpointRequest
-	384,  // 466: forge.CopyBfbToDpuRshimRequest.ssh_request:type_name -> forge.SshRequest
-	1005, // 467: forge.UpdateMachineHardwareInfoRequest.machine_id:type_name -> common.MachineId
-	387,  // 468: forge.UpdateMachineHardwareInfoRequest.info:type_name -> forge.MachineHardwareInfo
+	1018, // 461: forge.GetSwitchNvosCredentialsRequest.switch_id:type_name -> common.SwitchId
+	376,  // 462: forge.GetBmcCredentialsResponse.credentials:type_name -> forge.BmcCredentials
+	844,  // 463: forge.BmcCredentials.username_password:type_name -> forge.UsernamePassword
+	845,  // 464: forge.BmcCredentials.session_token:type_name -> forge.SessionToken
+	384,  // 465: forge.SshRequest.endpoint_request:type_name -> forge.BmcEndpointRequest
+	386,  // 466: forge.CopyBfbToDpuRshimRequest.ssh_request:type_name -> forge.SshRequest
+	1007, // 467: forge.UpdateMachineHardwareInfoRequest.machine_id:type_name -> common.MachineId
+	389,  // 468: forge.UpdateMachineHardwareInfoRequest.info:type_name -> forge.MachineHardwareInfo
 	32,   // 469: forge.UpdateMachineHardwareInfoRequest.update_type:type_name -> forge.MachineHardwareInfoUpdateType
-	1030, // 470: forge.MachineHardwareInfo.gpus:type_name -> machine_discovery.Gpu
-	1005, // 471: forge.ManagedHostNetworkConfigRequest.dpu_machine_id:type_name -> common.MachineId
-	400,  // 472: forge.ManagedHostNetworkConfigResponse.managed_host_config:type_name -> forge.ManagedHostNetworkConfig
-	401,  // 473: forge.ManagedHostNetworkConfigResponse.admin_interface:type_name -> forge.FlatInterfaceConfig
-	401,  // 474: forge.ManagedHostNetworkConfigResponse.tenant_interfaces:type_name -> forge.FlatInterfaceConfig
-	1021, // 475: forge.ManagedHostNetworkConfigResponse.instance_id:type_name -> common.InstanceId
+	1032, // 470: forge.MachineHardwareInfo.gpus:type_name -> machine_discovery.Gpu
+	1007, // 471: forge.ManagedHostNetworkConfigRequest.dpu_machine_id:type_name -> common.MachineId
+	402,  // 472: forge.ManagedHostNetworkConfigResponse.managed_host_config:type_name -> forge.ManagedHostNetworkConfig
+	403,  // 473: forge.ManagedHostNetworkConfigResponse.admin_interface:type_name -> forge.FlatInterfaceConfig
+	403,  // 474: forge.ManagedHostNetworkConfigResponse.tenant_interfaces:type_name -> forge.FlatInterfaceConfig
+	1023, // 475: forge.ManagedHostNetworkConfigResponse.instance_id:type_name -> common.InstanceId
 	6,    // 476: forge.ManagedHostNetworkConfigResponse.network_virtualization_type:type_name -> forge.VpcVirtualizationType
 	34,   // 477: forge.ManagedHostNetworkConfigResponse.vpc_isolation_behavior:type_name -> forge.VpcIsolationBehaviorType
-	298,  // 478: forge.ManagedHostNetworkConfigResponse.instance:type_name -> forge.Instance
-	1031, // 479: forge.ManagedHostNetworkConfigResponse.common_internal_route_target:type_name -> common.RouteTarget
-	1031, // 480: forge.ManagedHostNetworkConfigResponse.additional_route_target_imports:type_name -> common.RouteTarget
-	690,  // 481: forge.ManagedHostNetworkConfigResponse.network_security_policy_overrides:type_name -> forge.ResolvedNetworkSecurityGroupRule
-	392,  // 482: forge.ManagedHostNetworkConfigResponse.dpu_extension_services:type_name -> forge.ManagedHostDpuExtensionServiceConfig
-	390,  // 483: forge.ManagedHostNetworkConfigResponse.traffic_intercept_config:type_name -> forge.TrafficInterceptConfig
-	878,  // 484: forge.ManagedHostNetworkConfigResponse.routing_profile:type_name -> forge.RoutingProfile
-	767,  // 485: forge.ManagedHostNetworkConfigResponse.astra_config:type_name -> forge.AstraConfig
-	391,  // 486: forge.TrafficInterceptConfig.bridging:type_name -> forge.TrafficInterceptBridging
-	974,  // 487: forge.TrafficInterceptBridging.host_representor_intercept_bridging:type_name -> forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
+	300,  // 478: forge.ManagedHostNetworkConfigResponse.instance:type_name -> forge.Instance
+	1033, // 479: forge.ManagedHostNetworkConfigResponse.common_internal_route_target:type_name -> common.RouteTarget
+	1033, // 480: forge.ManagedHostNetworkConfigResponse.additional_route_target_imports:type_name -> common.RouteTarget
+	692,  // 481: forge.ManagedHostNetworkConfigResponse.network_security_policy_overrides:type_name -> forge.ResolvedNetworkSecurityGroupRule
+	394,  // 482: forge.ManagedHostNetworkConfigResponse.dpu_extension_services:type_name -> forge.ManagedHostDpuExtensionServiceConfig
+	392,  // 483: forge.ManagedHostNetworkConfigResponse.traffic_intercept_config:type_name -> forge.TrafficInterceptConfig
+	880,  // 484: forge.ManagedHostNetworkConfigResponse.routing_profile:type_name -> forge.RoutingProfile
+	769,  // 485: forge.ManagedHostNetworkConfigResponse.astra_config:type_name -> forge.AstraConfig
+	393,  // 486: forge.TrafficInterceptConfig.bridging:type_name -> forge.TrafficInterceptBridging
+	976,  // 487: forge.TrafficInterceptBridging.host_representor_intercept_bridging:type_name -> forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
 	73,   // 488: forge.ManagedHostDpuExtensionServiceConfig.service_type:type_name -> forge.DpuExtensionServiceType
-	844,  // 489: forge.ManagedHostDpuExtensionServiceConfig.credential:type_name -> forge.DpuExtensionServiceCredential
-	863,  // 490: forge.ManagedHostDpuExtensionServiceConfig.observability:type_name -> forge.DpuExtensionServiceObservability
+	846,  // 489: forge.ManagedHostDpuExtensionServiceConfig.credential:type_name -> forge.DpuExtensionServiceCredential
+	865,  // 490: forge.ManagedHostDpuExtensionServiceConfig.observability:type_name -> forge.DpuExtensionServiceObservability
 	33,   // 491: forge.ManagedHostQuarantineState.mode:type_name -> forge.ManagedHostQuarantineMode
-	1005, // 492: forge.GetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
-	393,  // 493: forge.GetManagedHostQuarantineStateResponse.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	1005, // 494: forge.SetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
-	393,  // 495: forge.SetManagedHostQuarantineStateRequest.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	393,  // 496: forge.SetManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	1005, // 497: forge.ClearManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
-	393,  // 498: forge.ClearManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	393,  // 499: forge.ManagedHostNetworkConfig.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	1007, // 492: forge.GetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	395,  // 493: forge.GetManagedHostQuarantineStateResponse.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	1007, // 494: forge.SetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	395,  // 495: forge.SetManagedHostQuarantineStateRequest.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	395,  // 496: forge.SetManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	1007, // 497: forge.ClearManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	395,  // 498: forge.ClearManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	395,  // 499: forge.ManagedHostNetworkConfig.quarantine_state:type_name -> forge.ManagedHostQuarantineState
 	40,   // 500: forge.FlatInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	403,  // 501: forge.FlatInterfaceConfig.ipv6_interface_config:type_name -> forge.FlatInterfaceIpv6Config
-	878,  // 502: forge.FlatInterfaceConfig.vpc_routing_profile:type_name -> forge.RoutingProfile
-	402,  // 503: forge.FlatInterfaceConfig.interface_routing_profile:type_name -> forge.FlatInterfaceRoutingProfile
-	404,  // 504: forge.FlatInterfaceConfig.network_security_group:type_name -> forge.FlatInterfaceNetworkSecurityGroupConfig
-	1015, // 505: forge.FlatInterfaceConfig.internal_uuid:type_name -> common.UUID
-	877,  // 506: forge.FlatInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	405,  // 501: forge.FlatInterfaceConfig.ipv6_interface_config:type_name -> forge.FlatInterfaceIpv6Config
+	880,  // 502: forge.FlatInterfaceConfig.vpc_routing_profile:type_name -> forge.RoutingProfile
+	404,  // 503: forge.FlatInterfaceConfig.interface_routing_profile:type_name -> forge.FlatInterfaceRoutingProfile
+	406,  // 504: forge.FlatInterfaceConfig.network_security_group:type_name -> forge.FlatInterfaceNetworkSecurityGroupConfig
+	1017, // 505: forge.FlatInterfaceConfig.internal_uuid:type_name -> common.UUID
+	879,  // 506: forge.FlatInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	58,   // 507: forge.FlatInterfaceNetworkSecurityGroupConfig.source:type_name -> forge.NetworkSecurityGroupSource
-	690,  // 508: forge.FlatInterfaceNetworkSecurityGroupConfig.rules:type_name -> forge.ResolvedNetworkSecurityGroupRule
-	453,  // 509: forge.ManagedHostNetworkStatusResponse.all:type_name -> forge.DpuNetworkStatus
-	1006, // 510: forge.DpuAgentUpgradeCheckRequest.binary_mtime:type_name -> google.protobuf.Timestamp
+	692,  // 508: forge.FlatInterfaceNetworkSecurityGroupConfig.rules:type_name -> forge.ResolvedNetworkSecurityGroupRule
+	455,  // 509: forge.ManagedHostNetworkStatusResponse.all:type_name -> forge.DpuNetworkStatus
+	1008, // 510: forge.DpuAgentUpgradeCheckRequest.binary_mtime:type_name -> google.protobuf.Timestamp
 	35,   // 511: forge.DpuAgentUpgradePolicyRequest.new_policy:type_name -> forge.AgentUpgradePolicy
 	35,   // 512: forge.DpuAgentUpgradePolicyResponse.active_policy:type_name -> forge.AgentUpgradePolicy
-	382,  // 513: forge.LockdownRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1005, // 514: forge.LockdownRequest.machine_id:type_name -> common.MachineId
+	384,  // 513: forge.LockdownRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1007, // 514: forge.LockdownRequest.machine_id:type_name -> common.MachineId
 	36,   // 515: forge.LockdownRequest.action:type_name -> forge.LockdownAction
-	382,  // 516: forge.LockdownStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1005, // 517: forge.LockdownStatusRequest.machine_id:type_name -> common.MachineId
-	382,  // 518: forge.MachineSetupStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 519: forge.MachineSetupRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 520: forge.SetDpuFirstBootOrderRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 521: forge.AdminRebootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 522: forge.AdminBmcResetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 523: forge.EnableInfiniteBootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 524: forge.IsInfiniteBootEnabledRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1005, // 525: forge.BMCMetaDataGetRequest.machine_id:type_name -> common.MachineId
+	384,  // 516: forge.LockdownStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1007, // 517: forge.LockdownStatusRequest.machine_id:type_name -> common.MachineId
+	384,  // 518: forge.MachineSetupStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 519: forge.MachineSetupRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 520: forge.SetDpuFirstBootOrderRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 521: forge.AdminRebootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 522: forge.AdminBmcResetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 523: forge.EnableInfiniteBootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 524: forge.IsInfiniteBootEnabledRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1007, // 525: forge.BMCMetaDataGetRequest.machine_id:type_name -> common.MachineId
 	31,   // 526: forge.BMCMetaDataGetRequest.role:type_name -> forge.UserRoles
 	37,   // 527: forge.BMCMetaDataGetRequest.request_type:type_name -> forge.BMCRequestType
-	382,  // 528: forge.BMCMetaDataGetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1005, // 529: forge.MachineCredentialsUpdateRequest.machine_id:type_name -> common.MachineId
-	975,  // 530: forge.MachineCredentialsUpdateRequest.credentials:type_name -> forge.MachineCredentialsUpdateRequest.Credentials
-	1005, // 531: forge.ForgeAgentControlRequest.machine_id:type_name -> common.MachineId
-	88,   // 532: forge.ForgeAgentControlResponse.legacy_action:type_name -> forge.ForgeAgentControlResponse.LegacyAction
-	976,  // 533: forge.ForgeAgentControlResponse.data:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
-	977,  // 534: forge.ForgeAgentControlResponse.noop:type_name -> forge.ForgeAgentControlResponse.Noop
-	978,  // 535: forge.ForgeAgentControlResponse.reset:type_name -> forge.ForgeAgentControlResponse.Reset
-	979,  // 536: forge.ForgeAgentControlResponse.discovery:type_name -> forge.ForgeAgentControlResponse.Discovery
-	980,  // 537: forge.ForgeAgentControlResponse.rebuild:type_name -> forge.ForgeAgentControlResponse.Rebuild
-	981,  // 538: forge.ForgeAgentControlResponse.retry:type_name -> forge.ForgeAgentControlResponse.Retry
-	982,  // 539: forge.ForgeAgentControlResponse.measure:type_name -> forge.ForgeAgentControlResponse.Measure
-	983,  // 540: forge.ForgeAgentControlResponse.log_error:type_name -> forge.ForgeAgentControlResponse.LogError
-	984,  // 541: forge.ForgeAgentControlResponse.machine_validation:type_name -> forge.ForgeAgentControlResponse.MachineValidation
-	986,  // 542: forge.ForgeAgentControlResponse.mlx_action:type_name -> forge.ForgeAgentControlResponse.MlxAction
-	993,  // 543: forge.ForgeAgentControlResponse.firmware_upgrade:type_name -> forge.ForgeAgentControlResponse.FirmwareUpgrade
-	1026, // 544: forge.MachineDiscoveryInfo.machine_interface_id:type_name -> common.MachineInterfaceId
-	1027, // 545: forge.MachineDiscoveryInfo.info:type_name -> machine_discovery.DiscoveryInfo
+	384,  // 528: forge.BMCMetaDataGetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1007, // 529: forge.MachineCredentialsUpdateRequest.machine_id:type_name -> common.MachineId
+	977,  // 530: forge.MachineCredentialsUpdateRequest.credentials:type_name -> forge.MachineCredentialsUpdateRequest.Credentials
+	1007, // 531: forge.ForgeAgentControlRequest.machine_id:type_name -> common.MachineId
+	90,   // 532: forge.ForgeAgentControlResponse.legacy_action:type_name -> forge.ForgeAgentControlResponse.LegacyAction
+	978,  // 533: forge.ForgeAgentControlResponse.data:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
+	979,  // 534: forge.ForgeAgentControlResponse.noop:type_name -> forge.ForgeAgentControlResponse.Noop
+	980,  // 535: forge.ForgeAgentControlResponse.reset:type_name -> forge.ForgeAgentControlResponse.Reset
+	981,  // 536: forge.ForgeAgentControlResponse.discovery:type_name -> forge.ForgeAgentControlResponse.Discovery
+	982,  // 537: forge.ForgeAgentControlResponse.rebuild:type_name -> forge.ForgeAgentControlResponse.Rebuild
+	983,  // 538: forge.ForgeAgentControlResponse.retry:type_name -> forge.ForgeAgentControlResponse.Retry
+	984,  // 539: forge.ForgeAgentControlResponse.measure:type_name -> forge.ForgeAgentControlResponse.Measure
+	985,  // 540: forge.ForgeAgentControlResponse.log_error:type_name -> forge.ForgeAgentControlResponse.LogError
+	986,  // 541: forge.ForgeAgentControlResponse.machine_validation:type_name -> forge.ForgeAgentControlResponse.MachineValidation
+	988,  // 542: forge.ForgeAgentControlResponse.mlx_action:type_name -> forge.ForgeAgentControlResponse.MlxAction
+	995,  // 543: forge.ForgeAgentControlResponse.firmware_upgrade:type_name -> forge.ForgeAgentControlResponse.FirmwareUpgrade
+	1028, // 544: forge.MachineDiscoveryInfo.machine_interface_id:type_name -> common.MachineInterfaceId
+	1029, // 545: forge.MachineDiscoveryInfo.info:type_name -> machine_discovery.DiscoveryInfo
 	38,   // 546: forge.MachineDiscoveryInfo.discovery_reporter:type_name -> forge.MachineDiscoveryReporter
-	1005, // 547: forge.MachineDiscoveryCompletedRequest.machine_id:type_name -> common.MachineId
-	1005, // 548: forge.MachineCleanupInfo.machine_id:type_name -> common.MachineId
-	995,  // 549: forge.MachineCleanupInfo.nvme:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	995,  // 550: forge.MachineCleanupInfo.ram:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	995,  // 551: forge.MachineCleanupInfo.mem_overwrite:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	995,  // 552: forge.MachineCleanupInfo.ib:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	995,  // 553: forge.MachineCleanupInfo.hdd:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	89,   // 554: forge.MachineCleanupInfo.result:type_name -> forge.MachineCleanupInfo.CleanupResult
-	439,  // 555: forge.MachineCertificateResult.machine_certificate:type_name -> forge.MachineCertificate
-	1005, // 556: forge.MachineDiscoveryResult.machine_id:type_name -> common.MachineId
-	439,  // 557: forge.MachineDiscoveryResult.machine_certificate:type_name -> forge.MachineCertificate
-	132,  // 558: forge.MachineDiscoveryResult.attest_key_challenge:type_name -> forge.AttestKeyBindChallenge
-	1026, // 559: forge.MachineDiscoveryResult.machine_interface_id:type_name -> common.MachineInterfaceId
-	1005, // 560: forge.ForgeScoutErrorReport.machine_id:type_name -> common.MachineId
-	1026, // 561: forge.ForgeScoutErrorReport.machine_interface_id:type_name -> common.MachineInterfaceId
+	1007, // 547: forge.MachineDiscoveryCompletedRequest.machine_id:type_name -> common.MachineId
+	1007, // 548: forge.MachineCleanupInfo.machine_id:type_name -> common.MachineId
+	997,  // 549: forge.MachineCleanupInfo.nvme:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	997,  // 550: forge.MachineCleanupInfo.ram:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	997,  // 551: forge.MachineCleanupInfo.mem_overwrite:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	997,  // 552: forge.MachineCleanupInfo.ib:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	997,  // 553: forge.MachineCleanupInfo.hdd:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	91,   // 554: forge.MachineCleanupInfo.result:type_name -> forge.MachineCleanupInfo.CleanupResult
+	441,  // 555: forge.MachineCertificateResult.machine_certificate:type_name -> forge.MachineCertificate
+	1007, // 556: forge.MachineDiscoveryResult.machine_id:type_name -> common.MachineId
+	441,  // 557: forge.MachineDiscoveryResult.machine_certificate:type_name -> forge.MachineCertificate
+	134,  // 558: forge.MachineDiscoveryResult.attest_key_challenge:type_name -> forge.AttestKeyBindChallenge
+	1028, // 559: forge.MachineDiscoveryResult.machine_interface_id:type_name -> common.MachineInterfaceId
+	1007, // 560: forge.ForgeScoutErrorReport.machine_id:type_name -> common.MachineId
+	1028, // 561: forge.ForgeScoutErrorReport.machine_interface_id:type_name -> common.MachineInterfaceId
 	25,   // 562: forge.PxeInstructionRequest.arch:type_name -> forge.MachineArchitecture
-	1026, // 563: forge.PxeInstructionRequest.interface_id:type_name -> common.MachineInterfaceId
-	361,  // 564: forge.CloudInitDiscoveryInstructions.machine_interface:type_name -> forge.MachineInterface
-	884,  // 565: forge.CloudInitDiscoveryInstructions.domain:type_name -> forge.PxeDomain
+	1028, // 563: forge.PxeInstructionRequest.interface_id:type_name -> common.MachineInterfaceId
+	363,  // 564: forge.CloudInitDiscoveryInstructions.machine_interface:type_name -> forge.MachineInterface
+	886,  // 565: forge.CloudInitDiscoveryInstructions.domain:type_name -> forge.PxeDomain
 	39,   // 566: forge.CloudInitDiscoveryInstructions.bootstrap_ca_source:type_name -> forge.BootstrapCaSource
-	449,  // 567: forge.CloudInitInstructions.discovery_instructions:type_name -> forge.CloudInitDiscoveryInstructions
-	450,  // 568: forge.CloudInitInstructions.metadata:type_name -> forge.CloudInitMetaData
-	1005, // 569: forge.DpuNetworkStatus.dpu_machine_id:type_name -> common.MachineId
-	1006, // 570: forge.DpuNetworkStatus.observed_at:type_name -> google.protobuf.Timestamp
-	474,  // 571: forge.DpuNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatusObservation
-	1021, // 572: forge.DpuNetworkStatus.instance_id:type_name -> common.InstanceId
-	1012, // 573: forge.DpuNetworkStatus.dpu_health:type_name -> health.HealthReport
-	475,  // 574: forge.DpuNetworkStatus.fabric_interfaces:type_name -> forge.FabricInterfaceData
-	454,  // 575: forge.DpuNetworkStatus.last_dhcp_requests:type_name -> forge.LastDhcpRequest
-	455,  // 576: forge.DpuNetworkStatus.dpu_extension_services:type_name -> forge.DpuExtensionServiceStatusObservation
-	769,  // 577: forge.DpuNetworkStatus.astra_config_status:type_name -> forge.AstraConfigStatus
-	1026, // 578: forge.LastDhcpRequest.host_interface_id:type_name -> common.MachineInterfaceId
+	451,  // 567: forge.CloudInitInstructions.discovery_instructions:type_name -> forge.CloudInitDiscoveryInstructions
+	452,  // 568: forge.CloudInitInstructions.metadata:type_name -> forge.CloudInitMetaData
+	1007, // 569: forge.DpuNetworkStatus.dpu_machine_id:type_name -> common.MachineId
+	1008, // 570: forge.DpuNetworkStatus.observed_at:type_name -> google.protobuf.Timestamp
+	476,  // 571: forge.DpuNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatusObservation
+	1023, // 572: forge.DpuNetworkStatus.instance_id:type_name -> common.InstanceId
+	1014, // 573: forge.DpuNetworkStatus.dpu_health:type_name -> health.HealthReport
+	477,  // 574: forge.DpuNetworkStatus.fabric_interfaces:type_name -> forge.FabricInterfaceData
+	456,  // 575: forge.DpuNetworkStatus.last_dhcp_requests:type_name -> forge.LastDhcpRequest
+	457,  // 576: forge.DpuNetworkStatus.dpu_extension_services:type_name -> forge.DpuExtensionServiceStatusObservation
+	771,  // 577: forge.DpuNetworkStatus.astra_config_status:type_name -> forge.AstraConfigStatus
+	1028, // 578: forge.LastDhcpRequest.host_interface_id:type_name -> common.MachineInterfaceId
 	73,   // 579: forge.DpuExtensionServiceStatusObservation.service_type:type_name -> forge.DpuExtensionServiceType
 	74,   // 580: forge.DpuExtensionServiceStatusObservation.state:type_name -> forge.DpuExtensionServiceDeploymentStatus
-	456,  // 581: forge.DpuExtensionServiceStatusObservation.components:type_name -> forge.DpuExtensionServiceComponent
-	1012, // 582: forge.OptionalHealthReport.report:type_name -> health.HealthReport
-	1012, // 583: forge.HealthReportEntry.report:type_name -> health.HealthReport
+	458,  // 581: forge.DpuExtensionServiceStatusObservation.components:type_name -> forge.DpuExtensionServiceComponent
+	1014, // 582: forge.OptionalHealthReport.report:type_name -> health.HealthReport
+	1014, // 583: forge.HealthReportEntry.report:type_name -> health.HealthReport
 	41,   // 584: forge.HealthReportEntry.mode:type_name -> forge.HealthReportApplyMode
-	1005, // 585: forge.InsertMachineHealthReportRequest.machine_id:type_name -> common.MachineId
-	458,  // 586: forge.InsertMachineHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1014, // 587: forge.InsertRackHealthReportRequest.rack_id:type_name -> common.RackId
-	458,  // 588: forge.InsertRackHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1014, // 589: forge.RemoveRackHealthReportRequest.rack_id:type_name -> common.RackId
-	1014, // 590: forge.ListRackHealthReportsRequest.rack_id:type_name -> common.RackId
-	1016, // 591: forge.InsertSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
-	458,  // 592: forge.InsertSwitchHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1016, // 593: forge.RemoveSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
-	1016, // 594: forge.ListSwitchHealthReportsRequest.switch_id:type_name -> common.SwitchId
-	1013, // 595: forge.InsertPowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
-	458,  // 596: forge.InsertPowerShelfHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1013, // 597: forge.RemovePowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1013, // 598: forge.ListPowerShelfHealthReportsRequest.power_shelf_id:type_name -> common.PowerShelfId
-	458,  // 599: forge.ListHealthReportResponse.health_report_entries:type_name -> forge.HealthReportEntry
-	1005, // 600: forge.RemoveMachineHealthReportRequest.machine_id:type_name -> common.MachineId
-	1025, // 601: forge.ListNVLinkDomainHealthReportsRequest.domain_id:type_name -> common.NVLinkDomainId
-	1025, // 602: forge.InsertNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
-	458,  // 603: forge.InsertNVLinkDomainHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1025, // 604: forge.RemoveNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
+	1007, // 585: forge.InsertMachineHealthReportRequest.machine_id:type_name -> common.MachineId
+	460,  // 586: forge.InsertMachineHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1016, // 587: forge.InsertRackHealthReportRequest.rack_id:type_name -> common.RackId
+	460,  // 588: forge.InsertRackHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1016, // 589: forge.RemoveRackHealthReportRequest.rack_id:type_name -> common.RackId
+	1016, // 590: forge.ListRackHealthReportsRequest.rack_id:type_name -> common.RackId
+	1018, // 591: forge.InsertSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
+	460,  // 592: forge.InsertSwitchHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1018, // 593: forge.RemoveSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
+	1018, // 594: forge.ListSwitchHealthReportsRequest.switch_id:type_name -> common.SwitchId
+	1015, // 595: forge.InsertPowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
+	460,  // 596: forge.InsertPowerShelfHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1015, // 597: forge.RemovePowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1015, // 598: forge.ListPowerShelfHealthReportsRequest.power_shelf_id:type_name -> common.PowerShelfId
+	460,  // 599: forge.ListHealthReportResponse.health_report_entries:type_name -> forge.HealthReportEntry
+	1007, // 600: forge.RemoveMachineHealthReportRequest.machine_id:type_name -> common.MachineId
+	1027, // 601: forge.ListNVLinkDomainHealthReportsRequest.domain_id:type_name -> common.NVLinkDomainId
+	1027, // 602: forge.InsertNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
+	460,  // 603: forge.InsertNVLinkDomainHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1027, // 604: forge.RemoveNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
 	40,   // 605: forge.InstanceInterfaceStatusObservation.function_type:type_name -> forge.InterfaceFunctionType
-	684,  // 606: forge.InstanceInterfaceStatusObservation.network_security_group:type_name -> forge.NetworkSecurityGroupStatus
-	1015, // 607: forge.InstanceInterfaceStatusObservation.internal_uuid:type_name -> common.UUID
-	476,  // 608: forge.FabricInterfaceData.link_data:type_name -> forge.LinkData
-	265,  // 609: forge.Tenant.metadata:type_name -> forge.Metadata
-	265,  // 610: forge.CreateTenantRequest.metadata:type_name -> forge.Metadata
-	477,  // 611: forge.CreateTenantResponse.tenant:type_name -> forge.Tenant
-	265,  // 612: forge.UpdateTenantRequest.metadata:type_name -> forge.Metadata
-	477,  // 613: forge.UpdateTenantResponse.tenant:type_name -> forge.Tenant
-	477,  // 614: forge.FindTenantResponse.tenant:type_name -> forge.Tenant
-	485,  // 615: forge.TenantKeysetContent.public_keys:type_name -> forge.TenantPublicKey
-	484,  // 616: forge.TenantKeyset.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	486,  // 617: forge.TenantKeyset.keyset_content:type_name -> forge.TenantKeysetContent
-	484,  // 618: forge.CreateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	486,  // 619: forge.CreateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
-	487,  // 620: forge.CreateTenantKeysetResponse.keyset:type_name -> forge.TenantKeyset
-	487,  // 621: forge.TenantKeySetList.keyset:type_name -> forge.TenantKeyset
-	484,  // 622: forge.UpdateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	486,  // 623: forge.UpdateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
-	484,  // 624: forge.DeleteTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	484,  // 625: forge.TenantKeysetIdList.keyset_ids:type_name -> forge.TenantKeysetIdentifier
-	484,  // 626: forge.TenantKeysetsByIdsRequest.keyset_ids:type_name -> forge.TenantKeysetIdentifier
-	502,  // 627: forge.ResourcePools.pools:type_name -> forge.ResourcePool
+	686,  // 606: forge.InstanceInterfaceStatusObservation.network_security_group:type_name -> forge.NetworkSecurityGroupStatus
+	1017, // 607: forge.InstanceInterfaceStatusObservation.internal_uuid:type_name -> common.UUID
+	478,  // 608: forge.FabricInterfaceData.link_data:type_name -> forge.LinkData
+	267,  // 609: forge.Tenant.metadata:type_name -> forge.Metadata
+	267,  // 610: forge.CreateTenantRequest.metadata:type_name -> forge.Metadata
+	479,  // 611: forge.CreateTenantResponse.tenant:type_name -> forge.Tenant
+	267,  // 612: forge.UpdateTenantRequest.metadata:type_name -> forge.Metadata
+	479,  // 613: forge.UpdateTenantResponse.tenant:type_name -> forge.Tenant
+	479,  // 614: forge.FindTenantResponse.tenant:type_name -> forge.Tenant
+	487,  // 615: forge.TenantKeysetContent.public_keys:type_name -> forge.TenantPublicKey
+	486,  // 616: forge.TenantKeyset.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	488,  // 617: forge.TenantKeyset.keyset_content:type_name -> forge.TenantKeysetContent
+	486,  // 618: forge.CreateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	488,  // 619: forge.CreateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
+	489,  // 620: forge.CreateTenantKeysetResponse.keyset:type_name -> forge.TenantKeyset
+	489,  // 621: forge.TenantKeySetList.keyset:type_name -> forge.TenantKeyset
+	486,  // 622: forge.UpdateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	488,  // 623: forge.UpdateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
+	486,  // 624: forge.DeleteTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	486,  // 625: forge.TenantKeysetIdList.keyset_ids:type_name -> forge.TenantKeysetIdentifier
+	486,  // 626: forge.TenantKeysetsByIdsRequest.keyset_ids:type_name -> forge.TenantKeysetIdentifier
+	504,  // 627: forge.ResourcePools.pools:type_name -> forge.ResourcePool
 	43,   // 628: forge.MaintenanceRequest.operation:type_name -> forge.MaintenanceOperation
-	1005, // 629: forge.MaintenanceRequest.host_id:type_name -> common.MachineId
+	1007, // 629: forge.MaintenanceRequest.host_id:type_name -> common.MachineId
 	44,   // 630: forge.SetDynamicConfigRequest.setting:type_name -> forge.ConfigSetting
-	530,  // 631: forge.FindIpAddressResponse.matches:type_name -> forge.IpAddressMatch
-	1015, // 632: forge.IdentifyUuidRequest.uuid:type_name -> common.UUID
-	1015, // 633: forge.IdentifyUuidResponse.uuid:type_name -> common.UUID
+	532,  // 631: forge.FindIpAddressResponse.matches:type_name -> forge.IpAddressMatch
+	1017, // 632: forge.IdentifyUuidRequest.uuid:type_name -> common.UUID
+	1017, // 633: forge.IdentifyUuidResponse.uuid:type_name -> common.UUID
 	45,   // 634: forge.IdentifyUuidResponse.object_type:type_name -> forge.UuidType
 	46,   // 635: forge.IdentifyMacResponse.object_type:type_name -> forge.MacOwner
-	1005, // 636: forge.IdentifySerialResponse.machine_id:type_name -> common.MachineId
-	1005, // 637: forge.DpuReprovisioningRequest.dpu_id:type_name -> common.MachineId
-	90,   // 638: forge.DpuReprovisioningRequest.mode:type_name -> forge.DpuReprovisioningRequest.Mode
+	1007, // 636: forge.IdentifySerialResponse.machine_id:type_name -> common.MachineId
+	1007, // 637: forge.DpuReprovisioningRequest.dpu_id:type_name -> common.MachineId
+	92,   // 638: forge.DpuReprovisioningRequest.mode:type_name -> forge.DpuReprovisioningRequest.Mode
 	47,   // 639: forge.DpuReprovisioningRequest.initiator:type_name -> forge.UpdateInitiator
-	1005, // 640: forge.DpuReprovisioningRequest.machine_id:type_name -> common.MachineId
-	996,  // 641: forge.DpuReprovisioningListResponse.dpus:type_name -> forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
-	1005, // 642: forge.HostReprovisioningRequest.machine_id:type_name -> common.MachineId
-	91,   // 643: forge.HostReprovisioningRequest.mode:type_name -> forge.HostReprovisioningRequest.Mode
+	1007, // 640: forge.DpuReprovisioningRequest.machine_id:type_name -> common.MachineId
+	998,  // 641: forge.DpuReprovisioningListResponse.dpus:type_name -> forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
+	1007, // 642: forge.HostReprovisioningRequest.machine_id:type_name -> common.MachineId
+	93,   // 643: forge.HostReprovisioningRequest.mode:type_name -> forge.HostReprovisioningRequest.Mode
 	47,   // 644: forge.HostReprovisioningRequest.initiator:type_name -> forge.UpdateInitiator
-	997,  // 645: forge.HostReprovisioningListResponse.hosts:type_name -> forge.HostReprovisioningListResponse.HostReprovisioningListItem
-	524,  // 646: forge.DpuInfoStatusObservation.os_operational_state:type_name -> forge.DpuOsOperationalState
-	525,  // 647: forge.DpuInfoStatusObservation.representors:type_name -> forge.DpuRepresentorStatus
-	1006, // 648: forge.DpuInfoStatusObservation.last_heartbeat:type_name -> google.protobuf.Timestamp
-	526,  // 649: forge.DpuInfo.observed_status:type_name -> forge.DpuInfoStatusObservation
-	527,  // 650: forge.GetDpuInfoListResponse.dpu_list:type_name -> forge.DpuInfo
+	999,  // 645: forge.HostReprovisioningListResponse.hosts:type_name -> forge.HostReprovisioningListResponse.HostReprovisioningListItem
+	526,  // 646: forge.DpuInfoStatusObservation.os_operational_state:type_name -> forge.DpuOsOperationalState
+	527,  // 647: forge.DpuInfoStatusObservation.representors:type_name -> forge.DpuRepresentorStatus
+	1008, // 648: forge.DpuInfoStatusObservation.last_heartbeat:type_name -> google.protobuf.Timestamp
+	528,  // 649: forge.DpuInfo.observed_status:type_name -> forge.DpuInfoStatusObservation
+	529,  // 650: forge.GetDpuInfoListResponse.dpu_list:type_name -> forge.DpuInfo
 	48,   // 651: forge.IpAddressMatch.ip_type:type_name -> forge.IpType
-	1026, // 652: forge.MachineBootOverride.machine_interface_id:type_name -> common.MachineInterfaceId
-	1005, // 653: forge.ConnectedDevice.id:type_name -> common.MachineId
-	532,  // 654: forge.ConnectedDeviceList.connected_devices:type_name -> forge.ConnectedDevice
-	538,  // 655: forge.MachineIdBmcIpPairs.pairs:type_name -> forge.MachineIdBmcIp
-	1005, // 656: forge.MachineIdBmcIp.machine_id:type_name -> common.MachineId
-	532,  // 657: forge.NetworkDevice.devices:type_name -> forge.ConnectedDevice
-	539,  // 658: forge.NetworkTopologyData.network_devices:type_name -> forge.NetworkDevice
+	1028, // 652: forge.MachineBootOverride.machine_interface_id:type_name -> common.MachineInterfaceId
+	1007, // 653: forge.ConnectedDevice.id:type_name -> common.MachineId
+	534,  // 654: forge.ConnectedDeviceList.connected_devices:type_name -> forge.ConnectedDevice
+	540,  // 655: forge.MachineIdBmcIpPairs.pairs:type_name -> forge.MachineIdBmcIp
+	1007, // 656: forge.MachineIdBmcIp.machine_id:type_name -> common.MachineId
+	534,  // 657: forge.NetworkDevice.devices:type_name -> forge.ConnectedDevice
+	541,  // 658: forge.NetworkTopologyData.network_devices:type_name -> forge.NetworkDevice
 	49,   // 659: forge.RouteServers.source_type:type_name -> forge.RouteServerSourceType
-	545,  // 660: forge.RouteServerEntries.route_servers:type_name -> forge.RouteServer
+	547,  // 660: forge.RouteServerEntries.route_servers:type_name -> forge.RouteServer
 	49,   // 661: forge.RouteServer.source_type:type_name -> forge.RouteServerSourceType
-	1005, // 662: forge.SetHostUefiPasswordRequest.host_id:type_name -> common.MachineId
-	1005, // 663: forge.ClearHostUefiPasswordRequest.host_id:type_name -> common.MachineId
-	1015, // 664: forge.OsImageAttributes.id:type_name -> common.UUID
-	550,  // 665: forge.OsImage.attributes:type_name -> forge.OsImageAttributes
+	1007, // 662: forge.SetHostUefiPasswordRequest.host_id:type_name -> common.MachineId
+	1007, // 663: forge.ClearHostUefiPasswordRequest.host_id:type_name -> common.MachineId
+	1017, // 664: forge.OsImageAttributes.id:type_name -> common.UUID
+	552,  // 665: forge.OsImage.attributes:type_name -> forge.OsImageAttributes
 	50,   // 666: forge.OsImage.status:type_name -> forge.OsImageStatus
-	551,  // 667: forge.ListOsImageResponse.images:type_name -> forge.OsImage
-	1015, // 668: forge.DeleteOsImageRequest.id:type_name -> common.UUID
-	1022, // 669: forge.GetIpxeTemplateRequest.id:type_name -> common.IpxeTemplateId
-	274,  // 670: forge.IpxeTemplateList.templates:type_name -> forge.IpxeTemplate
+	553,  // 667: forge.ListOsImageResponse.images:type_name -> forge.OsImage
+	1017, // 668: forge.DeleteOsImageRequest.id:type_name -> common.UUID
+	1024, // 669: forge.GetIpxeTemplateRequest.id:type_name -> common.IpxeTemplateId
+	276,  // 670: forge.IpxeTemplateList.templates:type_name -> forge.IpxeTemplate
 	12,   // 671: forge.ExpectedHostNic.network_segment_type:type_name -> forge.NetworkSegmentType
-	265,  // 672: forge.ExpectedMachine.metadata:type_name -> forge.Metadata
-	1015, // 673: forge.ExpectedMachine.id:type_name -> common.UUID
-	559,  // 674: forge.ExpectedMachine.host_nics:type_name -> forge.ExpectedHostNic
-	1014, // 675: forge.ExpectedMachine.rack_id:type_name -> common.RackId
-	51,   // 676: forge.ExpectedMachine.dpu_mode:type_name -> forge.DpuMode
-	560,  // 677: forge.ExpectedMachine.host_lifecycle_profile:type_name -> forge.HostLifecycleProfile
-	52,   // 678: forge.ExpectedMachine.bmc_ip_allocation:type_name -> forge.BmcIpAllocationType
-	1015, // 679: forge.ExpectedMachineRequest.id:type_name -> common.UUID
-	561,  // 680: forge.ExpectedMachineList.expected_machines:type_name -> forge.ExpectedMachine
-	565,  // 681: forge.LinkedExpectedMachineList.expected_machines:type_name -> forge.LinkedExpectedMachine
-	1005, // 682: forge.LinkedExpectedMachine.machine_id:type_name -> common.MachineId
-	1015, // 683: forge.LinkedExpectedMachine.expected_machine_id:type_name -> common.UUID
-	567,  // 684: forge.UnexpectedMachineList.unexpected_machines:type_name -> forge.UnexpectedMachine
-	1005, // 685: forge.UnexpectedMachine.machine_id:type_name -> common.MachineId
-	563,  // 686: forge.BatchExpectedMachineOperationRequest.expected_machines:type_name -> forge.ExpectedMachineList
-	1015, // 687: forge.ExpectedMachineOperationResult.id:type_name -> common.UUID
-	561,  // 688: forge.ExpectedMachineOperationResult.expected_machine:type_name -> forge.ExpectedMachine
-	569,  // 689: forge.BatchExpectedMachineOperationResponse.results:type_name -> forge.ExpectedMachineOperationResult
-	1005, // 690: forge.MachineRebootCompletedRequest.machine_id:type_name -> common.MachineId
-	1005, // 691: forge.ScoutFirmwareUpgradeStatusRequest.machine_id:type_name -> common.MachineId
-	1005, // 692: forge.MachineValidationCompletedRequest.machine_id:type_name -> common.MachineId
-	1032, // 693: forge.MachineValidationCompletedRequest.validation_id:type_name -> common.MachineValidationId
-	1006, // 694: forge.MachineValidationResult.start_time:type_name -> google.protobuf.Timestamp
-	1006, // 695: forge.MachineValidationResult.end_time:type_name -> google.protobuf.Timestamp
-	1032, // 696: forge.MachineValidationResult.validation_id:type_name -> common.MachineValidationId
-	576,  // 697: forge.MachineValidationResultPostRequest.result:type_name -> forge.MachineValidationResult
-	576,  // 698: forge.MachineValidationResultList.results:type_name -> forge.MachineValidationResult
-	1005, // 699: forge.MachineValidationGetRequest.machine_id:type_name -> common.MachineId
-	1032, // 700: forge.MachineValidationGetRequest.validation_id:type_name -> common.MachineValidationId
-	53,   // 701: forge.MachineValidationStatus.started:type_name -> forge.MachineValidationStarted
-	54,   // 702: forge.MachineValidationStatus.in_progress:type_name -> forge.MachineValidationInProgress
-	55,   // 703: forge.MachineValidationStatus.completed:type_name -> forge.MachineValidationCompleted
-	1032, // 704: forge.MachineValidationRun.validation_id:type_name -> common.MachineValidationId
-	1005, // 705: forge.MachineValidationRun.machine_id:type_name -> common.MachineId
-	1006, // 706: forge.MachineValidationRun.start_time:type_name -> google.protobuf.Timestamp
-	1006, // 707: forge.MachineValidationRun.end_time:type_name -> google.protobuf.Timestamp
-	580,  // 708: forge.MachineValidationRun.status:type_name -> forge.MachineValidationStatus
-	1028, // 709: forge.MachineValidationRun.duration_to_complete:type_name -> google.protobuf.Duration
-	1006, // 710: forge.MachineValidationRun.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1005, // 711: forge.MachineSetAutoUpdateRequest.machine_id:type_name -> common.MachineId
-	92,   // 712: forge.MachineSetAutoUpdateRequest.action:type_name -> forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
-	1006, // 713: forge.MachineValidationExternalConfig.timestamp:type_name -> google.protobuf.Timestamp
-	585,  // 714: forge.GetMachineValidationExternalConfigResponse.config:type_name -> forge.MachineValidationExternalConfig
-	585,  // 715: forge.GetMachineValidationExternalConfigsResponse.configs:type_name -> forge.MachineValidationExternalConfig
-	1005, // 716: forge.MachineValidationOnDemandRequest.machine_id:type_name -> common.MachineId
-	93,   // 717: forge.MachineValidationOnDemandRequest.action:type_name -> forge.MachineValidationOnDemandRequest.Action
-	1032, // 718: forge.MachineValidationOnDemandResponse.validation_id:type_name -> common.MachineValidationId
-	593,  // 719: forge.MaintenanceActivityConfig.firmware_upgrade:type_name -> forge.FirmwareUpgradeActivity
-	595,  // 720: forge.MaintenanceActivityConfig.configure_nmx_cluster:type_name -> forge.ConfigureNmxClusterActivity
-	596,  // 721: forge.MaintenanceActivityConfig.power_sequence:type_name -> forge.PowerSequenceActivity
-	594,  // 722: forge.MaintenanceActivityConfig.nvos_update:type_name -> forge.NvosUpdateActivity
-	597,  // 723: forge.RackMaintenanceScope.activities:type_name -> forge.MaintenanceActivityConfig
-	1014, // 724: forge.RackMaintenanceOnDemandRequest.rack_id:type_name -> common.RackId
-	598,  // 725: forge.RackMaintenanceOnDemandRequest.scope:type_name -> forge.RackMaintenanceScope
-	382,  // 726: forge.AdminPowerControlRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	94,   // 727: forge.AdminPowerControlRequest.action:type_name -> forge.AdminPowerControlRequest.SystemPowerControl
-	1005, // 728: forge.GetRedfishJobStateRequest.machine_id:type_name -> common.MachineId
-	95,   // 729: forge.GetRedfishJobStateResponse.job_state:type_name -> forge.GetRedfishJobStateResponse.RedfishJobState
-	581,  // 730: forge.MachineValidationRunList.runs:type_name -> forge.MachineValidationRun
-	1005, // 731: forge.MachineValidationRunListGetRequest.machine_id:type_name -> common.MachineId
-	1032, // 732: forge.MachineValidationRunItemSearchFilter.validation_id:type_name -> common.MachineValidationId
-	1015, // 733: forge.MachineValidationRunItemIdList.run_item_ids:type_name -> common.UUID
-	1015, // 734: forge.MachineValidationRunItemsByIdsRequest.run_item_ids:type_name -> common.UUID
-	611,  // 735: forge.MachineValidationRunItemList.run_items:type_name -> forge.MachineValidationRunItem
-	1015, // 736: forge.MachineValidationRunItem.run_item_id:type_name -> common.UUID
-	1032, // 737: forge.MachineValidationRunItem.validation_id:type_name -> common.MachineValidationId
-	1028, // 738: forge.MachineValidationRunItem.timeout:type_name -> google.protobuf.Duration
-	1006, // 739: forge.MachineValidationRunItem.started_at:type_name -> google.protobuf.Timestamp
-	1006, // 740: forge.MachineValidationRunItem.ended_at:type_name -> google.protobuf.Timestamp
-	1006, // 741: forge.MachineValidationRunItem.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1015, // 742: forge.MachineValidationRunItem.current_attempt_id:type_name -> common.UUID
-	1015, // 743: forge.MachineValidationAttemptGetRequest.attempt_id:type_name -> common.UUID
-	1015, // 744: forge.MachineValidationAttempt.attempt_id:type_name -> common.UUID
-	1015, // 745: forge.MachineValidationAttempt.run_item_id:type_name -> common.UUID
-	1006, // 746: forge.MachineValidationAttempt.started_at:type_name -> google.protobuf.Timestamp
-	1006, // 747: forge.MachineValidationAttempt.ended_at:type_name -> google.protobuf.Timestamp
-	1006, // 748: forge.MachineValidationAttempt.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1032, // 749: forge.MachineValidationHeartbeatRequest.validation_id:type_name -> common.MachineValidationId
-	1015, // 750: forge.MachineValidationHeartbeatRequest.run_item_id:type_name -> common.UUID
-	1015, // 751: forge.MachineValidationHeartbeatRequest.attempt_id:type_name -> common.UUID
-	998,  // 752: forge.MachineValidationTestUpdateRequest.payload:type_name -> forge.MachineValidationTestUpdateRequest.Payload
-	625,  // 753: forge.MachineValidationTestsGetResponse.tests:type_name -> forge.MachineValidationTest
-	1032, // 754: forge.MachineValidationRunRequest.validation_id:type_name -> common.MachineValidationId
-	1028, // 755: forge.MachineValidationRunRequest.duration_to_complete:type_name -> google.protobuf.Duration
-	625,  // 756: forge.MachineValidationRunRequest.selected_tests:type_name -> forge.MachineValidationTest
-	56,   // 757: forge.MachineCapabilityAttributesGpu.device_type:type_name -> forge.MachineCapabilityDeviceType
-	56,   // 758: forge.MachineCapabilityAttributesNetwork.device_type:type_name -> forge.MachineCapabilityDeviceType
-	632,  // 759: forge.MachineCapabilitiesSet.cpu:type_name -> forge.MachineCapabilityAttributesCpu
-	633,  // 760: forge.MachineCapabilitiesSet.gpu:type_name -> forge.MachineCapabilityAttributesGpu
-	634,  // 761: forge.MachineCapabilitiesSet.memory:type_name -> forge.MachineCapabilityAttributesMemory
-	635,  // 762: forge.MachineCapabilitiesSet.storage:type_name -> forge.MachineCapabilityAttributesStorage
-	636,  // 763: forge.MachineCapabilitiesSet.network:type_name -> forge.MachineCapabilityAttributesNetwork
-	637,  // 764: forge.MachineCapabilitiesSet.infiniband:type_name -> forge.MachineCapabilityAttributesInfiniband
-	638,  // 765: forge.MachineCapabilitiesSet.dpu:type_name -> forge.MachineCapabilityAttributesDpu
-	642,  // 766: forge.InstanceTypeAttributes.desired_capabilities:type_name -> forge.InstanceTypeMachineCapabilityFilterAttributes
-	640,  // 767: forge.InstanceType.attributes:type_name -> forge.InstanceTypeAttributes
-	265,  // 768: forge.InstanceType.metadata:type_name -> forge.Metadata
-	740,  // 769: forge.InstanceType.allocation_stats:type_name -> forge.InstanceTypeAllocationStats
-	57,   // 770: forge.InstanceTypeMachineCapabilityFilterAttributes.capability_type:type_name -> forge.MachineCapabilityType
-	1033, // 771: forge.InstanceTypeMachineCapabilityFilterAttributes.inactive_devices:type_name -> common.Uint32List
-	56,   // 772: forge.InstanceTypeMachineCapabilityFilterAttributes.device_type:type_name -> forge.MachineCapabilityDeviceType
-	265,  // 773: forge.CreateInstanceTypeRequest.metadata:type_name -> forge.Metadata
-	640,  // 774: forge.CreateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
-	641,  // 775: forge.CreateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
-	641,  // 776: forge.FindInstanceTypesByIdsResponse.instance_types:type_name -> forge.InstanceType
-	641,  // 777: forge.UpdateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
-	265,  // 778: forge.UpdateInstanceTypeRequest.metadata:type_name -> forge.Metadata
-	640,  // 779: forge.UpdateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
-	999,  // 780: forge.RedfishBrowseResponse.headers:type_name -> forge.RedfishBrowseResponse.HeadersEntry
-	661,  // 781: forge.RedfishListActionsResponse.actions:type_name -> forge.RedfishAction
-	1006, // 782: forge.RedfishAction.approver_dates:type_name -> google.protobuf.Timestamp
-	1006, // 783: forge.RedfishAction.applied_at:type_name -> google.protobuf.Timestamp
-	662,  // 784: forge.RedfishAction.results:type_name -> forge.OptionalRedfishActionResult
-	663,  // 785: forge.OptionalRedfishActionResult.result:type_name -> forge.RedfishActionResult
-	1000, // 786: forge.RedfishActionResult.headers:type_name -> forge.RedfishActionResult.HeadersEntry
-	1006, // 787: forge.RedfishActionResult.completed_at:type_name -> google.protobuf.Timestamp
-	1001, // 788: forge.UfmBrowseResponse.headers:type_name -> forge.UfmBrowseResponse.HeadersEntry
-	689,  // 789: forge.NetworkSecurityGroupAttributes.rules:type_name -> forge.NetworkSecurityGroupRuleAttributes
-	265,  // 790: forge.NetworkSecurityGroup.metadata:type_name -> forge.Metadata
-	672,  // 791: forge.NetworkSecurityGroup.attributes:type_name -> forge.NetworkSecurityGroupAttributes
-	265,  // 792: forge.CreateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
-	672,  // 793: forge.CreateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
-	673,  // 794: forge.CreateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
-	673,  // 795: forge.FindNetworkSecurityGroupsByIdsResponse.network_security_groups:type_name -> forge.NetworkSecurityGroup
-	673,  // 796: forge.UpdateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
-	265,  // 797: forge.UpdateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
-	672,  // 798: forge.UpdateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
-	58,   // 799: forge.NetworkSecurityGroupStatus.source:type_name -> forge.NetworkSecurityGroupSource
-	59,   // 800: forge.NetworkSecurityGroupPropagationObjectStatus.status:type_name -> forge.NetworkSecurityGroupPropagationStatus
-	685,  // 801: forge.GetNetworkSecurityGroupPropagationStatusResponse.vpcs:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	685,  // 802: forge.GetNetworkSecurityGroupPropagationStatusResponse.instances:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	687,  // 803: forge.GetNetworkSecurityGroupPropagationStatusRequest.network_security_group_ids:type_name -> forge.NetworkSecurityGroupIdList
-	60,   // 804: forge.NetworkSecurityGroupRuleAttributes.direction:type_name -> forge.NetworkSecurityGroupRuleDirection
-	61,   // 805: forge.NetworkSecurityGroupRuleAttributes.protocol:type_name -> forge.NetworkSecurityGroupRuleProtocol
-	62,   // 806: forge.NetworkSecurityGroupRuleAttributes.action:type_name -> forge.NetworkSecurityGroupRuleAction
-	689,  // 807: forge.ResolvedNetworkSecurityGroupRule.rule:type_name -> forge.NetworkSecurityGroupRuleAttributes
-	692,  // 808: forge.GetNetworkSecurityGroupAttachmentsResponse.attachments:type_name -> forge.NetworkSecurityGroupAttachments
-	696,  // 809: forge.GetDesiredFirmwareVersionsResponse.entries:type_name -> forge.DesiredFirmwareVersionEntry
-	1002, // 810: forge.DesiredFirmwareVersionEntry.component_versions:type_name -> forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
-	697,  // 811: forge.SkuComponents.chassis:type_name -> forge.SkuComponentChassis
-	698,  // 812: forge.SkuComponents.cpus:type_name -> forge.SkuComponentCpu
-	699,  // 813: forge.SkuComponents.gpus:type_name -> forge.SkuComponentGpu
-	700,  // 814: forge.SkuComponents.ethernet_devices:type_name -> forge.SkuComponentEthernetDevices
-	701,  // 815: forge.SkuComponents.infiniband_devices:type_name -> forge.SkuComponentInfinibandDevices
-	702,  // 816: forge.SkuComponents.storage:type_name -> forge.SkuComponentStorage
-	704,  // 817: forge.SkuComponents.memory:type_name -> forge.SkuComponentMemory
-	705,  // 818: forge.SkuComponents.tpm:type_name -> forge.SkuComponentTpm
-	1006, // 819: forge.Sku.created:type_name -> google.protobuf.Timestamp
-	706,  // 820: forge.Sku.components:type_name -> forge.SkuComponents
-	1005, // 821: forge.Sku.associated_machine_ids:type_name -> common.MachineId
-	1005, // 822: forge.SkuMachinePair.machine_id:type_name -> common.MachineId
-	1005, // 823: forge.RemoveSkuRequest.machine_id:type_name -> common.MachineId
-	707,  // 824: forge.SkuList.skus:type_name -> forge.Sku
-	1006, // 825: forge.SkuStatus.verify_request_time:type_name -> google.protobuf.Timestamp
-	1006, // 826: forge.SkuStatus.last_match_attempt:type_name -> google.protobuf.Timestamp
-	1006, // 827: forge.SkuStatus.last_generate_attempt:type_name -> google.protobuf.Timestamp
-	1034, // 828: forge.DpaInterface.id:type_name -> common.DpaInterfaceId
-	1005, // 829: forge.DpaInterface.machine_id:type_name -> common.MachineId
-	1006, // 830: forge.DpaInterface.created:type_name -> google.protobuf.Timestamp
-	1006, // 831: forge.DpaInterface.updated:type_name -> google.protobuf.Timestamp
-	1006, // 832: forge.DpaInterface.deleted:type_name -> google.protobuf.Timestamp
-	229,  // 833: forge.DpaInterface.history:type_name -> forge.StateHistoryRecord
-	1006, // 834: forge.DpaInterface.last_hb_time:type_name -> google.protobuf.Timestamp
-	63,   // 835: forge.DpaInterface.interface_type:type_name -> forge.DpaInterfaceType
-	1005, // 836: forge.DpaInterfaceCreationRequest.machine_id:type_name -> common.MachineId
-	63,   // 837: forge.DpaInterfaceCreationRequest.interface_type:type_name -> forge.DpaInterfaceType
-	1034, // 838: forge.DpaInterfaceIdList.ids:type_name -> common.DpaInterfaceId
-	1034, // 839: forge.DpaInterfacesByIdsRequest.ids:type_name -> common.DpaInterfaceId
-	715,  // 840: forge.DpaInterfaceList.interfaces:type_name -> forge.DpaInterface
-	1034, // 841: forge.DpaNetworkObservationSetRequest.id:type_name -> common.DpaInterfaceId
-	1034, // 842: forge.DpaInterfaceDeletionRequest.id:type_name -> common.DpaInterfaceId
-	1005, // 843: forge.PowerOptionRequest.machine_id:type_name -> common.MachineId
-	1005, // 844: forge.PowerOptionUpdateRequest.machine_id:type_name -> common.MachineId
-	64,   // 845: forge.PowerOptionUpdateRequest.power_state:type_name -> forge.PowerState
-	64,   // 846: forge.PowerOptions.desired_state:type_name -> forge.PowerState
-	1006, // 847: forge.PowerOptions.desired_state_updated_at:type_name -> google.protobuf.Timestamp
-	64,   // 848: forge.PowerOptions.actual_state:type_name -> forge.PowerState
-	1006, // 849: forge.PowerOptions.actual_state_updated_at:type_name -> google.protobuf.Timestamp
-	1005, // 850: forge.PowerOptions.host_id:type_name -> common.MachineId
-	1006, // 851: forge.PowerOptions.next_power_state_fetch_at:type_name -> google.protobuf.Timestamp
-	1006, // 852: forge.PowerOptions.tried_triggering_on_at:type_name -> google.protobuf.Timestamp
-	1006, // 853: forge.PowerOptions.wait_until_time_before_performing_next_power_action:type_name -> google.protobuf.Timestamp
-	726,  // 854: forge.PowerOptionResponse.response:type_name -> forge.PowerOptions
-	1035, // 855: forge.ComputeAllocation.id:type_name -> common.ComputeAllocationId
-	728,  // 856: forge.ComputeAllocation.attributes:type_name -> forge.ComputeAllocationAttributes
-	265,  // 857: forge.ComputeAllocation.metadata:type_name -> forge.Metadata
-	1035, // 858: forge.CreateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
-	265,  // 859: forge.CreateComputeAllocationRequest.metadata:type_name -> forge.Metadata
-	728,  // 860: forge.CreateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
-	729,  // 861: forge.CreateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
-	1035, // 862: forge.FindComputeAllocationIdsResponse.ids:type_name -> common.ComputeAllocationId
-	1035, // 863: forge.FindComputeAllocationsByIdsRequest.ids:type_name -> common.ComputeAllocationId
-	729,  // 864: forge.FindComputeAllocationsByIdsResponse.allocations:type_name -> forge.ComputeAllocation
-	729,  // 865: forge.UpdateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
-	1035, // 866: forge.UpdateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
-	265,  // 867: forge.UpdateComputeAllocationRequest.metadata:type_name -> forge.Metadata
-	728,  // 868: forge.UpdateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
-	1035, // 869: forge.DeleteComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
-	747,  // 870: forge.GetRackResponse.rack:type_name -> forge.Rack
-	747,  // 871: forge.RackList.racks:type_name -> forge.Rack
-	264,  // 872: forge.RackSearchFilter.label:type_name -> forge.Label
-	1014, // 873: forge.RackIdList.rack_ids:type_name -> common.RackId
-	1014, // 874: forge.RacksByIdsRequest.rack_ids:type_name -> common.RackId
-	1014, // 875: forge.Rack.id:type_name -> common.RackId
-	1006, // 876: forge.Rack.created:type_name -> google.protobuf.Timestamp
-	1006, // 877: forge.Rack.updated:type_name -> google.protobuf.Timestamp
-	1006, // 878: forge.Rack.deleted:type_name -> google.protobuf.Timestamp
-	265,  // 879: forge.Rack.metadata:type_name -> forge.Metadata
-	748,  // 880: forge.Rack.config:type_name -> forge.RackConfig
-	749,  // 881: forge.Rack.status:type_name -> forge.RackStatus
-	1012, // 882: forge.RackStatus.health:type_name -> health.HealthReport
-	355,  // 883: forge.RackStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	96,   // 884: forge.RackStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1014, // 885: forge.RackStateHistoriesRequest.rack_ids:type_name -> common.RackId
-	1014, // 886: forge.AdminForceDeleteRackRequest.rack_id:type_name -> common.RackId
-	754,  // 887: forge.RackCapabilitiesSet.compute:type_name -> forge.RackCapabilityCompute
-	755,  // 888: forge.RackCapabilitiesSet.switch:type_name -> forge.RackCapabilitySwitch
-	756,  // 889: forge.RackCapabilitiesSet.power_shelf:type_name -> forge.RackCapabilityPowerShelf
-	1036, // 890: forge.RackProfile.rack_hardware_type:type_name -> common.RackHardwareType
-	65,   // 891: forge.RackProfile.rack_hardware_topology:type_name -> forge.RackHardwareTopology
-	67,   // 892: forge.RackProfile.rack_hardware_class:type_name -> forge.RackHardwareClass
-	757,  // 893: forge.RackProfile.capabilities:type_name -> forge.RackCapabilitiesSet
-	66,   // 894: forge.RackProfile.product_family:type_name -> forge.RackProductFamily
-	1014, // 895: forge.GetRackProfileRequest.rack_id:type_name -> common.RackId
-	1014, // 896: forge.GetRackProfileResponse.rack_id:type_name -> common.RackId
-	1017, // 897: forge.GetRackProfileResponse.rack_profile_id:type_name -> common.RackProfileId
-	758,  // 898: forge.GetRackProfileResponse.profile:type_name -> forge.RackProfile
-	68,   // 899: forge.RackManagerForgeRequest.cmd:type_name -> forge.RackManagerForgeCmd
-	1025, // 900: forge.MachineNVLinkInfo.domain_uuid:type_name -> common.NVLinkDomainId
-	772,  // 901: forge.MachineNVLinkInfo.gpus:type_name -> forge.NVLinkGpu
-	1005, // 902: forge.UpdateMachineNvLinkInfoRequest.machine_id:type_name -> common.MachineId
-	763,  // 903: forge.UpdateMachineNvLinkInfoRequest.nvlink_info:type_name -> forge.MachineNVLinkInfo
-	766,  // 904: forge.MachineSpxStatusObservation.attachment_status:type_name -> forge.MachineSpxAttachmentStatusObservation
-	1006, // 905: forge.MachineSpxStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	1024, // 906: forge.MachineSpxAttachmentStatusObservation.partition_id:type_name -> common.SpxPartitionId
-	16,   // 907: forge.MachineSpxAttachmentStatusObservation.attachment_type:type_name -> forge.SpxAttachmentType
-	1006, // 908: forge.MachineSpxAttachmentStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	768,  // 909: forge.AstraConfig.astra_attachments:type_name -> forge.AstraAttachment
-	16,   // 910: forge.AstraAttachment.attachment_type:type_name -> forge.SpxAttachmentType
-	770,  // 911: forge.AstraConfigStatus.astra_attachments_status:type_name -> forge.AstraAttachmentStatus
-	16,   // 912: forge.AstraAttachmentStatus.attachment_type:type_name -> forge.SpxAttachmentType
-	771,  // 913: forge.AstraAttachmentStatus.status:type_name -> forge.AstraStatus
-	69,   // 914: forge.AstraStatus.phase:type_name -> forge.AstraPhase
-	774,  // 915: forge.MachineNVLinkStatusObservation.gpu_status:type_name -> forge.MachineNVLinkGpuStatusObservation
-	1037, // 916: forge.MachineNVLinkGpuStatusObservation.partition_id:type_name -> common.NVLinkPartitionId
-	1008, // 917: forge.MachineNVLinkGpuStatusObservation.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1025, // 918: forge.MachineNVLinkGpuStatusObservation.domain_id:type_name -> common.NVLinkDomainId
-	70,   // 919: forge.NmxcBrowseRequest.operation:type_name -> forge.NmxcBrowseOperation
-	1003, // 920: forge.NmxcBrowseResponse.headers:type_name -> forge.NmxcBrowseResponse.HeadersEntry
-	1037, // 921: forge.NVLinkPartition.id:type_name -> common.NVLinkPartitionId
-	1025, // 922: forge.NVLinkPartition.domain_uuid:type_name -> common.NVLinkDomainId
-	1008, // 923: forge.NVLinkPartition.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	777,  // 924: forge.NVLinkPartitionList.partitions:type_name -> forge.NVLinkPartition
-	1015, // 925: forge.NVLinkPartitionQuery.id:type_name -> common.UUID
-	779,  // 926: forge.NVLinkPartitionQuery.search_config:type_name -> forge.NVLinkPartitionSearchConfig
-	1037, // 927: forge.NVLinkPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkPartitionId
-	1037, // 928: forge.NVLinkPartitionIdList.partition_ids:type_name -> common.NVLinkPartitionId
-	265,  // 929: forge.NVLinkLogicalPartitionConfig.metadata:type_name -> forge.Metadata
-	8,    // 930: forge.NVLinkLogicalPartitionStatus.state:type_name -> forge.TenantState
-	1008, // 931: forge.NVLinkLogicalPartition.id:type_name -> common.NVLinkLogicalPartitionId
-	785,  // 932: forge.NVLinkLogicalPartition.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	786,  // 933: forge.NVLinkLogicalPartition.status:type_name -> forge.NVLinkLogicalPartitionStatus
-	1006, // 934: forge.NVLinkLogicalPartition.created:type_name -> google.protobuf.Timestamp
-	787,  // 935: forge.NVLinkLogicalPartitionList.partitions:type_name -> forge.NVLinkLogicalPartition
-	785,  // 936: forge.NVLinkLogicalPartitionCreationRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	1008, // 937: forge.NVLinkLogicalPartitionCreationRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	1008, // 938: forge.NVLinkLogicalPartitionDeletionRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	1008, // 939: forge.NVLinkLogicalPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkLogicalPartitionId
-	1008, // 940: forge.NVLinkLogicalPartitionIdList.partition_ids:type_name -> common.NVLinkLogicalPartitionId
-	1008, // 941: forge.NVLinkLogicalPartitionUpdateRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	785,  // 942: forge.NVLinkLogicalPartitionUpdateRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	382,  // 943: forge.CreateBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 944: forge.DeleteBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 945: forge.SetBmcRootPasswordRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	382,  // 946: forge.ProbeBmcVendorRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1005, // 947: forge.SetFirmwareUpdateTimeWindowRequest.machine_ids:type_name -> common.MachineId
-	1006, // 948: forge.SetFirmwareUpdateTimeWindowRequest.start_timestamp:type_name -> google.protobuf.Timestamp
-	1006, // 949: forge.SetFirmwareUpdateTimeWindowRequest.end_timestamp:type_name -> google.protobuf.Timestamp
-	809,  // 950: forge.UpsertHostFirmwareConfigRequest.components:type_name -> forge.UpsertHostFirmwareComponentConfig
-	71,   // 951: forge.UpsertHostFirmwareConfigRequest.ordering:type_name -> forge.HostFirmwareComponentType
-	71,   // 952: forge.UpsertHostFirmwareComponentConfig.type:type_name -> forge.HostFirmwareComponentType
-	811,  // 953: forge.UpsertHostFirmwareComponentConfig.firmware:type_name -> forge.HostFirmwareVersionConfig
-	71,   // 954: forge.HostFirmwareComponentConfigResponse.type:type_name -> forge.HostFirmwareComponentType
-	811,  // 955: forge.HostFirmwareComponentConfigResponse.firmware:type_name -> forge.HostFirmwareVersionConfig
-	812,  // 956: forge.HostFirmwareVersionConfig.artifacts:type_name -> forge.HostFirmwareArtifact
-	810,  // 957: forge.HostFirmwareConfigResponse.components:type_name -> forge.HostFirmwareComponentConfigResponse
-	71,   // 958: forge.HostFirmwareConfigResponse.ordering:type_name -> forge.HostFirmwareComponentType
-	1006, // 959: forge.HostFirmwareConfigResponse.created_at:type_name -> google.protobuf.Timestamp
-	1006, // 960: forge.HostFirmwareConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
-	816,  // 961: forge.ListHostFirmwareResponse.available:type_name -> forge.AvailableHostFirmware
-	72,   // 962: forge.TrimTableRequest.target:type_name -> forge.TrimTableTarget
-	819,  // 963: forge.NvlinkNmxcEndpointList.entries:type_name -> forge.NvlinkNmxcEndpoint
-	265,  // 964: forge.CreateRemediationRequest.metadata:type_name -> forge.Metadata
-	1038, // 965: forge.CreateRemediationResponse.remediation_id:type_name -> common.RemediationId
-	1038, // 966: forge.RemediationIdList.remediation_ids:type_name -> common.RemediationId
-	826,  // 967: forge.RemediationList.remediations:type_name -> forge.Remediation
-	1038, // 968: forge.Remediation.id:type_name -> common.RemediationId
-	265,  // 969: forge.Remediation.metadata:type_name -> forge.Metadata
-	1006, // 970: forge.Remediation.creation_time:type_name -> google.protobuf.Timestamp
-	1038, // 971: forge.ApproveRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1038, // 972: forge.RevokeRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1038, // 973: forge.EnableRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1038, // 974: forge.DisableRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1038, // 975: forge.FindAppliedRemediationIdsRequest.remediation_id:type_name -> common.RemediationId
-	1005, // 976: forge.FindAppliedRemediationIdsRequest.dpu_machine_id:type_name -> common.MachineId
-	1038, // 977: forge.AppliedRemediationIdList.remediation_ids:type_name -> common.RemediationId
-	1005, // 978: forge.AppliedRemediationIdList.dpu_machine_ids:type_name -> common.MachineId
-	1038, // 979: forge.FindAppliedRemediationsRequest.remediation_id:type_name -> common.RemediationId
-	1005, // 980: forge.FindAppliedRemediationsRequest.dpu_machine_id:type_name -> common.MachineId
-	1038, // 981: forge.AppliedRemediation.remediation_id:type_name -> common.RemediationId
-	1005, // 982: forge.AppliedRemediation.dpu_machine_id:type_name -> common.MachineId
-	1006, // 983: forge.AppliedRemediation.applied_time:type_name -> google.protobuf.Timestamp
-	265,  // 984: forge.AppliedRemediation.metadata:type_name -> forge.Metadata
-	834,  // 985: forge.AppliedRemediationList.applied_remediations:type_name -> forge.AppliedRemediation
-	1005, // 986: forge.GetNextRemediationForMachineRequest.dpu_machine_id:type_name -> common.MachineId
-	1038, // 987: forge.GetNextRemediationForMachineResponse.remediation_id:type_name -> common.RemediationId
-	1038, // 988: forge.RemediationAppliedRequest.remediation_id:type_name -> common.RemediationId
-	1005, // 989: forge.RemediationAppliedRequest.dpu_machine_id:type_name -> common.MachineId
-	839,  // 990: forge.RemediationAppliedRequest.status:type_name -> forge.RemediationApplicationStatus
-	265,  // 991: forge.RemediationApplicationStatus.metadata:type_name -> forge.Metadata
-	1005, // 992: forge.SetPrimaryDpuRequest.host_machine_id:type_name -> common.MachineId
-	1005, // 993: forge.SetPrimaryDpuRequest.dpu_machine_id:type_name -> common.MachineId
-	1005, // 994: forge.SetPrimaryInterfaceRequest.host_machine_id:type_name -> common.MachineId
-	1026, // 995: forge.SetPrimaryInterfaceRequest.interface_id:type_name -> common.MachineInterfaceId
-	842,  // 996: forge.DpuExtensionServiceCredential.username_password:type_name -> forge.UsernamePassword
-	863,  // 997: forge.DpuExtensionServiceVersionInfo.observability:type_name -> forge.DpuExtensionServiceObservability
-	73,   // 998: forge.DpuExtensionService.service_type:type_name -> forge.DpuExtensionServiceType
-	845,  // 999: forge.DpuExtensionService.latest_version_info:type_name -> forge.DpuExtensionServiceVersionInfo
-	73,   // 1000: forge.CreateDpuExtensionServiceRequest.service_type:type_name -> forge.DpuExtensionServiceType
-	844,  // 1001: forge.CreateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
-	863,  // 1002: forge.CreateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
-	844,  // 1003: forge.UpdateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
-	863,  // 1004: forge.UpdateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
-	73,   // 1005: forge.DpuExtensionServiceSearchFilter.service_type:type_name -> forge.DpuExtensionServiceType
-	846,  // 1006: forge.DpuExtensionServiceList.services:type_name -> forge.DpuExtensionService
-	845,  // 1007: forge.DpuExtensionServiceVersionInfoList.version_infos:type_name -> forge.DpuExtensionServiceVersionInfo
-	859,  // 1008: forge.FindInstancesByDpuExtensionServiceResponse.instances:type_name -> forge.InstanceDpuExtensionServiceInfo
-	860,  // 1009: forge.DpuExtensionServiceObservabilityConfig.prometheus:type_name -> forge.DpuExtensionServiceObservabilityConfigPrometheus
-	861,  // 1010: forge.DpuExtensionServiceObservabilityConfig.logging:type_name -> forge.DpuExtensionServiceObservabilityConfigLogging
-	862,  // 1011: forge.DpuExtensionServiceObservability.configs:type_name -> forge.DpuExtensionServiceObservabilityConfig
-	1015, // 1012: forge.ScoutStreamApiBoundMessage.flow_uuid:type_name -> common.UUID
-	866,  // 1013: forge.ScoutStreamApiBoundMessage.init:type_name -> forge.ScoutStreamInitRequest
-	1039, // 1014: forge.ScoutStreamApiBoundMessage.mlx_device_lockdown_response:type_name -> mlx_device.MlxDeviceLockdownResponse
-	1040, // 1015: forge.ScoutStreamApiBoundMessage.mlx_device_profile_sync_response:type_name -> mlx_device.MlxDeviceProfileSyncResponse
-	1041, // 1016: forge.ScoutStreamApiBoundMessage.mlx_device_profile_compare_response:type_name -> mlx_device.MlxDeviceProfileCompareResponse
-	1042, // 1017: forge.ScoutStreamApiBoundMessage.mlx_device_info_device_response:type_name -> mlx_device.MlxDeviceInfoDeviceResponse
-	1043, // 1018: forge.ScoutStreamApiBoundMessage.mlx_device_info_report_response:type_name -> mlx_device.MlxDeviceInfoReportResponse
-	1044, // 1019: forge.ScoutStreamApiBoundMessage.mlx_device_registry_list_response:type_name -> mlx_device.MlxDeviceRegistryListResponse
-	1045, // 1020: forge.ScoutStreamApiBoundMessage.mlx_device_registry_show_response:type_name -> mlx_device.MlxDeviceRegistryShowResponse
-	1046, // 1021: forge.ScoutStreamApiBoundMessage.mlx_device_config_query_response:type_name -> mlx_device.MlxDeviceConfigQueryResponse
-	1047, // 1022: forge.ScoutStreamApiBoundMessage.mlx_device_config_set_response:type_name -> mlx_device.MlxDeviceConfigSetResponse
-	1048, // 1023: forge.ScoutStreamApiBoundMessage.mlx_device_config_sync_response:type_name -> mlx_device.MlxDeviceConfigSyncResponse
-	1049, // 1024: forge.ScoutStreamApiBoundMessage.mlx_device_config_compare_response:type_name -> mlx_device.MlxDeviceConfigCompareResponse
-	874,  // 1025: forge.ScoutStreamApiBoundMessage.scout_stream_agent_ping_response:type_name -> forge.ScoutStreamAgentPingResponse
-	1015, // 1026: forge.ScoutStreamScoutBoundMessage.flow_uuid:type_name -> common.UUID
-	1050, // 1027: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_lock_request:type_name -> mlx_device.MlxDeviceLockdownLockRequest
-	1051, // 1028: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_unlock_request:type_name -> mlx_device.MlxDeviceLockdownUnlockRequest
-	1052, // 1029: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_status_request:type_name -> mlx_device.MlxDeviceLockdownStatusRequest
-	1053, // 1030: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_sync_request:type_name -> mlx_device.MlxDeviceProfileSyncRequest
-	1054, // 1031: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_compare_request:type_name -> mlx_device.MlxDeviceProfileCompareRequest
-	1055, // 1032: forge.ScoutStreamScoutBoundMessage.mlx_device_info_device_request:type_name -> mlx_device.MlxDeviceInfoDeviceRequest
-	1056, // 1033: forge.ScoutStreamScoutBoundMessage.mlx_device_info_report_request:type_name -> mlx_device.MlxDeviceInfoReportRequest
-	1057, // 1034: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_list_request:type_name -> mlx_device.MlxDeviceRegistryListRequest
-	1058, // 1035: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_show_request:type_name -> mlx_device.MlxDeviceRegistryShowRequest
-	1059, // 1036: forge.ScoutStreamScoutBoundMessage.mlx_device_config_query_request:type_name -> mlx_device.MlxDeviceConfigQueryRequest
-	1060, // 1037: forge.ScoutStreamScoutBoundMessage.mlx_device_config_set_request:type_name -> mlx_device.MlxDeviceConfigSetRequest
-	1061, // 1038: forge.ScoutStreamScoutBoundMessage.mlx_device_config_sync_request:type_name -> mlx_device.MlxDeviceConfigSyncRequest
-	1062, // 1039: forge.ScoutStreamScoutBoundMessage.mlx_device_config_compare_request:type_name -> mlx_device.MlxDeviceConfigCompareRequest
-	873,  // 1040: forge.ScoutStreamScoutBoundMessage.scout_stream_agent_ping_request:type_name -> forge.ScoutStreamAgentPingRequest
-	1005, // 1041: forge.ScoutStreamInitRequest.machine_id:type_name -> common.MachineId
-	875,  // 1042: forge.ScoutStreamShowConnectionsResponse.scout_stream_connections:type_name -> forge.ScoutStreamConnectionInfo
-	1005, // 1043: forge.ScoutStreamDisconnectRequest.machine_id:type_name -> common.MachineId
-	1005, // 1044: forge.ScoutStreamDisconnectResponse.machine_id:type_name -> common.MachineId
-	1005, // 1045: forge.ScoutStreamAdminPingRequest.machine_id:type_name -> common.MachineId
-	876,  // 1046: forge.ScoutStreamAgentPingResponse.error:type_name -> forge.ScoutStreamError
-	1005, // 1047: forge.ScoutStreamConnectionInfo.machine_id:type_name -> common.MachineId
-	75,   // 1048: forge.ScoutStreamError.status:type_name -> forge.ScoutStreamErrorStatus
-	1031, // 1049: forge.RoutingProfile.route_target_imports:type_name -> common.RouteTarget
-	1031, // 1050: forge.RoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
-	877,  // 1051: forge.RoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
-	877,  // 1052: forge.RoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
-	1018, // 1053: forge.DomainLegacy.id:type_name -> common.DomainId
-	1006, // 1054: forge.DomainLegacy.created:type_name -> google.protobuf.Timestamp
-	1006, // 1055: forge.DomainLegacy.updated:type_name -> google.protobuf.Timestamp
-	1006, // 1056: forge.DomainLegacy.deleted:type_name -> google.protobuf.Timestamp
-	879,  // 1057: forge.DomainListLegacy.domains:type_name -> forge.DomainLegacy
-	1018, // 1058: forge.DomainDeletionLegacy.id:type_name -> common.DomainId
-	1018, // 1059: forge.DomainSearchQueryLegacy.id:type_name -> common.DomainId
-	1063, // 1060: forge.PxeDomain.new_domain:type_name -> dns.Domain
-	879,  // 1061: forge.PxeDomain.legacy_domain:type_name -> forge.DomainLegacy
-	1005, // 1062: forge.MachinePositionQuery.machine_ids:type_name -> common.MachineId
-	887,  // 1063: forge.MachinePositionInfoList.machine_position_info:type_name -> forge.MachinePositionInfo
-	1005, // 1064: forge.MachinePositionInfo.machine_id:type_name -> common.MachineId
-	1016, // 1065: forge.MachinePositionInfo.switch_id:type_name -> common.SwitchId
-	1013, // 1066: forge.MachinePositionInfo.power_shelf_id:type_name -> common.PowerShelfId
-	1005, // 1067: forge.ModifyDPFStateRequest.machine_id:type_name -> common.MachineId
-	1004, // 1068: forge.DPFStateResponse.dpf_states:type_name -> forge.DPFStateResponse.DPFState
-	1005, // 1069: forge.GetDPFStateRequest.machine_ids:type_name -> common.MachineId
-	1005, // 1070: forge.GetDPFHostSnapshotRequest.host_machine_id:type_name -> common.MachineId
-	894,  // 1071: forge.DPFServiceVersionsResponse.services:type_name -> forge.DPFServiceVersion
-	76,   // 1072: forge.ComponentResult.status:type_name -> forge.ComponentManagerStatusCode
-	1016, // 1073: forge.SwitchIdList.ids:type_name -> common.SwitchId
-	1013, // 1074: forge.PowerShelfIdList.ids:type_name -> common.PowerShelfId
-	1064, // 1075: forge.GetComponentInventoryRequest.machine_ids:type_name -> common.MachineIdList
-	897,  // 1076: forge.GetComponentInventoryRequest.switch_ids:type_name -> forge.SwitchIdList
-	898,  // 1077: forge.GetComponentInventoryRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	896,  // 1078: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
-	1065, // 1079: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
-	900,  // 1080: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
-	1064, // 1081: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
-	897,  // 1082: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
-	898,  // 1083: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	1066, // 1084: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
-	896,  // 1085: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
-	897,  // 1086: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
-	896,  // 1087: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
-	896,  // 1088: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
-	77,   // 1089: forge.FirmwareUpdateStatus.state:type_name -> forge.FirmwareUpdateState
-	1006, // 1090: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
-	1064, // 1091: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
-	80,   // 1092: forge.UpdateComputeTrayFirmwareTarget.components:type_name -> forge.ComputeTrayComponent
-	897,  // 1093: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
-	78,   // 1094: forge.UpdateSwitchFirmwareTarget.components:type_name -> forge.NvSwitchComponent
-	898,  // 1095: forge.UpdatePowerShelfFirmwareTarget.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	79,   // 1096: forge.UpdatePowerShelfFirmwareTarget.components:type_name -> forge.PowerShelfComponent
-	745,  // 1097: forge.UpdateFirmwareObjectTarget.rack_ids:type_name -> forge.RackIdList
-	907,  // 1098: forge.UpdateComponentFirmwareRequest.compute_trays:type_name -> forge.UpdateComputeTrayFirmwareTarget
-	908,  // 1099: forge.UpdateComponentFirmwareRequest.switches:type_name -> forge.UpdateSwitchFirmwareTarget
-	909,  // 1100: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
-	910,  // 1101: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
-	896,  // 1102: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
-	1064, // 1103: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
-	897,  // 1104: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
-	898,  // 1105: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	745,  // 1106: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
-	906,  // 1107: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
-	1064, // 1108: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
-	897,  // 1109: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
-	898,  // 1110: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	745,  // 1111: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
-	80,   // 1112: forge.ComputeTrayFirmwareVersions.component:type_name -> forge.ComputeTrayComponent
-	896,  // 1113: forge.DeviceFirmwareVersions.result:type_name -> forge.ComponentResult
-	916,  // 1114: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
-	917,  // 1115: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
-	265,  // 1116: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1024, // 1117: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
-	265,  // 1118: forge.SpxPartition.metadata:type_name -> forge.Metadata
-	1024, // 1119: forge.SpxPartition.id:type_name -> common.SpxPartitionId
-	1024, // 1120: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
-	1024, // 1121: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
-	264,  // 1122: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
-	920,  // 1123: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
-	1024, // 1124: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
-	1016, // 1125: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
-	1013, // 1126: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1023, // 1127: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
-	81,   // 1128: forge.OperatingSystem.type:type_name -> forge.OperatingSystemType
-	8,    // 1129: forge.OperatingSystem.status:type_name -> forge.TenantState
-	1022, // 1130: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
-	272,  // 1131: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
-	273,  // 1132: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	1023, // 1133: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1022, // 1134: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
-	272,  // 1135: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
-	273,  // 1136: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	272,  // 1137: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
-	273,  // 1138: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
-	1023, // 1139: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1022, // 1140: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
-	933,  // 1141: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
-	934,  // 1142: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
-	1023, // 1143: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1023, // 1144: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
-	1023, // 1145: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
-	931,  // 1146: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
-	1023, // 1147: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
-	273,  // 1148: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
-	1023, // 1149: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
-	944,  // 1150: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
-	1005, // 1151: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
-	1026, // 1152: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
-	1006, // 1153: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
-	1005, // 1154: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
-	951,  // 1155: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
-	952,  // 1156: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
-	953,  // 1157: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
-	954,  // 1158: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
-	950,  // 1159: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
-	950,  // 1160: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
-	1067, // 1161: forge.SitePrefix.id:type_name -> common.SitePrefixId
-	960,  // 1162: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
-	961,  // 1163: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
-	265,  // 1164: forge.SitePrefix.metadata:type_name -> forge.Metadata
-	1006, // 1165: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
-	1006, // 1166: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
-	83,   // 1167: forge.SitePrefixConfig.routing_scope:type_name -> forge.SitePrefixRoutingScope
-	82,   // 1168: forge.SitePrefixStatus.authority:type_name -> forge.SitePrefixAuthority
-	84,   // 1169: forge.SitePrefixStatus.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
-	82,   // 1170: forge.SitePrefixSearchFilter.authority:type_name -> forge.SitePrefixAuthority
-	83,   // 1171: forge.SitePrefixSearchFilter.routing_scope:type_name -> forge.SitePrefixRoutingScope
-	84,   // 1172: forge.SitePrefixSearchFilter.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
-	7,    // 1173: forge.SitePrefixSearchFilter.prefix_match_type:type_name -> forge.PrefixMatchType
-	1067, // 1174: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
-	1067, // 1175: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
-	959,  // 1176: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
-	969,  // 1177: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
-	230,  // 1178: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
-	321,  // 1179: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
-	324,  // 1180: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
-	946,  // 1181: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry.value:type_name -> forge.HostRepresentorInterceptBridging
-	87,   // 1182: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
-	994,  // 1183: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	1032, // 1184: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
-	985,  // 1185: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
-	1029, // 1186: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
-	987,  // 1187: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
-	988,  // 1188: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
-	989,  // 1189: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
-	990,  // 1190: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	991,  // 1191: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	992,  // 1192: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	1068, // 1193: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
-	1069, // 1194: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
-	1070, // 1195: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
-	89,   // 1196: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
-	1005, // 1197: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
-	1006, // 1198: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1006, // 1199: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	1005, // 1200: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
-	1006, // 1201: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1006, // 1202: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	1005, // 1203: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
-	144,  // 1204: forge.Forge.Version:input_type -> forge.VersionRequest
-	1071, // 1205: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
-	1072, // 1206: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
-	1073, // 1207: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
-	1074, // 1208: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
-	879,  // 1209: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
-	879,  // 1210: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
-	881,  // 1211: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
-	883,  // 1212: forge.Forge.FindDomainLegacy:input_type -> forge.DomainSearchQueryLegacy
-	163,  // 1213: forge.Forge.CreateVpc:input_type -> forge.VpcCreationRequest
-	164,  // 1214: forge.Forge.UpdateVpc:input_type -> forge.VpcUpdateRequest
-	166,  // 1215: forge.Forge.UpdateVpcVirtualization:input_type -> forge.VpcUpdateVirtualizationRequest
-	168,  // 1216: forge.Forge.DeleteVpc:input_type -> forge.VpcDeletionRequest
-	156,  // 1217: forge.Forge.FindVpcIds:input_type -> forge.VpcSearchFilter
-	158,  // 1218: forge.Forge.FindVpcsByIds:input_type -> forge.VpcsByIdsRequest
-	919,  // 1219: forge.Forge.CreateSpxPartition:input_type -> forge.SpxPartitionCreationRequest
-	922,  // 1220: forge.Forge.DeleteSpxPartition:input_type -> forge.SpxPartitionDeletionRequest
-	924,  // 1221: forge.Forge.FindSpxPartitionIds:input_type -> forge.SpxPartitionSearchFilter
-	926,  // 1222: forge.Forge.FindSpxPartitionsByIds:input_type -> forge.SpxPartitionsByIdsRequest
-	174,  // 1223: forge.Forge.CreateVpcPrefix:input_type -> forge.VpcPrefixCreationRequest
-	175,  // 1224: forge.Forge.SearchVpcPrefixes:input_type -> forge.VpcPrefixSearchQuery
-	176,  // 1225: forge.Forge.GetVpcPrefixes:input_type -> forge.VpcPrefixGetRequest
-	179,  // 1226: forge.Forge.UpdateVpcPrefix:input_type -> forge.VpcPrefixUpdateRequest
-	180,  // 1227: forge.Forge.DeleteVpcPrefix:input_type -> forge.VpcPrefixDeletionRequest
-	962,  // 1228: forge.Forge.FindSitePrefixIds:input_type -> forge.SitePrefixSearchFilter
-	963,  // 1229: forge.Forge.FindSitePrefixesByIds:input_type -> forge.SitePrefixesByIdsRequest
-	186,  // 1230: forge.Forge.CreateVpcPeering:input_type -> forge.VpcPeeringCreationRequest
-	187,  // 1231: forge.Forge.FindVpcPeeringIds:input_type -> forge.VpcPeeringSearchFilter
-	188,  // 1232: forge.Forge.FindVpcPeeringsByIds:input_type -> forge.VpcPeeringsByIdsRequest
-	189,  // 1233: forge.Forge.DeleteVpcPeering:input_type -> forge.VpcPeeringDeletionRequest
-	256,  // 1234: forge.Forge.FindNetworkSegmentIds:input_type -> forge.NetworkSegmentSearchFilter
-	258,  // 1235: forge.Forge.FindNetworkSegmentsByIds:input_type -> forge.NetworkSegmentsByIdsRequest
-	250,  // 1236: forge.Forge.CreateNetworkSegment:input_type -> forge.NetworkSegmentCreationRequest
-	252,  // 1237: forge.Forge.AttachNetworkSegmentToVpc:input_type -> forge.AttachNetworkSegmentToVpcRequest
-	251,  // 1238: forge.Forge.DeleteNetworkSegment:input_type -> forge.NetworkSegmentDeletionRequest
-	155,  // 1239: forge.Forge.NetworkSegmentsForVpc:input_type -> forge.VpcSearchQuery
-	199,  // 1240: forge.Forge.FindIBPartitionIds:input_type -> forge.IBPartitionSearchFilter
-	200,  // 1241: forge.Forge.FindIBPartitionsByIds:input_type -> forge.IBPartitionsByIdsRequest
-	195,  // 1242: forge.Forge.CreateIBPartition:input_type -> forge.IBPartitionCreationRequest
-	196,  // 1243: forge.Forge.UpdateIBPartition:input_type -> forge.IBPartitionUpdateRequest
-	197,  // 1244: forge.Forge.DeleteIBPartition:input_type -> forge.IBPartitionDeletionRequest
-	159,  // 1245: forge.Forge.IBPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	211,  // 1246: forge.Forge.FindPowerShelves:input_type -> forge.PowerShelfQuery
-	212,  // 1247: forge.Forge.FindPowerShelfIds:input_type -> forge.PowerShelfSearchFilter
-	213,  // 1248: forge.Forge.FindPowerShelvesByIds:input_type -> forge.PowerShelvesByIdsRequest
-	207,  // 1249: forge.Forge.DeletePowerShelf:input_type -> forge.PowerShelfDeletionRequest
-	929,  // 1250: forge.Forge.AdminForceDeletePowerShelf:input_type -> forge.AdminForceDeletePowerShelfRequest
-	209,  // 1251: forge.Forge.SetPowerShelfMaintenance:input_type -> forge.PowerShelfMaintenanceRequest
-	233,  // 1252: forge.Forge.FindSwitches:input_type -> forge.SwitchQuery
-	234,  // 1253: forge.Forge.FindSwitchIds:input_type -> forge.SwitchSearchFilter
-	235,  // 1254: forge.Forge.FindSwitchesByIds:input_type -> forge.SwitchesByIdsRequest
-	227,  // 1255: forge.Forge.DeleteSwitch:input_type -> forge.SwitchDeletionRequest
-	927,  // 1256: forge.Forge.AdminForceDeleteSwitch:input_type -> forge.AdminForceDeleteSwitchRequest
-	244,  // 1257: forge.Forge.FindIBFabricIds:input_type -> forge.IBFabricSearchFilter
-	269,  // 1258: forge.Forge.AllocateInstance:input_type -> forge.InstanceAllocationRequest
-	270,  // 1259: forge.Forge.AllocateInstances:input_type -> forge.BatchInstanceAllocationRequest
-	315,  // 1260: forge.Forge.ReleaseInstance:input_type -> forge.InstanceReleaseRequest
-	287,  // 1261: forge.Forge.UpdateInstanceOperatingSystem:input_type -> forge.InstanceOperatingSystemUpdateRequest
-	288,  // 1262: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
-	266,  // 1263: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
-	268,  // 1264: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
-	1005, // 1265: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
-	388,  // 1266: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
-	453,  // 1267: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
-	1005, // 1268: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
-	459,  // 1269: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
-	470,  // 1270: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
-	462,  // 1271: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
-	460,  // 1272: forge.Forge.InsertRackHealthReport:input_type -> forge.InsertRackHealthReportRequest
-	461,  // 1273: forge.Forge.RemoveRackHealthReport:input_type -> forge.RemoveRackHealthReportRequest
-	465,  // 1274: forge.Forge.ListSwitchHealthReports:input_type -> forge.ListSwitchHealthReportsRequest
-	463,  // 1275: forge.Forge.InsertSwitchHealthReport:input_type -> forge.InsertSwitchHealthReportRequest
-	464,  // 1276: forge.Forge.RemoveSwitchHealthReport:input_type -> forge.RemoveSwitchHealthReportRequest
-	468,  // 1277: forge.Forge.ListPowerShelfHealthReports:input_type -> forge.ListPowerShelfHealthReportsRequest
-	466,  // 1278: forge.Forge.InsertPowerShelfHealthReport:input_type -> forge.InsertPowerShelfHealthReportRequest
-	467,  // 1279: forge.Forge.RemovePowerShelfHealthReport:input_type -> forge.RemovePowerShelfHealthReportRequest
-	471,  // 1280: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
-	472,  // 1281: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
-	473,  // 1282: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
-	1005, // 1283: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
-	459,  // 1284: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
-	470,  // 1285: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
-	407,  // 1286: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
-	409,  // 1287: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
-	1075, // 1288: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
-	1076, // 1289: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
-	1077, // 1290: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
-	261,  // 1291: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
-	434,  // 1292: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
-	436,  // 1293: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
-	440,  // 1294: forge.Forge.RenewMachineCertificate:input_type -> forge.MachineCertificateRenewRequest
-	437,  // 1295: forge.Forge.DiscoveryCompleted:input_type -> forge.MachineDiscoveryCompletedRequest
-	438,  // 1296: forge.Forge.CleanupMachineCompleted:input_type -> forge.MachineCleanupInfo
-	445,  // 1297: forge.Forge.ReportForgeScoutError:input_type -> forge.ForgeScoutErrorReport
-	364,  // 1298: forge.Forge.DiscoverDhcp:input_type -> forge.DhcpDiscovery
-	365,  // 1299: forge.Forge.ExpireDhcpLease:input_type -> forge.ExpireDhcpLeaseRequest
-	334,  // 1300: forge.Forge.AssignStaticAddress:input_type -> forge.AssignStaticAddressRequest
-	336,  // 1301: forge.Forge.RemoveStaticAddress:input_type -> forge.RemoveStaticAddressRequest
-	338,  // 1302: forge.Forge.FindInterfaceAddresses:input_type -> forge.FindInterfaceAddressesRequest
-	333,  // 1303: forge.Forge.FindInterfaces:input_type -> forge.InterfaceSearchQuery
-	332,  // 1304: forge.Forge.DeleteInterface:input_type -> forge.InterfaceDeleteQuery
-	509,  // 1305: forge.Forge.FindIpAddress:input_type -> forge.FindIpAddressRequest
-	318,  // 1306: forge.Forge.FindMachineIds:input_type -> forge.MachineSearchConfig
-	317,  // 1307: forge.Forge.FindMachinesByIds:input_type -> forge.MachinesByIdsRequest
-	319,  // 1308: forge.Forge.FindMachineStateHistories:input_type -> forge.MachineStateHistoriesRequest
-	322,  // 1309: forge.Forge.FindMachineHealthHistories:input_type -> forge.MachineHealthHistoriesRequest
-	210,  // 1310: forge.Forge.FindPowerShelfStateHistories:input_type -> forge.PowerShelfStateHistoriesRequest
-	750,  // 1311: forge.Forge.FindRackStateHistories:input_type -> forge.RackStateHistoriesRequest
-	231,  // 1312: forge.Forge.FindSwitchStateHistories:input_type -> forge.SwitchStateHistoriesRequest
-	254,  // 1313: forge.Forge.FindNetworkSegmentStateHistories:input_type -> forge.NetworkSegmentStateHistoriesRequest
-	182,  // 1314: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
-	327,  // 1315: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
-	326,  // 1316: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
-	1064, // 1317: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
-	534,  // 1318: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
-	535,  // 1319: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
-	513,  // 1320: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
-	511,  // 1321: forge.Forge.IdentifyUuid:input_type -> forge.IdentifyUuidRequest
-	514,  // 1322: forge.Forge.IdentifyMac:input_type -> forge.IdentifyMacRequest
-	516,  // 1323: forge.Forge.IdentifySerial:input_type -> forge.IdentifySerialRequest
-	430,  // 1324: forge.Forge.GetBMCMetaData:input_type -> forge.BMCMetaDataGetRequest
-	432,  // 1325: forge.Forge.UpdateMachineCredentials:input_type -> forge.MachineCredentialsUpdateRequest
-	447,  // 1326: forge.Forge.GetPxeInstructions:input_type -> forge.PxeInstructionRequest
-	451,  // 1327: forge.Forge.GetCloudInitInstructions:input_type -> forge.CloudInitInstructionsRequest
-	147,  // 1328: forge.Forge.Echo:input_type -> forge.EchoRequest
-	478,  // 1329: forge.Forge.CreateTenant:input_type -> forge.CreateTenantRequest
-	482,  // 1330: forge.Forge.FindTenant:input_type -> forge.FindTenantRequest
-	480,  // 1331: forge.Forge.UpdateTenant:input_type -> forge.UpdateTenantRequest
-	488,  // 1332: forge.Forge.CreateTenantKeyset:input_type -> forge.CreateTenantKeysetRequest
-	495,  // 1333: forge.Forge.FindTenantKeysetIds:input_type -> forge.TenantKeysetSearchFilter
-	497,  // 1334: forge.Forge.FindTenantKeysetsByIds:input_type -> forge.TenantKeysetsByIdsRequest
-	491,  // 1335: forge.Forge.UpdateTenantKeyset:input_type -> forge.UpdateTenantKeysetRequest
-	493,  // 1336: forge.Forge.DeleteTenantKeyset:input_type -> forge.DeleteTenantKeysetRequest
-	498,  // 1337: forge.Forge.ValidateTenantPublicKey:input_type -> forge.ValidateTenantPublicKeyRequest
-	371,  // 1338: forge.Forge.GetBmcCredentials:input_type -> forge.GetBmcCredentialsRequest
-	372,  // 1339: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
-	405,  // 1340: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
-	375,  // 1341: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
-	1078, // 1342: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
-	376,  // 1343: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
-	382,  // 1344: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
-	382,  // 1345: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
-	382,  // 1346: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
-	377,  // 1347: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
-	378,  // 1348: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
-	379,  // 1349: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
-	380,  // 1350: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
-	1079, // 1351: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
-	1080, // 1352: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
-	1081, // 1353: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
-	1082, // 1354: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
-	1083, // 1355: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
-	1084, // 1356: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
-	386,  // 1357: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
-	411,  // 1358: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
-	500,  // 1359: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
-	503,  // 1360: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
-	348,  // 1361: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
-	349,  // 1362: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
-	350,  // 1363: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
-	351,  // 1364: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
-	764,  // 1365: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
-	507,  // 1366: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
-	508,  // 1367: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
-	518,  // 1368: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
-	519,  // 1369: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
-	521,  // 1370: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
-	522,  // 1371: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
-	1005, // 1372: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
-	573,  // 1373: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
-	528,  // 1374: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
-	1026, // 1375: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
-	531,  // 1376: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
-	1026, // 1377: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
-	949,  // 1378: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
-	540,  // 1379: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
-	541,  // 1380: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
-	135,  // 1381: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
-	136,  // 1382: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
-	139,  // 1383: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
-	141,  // 1384: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
-	956,  // 1385: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
-	958,  // 1386: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
-	1078, // 1387: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
-	543,  // 1388: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
-	543,  // 1389: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
-	543,  // 1390: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
-	352,  // 1391: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
-	310,  // 1392: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
-	546,  // 1393: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
-	548,  // 1394: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
-	561,  // 1395: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
-	562,  // 1396: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	561,  // 1397: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
-	562,  // 1398: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	1078, // 1399: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
-	563,  // 1400: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
-	1078, // 1401: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
-	1078, // 1402: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
-	1078, // 1403: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
-	568,  // 1404: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	568,  // 1405: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	214,  // 1406: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	215,  // 1407: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	214,  // 1408: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	215,  // 1409: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	1078, // 1410: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	216,  // 1411: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
-	1078, // 1412: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	1078, // 1413: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
-	236,  // 1414: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
-	237,  // 1415: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	236,  // 1416: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
-	237,  // 1417: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	1078, // 1418: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
-	238,  // 1419: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
-	1078, // 1420: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
-	1078, // 1421: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
-	241,  // 1422: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
-	242,  // 1423: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
-	241,  // 1424: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
-	242,  // 1425: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
-	1078, // 1426: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
-	243,  // 1427: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
-	1078, // 1428: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
-	133,  // 1429: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
-	643,  // 1430: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
-	645,  // 1431: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
-	647,  // 1432: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
-	652,  // 1433: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
-	649,  // 1434: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
-	653,  // 1435: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
-	655,  // 1436: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
-	1085, // 1437: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
-	1086, // 1438: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
-	1087, // 1439: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
-	1088, // 1440: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
-	1089, // 1441: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
-	1090, // 1442: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
-	1091, // 1443: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
-	1092, // 1444: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
-	1093, // 1445: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
-	1094, // 1446: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
-	1095, // 1447: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
-	1096, // 1448: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
-	1097, // 1449: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
-	1098, // 1450: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
-	1099, // 1451: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
-	1100, // 1452: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
-	1101, // 1453: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
-	1102, // 1454: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
-	1103, // 1455: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
-	1104, // 1456: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
-	1105, // 1457: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
-	1106, // 1458: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
-	1107, // 1459: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
-	1108, // 1460: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
-	1109, // 1461: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
-	1110, // 1462: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
-	1111, // 1463: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
-	1112, // 1464: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
-	1113, // 1465: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
-	1114, // 1466: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
-	1115, // 1467: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
-	1116, // 1468: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
-	1117, // 1469: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
-	1118, // 1470: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
-	1119, // 1471: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
-	1120, // 1472: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
-	1121, // 1473: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
-	1122, // 1474: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
-	1123, // 1475: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
-	1124, // 1476: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
-	1125, // 1477: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
-	1126, // 1478: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
-	1127, // 1479: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
-	674,  // 1480: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
-	676,  // 1481: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
-	678,  // 1482: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
-	681,  // 1483: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
-	682,  // 1484: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
-	688,  // 1485: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
-	691,  // 1486: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
-	550,  // 1487: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
-	554,  // 1488: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
-	552,  // 1489: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
-	1015, // 1490: forge.Forge.GetOsImage:input_type -> common.UUID
-	550,  // 1491: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
-	556,  // 1492: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
-	557,  // 1493: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
-	572,  // 1494: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
-	577,  // 1495: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
-	579,  // 1496: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
-	574,  // 1497: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
-	582,  // 1498: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
-	584,  // 1499: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
-	587,  // 1500: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
-	589,  // 1501: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
-	606,  // 1502: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
-	607,  // 1503: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
-	609,  // 1504: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
-	612,  // 1505: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
-	614,  // 1506: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
-	590,  // 1507: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
-	618,  // 1508: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
-	620,  // 1509: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
-	619,  // 1510: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
-	623,  // 1511: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
-	627,  // 1512: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
-	628,  // 1513: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
-	630,  // 1514: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
-	424,  // 1515: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
-	601,  // 1516: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
-	382,  // 1517: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
-	414,  // 1518: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
-	416,  // 1519: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
-	418,  // 1520: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
-	420,  // 1521: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
-	797,  // 1522: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
-	799,  // 1523: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
-	801,  // 1524: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
-	803,  // 1525: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
-	426,  // 1526: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
-	428,  // 1527: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
-	591,  // 1528: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
-	599,  // 1529: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
-	129,  // 1530: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
-	1078, // 1531: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
-	1078, // 1532: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
-	126,  // 1533: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
-	657,  // 1534: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
-	659,  // 1535: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
-	664,  // 1536: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
-	666,  // 1537: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
-	666,  // 1538: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
-	666,  // 1539: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
-	670,  // 1540: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
-	694,  // 1541: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
-	807,  // 1542: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
-	808,  // 1543: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
-	710,  // 1544: forge.Forge.CreateSku:input_type -> forge.SkuList
-	1005, // 1545: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
-	1005, // 1546: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
-	708,  // 1547: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
-	709,  // 1548: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
-	711,  // 1549: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
-	1078, // 1550: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
-	713,  // 1551: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
-	723,  // 1552: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
-	707,  // 1553: forge.Forge.ReplaceSku:input_type -> forge.Sku
-	394,  // 1554: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
-	396,  // 1555: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
-	398,  // 1556: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
-	1005, // 1557: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
-	385,  // 1558: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
-	1078, // 1559: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
-	718,  // 1560: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
-	716,  // 1561: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	716,  // 1562: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	721,  // 1563: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
-	724,  // 1564: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
-	725,  // 1565: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
-	382,  // 1566: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
-	382,  // 1567: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
-	744,  // 1568: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
-	746,  // 1569: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
-	741,  // 1570: forge.Forge.GetRack:input_type -> forge.GetRackRequest
-	751,  // 1571: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
-	752,  // 1572: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
-	759,  // 1573: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
-	730,  // 1574: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
-	732,  // 1575: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
-	734,  // 1576: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
-	737,  // 1577: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
-	738,  // 1578: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
-	805,  // 1579: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
-	814,  // 1580: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
-	1128, // 1581: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
-	1129, // 1582: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
-	817,  // 1583: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
-	1078, // 1584: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
-	819,  // 1585: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	819,  // 1586: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	821,  // 1587: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
-	822,  // 1588: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
-	827,  // 1589: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
-	828,  // 1590: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
-	829,  // 1591: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
-	830,  // 1592: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
-	1078, // 1593: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
-	824,  // 1594: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
-	831,  // 1595: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
-	833,  // 1596: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
-	836,  // 1597: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
-	838,  // 1598: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
-	840,  // 1599: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
-	841,  // 1600: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
-	847,  // 1601: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
-	848,  // 1602: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
-	849,  // 1603: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
-	851,  // 1604: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
-	853,  // 1605: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
-	855,  // 1606: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
-	857,  // 1607: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
-	101,  // 1608: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
-	1005, // 1609: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
-	102,  // 1610: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
-	1005, // 1611: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
-	104,  // 1612: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
-	106,  // 1613: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	109,  // 1614: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
-	106,  // 1615: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	114,  // 1616: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	116,  // 1617: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
-	114,  // 1618: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	117,  // 1619: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
-	122,  // 1620: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
-	123,  // 1621: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
-	864,  // 1622: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
-	867,  // 1623: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
-	869,  // 1624: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
-	871,  // 1625: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
-	1130, // 1626: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
-	1131, // 1627: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
-	1132, // 1628: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
-	1133, // 1629: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
-	1134, // 1630: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
-	1135, // 1631: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
-	1136, // 1632: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
-	1137, // 1633: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
-	1138, // 1634: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
-	1139, // 1635: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
-	1140, // 1636: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
-	1141, // 1637: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
-	1142, // 1638: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
-	1143, // 1639: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
-	1144, // 1640: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
-	781,  // 1641: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
-	782,  // 1642: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
-	159,  // 1643: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	792,  // 1644: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
-	793,  // 1645: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
-	789,  // 1646: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
-	795,  // 1647: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
-	790,  // 1648: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
-	159,  // 1649: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	885,  // 1650: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
-	775,  // 1651: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
-	888,  // 1652: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
-	890,  // 1653: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
-	891,  // 1654: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
-	893,  // 1655: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
-	902,  // 1656: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
-	904,  // 1657: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
-	899,  // 1658: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
-	911,  // 1659: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
-	913,  // 1660: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
-	915,  // 1661: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
-	932,  // 1662: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
-	1023, // 1663: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
-	935,  // 1664: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
-	936,  // 1665: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
-	938,  // 1666: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
-	940,  // 1667: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
-	942,  // 1668: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	945,  // 1669: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	947,  // 1670: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
-	145,  // 1671: forge.Forge.Version:output_type -> forge.BuildInfo
-	1063, // 1672: forge.Forge.CreateDomain:output_type -> dns.Domain
-	1063, // 1673: forge.Forge.UpdateDomain:output_type -> dns.Domain
-	1145, // 1674: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
-	1146, // 1675: forge.Forge.FindDomain:output_type -> dns.DomainList
-	879,  // 1676: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
-	879,  // 1677: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
-	882,  // 1678: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
-	880,  // 1679: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
-	162,  // 1680: forge.Forge.CreateVpc:output_type -> forge.Vpc
-	165,  // 1681: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
-	167,  // 1682: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
-	169,  // 1683: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
-	157,  // 1684: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
-	170,  // 1685: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
-	920,  // 1686: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
-	923,  // 1687: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
-	921,  // 1688: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
-	925,  // 1689: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
-	171,  // 1690: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
-	177,  // 1691: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
-	178,  // 1692: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
-	171,  // 1693: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
-	181,  // 1694: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
-	964,  // 1695: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
-	965,  // 1696: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
-	183,  // 1697: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
-	184,  // 1698: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
-	185,  // 1699: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
-	190,  // 1700: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
-	257,  // 1701: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
-	368,  // 1702: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
-	249,  // 1703: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
-	249,  // 1704: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
-	253,  // 1705: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
-	368,  // 1706: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
-	201,  // 1707: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
-	194,  // 1708: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
-	193,  // 1709: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
-	193,  // 1710: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
-	198,  // 1711: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
-	194,  // 1712: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
-	205,  // 1713: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
-	898,  // 1714: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
-	205,  // 1715: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
-	208,  // 1716: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
-	930,  // 1717: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
-	1078, // 1718: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
-	225,  // 1719: forge.Forge.FindSwitches:output_type -> forge.SwitchList
-	897,  // 1720: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
-	225,  // 1721: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
-	228,  // 1722: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
-	928,  // 1723: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
-	245,  // 1724: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
-	298,  // 1725: forge.Forge.AllocateInstance:output_type -> forge.Instance
-	271,  // 1726: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
-	316,  // 1727: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
-	298,  // 1728: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
-	298,  // 1729: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
-	267,  // 1730: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
-	263,  // 1731: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
-	263,  // 1732: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
-	389,  // 1733: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
-	1078, // 1734: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
-	469,  // 1735: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
-	1078, // 1736: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
-	1078, // 1737: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
-	469,  // 1738: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
-	1078, // 1739: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
-	1078, // 1740: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
-	469,  // 1741: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
-	1078, // 1742: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
-	1078, // 1743: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
-	469,  // 1744: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
-	1078, // 1745: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
-	1078, // 1746: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
-	469,  // 1747: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
-	1078, // 1748: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	1078, // 1749: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	469,  // 1750: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
-	1078, // 1751: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
-	1078, // 1752: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
-	408,  // 1753: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
-	410,  // 1754: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
-	1147, // 1755: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
-	1148, // 1756: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
-	1149, // 1757: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
-	262,  // 1758: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
-	435,  // 1759: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
-	442,  // 1760: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
-	441,  // 1761: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
-	443,  // 1762: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
-	444,  // 1763: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
-	446,  // 1764: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
-	367,  // 1765: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
-	366,  // 1766: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
-	335,  // 1767: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
-	337,  // 1768: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
-	340,  // 1769: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
-	330,  // 1770: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
-	1078, // 1771: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
-	510,  // 1772: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
-	1064, // 1773: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
-	331,  // 1774: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
-	320,  // 1775: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
-	323,  // 1776: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
-	232,  // 1777: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
-	232,  // 1778: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
-	232,  // 1779: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
-	232,  // 1780: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
-	232,  // 1781: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
-	329,  // 1782: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
-	328,  // 1783: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
-	533,  // 1784: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
-	537,  // 1785: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
-	536,  // 1786: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
-	534,  // 1787: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
-	512,  // 1788: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
-	515,  // 1789: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
-	517,  // 1790: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
-	431,  // 1791: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
-	433,  // 1792: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
-	448,  // 1793: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
-	452,  // 1794: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
-	148,  // 1795: forge.Forge.Echo:output_type -> forge.EchoResponse
-	479,  // 1796: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
-	483,  // 1797: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
-	481,  // 1798: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
-	489,  // 1799: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
-	496,  // 1800: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
-	490,  // 1801: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
-	492,  // 1802: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
-	494,  // 1803: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
-	499,  // 1804: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
-	373,  // 1805: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
-	373,  // 1806: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
-	406,  // 1807: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
-	1150, // 1808: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
-	1151, // 1809: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
-	1078, // 1810: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
-	616,  // 1811: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
-	617,  // 1812: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
-	1065, // 1813: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
-	1078, // 1814: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
-	1152, // 1815: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
-	381,  // 1816: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
-	1078, // 1817: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
-	1153, // 1818: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
-	1154, // 1819: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
-	1155, // 1820: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
-	1156, // 1821: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
-	1157, // 1822: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
-	1158, // 1823: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
-	1078, // 1824: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
-	412,  // 1825: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
-	501,  // 1826: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
-	504,  // 1827: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
-	1078, // 1828: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
-	1078, // 1829: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
-	1078, // 1830: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
-	1078, // 1831: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
-	1078, // 1832: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
-	1078, // 1833: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
-	1078, // 1834: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
-	1078, // 1835: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
-	520,  // 1836: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
-	1078, // 1837: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
-	523,  // 1838: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
-	1078, // 1839: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
-	1078, // 1840: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
-	529,  // 1841: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
-	531,  // 1842: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
-	1078, // 1843: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
-	1078, // 1844: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
-	955,  // 1845: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
-	542,  // 1846: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
-	542,  // 1847: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
-	137,  // 1848: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
-	138,  // 1849: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
-	140,  // 1850: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
-	143,  // 1851: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
-	957,  // 1852: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
-	1078, // 1853: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
-	544,  // 1854: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
-	1078, // 1855: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
-	1078, // 1856: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
-	1078, // 1857: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
-	1078, // 1858: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
-	311,  // 1859: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
-	547,  // 1860: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
-	549,  // 1861: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
-	1078, // 1862: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
-	1078, // 1863: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
-	1078, // 1864: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
-	561,  // 1865: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
-	563,  // 1866: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
-	1078, // 1867: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
-	1078, // 1868: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
-	564,  // 1869: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
-	566,  // 1870: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
-	570,  // 1871: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	570,  // 1872: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	1078, // 1873: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1078, // 1874: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1078, // 1875: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
-	214,  // 1876: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
-	216,  // 1877: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
-	1078, // 1878: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	1078, // 1879: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	217,  // 1880: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
-	1078, // 1881: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
-	1078, // 1882: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
-	1078, // 1883: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
-	236,  // 1884: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
-	238,  // 1885: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
-	1078, // 1886: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
-	1078, // 1887: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
-	239,  // 1888: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
-	1078, // 1889: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
-	1078, // 1890: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
-	1078, // 1891: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
-	241,  // 1892: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
-	243,  // 1893: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
-	1078, // 1894: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
-	1078, // 1895: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
-	134,  // 1896: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
-	644,  // 1897: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
-	646,  // 1898: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
-	648,  // 1899: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
-	651,  // 1900: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
-	650,  // 1901: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
-	654,  // 1902: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
-	656,  // 1903: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
-	1159, // 1904: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
-	1160, // 1905: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
-	1161, // 1906: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
-	1162, // 1907: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
-	1163, // 1908: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1164, // 1909: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
-	1165, // 1910: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
-	1166, // 1911: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
-	1163, // 1912: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1167, // 1913: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
-	1168, // 1914: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
-	1169, // 1915: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
-	1170, // 1916: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
-	1171, // 1917: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
-	1172, // 1918: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
-	1173, // 1919: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
-	1174, // 1920: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
-	1175, // 1921: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
-	1176, // 1922: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
-	1177, // 1923: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
-	1178, // 1924: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
-	1179, // 1925: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
-	1180, // 1926: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
-	1181, // 1927: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
-	1182, // 1928: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
-	1183, // 1929: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
-	1184, // 1930: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
-	1185, // 1931: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
-	1186, // 1932: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
-	1187, // 1933: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
-	1188, // 1934: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
-	1189, // 1935: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
-	1190, // 1936: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
-	1191, // 1937: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
-	1192, // 1938: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
-	1193, // 1939: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
-	1194, // 1940: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
-	1195, // 1941: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
-	1196, // 1942: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
-	1197, // 1943: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
-	1198, // 1944: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
-	1199, // 1945: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
-	1200, // 1946: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
-	675,  // 1947: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
-	677,  // 1948: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
-	679,  // 1949: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
-	680,  // 1950: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
-	683,  // 1951: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
-	686,  // 1952: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
-	693,  // 1953: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
-	551,  // 1954: forge.Forge.CreateOsImage:output_type -> forge.OsImage
-	555,  // 1955: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
-	553,  // 1956: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
-	551,  // 1957: forge.Forge.GetOsImage:output_type -> forge.OsImage
-	551,  // 1958: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
-	274,  // 1959: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
-	558,  // 1960: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
-	571,  // 1961: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
-	1078, // 1962: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
-	578,  // 1963: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
-	575,  // 1964: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
-	583,  // 1965: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
-	586,  // 1966: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
-	588,  // 1967: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
-	1078, // 1968: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	605,  // 1969: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
-	608,  // 1970: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
-	610,  // 1971: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
-	613,  // 1972: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
-	615,  // 1973: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
-	1078, // 1974: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	622,  // 1975: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
-	621,  // 1976: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	621,  // 1977: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	624,  // 1978: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
-	626,  // 1979: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
-	629,  // 1980: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
-	631,  // 1981: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
-	425,  // 1982: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
-	602,  // 1983: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
-	413,  // 1984: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
-	415,  // 1985: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
-	1201, // 1986: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
-	419,  // 1987: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
-	421,  // 1988: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
-	798,  // 1989: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
-	800,  // 1990: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
-	802,  // 1991: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
-	804,  // 1992: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
-	427,  // 1993: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
-	429,  // 1994: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
-	592,  // 1995: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
-	600,  // 1996: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
-	125,  // 1997: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
-	131,  // 1998: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
-	128,  // 1999: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
-	1078, // 2000: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
-	658,  // 2001: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
-	660,  // 2002: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
-	665,  // 2003: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
-	667,  // 2004: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
-	668,  // 2005: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
-	669,  // 2006: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
-	671,  // 2007: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
-	695,  // 2008: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
-	813,  // 2009: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
-	1078, // 2010: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
-	711,  // 2011: forge.Forge.CreateSku:output_type -> forge.SkuIdList
-	707,  // 2012: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
-	1078, // 2013: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
-	1078, // 2014: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
-	1078, // 2015: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
-	1078, // 2016: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
-	711,  // 2017: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
-	710,  // 2018: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
-	1078, // 2019: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
-	707,  // 2020: forge.Forge.ReplaceSku:output_type -> forge.Sku
-	395,  // 2021: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
-	397,  // 2022: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
-	399,  // 2023: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
-	1078, // 2024: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
-	1078, // 2025: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
-	717,  // 2026: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
-	719,  // 2027: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
-	715,  // 2028: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
-	715,  // 2029: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
-	722,  // 2030: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
-	727,  // 2031: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
-	727,  // 2032: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
-	1078, // 2033: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
-	124,  // 2034: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
-	745,  // 2035: forge.Forge.FindRackIds:output_type -> forge.RackIdList
-	743,  // 2036: forge.Forge.FindRacksByIds:output_type -> forge.RackList
-	742,  // 2037: forge.Forge.GetRack:output_type -> forge.GetRackResponse
-	1078, // 2038: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
-	753,  // 2039: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
-	760,  // 2040: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
-	731,  // 2041: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
-	733,  // 2042: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
-	735,  // 2043: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
-	736,  // 2044: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
-	739,  // 2045: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
-	806,  // 2046: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
-	815,  // 2047: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
-	1202, // 2048: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
-	1203, // 2049: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
-	818,  // 2050: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
-	820,  // 2051: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
-	819,  // 2052: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	819,  // 2053: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	1078, // 2054: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
-	823,  // 2055: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
-	1078, // 2056: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
-	1078, // 2057: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
-	1078, // 2058: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
-	1078, // 2059: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
-	824,  // 2060: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
-	825,  // 2061: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
-	832,  // 2062: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
-	835,  // 2063: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
-	837,  // 2064: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
-	1078, // 2065: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
-	1078, // 2066: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
-	1078, // 2067: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
-	846,  // 2068: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
-	846,  // 2069: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
-	850,  // 2070: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
-	852,  // 2071: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
-	854,  // 2072: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
-	856,  // 2073: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
-	858,  // 2074: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
-	98,   // 2075: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
-	1078, // 2076: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
-	103,  // 2077: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
-	100,  // 2078: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
-	105,  // 2079: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
-	110,  // 2080: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	110,  // 2081: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	1078, // 2082: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
-	113,  // 2083: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	113,  // 2084: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	1078, // 2085: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
-	119,  // 2086: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
-	120,  // 2087: forge.Forge.GetJWKS:output_type -> forge.Jwks
-	121,  // 2088: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
-	865,  // 2089: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
-	868,  // 2090: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
-	870,  // 2091: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
-	872,  // 2092: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
-	1204, // 2093: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
-	1205, // 2094: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
-	1206, // 2095: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
-	1207, // 2096: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
-	1208, // 2097: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
-	1209, // 2098: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
-	1210, // 2099: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
-	1211, // 2100: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
-	1212, // 2101: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
-	1213, // 2102: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
-	1214, // 2103: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
-	1215, // 2104: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
-	1216, // 2105: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
-	1217, // 2106: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
-	1218, // 2107: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
-	783,  // 2108: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
-	778,  // 2109: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
-	778,  // 2110: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
-	794,  // 2111: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
-	788,  // 2112: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
-	787,  // 2113: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
-	796,  // 2114: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
-	791,  // 2115: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
-	788,  // 2116: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
-	886,  // 2117: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
-	776,  // 2118: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
-	1078, // 2119: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
-	889,  // 2120: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
-	892,  // 2121: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
-	895,  // 2122: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
-	903,  // 2123: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
-	905,  // 2124: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
-	901,  // 2125: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
-	912,  // 2126: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
-	914,  // 2127: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
-	918,  // 2128: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
-	931,  // 2129: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
-	931,  // 2130: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
-	931,  // 2131: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
-	937,  // 2132: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
-	939,  // 2133: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
-	941,  // 2134: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
-	943,  // 2135: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	943,  // 2136: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	948,  // 2137: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
-	1671, // [1671:2138] is the sub-list for method output_type
-	1204, // [1204:1671] is the sub-list for method input_type
-	1204, // [1204:1204] is the sub-list for extension type_name
-	1204, // [1204:1204] is the sub-list for extension extendee
-	0,    // [0:1204] is the sub-list for field type_name
+	82,   // 672: forge.ExpectedHostNic.role:type_name -> forge.ExpectedInterfaceRole
+	83,   // 673: forge.ExpectedHostNic.ip_allocation:type_name -> forge.ExpectedInterfaceIpAllocation
+	267,  // 674: forge.ExpectedMachine.metadata:type_name -> forge.Metadata
+	1017, // 675: forge.ExpectedMachine.id:type_name -> common.UUID
+	561,  // 676: forge.ExpectedMachine.host_nics:type_name -> forge.ExpectedHostNic
+	1016, // 677: forge.ExpectedMachine.rack_id:type_name -> common.RackId
+	51,   // 678: forge.ExpectedMachine.dpu_mode:type_name -> forge.DpuMode
+	562,  // 679: forge.ExpectedMachine.host_lifecycle_profile:type_name -> forge.HostLifecycleProfile
+	52,   // 680: forge.ExpectedMachine.bmc_ip_allocation:type_name -> forge.BmcIpAllocationType
+	1017, // 681: forge.ExpectedMachineRequest.id:type_name -> common.UUID
+	563,  // 682: forge.ExpectedMachineList.expected_machines:type_name -> forge.ExpectedMachine
+	567,  // 683: forge.LinkedExpectedMachineList.expected_machines:type_name -> forge.LinkedExpectedMachine
+	1007, // 684: forge.LinkedExpectedMachine.machine_id:type_name -> common.MachineId
+	1017, // 685: forge.LinkedExpectedMachine.expected_machine_id:type_name -> common.UUID
+	569,  // 686: forge.UnexpectedMachineList.unexpected_machines:type_name -> forge.UnexpectedMachine
+	1007, // 687: forge.UnexpectedMachine.machine_id:type_name -> common.MachineId
+	565,  // 688: forge.BatchExpectedMachineOperationRequest.expected_machines:type_name -> forge.ExpectedMachineList
+	1017, // 689: forge.ExpectedMachineOperationResult.id:type_name -> common.UUID
+	563,  // 690: forge.ExpectedMachineOperationResult.expected_machine:type_name -> forge.ExpectedMachine
+	571,  // 691: forge.BatchExpectedMachineOperationResponse.results:type_name -> forge.ExpectedMachineOperationResult
+	1007, // 692: forge.MachineRebootCompletedRequest.machine_id:type_name -> common.MachineId
+	1007, // 693: forge.ScoutFirmwareUpgradeStatusRequest.machine_id:type_name -> common.MachineId
+	1007, // 694: forge.MachineValidationCompletedRequest.machine_id:type_name -> common.MachineId
+	1034, // 695: forge.MachineValidationCompletedRequest.validation_id:type_name -> common.MachineValidationId
+	1008, // 696: forge.MachineValidationResult.start_time:type_name -> google.protobuf.Timestamp
+	1008, // 697: forge.MachineValidationResult.end_time:type_name -> google.protobuf.Timestamp
+	1034, // 698: forge.MachineValidationResult.validation_id:type_name -> common.MachineValidationId
+	578,  // 699: forge.MachineValidationResultPostRequest.result:type_name -> forge.MachineValidationResult
+	578,  // 700: forge.MachineValidationResultList.results:type_name -> forge.MachineValidationResult
+	1007, // 701: forge.MachineValidationGetRequest.machine_id:type_name -> common.MachineId
+	1034, // 702: forge.MachineValidationGetRequest.validation_id:type_name -> common.MachineValidationId
+	53,   // 703: forge.MachineValidationStatus.started:type_name -> forge.MachineValidationStarted
+	54,   // 704: forge.MachineValidationStatus.in_progress:type_name -> forge.MachineValidationInProgress
+	55,   // 705: forge.MachineValidationStatus.completed:type_name -> forge.MachineValidationCompleted
+	1034, // 706: forge.MachineValidationRun.validation_id:type_name -> common.MachineValidationId
+	1007, // 707: forge.MachineValidationRun.machine_id:type_name -> common.MachineId
+	1008, // 708: forge.MachineValidationRun.start_time:type_name -> google.protobuf.Timestamp
+	1008, // 709: forge.MachineValidationRun.end_time:type_name -> google.protobuf.Timestamp
+	582,  // 710: forge.MachineValidationRun.status:type_name -> forge.MachineValidationStatus
+	1030, // 711: forge.MachineValidationRun.duration_to_complete:type_name -> google.protobuf.Duration
+	1008, // 712: forge.MachineValidationRun.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1007, // 713: forge.MachineSetAutoUpdateRequest.machine_id:type_name -> common.MachineId
+	94,   // 714: forge.MachineSetAutoUpdateRequest.action:type_name -> forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
+	1008, // 715: forge.MachineValidationExternalConfig.timestamp:type_name -> google.protobuf.Timestamp
+	587,  // 716: forge.GetMachineValidationExternalConfigResponse.config:type_name -> forge.MachineValidationExternalConfig
+	587,  // 717: forge.GetMachineValidationExternalConfigsResponse.configs:type_name -> forge.MachineValidationExternalConfig
+	1007, // 718: forge.MachineValidationOnDemandRequest.machine_id:type_name -> common.MachineId
+	95,   // 719: forge.MachineValidationOnDemandRequest.action:type_name -> forge.MachineValidationOnDemandRequest.Action
+	1034, // 720: forge.MachineValidationOnDemandResponse.validation_id:type_name -> common.MachineValidationId
+	595,  // 721: forge.MaintenanceActivityConfig.firmware_upgrade:type_name -> forge.FirmwareUpgradeActivity
+	597,  // 722: forge.MaintenanceActivityConfig.configure_nmx_cluster:type_name -> forge.ConfigureNmxClusterActivity
+	598,  // 723: forge.MaintenanceActivityConfig.power_sequence:type_name -> forge.PowerSequenceActivity
+	596,  // 724: forge.MaintenanceActivityConfig.nvos_update:type_name -> forge.NvosUpdateActivity
+	599,  // 725: forge.RackMaintenanceScope.activities:type_name -> forge.MaintenanceActivityConfig
+	1016, // 726: forge.RackMaintenanceOnDemandRequest.rack_id:type_name -> common.RackId
+	600,  // 727: forge.RackMaintenanceOnDemandRequest.scope:type_name -> forge.RackMaintenanceScope
+	384,  // 728: forge.AdminPowerControlRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	96,   // 729: forge.AdminPowerControlRequest.action:type_name -> forge.AdminPowerControlRequest.SystemPowerControl
+	1007, // 730: forge.GetRedfishJobStateRequest.machine_id:type_name -> common.MachineId
+	97,   // 731: forge.GetRedfishJobStateResponse.job_state:type_name -> forge.GetRedfishJobStateResponse.RedfishJobState
+	583,  // 732: forge.MachineValidationRunList.runs:type_name -> forge.MachineValidationRun
+	1007, // 733: forge.MachineValidationRunListGetRequest.machine_id:type_name -> common.MachineId
+	1034, // 734: forge.MachineValidationRunItemSearchFilter.validation_id:type_name -> common.MachineValidationId
+	1017, // 735: forge.MachineValidationRunItemIdList.run_item_ids:type_name -> common.UUID
+	1017, // 736: forge.MachineValidationRunItemsByIdsRequest.run_item_ids:type_name -> common.UUID
+	613,  // 737: forge.MachineValidationRunItemList.run_items:type_name -> forge.MachineValidationRunItem
+	1017, // 738: forge.MachineValidationRunItem.run_item_id:type_name -> common.UUID
+	1034, // 739: forge.MachineValidationRunItem.validation_id:type_name -> common.MachineValidationId
+	1030, // 740: forge.MachineValidationRunItem.timeout:type_name -> google.protobuf.Duration
+	1008, // 741: forge.MachineValidationRunItem.started_at:type_name -> google.protobuf.Timestamp
+	1008, // 742: forge.MachineValidationRunItem.ended_at:type_name -> google.protobuf.Timestamp
+	1008, // 743: forge.MachineValidationRunItem.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1017, // 744: forge.MachineValidationRunItem.current_attempt_id:type_name -> common.UUID
+	1017, // 745: forge.MachineValidationAttemptGetRequest.attempt_id:type_name -> common.UUID
+	1017, // 746: forge.MachineValidationAttempt.attempt_id:type_name -> common.UUID
+	1017, // 747: forge.MachineValidationAttempt.run_item_id:type_name -> common.UUID
+	1008, // 748: forge.MachineValidationAttempt.started_at:type_name -> google.protobuf.Timestamp
+	1008, // 749: forge.MachineValidationAttempt.ended_at:type_name -> google.protobuf.Timestamp
+	1008, // 750: forge.MachineValidationAttempt.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1034, // 751: forge.MachineValidationHeartbeatRequest.validation_id:type_name -> common.MachineValidationId
+	1017, // 752: forge.MachineValidationHeartbeatRequest.run_item_id:type_name -> common.UUID
+	1017, // 753: forge.MachineValidationHeartbeatRequest.attempt_id:type_name -> common.UUID
+	1000, // 754: forge.MachineValidationTestUpdateRequest.payload:type_name -> forge.MachineValidationTestUpdateRequest.Payload
+	627,  // 755: forge.MachineValidationTestsGetResponse.tests:type_name -> forge.MachineValidationTest
+	1034, // 756: forge.MachineValidationRunRequest.validation_id:type_name -> common.MachineValidationId
+	1030, // 757: forge.MachineValidationRunRequest.duration_to_complete:type_name -> google.protobuf.Duration
+	627,  // 758: forge.MachineValidationRunRequest.selected_tests:type_name -> forge.MachineValidationTest
+	56,   // 759: forge.MachineCapabilityAttributesGpu.device_type:type_name -> forge.MachineCapabilityDeviceType
+	56,   // 760: forge.MachineCapabilityAttributesNetwork.device_type:type_name -> forge.MachineCapabilityDeviceType
+	634,  // 761: forge.MachineCapabilitiesSet.cpu:type_name -> forge.MachineCapabilityAttributesCpu
+	635,  // 762: forge.MachineCapabilitiesSet.gpu:type_name -> forge.MachineCapabilityAttributesGpu
+	636,  // 763: forge.MachineCapabilitiesSet.memory:type_name -> forge.MachineCapabilityAttributesMemory
+	637,  // 764: forge.MachineCapabilitiesSet.storage:type_name -> forge.MachineCapabilityAttributesStorage
+	638,  // 765: forge.MachineCapabilitiesSet.network:type_name -> forge.MachineCapabilityAttributesNetwork
+	639,  // 766: forge.MachineCapabilitiesSet.infiniband:type_name -> forge.MachineCapabilityAttributesInfiniband
+	640,  // 767: forge.MachineCapabilitiesSet.dpu:type_name -> forge.MachineCapabilityAttributesDpu
+	644,  // 768: forge.InstanceTypeAttributes.desired_capabilities:type_name -> forge.InstanceTypeMachineCapabilityFilterAttributes
+	642,  // 769: forge.InstanceType.attributes:type_name -> forge.InstanceTypeAttributes
+	267,  // 770: forge.InstanceType.metadata:type_name -> forge.Metadata
+	742,  // 771: forge.InstanceType.allocation_stats:type_name -> forge.InstanceTypeAllocationStats
+	57,   // 772: forge.InstanceTypeMachineCapabilityFilterAttributes.capability_type:type_name -> forge.MachineCapabilityType
+	1035, // 773: forge.InstanceTypeMachineCapabilityFilterAttributes.inactive_devices:type_name -> common.Uint32List
+	56,   // 774: forge.InstanceTypeMachineCapabilityFilterAttributes.device_type:type_name -> forge.MachineCapabilityDeviceType
+	267,  // 775: forge.CreateInstanceTypeRequest.metadata:type_name -> forge.Metadata
+	642,  // 776: forge.CreateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
+	643,  // 777: forge.CreateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
+	643,  // 778: forge.FindInstanceTypesByIdsResponse.instance_types:type_name -> forge.InstanceType
+	643,  // 779: forge.UpdateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
+	267,  // 780: forge.UpdateInstanceTypeRequest.metadata:type_name -> forge.Metadata
+	642,  // 781: forge.UpdateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
+	1001, // 782: forge.RedfishBrowseResponse.headers:type_name -> forge.RedfishBrowseResponse.HeadersEntry
+	663,  // 783: forge.RedfishListActionsResponse.actions:type_name -> forge.RedfishAction
+	1008, // 784: forge.RedfishAction.approver_dates:type_name -> google.protobuf.Timestamp
+	1008, // 785: forge.RedfishAction.applied_at:type_name -> google.protobuf.Timestamp
+	664,  // 786: forge.RedfishAction.results:type_name -> forge.OptionalRedfishActionResult
+	665,  // 787: forge.OptionalRedfishActionResult.result:type_name -> forge.RedfishActionResult
+	1002, // 788: forge.RedfishActionResult.headers:type_name -> forge.RedfishActionResult.HeadersEntry
+	1008, // 789: forge.RedfishActionResult.completed_at:type_name -> google.protobuf.Timestamp
+	1003, // 790: forge.UfmBrowseResponse.headers:type_name -> forge.UfmBrowseResponse.HeadersEntry
+	691,  // 791: forge.NetworkSecurityGroupAttributes.rules:type_name -> forge.NetworkSecurityGroupRuleAttributes
+	267,  // 792: forge.NetworkSecurityGroup.metadata:type_name -> forge.Metadata
+	674,  // 793: forge.NetworkSecurityGroup.attributes:type_name -> forge.NetworkSecurityGroupAttributes
+	267,  // 794: forge.CreateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
+	674,  // 795: forge.CreateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
+	675,  // 796: forge.CreateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
+	675,  // 797: forge.FindNetworkSecurityGroupsByIdsResponse.network_security_groups:type_name -> forge.NetworkSecurityGroup
+	675,  // 798: forge.UpdateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
+	267,  // 799: forge.UpdateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
+	674,  // 800: forge.UpdateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
+	58,   // 801: forge.NetworkSecurityGroupStatus.source:type_name -> forge.NetworkSecurityGroupSource
+	59,   // 802: forge.NetworkSecurityGroupPropagationObjectStatus.status:type_name -> forge.NetworkSecurityGroupPropagationStatus
+	687,  // 803: forge.GetNetworkSecurityGroupPropagationStatusResponse.vpcs:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	687,  // 804: forge.GetNetworkSecurityGroupPropagationStatusResponse.instances:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	689,  // 805: forge.GetNetworkSecurityGroupPropagationStatusRequest.network_security_group_ids:type_name -> forge.NetworkSecurityGroupIdList
+	60,   // 806: forge.NetworkSecurityGroupRuleAttributes.direction:type_name -> forge.NetworkSecurityGroupRuleDirection
+	61,   // 807: forge.NetworkSecurityGroupRuleAttributes.protocol:type_name -> forge.NetworkSecurityGroupRuleProtocol
+	62,   // 808: forge.NetworkSecurityGroupRuleAttributes.action:type_name -> forge.NetworkSecurityGroupRuleAction
+	691,  // 809: forge.ResolvedNetworkSecurityGroupRule.rule:type_name -> forge.NetworkSecurityGroupRuleAttributes
+	694,  // 810: forge.GetNetworkSecurityGroupAttachmentsResponse.attachments:type_name -> forge.NetworkSecurityGroupAttachments
+	698,  // 811: forge.GetDesiredFirmwareVersionsResponse.entries:type_name -> forge.DesiredFirmwareVersionEntry
+	1004, // 812: forge.DesiredFirmwareVersionEntry.component_versions:type_name -> forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
+	699,  // 813: forge.SkuComponents.chassis:type_name -> forge.SkuComponentChassis
+	700,  // 814: forge.SkuComponents.cpus:type_name -> forge.SkuComponentCpu
+	701,  // 815: forge.SkuComponents.gpus:type_name -> forge.SkuComponentGpu
+	702,  // 816: forge.SkuComponents.ethernet_devices:type_name -> forge.SkuComponentEthernetDevices
+	703,  // 817: forge.SkuComponents.infiniband_devices:type_name -> forge.SkuComponentInfinibandDevices
+	704,  // 818: forge.SkuComponents.storage:type_name -> forge.SkuComponentStorage
+	706,  // 819: forge.SkuComponents.memory:type_name -> forge.SkuComponentMemory
+	707,  // 820: forge.SkuComponents.tpm:type_name -> forge.SkuComponentTpm
+	1008, // 821: forge.Sku.created:type_name -> google.protobuf.Timestamp
+	708,  // 822: forge.Sku.components:type_name -> forge.SkuComponents
+	1007, // 823: forge.Sku.associated_machine_ids:type_name -> common.MachineId
+	1007, // 824: forge.SkuMachinePair.machine_id:type_name -> common.MachineId
+	1007, // 825: forge.RemoveSkuRequest.machine_id:type_name -> common.MachineId
+	709,  // 826: forge.SkuList.skus:type_name -> forge.Sku
+	1008, // 827: forge.SkuStatus.verify_request_time:type_name -> google.protobuf.Timestamp
+	1008, // 828: forge.SkuStatus.last_match_attempt:type_name -> google.protobuf.Timestamp
+	1008, // 829: forge.SkuStatus.last_generate_attempt:type_name -> google.protobuf.Timestamp
+	1036, // 830: forge.DpaInterface.id:type_name -> common.DpaInterfaceId
+	1007, // 831: forge.DpaInterface.machine_id:type_name -> common.MachineId
+	1008, // 832: forge.DpaInterface.created:type_name -> google.protobuf.Timestamp
+	1008, // 833: forge.DpaInterface.updated:type_name -> google.protobuf.Timestamp
+	1008, // 834: forge.DpaInterface.deleted:type_name -> google.protobuf.Timestamp
+	231,  // 835: forge.DpaInterface.history:type_name -> forge.StateHistoryRecord
+	1008, // 836: forge.DpaInterface.last_hb_time:type_name -> google.protobuf.Timestamp
+	63,   // 837: forge.DpaInterface.interface_type:type_name -> forge.DpaInterfaceType
+	1007, // 838: forge.DpaInterfaceCreationRequest.machine_id:type_name -> common.MachineId
+	63,   // 839: forge.DpaInterfaceCreationRequest.interface_type:type_name -> forge.DpaInterfaceType
+	1036, // 840: forge.DpaInterfaceIdList.ids:type_name -> common.DpaInterfaceId
+	1036, // 841: forge.DpaInterfacesByIdsRequest.ids:type_name -> common.DpaInterfaceId
+	717,  // 842: forge.DpaInterfaceList.interfaces:type_name -> forge.DpaInterface
+	1036, // 843: forge.DpaNetworkObservationSetRequest.id:type_name -> common.DpaInterfaceId
+	1036, // 844: forge.DpaInterfaceDeletionRequest.id:type_name -> common.DpaInterfaceId
+	1007, // 845: forge.PowerOptionRequest.machine_id:type_name -> common.MachineId
+	1007, // 846: forge.PowerOptionUpdateRequest.machine_id:type_name -> common.MachineId
+	64,   // 847: forge.PowerOptionUpdateRequest.power_state:type_name -> forge.PowerState
+	64,   // 848: forge.PowerOptions.desired_state:type_name -> forge.PowerState
+	1008, // 849: forge.PowerOptions.desired_state_updated_at:type_name -> google.protobuf.Timestamp
+	64,   // 850: forge.PowerOptions.actual_state:type_name -> forge.PowerState
+	1008, // 851: forge.PowerOptions.actual_state_updated_at:type_name -> google.protobuf.Timestamp
+	1007, // 852: forge.PowerOptions.host_id:type_name -> common.MachineId
+	1008, // 853: forge.PowerOptions.next_power_state_fetch_at:type_name -> google.protobuf.Timestamp
+	1008, // 854: forge.PowerOptions.tried_triggering_on_at:type_name -> google.protobuf.Timestamp
+	1008, // 855: forge.PowerOptions.wait_until_time_before_performing_next_power_action:type_name -> google.protobuf.Timestamp
+	728,  // 856: forge.PowerOptionResponse.response:type_name -> forge.PowerOptions
+	1037, // 857: forge.ComputeAllocation.id:type_name -> common.ComputeAllocationId
+	730,  // 858: forge.ComputeAllocation.attributes:type_name -> forge.ComputeAllocationAttributes
+	267,  // 859: forge.ComputeAllocation.metadata:type_name -> forge.Metadata
+	1037, // 860: forge.CreateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	267,  // 861: forge.CreateComputeAllocationRequest.metadata:type_name -> forge.Metadata
+	730,  // 862: forge.CreateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
+	731,  // 863: forge.CreateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
+	1037, // 864: forge.FindComputeAllocationIdsResponse.ids:type_name -> common.ComputeAllocationId
+	1037, // 865: forge.FindComputeAllocationsByIdsRequest.ids:type_name -> common.ComputeAllocationId
+	731,  // 866: forge.FindComputeAllocationsByIdsResponse.allocations:type_name -> forge.ComputeAllocation
+	731,  // 867: forge.UpdateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
+	1037, // 868: forge.UpdateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	267,  // 869: forge.UpdateComputeAllocationRequest.metadata:type_name -> forge.Metadata
+	730,  // 870: forge.UpdateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
+	1037, // 871: forge.DeleteComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	749,  // 872: forge.GetRackResponse.rack:type_name -> forge.Rack
+	749,  // 873: forge.RackList.racks:type_name -> forge.Rack
+	266,  // 874: forge.RackSearchFilter.label:type_name -> forge.Label
+	1016, // 875: forge.RackIdList.rack_ids:type_name -> common.RackId
+	1016, // 876: forge.RacksByIdsRequest.rack_ids:type_name -> common.RackId
+	1016, // 877: forge.Rack.id:type_name -> common.RackId
+	1008, // 878: forge.Rack.created:type_name -> google.protobuf.Timestamp
+	1008, // 879: forge.Rack.updated:type_name -> google.protobuf.Timestamp
+	1008, // 880: forge.Rack.deleted:type_name -> google.protobuf.Timestamp
+	267,  // 881: forge.Rack.metadata:type_name -> forge.Metadata
+	750,  // 882: forge.Rack.config:type_name -> forge.RackConfig
+	751,  // 883: forge.Rack.status:type_name -> forge.RackStatus
+	1014, // 884: forge.RackStatus.health:type_name -> health.HealthReport
+	357,  // 885: forge.RackStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	98,   // 886: forge.RackStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1016, // 887: forge.RackStateHistoriesRequest.rack_ids:type_name -> common.RackId
+	1016, // 888: forge.AdminForceDeleteRackRequest.rack_id:type_name -> common.RackId
+	756,  // 889: forge.RackCapabilitiesSet.compute:type_name -> forge.RackCapabilityCompute
+	757,  // 890: forge.RackCapabilitiesSet.switch:type_name -> forge.RackCapabilitySwitch
+	758,  // 891: forge.RackCapabilitiesSet.power_shelf:type_name -> forge.RackCapabilityPowerShelf
+	1038, // 892: forge.RackProfile.rack_hardware_type:type_name -> common.RackHardwareType
+	65,   // 893: forge.RackProfile.rack_hardware_topology:type_name -> forge.RackHardwareTopology
+	67,   // 894: forge.RackProfile.rack_hardware_class:type_name -> forge.RackHardwareClass
+	759,  // 895: forge.RackProfile.capabilities:type_name -> forge.RackCapabilitiesSet
+	66,   // 896: forge.RackProfile.product_family:type_name -> forge.RackProductFamily
+	1016, // 897: forge.GetRackProfileRequest.rack_id:type_name -> common.RackId
+	1016, // 898: forge.GetRackProfileResponse.rack_id:type_name -> common.RackId
+	1019, // 899: forge.GetRackProfileResponse.rack_profile_id:type_name -> common.RackProfileId
+	760,  // 900: forge.GetRackProfileResponse.profile:type_name -> forge.RackProfile
+	68,   // 901: forge.RackManagerForgeRequest.cmd:type_name -> forge.RackManagerForgeCmd
+	1027, // 902: forge.MachineNVLinkInfo.domain_uuid:type_name -> common.NVLinkDomainId
+	774,  // 903: forge.MachineNVLinkInfo.gpus:type_name -> forge.NVLinkGpu
+	1007, // 904: forge.UpdateMachineNvLinkInfoRequest.machine_id:type_name -> common.MachineId
+	765,  // 905: forge.UpdateMachineNvLinkInfoRequest.nvlink_info:type_name -> forge.MachineNVLinkInfo
+	768,  // 906: forge.MachineSpxStatusObservation.attachment_status:type_name -> forge.MachineSpxAttachmentStatusObservation
+	1008, // 907: forge.MachineSpxStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1026, // 908: forge.MachineSpxAttachmentStatusObservation.partition_id:type_name -> common.SpxPartitionId
+	16,   // 909: forge.MachineSpxAttachmentStatusObservation.attachment_type:type_name -> forge.SpxAttachmentType
+	1008, // 910: forge.MachineSpxAttachmentStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	770,  // 911: forge.AstraConfig.astra_attachments:type_name -> forge.AstraAttachment
+	16,   // 912: forge.AstraAttachment.attachment_type:type_name -> forge.SpxAttachmentType
+	772,  // 913: forge.AstraConfigStatus.astra_attachments_status:type_name -> forge.AstraAttachmentStatus
+	16,   // 914: forge.AstraAttachmentStatus.attachment_type:type_name -> forge.SpxAttachmentType
+	773,  // 915: forge.AstraAttachmentStatus.status:type_name -> forge.AstraStatus
+	69,   // 916: forge.AstraStatus.phase:type_name -> forge.AstraPhase
+	776,  // 917: forge.MachineNVLinkStatusObservation.gpu_status:type_name -> forge.MachineNVLinkGpuStatusObservation
+	1039, // 918: forge.MachineNVLinkGpuStatusObservation.partition_id:type_name -> common.NVLinkPartitionId
+	1010, // 919: forge.MachineNVLinkGpuStatusObservation.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1027, // 920: forge.MachineNVLinkGpuStatusObservation.domain_id:type_name -> common.NVLinkDomainId
+	70,   // 921: forge.NmxcBrowseRequest.operation:type_name -> forge.NmxcBrowseOperation
+	1005, // 922: forge.NmxcBrowseResponse.headers:type_name -> forge.NmxcBrowseResponse.HeadersEntry
+	1039, // 923: forge.NVLinkPartition.id:type_name -> common.NVLinkPartitionId
+	1027, // 924: forge.NVLinkPartition.domain_uuid:type_name -> common.NVLinkDomainId
+	1010, // 925: forge.NVLinkPartition.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	779,  // 926: forge.NVLinkPartitionList.partitions:type_name -> forge.NVLinkPartition
+	1017, // 927: forge.NVLinkPartitionQuery.id:type_name -> common.UUID
+	781,  // 928: forge.NVLinkPartitionQuery.search_config:type_name -> forge.NVLinkPartitionSearchConfig
+	1039, // 929: forge.NVLinkPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkPartitionId
+	1039, // 930: forge.NVLinkPartitionIdList.partition_ids:type_name -> common.NVLinkPartitionId
+	267,  // 931: forge.NVLinkLogicalPartitionConfig.metadata:type_name -> forge.Metadata
+	8,    // 932: forge.NVLinkLogicalPartitionStatus.state:type_name -> forge.TenantState
+	1010, // 933: forge.NVLinkLogicalPartition.id:type_name -> common.NVLinkLogicalPartitionId
+	787,  // 934: forge.NVLinkLogicalPartition.config:type_name -> forge.NVLinkLogicalPartitionConfig
+	788,  // 935: forge.NVLinkLogicalPartition.status:type_name -> forge.NVLinkLogicalPartitionStatus
+	1008, // 936: forge.NVLinkLogicalPartition.created:type_name -> google.protobuf.Timestamp
+	789,  // 937: forge.NVLinkLogicalPartitionList.partitions:type_name -> forge.NVLinkLogicalPartition
+	787,  // 938: forge.NVLinkLogicalPartitionCreationRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
+	1010, // 939: forge.NVLinkLogicalPartitionCreationRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1010, // 940: forge.NVLinkLogicalPartitionDeletionRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1010, // 941: forge.NVLinkLogicalPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkLogicalPartitionId
+	1010, // 942: forge.NVLinkLogicalPartitionIdList.partition_ids:type_name -> common.NVLinkLogicalPartitionId
+	1010, // 943: forge.NVLinkLogicalPartitionUpdateRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	787,  // 944: forge.NVLinkLogicalPartitionUpdateRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
+	384,  // 945: forge.CreateBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 946: forge.DeleteBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 947: forge.SetBmcRootPasswordRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	384,  // 948: forge.ProbeBmcVendorRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1007, // 949: forge.SetFirmwareUpdateTimeWindowRequest.machine_ids:type_name -> common.MachineId
+	1008, // 950: forge.SetFirmwareUpdateTimeWindowRequest.start_timestamp:type_name -> google.protobuf.Timestamp
+	1008, // 951: forge.SetFirmwareUpdateTimeWindowRequest.end_timestamp:type_name -> google.protobuf.Timestamp
+	811,  // 952: forge.UpsertHostFirmwareConfigRequest.components:type_name -> forge.UpsertHostFirmwareComponentConfig
+	71,   // 953: forge.UpsertHostFirmwareConfigRequest.ordering:type_name -> forge.HostFirmwareComponentType
+	71,   // 954: forge.UpsertHostFirmwareComponentConfig.type:type_name -> forge.HostFirmwareComponentType
+	813,  // 955: forge.UpsertHostFirmwareComponentConfig.firmware:type_name -> forge.HostFirmwareVersionConfig
+	71,   // 956: forge.HostFirmwareComponentConfigResponse.type:type_name -> forge.HostFirmwareComponentType
+	813,  // 957: forge.HostFirmwareComponentConfigResponse.firmware:type_name -> forge.HostFirmwareVersionConfig
+	814,  // 958: forge.HostFirmwareVersionConfig.artifacts:type_name -> forge.HostFirmwareArtifact
+	812,  // 959: forge.HostFirmwareConfigResponse.components:type_name -> forge.HostFirmwareComponentConfigResponse
+	71,   // 960: forge.HostFirmwareConfigResponse.ordering:type_name -> forge.HostFirmwareComponentType
+	1008, // 961: forge.HostFirmwareConfigResponse.created_at:type_name -> google.protobuf.Timestamp
+	1008, // 962: forge.HostFirmwareConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
+	818,  // 963: forge.ListHostFirmwareResponse.available:type_name -> forge.AvailableHostFirmware
+	72,   // 964: forge.TrimTableRequest.target:type_name -> forge.TrimTableTarget
+	821,  // 965: forge.NvlinkNmxcEndpointList.entries:type_name -> forge.NvlinkNmxcEndpoint
+	267,  // 966: forge.CreateRemediationRequest.metadata:type_name -> forge.Metadata
+	1040, // 967: forge.CreateRemediationResponse.remediation_id:type_name -> common.RemediationId
+	1040, // 968: forge.RemediationIdList.remediation_ids:type_name -> common.RemediationId
+	828,  // 969: forge.RemediationList.remediations:type_name -> forge.Remediation
+	1040, // 970: forge.Remediation.id:type_name -> common.RemediationId
+	267,  // 971: forge.Remediation.metadata:type_name -> forge.Metadata
+	1008, // 972: forge.Remediation.creation_time:type_name -> google.protobuf.Timestamp
+	1040, // 973: forge.ApproveRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1040, // 974: forge.RevokeRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1040, // 975: forge.EnableRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1040, // 976: forge.DisableRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1040, // 977: forge.FindAppliedRemediationIdsRequest.remediation_id:type_name -> common.RemediationId
+	1007, // 978: forge.FindAppliedRemediationIdsRequest.dpu_machine_id:type_name -> common.MachineId
+	1040, // 979: forge.AppliedRemediationIdList.remediation_ids:type_name -> common.RemediationId
+	1007, // 980: forge.AppliedRemediationIdList.dpu_machine_ids:type_name -> common.MachineId
+	1040, // 981: forge.FindAppliedRemediationsRequest.remediation_id:type_name -> common.RemediationId
+	1007, // 982: forge.FindAppliedRemediationsRequest.dpu_machine_id:type_name -> common.MachineId
+	1040, // 983: forge.AppliedRemediation.remediation_id:type_name -> common.RemediationId
+	1007, // 984: forge.AppliedRemediation.dpu_machine_id:type_name -> common.MachineId
+	1008, // 985: forge.AppliedRemediation.applied_time:type_name -> google.protobuf.Timestamp
+	267,  // 986: forge.AppliedRemediation.metadata:type_name -> forge.Metadata
+	836,  // 987: forge.AppliedRemediationList.applied_remediations:type_name -> forge.AppliedRemediation
+	1007, // 988: forge.GetNextRemediationForMachineRequest.dpu_machine_id:type_name -> common.MachineId
+	1040, // 989: forge.GetNextRemediationForMachineResponse.remediation_id:type_name -> common.RemediationId
+	1040, // 990: forge.RemediationAppliedRequest.remediation_id:type_name -> common.RemediationId
+	1007, // 991: forge.RemediationAppliedRequest.dpu_machine_id:type_name -> common.MachineId
+	841,  // 992: forge.RemediationAppliedRequest.status:type_name -> forge.RemediationApplicationStatus
+	267,  // 993: forge.RemediationApplicationStatus.metadata:type_name -> forge.Metadata
+	1007, // 994: forge.SetPrimaryDpuRequest.host_machine_id:type_name -> common.MachineId
+	1007, // 995: forge.SetPrimaryDpuRequest.dpu_machine_id:type_name -> common.MachineId
+	1007, // 996: forge.SetPrimaryInterfaceRequest.host_machine_id:type_name -> common.MachineId
+	1028, // 997: forge.SetPrimaryInterfaceRequest.interface_id:type_name -> common.MachineInterfaceId
+	844,  // 998: forge.DpuExtensionServiceCredential.username_password:type_name -> forge.UsernamePassword
+	865,  // 999: forge.DpuExtensionServiceVersionInfo.observability:type_name -> forge.DpuExtensionServiceObservability
+	73,   // 1000: forge.DpuExtensionService.service_type:type_name -> forge.DpuExtensionServiceType
+	847,  // 1001: forge.DpuExtensionService.latest_version_info:type_name -> forge.DpuExtensionServiceVersionInfo
+	73,   // 1002: forge.CreateDpuExtensionServiceRequest.service_type:type_name -> forge.DpuExtensionServiceType
+	846,  // 1003: forge.CreateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
+	865,  // 1004: forge.CreateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
+	846,  // 1005: forge.UpdateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
+	865,  // 1006: forge.UpdateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
+	73,   // 1007: forge.DpuExtensionServiceSearchFilter.service_type:type_name -> forge.DpuExtensionServiceType
+	848,  // 1008: forge.DpuExtensionServiceList.services:type_name -> forge.DpuExtensionService
+	847,  // 1009: forge.DpuExtensionServiceVersionInfoList.version_infos:type_name -> forge.DpuExtensionServiceVersionInfo
+	861,  // 1010: forge.FindInstancesByDpuExtensionServiceResponse.instances:type_name -> forge.InstanceDpuExtensionServiceInfo
+	862,  // 1011: forge.DpuExtensionServiceObservabilityConfig.prometheus:type_name -> forge.DpuExtensionServiceObservabilityConfigPrometheus
+	863,  // 1012: forge.DpuExtensionServiceObservabilityConfig.logging:type_name -> forge.DpuExtensionServiceObservabilityConfigLogging
+	864,  // 1013: forge.DpuExtensionServiceObservability.configs:type_name -> forge.DpuExtensionServiceObservabilityConfig
+	1017, // 1014: forge.ScoutStreamApiBoundMessage.flow_uuid:type_name -> common.UUID
+	868,  // 1015: forge.ScoutStreamApiBoundMessage.init:type_name -> forge.ScoutStreamInitRequest
+	1041, // 1016: forge.ScoutStreamApiBoundMessage.mlx_device_lockdown_response:type_name -> mlx_device.MlxDeviceLockdownResponse
+	1042, // 1017: forge.ScoutStreamApiBoundMessage.mlx_device_profile_sync_response:type_name -> mlx_device.MlxDeviceProfileSyncResponse
+	1043, // 1018: forge.ScoutStreamApiBoundMessage.mlx_device_profile_compare_response:type_name -> mlx_device.MlxDeviceProfileCompareResponse
+	1044, // 1019: forge.ScoutStreamApiBoundMessage.mlx_device_info_device_response:type_name -> mlx_device.MlxDeviceInfoDeviceResponse
+	1045, // 1020: forge.ScoutStreamApiBoundMessage.mlx_device_info_report_response:type_name -> mlx_device.MlxDeviceInfoReportResponse
+	1046, // 1021: forge.ScoutStreamApiBoundMessage.mlx_device_registry_list_response:type_name -> mlx_device.MlxDeviceRegistryListResponse
+	1047, // 1022: forge.ScoutStreamApiBoundMessage.mlx_device_registry_show_response:type_name -> mlx_device.MlxDeviceRegistryShowResponse
+	1048, // 1023: forge.ScoutStreamApiBoundMessage.mlx_device_config_query_response:type_name -> mlx_device.MlxDeviceConfigQueryResponse
+	1049, // 1024: forge.ScoutStreamApiBoundMessage.mlx_device_config_set_response:type_name -> mlx_device.MlxDeviceConfigSetResponse
+	1050, // 1025: forge.ScoutStreamApiBoundMessage.mlx_device_config_sync_response:type_name -> mlx_device.MlxDeviceConfigSyncResponse
+	1051, // 1026: forge.ScoutStreamApiBoundMessage.mlx_device_config_compare_response:type_name -> mlx_device.MlxDeviceConfigCompareResponse
+	876,  // 1027: forge.ScoutStreamApiBoundMessage.scout_stream_agent_ping_response:type_name -> forge.ScoutStreamAgentPingResponse
+	1017, // 1028: forge.ScoutStreamScoutBoundMessage.flow_uuid:type_name -> common.UUID
+	1052, // 1029: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_lock_request:type_name -> mlx_device.MlxDeviceLockdownLockRequest
+	1053, // 1030: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_unlock_request:type_name -> mlx_device.MlxDeviceLockdownUnlockRequest
+	1054, // 1031: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_status_request:type_name -> mlx_device.MlxDeviceLockdownStatusRequest
+	1055, // 1032: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_sync_request:type_name -> mlx_device.MlxDeviceProfileSyncRequest
+	1056, // 1033: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_compare_request:type_name -> mlx_device.MlxDeviceProfileCompareRequest
+	1057, // 1034: forge.ScoutStreamScoutBoundMessage.mlx_device_info_device_request:type_name -> mlx_device.MlxDeviceInfoDeviceRequest
+	1058, // 1035: forge.ScoutStreamScoutBoundMessage.mlx_device_info_report_request:type_name -> mlx_device.MlxDeviceInfoReportRequest
+	1059, // 1036: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_list_request:type_name -> mlx_device.MlxDeviceRegistryListRequest
+	1060, // 1037: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_show_request:type_name -> mlx_device.MlxDeviceRegistryShowRequest
+	1061, // 1038: forge.ScoutStreamScoutBoundMessage.mlx_device_config_query_request:type_name -> mlx_device.MlxDeviceConfigQueryRequest
+	1062, // 1039: forge.ScoutStreamScoutBoundMessage.mlx_device_config_set_request:type_name -> mlx_device.MlxDeviceConfigSetRequest
+	1063, // 1040: forge.ScoutStreamScoutBoundMessage.mlx_device_config_sync_request:type_name -> mlx_device.MlxDeviceConfigSyncRequest
+	1064, // 1041: forge.ScoutStreamScoutBoundMessage.mlx_device_config_compare_request:type_name -> mlx_device.MlxDeviceConfigCompareRequest
+	875,  // 1042: forge.ScoutStreamScoutBoundMessage.scout_stream_agent_ping_request:type_name -> forge.ScoutStreamAgentPingRequest
+	1007, // 1043: forge.ScoutStreamInitRequest.machine_id:type_name -> common.MachineId
+	877,  // 1044: forge.ScoutStreamShowConnectionsResponse.scout_stream_connections:type_name -> forge.ScoutStreamConnectionInfo
+	1007, // 1045: forge.ScoutStreamDisconnectRequest.machine_id:type_name -> common.MachineId
+	1007, // 1046: forge.ScoutStreamDisconnectResponse.machine_id:type_name -> common.MachineId
+	1007, // 1047: forge.ScoutStreamAdminPingRequest.machine_id:type_name -> common.MachineId
+	878,  // 1048: forge.ScoutStreamAgentPingResponse.error:type_name -> forge.ScoutStreamError
+	1007, // 1049: forge.ScoutStreamConnectionInfo.machine_id:type_name -> common.MachineId
+	75,   // 1050: forge.ScoutStreamError.status:type_name -> forge.ScoutStreamErrorStatus
+	1033, // 1051: forge.RoutingProfile.route_target_imports:type_name -> common.RouteTarget
+	1033, // 1052: forge.RoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
+	879,  // 1053: forge.RoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
+	879,  // 1054: forge.RoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	1020, // 1055: forge.DomainLegacy.id:type_name -> common.DomainId
+	1008, // 1056: forge.DomainLegacy.created:type_name -> google.protobuf.Timestamp
+	1008, // 1057: forge.DomainLegacy.updated:type_name -> google.protobuf.Timestamp
+	1008, // 1058: forge.DomainLegacy.deleted:type_name -> google.protobuf.Timestamp
+	881,  // 1059: forge.DomainListLegacy.domains:type_name -> forge.DomainLegacy
+	1020, // 1060: forge.DomainDeletionLegacy.id:type_name -> common.DomainId
+	1020, // 1061: forge.DomainSearchQueryLegacy.id:type_name -> common.DomainId
+	1065, // 1062: forge.PxeDomain.new_domain:type_name -> dns.Domain
+	881,  // 1063: forge.PxeDomain.legacy_domain:type_name -> forge.DomainLegacy
+	1007, // 1064: forge.MachinePositionQuery.machine_ids:type_name -> common.MachineId
+	889,  // 1065: forge.MachinePositionInfoList.machine_position_info:type_name -> forge.MachinePositionInfo
+	1007, // 1066: forge.MachinePositionInfo.machine_id:type_name -> common.MachineId
+	1018, // 1067: forge.MachinePositionInfo.switch_id:type_name -> common.SwitchId
+	1015, // 1068: forge.MachinePositionInfo.power_shelf_id:type_name -> common.PowerShelfId
+	1007, // 1069: forge.ModifyDPFStateRequest.machine_id:type_name -> common.MachineId
+	1006, // 1070: forge.DPFStateResponse.dpf_states:type_name -> forge.DPFStateResponse.DPFState
+	1007, // 1071: forge.GetDPFStateRequest.machine_ids:type_name -> common.MachineId
+	1007, // 1072: forge.GetDPFHostSnapshotRequest.host_machine_id:type_name -> common.MachineId
+	896,  // 1073: forge.DPFServiceVersionsResponse.services:type_name -> forge.DPFServiceVersion
+	76,   // 1074: forge.ComponentResult.status:type_name -> forge.ComponentManagerStatusCode
+	1018, // 1075: forge.SwitchIdList.ids:type_name -> common.SwitchId
+	1015, // 1076: forge.PowerShelfIdList.ids:type_name -> common.PowerShelfId
+	1066, // 1077: forge.GetComponentInventoryRequest.machine_ids:type_name -> common.MachineIdList
+	899,  // 1078: forge.GetComponentInventoryRequest.switch_ids:type_name -> forge.SwitchIdList
+	900,  // 1079: forge.GetComponentInventoryRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	898,  // 1080: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
+	1067, // 1081: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
+	902,  // 1082: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
+	1066, // 1083: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
+	899,  // 1084: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
+	900,  // 1085: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	1068, // 1086: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
+	898,  // 1087: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
+	899,  // 1088: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
+	898,  // 1089: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
+	898,  // 1090: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
+	77,   // 1091: forge.FirmwareUpdateStatus.state:type_name -> forge.FirmwareUpdateState
+	1008, // 1092: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
+	1066, // 1093: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
+	80,   // 1094: forge.UpdateComputeTrayFirmwareTarget.components:type_name -> forge.ComputeTrayComponent
+	899,  // 1095: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
+	78,   // 1096: forge.UpdateSwitchFirmwareTarget.components:type_name -> forge.NvSwitchComponent
+	900,  // 1097: forge.UpdatePowerShelfFirmwareTarget.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	79,   // 1098: forge.UpdatePowerShelfFirmwareTarget.components:type_name -> forge.PowerShelfComponent
+	747,  // 1099: forge.UpdateFirmwareObjectTarget.rack_ids:type_name -> forge.RackIdList
+	909,  // 1100: forge.UpdateComponentFirmwareRequest.compute_trays:type_name -> forge.UpdateComputeTrayFirmwareTarget
+	910,  // 1101: forge.UpdateComponentFirmwareRequest.switches:type_name -> forge.UpdateSwitchFirmwareTarget
+	911,  // 1102: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
+	912,  // 1103: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
+	898,  // 1104: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
+	1066, // 1105: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
+	899,  // 1106: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
+	900,  // 1107: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	747,  // 1108: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
+	908,  // 1109: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
+	1066, // 1110: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
+	899,  // 1111: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
+	900,  // 1112: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	747,  // 1113: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
+	80,   // 1114: forge.ComputeTrayFirmwareVersions.component:type_name -> forge.ComputeTrayComponent
+	898,  // 1115: forge.DeviceFirmwareVersions.result:type_name -> forge.ComponentResult
+	918,  // 1116: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
+	919,  // 1117: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
+	267,  // 1118: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
+	1026, // 1119: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
+	267,  // 1120: forge.SpxPartition.metadata:type_name -> forge.Metadata
+	1026, // 1121: forge.SpxPartition.id:type_name -> common.SpxPartitionId
+	1026, // 1122: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
+	1026, // 1123: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
+	266,  // 1124: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
+	922,  // 1125: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
+	1026, // 1126: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
+	1018, // 1127: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
+	1015, // 1128: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1025, // 1129: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
+	81,   // 1130: forge.OperatingSystem.type:type_name -> forge.OperatingSystemType
+	8,    // 1131: forge.OperatingSystem.status:type_name -> forge.TenantState
+	1024, // 1132: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
+	274,  // 1133: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
+	275,  // 1134: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
+	1025, // 1135: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1024, // 1136: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	274,  // 1137: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
+	275,  // 1138: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
+	274,  // 1139: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
+	275,  // 1140: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
+	1025, // 1141: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1024, // 1142: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	935,  // 1143: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
+	936,  // 1144: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
+	1025, // 1145: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1025, // 1146: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
+	1025, // 1147: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
+	933,  // 1148: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
+	1025, // 1149: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
+	275,  // 1150: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
+	1025, // 1151: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
+	946,  // 1152: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
+	1007, // 1153: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
+	1028, // 1154: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
+	1008, // 1155: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
+	1007, // 1156: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
+	953,  // 1157: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
+	954,  // 1158: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
+	955,  // 1159: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
+	956,  // 1160: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
+	952,  // 1161: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
+	952,  // 1162: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
+	1069, // 1163: forge.SitePrefix.id:type_name -> common.SitePrefixId
+	962,  // 1164: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
+	963,  // 1165: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
+	267,  // 1166: forge.SitePrefix.metadata:type_name -> forge.Metadata
+	1008, // 1167: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
+	1008, // 1168: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
+	85,   // 1169: forge.SitePrefixConfig.routing_scope:type_name -> forge.SitePrefixRoutingScope
+	84,   // 1170: forge.SitePrefixStatus.authority:type_name -> forge.SitePrefixAuthority
+	86,   // 1171: forge.SitePrefixStatus.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
+	84,   // 1172: forge.SitePrefixSearchFilter.authority:type_name -> forge.SitePrefixAuthority
+	85,   // 1173: forge.SitePrefixSearchFilter.routing_scope:type_name -> forge.SitePrefixRoutingScope
+	86,   // 1174: forge.SitePrefixSearchFilter.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
+	7,    // 1175: forge.SitePrefixSearchFilter.prefix_match_type:type_name -> forge.PrefixMatchType
+	1069, // 1176: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
+	1069, // 1177: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
+	961,  // 1178: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
+	971,  // 1179: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
+	232,  // 1180: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
+	323,  // 1181: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
+	326,  // 1182: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
+	948,  // 1183: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry.value:type_name -> forge.HostRepresentorInterceptBridging
+	89,   // 1184: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
+	996,  // 1185: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	1034, // 1186: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
+	987,  // 1187: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
+	1031, // 1188: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
+	989,  // 1189: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
+	990,  // 1190: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
+	991,  // 1191: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
+	992,  // 1192: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	993,  // 1193: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	994,  // 1194: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	1070, // 1195: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
+	1071, // 1196: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
+	1072, // 1197: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	91,   // 1198: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
+	1007, // 1199: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
+	1008, // 1200: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1008, // 1201: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	1007, // 1202: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
+	1008, // 1203: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1008, // 1204: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	1007, // 1205: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
+	146,  // 1206: forge.Forge.Version:input_type -> forge.VersionRequest
+	1073, // 1207: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
+	1074, // 1208: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
+	1075, // 1209: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
+	1076, // 1210: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
+	881,  // 1211: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
+	881,  // 1212: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
+	883,  // 1213: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
+	885,  // 1214: forge.Forge.FindDomainLegacy:input_type -> forge.DomainSearchQueryLegacy
+	165,  // 1215: forge.Forge.CreateVpc:input_type -> forge.VpcCreationRequest
+	166,  // 1216: forge.Forge.UpdateVpc:input_type -> forge.VpcUpdateRequest
+	168,  // 1217: forge.Forge.UpdateVpcVirtualization:input_type -> forge.VpcUpdateVirtualizationRequest
+	170,  // 1218: forge.Forge.DeleteVpc:input_type -> forge.VpcDeletionRequest
+	158,  // 1219: forge.Forge.FindVpcIds:input_type -> forge.VpcSearchFilter
+	160,  // 1220: forge.Forge.FindVpcsByIds:input_type -> forge.VpcsByIdsRequest
+	921,  // 1221: forge.Forge.CreateSpxPartition:input_type -> forge.SpxPartitionCreationRequest
+	924,  // 1222: forge.Forge.DeleteSpxPartition:input_type -> forge.SpxPartitionDeletionRequest
+	926,  // 1223: forge.Forge.FindSpxPartitionIds:input_type -> forge.SpxPartitionSearchFilter
+	928,  // 1224: forge.Forge.FindSpxPartitionsByIds:input_type -> forge.SpxPartitionsByIdsRequest
+	176,  // 1225: forge.Forge.CreateVpcPrefix:input_type -> forge.VpcPrefixCreationRequest
+	177,  // 1226: forge.Forge.SearchVpcPrefixes:input_type -> forge.VpcPrefixSearchQuery
+	178,  // 1227: forge.Forge.GetVpcPrefixes:input_type -> forge.VpcPrefixGetRequest
+	181,  // 1228: forge.Forge.UpdateVpcPrefix:input_type -> forge.VpcPrefixUpdateRequest
+	182,  // 1229: forge.Forge.DeleteVpcPrefix:input_type -> forge.VpcPrefixDeletionRequest
+	964,  // 1230: forge.Forge.FindSitePrefixIds:input_type -> forge.SitePrefixSearchFilter
+	965,  // 1231: forge.Forge.FindSitePrefixesByIds:input_type -> forge.SitePrefixesByIdsRequest
+	188,  // 1232: forge.Forge.CreateVpcPeering:input_type -> forge.VpcPeeringCreationRequest
+	189,  // 1233: forge.Forge.FindVpcPeeringIds:input_type -> forge.VpcPeeringSearchFilter
+	190,  // 1234: forge.Forge.FindVpcPeeringsByIds:input_type -> forge.VpcPeeringsByIdsRequest
+	191,  // 1235: forge.Forge.DeleteVpcPeering:input_type -> forge.VpcPeeringDeletionRequest
+	258,  // 1236: forge.Forge.FindNetworkSegmentIds:input_type -> forge.NetworkSegmentSearchFilter
+	260,  // 1237: forge.Forge.FindNetworkSegmentsByIds:input_type -> forge.NetworkSegmentsByIdsRequest
+	252,  // 1238: forge.Forge.CreateNetworkSegment:input_type -> forge.NetworkSegmentCreationRequest
+	254,  // 1239: forge.Forge.AttachNetworkSegmentToVpc:input_type -> forge.AttachNetworkSegmentToVpcRequest
+	253,  // 1240: forge.Forge.DeleteNetworkSegment:input_type -> forge.NetworkSegmentDeletionRequest
+	157,  // 1241: forge.Forge.NetworkSegmentsForVpc:input_type -> forge.VpcSearchQuery
+	201,  // 1242: forge.Forge.FindIBPartitionIds:input_type -> forge.IBPartitionSearchFilter
+	202,  // 1243: forge.Forge.FindIBPartitionsByIds:input_type -> forge.IBPartitionsByIdsRequest
+	197,  // 1244: forge.Forge.CreateIBPartition:input_type -> forge.IBPartitionCreationRequest
+	198,  // 1245: forge.Forge.UpdateIBPartition:input_type -> forge.IBPartitionUpdateRequest
+	199,  // 1246: forge.Forge.DeleteIBPartition:input_type -> forge.IBPartitionDeletionRequest
+	161,  // 1247: forge.Forge.IBPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	213,  // 1248: forge.Forge.FindPowerShelves:input_type -> forge.PowerShelfQuery
+	214,  // 1249: forge.Forge.FindPowerShelfIds:input_type -> forge.PowerShelfSearchFilter
+	215,  // 1250: forge.Forge.FindPowerShelvesByIds:input_type -> forge.PowerShelvesByIdsRequest
+	209,  // 1251: forge.Forge.DeletePowerShelf:input_type -> forge.PowerShelfDeletionRequest
+	931,  // 1252: forge.Forge.AdminForceDeletePowerShelf:input_type -> forge.AdminForceDeletePowerShelfRequest
+	211,  // 1253: forge.Forge.SetPowerShelfMaintenance:input_type -> forge.PowerShelfMaintenanceRequest
+	235,  // 1254: forge.Forge.FindSwitches:input_type -> forge.SwitchQuery
+	236,  // 1255: forge.Forge.FindSwitchIds:input_type -> forge.SwitchSearchFilter
+	237,  // 1256: forge.Forge.FindSwitchesByIds:input_type -> forge.SwitchesByIdsRequest
+	229,  // 1257: forge.Forge.DeleteSwitch:input_type -> forge.SwitchDeletionRequest
+	929,  // 1258: forge.Forge.AdminForceDeleteSwitch:input_type -> forge.AdminForceDeleteSwitchRequest
+	246,  // 1259: forge.Forge.FindIBFabricIds:input_type -> forge.IBFabricSearchFilter
+	271,  // 1260: forge.Forge.AllocateInstance:input_type -> forge.InstanceAllocationRequest
+	272,  // 1261: forge.Forge.AllocateInstances:input_type -> forge.BatchInstanceAllocationRequest
+	317,  // 1262: forge.Forge.ReleaseInstance:input_type -> forge.InstanceReleaseRequest
+	289,  // 1263: forge.Forge.UpdateInstanceOperatingSystem:input_type -> forge.InstanceOperatingSystemUpdateRequest
+	290,  // 1264: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
+	268,  // 1265: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
+	270,  // 1266: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
+	1007, // 1267: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
+	390,  // 1268: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
+	455,  // 1269: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
+	1007, // 1270: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
+	461,  // 1271: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
+	472,  // 1272: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
+	464,  // 1273: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
+	462,  // 1274: forge.Forge.InsertRackHealthReport:input_type -> forge.InsertRackHealthReportRequest
+	463,  // 1275: forge.Forge.RemoveRackHealthReport:input_type -> forge.RemoveRackHealthReportRequest
+	467,  // 1276: forge.Forge.ListSwitchHealthReports:input_type -> forge.ListSwitchHealthReportsRequest
+	465,  // 1277: forge.Forge.InsertSwitchHealthReport:input_type -> forge.InsertSwitchHealthReportRequest
+	466,  // 1278: forge.Forge.RemoveSwitchHealthReport:input_type -> forge.RemoveSwitchHealthReportRequest
+	470,  // 1279: forge.Forge.ListPowerShelfHealthReports:input_type -> forge.ListPowerShelfHealthReportsRequest
+	468,  // 1280: forge.Forge.InsertPowerShelfHealthReport:input_type -> forge.InsertPowerShelfHealthReportRequest
+	469,  // 1281: forge.Forge.RemovePowerShelfHealthReport:input_type -> forge.RemovePowerShelfHealthReportRequest
+	473,  // 1282: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
+	474,  // 1283: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
+	475,  // 1284: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
+	1007, // 1285: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
+	461,  // 1286: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
+	472,  // 1287: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
+	409,  // 1288: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
+	411,  // 1289: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
+	1077, // 1290: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
+	1078, // 1291: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
+	1079, // 1292: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
+	263,  // 1293: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
+	436,  // 1294: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
+	438,  // 1295: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
+	442,  // 1296: forge.Forge.RenewMachineCertificate:input_type -> forge.MachineCertificateRenewRequest
+	439,  // 1297: forge.Forge.DiscoveryCompleted:input_type -> forge.MachineDiscoveryCompletedRequest
+	440,  // 1298: forge.Forge.CleanupMachineCompleted:input_type -> forge.MachineCleanupInfo
+	447,  // 1299: forge.Forge.ReportForgeScoutError:input_type -> forge.ForgeScoutErrorReport
+	366,  // 1300: forge.Forge.DiscoverDhcp:input_type -> forge.DhcpDiscovery
+	367,  // 1301: forge.Forge.ExpireDhcpLease:input_type -> forge.ExpireDhcpLeaseRequest
+	336,  // 1302: forge.Forge.AssignStaticAddress:input_type -> forge.AssignStaticAddressRequest
+	338,  // 1303: forge.Forge.RemoveStaticAddress:input_type -> forge.RemoveStaticAddressRequest
+	340,  // 1304: forge.Forge.FindInterfaceAddresses:input_type -> forge.FindInterfaceAddressesRequest
+	335,  // 1305: forge.Forge.FindInterfaces:input_type -> forge.InterfaceSearchQuery
+	334,  // 1306: forge.Forge.DeleteInterface:input_type -> forge.InterfaceDeleteQuery
+	511,  // 1307: forge.Forge.FindIpAddress:input_type -> forge.FindIpAddressRequest
+	320,  // 1308: forge.Forge.FindMachineIds:input_type -> forge.MachineSearchConfig
+	319,  // 1309: forge.Forge.FindMachinesByIds:input_type -> forge.MachinesByIdsRequest
+	321,  // 1310: forge.Forge.FindMachineStateHistories:input_type -> forge.MachineStateHistoriesRequest
+	324,  // 1311: forge.Forge.FindMachineHealthHistories:input_type -> forge.MachineHealthHistoriesRequest
+	212,  // 1312: forge.Forge.FindPowerShelfStateHistories:input_type -> forge.PowerShelfStateHistoriesRequest
+	752,  // 1313: forge.Forge.FindRackStateHistories:input_type -> forge.RackStateHistoriesRequest
+	233,  // 1314: forge.Forge.FindSwitchStateHistories:input_type -> forge.SwitchStateHistoriesRequest
+	256,  // 1315: forge.Forge.FindNetworkSegmentStateHistories:input_type -> forge.NetworkSegmentStateHistoriesRequest
+	184,  // 1316: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
+	329,  // 1317: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
+	328,  // 1318: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
+	1066, // 1319: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
+	536,  // 1320: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
+	537,  // 1321: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
+	515,  // 1322: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
+	513,  // 1323: forge.Forge.IdentifyUuid:input_type -> forge.IdentifyUuidRequest
+	516,  // 1324: forge.Forge.IdentifyMac:input_type -> forge.IdentifyMacRequest
+	518,  // 1325: forge.Forge.IdentifySerial:input_type -> forge.IdentifySerialRequest
+	432,  // 1326: forge.Forge.GetBMCMetaData:input_type -> forge.BMCMetaDataGetRequest
+	434,  // 1327: forge.Forge.UpdateMachineCredentials:input_type -> forge.MachineCredentialsUpdateRequest
+	449,  // 1328: forge.Forge.GetPxeInstructions:input_type -> forge.PxeInstructionRequest
+	453,  // 1329: forge.Forge.GetCloudInitInstructions:input_type -> forge.CloudInitInstructionsRequest
+	149,  // 1330: forge.Forge.Echo:input_type -> forge.EchoRequest
+	480,  // 1331: forge.Forge.CreateTenant:input_type -> forge.CreateTenantRequest
+	484,  // 1332: forge.Forge.FindTenant:input_type -> forge.FindTenantRequest
+	482,  // 1333: forge.Forge.UpdateTenant:input_type -> forge.UpdateTenantRequest
+	490,  // 1334: forge.Forge.CreateTenantKeyset:input_type -> forge.CreateTenantKeysetRequest
+	497,  // 1335: forge.Forge.FindTenantKeysetIds:input_type -> forge.TenantKeysetSearchFilter
+	499,  // 1336: forge.Forge.FindTenantKeysetsByIds:input_type -> forge.TenantKeysetsByIdsRequest
+	493,  // 1337: forge.Forge.UpdateTenantKeyset:input_type -> forge.UpdateTenantKeysetRequest
+	495,  // 1338: forge.Forge.DeleteTenantKeyset:input_type -> forge.DeleteTenantKeysetRequest
+	500,  // 1339: forge.Forge.ValidateTenantPublicKey:input_type -> forge.ValidateTenantPublicKeyRequest
+	373,  // 1340: forge.Forge.GetBmcCredentials:input_type -> forge.GetBmcCredentialsRequest
+	374,  // 1341: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
+	407,  // 1342: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
+	377,  // 1343: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
+	1080, // 1344: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
+	378,  // 1345: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
+	384,  // 1346: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
+	384,  // 1347: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
+	384,  // 1348: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
+	379,  // 1349: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
+	380,  // 1350: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
+	381,  // 1351: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
+	382,  // 1352: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
+	1081, // 1353: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
+	1082, // 1354: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
+	1083, // 1355: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
+	1084, // 1356: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
+	1085, // 1357: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
+	1086, // 1358: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
+	388,  // 1359: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
+	413,  // 1360: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
+	502,  // 1361: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
+	505,  // 1362: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
+	350,  // 1363: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
+	351,  // 1364: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
+	352,  // 1365: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
+	353,  // 1366: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
+	766,  // 1367: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
+	509,  // 1368: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
+	510,  // 1369: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
+	520,  // 1370: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
+	521,  // 1371: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
+	523,  // 1372: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
+	524,  // 1373: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
+	1007, // 1374: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
+	575,  // 1375: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
+	530,  // 1376: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
+	1028, // 1377: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
+	533,  // 1378: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
+	1028, // 1379: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
+	951,  // 1380: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
+	542,  // 1381: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
+	543,  // 1382: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
+	137,  // 1383: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
+	138,  // 1384: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
+	141,  // 1385: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
+	143,  // 1386: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
+	958,  // 1387: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
+	960,  // 1388: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
+	1080, // 1389: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
+	545,  // 1390: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
+	545,  // 1391: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
+	545,  // 1392: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
+	354,  // 1393: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
+	312,  // 1394: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
+	548,  // 1395: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
+	550,  // 1396: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
+	563,  // 1397: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
+	564,  // 1398: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	563,  // 1399: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
+	564,  // 1400: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	1080, // 1401: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
+	565,  // 1402: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
+	1080, // 1403: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
+	1080, // 1404: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
+	1080, // 1405: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
+	570,  // 1406: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	570,  // 1407: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	216,  // 1408: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	217,  // 1409: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	216,  // 1410: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	217,  // 1411: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	1080, // 1412: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	218,  // 1413: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
+	1080, // 1414: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	1080, // 1415: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
+	238,  // 1416: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
+	239,  // 1417: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	238,  // 1418: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
+	239,  // 1419: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	1080, // 1420: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
+	240,  // 1421: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
+	1080, // 1422: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
+	1080, // 1423: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
+	243,  // 1424: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
+	244,  // 1425: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
+	243,  // 1426: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
+	244,  // 1427: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
+	1080, // 1428: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
+	245,  // 1429: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
+	1080, // 1430: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
+	135,  // 1431: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
+	645,  // 1432: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
+	647,  // 1433: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
+	649,  // 1434: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
+	654,  // 1435: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
+	651,  // 1436: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
+	655,  // 1437: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
+	657,  // 1438: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
+	1087, // 1439: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
+	1088, // 1440: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
+	1089, // 1441: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
+	1090, // 1442: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
+	1091, // 1443: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
+	1092, // 1444: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
+	1093, // 1445: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
+	1094, // 1446: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
+	1095, // 1447: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
+	1096, // 1448: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
+	1097, // 1449: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
+	1098, // 1450: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
+	1099, // 1451: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
+	1100, // 1452: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
+	1101, // 1453: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
+	1102, // 1454: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
+	1103, // 1455: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
+	1104, // 1456: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
+	1105, // 1457: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
+	1106, // 1458: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
+	1107, // 1459: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
+	1108, // 1460: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
+	1109, // 1461: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
+	1110, // 1462: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
+	1111, // 1463: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
+	1112, // 1464: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
+	1113, // 1465: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
+	1114, // 1466: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
+	1115, // 1467: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
+	1116, // 1468: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
+	1117, // 1469: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
+	1118, // 1470: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
+	1119, // 1471: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
+	1120, // 1472: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
+	1121, // 1473: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
+	1122, // 1474: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
+	1123, // 1475: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
+	1124, // 1476: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
+	1125, // 1477: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
+	1126, // 1478: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
+	1127, // 1479: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
+	1128, // 1480: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
+	1129, // 1481: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
+	676,  // 1482: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
+	678,  // 1483: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
+	680,  // 1484: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
+	683,  // 1485: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
+	684,  // 1486: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
+	690,  // 1487: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
+	693,  // 1488: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
+	552,  // 1489: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
+	556,  // 1490: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
+	554,  // 1491: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
+	1017, // 1492: forge.Forge.GetOsImage:input_type -> common.UUID
+	552,  // 1493: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
+	558,  // 1494: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
+	559,  // 1495: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
+	574,  // 1496: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
+	579,  // 1497: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
+	581,  // 1498: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
+	576,  // 1499: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
+	584,  // 1500: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
+	586,  // 1501: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
+	589,  // 1502: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
+	591,  // 1503: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
+	608,  // 1504: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
+	609,  // 1505: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
+	611,  // 1506: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
+	614,  // 1507: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
+	616,  // 1508: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
+	592,  // 1509: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
+	620,  // 1510: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
+	622,  // 1511: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
+	621,  // 1512: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
+	625,  // 1513: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
+	629,  // 1514: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
+	630,  // 1515: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
+	632,  // 1516: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
+	426,  // 1517: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
+	603,  // 1518: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
+	384,  // 1519: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
+	416,  // 1520: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
+	418,  // 1521: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
+	420,  // 1522: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
+	422,  // 1523: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
+	799,  // 1524: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
+	801,  // 1525: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
+	803,  // 1526: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
+	805,  // 1527: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
+	428,  // 1528: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
+	430,  // 1529: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
+	593,  // 1530: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
+	601,  // 1531: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
+	131,  // 1532: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
+	1080, // 1533: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
+	1080, // 1534: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
+	128,  // 1535: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
+	659,  // 1536: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
+	661,  // 1537: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
+	666,  // 1538: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
+	668,  // 1539: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
+	668,  // 1540: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
+	668,  // 1541: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
+	672,  // 1542: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
+	696,  // 1543: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
+	809,  // 1544: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
+	810,  // 1545: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
+	712,  // 1546: forge.Forge.CreateSku:input_type -> forge.SkuList
+	1007, // 1547: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
+	1007, // 1548: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
+	710,  // 1549: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
+	711,  // 1550: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
+	713,  // 1551: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
+	1080, // 1552: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
+	715,  // 1553: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
+	725,  // 1554: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
+	709,  // 1555: forge.Forge.ReplaceSku:input_type -> forge.Sku
+	396,  // 1556: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
+	398,  // 1557: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
+	400,  // 1558: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
+	1007, // 1559: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
+	387,  // 1560: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
+	1080, // 1561: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
+	720,  // 1562: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
+	718,  // 1563: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	718,  // 1564: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	723,  // 1565: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
+	726,  // 1566: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
+	727,  // 1567: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
+	384,  // 1568: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
+	384,  // 1569: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
+	746,  // 1570: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
+	748,  // 1571: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
+	743,  // 1572: forge.Forge.GetRack:input_type -> forge.GetRackRequest
+	753,  // 1573: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
+	754,  // 1574: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
+	761,  // 1575: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
+	732,  // 1576: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
+	734,  // 1577: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
+	736,  // 1578: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
+	739,  // 1579: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
+	740,  // 1580: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
+	807,  // 1581: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
+	816,  // 1582: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
+	1130, // 1583: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
+	1131, // 1584: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
+	819,  // 1585: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
+	1080, // 1586: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
+	821,  // 1587: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	821,  // 1588: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	823,  // 1589: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
+	824,  // 1590: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
+	829,  // 1591: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
+	830,  // 1592: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
+	831,  // 1593: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
+	832,  // 1594: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
+	1080, // 1595: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
+	826,  // 1596: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
+	833,  // 1597: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
+	835,  // 1598: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
+	838,  // 1599: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
+	840,  // 1600: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
+	842,  // 1601: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
+	843,  // 1602: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
+	849,  // 1603: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
+	850,  // 1604: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
+	851,  // 1605: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
+	853,  // 1606: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
+	855,  // 1607: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
+	857,  // 1608: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
+	859,  // 1609: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
+	103,  // 1610: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
+	1007, // 1611: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
+	104,  // 1612: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
+	1007, // 1613: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
+	106,  // 1614: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
+	108,  // 1615: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	111,  // 1616: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
+	108,  // 1617: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	116,  // 1618: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	118,  // 1619: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
+	116,  // 1620: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	119,  // 1621: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
+	124,  // 1622: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
+	125,  // 1623: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
+	866,  // 1624: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
+	869,  // 1625: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
+	871,  // 1626: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
+	873,  // 1627: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
+	1132, // 1628: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
+	1133, // 1629: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
+	1134, // 1630: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
+	1135, // 1631: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
+	1136, // 1632: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
+	1137, // 1633: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
+	1138, // 1634: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
+	1139, // 1635: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
+	1140, // 1636: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
+	1141, // 1637: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
+	1142, // 1638: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
+	1143, // 1639: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
+	1144, // 1640: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
+	1145, // 1641: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
+	1146, // 1642: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
+	783,  // 1643: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
+	784,  // 1644: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
+	161,  // 1645: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	794,  // 1646: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
+	795,  // 1647: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
+	791,  // 1648: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
+	797,  // 1649: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
+	792,  // 1650: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
+	161,  // 1651: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	887,  // 1652: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
+	777,  // 1653: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
+	890,  // 1654: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
+	892,  // 1655: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
+	893,  // 1656: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
+	895,  // 1657: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
+	904,  // 1658: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
+	906,  // 1659: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
+	901,  // 1660: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
+	913,  // 1661: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
+	915,  // 1662: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
+	917,  // 1663: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
+	934,  // 1664: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
+	1025, // 1665: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
+	937,  // 1666: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
+	938,  // 1667: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
+	940,  // 1668: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
+	942,  // 1669: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
+	944,  // 1670: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	947,  // 1671: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	949,  // 1672: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
+	147,  // 1673: forge.Forge.Version:output_type -> forge.BuildInfo
+	1065, // 1674: forge.Forge.CreateDomain:output_type -> dns.Domain
+	1065, // 1675: forge.Forge.UpdateDomain:output_type -> dns.Domain
+	1147, // 1676: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
+	1148, // 1677: forge.Forge.FindDomain:output_type -> dns.DomainList
+	881,  // 1678: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
+	881,  // 1679: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
+	884,  // 1680: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
+	882,  // 1681: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
+	164,  // 1682: forge.Forge.CreateVpc:output_type -> forge.Vpc
+	167,  // 1683: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
+	169,  // 1684: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
+	171,  // 1685: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
+	159,  // 1686: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
+	172,  // 1687: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
+	922,  // 1688: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
+	925,  // 1689: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
+	923,  // 1690: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
+	927,  // 1691: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
+	173,  // 1692: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
+	179,  // 1693: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
+	180,  // 1694: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
+	173,  // 1695: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
+	183,  // 1696: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
+	966,  // 1697: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
+	967,  // 1698: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
+	185,  // 1699: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
+	186,  // 1700: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
+	187,  // 1701: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
+	192,  // 1702: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
+	259,  // 1703: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
+	370,  // 1704: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
+	251,  // 1705: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
+	251,  // 1706: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
+	255,  // 1707: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
+	370,  // 1708: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
+	203,  // 1709: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
+	196,  // 1710: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
+	195,  // 1711: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
+	195,  // 1712: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
+	200,  // 1713: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
+	196,  // 1714: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
+	207,  // 1715: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
+	900,  // 1716: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
+	207,  // 1717: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
+	210,  // 1718: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
+	932,  // 1719: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
+	1080, // 1720: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
+	227,  // 1721: forge.Forge.FindSwitches:output_type -> forge.SwitchList
+	899,  // 1722: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
+	227,  // 1723: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
+	230,  // 1724: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
+	930,  // 1725: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
+	247,  // 1726: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
+	300,  // 1727: forge.Forge.AllocateInstance:output_type -> forge.Instance
+	273,  // 1728: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
+	318,  // 1729: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
+	300,  // 1730: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
+	300,  // 1731: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
+	269,  // 1732: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
+	265,  // 1733: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
+	265,  // 1734: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
+	391,  // 1735: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
+	1080, // 1736: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
+	471,  // 1737: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
+	1080, // 1738: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
+	1080, // 1739: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1740: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
+	1080, // 1741: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
+	1080, // 1742: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1743: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
+	1080, // 1744: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
+	1080, // 1745: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1746: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
+	1080, // 1747: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
+	1080, // 1748: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1749: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
+	1080, // 1750: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	1080, // 1751: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1752: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
+	1080, // 1753: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
+	1080, // 1754: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
+	410,  // 1755: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
+	412,  // 1756: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
+	1149, // 1757: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
+	1150, // 1758: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
+	1151, // 1759: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
+	264,  // 1760: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
+	437,  // 1761: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
+	444,  // 1762: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
+	443,  // 1763: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
+	445,  // 1764: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
+	446,  // 1765: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
+	448,  // 1766: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
+	369,  // 1767: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
+	368,  // 1768: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
+	337,  // 1769: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
+	339,  // 1770: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
+	342,  // 1771: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
+	332,  // 1772: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
+	1080, // 1773: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
+	512,  // 1774: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
+	1066, // 1775: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
+	333,  // 1776: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
+	322,  // 1777: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
+	325,  // 1778: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
+	234,  // 1779: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
+	234,  // 1780: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
+	234,  // 1781: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
+	234,  // 1782: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
+	234,  // 1783: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
+	331,  // 1784: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
+	330,  // 1785: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
+	535,  // 1786: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
+	539,  // 1787: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
+	538,  // 1788: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
+	536,  // 1789: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
+	514,  // 1790: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
+	517,  // 1791: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
+	519,  // 1792: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
+	433,  // 1793: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
+	435,  // 1794: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
+	450,  // 1795: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
+	454,  // 1796: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
+	150,  // 1797: forge.Forge.Echo:output_type -> forge.EchoResponse
+	481,  // 1798: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
+	485,  // 1799: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
+	483,  // 1800: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
+	491,  // 1801: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
+	498,  // 1802: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
+	492,  // 1803: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
+	494,  // 1804: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
+	496,  // 1805: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
+	501,  // 1806: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
+	375,  // 1807: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
+	375,  // 1808: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
+	408,  // 1809: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
+	1152, // 1810: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
+	1153, // 1811: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
+	1080, // 1812: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
+	618,  // 1813: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
+	619,  // 1814: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
+	1067, // 1815: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
+	1080, // 1816: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
+	1154, // 1817: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
+	383,  // 1818: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
+	1080, // 1819: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
+	1155, // 1820: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
+	1156, // 1821: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
+	1157, // 1822: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
+	1158, // 1823: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
+	1159, // 1824: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
+	1160, // 1825: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
+	1080, // 1826: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
+	414,  // 1827: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
+	503,  // 1828: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
+	506,  // 1829: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
+	1080, // 1830: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
+	1080, // 1831: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
+	1080, // 1832: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
+	1080, // 1833: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
+	1080, // 1834: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
+	1080, // 1835: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
+	1080, // 1836: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
+	1080, // 1837: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
+	522,  // 1838: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
+	1080, // 1839: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
+	525,  // 1840: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
+	1080, // 1841: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
+	1080, // 1842: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
+	531,  // 1843: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
+	533,  // 1844: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
+	1080, // 1845: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
+	1080, // 1846: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
+	957,  // 1847: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
+	544,  // 1848: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
+	544,  // 1849: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
+	139,  // 1850: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
+	140,  // 1851: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
+	142,  // 1852: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
+	145,  // 1853: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
+	959,  // 1854: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
+	1080, // 1855: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
+	546,  // 1856: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
+	1080, // 1857: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
+	1080, // 1858: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
+	1080, // 1859: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
+	1080, // 1860: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
+	313,  // 1861: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
+	549,  // 1862: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
+	551,  // 1863: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
+	1080, // 1864: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
+	1080, // 1865: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
+	1080, // 1866: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
+	563,  // 1867: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
+	565,  // 1868: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
+	1080, // 1869: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
+	1080, // 1870: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
+	566,  // 1871: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
+	568,  // 1872: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
+	572,  // 1873: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	572,  // 1874: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	1080, // 1875: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1080, // 1876: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1080, // 1877: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
+	216,  // 1878: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
+	218,  // 1879: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
+	1080, // 1880: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	1080, // 1881: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	219,  // 1882: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
+	1080, // 1883: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
+	1080, // 1884: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
+	1080, // 1885: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
+	238,  // 1886: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
+	240,  // 1887: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
+	1080, // 1888: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
+	1080, // 1889: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
+	241,  // 1890: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
+	1080, // 1891: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
+	1080, // 1892: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
+	1080, // 1893: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
+	243,  // 1894: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
+	245,  // 1895: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
+	1080, // 1896: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
+	1080, // 1897: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
+	136,  // 1898: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
+	646,  // 1899: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
+	648,  // 1900: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
+	650,  // 1901: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
+	653,  // 1902: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
+	652,  // 1903: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
+	656,  // 1904: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
+	658,  // 1905: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
+	1161, // 1906: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
+	1162, // 1907: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
+	1163, // 1908: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
+	1164, // 1909: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
+	1165, // 1910: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1166, // 1911: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
+	1167, // 1912: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
+	1168, // 1913: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
+	1165, // 1914: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1169, // 1915: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
+	1170, // 1916: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
+	1171, // 1917: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
+	1172, // 1918: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
+	1173, // 1919: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
+	1174, // 1920: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
+	1175, // 1921: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
+	1176, // 1922: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
+	1177, // 1923: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
+	1178, // 1924: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
+	1179, // 1925: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
+	1180, // 1926: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
+	1181, // 1927: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
+	1182, // 1928: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
+	1183, // 1929: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
+	1184, // 1930: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
+	1185, // 1931: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
+	1186, // 1932: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
+	1187, // 1933: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
+	1188, // 1934: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
+	1189, // 1935: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
+	1190, // 1936: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
+	1191, // 1937: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
+	1192, // 1938: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
+	1193, // 1939: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
+	1194, // 1940: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
+	1195, // 1941: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
+	1196, // 1942: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
+	1197, // 1943: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
+	1198, // 1944: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
+	1199, // 1945: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
+	1200, // 1946: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
+	1201, // 1947: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
+	1202, // 1948: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
+	677,  // 1949: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
+	679,  // 1950: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
+	681,  // 1951: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
+	682,  // 1952: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
+	685,  // 1953: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
+	688,  // 1954: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
+	695,  // 1955: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
+	553,  // 1956: forge.Forge.CreateOsImage:output_type -> forge.OsImage
+	557,  // 1957: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
+	555,  // 1958: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
+	553,  // 1959: forge.Forge.GetOsImage:output_type -> forge.OsImage
+	553,  // 1960: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
+	276,  // 1961: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
+	560,  // 1962: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
+	573,  // 1963: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
+	1080, // 1964: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
+	580,  // 1965: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
+	577,  // 1966: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
+	585,  // 1967: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
+	588,  // 1968: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
+	590,  // 1969: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
+	1080, // 1970: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	607,  // 1971: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
+	610,  // 1972: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
+	612,  // 1973: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
+	615,  // 1974: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
+	617,  // 1975: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
+	1080, // 1976: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	624,  // 1977: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
+	623,  // 1978: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	623,  // 1979: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	626,  // 1980: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
+	628,  // 1981: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
+	631,  // 1982: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
+	633,  // 1983: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
+	427,  // 1984: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
+	604,  // 1985: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
+	415,  // 1986: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
+	417,  // 1987: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
+	1203, // 1988: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
+	421,  // 1989: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
+	423,  // 1990: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
+	800,  // 1991: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
+	802,  // 1992: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
+	804,  // 1993: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
+	806,  // 1994: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
+	429,  // 1995: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
+	431,  // 1996: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
+	594,  // 1997: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
+	602,  // 1998: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
+	127,  // 1999: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
+	133,  // 2000: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
+	130,  // 2001: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
+	1080, // 2002: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
+	660,  // 2003: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
+	662,  // 2004: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
+	667,  // 2005: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
+	669,  // 2006: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
+	670,  // 2007: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
+	671,  // 2008: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
+	673,  // 2009: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
+	697,  // 2010: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
+	815,  // 2011: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
+	1080, // 2012: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
+	713,  // 2013: forge.Forge.CreateSku:output_type -> forge.SkuIdList
+	709,  // 2014: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
+	1080, // 2015: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
+	1080, // 2016: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
+	1080, // 2017: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
+	1080, // 2018: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
+	713,  // 2019: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
+	712,  // 2020: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
+	1080, // 2021: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
+	709,  // 2022: forge.Forge.ReplaceSku:output_type -> forge.Sku
+	397,  // 2023: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
+	399,  // 2024: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
+	401,  // 2025: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
+	1080, // 2026: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
+	1080, // 2027: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
+	719,  // 2028: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
+	721,  // 2029: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
+	717,  // 2030: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
+	717,  // 2031: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
+	724,  // 2032: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
+	729,  // 2033: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
+	729,  // 2034: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
+	1080, // 2035: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
+	126,  // 2036: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
+	747,  // 2037: forge.Forge.FindRackIds:output_type -> forge.RackIdList
+	745,  // 2038: forge.Forge.FindRacksByIds:output_type -> forge.RackList
+	744,  // 2039: forge.Forge.GetRack:output_type -> forge.GetRackResponse
+	1080, // 2040: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
+	755,  // 2041: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
+	762,  // 2042: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
+	733,  // 2043: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
+	735,  // 2044: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
+	737,  // 2045: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
+	738,  // 2046: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
+	741,  // 2047: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
+	808,  // 2048: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
+	817,  // 2049: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
+	1204, // 2050: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
+	1205, // 2051: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
+	820,  // 2052: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
+	822,  // 2053: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
+	821,  // 2054: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	821,  // 2055: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	1080, // 2056: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
+	825,  // 2057: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
+	1080, // 2058: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
+	1080, // 2059: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
+	1080, // 2060: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
+	1080, // 2061: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
+	826,  // 2062: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
+	827,  // 2063: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
+	834,  // 2064: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
+	837,  // 2065: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
+	839,  // 2066: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
+	1080, // 2067: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
+	1080, // 2068: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
+	1080, // 2069: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
+	848,  // 2070: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
+	848,  // 2071: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
+	852,  // 2072: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
+	854,  // 2073: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
+	856,  // 2074: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
+	858,  // 2075: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
+	860,  // 2076: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
+	100,  // 2077: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
+	1080, // 2078: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
+	105,  // 2079: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
+	102,  // 2080: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
+	107,  // 2081: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
+	112,  // 2082: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	112,  // 2083: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	1080, // 2084: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
+	115,  // 2085: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	115,  // 2086: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	1080, // 2087: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
+	121,  // 2088: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
+	122,  // 2089: forge.Forge.GetJWKS:output_type -> forge.Jwks
+	123,  // 2090: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
+	867,  // 2091: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
+	870,  // 2092: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
+	872,  // 2093: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
+	874,  // 2094: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
+	1206, // 2095: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
+	1207, // 2096: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
+	1208, // 2097: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
+	1209, // 2098: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
+	1210, // 2099: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
+	1211, // 2100: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
+	1212, // 2101: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
+	1213, // 2102: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
+	1214, // 2103: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
+	1215, // 2104: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
+	1216, // 2105: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
+	1217, // 2106: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
+	1218, // 2107: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
+	1219, // 2108: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
+	1220, // 2109: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
+	785,  // 2110: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
+	780,  // 2111: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
+	780,  // 2112: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
+	796,  // 2113: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
+	790,  // 2114: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
+	789,  // 2115: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
+	798,  // 2116: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
+	793,  // 2117: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
+	790,  // 2118: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
+	888,  // 2119: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
+	778,  // 2120: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
+	1080, // 2121: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
+	891,  // 2122: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
+	894,  // 2123: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
+	897,  // 2124: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
+	905,  // 2125: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
+	907,  // 2126: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
+	903,  // 2127: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
+	914,  // 2128: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
+	916,  // 2129: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
+	920,  // 2130: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
+	933,  // 2131: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
+	933,  // 2132: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
+	933,  // 2133: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
+	939,  // 2134: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
+	941,  // 2135: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
+	943,  // 2136: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
+	945,  // 2137: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	945,  // 2138: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	950,  // 2139: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
+	1673, // [1673:2140] is the sub-list for method output_type
+	1206, // [1206:1673] is the sub-list for method input_type
+	1206, // [1206:1206] is the sub-list for extension type_name
+	1206, // [1206:1206] is the sub-list for extension extendee
+	0,    // [0:1206] is the sub-list for field type_name
 }
 
 func init() { file_nico_nico_proto_init() }
@@ -71843,7 +72019,7 @@ func file_nico_nico_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_nico_nico_proto_rawDesc), len(file_nico_nico_proto_rawDesc)),
-			NumEnums:      96,
+			NumEnums:      98,
 			NumMessages:   909,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -6167,27 +6167,41 @@ message IpxeTemplateList {
 message ExpectedHostNic {
   string mac_address = 1;
   // Legacy free-form segment hint (bf3, onboard, oob, ...). Kept for backward
-  // compatibility; declare network_segment_type instead, which wins.
+  // compatibility; declare `network_segment_type` instead, which wins.
   optional string nic_type = 2;
   optional string fixed_ip = 3;
   optional string fixed_mask = 4;
   optional string fixed_gateway = 5;
-  // When true, this flags the given NIC as the host's primary (boot)
-  // interface (used in cases of zero DPU).
+  // Host-role interfaces may set this to true to declare the host's primary
+  // (boot) interface.
   //
-  // Up to one NIC per ExpectedMachine may be marked primary, if set at
-  // all. Propagates to `machine_interfaces.primary_interface` during DHCP
-  // when this NIC is first discovered.
-  //
-  // Some day this could be even possibly used to say "this dumb NIC
-  // *is* the primary interface, even though I know I have a DPU."
+  // At most one Host interface per `ExpectedMachine` may set it to true; the
+  // other Host interfaces then become non-primary. False remains accepted for
+  // compatibility but does not replace that machine-wide selection. DPU OS
+  // interfaces are primary data interfaces and DPU BMC interfaces are
+  // non-primary; those roles must omit this field.
   optional bool primary = 6;
-  // The network segment type this NIC's first DHCP lease should come from.
-  // A NIC's segment normally follows its DHCP relay; where segment prefixes
-  // nest or overlap and a relay matches several, this narrows the choice to
-  // the segment of this type. Supersedes nic_type; absent both, the relay's
-  // match stands.
+  // Optional guard for this interface's network segment type. An explicit
+  // allocation policy or DPU role applies the guard to DHCP-selected segments
+  // and fixed-address containment. A legacy Host declaration with an omitted
+  // policy keeps the earlier first-DHCP selection-only behavior. Supersedes
+  // `nic_type` for DHCP; absent both, relay selection remains unconstrained.
+  // On update, omission clears this guard.
   optional NetworkSegmentType network_segment_type = 7;
+  // Machine endpoint that owns this interface. The role selects interface type
+  // and primary behavior only; Host, DPU OS, and DPU BMC all accept the same
+  // allocation policies and optional segment guard. On create, missing and
+  // Unspecified mean Host. On update, omission preserves the stored role while
+  // explicit Unspecified resets it to Host.
+  optional ExpectedInterfaceRole role = 8;
+  // Optional allocation policy. On create, missing and Unspecified infer Fixed
+  // from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
+  // stored policy while explicit Unspecified resets to that inference.
+  // Explicit Dynamic rejects `fixed_ip`. For a legacy Host declaration,
+  // inferred Fixed still selects the segment by address-prefix containment but
+  // does not turn `network_segment_type` into a fixed-address guard; configure
+  // Fixed explicitly to request that check.
+  optional ExpectedInterfaceIpAllocation ip_allocation = 9;
 }
 
 // NICo RPC representation of the per-host policy for how NICo treats DPU
@@ -9148,6 +9162,46 @@ enum OperatingSystemType {
   OS_TYPE_UNSPECIFIED = 0;
   OS_TYPE_IPXE = 1;              // Raw inline iPXE script
   OS_TYPE_TEMPLATED_IPXE = 2; // iPXE OS using an iPXE template
+}
+
+// Identifies which machine endpoint owns an entry in `ExpectedMachine.host_nics`.
+// Each role accepts Dynamic, Fixed, and Retained allocation plus the optional
+// segment guard. The role only derives interface type and primary behavior.
+//
+// On create, missing and `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` mean Host. On
+// update, omission preserves the stored role, while explicit
+// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. Host BMC identity
+// remains on `ExpectedMachine.bmc_mac_address`. NVIDIA/infra-controller#4103
+// tracks adding its network settings to this same interface model.
+enum ExpectedInterfaceRole {
+  // Preserve the legacy Host role when the optional field is absent.
+  EXPECTED_INTERFACE_ROLE_UNSPECIFIED = 0;
+  // Host operating-system data interface. Primary selection is machine-wide.
+  EXPECTED_INTERFACE_ROLE_HOST = 1;
+  // DPU operating-system data interface. Always primary for its DPU.
+  EXPECTED_INTERFACE_ROLE_DPU_OS = 2;
+  // DPU Redfish/BMC interface. Never primary.
+  EXPECTED_INTERFACE_ROLE_DPU_BMC = 3;
+}
+
+// Controls how an expected interface receives and retains its IP address.
+// Missing and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` preserve legacy
+// behavior: `fixed_ip` implies `FIXED`, while its absence implies `DYNAMIC`.
+enum ExpectedInterfaceIpAllocation {
+  // Infer Fixed or Dynamic from whether `fixed_ip` is configured. For a legacy
+  // Host declaration, this does not opt into the fixed-address segment guard.
+  EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED = 0;
+  // Use an expiring DHCP lease. The segment guard must match the relay's
+  // selected segment when configured.
+  EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC = 1;
+  // Reserve `fixed_ip`. Its prefix selects the segment, and the segment guard
+  // must match that segment when configured.
+  EXPECTED_INTERFACE_IP_ALLOCATION_FIXED = 2;
+  // Allocate through DHCP, then make the address Static for this interface
+  // row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The
+  // address is not converted back to DHCP if the policy later changes. The
+  // segment guard must match the relay's selected segment when configured.
+  EXPECTED_INTERFACE_IP_ALLOCATION_RETAINED = 3;
 }
 
 message OperatingSystem {


### PR DESCRIPTION
As it stands, `ExpectedMachine.host_nics` can reserve a fixed address, but every entry is treated as a host data interface. There is no way to identify a DPU OS or DPU BMC interface, or explicitly choose `Dynamic`, `Fixed`, or `Retained` allocation for one of those interfaces.

So, this adds optional `role` and `ip_allocation` fields to `ExpectedHostNic`. `Host`, `DpuOs`, and `DpuBmc` interfaces can all use any of the three allocation policies. Fixed addresses use the configured prefix containing `fixed_ip`; Dynamic and Retained addresses use the DHCP relay or DHCPv6 link segment. `network_segment_type` is an optional guard for either path and is not inferred from the role.

Retained follows the existing Host BMC behavior: DHCP selects an address, then Site Explorer changes the matching DHCP row to `Static` so lease expiry does not remove it. Fixed can replace an existing same-family DHCP or SLAAC row with the configured Static address.

This intentionally stops short of reverse reconciliation. It does not turn Static back into DHCP, remove a Static address after `fixed_ip` is cleared, replace Fixed address A with Fixed address B, keep one policy fixed for an entire machine lifetime, or reuse a Retained address across machine lifetimes. Those cases are tracked in the follow-up issues below.

The new protobuf and JSON fields are optional. Existing payloads infer Fixed when `fixed_ip` is present and Dynamic otherwise; an omitted role means Host. Updates from older clients preserve explicit role and policy fields they do not know about while keeping legacy `fixed_ip` changes working as before.

The legacy compatibility seam is deliberate: a Host entry that omits both new fields keeps the old selector-only `network_segment_type` behavior. An explicit allocation policy, or either DPU role, opts into the same guard enforcement for Dynamic, Fixed, and Retained.

There is no database migration or second runtime copy of the policy. Role and policy remain in the existing ExpectedMachine JSONB data. The mapped interface type, primary setting, network segment, and address use the existing interface and address tables.

## Configuration examples

Expected Machine manifests are JSON today, so these examples use the current `expected_machines.json` input rather than TOML. A machine can mix the supported roles and allocation policies:

```json
{
  "expected_machines": [
    {
      "bmc_mac_address": "02:00:00:00:00:01",
      "bmc_username": "root",
      "bmc_password": "default-password",
      "chassis_serial_number": "SERIAL-1",
      "host_nics": [
        {
          "mac_address": "02:00:00:00:00:10",
          "role": "host",
          "ip_allocation": "dynamic",
          "primary": true
        },
        {
          "mac_address": "02:00:00:00:00:20",
          "role": "dpu_os",
          "ip_allocation": "fixed",
          "fixed_ip": "192.0.2.20"
        },
        {
          "mac_address": "02:00:00:00:00:21",
          "role": "dpu_bmc",
          "ip_allocation": "retained"
        }
      ]
    }
  ]
}
```

`Fixed` requires `fixed_ip`. `Dynamic` and `Retained` must omit it. Host interfaces may set `primary`; DPU OS and DPU BMC interfaces derive that setting from their role and must omit it.

`network_segment_type` can be omitted to select the segment from the fixed IP or DHCP relay. When used in the current admin CLI JSON, it is the protobuf enum number—for example, `"network_segment_type": 2` guards for `UNDERLAY`.

Existing host reservations remain valid without either new field:

```json
{
  "host_nics": [
    {
      "mac_address": "02:00:00:00:00:30",
      "fixed_ip": "192.0.2.30"
    },
    {
      "mac_address": "02:00:00:00:00:31"
    }
  ]
}
```

The first entry remains a fixed Host interface, and the second remains a dynamic Host interface.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3990

Part of #3491.

Follow-up work is tracked in #4187, #4188, and #4189.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

The fields are additive and optional, legacy inference remains in place, and no database migration is required.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make generate-rest-core-proto`
- Focused model, RPC, database, DHCPv4/DHCPv6, ExpectedMachine, and Site Explorer tests
- Core ExpectedMachine test slice, including an isolated retry after a shared SQLx template rebuild collision
- `go test ./proto/core/gen/v1`
- CodeRabbit CLI and external read-only reviews; all actionable findings addressed

## Additional Notes

- The generated Go protobuf accounts for most of the line count because adding enum descriptors shifts generated indexes throughout the file.
- Retained uses the existing `Static` database representation; this PR does not add another address allocation type or convert an existing Static row back to DHCP after a policy change.
- A configured segment guard fails closed when the DHCP-selected or fixed-address segment has a different type.
- Assigning a fixed address to an existing addressless legacy Host BMC row now refreshes its hostname and domain through the same address-assignment path.
- Host BMC configuration is tracked in #4103, the `ExpectedHostNic`/`host_nics` rename is tracked in #4104, and the docs-only update is tracked in #4151.
- DPU loopback reservations remain separate work.

Closes #3990
