### PR TITLE
txn_held_across_await lint: Teach to deal with inner transactions

### DIFF
--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -488,11 +488,6 @@ async fn allocate_prefix_candidate_once(
 ///
 /// Every unsuccessful attempt explicitly rolls back its savepoint before the
 /// caller advances or retries, releasing any lock acquired only by that attempt.
-// Custom-lint exception for #3456 (@bcavnvidia): the lint treats the outer
-// `PgConnection` as a transaction held across every await. All awaits here are
-// database work performed through an inner savepoint, which is explicitly
-// committed or rolled back before returning.
-#[allow(txn_held_across_await)]
 async fn attempt_prefix_candidate(
     txn: &mut PgConnection,
     vpc_id: VpcId,

--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -517,12 +517,8 @@ fn build_kms_backend(
 /// where they are stranded. Site-explorer credential rotation is the writer
 /// to worry about; keep it disabled until the whole fleet runs a consistent
 /// config.
-// Custom-lint exception for #2665 (@chet): this function intentionally keeps a
-// dedicated detached connection alive across awaits because the Vault import
-// lock is session-scoped and releases when that connection closes. The custom
-// lint also classifies bare `PgConnection`s as transactions, but no transaction
-// is open here: Vault reads and Postgres writes use separate pool connections so
-// the importer cannot block itself on pool capacity.
+/// TODO(@chet): Migrate this to using WorkLockManager to do scoped locks of
+/// work without holding open a database connection or transaction.
 #[allow(txn_held_across_await)]
 async fn import_vault_secrets_once(
     db_pool: &PgPool,

--- a/crates/api-core/src/secrets/re_wrap.rs
+++ b/crates/api-core/src/secrets/re_wrap.rs
@@ -60,13 +60,8 @@ struct PendingReWrap {
 /// Historical journal entries are re-wrapped too: they must stay
 /// decryptable, and re-wrapping them is what lets an old KEK be retired
 /// completely.
-// Custom-lint exception for #2665 (@chet): this function intentionally keeps a
-// dedicated detached connection alive across awaits because the re-wrap lock is
-// session-scoped and releases when that connection closes. The custom lint
-// classifies bare `PgConnection`s as transactions, but no transaction is open on
-// this connection; batch reads, KMS work, and batch-write transactions use
-// separate pool connections.
-#[allow(txn_held_across_await)]
+/// TODO(@chet): Migrate this to using WorkLockManager to do scoped locks of
+/// work without holding open a database connection or transaction.
 pub async fn re_wrap_stale(
     pool: &PgPool,
     kms: &dyn KmsBackend,

--- a/crates/api-core/src/secrets/re_wrap.rs
+++ b/crates/api-core/src/secrets/re_wrap.rs
@@ -62,6 +62,7 @@ struct PendingReWrap {
 /// completely.
 /// TODO(@chet): Migrate this to using WorkLockManager to do scoped locks of
 /// work without holding open a database connection or transaction.
+#[allow(txn_held_across_await)]
 pub async fn re_wrap_stale(
     pool: &PgPool,
     kms: &dyn KmsBackend,

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -37,7 +37,6 @@ pub async fn get_fw_updates_running_count(txn: &mut PgConnection) -> Result<i64,
     Ok(count)
 }
 
-#[allow(txn_held_across_await)]
 pub async fn trigger_reprovisioning_for_managed_host(
     txn: &mut PgConnection,
     machine_updates: &[DpuMachineUpdate],

--- a/crates/api-db/src/instance_address.rs
+++ b/crates/api-db/src/instance_address.rs
@@ -294,7 +294,6 @@ async fn insert_instance_addresses(
 
 /// Tries to allocate IP addresses for a tenant network configuration
 /// Returns the updated configuration which includes allocated addresses
-#[allow(txn_held_across_await)]
 pub async fn allocate(
     txn: &mut PgConnection,
     instance_id: InstanceId,

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1309,7 +1309,6 @@ pub async fn create_with_type(
     Ok(snapshot)
 }
 
-#[allow(txn_held_across_await)]
 async fn create_fast_path(
     txn: &mut PgConnection,
     segments: &[NetworkSegment],
@@ -1373,7 +1372,6 @@ async fn create_fast_path(
             };
 
             fast_txn.rollback().await?;
-            tokio::task::yield_now().await;
 
             // If this segment is exhausted, go to the next segment.
             if segment_exhausted {
@@ -1467,7 +1465,6 @@ async fn create_static_path(
 /// - Locking the machine_interfaces_lock table
 /// - Reading all used IP's from the database for the given segment
 /// - Selecting a batch of IP's according to the selection strategy
-#[allow(txn_held_across_await)]
 pub async fn create_slow_path(
     txn: &mut PgConnection,
     segment: &NetworkSegment,
@@ -2316,20 +2313,10 @@ pub async fn create_host_machine_dpu_interface_proactively(
 ///
 /// Returns `true` only when the externally visible active admin config changed. Dormant-interface
 /// cleanup is persisted but intentionally returns `false` by itself.
-#[allow(txn_held_across_await)]
 pub async fn reconcile_admin_addresses_for_host(
     txn: &mut PgConnection,
     host_machine_id: &MachineId,
 ) -> DatabaseResult<bool> {
-    // This allow is for a limitation in the custom `txn_held_across_await` lint, not for unrelated
-    // async work. The input `&mut PgConnection` is immediately wrapped in an inner transaction
-    // savepoint, and every await before commit is database work performed through that savepoint
-    // (`txn.as_pgconn()`, `&mut txn`, or helpers that receive it). The lint still reports the outer
-    // connection parameter as held across those awaits because it does not track that
-    // `Transaction::begin_inner(txn)` transfers subsequent DB work onto the wrapper.
-    // Treat reconciliation as one savepoint inside the caller's transaction. All row locks,
-    // advisory segment locks, address moves, and cleanup either commit together or roll back
-    // together.
     let mut txn = Transaction::begin_inner(txn).await?;
 
     // Lock all admin segments up front instead of doing a precise pre-read of
@@ -3022,7 +3009,6 @@ async fn reconcile_interface_segment(
 /// allocation logic that we use for allocating initial addresses, and
 /// only allocates from prefixes matching the requested family (IPv4
 /// or IPv6).
-#[allow(txn_held_across_await)]
 pub async fn allocate_address_for_family(
     txn: &mut PgConnection,
     interface_id: MachineInterfaceId,

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -196,7 +196,6 @@ pub async fn insert(
 /// - `Static`: the old static address is replaced.
 /// - `Dhcp` or `Slaac`: the managed allocation is removed and
 ///   replaced with the static assignment.
-#[allow(txn_held_across_await)]
 pub async fn assign_static(
     txn: &mut PgConnection,
     interface_id: MachineInterfaceId,

--- a/crates/api-db/src/network_prefix.rs
+++ b/crates/api-db/src/network_prefix.rs
@@ -164,7 +164,6 @@ pub async fn find_by_vpcs(
  * transaction
  * prefixes: A slice of the `NewNetworkPrefix` to create.
  */
-#[allow(txn_held_across_await)]
 pub async fn create_for(
     txn: &mut PgConnection,
     segment_id: &NetworkSegmentId,

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -80,7 +80,6 @@ pub async fn find_matching_with_exclusion(
     Ok(None)
 }
 
-#[allow(txn_held_across_await)]
 pub async fn create(txn: &mut PgConnection, sku: &Sku) -> Result<(), DatabaseError> {
     if sku.schema_version != CURRENT_SKU_VERSION {
         return Err(DatabaseError::InvalidArgument(
@@ -210,7 +209,6 @@ pub async fn update_metadata(
     Ok(())
 }
 
-#[allow(txn_held_across_await)]
 pub async fn replace(txn: &mut PgConnection, sku: &Sku) -> Result<Sku, DatabaseError> {
     if sku.schema_version != CURRENT_SKU_VERSION {
         return Err(DatabaseError::InvalidArgument(

--- a/lints/carbide-lints/src/txn_held_across_await.rs
+++ b/lints/carbide-lints/src/txn_held_across_await.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 use rustc_ast::UnOp;
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::DiagDecorator;
 use rustc_hir as hir;
-use rustc_hir::def::Res;
+use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{
     Body, Expr, ExprKind, HirId, ImplItem, ImplItemKind, Item, ItemKind, LetStmt, Node, Param,
@@ -195,6 +195,7 @@ impl TxnHeldAcrossAwait {
 
         // Gather typeck results, needed to get type info for locals
         let typeck_results = tcx.typeck_body(hir_body_id);
+        let txn_lineage = TxnLineage::gather(self, hir_body, typeck_results, tcx, param_env);
 
         // Gather all move data in the MIR body (to analyze when txn's are moved out of scope)
         let move_data = MoveData::gather_moves(&mir_body, tcx, |_| true);
@@ -258,10 +259,9 @@ impl TxnHeldAcrossAwait {
                         await_span: source_info.span,
                         txn_local: SpanOrHirId::Span(local_decl.source_info.span),
                     },
+                    &txn_lineage,
                     hir_body,
-                    typeck_results,
                     tcx,
-                    param_env,
                 ) {
                     continue;
                 }
@@ -299,6 +299,8 @@ impl TxnHeldAcrossAwait {
 
         // Gather typeck results, needed to get type info for locals
         let typeck_results = tcx.typeck_body(closure.body);
+        let hir_body = tcx.hir_body(closure.body);
+        let txn_lineage = TxnLineage::gather(self, hir_body, typeck_results, tcx, param_env);
 
         // Gather all move data in the MIR body (to analyze when txn's are moved out of scope)
         let move_data = MoveData::gather_moves(&mir_body, tcx, |_| true);
@@ -386,10 +388,9 @@ impl TxnHeldAcrossAwait {
                         await_span: source_info.span,
                         txn_local: SpanOrHirId::HirId(txn_local_hir_id),
                     },
-                    tcx.hir_body(closure.body),
-                    typeck_results,
+                    &txn_lineage,
+                    hir_body,
                     tcx,
-                    param_env,
                 ) {
                     continue;
                 }
@@ -552,11 +553,8 @@ impl TxnHeldAcrossAwait {
     /// - `some_fn(txn.deref_mut()) // deref_mut() is a special case`
     pub fn is_passing_txn<'tcx>(
         &self,
-        txn_local_hir_id: HirId,
+        txn_local_hir_ids: &FxHashSet<HirId>,
         awaited: &Expr<'tcx>,
-        tcx: TyCtxt<'tcx>,
-        typeck_results: &TypeckResults<'tcx>,
-        param_env: ParamEnv<'tcx>,
     ) -> bool {
         let args = match awaited.peel_borrows().kind {
             // e.g. `db::machine::get(db)`
@@ -567,14 +565,12 @@ impl TxnHeldAcrossAwait {
                 // txn.prepare(...).await(), etc count as passing txn (as the self param)
                 if let ExprKind::Path(qpath) = recv.kind {
                     if let Some(Res::Local(hir_id)) = qpath_res(&qpath)
-                        && hir_id == txn_local_hir_id
+                        && txn_local_hir_ids.contains(&hir_id)
                     {
                         return true;
                     }
                 }
-                if let Some(ty) = typeck_results.expr_ty_opt(recv)
-                    && self.is_sqlx_transaction_ty(tcx, param_env, &ty)
-                {
+                if local_hir_id(recv).is_some_and(|hir_id| txn_local_hir_ids.contains(&hir_id)) {
                     return true;
                 }
                 args
@@ -621,7 +617,7 @@ impl TxnHeldAcrossAwait {
 
             txn_param_res.is_some_and(|res| {
                 if let Res::Local(hir_id) = res {
-                    hir_id.local_id == txn_local_hir_id.local_id
+                    txn_local_hir_ids.contains(hir_id)
                 } else {
                     false
                 }
@@ -643,6 +639,190 @@ impl TxnHeldAcrossAwait {
             }
         }
         None
+    }
+}
+
+#[derive(Default)]
+struct TxnLineage {
+    children: FxHashMap<HirId, Vec<HirId>>,
+}
+
+impl TxnLineage {
+    fn gather<'tcx>(
+        lint: &TxnHeldAcrossAwait,
+        body: &'tcx Body<'tcx>,
+        typeck_results: &'tcx TypeckResults<'tcx>,
+        tcx: TyCtxt<'tcx>,
+        param_env: ParamEnv<'tcx>,
+    ) -> Self {
+        let mut finder = TxnLineageFinder {
+            lint,
+            typeck_results,
+            tcx,
+            param_env,
+            lineage: Self::default(),
+        };
+        finder.visit_body(body);
+        finder.lineage
+    }
+
+    fn descendants_including(&self, local: HirId) -> FxHashSet<HirId> {
+        let mut descendants = FxHashSet::default();
+        let mut pending = vec![local];
+        while let Some(local) = pending.pop() {
+            if descendants.insert(local)
+                && let Some(children) = self.children.get(&local)
+            {
+                pending.extend(children);
+            }
+        }
+        descendants
+    }
+}
+
+struct TxnLineageFinder<'a, 'tcx> {
+    lint: &'a TxnHeldAcrossAwait,
+    typeck_results: &'tcx TypeckResults<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    lineage: TxnLineage,
+}
+
+impl<'tcx> Visitor<'tcx> for TxnLineageFinder<'_, 'tcx> {
+    // TypeckResults is scoped to one HIR owner. Nested items and closures have their own results
+    // and are checked independently, so crossing into them would query this owner's table with
+    // foreign HirIds and trigger an internal compiler error.
+    type NestedFilter = rustc_hir::intravisit::nested_filter::None;
+
+    fn visit_local(&mut self, let_stmt: &'tcx LetStmt<'tcx>) {
+        if let Some(init) = let_stmt.init
+            && let PatKind::Binding(_, child, ..) = let_stmt.pat.kind
+            && self.typeck_results.node_type_opt(child).is_some_and(|ty| {
+                self.lint
+                    .is_sqlx_transaction_ty(self.tcx, self.param_env, &ty)
+            })
+            && let Some(parent) = self.nested_transaction_parent(init)
+        {
+            self.lineage.children.entry(parent).or_default().push(child);
+        }
+
+        intravisit::walk_local(self, let_stmt);
+    }
+}
+
+impl<'tcx> TxnLineageFinder<'_, 'tcx> {
+    fn nested_transaction_parent(&self, init: &'tcx Expr<'tcx>) -> Option<HirId> {
+        let mut call_finder = NestedTransactionCallFinder {
+            lint: self.lint,
+            typeck_results: self.typeck_results,
+            tcx: self.tcx,
+            param_env: self.param_env,
+            parent: None,
+        };
+        call_finder.visit_expr(init);
+        call_finder.parent
+    }
+}
+
+struct NestedTransactionCallFinder<'a, 'tcx> {
+    lint: &'a TxnHeldAcrossAwait,
+    typeck_results: &'tcx TypeckResults<'tcx>,
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    parent: Option<HirId>,
+}
+
+impl<'tcx> Visitor<'tcx> for NestedTransactionCallFinder<'_, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        if self.parent.is_some() {
+            return;
+        }
+
+        self.parent = match expr.kind {
+            ExprKind::MethodCall(_, receiver, _, _) => {
+                let def_id = self.typeck_results.type_dependent_def_id(expr.hir_id);
+                if self.source_is_transaction(receiver)
+                    && def_id.is_some_and(|def_id| {
+                        self.tcx.item_name(def_id).as_str() == "begin"
+                            && self
+                                .tcx
+                                .def_path_str(def_id)
+                                .ends_with("sqlx::Acquire::begin")
+                    })
+                {
+                    local_hir_id(receiver)
+                } else {
+                    None
+                }
+            }
+            ExprKind::Call(callee, [first, ..]) => {
+                let def_id = match callee.kind {
+                    ExprKind::Path(ref qpath) => self
+                        .typeck_results
+                        .qpath_res(qpath, callee.hir_id)
+                        .opt_def_id(),
+                    _ => None,
+                };
+                if self.source_is_transaction(first)
+                    && def_id.is_some_and(|def_id| {
+                        let parent = self.tcx.parent(def_id);
+                        if !matches!(self.tcx.def_kind(parent), DefKind::Impl { .. }) {
+                            return false;
+                        }
+                        let parent_ty = self
+                            .tcx
+                            .type_of(parent)
+                            .instantiate_identity()
+                            .skip_norm_wip();
+                        self.tcx.item_name(def_id).as_str() == "begin_inner"
+                            && (self.lint.is_sqlx_transaction_ty(
+                                self.tcx,
+                                self.param_env,
+                                &parent_ty,
+                            ) || self
+                                .tcx
+                                .def_path_str(def_id)
+                                .ends_with("db::Transaction::begin_inner"))
+                    })
+                {
+                    local_hir_id(first)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+
+        intravisit::walk_expr(self, expr);
+    }
+}
+
+impl NestedTransactionCallFinder<'_, '_> {
+    fn source_is_transaction(&self, source: &Expr<'_>) -> bool {
+        self.typeck_results.expr_ty_opt(source).is_some_and(|ty| {
+            self.lint
+                .is_sqlx_transaction_ty(self.tcx, self.param_env, &ty)
+        })
+    }
+}
+
+fn local_hir_id(expr: &Expr<'_>) -> Option<HirId> {
+    let expr = expr.peel_borrows().peel_derefs();
+    match expr.kind {
+        ExprKind::Path(ref qpath) => match qpath_res(qpath) {
+            Some(Res::Local(hir_id)) => Some(hir_id),
+            _ => None,
+        },
+        ExprKind::MethodCall(ref segment, receiver, _, _)
+            if matches!(
+                segment.ident.name.as_str(),
+                "deref_mut" | "as_pgconn" | "as_mut"
+            ) =>
+        {
+            local_hir_id(receiver)
+        }
+        ExprKind::Field(base, _) => local_hir_id(base),
+        _ => None,
     }
 }
 
@@ -782,10 +962,9 @@ impl<'tcx> DbAwaitFinder<'tcx> {
     fn await_is_passing_local_as_param(
         lint: &TxnHeldAcrossAwait,
         params: DbAwaitSearchParams,
+        txn_lineage: &TxnLineage,
         body: &'tcx Body,
-        typeck_results: &'tcx TypeckResults<'tcx>,
         tcx: TyCtxt<'tcx>,
-        param_env: ParamEnv<'tcx>,
     ) -> bool {
         let mut finder = Self {
             tcx,
@@ -823,7 +1002,8 @@ impl<'tcx> DbAwaitFinder<'tcx> {
             return false;
         };
 
-        lint.is_passing_txn(txn_local_hir_id, await_expr, tcx, typeck_results, param_env)
+        let accepted_locals = txn_lineage.descendants_including(txn_local_hir_id);
+        lint.is_passing_txn(&accepted_locals, await_expr)
     }
 
     fn awaited_expr(&self) -> Option<&'tcx Expr<'tcx>> {

--- a/lints/carbide-lints/tests/fixtures/app/src/main.rs
+++ b/lints/carbide-lints/tests/fixtures/app/src/main.rs
@@ -1,7 +1,7 @@
 use std::ops::DerefMut;
 
 use sqlx::pool::PoolConnection;
-use sqlx::{Executor, PgConnection, PgTransaction, Postgres};
+use sqlx::{Acquire, Connection, Executor, PgConnection, PgTransaction, Postgres};
 
 async fn good_db_related() {
     let mut txn = make_transaction();
@@ -155,7 +155,18 @@ async fn unrelated_async_work(desc: &'static str) {
 fn non_async_work() {}
 
 mod db {
-    use sqlx::PgExecutor;
+    use sqlx::{PgExecutor, PgTransaction, Postgres};
+
+    pub struct Transaction;
+
+    impl Transaction {
+        pub async fn begin_inner<'a, A>(acquire: A) -> PgTransaction<'a>
+        where
+            A: sqlx::Acquire<'a, Database = Postgres>,
+        {
+            acquire.begin().await.unwrap()
+        }
+    }
 
     pub async fn actually_use_txn(_db: impl sqlx::PgExecutor<'_>) {}
     pub async fn use_db_as_trait<DB>(_db: &mut DB)
@@ -235,6 +246,67 @@ async fn bad_pgpoolconn_fn(_conn: &mut PoolConnection<Postgres>) {
 async fn good_pgpoolconn_fn(conn: PoolConnection<Postgres>) {
     std::mem::drop(conn);
     unrelated_async_work("good").await
+}
+
+async fn good_direct_nested_transaction() {
+    let mut txn = make_transaction();
+    let mut inner = txn.begin().await.unwrap();
+    db::actually_use_txn(inner.deref_mut()).await;
+    inner.commit().await.unwrap();
+    txn.commit().await.unwrap();
+}
+
+async fn good_begin_inner_from_connection() {
+    let mut conn = make_pgconn();
+    let mut inner = db::Transaction::begin_inner(&mut conn).await;
+    db::actually_use_txn(inner.deref_mut()).await;
+    inner.commit().await.unwrap();
+    conn.close().await.unwrap();
+}
+
+#[allow(txn_without_commit)]
+async fn good_shadowed_nested_transaction() {
+    let mut txn = make_transaction();
+    let mut txn = db::Transaction::begin_inner(&mut txn).await;
+    db::actually_use_txn(txn.deref_mut()).await;
+    txn.commit().await.unwrap();
+}
+
+async fn good_transitively_nested_transactions() {
+    let mut outer = make_transaction();
+    let mut inner = db::Transaction::begin_inner(&mut outer).await;
+    let mut deepest = db::Transaction::begin_inner(&mut inner).await;
+    db::actually_use_txn(deepest.deref_mut()).await;
+    deepest.commit().await.unwrap();
+    inner.commit().await.unwrap();
+    outer.commit().await.unwrap();
+}
+
+async fn bad_unrelated_work_with_nested_transaction() {
+    let mut outer = make_transaction();
+    let inner = db::Transaction::begin_inner(&mut outer).await;
+    unrelated_async_work("bad").await;
+    inner.commit().await.unwrap();
+    outer.commit().await.unwrap();
+}
+
+#[allow(txn_without_commit)]
+async fn bad_independent_transaction_lineages() {
+    let mut first = make_transaction();
+    let mut inner = db::Transaction::begin_inner(&mut first).await;
+    let second = make_transaction();
+    db::actually_use_txn(inner.deref_mut()).await;
+    std::mem::drop(second);
+    inner.commit().await.unwrap();
+    first.commit().await.unwrap();
+}
+
+async fn bad_after_inner_transaction_commit() {
+    let mut outer = make_transaction();
+    let inner = db::Transaction::begin_inner(&mut outer).await;
+    inner.commit().await.unwrap();
+    unrelated_async_work("bad").await;
+    outer.commit().await.unwrap();
 }
 
 async fn bad_unrelated_work_in_closure_upvars() {
@@ -325,6 +397,16 @@ async fn main() {
     good_txn_as_receiver().await;
     do_txn_by_value().await;
     pgconn_calls().await;
+    good_direct_nested_transaction().await;
+    make_wrapped_transaction().commit_inner().await;
+    good_root_begin_inner().await;
+    good_begin_inner_from_connection().await;
+    good_shadowed_nested_transaction().await;
+    good_transitively_nested_transactions().await;
+    good_nested_typeck_owner().await;
+    bad_unrelated_work_with_nested_transaction().await;
+    bad_independent_transaction_lineages().await;
+    bad_after_inner_transaction_commit().await;
     bad_unrelated_work_in_closure_upvars().await;
     good_related_work_in_closure_upvars().await;
     bad_unrelated_work_in_closure_locals().await;
@@ -334,6 +416,55 @@ async fn main() {
     let owned_txn = good_move_out().await;
     owned_txn.commit().await.unwrap();
     bad_takes_db_reader().await;
+}
+
+async fn good_nested_typeck_owner() {
+    struct Local;
+
+    impl PartialEq for Local {
+        fn eq(&self, _other: &Self) -> bool {
+            let equal = true;
+            equal
+        }
+    }
+
+    let _ = Local == Local;
+    let mut txn = make_transaction();
+    db::actually_use_txn(txn.deref_mut()).await;
+    txn.commit().await.unwrap();
+}
+
+struct Transaction<'a> {
+    inner: PgTransaction<'a>,
+}
+
+impl<'a> Transaction<'a> {
+    async fn begin_inner(conn: &'a mut PgConnection) -> Self {
+        Self {
+            inner: Acquire::begin(conn).await.unwrap(),
+        }
+    }
+
+    fn as_pgconn(&mut self) -> &mut PgConnection {
+        &mut self.inner
+    }
+
+    #[allow(txn_without_commit)]
+    async fn commit_inner(self) {
+        self.inner.commit().await.unwrap();
+    }
+}
+
+fn make_wrapped_transaction() -> Transaction<'static> {
+    todo!()
+}
+
+async fn good_root_begin_inner() {
+    let mut conn = make_pgconn();
+    let mut txn = Transaction::begin_inner(&mut conn).await;
+    db::actually_use_txn(txn.as_pgconn()).await;
+    txn.commit_inner().await;
+    conn.close().await.unwrap();
 }
 
 pub mod db_read {

--- a/lints/carbide-lints/tests/fixtures/app/src/main.stderr
+++ b/lints/carbide-lints/tests/fixtures/app/src/main.stderr
@@ -85,90 +85,138 @@ note: Transaction declared here
     |                         ^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:180:37
+   --> src/main.rs:191:37
     |
-180 |         unrelated_async_work("bad").await;
+191 |         unrelated_async_work("bad").await;
     |                                     ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:179:32
+   --> src/main.rs:190:32
     |
-179 |     pub async fn bad_fn(&self, _txn: &mut PgTransaction<'_>) {
+190 |     pub async fn bad_fn(&self, _txn: &mut PgTransaction<'_>) {
     |                                ^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:223:33
+   --> src/main.rs:234:33
     |
-223 |     unrelated_async_work("bad").await
+234 |     unrelated_async_work("bad").await
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:222:24
+   --> src/main.rs:233:24
     |
-222 | async fn bad_pgconn_fn(_conn: &mut PgConnection) {
+233 | async fn bad_pgconn_fn(_conn: &mut PgConnection) {
     |                        ^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:232:33
+   --> src/main.rs:243:33
     |
-232 |     unrelated_async_work("bad").await
+243 |     unrelated_async_work("bad").await
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:231:28
+   --> src/main.rs:242:28
     |
-231 | async fn bad_pgpoolconn_fn(_conn: &mut PoolConnection<Postgres>) {
+242 | async fn bad_pgpoolconn_fn(_conn: &mut PoolConnection<Postgres>) {
     |                            ^^^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:243:37
+   --> src/main.rs:288:33
     |
-243 |         unrelated_async_work("bad").await;
+288 |     unrelated_async_work("bad").await;
+    |                                 ^^^^^
+    |
+note: Transaction declared here
+   --> src/main.rs:286:9
+    |
+286 |     let mut outer = make_transaction();
+    |         ^^^^^^^^^
+
+error: A sqlx::Transaction is being held across this 'await' point
+   --> src/main.rs:288:33
+    |
+288 |     unrelated_async_work("bad").await;
+    |                                 ^^^^^
+    |
+note: Transaction declared here
+   --> src/main.rs:287:9
+    |
+287 |     let inner = db::Transaction::begin_inner(&mut outer).await;
+    |         ^^^^^
+
+error: A sqlx::Transaction is being held across this 'await' point
+   --> src/main.rs:298:45
+    |
+298 |     db::actually_use_txn(inner.deref_mut()).await;
+    |                                             ^^^^^
+    |
+note: Transaction declared here
+   --> src/main.rs:297:9
+    |
+297 |     let second = make_transaction();
+    |         ^^^^^^
+
+error: A sqlx::Transaction is being held across this 'await' point
+   --> src/main.rs:308:33
+    |
+308 |     unrelated_async_work("bad").await;
+    |                                 ^^^^^
+    |
+note: Transaction declared here
+   --> src/main.rs:305:9
+    |
+305 |     let mut outer = make_transaction();
+    |         ^^^^^^^^^
+
+error: A sqlx::Transaction is being held across this 'await' point
+   --> src/main.rs:315:37
+    |
+315 |         unrelated_async_work("bad").await;
     |                                     ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:241:9
+   --> src/main.rs:313:9
     |
-241 |     let txn = make_transaction();
+313 |     let txn = make_transaction();
     |         ^^^
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:263:37
+   --> src/main.rs:335:37
     |
-263 |         unrelated_async_work("bad").await;
+335 |         unrelated_async_work("bad").await;
     |                                     ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:262:13
+   --> src/main.rs:334:13
     |
-262 |         let txn = make_transaction();
+334 |         let txn = make_transaction();
     |             ^^^
 
 error: sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out
-   --> src/main.rs:285:9
+   --> src/main.rs:357:9
     |
-285 |     let txn = make_transaction();
+357 |     let txn = make_transaction();
     |         ^^^
     |
     = note: `-D txn-without-commit` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(txn_without_commit)]`
 
 error: A sqlx::Transaction is being held across this 'await' point
-   --> src/main.rs:309:33
+   --> src/main.rs:381:33
     |
-309 |     unrelated_async_work("bad").await;
+381 |     unrelated_async_work("bad").await;
     |                                 ^^^^^
     |
 note: Transaction declared here
-   --> src/main.rs:305:40
+   --> src/main.rs:377:40
     |
-305 | async fn bad_takes_db_reader_inner<DB>(_db: &mut DB)
+377 | async fn bad_takes_db_reader_inner<DB>(_db: &mut DB)
     |                                        ^^^
 
 error: sqlx::Transaction is dropped by this function without commit()/rollback(), or being moved out
-   --> src/main.rs:290:29
+   --> src/main.rs:362:29
     |
-290 | fn bad_missing_commit_param(_txn: PgTransaction<'_>) {
+362 | fn bad_missing_commit_param(_txn: PgTransaction<'_>) {
     |                             ^^^^
 
-error: could not compile `sqlx_app` (bin "sqlx_app") due to 15 previous errors
+error: could not compile `sqlx_app` (bin "sqlx_app") due to 19 previous errors

--- a/lints/carbide-lints/tests/integration.rs
+++ b/lints/carbide-lints/tests/integration.rs
@@ -74,11 +74,12 @@ fn driver_runs_and_emits_expected_lint() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let diff = similar::TextDiff::from_lines(&expected_stderr, &relevant_stderr)
-        .unified_diff()
-        .context_radius(3)
-        .header("expected", "output")
-        .to_string();
+    let diff =
+        similar::TextDiff::from_lines(expected_stderr.trim_end(), relevant_stderr.trim_end())
+            .unified_diff()
+            .context_radius(3)
+            .header("expected", "output")
+            .to_string();
 
     // Now assert on stderr
     assert!(


### PR DESCRIPTION
This fixes one of the main false-positives we still had with this lint: It wasn't able to keep track of inner transactions and treat them as "allowed" if the inner transaction is passed to a function instead of the outer one.

Since inner transactions are just additional "begin" statements on the same connection, passing an inner transaction to a .await'ed function should exempt it from the lint (since it would be considered "database work" while holding the transaction.)

Do this by keeping track of the "lineage" of HIR locals, and if they came from the original transaction through a "begin" statement, consider any functions they're passed to to be "related work" and exempt the await calls from the lint.

This eliminates 11 `#[allow(txn_held_across_await)]` statements, the remaining are no longer false-positives. (Comments marked with a `TODO` are ones we need to fix, others are exempt because they need to be.)

Notable other changes (other than dropping no-longer-necessary allows):

- Drop a single tokio::task::yield_now().await which was not really doing anything: yielding a task only helps cases of starvation where a thread isn't awaiting anything and is looping over and over, but (a) we don't loop that many times, and (b) we're already awaiting things in that loop, which gives plenty of time for the tokio thread to do other work.

- Change some of the comments for "exempt" places to TODO's, particularly to use WorkLockManager, which was designed specifically to be able to logically lock work using postgres, without needing to hold a connection open. (Note, the old comments had mentioned that it's ok because there was no transaction, just a connection... but this lint's purpose is also to prevent long-lived checked-out pool connections too, since those still consume a connection slot. They're basically just as bad as transactions, but without the issue of potentially holding write locks like transactions do.)

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

