### PR TITLE
feat(api-core): count extension-service credential cleanup failures

### DIFF
--- a/crates/api-core/src/handlers/extension_service.rs
+++ b/crates/api-core/src/handlers/extension_service.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
+use carbide_instrument::{Event, LabelValue, emit};
 use carbide_secrets::credentials::{CredentialKey, Credentials};
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::extension_service::ExtensionServiceId;
@@ -32,6 +33,61 @@ use crate::api::{Api, log_request_data, log_tenant_organization_id};
 
 const MAX_POD_SPEC_SIZE: usize = 2 << 15; // 64 KB
 const MAX_OBSERVABILITY_CONFIG_PER_SERVICE: usize = 20;
+
+/// Which API operation left an extension-service credential for cleanup.
+///
+/// `operation` is the only metric label. Service IDs, versions, and errors
+/// stay on the log record so individual credentials cannot create new series.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum ExtensionServiceCredentialCleanupOperation {
+    Create,
+    Update,
+    Delete,
+}
+
+/// A create or update stored a credential before its database transaction
+/// failed, and the follow-up cleanup could not delete it.
+#[derive(Event)]
+#[event(
+    event_name = "extension_service_credential_rollback_cleanup_failed",
+    metric_name = "carbide_extension_service_credential_cleanup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "Failed to delete extension service credential after transaction failure",
+    describe = "Number of extension-service credential cleanup failures, by operation."
+)]
+struct ExtensionServiceCredentialRollbackCleanupFailed {
+    #[label]
+    operation: ExtensionServiceCredentialCleanupOperation,
+    #[context]
+    extension_service_id: ExtensionServiceId,
+    #[context]
+    error: String,
+}
+
+/// A version was deleted in the database, but its post-commit credential
+/// cleanup failed.
+#[derive(Event)]
+#[event(
+    event_name = "extension_service_credential_delete_cleanup_failed",
+    metric_name = "carbide_extension_service_credential_cleanup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "Failed to delete extension service credential",
+    describe = "Number of extension-service credential cleanup failures, by operation."
+)]
+struct ExtensionServiceCredentialDeleteCleanupFailed {
+    #[label]
+    operation: ExtensionServiceCredentialCleanupOperation,
+    #[context]
+    extension_service_id: ExtensionServiceId,
+    #[context]
+    version: ConfigVersion,
+    #[context]
+    error: String,
+}
 
 /// Creates a new extension service with an initial version.
 pub(crate) async fn create(
@@ -136,16 +192,17 @@ pub(crate) async fn create(
             if req.credential.is_some() {
                 let credential_key =
                     create_extension_service_credential_key(&service_id, initial_version);
-                // Best effort deletion - log but don't fail the request if deletion fails
+                // Cleanup is best effort: keep the transaction error as the
+                // request error, but record any credential it leaves behind.
                 if let Err(delete_err) =
                     delete_extension_service_credential(&api.credential_manager, credential_key)
                         .await
                 {
-                    tracing::warn!(
-                        extension_service_id = %service_id,
-                        error = %delete_err,
-                        "Failed to delete extension service credential after transaction failure",
-                    );
+                    emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                        operation: ExtensionServiceCredentialCleanupOperation::Create,
+                        extension_service_id: service_id,
+                        error: delete_err.to_string(),
+                    });
                 }
             }
             return Err(e.into());
@@ -388,11 +445,11 @@ pub(crate) async fn update(
                         delete_extension_service_credential(&api.credential_manager, credential_key)
                             .await
                     {
-                        tracing::warn!(
-                            extension_service_id = %service_id,
-                            error = %delete_err,
-                            "Failed to delete extension service credential after transaction failure",
-                        );
+                        emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                            operation: ExtensionServiceCredentialCleanupOperation::Update,
+                            extension_service_id: service_id,
+                            error: delete_err.to_string(),
+                        });
                     }
                 }
                 return Err(e.into());
