### PR TITLE
feat(scout): count dropped stream responses

### DIFF
--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -137,6 +137,28 @@ pub struct ScoutStreamReconnect {
     pub machine_id: MachineId,
 }
 
+/// `ScoutStreamResponseDropped` records a response scout could not return
+/// after the outbound request stream closed. The stream loop still breaks and
+/// reconnects, while this Event identifies the response that was lost.
+#[derive(Event)]
+#[event(
+    event_name = "scout_stream_response_dropped",
+    metric_name = "carbide_scout_stream_responses_dropped_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "scout stream failed to send response",
+    describe = "Number of scout stream responses dropped after the outbound request stream closed."
+)]
+pub(crate) struct ScoutStreamResponseDropped {
+    #[context]
+    pub api_endpoint: String,
+    #[context]
+    pub machine_id: MachineId,
+    #[context]
+    pub error: String,
+}
+
 /// Which storage cleanup path scout ran for a device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
 pub(crate) enum StorageDeviceType {
@@ -507,6 +529,43 @@ mod tests {
 
         assert_eq!(
             metrics.counter_delta("carbide_scout_stream_reconnects_total", &[]),
+            1.0
+        );
+    }
+
+    #[test]
+    fn scout_stream_response_drop_logs_and_counts() {
+        let metrics = MetricsCapture::start();
+        let machine_id =
+            MachineId::from_str("fm100htes3rn1npvbtm5qd57dkilaag7ljugl1llmm7rfuq1ov50i0rpl30")
+                .expect("valid machine id");
+        let logs = capture_logs(|| {
+            emit(ScoutStreamResponseDropped {
+                api_endpoint: "https://[::1]:1079".to_string(),
+                machine_id,
+                error: "request stream closed".to_string(),
+            });
+        });
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].metadata_name, "scout_stream_response_dropped");
+        assert_eq!(logs[0].level, tracing::Level::ERROR);
+        assert_eq!(logs[0].message, "scout stream failed to send response");
+        assert_eq!(
+            logs[0].field("event_name"),
+            Some("scout_stream_response_dropped")
+        );
+        assert_eq!(
+            logs[0].field("metric_name"),
+            Some("carbide_scout_stream_responses_dropped_total")
+        );
+        assert_eq!(logs[0].field("api_endpoint"), Some("https://[::1]:1079"));
+        let machine_id = machine_id.to_string();
+        assert_eq!(logs[0].field("machine_id"), Some(machine_id.as_str()));
+        assert_eq!(logs[0].field("error"), Some("request stream closed"));
+
+        assert_eq!(
+            metrics.counter_delta("carbide_scout_stream_responses_dropped_total", &[]),
             1.0
         );
     }

--- a/crates/scout/src/stream.rs
+++ b/crates/scout/src/stream.rs
@@ -25,7 +25,7 @@ use rpc::protos::forge::{scout_stream_api_bound_message, scout_stream_scout_boun
 use tokio::sync::mpsc;
 
 use crate::cfg::Options;
-use crate::metrics::{ScoutStreamConnection, ScoutStreamReconnect};
+use crate::metrics::{ScoutStreamConnection, ScoutStreamReconnect, ScoutStreamResponseDropped};
 use crate::{client, mlx_device};
 
 // ScoutStreamError represents errors that can
@@ -159,12 +159,11 @@ async fn run_scout_stream_loop(
 
             // And then send the response back to carbide-api.
             if let Err(e) = tx.send(payload).await {
-                tracing::error!(
-                    api_endpoint = %options.api,
-                    %machine_id,
-                    error = %e,
-                    "scout stream failed to send response",
-                );
+                emit(ScoutStreamResponseDropped {
+                    api_endpoint: options.api.clone(),
+                    machine_id,
+                    error: e.to_string(),
+                });
                 break;
             }
         }

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -202,6 +202,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_scout_storage_device_cleanup_duration_seconds</td><td>histogram</td><td>Duration of per-device scout storage cleanup operations, by device type and outcome.</td></tr>
 <tr><td>carbide_scout_stream_connections_total</td><td>counter</td><td>Number of scout stream connection attempts, by outcome.</td></tr>
 <tr><td>carbide_scout_stream_reconnects_total</td><td>counter</td><td>Number of scout stream reconnect cycles after a stream closed or errored.</td></tr>
+<tr><td>carbide_scout_stream_responses_dropped_total</td><td>counter</td><td>Number of scout stream responses dropped after the outbound request stream closed.</td></tr>
 <tr><td>carbide_site_exploration_expected_machines_sku_count</td><td>gauge</td><td>Number of expected machines by SKU ID and device type</td></tr>
 <tr><td>carbide_site_exploration_identified_managed_hosts_count</td><td>gauge</td><td>Number of Host+DPU pairs identified in the last SiteExplorer run</td></tr>
 <tr><td>carbide_site_explorer_bmc_password_rotations_total</td><td>counter</td><td>Number of BMC root password rotations onto the site-wide credential, by outcome</td></tr>


### PR DESCRIPTION
Scout can finish handling a stream request just as the API side closes the outbound channel. The response is then lost and Scout enters its normal reconnect path, so this converts the existing error to an Event that also counts the dropped response.

The new counter has no labels. API endpoint, machine ID, and error detail remain on the log record, and the loop break, connection-loss return, and reconnect behavior remain unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3983

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-scout metrics`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

The existing connection and reconnect Events remain separate because they describe different stream boundaries.

Closes #3983
