### PR TITLE
feat(auth): count authentication guardrails

### DIFF
--- a/crates/api-core/src/auth.rs
+++ b/crates/api-core/src/auth.rs
@@ -29,6 +29,37 @@ mod test_certs;
 
 pub type AuthContext = carbide_authn::middleware::AuthContext<Authorization>;
 
+/// `PrincipalClass` keeps the identity labels on authorization decisions
+/// bounded. Both a normal denial and a permissive-mode override use the
+/// strongest principal, so the two counters group callers the same way.
+/// Variants stay weakest-first because the derived ordering selects that
+/// strongest principal with `max`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, carbide_instrument::LabelValue)]
+enum PrincipalClass {
+    Anonymous,
+    TrustedCertificate,
+    SpiffeMachine,
+    SpiffeService,
+    ExternalUser,
+}
+
+impl PrincipalClass {
+    fn classify(principals: &[Principal]) -> Self {
+        principals
+            .iter()
+            .map(|principal| match principal {
+                Principal::ExternalUser(_) => PrincipalClass::ExternalUser,
+                Principal::SpiffeServiceIdentifier(_) => PrincipalClass::SpiffeService,
+                Principal::SpiffeMachineIdentifier(_) => PrincipalClass::SpiffeMachine,
+                Principal::TrustedCertificate => PrincipalClass::TrustedCertificate,
+                Principal::Anonymous => PrincipalClass::Anonymous,
+            })
+            .max()
+            // A request that presented no principals at all is anonymous.
+            .unwrap_or(PrincipalClass::Anonymous)
+    }
+}
+
 // An Authorization is sort of like a ticket that says we're allowed to do the
 // thing we're trying to do, and specifically which Principal was permitted to
 // do it.
@@ -167,6 +198,31 @@ pub enum CasbinAuthorizerError {
     InitializationError(String),
 }
 
+/// `AuthorizationPermissiveOverride` records a policy denial that permissive
+/// mode turns into a successful authorization. Concrete identities and the
+/// requested method stay on the warning; only the bounded principal class
+/// becomes a metric label.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "authorization_permissive_override",
+    metric_name = "carbide_auth_permissive_overrides_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "The policy engine denied this request, but --auth-permissive-mode overrides it.",
+    describe = "Number of policy denials overridden by authorization permissive mode, by principal class"
+)]
+struct AuthorizationPermissiveOverride {
+    #[label]
+    principal_class: PrincipalClass,
+    #[context]
+    principals: String,
+    #[context]
+    predicate: String,
+    #[context]
+    error: String,
+}
+
 struct PermissiveWrapper {
     inner: Arc<PolicyEngineObject>,
 }