@@ -518,16 +575,17 @@ pub(crate) async fn delete(
         for version in &credential_version {
             let credential_key = create_extension_service_credential_key(&service_id, *version);
 
-            // Best effort deletion - log but don't fail if deletion fails
-            if let Err(e) =
+            // The database deletion is already committed, so credential
+            // cleanup stays best effort and does not fail the API request.
+            if let Err(error) =
                 delete_extension_service_credential(&api.credential_manager, credential_key).await
             {
-                tracing::warn!(
-                    extension_service_id = %service_id,
-                    version = %version,
-                    error = %e,
-                    "Failed to delete extension service credential",
-                );
+                emit(ExtensionServiceCredentialDeleteCleanupFailed {
+                    operation: ExtensionServiceCredentialCleanupOperation::Delete,
+                    extension_service_id: service_id,
+                    version: *version,
+                    error: error.to_string(),
+                });
             }
         }
     }
@@ -1087,4 +1145,136 @@ pub(crate) async fn get_extension_service_credential(
             }),
         ),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    const CLEANUP_FAILURE_METRIC: &str =
+        "carbide_extension_service_credential_cleanup_failures_total";
+    const EXTENSION_SERVICE_ID: &str = "00000000-0000-0000-0000-000000000000";
+    const VERSION: &str = "V3-T0";
+
+    #[derive(Debug)]
+    enum CleanupFailureCase {
+        Create,
+        Update,
+        Delete,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct CleanupFailureObservation {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        operation: Option<String>,
+        extension_service_id: Option<String>,
+        version: Option<String>,
+        error: Option<String>,
+        counter_delta: f64,
+    }
+
+    #[test]
+    fn credential_cleanup_failures_log_and_count_by_operation() {
+        value_scenarios!(
+            run = |case| {
+                let extension_service_id = ExtensionServiceId::nil();
+                let version = VERSION.parse::<ConfigVersion>().unwrap();
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| match case {
+                    CleanupFailureCase::Create => {
+                        emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                            operation: ExtensionServiceCredentialCleanupOperation::Create,
+                            extension_service_id,
+                            error: "credential delete failed".to_string(),
+                        });
+                    }
+                    CleanupFailureCase::Update => {
+                        emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                            operation: ExtensionServiceCredentialCleanupOperation::Update,
+                            extension_service_id,
+                            error: "credential delete failed".to_string(),
+                        });
+                    }
+                    CleanupFailureCase::Delete => {
+                        emit(ExtensionServiceCredentialDeleteCleanupFailed {
+                            operation: ExtensionServiceCredentialCleanupOperation::Delete,
+                            extension_service_id,
+                            version,
+                            error: "credential delete failed".to_string(),
+                        });
+                    }
+                });
+                assert_eq!(logs.len(), 1, "each cleanup failure should write one record");
+                let log = logs.first().expect("cleanup failure Event did not log");
+                let operation = log.field("operation").map(str::to_string);
+
+                CleanupFailureObservation {
+                    level: log.level,
+                    metadata_name: log.metadata_name.clone(),
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    operation: operation.clone(),
+                    extension_service_id: log
+                        .field("extension_service_id")
+                        .map(str::to_string),
+                    version: log.field("version").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    counter_delta: metrics.counter_delta(
+                        CLEANUP_FAILURE_METRIC,
+                        &[("operation", operation.as_deref().unwrap())],
+                    ),
+                }
+            };
+            "create transaction cleanup fails" {
+                CleanupFailureCase::Create => CleanupFailureObservation {
+                    level: tracing::Level::WARN,
+                    metadata_name: "extension_service_credential_rollback_cleanup_failed".to_string(),
+                    message: "Failed to delete extension service credential after transaction failure".to_string(),
+                    event_name: Some("extension_service_credential_rollback_cleanup_failed".to_string()),
+                    metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
+                    operation: Some("create".to_string()),
+                    extension_service_id: Some(EXTENSION_SERVICE_ID.to_string()),
+                    version: None,
+                    error: Some("credential delete failed".to_string()),
+                    counter_delta: 1.0,
+                },
+            }
+            "update transaction cleanup fails" {
+                CleanupFailureCase::Update => CleanupFailureObservation {
+                    level: tracing::Level::WARN,
+                    metadata_name: "extension_service_credential_rollback_cleanup_failed".to_string(),
+                    message: "Failed to delete extension service credential after transaction failure".to_string(),
+                    event_name: Some("extension_service_credential_rollback_cleanup_failed".to_string()),
+                    metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
+                    operation: Some("update".to_string()),
+                    extension_service_id: Some(EXTENSION_SERVICE_ID.to_string()),
+                    version: None,
+                    error: Some("credential delete failed".to_string()),
+                    counter_delta: 1.0,
+                },
+            }
+            "post-commit delete cleanup fails" {
+                CleanupFailureCase::Delete => CleanupFailureObservation {
+                    level: tracing::Level::WARN,
+                    metadata_name: "extension_service_credential_delete_cleanup_failed".to_string(),
+                    message: "Failed to delete extension service credential".to_string(),
+                    event_name: Some("extension_service_credential_delete_cleanup_failed".to_string()),
+                    metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
+                    operation: Some("delete".to_string()),
+                    extension_service_id: Some(EXTENSION_SERVICE_ID.to_string()),
+                    version: Some(VERSION.to_string()),
+                    error: Some("credential delete failed".to_string()),
+                    counter_delta: 1.0,
+                },
+            }
+        );
+    }
 }

