### PR TITLE
fix: hw-health make machine_id optional in static config

### DIFF
--- a/crates/health/benches/collector_pipeline.rs
+++ b/crates/health/benches/collector_pipeline.rs
@@ -60,7 +60,7 @@ fn event_context() -> EventContext {
         },
         collector_type: "sensor_collector",
         metadata: Some(EndpointMetadata::Machine(MachineData {
-            machine_id: MACHINE_ID.parse().expect("valid machine id"),
+            machine_id: Some(MACHINE_ID.parse().expect("valid machine id")),
             machine_serial: None,
             slot_number: None,
             tray_index: None,

--- a/crates/health/benches/processor_pipeline.rs
+++ b/crates/health/benches/processor_pipeline.rs
@@ -96,7 +96,7 @@ fn event_context() -> EventContext {
         },
         collector_type: "sensor_collector",
         metadata: Some(EndpointMetadata::Machine(MachineData {
-            machine_id: MACHINE_ID.parse().expect("valid machine id"),
+            machine_id: Some(MACHINE_ID.parse().expect("valid machine id")),
             machine_serial: None,
             slot_number: None,
             tray_index: None,
@@ -274,7 +274,7 @@ fn rack_event_contexts(rack_id: &str, tray_count: usize) -> Vec<EventContext> {
                 },
                 collector_type: "sensor_collector",
                 metadata: Some(EndpointMetadata::Machine(MachineData {
-                    machine_id: MACHINE_ID.parse().expect("valid machine id"),
+                    machine_id: Some(MACHINE_ID.parse().expect("valid machine id")),
                     machine_serial: None,
                     slot_number: None,
                     tray_index: None,

--- a/crates/health/benches/sink_pipeline.rs
+++ b/crates/health/benches/sink_pipeline.rs
@@ -70,7 +70,7 @@ fn event_context_for_machine(machine_id: &str) -> EventContext {
         },
         collector_type: "sensor_collector",
         metadata: Some(EndpointMetadata::Machine(MachineData {
-            machine_id: machine_id.parse().expect("valid machine id"),
+            machine_id: Some(machine_id.parse().expect("valid machine id")),
             machine_serial: None,
             slot_number: None,
             tray_index: None,

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -478,7 +478,7 @@ impl ApiEndpointSource {
         let addr = BmcAddr::try_from(bmc_info)?;
         let metadata = machine.id.map(|machine_id| {
             EndpointMetadata::Machine(MachineData {
-                machine_id,
+                machine_id: Some(machine_id),
                 machine_serial: machine
                     .discovery_info
                     .as_ref()

--- a/crates/health/src/collectors/gpu_inventory.rs
+++ b/crates/health/src/collectors/gpu_inventory.rs
@@ -266,7 +266,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for GpuInventoryCollector<B> {
         let event_context =
             EventContext::from_endpoint(endpoint.as_ref(), "gpu_inventory_collector");
         let machine_id = match &endpoint.metadata {
-            Some(EndpointMetadata::Machine(m)) => Some(m.machine_id),
+            Some(EndpointMetadata::Machine(m)) => m.machine_id,
             _ => None,
         };
         Ok(Self {

--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -269,7 +269,7 @@ impl<B: Bmc + 'static> LogsCollector<B> {
         let Some(EndpointMetadata::Machine(machine)) = &self.endpoint.metadata else {
             return Ok((0, 0));
         };
-        let machine_id = machine.machine_id.to_string();
+        let machine_id = machine.machine_id.map(|id| id.to_string());
 
         let Some(state) = self.state.as_mut() else {
             return Ok((0, 0));
@@ -417,15 +417,18 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                     })
                     .flatten();
 
+                let mut attributes = Vec::with_capacity(3);
+                if let Some(machine_id) = &machine_id {
+                    attributes.push((Cow::Borrowed("machine_id"), machine_id.clone()));
+                }
+                attributes.push((Cow::Borrowed("entry_id"), entry.base.id.clone()));
+                attributes.push((Cow::Borrowed("service_id"), service_id.clone()));
+
                 let log_event = CollectorEvent::Log(
                     LogRecord {
                         body,
                         severity: severity_text,
-                        attributes: vec![
-                            (Cow::Borrowed("machine_id"), machine_id.clone()),
-                            (Cow::Borrowed("entry_id"), entry.base.id.clone()),
-                            (Cow::Borrowed("service_id"), service_id.clone()),
-                        ],
+                        attributes,
                         diagnostic_record,
                     }
                     .into(),

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -3350,6 +3350,38 @@ power_shelf = { id = "fps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1
     }
 
     #[test]
+    fn test_static_machine_endpoint_without_id() {
+        let toml_content = r#"
+[endpoint_sources.carbide_api]
+enabled = false
+
+[sinks.health_report]
+enabled = false
+
+[[endpoint_sources.static_bmc_endpoints]]
+ip = "10.0.1.2"
+mac = "11:22:33:44:55:11"
+username = "admin"
+password = "pass"
+machine = { serial = "MN-001" }
+"#;
+
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(toml_content))
+            .extract()
+            .expect("failed to parse static machine endpoint config without id");
+
+        assert_eq!(config.endpoint_sources.static_bmc_endpoints.len(), 1);
+        let machine = config.endpoint_sources.static_bmc_endpoints[0]
+            .machine
+            .as_ref()
+            .expect("machine metadata should be present");
+        assert_eq!(machine.id, None);
+        assert_eq!(machine.serial.as_deref(), Some("MN-001"));
+    }
+
+    #[test]
     fn test_static_switch_host_accepts_primary_without_nmxt_override() {
         let toml_content = r#"
 [endpoint_sources.carbide_api]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -206,8 +206,8 @@ pub struct StaticBmcEndpoint {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct StaticMachineEndpoint {
-    /// Stable NICo machine ID for this BMC endpoint.
-    pub id: String,
+    /// Stable NICo machine ID for this BMC endpoint. Optional when running without NICo.
+    pub id: Option<String>,
 
     /// Optional chassis serial to emit as machine telemetry metadata.
     pub serial: Option<String>,
@@ -3295,7 +3295,7 @@ power_shelf = { id = "fps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1
             config.endpoint_sources.static_bmc_endpoints[1]
                 .machine
                 .as_ref()
-                .map(|machine| machine.id.as_ref()),
+                .and_then(|machine| machine.id.as_deref()),
             Some("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
         );
         assert_eq!(

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -782,9 +782,11 @@ mod tests {
 
     fn machine_metadata() -> EndpointMetadata {
         EndpointMetadata::Machine(MachineData {
-            machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                .parse()
-                .expect("valid machine id"),
+            machine_id: Some(
+                "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                    .parse()
+                    .expect("valid machine id"),
+            ),
             machine_serial: None,
             slot_number: None,
             tray_index: None,

--- a/crates/health/src/endpoint/model.rs
+++ b/crates/health/src/endpoint/model.rs
@@ -54,10 +54,13 @@ impl BmcEndpoint {
 
     pub fn log_identity(&self) -> Cow<'_, str> {
         match &self.metadata {
-            Some(EndpointMetadata::Machine(machine)) => Cow::Owned(machine.machine_id.to_string()),
+            Some(EndpointMetadata::Machine(MachineData {
+                machine_id: Some(id),
+                ..
+            })) => Cow::Owned(id.to_string()),
             Some(EndpointMetadata::PowerShelf(power_shelf)) => Cow::Borrowed(&power_shelf.serial),
             Some(EndpointMetadata::Switch(switch)) => Cow::Borrowed(&switch.serial),
-            None => Cow::Owned(self.addr.mac.to_string()),
+            _ => Cow::Owned(self.addr.mac.to_string()),
         }
     }
 
@@ -117,8 +120,8 @@ impl EndpointMetadata {
 /// Metadata that describes a machine endpoint for health telemetry.
 #[derive(Clone, Debug)]
 pub struct MachineData {
-    /// Stable NICo machine identifier.
-    pub machine_id: MachineId,
+    /// Stable NICo machine identifier. None when running without NICo.
+    pub machine_id: Option<MachineId>,
 
     /// Hardware chassis serial discovered from machine DMI data, when known.
     pub machine_serial: Option<String>,

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -120,7 +120,13 @@ impl StaticEndpointSource {
                     nmxt_enabled,
                 }))
             } else if let Some(machine) = &cfg.machine {
-                let machine_id = &machine.id;
+                let machine_id = machine.id.as_deref().and_then(|id| match id.parse() {
+                    Ok(machine_id) => Some(machine_id),
+                    Err(error) => {
+                        tracing::warn!(?error, ?id, "Invalid machine.id in static endpoint config");
+                        None
+                    }
+                });
                 let nvlink_domain_uuid =
                     machine.nvlink_domain_uuid.as_ref().and_then(
                         |id| match NvLinkDomainId::from_str(id) {
@@ -143,24 +149,14 @@ impl StaticEndpointSource {
                     .none_if_empty()
                     .map(str::to_string);
 
-                match machine_id.parse() {
-                    Ok(machine_id) => Some(EndpointMetadata::Machine(MachineData {
-                        machine_id,
-                        machine_serial: machine.serial.clone(),
-                        slot_number: machine.slot_number,
-                        tray_index: machine.tray_index,
-                        nvlink_domain_uuid,
-                        driver_version,
-                    })),
-                    Err(error) => {
-                        tracing::warn!(
-                            ?error,
-                            ?machine_id,
-                            "Invalid machine.id in static endpoint config"
-                        );
-                        None
-                    }
-                }
+                Some(EndpointMetadata::Machine(MachineData {
+                    machine_id,
+                    machine_serial: machine.serial.clone(),
+                    slot_number: machine.slot_number,
+                    tray_index: machine.tray_index,
+                    nvlink_domain_uuid,
+                    driver_version,
+                }))
             } else {
                 None
             };
@@ -405,7 +401,7 @@ mod tests {
             username: "admin".to_string(),
             password: Some("pass".to_string()),
             machine: Some(StaticMachineEndpoint {
-                id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string(),
+                id: Some("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string()),
                 serial: Some("MN-001".to_string()),
                 slot_number: Some(15),
                 tray_index: Some(5),
@@ -430,7 +426,7 @@ mod tests {
         );
         match &endpoints[0].metadata {
             Some(EndpointMetadata::Machine(machine)) => {
-                assert_eq!(machine.machine_id, machine_id);
+                assert_eq!(machine.machine_id, Some(machine_id));
                 assert_eq!(machine.machine_serial.as_deref(), Some("MN-001"));
                 assert_eq!(machine.slot_number, Some(15));
                 assert_eq!(machine.tray_index, Some(5));
@@ -450,7 +446,7 @@ mod tests {
             username: "admin".to_string(),
             password: Some("pass".to_string()),
             machine: Some(StaticMachineEndpoint {
-                id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string(),
+                id: Some("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0".to_string()),
                 serial: None,
                 slot_number: None,
                 tray_index: None,

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -400,9 +400,11 @@ mod tests {
             },
             collector_type: "test",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: Some("MN-001".to_string()),
                 slot_number: Some(15),
                 tray_index: Some(5),
@@ -438,9 +440,11 @@ mod tests {
             },
             collector_type: "test",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -440,11 +440,7 @@ mod tests {
             },
             collector_type: "test",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: Some(
-                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                        .parse()
-                        .expect("valid machine id"),
-                ),
+                machine_id: None,
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,
@@ -456,10 +452,8 @@ mod tests {
 
         let attrs = resource_attributes(&context);
 
-        assert_eq!(
-            attr_value(&attrs, "machine.id"),
-            Some("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
-        );
+        assert_eq!(attr_value(&attrs, "machine.id"), None);
+        assert_eq!(attr_value(&attrs, "component.type"), Some("compute_node"));
         assert_eq!(attr_value(&attrs, "machine.serial"), None);
         assert_eq!(attr_value(&attrs, "driver.version"), None);
         assert_eq!(attr_value(&attrs, "nvlink.domain.uuid"), None);

--- a/crates/health/src/processor/health_report.rs
+++ b/crates/health/src/processor/health_report.rs
@@ -281,9 +281,11 @@ mod tests {
             },
             collector_type: "sensor_collector",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -76,7 +76,8 @@ impl EventContext {
 
     /// Returns the stable NICo machine ID when the endpoint is a machine.
     pub fn machine_id(&self) -> Option<MachineId> {
-        self.machine_metadata().map(|machine| machine.machine_id)
+        self.machine_metadata()
+            .and_then(|machine| machine.machine_id)
     }
 
     /// Returns the machine chassis serial when the endpoint is a machine.
@@ -640,7 +641,7 @@ mod tests {
         let metadata = match kind {
             ContextKind::Empty => None,
             ContextKind::Machine => Some(EndpointMetadata::Machine(MachineData {
-                machine_id: machine_id(),
+                machine_id: Some(machine_id()),
                 machine_serial: Some("MN-001".to_string()),
                 slot_number: Some(7),
                 tray_index: Some(3),

--- a/crates/health/src/sink/health_report.rs
+++ b/crates/health/src/sink/health_report.rs
@@ -281,7 +281,7 @@ mod tests {
             },
             collector_type: "test",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: id,
+                machine_id: Some(id),
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,

--- a/crates/health/src/sink/log_file.rs
+++ b/crates/health/src/sink/log_file.rs
@@ -297,9 +297,11 @@ mod tests {
     fn machine_context() -> EventContext {
         EventContext {
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: Some("MN-001".to_string()),
                 slot_number: None,
                 tray_index: None,

--- a/crates/health/src/sink/mod.rs
+++ b/crates/health/src/sink/mod.rs
@@ -363,9 +363,11 @@ mod tests {
             },
             collector_type: "test",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,
@@ -436,9 +438,11 @@ mod tests {
             },
             collector_type: "sensor_collector",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,
@@ -492,9 +496,11 @@ mod tests {
             },
             collector_type: "sensor_collector",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: None,
                 slot_number: None,
                 tray_index: None,

--- a/crates/health/src/sink/prometheus.rs
+++ b/crates/health/src/sink/prometheus.rs
@@ -275,9 +275,11 @@ mod tests {
             },
             collector_type: "sensor_collector",
             metadata: Some(EndpointMetadata::Machine(MachineData {
-                machine_id: "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
-                    .parse()
-                    .expect("valid machine id"),
+                machine_id: Some(
+                    "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0"
+                        .parse()
+                        .expect("valid machine id"),
+                ),
                 machine_serial: Some("MN-001".to_string()),
                 slot_number: Some(15),
                 tray_index: Some(5),


### PR DESCRIPTION
Right now hw-health requires machine id to bet set in metadata in static config. So in envs without NICo one would not be able to specify machine metadata (id does not exists).

This PR makes this param optional.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3989

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