@@ -185,13 +241,16 @@ impl PolicyEngine for PermissiveWrapper {
     ) -> Result<Authorization, AuthorizationError> {
         let result = self.inner.authorize(principals, predicate.clone());
         result.or_else(|e| {
-            tracing::warn!(
-                ?principals,
-                ?predicate,
-                error = %e,
-                "The policy engine denied this request, but \
-                --auth-permissive-mode overrides it."
-            );
+            carbide_instrument::emit(AuthorizationPermissiveOverride {
+                principal_class: PrincipalClass::classify(principals),
+                principals: principals
+                    .iter()
+                    .map(Principal::audit_identity)
+                    .collect::<Vec<_>>()
+                    .join(","),
+                predicate: format!("{predicate:?}"),
+                error: e.to_string(),
+            });
 
             // FIXME: Strictly speaking, it's not true that Anonymous is
             // authorized to do this. Maybe define a different principal
@@ -215,13 +274,82 @@ mod tests {
     use carbide_authn::config::{AllowedCertCriteria, CertComponent};
     use carbide_authn::middleware::CertDescriptionMiddleware;
     use carbide_authn::spiffe_id::TrustDomain;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use eyre::Context;
 
     use super::*;
 
+    /// A rejecting policy lets the permissive wrapper exercise the exact
+    /// branch that production uses after Casbin denies a request.
+    struct DenyAll;
+
+    impl PolicyEngine for DenyAll {
+        fn authorize(
+            &self,
+            _principals: &[Principal],
+            _predicate: Predicate,
+        ) -> Result<Authorization, AuthorizationError> {
+            Err(AuthorizationError::Unauthorized)
+        }
+    }
+
     struct ClientCertTable {
         cert: Cow<'static, str>,
         desired: Principal,
+    }
+
+    /// A permissive override still authorizes the request, but one emit writes
+    /// the existing warning and increments the caller's bounded metric series.
+    #[test]
+    fn permissive_override_logs_counts_and_authorizes() {
+        let metrics = MetricsCapture::start();
+        let wrapper = PermissiveWrapper::new(Arc::new(DenyAll));
+        let principals = vec![
+            Principal::SpiffeServiceIdentifier("scout".to_string()),
+            Principal::TrustedCertificate,
+        ];
+        let mut authorized = false;
+
+        let logs = capture_logs(|| {
+            authorized = wrapper
+                .authorize(
+                    &principals,
+                    Predicate::ForgeCall("PowerControl".to_string()),
+                )
+                .is_ok();
+        });
+
+        assert!(authorized, "permissive mode must still allow the request");
+        let event = logs
+            .iter()
+            .find(|log| {
+                log.metadata_name == "authorization_permissive_override"
+                    && log.message
+                        == "The policy engine denied this request, but \
+                            --auth-permissive-mode overrides it."
+            })
+            .expect("the permissive override warning");
+        assert_eq!(event.level, tracing::Level::WARN);
+        assert_eq!(event.field("principal_class"), Some("spiffe_service"));
+        assert_eq!(
+            event.field("principals"),
+            Some("spiffe-service-id/scout,trusted-certificate")
+        );
+        assert_eq!(
+            event.field("predicate"),
+            Some("ForgeCall(\"PowerControl\")")
+        );
+        assert_eq!(
+            event.field("error"),
+            Some("unauthorized: CasbinEngine: all auth principals denied by enforcer")
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_auth_permissive_overrides_total",
+                &[("principal_class", "spiffe_service")]
+            ),
+            1.0
+        );
     }
 
     #[test]

--- a/crates/api-core/src/auth/middleware.rs
+++ b/crates/api-core/src/auth/middleware.rs
@@ -23,7 +23,7 @@ use tonic::service::AxumBody;
 use tower_http::auth::AsyncAuthorizeRequest;
 
 use crate::auth::internal_rbac_rules::InternalRBACRules;
-use crate::auth::{AuthContext, CasbinAuthorizer, Predicate};
+use crate::auth::{AuthContext, CasbinAuthorizer, Predicate, PrincipalClass};
 
 /// A caller was denied by an authorizer -- the canonical security signal.
 /// The denial rate is the alert; `authorizer` names the engine that denied
@@ -57,40 +57,55 @@ struct AuthorizationDenied {
     reason: String,
 }
 
-/// The strongest kind of identity among a request's principals, as the
-/// bounded `principal_class` label on [`AuthorizationDenied`]. Variants are
-/// declared weakest-first so the derived `Ord` is the precedence order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, carbide_instrument::LabelValue)]
-enum PrincipalClass {
-    Anonymous,
-    TrustedCertificate,
-    SpiffeMachine,
-    SpiffeService,
-    ExternalUser,
-}
-
-impl PrincipalClass {
-    fn classify(principals: &[Principal]) -> Self {
-        principals
-            .iter()
-            .map(|principal| match principal {
-                Principal::ExternalUser(_) => PrincipalClass::ExternalUser,
-                Principal::SpiffeServiceIdentifier(_) => PrincipalClass::SpiffeService,
-                Principal::SpiffeMachineIdentifier(_) => PrincipalClass::SpiffeMachine,
-                Principal::TrustedCertificate => PrincipalClass::TrustedCertificate,
-                Principal::Anonymous => PrincipalClass::Anonymous,
-            })
-            .max()
-            // A request that presented no principals at all is anonymous.
-            .unwrap_or(PrincipalClass::Anonymous)
-    }
-}
-
-/// Which authorization engine denied the call.
+/// Which authorization engine handled the call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
 enum Authorizer {
     Casbin,
     InternalRbac,
+}
+
+/// `CasbinAuthContextMissing` means the authentication middleware did not run
+/// before Casbin. The request still fails closed with a 500; the Event keeps
+/// the existing warning and makes the wiring error visible as a counter.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "casbin_auth_context_missing",
+    metric_name = "carbide_auth_context_missing_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "CasbinHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.",
+    describe = "Number of Forge authorization requests missing authentication context, by authorizer"
+)]
+struct CasbinAuthContextMissing {
+    #[label]
+    authorizer: Authorizer,
+    #[context]
+    method: String,
+    #[context]
+    client_address: String,
+}
+
+/// `InternalRbacAuthContextMissing` records the same wiring failure at the
+/// static rule layer. It shares the counter with Casbin while retaining the
+/// handler-specific warning operators already see.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "internal_rbac_auth_context_missing",
+    metric_name = "carbide_auth_context_missing_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "InternalRBACHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.",
+    describe = "Number of Forge authorization requests missing authentication context, by authorizer"
+)]
+struct InternalRbacAuthContextMissing {
+    #[label]
+    authorizer: Authorizer,
+    #[context]
+    method: String,
+    #[context]
+    client_address: String,
 }
 
 /// The peer address of the connection a request arrived on, as recorded by