--- a/crates/api-core/src/tests/extension_service.rs
+++ b/crates/api-core/src/tests/extension_service.rs
@@ -22,6 +22,7 @@ use ::rpc::forge::{
     self as rpc, DpuExtensionServiceObservabilityConfig,
     DpuExtensionServiceObservabilityConfigLogging,
 };
+use carbide_instrument::testing::MetricsCapture;
 use carbide_secrets::credentials::{CredentialKey, Credentials};
 use config_version::ConfigVersion;
 use tonic::Request;
@@ -33,6 +34,8 @@ use crate::tests::common::api_fixtures::{TestEnv, create_managed_host, create_te
 const TEST_SERVICE_DATA: &str = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: test\nspec:\n  containers:\n    - name: app\n      image: nginx:1.27";
 const TEST_SERVICE_DATA_VERSION_2: &str = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: version-2\nspec:\n  containers:\n    - name: app\n      image: nginx:1.27";
 const TEST_SERVICE_DATA_VERSION_3: &str = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: version-3\nspec:\n  containers:\n    - name: app\n      image: nginx:1.27";
+const CREDENTIAL_CLEANUP_FAILURE_METRIC: &str =
+    "carbide_extension_service_credential_cleanup_failures_total";
 
 fn create_credential() -> rpc::DpuExtensionServiceCredential {
     rpc::DpuExtensionServiceCredential {
@@ -392,7 +395,13 @@ async fn test_extension_service_create_failure(db_pool: sqlx::PgPool) -> Result<
         .await?
         .expect("creating an extension service should have created a credential");
 
-    // Try to create an identical extension service
+    let metrics = MetricsCapture::start();
+    env.test_credential_manager
+        .set_delete_credentials_failure(true);
+
+    // Try to create an identical extension service. The database rejects the
+    // duplicate after the new credential was stored, and this fixture makes
+    // the follow-up credential cleanup fail too.
     let create_resp_2 = env
         .api
         .create_dpu_extension_service(Request::new(requested_extension_service))
@@ -400,6 +409,13 @@ async fn test_extension_service_create_failure(db_pool: sqlx::PgPool) -> Result<
     assert!(
         create_resp_2.is_err(),
         "creating a second identical extension service should have failed"
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            CREDENTIAL_CLEANUP_FAILURE_METRIC,
+            &[("operation", "create")],
+        ),
+        1.0,
     );
 
     let stored_credential_2 = env
@@ -578,6 +594,10 @@ async fn test_extension_service_update_failure(db_pool: sqlx::PgPool) -> Result<
         c
     };
 
+    let metrics = MetricsCapture::start();
+    env.test_credential_manager
+        .set_delete_credentials_failure(true);
+
     let update_response = env
         .api
         .update_dpu_extension_service(Request::new(rpc::UpdateDpuExtensionServiceRequest {
@@ -594,6 +614,13 @@ async fn test_extension_service_update_failure(db_pool: sqlx::PgPool) -> Result<
     assert!(
         update_response.is_err(),
         "update_dpu_extension_service should have failed, got: {update_response:?}"
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            CREDENTIAL_CLEANUP_FAILURE_METRIC,
+            &[("operation", "update")],
+        ),
+        1.0,
     );
 
     let service_2_credentials_after =
@@ -1922,6 +1949,108 @@ async fn test_extension_service_create_update_delete_credential(
         .await;
     assert!(stored_credential.is_ok());
     assert!(stored_credential.unwrap().is_none());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_extension_service_delete_credential_cleanup_failure(
+    db_pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env = create_test_env(db_pool).await;
+    create_test_tenants(&env).await?;
+    let first_service_version =
+        create_test_extension_service(&env.api, "test-service", Some(create_credential())).await?;
+    let service_id = first_service_version.service_id.clone();
+    let first_version = first_service_version
+        .latest_version_info
+        .as_ref()
+        .unwrap()
+        .version
+        .parse::<ConfigVersion>()?;
+
+    let second_service_version = env
+        .api
+        .update_dpu_extension_service(Request::new(rpc::UpdateDpuExtensionServiceRequest {
+            service_id: service_id.clone(),
+            service_name: None,
+            description: None,
+            data: TEST_SERVICE_DATA_VERSION_2.to_string(),
+            credential: Some(create_credential()),
+            observability: None,
+            if_version_ctr_match: Some(1),
+        }))
+        .await?
+        .into_inner();
+    let second_version = second_service_version
+        .latest_version_info
+        .as_ref()
+        .unwrap()
+        .version
+        .parse::<ConfigVersion>()?;
+    let first_credential_key = CredentialKey::ExtensionService {
+        service_id: service_id.clone(),
+        version: first_version.version_nr().to_string(),
+    };
+    let second_credential_key = CredentialKey::ExtensionService {
+        service_id: service_id.clone(),
+        version: second_version.version_nr().to_string(),
+    };
+    let first_credential_before = env
+        .api
+        .credential_manager
+        .get_credentials(&first_credential_key)
+        .await?;
+    let second_credential_before = env
+        .api
+        .credential_manager
+        .get_credentials(&second_credential_key)
+        .await?;
+
+    let metrics = MetricsCapture::start();
+    env.test_credential_manager
+        .set_delete_credentials_failure(true);
+
+    // The service version is committed as deleted before credential cleanup
+    // runs. A credential-store failure must be visible without turning the RPC
+    // into an error that suggests the database deletion can be retried.
+    let delete_response = env
+        .api
+        .delete_dpu_extension_service(Request::new(rpc::DeleteDpuExtensionServiceRequest {
+            service_id: service_id.clone(),
+            versions: vec![first_version.to_string(), second_version.to_string()],
+        }))
+        .await;
+
+    assert!(delete_response.is_ok());
+    assert_eq!(
+        metrics.counter_delta(
+            CREDENTIAL_CLEANUP_FAILURE_METRIC,
+            &[("operation", "delete")],
+        ),
+        2.0,
+    );
+
+    let find_response = env
+        .api
+        .find_dpu_extension_services_by_ids(Request::new(rpc::DpuExtensionServicesByIdsRequest {
+            service_ids: vec![service_id],
+        }))
+        .await?;
+    assert!(find_response.into_inner().services.is_empty());
+
+    let first_credential_after = env
+        .api
+        .credential_manager
+        .get_credentials(&first_credential_key)
+        .await?;
+    let second_credential_after = env
+        .api
+        .credential_manager
+        .get_credentials(&second_credential_key)
+        .await?;
+    assert_eq!(first_credential_after, first_credential_before);
+    assert_eq!(second_credential_after, second_credential_before);
 
     Ok(())
 }

--- a/crates/secrets/src/test_support/credentials.rs
+++ b/crates/secrets/src/test_support/credentials.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic;
-use std::sync::atomic::AtomicU32;
+use std::sync::atomic::{AtomicBool, AtomicU32};
 
 use async_trait::async_trait;
 use tokio::sync::Mutex;
@@ -30,6 +30,7 @@ pub struct TestCredentialManager {
     credentials: Mutex<HashMap<String, Credentials>>,
     fallback_credentials: Option<Credentials>,
     pub set_credentials_sleep_time_ms: AtomicU32,
+    delete_credentials_failure: AtomicBool,
 }
 
 impl TestCredentialManager {
@@ -40,7 +41,15 @@ impl TestCredentialManager {
             credentials: Mutex::new(HashMap::new()),
             fallback_credentials: Some(fallback_credentials),
             set_credentials_sleep_time_ms: Default::default(),
+            delete_credentials_failure: Default::default(),
         }
+    }
+
+    /// Makes `delete_credentials` return an error without removing the stored
+    /// credential.
+    pub fn set_delete_credentials_failure(&self, fail: bool) {
+        self.delete_credentials_failure
+            .store(fail, atomic::Ordering::Release);
     }
 }
 
@@ -101,6 +110,15 @@ impl CredentialWriter for TestCredentialManager {
     }
 
     async fn delete_credentials(&self, key: &CredentialKey) -> Result<(), SecretsError> {
+        if self
+            .delete_credentials_failure
+            .load(atomic::Ordering::Acquire)
+        {
+            return Err(SecretsError::GenericError(eyre::eyre!(
+                "test credential delete failure"
+            )));
+        }
+
         let mut data = self.credentials.lock().await;
         let _ = data.remove(key.to_key_str().as_ref());
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -78,6 +78,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_endpoint_exploration_success_count</td><td>gauge</td><td>Number of successful endpoint explorations</td></tr>
 <tr><td>carbide_endpoint_explorations_count</td><td>gauge</td><td>Number of attempted endpoint explorations</td></tr>
 <tr><td>carbide_exhausted_reprovision_retry_count</td><td>gauge</td><td>Number of host machines in the system whose host firmware upgrade retry budget is exhausted.</td></tr>
+<tr><td>carbide_extension_service_credential_cleanup_failures_total</td><td>counter</td><td>Number of extension-service credential cleanup failures, by operation.</td></tr>
 <tr><td>carbide_external_call_duration_milliseconds</td><td>histogram</td><td>Duration of outbound calls by backend, operation, and outcome; the _count series, split by outcome, gives the request and error rates.</td></tr>
 <tr><td>carbide_firmware_download_duration_seconds</td><td>histogram</td><td>Duration of background firmware artifact downloads, by outcome; an ok attempt spans fetch, checksum verification, and publish, and the _count series, split by outcome, is the download and failure rate.</td></tr>
 <tr><td>carbide_firmware_update_failures_total</td><td>counter</td><td>Number of firmware update failures, by update target and cause</td></tr>


### PR DESCRIPTION
Extension-service create and update can store a credential before their database transaction finishes, while delete removes credentials after its soft deletion commits. When that best-effort cleanup fails, an orphaned credential can remain and only the warning explains it. This converts those warnings to Events backed by one operation-labeled cleanup counter.

The existing request behavior remains unchanged: create and update return the original transaction error, delete stays successful after its database commit, and the counter advances once for each credential deletion attempt that fails.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3982

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-api-core extension_service --lib`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

This application-level metric is separate from the existing ForgeVault request-failure metric because it records the orphaned-credential consequence across credential writers.

Closes #3982