@@ -150,13 +165,11 @@ where
                         .extensions_mut()
                         .get_mut::<AuthContext>()
                         .ok_or_else(|| {
-                            tracing::warn!(
-                                "CasbinHandler::authorize() found a request with \
-                                no AuthContext in its extensions. This may mean \
-                                the authentication middleware didn't run \
-                                successfully, or the middleware layers are \
-                                nested in the wrong order."
-                            );
+                            carbide_instrument::emit(CasbinAuthContextMissing {
+                                authorizer: Authorizer::Casbin,
+                                method: method_name.clone(),
+                                client_address: client_address(peer_address),
+                            });
                             empty_response_with_status(StatusCode::INTERNAL_SERVER_ERROR)
                         })?;
 
@@ -285,15 +298,14 @@ where
             let request_permitted = match RequestClass::from(&request) {
                 // Forge-owned endpoints must go through access control.
                 RequestClass::ForgeMethod(method_name) => {
+                    let request_peer_address = peer_address(&request);
                     let req_auth_context =
                         request.extensions().get::<AuthContext>().ok_or_else(|| {
-                            tracing::warn!(
-                                "InternalRBACHandler::authorize() found a request with \
-                                no AuthContext in its extensions. This may mean \
-                                the authentication middleware didn't run \
-                                successfully, or the middleware layers are \
-                                nested in the wrong order."
-                            );
+                            carbide_instrument::emit(InternalRbacAuthContextMissing {
+                                authorizer: Authorizer::InternalRbac,
+                                method: method_name.clone(),
+                                client_address: client_address(request_peer_address),
+                            });
                             empty_response_with_status(StatusCode::INTERNAL_SERVER_ERROR)
                         })?;
                     let principals = &req_auth_context.principals;
@@ -310,7 +322,7 @@ where
                                 .map(Principal::audit_identity)
                                 .collect::<Vec<_>>()
                                 .join(","),
-                            client_address: client_address(peer_address(&request)),
+                            client_address: client_address(request_peer_address),
                             reason: "no internal RBAC rule permits these principals".to_string(),
                         });
                     }
@@ -374,11 +386,131 @@ mod tests {
         request
     }
 
+    fn forge_request_without_auth_context(uri: &str, peer_address: &str) -> Request<()> {
+        let mut request = Request::builder().uri(uri).body(()).expect("request");
+        request
+            .extensions_mut()
+            .insert(Arc::new(ConnectionAttributes {
+                peer_address: peer_address.parse().expect("socket address"),
+                peer_certificates: Vec::new(),
+            }));
+        request
+    }
+
     fn field<'a>(log: &'a CapturedLog, name: &str) -> Option<&'a str> {
         log.fields
             .iter()
             .find(|(key, _)| key == name)
             .map(|(_, value)| value.as_str())
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum MissingAuthContextHandler {
+        Casbin,
+        InternalRbac,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct MissingAuthContextObservation {
+        status: StatusCode,
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        authorizer: String,
+        method: String,
+        client_address: String,
+        counter_delta: f64,
+    }
+
+    fn observe_missing_auth_context(
+        handler: MissingAuthContextHandler,
+    ) -> MissingAuthContextObservation {
+        let metrics = MetricsCapture::start();
+        let request =
+            forge_request_without_auth_context("/forge.Forge/PowerControl", "203.0.113.15:41000");
+        let mut status = None;
+
+        let logs = capture_logs(|| {
+            let result = match handler {
+                MissingAuthContextHandler::Casbin => {
+                    let mut handler =
+                        CasbinHandler::new(Arc::new(CasbinAuthorizer::new(Arc::new(DenyAll))));
+                    handler.authorize(request).now_or_never()
+                }
+                MissingAuthContextHandler::InternalRbac => {
+                    let mut handler = InternalRBACHandler::new();
+                    handler.authorize(request).now_or_never()
+                }
+            }
+            .expect("the authorization future has no awaits");
+            status = Some(
+                result
+                    .expect_err("missing AuthContext must fail closed")
+                    .status(),
+            );
+        });
+
+        let event = logs
+            .iter()
+            .find(|log| field(log, "metric_name") == Some("carbide_auth_context_missing_total"))
+            .expect("the missing AuthContext warning");
+        let authorizer = field(event, "authorizer").expect("authorizer label");
+
+        MissingAuthContextObservation {
+            status: status.expect("the handler returned a response"),
+            level: event.level,
+            metadata_name: event.metadata_name.clone(),
+            message: event.message.clone(),
+            authorizer: authorizer.to_string(),
+            method: field(event, "method").expect("method context").to_string(),
+            client_address: field(event, "client_address")
+                .expect("client address context")
+                .to_string(),
+            counter_delta: metrics.counter_delta(
+                "carbide_auth_context_missing_total",
+                &[("authorizer", authorizer)],
+            ),
+        }
+    }
+
+    /// Both authorizers fail closed when authentication did not attach an
+    /// `AuthContext`. Their Events keep the existing handler-specific warning
+    /// while sharing one counter, split by the bounded `authorizer` label.
+    #[test]
+    fn missing_auth_context_logs_counts_and_fails_closed() {
+        check_values(
+            [
+                Check {
+                    scenario: "Casbin",
+                    input: MissingAuthContextHandler::Casbin,
+                    expect: MissingAuthContextObservation {
+                        status: StatusCode::INTERNAL_SERVER_ERROR,
+                        level: tracing::Level::WARN,
+                        metadata_name: "casbin_auth_context_missing".to_string(),
+                        message: "CasbinHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.".to_string(),
+                        authorizer: "casbin".to_string(),
+                        method: "PowerControl".to_string(),
+                        client_address: "203.0.113.15:41000".to_string(),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "internal RBAC",
+                    input: MissingAuthContextHandler::InternalRbac,
+                    expect: MissingAuthContextObservation {
+                        status: StatusCode::INTERNAL_SERVER_ERROR,
+                        level: tracing::Level::WARN,
+                        metadata_name: "internal_rbac_auth_context_missing".to_string(),
+                        message: "InternalRBACHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.".to_string(),
+                        authorizer: "internal_rbac".to_string(),
+                        method: "PowerControl".to_string(),
+                        client_address: "203.0.113.15:41000".to_string(),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            observe_missing_auth_context,
+        );
     }
 
     /// The denial branch is a contract: one emit writes the log line (method,

--- a/crates/authn/src/middleware.rs
+++ b/crates/authn/src/middleware.rs
@@ -465,6 +465,22 @@ pub struct ConnectionAttributes {
     pub peer_certificates: Vec<CertificateDer<'static>>,
 }
 
+/// `AuthenticationConnectionAttributesMissing` records a request that reached
+/// authentication without the connection metadata installed by the listener.
+/// We still insert an empty `AuthContext` and delegate, leaving authorization
+/// to fail closed according to its existing rules.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "authentication_connection_attributes_missing",
+    metric_name = "carbide_authn_connection_attributes_missing_total",
+    component = "authn",
+    log = warn,
+    metric = counter,
+    message = "No ConnectionAttributes in request extensions!",
+    describe = "Number of requests authentication could not inspect because connection attributes were missing"
+)]
+struct AuthenticationConnectionAttributesMissing;
+
 /// A request whose presented certificate chain minted no principal, counted
 /// once per request with the end-entity certificate's error. A healthy chain
 /// whose intermediates don't map -- CA certificates never do -- is not a
@@ -566,7 +582,7 @@ where
                 auth_context.principals.push(Principal::TrustedCertificate);
             }
         } else {
-            tracing::warn!("No ConnectionAttributes in request extensions!");
+            carbide_instrument::emit(AuthenticationConnectionAttributesMissing);
         }
 
         extensions.insert(auth_context);
@@ -577,6 +593,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::sync::Mutex;
     use std::task::{Context, Poll};
 
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
@@ -605,6 +622,45 @@ mod tests {
         }
     }
 
+    /// `AuthContextRecorder` captures what authentication passed to the inner
+    /// service, which lets the missing-metadata test verify that the warning
+    /// does not stop or bypass the rest of the middleware chain.
+    #[derive(Clone, Default)]
+    struct AuthContextRecorder {
+        principals: Arc<Mutex<Option<Vec<Principal>>>>,
+    }
+
+    impl AuthContextRecorder {
+        fn principals(&self) -> Option<Vec<Principal>> {
+            self.principals
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+    }
+
+    impl<B> Service<Request<B>> for AuthContextRecorder {
+        type Response = ();
+        type Error = std::convert::Infallible;
+        type Future = std::future::Ready<Result<(), Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, request: Request<B>) -> Self::Future {
+            let principals = request
+                .extensions()
+                .get::<AuthContext<NoAuthorization>>()
+                .map(|context| context.principals.clone());
+            *self
+                .principals
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = principals;
+            std::future::ready(Ok(()))
+        }
+    }
+
     fn spiffe_context() -> SpiffeContext {
         SpiffeContext {
             trust_domain: TrustDomain::new("example.test").expect("trust domain"),
@@ -625,6 +681,56 @@ mod tests {
         )];
         let key = rcgen::KeyPair::generate().expect("key pair");
         params.self_signed(&key).expect("certificate").der().clone()
+    }
+
+    /// Missing `ConnectionAttributes` is a wiring error, but authentication
+    /// still installs an empty `AuthContext` before calling the inner service.
+    /// The Event records that single request without also counting a rejected
+    /// certificate.
+    #[test]
+    fn missing_connection_attributes_logs_counts_and_delegates() {
+        let metrics = MetricsCapture::start();
+        let recorder = AuthContextRecorder::default();
+        let middleware = CertDescriptionMiddleware::<NoAuthorization>::new(None, spiffe_context());
+        let mut service = middleware.layer(recorder.clone());
+
+        let logs = capture_logs(|| {
+            let request = Request::builder()
+                .uri("/forge.Forge/Anything")
+                .body(String::new())
+                .expect("request");
+            let _response_future = service.call(request);
+        });
+
+        let event = logs
+            .iter()
+            .find(|log| log.metadata_name == "authentication_connection_attributes_missing")
+            .expect("the missing connection attributes warning");
+        assert_eq!(event.level, tracing::Level::WARN);
+        assert_eq!(
+            event.message,
+            "No ConnectionAttributes in request extensions!"
+        );
+        assert_eq!(
+            event.field("event_name"),
+            Some("authentication_connection_attributes_missing")
+        );
+        assert_eq!(
+            event.field("metric_name"),
+            Some("carbide_authn_connection_attributes_missing_total")
+        );
+        assert_eq!(recorder.principals(), Some(Vec::new()));
+        assert_eq!(
+            metrics.counter_delta("carbide_authn_connection_attributes_missing_total", &[]),
+            1.0
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_authn_client_cert_rejected_total",
+                &[("reason", "validation")]
+            ),
+            0.0
+        );
     }
 
     /// A healthy chain -- a mapping leaf plus a non-mapping second

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -25,8 +25,11 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_api_vault_token_time_until_refresh_seconds</td><td>gauge</td><td>The amount of time, in seconds, until the Vault token is required to be refreshed</td></tr>
 <tr><td>carbide_api_version</td><td>gauge</td><td>Version (git sha, build date, etc) of this service</td></tr>
 <tr><td>carbide_attestation_total</td><td>counter</td><td>Number of device attestations performed, by device type and outcome.</td></tr>
+<tr><td>carbide_auth_context_missing_total</td><td>counter</td><td>Number of Forge authorization requests missing authentication context, by authorizer</td></tr>
 <tr><td>carbide_auth_denied_total</td><td>counter</td><td>Number of Forge calls denied by the authorizer</td></tr>
+<tr><td>carbide_auth_permissive_overrides_total</td><td>counter</td><td>Number of policy denials overridden by authorization permissive mode, by principal class</td></tr>
 <tr><td>carbide_authn_client_cert_rejected_total</td><td>counter</td><td>Number of client certificates rejected during authentication</td></tr>
+<tr><td>carbide_authn_connection_attributes_missing_total</td><td>counter</td><td>Number of requests authentication could not inspect because connection attributes were missing</td></tr>
 <tr><td>carbide_available_ips_count</td><td>gauge</td><td>Number of available IPs per network segment</td></tr>
 <tr><td>carbide_bmc_proxy_authorization_denied_total</td><td>counter</td><td>Number of BMC proxy requests denied by authorization layer and HTTP method</td></tr>
 <tr><td>carbide_bmc_proxy_authorization_errors_total</td><td>counter</td><td>Number of BMC proxy authorization errors caused by missing authentication context, by authorization layer and HTTP method</td></tr>


### PR DESCRIPTION
Authentication already warns when connection metadata or authorization context is missing, and permissive mode warns when it turns a policy denial into an allow. These are guardrails we want to trend without scraping logs, so this converts the existing warnings to Events that emit each record and its counter together.

The metrics use only bounded authorizer and principal-class labels. Request methods, client addresses, identities, predicates, and errors stay on the log record, while the existing fail-closed and permissive behavior remains unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3981

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-authn middleware`
- `cargo test -p carbide-api-core auth:: --lib`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

Casbin enforcer errors, unrecognized routes, OAuth response diagnostics, and machine-identity issuance rejections remain outside this PR.

Closes #3981
