### PR TITLE
feat(admin-cli): erase site metadata for a BMC MAC (#3046)

### DIFF
--- a/crates/admin-cli/src/machine/erase_metadata/args.rs
+++ b/crates/admin-cli/src/machine/erase_metadata/args.rs
@@ -1,0 +1,63 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use rpc::forge::EraseHostMetadataByBmcMacRequest;
+
+/// Erase all NICo-owned site records for a server BMC MAC address.
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Preview which records exist for a BMC MAC (nothing is deleted):
+    $ nico-admin-cli machine erase-metadata --bmc-mac 00:11:22:33:44:55 --dry-run
+
+Erase all lingering records for a BMC MAC to prepare for re-ingestion:
+    $ nico-admin-cli machine erase-metadata --bmc-mac 00:11:22:33:44:55 --confirm
+
+")]
+pub struct Args {
+    #[clap(
+        long,
+        required(true),
+        help = "Server BMC MAC address whose lingering site records should be erased"
+    )]
+    pub bmc_mac: String,
+
+    #[clap(
+        long,
+        action,
+        help = "Report the records that would be erased without deleting anything"
+    )]
+    pub dry_run: bool,
+
+    #[clap(
+        long,
+        action,
+        help = "Confirm you want to erase these records. Required for a real run (ignored with --dry-run)."
+    )]
+    pub confirm: bool,
+}
+
+impl From<&Args> for EraseHostMetadataByBmcMacRequest {
+    fn from(args: &Args) -> Self {
+        Self {
+            bmc_mac: args.bmc_mac.clone(),
+            dry_run: args.dry_run,
+        }
+    }
+}

--- a/crates/admin-cli/src/machine/erase_metadata/cmd.rs
+++ b/crates/admin-cli/src/machine/erase_metadata/cmd.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::forge::EraseHostMetadataByBmcMacRequest;
+
+use super::args::Args;
+use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::rpc::ApiClient;
+
+pub async fn erase_metadata(api_client: &ApiClient, args: Args) -> CarbideCliResult<()> {
+    // Guard the destructive path: a real run must be explicitly confirmed. --dry-run
+    // is always safe, so it does not require --confirm. Return an error (non-zero
+    // exit) so scripts can distinguish a refused run from a completed one.
+    if !args.dry_run && !args.confirm {
+        return Err(CarbideCliError::GenericError(format!(
+            "Refusing to erase records for BMC MAC {} without confirmation. \
+             Re-run with --dry-run to preview, or add --confirm to proceed.",
+            args.bmc_mac
+        )));
+    }
+
+    let req: EraseHostMetadataByBmcMacRequest = (&args).into();
+    let response = api_client.0.erase_host_metadata_by_bmc_mac(req).await?;
+
+    if response.dry_run {
+        println!("DRY RUN -- no records were deleted. The following would be erased:");
+    } else {
+        println!("Erased the following records for BMC MAC {}:", args.bmc_mac);
+    }
+    println!("{}", serde_json::to_string_pretty(&response)?);
+
+    Ok(())
+}

--- a/crates/admin-cli/src/machine/erase_metadata/mod.rs
+++ b/crates/admin-cli/src/machine/erase_metadata/mod.rs
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+pub use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::erase_metadata(&ctx.api_client, self).await?;
+        Ok(())
+    }
+}

--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod auto_update;
 pub mod common;
+pub mod erase_metadata;
 pub mod force_delete;
 pub mod hardware_info;
 pub mod health_report;
@@ -66,6 +67,10 @@ pub enum Cmd {
     Reboot(reboot::Args),
     #[clap(about = "Force delete a machine")]
     ForceDelete(force_delete::Args),
+    #[clap(
+        about = "Erase all NICo-owned site records for a server BMC MAC address (does not touch expected machines)"
+    )]
+    EraseMetadata(erase_metadata::Args),
     #[clap(about = "Set individual machine firmware autoupdate (host only)")]
     AutoUpdate(auto_update::Args),
     #[clap(subcommand, about = "Edit Metadata associated with a Machine")]

--- a/crates/admin-cli/src/machine/tests.rs
+++ b/crates/admin-cli/src/machine/tests.rs
@@ -360,3 +360,51 @@ fn health_override_templates_value_enum() {
         }
     );
 }
+
+// erase-metadata routes to the EraseMetadata variant. Each row yields
+// (bmc_mac, dry_run, confirm); the required --bmc-mac is missing in the failing row.
+#[test]
+fn parse_erase_metadata_routes_to_erase_metadata() {
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::EraseMetadata(args) => (args.bmc_mac, args.dry_run, args.confirm),
+                    _ => panic!("expected EraseMetadata variant"),
+                })
+                .map_err(drop)
+        };
+        "with bmc mac" {
+            &[
+                "machine",
+                "erase-metadata",
+                "--bmc-mac",
+                "00:11:22:33:44:55",
+            ][..] => Yields(("00:11:22:33:44:55".to_string(), false, false)),
+        }
+
+        "with bmc mac and dry-run" {
+            &[
+                "machine",
+                "erase-metadata",
+                "--bmc-mac",
+                "00:11:22:33:44:55",
+                "--dry-run",
+            ][..] => Yields(("00:11:22:33:44:55".to_string(), true, false)),
+        }
+
+        "with bmc mac and confirm" {
+            &[
+                "machine",
+                "erase-metadata",
+                "--bmc-mac",
+                "00:11:22:33:44:55",
+                "--confirm",
+            ][..] => Yields(("00:11:22:33:44:55".to_string(), false, true)),
+        }
+
+        "missing required bmc mac" {
+            &["machine", "erase-metadata"][..] => Fails,
+        }
+    );
+}

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -1174,6 +1174,13 @@ impl Forge for Api {
         crate::handlers::machine::admin_force_delete_machine(self, request).await
     }
 
+    async fn erase_host_metadata_by_bmc_mac(
+        &self,
+        request: Request<rpc::EraseHostMetadataByBmcMacRequest>,
+    ) -> Result<Response<rpc::EraseHostMetadataByBmcMacResponse>, Status> {
+        crate::handlers::erase_host_metadata::erase_host_metadata_by_bmc_mac(self, request).await
+    }
+
     /// Example TOML data in request.text:
     ///
     /// [lo-ip]

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -290,6 +290,7 @@ impl InternalRBACRules {
         x.perm("FindExploredMlxDeviceHostIds", vec![ForgeAdminCLI]);
         x.perm("FindExploredMlxDevicesByIds", vec![ForgeAdminCLI]);
         x.perm("AdminForceDeleteMachine", vec![ForgeAdminCLI, Machineatron]);
+        x.perm("EraseHostMetadataByBmcMac", vec![ForgeAdminCLI]);
         x.perm("AdminForceDeleteRack", vec![ForgeAdminCLI, Machineatron]);
         x.perm("AdminForceDeleteSwitch", vec![ForgeAdminCLI, Machineatron]);
         x.perm(

--- a/crates/api-core/src/handlers/erase_host_metadata.rs
+++ b/crates/api-core/src/handlers/erase_host_metadata.rs
@@ -1,0 +1,281 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use ::rpc::forge as rpc;
+use carbide_secrets::credentials::{BmcCredentialType, CredentialKey};
+use mac_address::MacAddress;
+use tonic::{Request, Response, Status};
+
+use crate::CarbideError;
+use crate::api::{Api, log_request_data};
+
+/// Erase all NICo-owned site records for a server BMC MAC address, giving an
+/// operator a clean slate to re-ingest a replacement host.
+///
+/// The MAC is the *input* to this operation: deletion is MAC-driven. Records are
+/// resolved from cached state -- machine interfaces (MAC-exact), the site-explorer
+/// exploration reports whose stored data references the MAC, and the explored
+/// managed-host rows at those BMC IPs -- plus the BMC credentials in vault and the
+/// convergence markers keyed by the MAC. No live BMC/Redfish call is made, so a
+/// machine that is powered off, gone, or relocated is still cleaned. It deliberately
+/// does not touch expected machines -- NICo does not own that data.
+///
+/// It refuses to run when any interface for the MAC is still owned by a live device
+/// (machine, DPU, switch or power shelf), or when a BMC IP for the MAC still belongs
+/// to an ingested machine; those go through the appropriate force-delete path.
+/// Safety for the destructive path comes from `dry_run` (which reports what would be
+/// erased, including whether BMC credentials exist) plus the CLI's `--confirm`.
+pub(crate) async fn erase_host_metadata_by_bmc_mac(
+    api: &Api,
+    request: Request<rpc::EraseHostMetadataByBmcMacRequest>,
+) -> Result<Response<rpc::EraseHostMetadataByBmcMacResponse>, Status> {
+    log_request_data(&request);
+    let request = request.into_inner();
+
+    // A malformed MAC is a client error, not an internal one.
+    let bmc_mac: MacAddress = request.bmc_mac.parse().map_err(|e| {
+        CarbideError::InvalidArgument(format!("invalid BMC MAC {:?}: {e}", request.bmc_mac))
+    })?;
+    let dry_run = request.dry_run;
+
+    // Read the vault BMC credential *before* acquiring the admin-segment lock, so the
+    // locked section below performs no network I/O and cannot stall other operations
+    // waiting on vault. This only reports/decides credential clearing; it never gates
+    // the DB deletion, which is MAC-driven.
+    let bmc_credential_key = CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::BmcRoot {
+            bmc_mac_address: bmc_mac,
+        },
+    };
+    let has_bmc_credentials = api
+        .credential_manager
+        .get_credentials(&bmc_credential_key)
+        .await
+        .map_err(|e| CarbideError::internal(format!("error reading BMC credential: {e:?}")))?
+        .is_some();
+
+    let mut txn = api.txn_begin().await?;
+
+    // Serialize with force-delete and the allocator by taking the admin-segment lock
+    // first, matching `admin_force_delete_machine`'s lock ordering. Everything below
+    // the lock is DB-only (no remote calls), so the lock is held only briefly.
+    db::machine_interface::lock_all_admin_segments(txn.as_pgconn()).await?;
+
+    let interfaces = db::machine_interface::find_by_mac_address(txn.as_pgconn(), bmc_mac).await?;
+
+    // Refuse when the MAC still belongs to a live device -- a machine, DPU, switch or
+    // power shelf. Those have their own lifecycle/force-delete paths; this cleanup
+    // tool must never delete a device that is still in service.
+    //
+    // Known limitation: the switch/power-shelf association paths do not take
+    // `lock_all_admin_segments`, so an association committed between this check and the
+    // deletes below could race. This matches `admin_force_delete_machine`, which relies
+    // on the same lock; hardening both is a separate, codebase-wide change.
+    if let Some(owner) = interfaces.iter().find_map(owning_device) {
+        return Err(CarbideError::InvalidArgument(format!(
+            "cannot erase metadata for {bmc_mac}: an interface is still owned by {owner}. \
+             use the appropriate force-delete instead"
+        ))
+        .into());
+    }
+
+    // Exploration reports whose cached data references this MAC (JSONB search over
+    // stored data, not a live BMC call). The search matches the MAC under Systems[]
+    // or Managers[]; only delete an endpoint that is actually this BMC -- protect any
+    // whose Manager advertises a *different* MAC (it belongs to another host that
+    // merely lists this MAC on a system NIC). Mirrors the managed-host protection.
+    let matched_endpoints =
+        db::explored_endpoints::find_by_mac_address(txn.as_pgconn(), bmc_mac).await?;
+    let (endpoints, protected_endpoints): (Vec<_>, Vec<_>) = matched_endpoints
+        .into_iter()
+        .partition(|e| !endpoint_claimed_by_other_bmc(e, bmc_mac));
+    for endpoint in &protected_endpoints {
+        tracing::warn!(
+            bmc_mac = %bmc_mac,
+            endpoint_ip = %endpoint.address,
+            "erase-metadata: protecting explored endpoint; its BMC advertises a different MAC",
+        );
+    }
+
+    // MAC-driven BMC IP set: interface addresses plus the IPs of the endpoints we
+    // will delete.
+    let mut bmc_ips: BTreeSet<IpAddr> = interfaces
+        .iter()
+        .flat_map(|i| i.addresses.iter().copied())
+        .collect();
+    bmc_ips.extend(endpoints.iter().map(|e| e.address));
+
+    // Classify the candidate IPs first: an IP where an exploration report currently
+    // advertises a *different* BMC MAC has been reassigned away from this MAC. Such an
+    // IP is no longer ours -- it is neither ours to clean nor ours to refuse over.
+    // This classification must run *before* the live-machine guard below: a stale
+    // interface for this MAC can still carry an old IP that now belongs to a different,
+    // ingested host, and refusing on that would abort a legitimate orphan cleanup while
+    // pointing the operator at force-delete for someone else's machine.
+    let mut ips_owned_by_other_bmc: BTreeSet<IpAddr> = BTreeSet::new();
+    for &bmc_ip in &bmc_ips {
+        let endpoints_at_ip =
+            db::explored_endpoints::find_all_by_ip(bmc_ip, txn.as_pgconn()).await?;
+        if endpoints_at_ip
+            .iter()
+            .any(|e| endpoint_claimed_by_other_bmc(e, bmc_mac))
+        {
+            tracing::warn!(
+                bmc_mac = %bmc_mac,
+                endpoint_ip = %bmc_ip,
+                "erase-metadata: BMC IP now belongs to a different BMC; leaving its records alone",
+            );
+            ips_owned_by_other_bmc.insert(bmc_ip);
+        }
+    }
+
+    // Refuse if a BMC IP that is still *ours* belongs to a live (ingested) machine --
+    // that is the force-delete path, not a leftover cleanup.
+    for bmc_ip in bmc_ips
+        .iter()
+        .filter(|ip| !ips_owned_by_other_bmc.contains(ip))
+    {
+        if carbide_site_explorer::is_endpoint_in_managed_host(*bmc_ip, txn.as_pgconn())
+            .await
+            .map_err(|e| CarbideError::internal(e.to_string()))?
+        {
+            return Err(CarbideError::InvalidArgument(format!(
+                "cannot erase metadata for {bmc_mac}: a machine exists for BMC endpoint \
+                 {bmc_ip}. use `nico-admin-cli machine force-delete` instead"
+            ))
+            .into());
+        }
+    }
+
+    // Only clean managed-host rows at IPs that are still ours.
+    let managed_host_ips: Vec<IpAddr> = bmc_ips
+        .iter()
+        .copied()
+        .filter(|ip| !ips_owned_by_other_bmc.contains(ip))
+        .collect();
+    let managed_hosts =
+        db::explored_managed_host::find_by_ips(txn.as_pgconn(), managed_host_ips).await?;
+
+    // Sorted for deterministic delete/lock ordering.
+    let mut endpoint_ips: Vec<IpAddr> = endpoints.iter().map(|e| e.address).collect();
+    endpoint_ips.sort();
+
+    let response = rpc::EraseHostMetadataByBmcMacResponse {
+        dry_run,
+        machine_interface_ids: interfaces.iter().map(|i| i.id.to_string()).collect(),
+        explored_endpoint_ips: endpoint_ips.iter().map(|ip| ip.to_string()).collect(),
+        explored_managed_host_ips: managed_hosts
+            .iter()
+            .map(|h| h.host_bmc_ip.to_string())
+            .collect(),
+        // In dry-run this reports whether credentials exist (and so would be
+        // cleared); in a real run it reports that they were cleared.
+        bmc_credentials_cleared: has_bmc_credentials,
+    };
+
+    if dry_run {
+        return Ok(Response::new(response));
+    }
+
+    // Erase the DB-backed records in one transaction, in the same deadlock-safe order
+    // `admin_force_delete_machine` uses: managed hosts, then endpoints, then
+    // interfaces.
+    for host in &managed_hosts {
+        db::explored_managed_host::delete_by_host_bmc_addr(txn.as_pgconn(), host.host_bmc_ip)
+            .await?;
+    }
+    db::explored_endpoints::delete_many(txn.as_pgconn(), &endpoint_ips).await?;
+    for iface in &interfaces {
+        // `machine_boot_override` has an FK to `machine_interfaces` with no
+        // ON DELETE CASCADE, so clear any override first or the interface delete
+        // fails with a foreign-key violation.
+        db::machine_boot_override::clear(txn.as_pgconn(), iface.id).await?;
+        db::machine_interface::delete(&iface.id, txn.as_pgconn()).await?;
+    }
+    // Interface deletion preserves a `retained_boot_interfaces` row for the MAC, so no
+    // stale boot metadata survives to affect re-ingestion of the replacement host.
+    //
+    // ORDER IS LOAD-BEARING: `machine_interface::delete` *upserts* the retained row on
+    // its way out, so this must run after the loop above. Hoisting it earlier would
+    // leave a freshly-created row behind and silently defeat the clean slate.
+    let _ = db::retained_boot_interface::take_by_mac(txn.as_pgconn(), bmc_mac, None).await?;
+    // Drop the host-UEFI convergence marker keyed by this MAC; the BMC marker is
+    // dropped alongside the vault secret below.
+    db::credential_rotation::delete_device_converged(
+        txn.as_pgconn(),
+        bmc_mac,
+        db::credential_rotation::CredentialRotationType::HostUefi,
+    )
+    .await?;
+
+    txn.commit().await?;
+
+    // Clear the BMC credentials in vault, the BMC convergence marker, and this MAC's
+    // Redfish sessions/lockout cache (the helper also calls `bmc_session_manager
+    // ::flush_mac`, so a stale session or lockout entry cannot block the returning
+    // spare). Runs after the DB commit -- outside the lock -- mirroring `machine
+    // force-delete --delete-bmc-credentials`. Called unconditionally: the underlying
+    // deletes are idempotent, so a marker left behind without a credential is still
+    // removed, and a run that failed after the vault delete can be safely re-run.
+    crate::handlers::credential::delete_bmc_root_credentials_by_mac(api, bmc_mac).await?;
+
+    Ok(Response::new(response))
+}
+
+/// Names the live device that owns this interface, if any. Machines, DPUs,
+/// switches and power shelves each have their own lifecycle and must never be
+/// cleaned up through erase-metadata.
+fn owning_device(iface: &model::machine::MachineInterfaceSnapshot) -> Option<String> {
+    iface
+        .machine_id
+        .map(|id| format!("machine {id}"))
+        .or_else(|| {
+            iface
+                .attached_dpu_machine_id
+                .map(|id| format!("DPU machine {id}"))
+        })
+        .or_else(|| iface.switch_id.map(|id| format!("switch {id}")))
+        .or_else(|| iface.power_shelf_id.map(|id| format!("power shelf {id}")))
+}
+
+/// True when the endpoint's own BMC (Redfish Manager) advertises at least one MAC and
+/// none of them is `mac` -- i.e. the exploration report at that IP belongs to a
+/// *different* BMC, and must be protected even if `mac` appears on one of its host
+/// system NICs. Endpoints with no Manager MAC recorded are not treated as owned by
+/// another BMC, so deletion stays MAC-driven for them.
+fn endpoint_claimed_by_other_bmc(
+    endpoint: &model::site_explorer::ExploredEndpoint,
+    mac: MacAddress,
+) -> bool {
+    let mut has_manager_mac = false;
+    for manager_mac in endpoint
+        .report
+        .managers
+        .iter()
+        .flat_map(|manager| &manager.ethernet_interfaces)
+        .filter_map(|iface| iface.mac_address)
+    {
+        if manager_mac == mac {
+            return false;
+        }
+        has_manager_mac = true;
+    }
+    has_manager_mac
+}

--- a/crates/api-core/src/handlers/mod.rs
+++ b/crates/api-core/src/handlers/mod.rs
@@ -33,6 +33,7 @@ pub mod dpa;
 pub mod dpf;
 pub mod dpu;
 pub mod dpu_remediation;
+pub mod erase_host_metadata;
 pub mod expected_machine;
 pub mod expected_power_shelf;
 pub mod expected_rack;

--- a/crates/api-core/src/tests/common/endpoint.rs
+++ b/crates/api-core/src/tests/common/endpoint.rs
@@ -23,7 +23,7 @@ use db::{self, DatabaseError};
 use model::firmware::FirmwareComponentType;
 use model::site_explorer::{
     Chassis, ComputerSystem, ComputerSystemAttributes, EndpointExplorationReport, EndpointType,
-    Inventory, PowerState, Service,
+    EthernetInterface, Inventory, Manager, PowerState, Service,
 };
 use sqlx::PgConnection;
 
@@ -62,6 +62,56 @@ pub async fn insert_endpoint_with_firmware_versions(
         txn,
     )
     .await
+}
+
+fn ethernet_interface(id: &str, mac: mac_address::MacAddress) -> EthernetInterface {
+    EthernetInterface {
+        description: None,
+        id: Some(id.to_string()),
+        interface_enabled: Some(true),
+        mac_address: Some(mac),
+        link_status: None,
+        uefi_device_path: None,
+    }
+}
+
+/// Seed an explored endpoint whose BMC (Redfish Manager) advertises `mac`, so it is
+/// discoverable by `find_by_mac_address`. No live machine is created, modelling the
+/// leftover-record state that `erase-metadata` cleans up.
+pub async fn insert_endpoint_with_bmc_mac(
+    txn: &mut PgConnection,
+    addr: &str,
+    mac: mac_address::MacAddress,
+) -> Result<(), DatabaseError> {
+    let mut report = build_exploration_report("Dell", "R750", "1.0", "");
+    report.managers.push(Manager {
+        ethernet_interfaces: vec![ethernet_interface("BMC.1", mac)],
+        id: "BMC".to_string(),
+        ipmi_port: None,
+    });
+    db::explored_endpoints::insert(IpAddr::from_str(addr).unwrap(), &report, false, txn).await
+}
+
+/// Seed an explored endpoint whose BMC (Manager) advertises `bmc_mac` but whose host
+/// *system* NIC advertises `system_mac`. `find_by_mac_address(system_mac)` matches it,
+/// yet the endpoint belongs to `bmc_mac` -- used to prove `erase-metadata` protects an
+/// endpoint owned by a different BMC.
+pub async fn insert_endpoint_system_mac_other_bmc(
+    txn: &mut PgConnection,
+    addr: &str,
+    system_mac: mac_address::MacAddress,
+    bmc_mac: mac_address::MacAddress,
+) -> Result<(), DatabaseError> {
+    let mut report = build_exploration_report("Dell", "R750", "1.0", "");
+    report.systems[0]
+        .ethernet_interfaces
+        .push(ethernet_interface("NIC.1", system_mac));
+    report.managers.push(Manager {
+        ethernet_interfaces: vec![ethernet_interface("BMC.1", bmc_mac)],
+        id: "BMC".to_string(),
+        ipmi_port: None,
+    });
+    db::explored_endpoints::insert(IpAddr::from_str(addr).unwrap(), &report, false, txn).await
 }
 
 async fn insert_endpoint(

--- a/crates/api-core/src/tests/erase_host_metadata.rs
+++ b/crates/api-core/src/tests/erase_host_metadata.rs
@@ -1,0 +1,593 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use ::rpc::forge as rpc;
+use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
+use carbide_uuid::machine::MachineInterfaceId;
+use db::{self, ObjectColumnFilter, network_segment};
+use mac_address::MacAddress;
+use model::address_selection_strategy::AddressSelectionStrategy;
+use model::machine_interface_address::MachineInterfaceAssociation;
+use model::site_explorer::ExploredManagedHost;
+use rpc::forge_server::Forge;
+use tonic::Code;
+
+use crate::tests::common;
+use crate::tests::common::api_fixtures::{TestEnv, create_managed_host, create_test_env};
+
+fn req(
+    bmc_mac: &MacAddress,
+    dry_run: bool,
+) -> tonic::Request<rpc::EraseHostMetadataByBmcMacRequest> {
+    tonic::Request::new(rpc::EraseHostMetadataByBmcMacRequest {
+        bmc_mac: bmc_mac.to_string(),
+        dry_run,
+    })
+}
+
+/// Create a real `machine_interfaces` row for `mac` on the admin segment (no live
+/// machine), returning its id and assigned IP.
+async fn seed_interface(env: &TestEnv, mac: MacAddress) -> (MachineInterfaceId, IpAddr) {
+    let mut txn = env.pool.begin().await.unwrap();
+    let segment = db::network_segment::find_by(
+        txn.as_mut(),
+        ObjectColumnFilter::One(network_segment::IdColumn, env.admin_segment_ref()),
+        model::network_segment::NetworkSegmentSearchConfig::default(),
+    )
+    .await
+    .unwrap()
+    .remove(0);
+    let iface = db::machine_interface::create(
+        &mut txn,
+        std::slice::from_ref(&segment),
+        &mac,
+        true,
+        AddressSelectionStrategy::NextAvailableIp,
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+    let ip = *iface
+        .addresses
+        .first()
+        .expect("interface must have an address");
+    (iface.id, ip)
+}
+
+async fn seed_managed_host(env: &TestEnv, host_bmc_ip: IpAddr) {
+    let host = ExploredManagedHost {
+        host_bmc_ip,
+        dpus: vec![],
+    };
+    let mut txn = env.pool.begin().await.unwrap();
+    db::explored_managed_host::update(txn.as_mut(), &[&host])
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+}
+
+fn bmc_credential_key(mac: MacAddress) -> CredentialKey {
+    CredentialKey::BmcCredentials {
+        credential_type: BmcCredentialType::BmcRoot {
+            bmc_mac_address: mac,
+        },
+    }
+}
+
+async fn seed_bmc_credential(env: &TestEnv, mac: MacAddress) {
+    env.api
+        .credential_manager
+        .set_credentials(
+            &bmc_credential_key(mac),
+            &Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "notforprod".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+}
+
+// The full leftover set for a MAC -- interface (with boot override), exploration
+// report, managed host, retained boot row and vault credential -- is reported by
+// dry-run without deletion, then fully erased by a real run.
+#[crate::sqlx_test]
+async fn test_erase_removes_all_leftover_records(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:ff").unwrap();
+
+    let (iface_id, ip) = seed_interface(&env, bmc_mac).await;
+
+    let mut txn = env.pool.begin().await.unwrap();
+    // A boot override on the interface: its FK to machine_interfaces has no cascade,
+    // so erase must clear it before deleting the interface.
+    db::machine_boot_override::create(txn.as_mut(), iface_id, Some("pxe-script".to_string()), None)
+        .await
+        .unwrap();
+    // Give the interface a boot_interface_id so its deletion produces a
+    // retained_boot_interfaces row -- which erase must then clear.
+    sqlx::query("UPDATE machine_interfaces SET boot_interface_id = $1 WHERE id = $2")
+        .bind("NIC.Integrated.1")
+        .bind(iface_id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    // Convergence markers for both credential types keyed by this MAC.
+    db::credential_rotation::record_device_converged(
+        txn.as_mut(),
+        bmc_mac,
+        db::credential_rotation::CredentialRotationType::HostUefi,
+    )
+    .await
+    .unwrap();
+    db::credential_rotation::record_device_converged(
+        txn.as_mut(),
+        bmc_mac,
+        db::credential_rotation::CredentialRotationType::Bmc,
+    )
+    .await
+    .unwrap();
+    common::endpoint::insert_endpoint_with_bmc_mac(txn.as_mut(), &ip.to_string(), bmc_mac)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    seed_managed_host(&env, ip).await;
+    seed_bmc_credential(&env, bmc_mac).await;
+
+    // Dry-run reports every record and clears nothing.
+    let dry = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, true))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(dry.dry_run);
+    assert_eq!(dry.machine_interface_ids, vec![iface_id.to_string()]);
+    assert_eq!(dry.explored_endpoint_ips, vec![ip.to_string()]);
+    assert_eq!(dry.explored_managed_host_ips, vec![ip.to_string()]);
+    assert!(
+        dry.bmc_credentials_cleared,
+        "dry-run must report creds exist"
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    assert_eq!(
+        db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "dry-run must not delete the interface"
+    );
+    txn.rollback().await.unwrap();
+    assert!(
+        env.api
+            .credential_manager
+            .get_credentials(&bmc_credential_key(bmc_mac))
+            .await
+            .unwrap()
+            .is_some(),
+        "dry-run must not delete credentials"
+    );
+
+    // Real run erases everything.
+    let done = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(!done.dry_run);
+    assert!(done.bmc_credentials_cleared);
+
+    let mut txn = env.pool.begin().await.unwrap();
+    assert!(
+        db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac)
+            .await
+            .unwrap()
+            .is_empty(),
+        "interface must be gone"
+    );
+    assert!(
+        db::explored_endpoints::find_by_mac_address(txn.as_mut(), bmc_mac)
+            .await
+            .unwrap()
+            .is_empty(),
+        "endpoint must be gone"
+    );
+    assert!(
+        db::explored_managed_host::find_by_ips(txn.as_mut(), vec![ip])
+            .await
+            .unwrap()
+            .is_empty(),
+        "managed host must be gone"
+    );
+    assert!(
+        db::machine_boot_override::find_optional(txn.as_mut(), iface_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "boot override must be gone"
+    );
+    assert!(
+        db::retained_boot_interface::find_by_mac(txn.as_mut(), bmc_mac, None)
+            .await
+            .unwrap()
+            .is_none(),
+        "retained boot row must be cleared for a clean slate"
+    );
+    let marker_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM device_credential_rotation WHERE device_mac = $1")
+            .bind(bmc_mac)
+            .fetch_one(txn.as_mut())
+            .await
+            .unwrap();
+    assert_eq!(marker_count, 0, "convergence markers must be cleared");
+    txn.rollback().await.unwrap();
+    assert!(
+        env.api
+            .credential_manager
+            .get_credentials(&bmc_credential_key(bmc_mac))
+            .await
+            .unwrap()
+            .is_none(),
+        "vault credential must be gone"
+    );
+}
+
+// An explored managed-host row left behind with no exploration report is still
+// cleaned via the MAC's interface IP -- the case the feature exists for. No live
+// BMC call is made, so an off/relocated host is handled from cached data alone.
+#[crate::sqlx_test]
+async fn test_erase_orphan_managed_host_with_no_endpoint(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:01").unwrap();
+
+    let (_iface_id, ip) = seed_interface(&env, bmc_mac).await;
+    seed_managed_host(&env, ip).await;
+
+    let done = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(done.explored_managed_host_ips, vec![ip.to_string()]);
+
+    let mut txn = env.pool.begin().await.unwrap();
+    assert!(
+        db::explored_managed_host::find_by_ips(txn.as_mut(), vec![ip])
+            .await
+            .unwrap()
+            .is_empty(),
+        "orphan managed host must be erased"
+    );
+    assert!(
+        db::machine_interface::find_by_mac_address(txn.as_mut(), bmc_mac)
+            .await
+            .unwrap()
+            .is_empty(),
+        "interface must be erased"
+    );
+    txn.rollback().await.unwrap();
+}
+
+// Dry-run reports credential presence without clearing; a real run clears them.
+#[crate::sqlx_test]
+async fn test_erase_dry_run_reports_then_clears_bmc_credentials(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:02").unwrap();
+    seed_bmc_credential(&env, bmc_mac).await;
+
+    let dry = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, true))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(dry.bmc_credentials_cleared, "dry-run reports creds present");
+    assert!(
+        env.api
+            .credential_manager
+            .get_credentials(&bmc_credential_key(bmc_mac))
+            .await
+            .unwrap()
+            .is_some(),
+        "dry-run must not clear credentials"
+    );
+
+    env.api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .unwrap();
+    assert!(
+        env.api
+            .credential_manager
+            .get_credentials(&bmc_credential_key(bmc_mac))
+            .await
+            .unwrap()
+            .is_none(),
+        "real run must clear credentials"
+    );
+}
+
+// A completely unknown MAC is a safe no-op: empty record lists, no error.
+#[crate::sqlx_test]
+async fn test_erase_unknown_mac_is_noop(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("00:11:22:33:44:55").unwrap();
+
+    let response = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(response.machine_interface_ids.is_empty());
+    assert!(response.explored_endpoint_ips.is_empty());
+    assert!(response.explored_managed_host_ips.is_empty());
+    assert!(!response.bmc_credentials_cleared);
+}
+
+// A malformed MAC is rejected as InvalidArgument, not Internal.
+#[crate::sqlx_test]
+async fn test_erase_invalid_mac_is_invalid_argument(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let err = env
+        .api
+        .erase_host_metadata_by_bmc_mac(tonic::Request::new(
+            rpc::EraseHostMetadataByBmcMacRequest {
+                bmc_mac: "not-a-mac".to_string(),
+                dry_run: true,
+            },
+        ))
+        .await
+        .expect_err("malformed MAC must be rejected");
+    assert_eq!(err.code(), Code::InvalidArgument);
+}
+
+// When a live machine still owns the BMC endpoint, erase-metadata refuses and
+// points the operator at force-delete instead.
+#[crate::sqlx_test]
+async fn test_erase_refuses_when_machine_exists(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
+    let host_machine = env.find_machine(host_machine_id).await.remove(0);
+    let bmc_mac = host_machine
+        .bmc_info
+        .expect("host must have BMC info")
+        .mac
+        .expect("host BMC must have a MAC");
+
+    let err = env
+        .api
+        .erase_host_metadata_by_bmc_mac(tonic::Request::new(
+            rpc::EraseHostMetadataByBmcMacRequest {
+                bmc_mac,
+                dry_run: true,
+            },
+        ))
+        .await
+        .expect_err("must refuse to erase metadata for a live machine");
+    assert_eq!(err.code(), Code::InvalidArgument);
+}
+
+// An interface owned by a switch (not a host machine) is refused -- this cleanup
+// tool must never touch a switch/power-shelf BMC.
+#[crate::sqlx_test]
+async fn test_erase_refuses_switch_owned_interface(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:03").unwrap();
+    let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None)
+        .await
+        .unwrap();
+
+    let (iface_id, _ip) = seed_interface(&env, bmc_mac).await;
+    let mut txn = env.pool.begin().await.unwrap();
+    db::machine_interface::associate_bmc_interface(
+        &iface_id,
+        MachineInterfaceAssociation::Switch(switch_id),
+        txn.as_mut(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let err = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .expect_err("must refuse a switch-owned interface");
+    assert_eq!(err.code(), Code::InvalidArgument);
+}
+
+// erase-metadata never touches expected machines -- NICo does not own that data.
+#[crate::sqlx_test]
+async fn test_erase_preserves_expected_machine(pool: sqlx::PgPool) {
+    use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
+
+    let env = create_test_env(pool).await;
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:04").unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    db::expected_machine::create(
+        txn.as_mut(),
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac,
+            data: ExpectedMachineData {
+                bmc_username: "ADMIN".into(),
+                bmc_password: "notforprod".into(),
+                serial_number: "SN-ERASE-TEST".into(),
+                ..Default::default()
+            },
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    // Give erase something real to do so it exercises the full path.
+    let (_iface_id, _ip) = seed_interface(&env, bmc_mac).await;
+
+    env.api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .unwrap();
+
+    let mut txn = env.pool.begin().await.unwrap();
+    assert!(
+        db::expected_machine::find_by_bmc_mac_address(txn.as_mut(), bmc_mac)
+            .await
+            .unwrap()
+            .is_some(),
+        "expected machine must be preserved"
+    );
+    txn.rollback().await.unwrap();
+}
+
+// A stale interface IP for the requested MAC that has since been reassigned to a
+// different, staged host must not take that host's managed-host row (or endpoint)
+// down. The stale interface is still cleaned; the other host is protected.
+#[crate::sqlx_test]
+async fn test_erase_protects_reused_ip_of_another_host(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let stale_mac = MacAddress::from_str("aa:bb:cc:dd:ee:05").unwrap();
+    let other_mac = MacAddress::from_str("aa:bb:cc:dd:ee:06").unwrap();
+
+    // Old host's leftover interface at some IP.
+    let (_iface_id, ip) = seed_interface(&env, stale_mac).await;
+
+    // That IP now belongs to a different, not-yet-ingested host: its BMC advertises
+    // `other_mac`, and it has a staged managed-host row at the same IP.
+    let mut txn = env.pool.begin().await.unwrap();
+    common::endpoint::insert_endpoint_with_bmc_mac(txn.as_mut(), &ip.to_string(), other_mac)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    seed_managed_host(&env, ip).await;
+
+    let done = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&stale_mac, false))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(
+        done.explored_managed_host_ips.is_empty(),
+        "must not report the other host's managed-host row"
+    );
+
+    let mut txn = env.pool.begin().await.unwrap();
+    assert!(
+        db::machine_interface::find_by_mac_address(txn.as_mut(), stale_mac)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the stale interface is still cleaned"
+    );
+    assert!(
+        !db::explored_managed_host::find_by_ips(txn.as_mut(), vec![ip])
+            .await
+            .unwrap()
+            .is_empty(),
+        "the other host's managed-host row must be protected"
+    );
+    assert!(
+        !db::explored_endpoints::find_all_by_ip(ip, txn.as_mut())
+            .await
+            .unwrap()
+            .is_empty(),
+        "the other host's endpoint must be protected"
+    );
+    txn.rollback().await.unwrap();
+}
+
+// An interface attached to a DPU machine is refused, like the switch case.
+#[crate::sqlx_test]
+async fn test_erase_refuses_dpu_owned_interface(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let (_host_machine_id, dpu_machine_id) = create_managed_host(&env).await.into();
+    let bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:07").unwrap();
+
+    let (iface_id, _ip) = seed_interface(&env, bmc_mac).await;
+    let mut txn = env.pool.begin().await.unwrap();
+    db::machine_interface::associate_interface_with_dpu_machine(
+        &iface_id,
+        &dpu_machine_id,
+        txn.as_mut(),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let err = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&bmc_mac, false))
+        .await
+        .expect_err("must refuse a DPU-owned interface");
+    assert_eq!(err.code(), Code::InvalidArgument);
+}
+
+// An endpoint that mentions the requested MAC only on a host *system* NIC, while its
+// BMC (Manager) advertises a different MAC, belongs to another host and must be
+// protected -- even though the JSONB search matches it.
+#[crate::sqlx_test]
+async fn test_erase_protects_endpoint_owned_by_another_bmc(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let requested_mac = MacAddress::from_str("aa:bb:cc:dd:ee:08").unwrap();
+    let other_bmc_mac = MacAddress::from_str("aa:bb:cc:dd:ee:09").unwrap();
+    let ip = "141.219.24.20";
+
+    let mut txn = env.pool.begin().await.unwrap();
+    common::endpoint::insert_endpoint_system_mac_other_bmc(
+        txn.as_mut(),
+        ip,
+        requested_mac,
+        other_bmc_mac,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let done = env
+        .api
+        .erase_host_metadata_by_bmc_mac(req(&requested_mac, false))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(
+        done.explored_endpoint_ips.is_empty(),
+        "an endpoint owned by another BMC must not be reported or deleted"
+    );
+
+    let ip_addr = IpAddr::from_str(ip).unwrap();
+    let mut txn = env.pool.begin().await.unwrap();
+    assert!(
+        !db::explored_endpoints::find_all_by_ip(ip_addr, txn.as_mut())
+            .await
+            .unwrap()
+            .is_empty(),
+        "the other BMC's endpoint must be left intact"
+    );
+    txn.rollback().await.unwrap();
+}

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -29,6 +29,7 @@ mod dpu_nic_firmware;
 mod dpu_remediation;
 mod dpu_reprovisioning;
 mod dynamic_config;
+mod erase_host_metadata;
 mod expected_machine;
 mod expected_switch;
 mod explored_endpoint_find;

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -119,6 +119,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "forge.AdminForceDeleteMachineResponse",
             "#[derive(serde::Serialize)]",
         )
+        .type_attribute(
+            "forge.EraseHostMetadataByBmcMacRequest",
+            "#[derive(serde::Serialize)]",
+        )
+        .type_attribute(
+            "forge.EraseHostMetadataByBmcMacResponse",
+            "#[derive(serde::Serialize)]",
+        )
         .type_attribute("forge.ClientSecretBasic", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute(".dns", "#[derive(serde::Serialize)]")
         .type_attribute("forge.FabricManagerConfig", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -335,6 +335,27 @@ service Forge {
   // appropriate customer-facing workflow available or where those workflows fail.
   rpc AdminForceDeleteMachine(AdminForceDeleteMachineRequest) returns (AdminForceDeleteMachineResponse);
 
+  // EraseHostMetadataByBmcMac removes all NICo-owned site records tied to a
+  // server BMC MAC address -- machine interfaces (and their addresses/DHCP
+  // entries/boot overrides), retained boot rows, site-explorer exploration
+  // reports, explored managed hosts and the BMC credentials in vault -- so an
+  // operator has a clean slate to re-ingest a replacement host. Deletion is
+  // MAC-driven from cached state (no live BMC call), so an off/relocated host is
+  // still cleaned. It intentionally does NOT touch expected machines, which NICo
+  // does not own.
+  //
+  // Refusals and protections:
+  //   * Refuses when any interface for the MAC is still owned by a live device
+  //     (machine, DPU, switch or power shelf), or when a candidate BMC IP still
+  //     belongs to an ingested machine -- use AdminForceDeleteMachine for those.
+  //   * Preserves an exploration endpoint or explored-managed-host row whose BMC
+  //     (Redfish Manager) advertises a *different* MAC, so a reused IP now owned by
+  //     another host is never taken down.
+  //
+  // Set dry_run to report which records (and whether BMC credentials) would be
+  // erased without deleting anything.
+  rpc EraseHostMetadataByBmcMac(EraseHostMetadataByBmcMacRequest) returns (EraseHostMetadataByBmcMacResponse);
+
   // List existing resource pools and their stats
   rpc AdminListResourcePools(ListResourcePoolsRequest) returns (ResourcePools);
 
@@ -9510,4 +9531,34 @@ message SitePrefixIdList {
 
 message SitePrefixList {
   repeated SitePrefix site_prefixes = 1;
+}
+
+// Request to erase all NICo-owned site records for a server BMC MAC address.
+message EraseHostMetadataByBmcMacRequest {
+  // The server BMC MAC address whose lingering records should be erased.
+  string bmc_mac = 1;
+
+  // When true, report the records that would be erased without deleting them.
+  bool dry_run = 2;
+}
+
+// Response describing the records that were erased (or, in dry-run mode, that
+// would be erased) for the requested BMC MAC address.
+message EraseHostMetadataByBmcMacResponse {
+  // Echoes the request: true when nothing was actually deleted.
+  bool dry_run = 1;
+
+  // IDs of the machine interfaces erased for this MAC.
+  repeated string machine_interface_ids = 2;
+
+  // BMC IP addresses of the site-explorer exploration reports erased.
+  repeated string explored_endpoint_ips = 3;
+
+  // Host BMC IP addresses of the explored managed host records erased.
+  repeated string explored_managed_host_ips = 4;
+
+  // In a real run, true when the BMC credentials in vault (and the convergence
+  // markers keyed by this MAC) were cleared. In dry-run mode, true when such BMC
+  // credentials exist and would be cleared.
+  bool bmc_credentials_cleared = 5;
 }

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -60541,6 +60541,146 @@ func (x *SitePrefixList) GetSitePrefixes() []*SitePrefix {
 	return nil
 }
 
+// Request to erase all NICo-owned site records for a server BMC MAC address.
+type EraseHostMetadataByBmcMacRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The server BMC MAC address whose lingering records should be erased.
+	BmcMac string `protobuf:"bytes,1,opt,name=bmc_mac,json=bmcMac,proto3" json:"bmc_mac,omitempty"`
+	// When true, report the records that would be erased without deleting them.
+	DryRun        bool `protobuf:"varint,2,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EraseHostMetadataByBmcMacRequest) Reset() {
+	*x = EraseHostMetadataByBmcMacRequest{}
+	mi := &file_nico_nico_proto_msgTypes[870]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EraseHostMetadataByBmcMacRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EraseHostMetadataByBmcMacRequest) ProtoMessage() {}
+
+func (x *EraseHostMetadataByBmcMacRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_nico_nico_proto_msgTypes[870]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EraseHostMetadataByBmcMacRequest.ProtoReflect.Descriptor instead.
+func (*EraseHostMetadataByBmcMacRequest) Descriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{870}
+}
+
+func (x *EraseHostMetadataByBmcMacRequest) GetBmcMac() string {
+	if x != nil {
+		return x.BmcMac
+	}
+	return ""
+}
+
+func (x *EraseHostMetadataByBmcMacRequest) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+// Response describing the records that were erased (or, in dry-run mode, that
+// would be erased) for the requested BMC MAC address.
+type EraseHostMetadataByBmcMacResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Echoes the request: true when nothing was actually deleted.
+	DryRun bool `protobuf:"varint,1,opt,name=dry_run,json=dryRun,proto3" json:"dry_run,omitempty"`
+	// IDs of the machine interfaces erased for this MAC.
+	MachineInterfaceIds []string `protobuf:"bytes,2,rep,name=machine_interface_ids,json=machineInterfaceIds,proto3" json:"machine_interface_ids,omitempty"`
+	// BMC IP addresses of the site-explorer exploration reports erased.
+	ExploredEndpointIps []string `protobuf:"bytes,3,rep,name=explored_endpoint_ips,json=exploredEndpointIps,proto3" json:"explored_endpoint_ips,omitempty"`
+	// Host BMC IP addresses of the explored managed host records erased.
+	ExploredManagedHostIps []string `protobuf:"bytes,4,rep,name=explored_managed_host_ips,json=exploredManagedHostIps,proto3" json:"explored_managed_host_ips,omitempty"`
+	// In a real run, true when the BMC credentials in vault (and the convergence
+	// markers keyed by this MAC) were cleared. In dry-run mode, true when such BMC
+	// credentials exist and would be cleared.
+	BmcCredentialsCleared bool `protobuf:"varint,5,opt,name=bmc_credentials_cleared,json=bmcCredentialsCleared,proto3" json:"bmc_credentials_cleared,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) Reset() {
+	*x = EraseHostMetadataByBmcMacResponse{}
+	mi := &file_nico_nico_proto_msgTypes[871]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EraseHostMetadataByBmcMacResponse) ProtoMessage() {}
+
+func (x *EraseHostMetadataByBmcMacResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_nico_nico_proto_msgTypes[871]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EraseHostMetadataByBmcMacResponse.ProtoReflect.Descriptor instead.
+func (*EraseHostMetadataByBmcMacResponse) Descriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{871}
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) GetDryRun() bool {
+	if x != nil {
+		return x.DryRun
+	}
+	return false
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) GetMachineInterfaceIds() []string {
+	if x != nil {
+		return x.MachineInterfaceIds
+	}
+	return nil
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) GetExploredEndpointIps() []string {
+	if x != nil {
+		return x.ExploredEndpointIps
+	}
+	return nil
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) GetExploredManagedHostIps() []string {
+	if x != nil {
+		return x.ExploredManagedHostIps
+	}
+	return nil
+}
+
+func (x *EraseHostMetadataByBmcMacResponse) GetBmcCredentialsCleared() bool {
+	if x != nil {
+		return x.BmcCredentialsCleared
+	}
+	return false
+}
+
 type DNSMessage_DNSQuestion struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	QName         *string                `protobuf:"bytes,1,opt,name=q_name,json=qName,proto3,oneof" json:"q_name,omitempty"` // FQDN including trailing dot
@@ -60552,7 +60692,7 @@ type DNSMessage_DNSQuestion struct {
 
 func (x *DNSMessage_DNSQuestion) Reset() {
 	*x = DNSMessage_DNSQuestion{}
-	mi := &file_nico_nico_proto_msgTypes[871]
+	mi := &file_nico_nico_proto_msgTypes[873]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60564,7 +60704,7 @@ func (x *DNSMessage_DNSQuestion) String() string {
 func (*DNSMessage_DNSQuestion) ProtoMessage() {}
 
 func (x *DNSMessage_DNSQuestion) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[871]
+	mi := &file_nico_nico_proto_msgTypes[873]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60610,7 +60750,7 @@ type DNSMessage_DNSResponse struct {
 
 func (x *DNSMessage_DNSResponse) Reset() {
 	*x = DNSMessage_DNSResponse{}
-	mi := &file_nico_nico_proto_msgTypes[872]
+	mi := &file_nico_nico_proto_msgTypes[874]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60622,7 +60762,7 @@ func (x *DNSMessage_DNSResponse) String() string {
 func (*DNSMessage_DNSResponse) ProtoMessage() {}
 
 func (x *DNSMessage_DNSResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[872]
+	mi := &file_nico_nico_proto_msgTypes[874]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60654,7 +60794,7 @@ type DNSMessage_DNSResponse_DNSRR struct {
 
 func (x *DNSMessage_DNSResponse_DNSRR) Reset() {
 	*x = DNSMessage_DNSResponse_DNSRR{}
-	mi := &file_nico_nico_proto_msgTypes[873]
+	mi := &file_nico_nico_proto_msgTypes[875]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60666,7 +60806,7 @@ func (x *DNSMessage_DNSResponse_DNSRR) String() string {
 func (*DNSMessage_DNSResponse_DNSRR) ProtoMessage() {}
 
 func (x *DNSMessage_DNSResponse_DNSRR) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[873]
+	mi := &file_nico_nico_proto_msgTypes[875]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60700,7 +60840,7 @@ type MachineCredentialsUpdateRequest_Credentials struct {
 
 func (x *MachineCredentialsUpdateRequest_Credentials) Reset() {
 	*x = MachineCredentialsUpdateRequest_Credentials{}
-	mi := &file_nico_nico_proto_msgTypes[879]
+	mi := &file_nico_nico_proto_msgTypes[881]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60712,7 +60852,7 @@ func (x *MachineCredentialsUpdateRequest_Credentials) String() string {
 func (*MachineCredentialsUpdateRequest_Credentials) ProtoMessage() {}
 
 func (x *MachineCredentialsUpdateRequest_Credentials) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[879]
+	mi := &file_nico_nico_proto_msgTypes[881]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60759,7 +60899,7 @@ type ForgeAgentControlResponse_ForgeAgentControlExtraInfo struct {
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo) Reset() {
 	*x = ForgeAgentControlResponse_ForgeAgentControlExtraInfo{}
-	mi := &file_nico_nico_proto_msgTypes[880]
+	mi := &file_nico_nico_proto_msgTypes[882]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60771,7 +60911,7 @@ func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo) String() string {
 func (*ForgeAgentControlResponse_ForgeAgentControlExtraInfo) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[880]
+	mi := &file_nico_nico_proto_msgTypes[882]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60802,7 +60942,7 @@ type ForgeAgentControlResponse_Noop struct {
 
 func (x *ForgeAgentControlResponse_Noop) Reset() {
 	*x = ForgeAgentControlResponse_Noop{}
-	mi := &file_nico_nico_proto_msgTypes[881]
+	mi := &file_nico_nico_proto_msgTypes[883]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60814,7 +60954,7 @@ func (x *ForgeAgentControlResponse_Noop) String() string {
 func (*ForgeAgentControlResponse_Noop) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Noop) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[881]
+	mi := &file_nico_nico_proto_msgTypes[883]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60838,7 +60978,7 @@ type ForgeAgentControlResponse_Reset struct {
 
 func (x *ForgeAgentControlResponse_Reset) Reset() {
 	*x = ForgeAgentControlResponse_Reset{}
-	mi := &file_nico_nico_proto_msgTypes[882]
+	mi := &file_nico_nico_proto_msgTypes[884]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60850,7 +60990,7 @@ func (x *ForgeAgentControlResponse_Reset) String() string {
 func (*ForgeAgentControlResponse_Reset) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Reset) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[882]
+	mi := &file_nico_nico_proto_msgTypes[884]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60874,7 +61014,7 @@ type ForgeAgentControlResponse_Discovery struct {
 
 func (x *ForgeAgentControlResponse_Discovery) Reset() {
 	*x = ForgeAgentControlResponse_Discovery{}
-	mi := &file_nico_nico_proto_msgTypes[883]
+	mi := &file_nico_nico_proto_msgTypes[885]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60886,7 +61026,7 @@ func (x *ForgeAgentControlResponse_Discovery) String() string {
 func (*ForgeAgentControlResponse_Discovery) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Discovery) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[883]
+	mi := &file_nico_nico_proto_msgTypes[885]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60910,7 +61050,7 @@ type ForgeAgentControlResponse_Rebuild struct {
 
 func (x *ForgeAgentControlResponse_Rebuild) Reset() {
 	*x = ForgeAgentControlResponse_Rebuild{}
-	mi := &file_nico_nico_proto_msgTypes[884]
+	mi := &file_nico_nico_proto_msgTypes[886]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60922,7 +61062,7 @@ func (x *ForgeAgentControlResponse_Rebuild) String() string {
 func (*ForgeAgentControlResponse_Rebuild) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Rebuild) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[884]
+	mi := &file_nico_nico_proto_msgTypes[886]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60946,7 +61086,7 @@ type ForgeAgentControlResponse_Retry struct {
 
 func (x *ForgeAgentControlResponse_Retry) Reset() {
 	*x = ForgeAgentControlResponse_Retry{}
-	mi := &file_nico_nico_proto_msgTypes[885]
+	mi := &file_nico_nico_proto_msgTypes[887]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60958,7 +61098,7 @@ func (x *ForgeAgentControlResponse_Retry) String() string {
 func (*ForgeAgentControlResponse_Retry) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Retry) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[885]
+	mi := &file_nico_nico_proto_msgTypes[887]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60982,7 +61122,7 @@ type ForgeAgentControlResponse_Measure struct {
 
 func (x *ForgeAgentControlResponse_Measure) Reset() {
 	*x = ForgeAgentControlResponse_Measure{}
-	mi := &file_nico_nico_proto_msgTypes[886]
+	mi := &file_nico_nico_proto_msgTypes[888]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -60994,7 +61134,7 @@ func (x *ForgeAgentControlResponse_Measure) String() string {
 func (*ForgeAgentControlResponse_Measure) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Measure) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[886]
+	mi := &file_nico_nico_proto_msgTypes[888]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61018,7 +61158,7 @@ type ForgeAgentControlResponse_LogError struct {
 
 func (x *ForgeAgentControlResponse_LogError) Reset() {
 	*x = ForgeAgentControlResponse_LogError{}
-	mi := &file_nico_nico_proto_msgTypes[887]
+	mi := &file_nico_nico_proto_msgTypes[889]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61030,7 +61170,7 @@ func (x *ForgeAgentControlResponse_LogError) String() string {
 func (*ForgeAgentControlResponse_LogError) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_LogError) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[887]
+	mi := &file_nico_nico_proto_msgTypes[889]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61058,7 +61198,7 @@ type ForgeAgentControlResponse_MachineValidation struct {
 
 func (x *ForgeAgentControlResponse_MachineValidation) Reset() {
 	*x = ForgeAgentControlResponse_MachineValidation{}
-	mi := &file_nico_nico_proto_msgTypes[888]
+	mi := &file_nico_nico_proto_msgTypes[890]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61070,7 +61210,7 @@ func (x *ForgeAgentControlResponse_MachineValidation) String() string {
 func (*ForgeAgentControlResponse_MachineValidation) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MachineValidation) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[888]
+	mi := &file_nico_nico_proto_msgTypes[890]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61126,7 +61266,7 @@ type ForgeAgentControlResponse_MachineValidationFilter struct {
 
 func (x *ForgeAgentControlResponse_MachineValidationFilter) Reset() {
 	*x = ForgeAgentControlResponse_MachineValidationFilter{}
-	mi := &file_nico_nico_proto_msgTypes[889]
+	mi := &file_nico_nico_proto_msgTypes[891]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61138,7 +61278,7 @@ func (x *ForgeAgentControlResponse_MachineValidationFilter) String() string {
 func (*ForgeAgentControlResponse_MachineValidationFilter) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MachineValidationFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[889]
+	mi := &file_nico_nico_proto_msgTypes[891]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61191,7 +61331,7 @@ type ForgeAgentControlResponse_MlxAction struct {
 
 func (x *ForgeAgentControlResponse_MlxAction) Reset() {
 	*x = ForgeAgentControlResponse_MlxAction{}
-	mi := &file_nico_nico_proto_msgTypes[890]
+	mi := &file_nico_nico_proto_msgTypes[892]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61203,7 +61343,7 @@ func (x *ForgeAgentControlResponse_MlxAction) String() string {
 func (*ForgeAgentControlResponse_MlxAction) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxAction) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[890]
+	mi := &file_nico_nico_proto_msgTypes[892]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61243,7 +61383,7 @@ type ForgeAgentControlResponse_MlxDeviceAction struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceAction) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceAction{}
-	mi := &file_nico_nico_proto_msgTypes[891]
+	mi := &file_nico_nico_proto_msgTypes[893]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61255,7 +61395,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceAction) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceAction) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceAction) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[891]
+	mi := &file_nico_nico_proto_msgTypes[893]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61377,7 +61517,7 @@ type ForgeAgentControlResponse_MlxDeviceNoop struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceNoop) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceNoop{}
-	mi := &file_nico_nico_proto_msgTypes[892]
+	mi := &file_nico_nico_proto_msgTypes[894]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61389,7 +61529,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceNoop) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceNoop) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceNoop) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[892]
+	mi := &file_nico_nico_proto_msgTypes[894]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61414,7 +61554,7 @@ type ForgeAgentControlResponse_MlxDeviceLock struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceLock) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceLock{}
-	mi := &file_nico_nico_proto_msgTypes[893]
+	mi := &file_nico_nico_proto_msgTypes[895]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61426,7 +61566,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceLock) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceLock) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceLock) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[893]
+	mi := &file_nico_nico_proto_msgTypes[895]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61458,7 +61598,7 @@ type ForgeAgentControlResponse_MlxDeviceUnlock struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceUnlock) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceUnlock{}
-	mi := &file_nico_nico_proto_msgTypes[894]
+	mi := &file_nico_nico_proto_msgTypes[896]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61470,7 +61610,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceUnlock) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceUnlock) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceUnlock) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[894]
+	mi := &file_nico_nico_proto_msgTypes[896]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61502,7 +61642,7 @@ type ForgeAgentControlResponse_MlxDeviceApplyProfile struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyProfile) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceApplyProfile{}
-	mi := &file_nico_nico_proto_msgTypes[895]
+	mi := &file_nico_nico_proto_msgTypes[897]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61514,7 +61654,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceApplyProfile) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceApplyProfile) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[895]
+	mi := &file_nico_nico_proto_msgTypes[897]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61546,7 +61686,7 @@ type ForgeAgentControlResponse_MlxDeviceApplyFirmware struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyFirmware) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceApplyFirmware{}
-	mi := &file_nico_nico_proto_msgTypes[896]
+	mi := &file_nico_nico_proto_msgTypes[898]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61558,7 +61698,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceApplyFirmware) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceApplyFirmware) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyFirmware) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[896]
+	mi := &file_nico_nico_proto_msgTypes[898]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61590,7 +61730,7 @@ type ForgeAgentControlResponse_FirmwareUpgrade struct {
 
 func (x *ForgeAgentControlResponse_FirmwareUpgrade) Reset() {
 	*x = ForgeAgentControlResponse_FirmwareUpgrade{}
-	mi := &file_nico_nico_proto_msgTypes[897]
+	mi := &file_nico_nico_proto_msgTypes[899]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61602,7 +61742,7 @@ func (x *ForgeAgentControlResponse_FirmwareUpgrade) String() string {
 func (*ForgeAgentControlResponse_FirmwareUpgrade) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_FirmwareUpgrade) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[897]
+	mi := &file_nico_nico_proto_msgTypes[899]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61635,7 +61775,7 @@ type ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair struct {
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) Reset() {
 	*x = ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair{}
-	mi := &file_nico_nico_proto_msgTypes[898]
+	mi := &file_nico_nico_proto_msgTypes[900]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61647,7 +61787,7 @@ func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) Stri
 func (*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[898]
+	mi := &file_nico_nico_proto_msgTypes[900]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61688,7 +61828,7 @@ type MachineCleanupInfo_CleanupStepResult struct {
 
 func (x *MachineCleanupInfo_CleanupStepResult) Reset() {
 	*x = MachineCleanupInfo_CleanupStepResult{}
-	mi := &file_nico_nico_proto_msgTypes[899]
+	mi := &file_nico_nico_proto_msgTypes[901]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61700,7 +61840,7 @@ func (x *MachineCleanupInfo_CleanupStepResult) String() string {
 func (*MachineCleanupInfo_CleanupStepResult) ProtoMessage() {}
 
 func (x *MachineCleanupInfo_CleanupStepResult) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[899]
+	mi := &file_nico_nico_proto_msgTypes[901]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61745,7 +61885,7 @@ type DpuReprovisioningListResponse_DpuReprovisioningListItem struct {
 
 func (x *DpuReprovisioningListResponse_DpuReprovisioningListItem) Reset() {
 	*x = DpuReprovisioningListResponse_DpuReprovisioningListItem{}
-	mi := &file_nico_nico_proto_msgTypes[900]
+	mi := &file_nico_nico_proto_msgTypes[902]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61757,7 +61897,7 @@ func (x *DpuReprovisioningListResponse_DpuReprovisioningListItem) String() strin
 func (*DpuReprovisioningListResponse_DpuReprovisioningListItem) ProtoMessage() {}
 
 func (x *DpuReprovisioningListResponse_DpuReprovisioningListItem) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[900]
+	mi := &file_nico_nico_proto_msgTypes[902]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61836,7 +61976,7 @@ type HostReprovisioningListResponse_HostReprovisioningListItem struct {
 
 func (x *HostReprovisioningListResponse_HostReprovisioningListItem) Reset() {
 	*x = HostReprovisioningListResponse_HostReprovisioningListItem{}
-	mi := &file_nico_nico_proto_msgTypes[901]
+	mi := &file_nico_nico_proto_msgTypes[903]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61848,7 +61988,7 @@ func (x *HostReprovisioningListResponse_HostReprovisioningListItem) String() str
 func (*HostReprovisioningListResponse_HostReprovisioningListItem) ProtoMessage() {}
 
 func (x *HostReprovisioningListResponse_HostReprovisioningListItem) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[901]
+	mi := &file_nico_nico_proto_msgTypes[903]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61932,7 +62072,7 @@ type MachineValidationTestUpdateRequest_Payload struct {
 
 func (x *MachineValidationTestUpdateRequest_Payload) Reset() {
 	*x = MachineValidationTestUpdateRequest_Payload{}
-	mi := &file_nico_nico_proto_msgTypes[902]
+	mi := &file_nico_nico_proto_msgTypes[904]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61944,7 +62084,7 @@ func (x *MachineValidationTestUpdateRequest_Payload) String() string {
 func (*MachineValidationTestUpdateRequest_Payload) ProtoMessage() {}
 
 func (x *MachineValidationTestUpdateRequest_Payload) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[902]
+	mi := &file_nico_nico_proto_msgTypes[904]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62097,7 +62237,7 @@ type DPFStateResponse_DPFState struct {
 
 func (x *DPFStateResponse_DPFState) Reset() {
 	*x = DPFStateResponse_DPFState{}
-	mi := &file_nico_nico_proto_msgTypes[908]
+	mi := &file_nico_nico_proto_msgTypes[910]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -62109,7 +62249,7 @@ func (x *DPFStateResponse_DPFState) String() string {
 func (*DPFStateResponse_DPFState) ProtoMessage() {}
 
 func (x *DPFStateResponse_DPFState) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[908]
+	mi := &file_nico_nico_proto_msgTypes[910]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67232,7 +67372,16 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x10SitePrefixIdList\x12<\n" +
 	"\x0fsite_prefix_ids\x18\x01 \x03(\v2\x14.common.SitePrefixIdR\rsitePrefixIds\"H\n" +
 	"\x0eSitePrefixList\x126\n" +
-	"\rsite_prefixes\x18\x01 \x03(\v2\x11.forge.SitePrefixR\fsitePrefixes*s\n" +
+	"\rsite_prefixes\x18\x01 \x03(\v2\x11.forge.SitePrefixR\fsitePrefixes\"T\n" +
+	" EraseHostMetadataByBmcMacRequest\x12\x17\n" +
+	"\abmc_mac\x18\x01 \x01(\tR\x06bmcMac\x12\x17\n" +
+	"\adry_run\x18\x02 \x01(\bR\x06dryRun\"\x97\x02\n" +
+	"!EraseHostMetadataByBmcMacResponse\x12\x17\n" +
+	"\adry_run\x18\x01 \x01(\bR\x06dryRun\x122\n" +
+	"\x15machine_interface_ids\x18\x02 \x03(\tR\x13machineInterfaceIds\x122\n" +
+	"\x15explored_endpoint_ips\x18\x03 \x03(\tR\x13exploredEndpointIps\x129\n" +
+	"\x19explored_managed_host_ips\x18\x04 \x03(\tR\x16exploredManagedHostIps\x126\n" +
+	"\x17bmc_credentials_cleared\x18\x05 \x01(\bR\x15bmcCredentialsCleared*s\n" +
 	"\x15SpdmAttestationStatus\x12\x18\n" +
 	"\x14SPDM_ATT_IN_PROGRESS\x10\x00\x12\x16\n" +
 	"\x12SPDM_ATT_CANCELLED\x10\x01\x12\x13\n" +
@@ -67701,7 +67850,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"(SITE_PREFIX_LIFECYCLE_STATE_PROVISIONING\x10\x01\x12%\n" +
 	"!SITE_PREFIX_LIFECYCLE_STATE_READY\x10\x02\x12(\n" +
 	"$SITE_PREFIX_LIFECYCLE_STATE_DELETING\x10\x03\x12%\n" +
-	"!SITE_PREFIX_LIFECYCLE_STATE_ERROR\x10\x042\x87\xd5\x02\n" +
+	"!SITE_PREFIX_LIFECYCLE_STATE_ERROR\x10\x042\xf7\xd5\x02\n" +
 	"\x05Forge\x122\n" +
 	"\aVersion\x12\x15.forge.VersionRequest\x1a\x10.forge.BuildInfo\x125\n" +
 	"\fCreateDomain\x12\x18.dns.CreateDomainRequest\x1a\v.dns.Domain\x125\n" +
@@ -67862,7 +68011,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x1cFindExploredMlxDeviceHostIds\x120.site_explorer.ExploredMlxDeviceHostSearchFilter\x1a*.site_explorer.ExploredMlxDeviceHostIdList\x12r\n" +
 	"\x1bFindExploredMlxDevicesByIds\x12-.site_explorer.ExploredMlxDevicesByIdsRequest\x1a$.site_explorer.ExploredMlxDeviceList\x12\\\n" +
 	"\x19UpdateMachineHardwareInfo\x12'.forge.UpdateMachineHardwareInfoRequest\x1a\x16.google.protobuf.Empty\x12h\n" +
-	"\x17AdminForceDeleteMachine\x12%.forge.AdminForceDeleteMachineRequest\x1a&.forge.AdminForceDeleteMachineResponse\x12O\n" +
+	"\x17AdminForceDeleteMachine\x12%.forge.AdminForceDeleteMachineRequest\x1a&.forge.AdminForceDeleteMachineResponse\x12n\n" +
+	"\x19EraseHostMetadataByBmcMac\x12'.forge.EraseHostMetadataByBmcMacRequest\x1a(.forge.EraseHostMetadataByBmcMacResponse\x12O\n" +
 	"\x16AdminListResourcePools\x12\x1f.forge.ListResourcePoolsRequest\x1a\x14.forge.ResourcePools\x12X\n" +
 	"\x15AdminGrowResourcePool\x12\x1e.forge.GrowResourcePoolRequest\x1a\x1f.forge.GrowResourcePoolResponse\x12T\n" +
 	"\x15UpdateMachineMetadata\x12#.forge.MachineMetadataUpdateRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
@@ -68196,1449 +68346,1451 @@ func file_nico_nico_proto_rawDescGZIP() []byte {
 }
 
 var file_nico_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 98)
-var file_nico_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 909)
+var file_nico_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 911)
 var file_nico_nico_proto_goTypes = []any{
 	(SpdmAttestationStatus)(0),                      // 0: forge.SpdmAttestationStatus
 	(SpdmListAttestationMachinesRequestSelector)(0), // 1: forge.SpdmListAttestationMachinesRequestSelector
-	(JwksKind)(0),                                                             // 2: forge.JwksKind
-	(MachineIngestionState)(0),                                                // 3: forge.MachineIngestionState
-	(CredentialType)(0),                                                       // 4: forge.CredentialType
-	(RotationCredentialType)(0),                                               // 5: forge.RotationCredentialType
-	(VpcVirtualizationType)(0),                                                // 6: forge.VpcVirtualizationType
-	(PrefixMatchType)(0),                                                      // 7: forge.PrefixMatchType
-	(TenantState)(0),                                                          // 8: forge.TenantState
-	(PowerShelfMaintenanceOperation)(0),                                       // 9: forge.PowerShelfMaintenanceOperation
-	(DeletedFilter)(0),                                                        // 10: forge.DeletedFilter
-	(FabricManagerState)(0),                                                   // 11: forge.FabricManagerState
-	(NetworkSegmentType)(0),                                                   // 12: forge.NetworkSegmentType
-	(NetworkSegmentFlag)(0),                                                   // 13: forge.NetworkSegmentFlag
-	(IpxeTemplateArtifactCacheStrategy)(0),                                    // 14: forge.IpxeTemplateArtifactCacheStrategy
-	(IpxeTemplateVisibility)(0),                                               // 15: forge.IpxeTemplateVisibility
-	(SpxAttachmentType)(0),                                                    // 16: forge.SpxAttachmentType
-	(InstanceInterfaceIpFamilyMode)(0),                                        // 17: forge.InstanceInterfaceIpFamilyMode
-	(IssueCategory)(0),                                                        // 18: forge.IssueCategory
-	(AssignStaticAddressStatus)(0),                                            // 19: forge.AssignStaticAddressStatus
-	(RemoveStaticAddressStatus)(0),                                            // 20: forge.RemoveStaticAddressStatus
-	(MachineType)(0),                                                          // 21: forge.MachineType
-	(InstanceNetworkSegmentMembershipType)(0),                                 // 22: forge.InstanceNetworkSegmentMembershipType
-	(ControllerStateOutcome)(0),                                               // 23: forge.ControllerStateOutcome
-	(SyncState)(0),                                                            // 24: forge.SyncState
-	(MachineArchitecture)(0),                                                  // 25: forge.MachineArchitecture
-	(InterfaceAssociationType)(0),                                             // 26: forge.InterfaceAssociationType
-	(InterfaceType)(0),                                                        // 27: forge.InterfaceType
-	(AddressFamily)(0),                                                        // 28: forge.AddressFamily
-	(MessageKind)(0),                                                          // 29: forge.MessageKind
-	(ExpireDhcpLeaseStatus)(0),                                                // 30: forge.ExpireDhcpLeaseStatus
-	(UserRoles)(0),                                                            // 31: forge.UserRoles
-	(MachineHardwareInfoUpdateType)(0),                                        // 32: forge.MachineHardwareInfoUpdateType
-	(ManagedHostQuarantineMode)(0),                                            // 33: forge.ManagedHostQuarantineMode
-	(VpcIsolationBehaviorType)(0),                                             // 34: forge.VpcIsolationBehaviorType
-	(AgentUpgradePolicy)(0),                                                   // 35: forge.AgentUpgradePolicy
-	(LockdownAction)(0),                                                       // 36: forge.LockdownAction
-	(BMCRequestType)(0),                                                       // 37: forge.BMCRequestType
-	(MachineDiscoveryReporter)(0),                                             // 38: forge.MachineDiscoveryReporter
-	(BootstrapCaSource)(0),                                                    // 39: forge.BootstrapCaSource
-	(InterfaceFunctionType)(0),                                                // 40: forge.InterfaceFunctionType
-	(HealthReportApplyMode)(0),                                                // 41: forge.HealthReportApplyMode
-	(ResourcePoolType)(0),                                                     // 42: forge.ResourcePoolType
-	(MaintenanceOperation)(0),                                                 // 43: forge.MaintenanceOperation
-	(ConfigSetting)(0),                                                        // 44: forge.ConfigSetting
-	(UuidType)(0),                                                             // 45: forge.UuidType
-	(MacOwner)(0),                                                             // 46: forge.MacOwner
-	(UpdateInitiator)(0),                                                      // 47: forge.UpdateInitiator
-	(IpType)(0),                                                               // 48: forge.IpType
-	(RouteServerSourceType)(0),                                                // 49: forge.RouteServerSourceType
-	(OsImageStatus)(0),                                                        // 50: forge.OsImageStatus
-	(DpuMode)(0),                                                              // 51: forge.DpuMode
-	(BmcIpAllocationType)(0),                                                  // 52: forge.BmcIpAllocationType
-	(MachineValidationStarted)(0),                                             // 53: forge.MachineValidationStarted
-	(MachineValidationInProgress)(0),                                          // 54: forge.MachineValidationInProgress
-	(MachineValidationCompleted)(0),                                           // 55: forge.MachineValidationCompleted
-	(MachineCapabilityDeviceType)(0),                                          // 56: forge.MachineCapabilityDeviceType
-	(MachineCapabilityType)(0),                                                // 57: forge.MachineCapabilityType
-	(NetworkSecurityGroupSource)(0),                                           // 58: forge.NetworkSecurityGroupSource
-	(NetworkSecurityGroupPropagationStatus)(0),                                // 59: forge.NetworkSecurityGroupPropagationStatus
-	(NetworkSecurityGroupRuleDirection)(0),                                    // 60: forge.NetworkSecurityGroupRuleDirection
-	(NetworkSecurityGroupRuleProtocol)(0),                                     // 61: forge.NetworkSecurityGroupRuleProtocol
-	(NetworkSecurityGroupRuleAction)(0),                                       // 62: forge.NetworkSecurityGroupRuleAction
-	(DpaInterfaceType)(0),                                                     // 63: forge.DpaInterfaceType
-	(PowerState)(0),                                                           // 64: forge.PowerState
-	(RackHardwareTopology)(0),                                                 // 65: forge.RackHardwareTopology
-	(RackProductFamily)(0),                                                    // 66: forge.RackProductFamily
-	(RackHardwareClass)(0),                                                    // 67: forge.RackHardwareClass
-	(RackManagerForgeCmd)(0),                                                  // 68: forge.RackManagerForgeCmd
-	(AstraPhase)(0),                                                           // 69: forge.AstraPhase
-	(NmxcBrowseOperation)(0),                                                  // 70: forge.NmxcBrowseOperation
-	(HostFirmwareComponentType)(0),                                            // 71: forge.HostFirmwareComponentType
-	(TrimTableTarget)(0),                                                      // 72: forge.TrimTableTarget
-	(DpuExtensionServiceType)(0),                                              // 73: forge.DpuExtensionServiceType
-	(DpuExtensionServiceDeploymentStatus)(0),                                  // 74: forge.DpuExtensionServiceDeploymentStatus
-	(ScoutStreamErrorStatus)(0),                                               // 75: forge.ScoutStreamErrorStatus
-	(ComponentManagerStatusCode)(0),                                           // 76: forge.ComponentManagerStatusCode
-	(FirmwareUpdateState)(0),                                                  // 77: forge.FirmwareUpdateState
-	(NvSwitchComponent)(0),                                                    // 78: forge.NvSwitchComponent
-	(PowerShelfComponent)(0),                                                  // 79: forge.PowerShelfComponent
-	(ComputeTrayComponent)(0),                                                 // 80: forge.ComputeTrayComponent
-	(OperatingSystemType)(0),                                                  // 81: forge.OperatingSystemType
-	(ExpectedInterfaceRole)(0),                                                // 82: forge.ExpectedInterfaceRole
-	(ExpectedInterfaceIpAllocation)(0),                                        // 83: forge.ExpectedInterfaceIpAllocation
-	(SitePrefixAuthority)(0),                                                  // 84: forge.SitePrefixAuthority
-	(SitePrefixRoutingScope)(0),                                               // 85: forge.SitePrefixRoutingScope
-	(SitePrefixLifecycleState)(0),                                             // 86: forge.SitePrefixLifecycleState
-	(InstancePowerRequest_Operation)(0),                                       // 87: forge.InstancePowerRequest.Operation
-	(InstanceUpdateStatus_Module)(0),                                          // 88: forge.InstanceUpdateStatus.Module
-	(MachineCredentialsUpdateRequest_CredentialPurpose)(0),                    // 89: forge.MachineCredentialsUpdateRequest.CredentialPurpose
-	(ForgeAgentControlResponse_LegacyAction)(0),                               // 90: forge.ForgeAgentControlResponse.LegacyAction
-	(MachineCleanupInfo_CleanupResult)(0),                                     // 91: forge.MachineCleanupInfo.CleanupResult
-	(DpuReprovisioningRequest_Mode)(0),                                        // 92: forge.DpuReprovisioningRequest.Mode
-	(HostReprovisioningRequest_Mode)(0),                                       // 93: forge.HostReprovisioningRequest.Mode
-	(MachineSetAutoUpdateRequest_SetAutoupdateAction)(0),                      // 94: forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
-	(MachineValidationOnDemandRequest_Action)(0),                              // 95: forge.MachineValidationOnDemandRequest.Action
-	(AdminPowerControlRequest_SystemPowerControl)(0),                          // 96: forge.AdminPowerControlRequest.SystemPowerControl
-	(GetRedfishJobStateResponse_RedfishJobState)(0),                           // 97: forge.GetRedfishJobStateResponse.RedfishJobState
-	(*LifecycleStatus)(nil),                                                   // 98: forge.LifecycleStatus
-	(*SpdmMachineAttestationStatus)(nil),                                      // 99: forge.SpdmMachineAttestationStatus
-	(*SpdmMachineAttestationTriggerResponse)(nil),                             // 100: forge.SpdmMachineAttestationTriggerResponse
-	(*SpdmAttestationDetails)(nil),                                            // 101: forge.SpdmAttestationDetails
-	(*SpdmGetAttestationMachineResponse)(nil),                                 // 102: forge.SpdmGetAttestationMachineResponse
-	(*SpdmMachineAttestationTriggerRequest)(nil),                              // 103: forge.SpdmMachineAttestationTriggerRequest
-	(*SpdmListAttestationMachinesRequest)(nil),                                // 104: forge.SpdmListAttestationMachinesRequest
-	(*SpdmListAttestationMachinesResponse)(nil),                               // 105: forge.SpdmListAttestationMachinesResponse
-	(*MachineIdentityRequest)(nil),                                            // 106: forge.MachineIdentityRequest
-	(*MachineIdentityResponse)(nil),                                           // 107: forge.MachineIdentityResponse
-	(*GetTenantIdentityConfigRequest)(nil),                                    // 108: forge.GetTenantIdentityConfigRequest
-	(*TenantIdentitySigningKey)(nil),                                          // 109: forge.TenantIdentitySigningKey
-	(*TenantIdentityConfig)(nil),                                              // 110: forge.TenantIdentityConfig
-	(*SetTenantIdentityConfigRequest)(nil),                                    // 111: forge.SetTenantIdentityConfigRequest
-	(*TenantIdentityConfigResponse)(nil),                                      // 112: forge.TenantIdentityConfigResponse
-	(*ClientSecretBasic)(nil),                                                 // 113: forge.ClientSecretBasic
-	(*ClientSecretBasicResponse)(nil),                                         // 114: forge.ClientSecretBasicResponse
-	(*TokenDelegationResponse)(nil),                                           // 115: forge.TokenDelegationResponse
-	(*GetTokenDelegationRequest)(nil),                                         // 116: forge.GetTokenDelegationRequest
-	(*TokenDelegation)(nil),                                                   // 117: forge.TokenDelegation
-	(*TokenDelegationRequest)(nil),                                            // 118: forge.TokenDelegationRequest
-	(*ReencryptTenantIdentitySecretsRequest)(nil),                             // 119: forge.ReencryptTenantIdentitySecretsRequest
-	(*ReencryptTenantIdentityFailure)(nil),                                    // 120: forge.ReencryptTenantIdentityFailure
-	(*ReencryptTenantIdentitySecretsResponse)(nil),                            // 121: forge.ReencryptTenantIdentitySecretsResponse
-	(*Jwks)(nil),                                                              // 122: forge.Jwks
-	(*OpenIdConfiguration)(nil),                                               // 123: forge.OpenIdConfiguration
-	(*JwksRequest)(nil),                                                       // 124: forge.JwksRequest
-	(*OpenIdConfigRequest)(nil),                                               // 125: forge.OpenIdConfigRequest
-	(*MachineIngestionStateResponse)(nil),                                     // 126: forge.MachineIngestionStateResponse
-	(*TpmCaAddedCaStatus)(nil),                                                // 127: forge.TpmCaAddedCaStatus
-	(*TpmCaCertId)(nil),                                                       // 128: forge.TpmCaCertId
-	(*TpmEkCertStatus)(nil),                                                   // 129: forge.TpmEkCertStatus
-	(*TpmEkCertStatusCollection)(nil),                                         // 130: forge.TpmEkCertStatusCollection
-	(*TpmCaCert)(nil),                                                         // 131: forge.TpmCaCert
-	(*TpmCaCertDetail)(nil),                                                   // 132: forge.TpmCaCertDetail
-	(*TpmCaCertDetailCollection)(nil),                                         // 133: forge.TpmCaCertDetailCollection
-	(*AttestKeyBindChallenge)(nil),                                            // 134: forge.AttestKeyBindChallenge
-	(*AttestQuoteRequest)(nil),                                                // 135: forge.AttestQuoteRequest
-	(*AttestQuoteResponse)(nil),                                               // 136: forge.AttestQuoteResponse
-	(*CredentialCreationRequest)(nil),                                         // 137: forge.CredentialCreationRequest
-	(*CredentialDeletionRequest)(nil),                                         // 138: forge.CredentialDeletionRequest
-	(*CredentialCreationResult)(nil),                                          // 139: forge.CredentialCreationResult
-	(*CredentialDeletionResult)(nil),                                          // 140: forge.CredentialDeletionResult
-	(*RotateCredentialRequest)(nil),                                           // 141: forge.RotateCredentialRequest
-	(*RotateCredentialResult)(nil),                                            // 142: forge.RotateCredentialResult
-	(*CredentialRotationStatusRequest)(nil),                                   // 143: forge.CredentialRotationStatusRequest
-	(*DeviceCredentialRotationStatus)(nil),                                    // 144: forge.DeviceCredentialRotationStatus
-	(*CredentialRotationStatusResult)(nil),                                    // 145: forge.CredentialRotationStatusResult
-	(*VersionRequest)(nil),                                                    // 146: forge.VersionRequest
-	(*BuildInfo)(nil),                                                         // 147: forge.BuildInfo
-	(*RuntimeConfig)(nil),                                                     // 148: forge.RuntimeConfig
-	(*EchoRequest)(nil),                                                       // 149: forge.EchoRequest
-	(*EchoResponse)(nil),                                                      // 150: forge.EchoResponse
-	(*DNSMessage)(nil),                                                        // 151: forge.DNSMessage
-	(*DnsRequest)(nil),                                                        // 152: forge.DnsRequest
-	(*DnsReply)(nil),                                                          // 153: forge.DnsReply
-	(*ConsoleInput)(nil),                                                      // 154: forge.ConsoleInput
-	(*ConsoleOutput)(nil),                                                     // 155: forge.ConsoleOutput
-	(*InstanceEvent)(nil),                                                     // 156: forge.InstanceEvent
-	(*VpcSearchQuery)(nil),                                                    // 157: forge.VpcSearchQuery
-	(*VpcSearchFilter)(nil),                                                   // 158: forge.VpcSearchFilter
-	(*VpcIdList)(nil),                                                         // 159: forge.VpcIdList
-	(*VpcsByIdsRequest)(nil),                                                  // 160: forge.VpcsByIdsRequest
-	(*TenantSearchQuery)(nil),                                                 // 161: forge.TenantSearchQuery
-	(*VpcConfig)(nil),                                                         // 162: forge.VpcConfig
-	(*VpcStatus)(nil),                                                         // 163: forge.VpcStatus
-	(*Vpc)(nil),                                                               // 164: forge.Vpc
-	(*VpcCreationRequest)(nil),                                                // 165: forge.VpcCreationRequest
-	(*VpcUpdateRequest)(nil),                                                  // 166: forge.VpcUpdateRequest
-	(*VpcUpdateResult)(nil),                                                   // 167: forge.VpcUpdateResult
-	(*VpcUpdateVirtualizationRequest)(nil),                                    // 168: forge.VpcUpdateVirtualizationRequest
-	(*VpcUpdateVirtualizationResult)(nil),                                     // 169: forge.VpcUpdateVirtualizationResult
-	(*VpcDeletionRequest)(nil),                                                // 170: forge.VpcDeletionRequest
-	(*VpcDeletionResult)(nil),                                                 // 171: forge.VpcDeletionResult
-	(*VpcList)(nil),                                                           // 172: forge.VpcList
-	(*VpcPrefix)(nil),                                                         // 173: forge.VpcPrefix
-	(*VpcPrefixConfig)(nil),                                                   // 174: forge.VpcPrefixConfig
-	(*VpcPrefixStatus)(nil),                                                   // 175: forge.VpcPrefixStatus
-	(*VpcPrefixCreationRequest)(nil),                                          // 176: forge.VpcPrefixCreationRequest
-	(*VpcPrefixSearchQuery)(nil),                                              // 177: forge.VpcPrefixSearchQuery
-	(*VpcPrefixGetRequest)(nil),                                               // 178: forge.VpcPrefixGetRequest
-	(*VpcPrefixIdList)(nil),                                                   // 179: forge.VpcPrefixIdList
-	(*VpcPrefixList)(nil),                                                     // 180: forge.VpcPrefixList
-	(*VpcPrefixUpdateRequest)(nil),                                            // 181: forge.VpcPrefixUpdateRequest
-	(*VpcPrefixDeletionRequest)(nil),                                          // 182: forge.VpcPrefixDeletionRequest
-	(*VpcPrefixDeletionResult)(nil),                                           // 183: forge.VpcPrefixDeletionResult
-	(*VpcPrefixStateHistoriesRequest)(nil),                                    // 184: forge.VpcPrefixStateHistoriesRequest
-	(*VpcPeering)(nil),                                                        // 185: forge.VpcPeering
-	(*VpcPeeringIdList)(nil),                                                  // 186: forge.VpcPeeringIdList
-	(*VpcPeeringList)(nil),                                                    // 187: forge.VpcPeeringList
-	(*VpcPeeringCreationRequest)(nil),                                         // 188: forge.VpcPeeringCreationRequest
-	(*VpcPeeringSearchFilter)(nil),                                            // 189: forge.VpcPeeringSearchFilter
-	(*VpcPeeringsByIdsRequest)(nil),                                           // 190: forge.VpcPeeringsByIdsRequest
-	(*VpcPeeringDeletionRequest)(nil),                                         // 191: forge.VpcPeeringDeletionRequest
-	(*VpcPeeringDeletionResult)(nil),                                          // 192: forge.VpcPeeringDeletionResult
-	(*IBPartitionConfig)(nil),                                                 // 193: forge.IBPartitionConfig
-	(*IBPartitionStatus)(nil),                                                 // 194: forge.IBPartitionStatus
-	(*IBPartition)(nil),                                                       // 195: forge.IBPartition
-	(*IBPartitionList)(nil),                                                   // 196: forge.IBPartitionList
-	(*IBPartitionCreationRequest)(nil),                                        // 197: forge.IBPartitionCreationRequest
-	(*IBPartitionUpdateRequest)(nil),                                          // 198: forge.IBPartitionUpdateRequest
-	(*IBPartitionDeletionRequest)(nil),                                        // 199: forge.IBPartitionDeletionRequest
-	(*IBPartitionDeletionResult)(nil),                                         // 200: forge.IBPartitionDeletionResult
-	(*IBPartitionSearchFilter)(nil),                                           // 201: forge.IBPartitionSearchFilter
-	(*IBPartitionsByIdsRequest)(nil),                                          // 202: forge.IBPartitionsByIdsRequest
-	(*IBPartitionIdList)(nil),                                                 // 203: forge.IBPartitionIdList
-	(*PowerShelfConfig)(nil),                                                  // 204: forge.PowerShelfConfig
-	(*PowerShelfStatus)(nil),                                                  // 205: forge.PowerShelfStatus
-	(*PowerShelf)(nil),                                                        // 206: forge.PowerShelf
-	(*PowerShelfList)(nil),                                                    // 207: forge.PowerShelfList
-	(*PowerShelfCreationRequest)(nil),                                         // 208: forge.PowerShelfCreationRequest
-	(*PowerShelfDeletionRequest)(nil),                                         // 209: forge.PowerShelfDeletionRequest
-	(*PowerShelfDeletionResult)(nil),                                          // 210: forge.PowerShelfDeletionResult
-	(*PowerShelfMaintenanceRequest)(nil),                                      // 211: forge.PowerShelfMaintenanceRequest
-	(*PowerShelfStateHistoriesRequest)(nil),                                   // 212: forge.PowerShelfStateHistoriesRequest
-	(*PowerShelfQuery)(nil),                                                   // 213: forge.PowerShelfQuery
-	(*PowerShelfSearchFilter)(nil),                                            // 214: forge.PowerShelfSearchFilter
-	(*PowerShelvesByIdsRequest)(nil),                                          // 215: forge.PowerShelvesByIdsRequest
-	(*ExpectedPowerShelf)(nil),                                                // 216: forge.ExpectedPowerShelf
-	(*ExpectedPowerShelfRequest)(nil),                                         // 217: forge.ExpectedPowerShelfRequest
-	(*ExpectedPowerShelfList)(nil),                                            // 218: forge.ExpectedPowerShelfList
-	(*LinkedExpectedPowerShelfList)(nil),                                      // 219: forge.LinkedExpectedPowerShelfList
-	(*LinkedExpectedPowerShelf)(nil),                                          // 220: forge.LinkedExpectedPowerShelf
-	(*SwitchConfig)(nil),                                                      // 221: forge.SwitchConfig
-	(*FabricManagerConfig)(nil),                                               // 222: forge.FabricManagerConfig
-	(*FabricManagerStatus)(nil),                                               // 223: forge.FabricManagerStatus
-	(*SwitchStatus)(nil),                                                      // 224: forge.SwitchStatus
-	(*PlacementInRack)(nil),                                                   // 225: forge.PlacementInRack
-	(*Switch)(nil),                                                            // 226: forge.Switch
-	(*SwitchList)(nil),                                                        // 227: forge.SwitchList
-	(*SwitchCreationRequest)(nil),                                             // 228: forge.SwitchCreationRequest
-	(*SwitchDeletionRequest)(nil),                                             // 229: forge.SwitchDeletionRequest
-	(*SwitchDeletionResult)(nil),                                              // 230: forge.SwitchDeletionResult
-	(*StateHistoryRecord)(nil),                                                // 231: forge.StateHistoryRecord
-	(*StateHistoryRecords)(nil),                                               // 232: forge.StateHistoryRecords
-	(*SwitchStateHistoriesRequest)(nil),                                       // 233: forge.SwitchStateHistoriesRequest
-	(*StateHistories)(nil),                                                    // 234: forge.StateHistories
-	(*SwitchQuery)(nil),                                                       // 235: forge.SwitchQuery
-	(*SwitchSearchFilter)(nil),                                                // 236: forge.SwitchSearchFilter
-	(*SwitchesByIdsRequest)(nil),                                              // 237: forge.SwitchesByIdsRequest
-	(*ExpectedSwitch)(nil),                                                    // 238: forge.ExpectedSwitch
-	(*ExpectedSwitchRequest)(nil),                                             // 239: forge.ExpectedSwitchRequest
-	(*ExpectedSwitchList)(nil),                                                // 240: forge.ExpectedSwitchList
-	(*LinkedExpectedSwitchList)(nil),                                          // 241: forge.LinkedExpectedSwitchList
-	(*LinkedExpectedSwitch)(nil),                                              // 242: forge.LinkedExpectedSwitch
-	(*ExpectedRack)(nil),                                                      // 243: forge.ExpectedRack
-	(*ExpectedRackRequest)(nil),                                               // 244: forge.ExpectedRackRequest
-	(*ExpectedRackList)(nil),                                                  // 245: forge.ExpectedRackList
-	(*IBFabricSearchFilter)(nil),                                              // 246: forge.IBFabricSearchFilter
-	(*IBFabricIdList)(nil),                                                    // 247: forge.IBFabricIdList
-	(*NetworkSegmentStateHistory)(nil),                                        // 248: forge.NetworkSegmentStateHistory
-	(*NetworkSegmentConfig)(nil),                                              // 249: forge.NetworkSegmentConfig
-	(*NetworkSegmentStatus)(nil),                                              // 250: forge.NetworkSegmentStatus
-	(*NetworkSegment)(nil),                                                    // 251: forge.NetworkSegment
-	(*NetworkSegmentCreationRequest)(nil),                                     // 252: forge.NetworkSegmentCreationRequest
-	(*NetworkSegmentDeletionRequest)(nil),                                     // 253: forge.NetworkSegmentDeletionRequest
-	(*AttachNetworkSegmentToVpcRequest)(nil),                                  // 254: forge.AttachNetworkSegmentToVpcRequest
-	(*NetworkSegmentDeletionResult)(nil),                                      // 255: forge.NetworkSegmentDeletionResult
-	(*NetworkSegmentStateHistoriesRequest)(nil),                               // 256: forge.NetworkSegmentStateHistoriesRequest
-	(*NetworkSegmentSearchConfig)(nil),                                        // 257: forge.NetworkSegmentSearchConfig
-	(*NetworkSegmentSearchFilter)(nil),                                        // 258: forge.NetworkSegmentSearchFilter
-	(*NetworkSegmentIdList)(nil),                                              // 259: forge.NetworkSegmentIdList
-	(*NetworkSegmentsByIdsRequest)(nil),                                       // 260: forge.NetworkSegmentsByIdsRequest
-	(*NetworkPrefix)(nil),                                                     // 261: forge.NetworkPrefix
-	(*MachineState)(nil),                                                      // 262: forge.MachineState
-	(*InstancePowerRequest)(nil),                                              // 263: forge.InstancePowerRequest
-	(*InstancePowerResult)(nil),                                               // 264: forge.InstancePowerResult
-	(*InstanceList)(nil),                                                      // 265: forge.InstanceList
-	(*Label)(nil),                                                             // 266: forge.Label
-	(*Metadata)(nil),                                                          // 267: forge.Metadata
-	(*InstanceSearchFilter)(nil),                                              // 268: forge.InstanceSearchFilter
-	(*InstanceIdList)(nil),                                                    // 269: forge.InstanceIdList
-	(*InstancesByIdsRequest)(nil),                                             // 270: forge.InstancesByIdsRequest
-	(*InstanceAllocationRequest)(nil),                                         // 271: forge.InstanceAllocationRequest
-	(*BatchInstanceAllocationRequest)(nil),                                    // 272: forge.BatchInstanceAllocationRequest
-	(*BatchInstanceAllocationResponse)(nil),                                   // 273: forge.BatchInstanceAllocationResponse
-	(*IpxeTemplateParameter)(nil),                                             // 274: forge.IpxeTemplateParameter
-	(*IpxeTemplateArtifact)(nil),                                              // 275: forge.IpxeTemplateArtifact
-	(*IpxeTemplate)(nil),                                                      // 276: forge.IpxeTemplate
-	(*TenantConfig)(nil),                                                      // 277: forge.TenantConfig
-	(*InstanceOperatingSystemConfig)(nil),                                     // 278: forge.InstanceOperatingSystemConfig
-	(*InlineIpxe)(nil),                                                        // 279: forge.InlineIpxe
-	(*InstanceConfig)(nil),                                                    // 280: forge.InstanceConfig
-	(*InstanceNetworkConfig)(nil),                                             // 281: forge.InstanceNetworkConfig
-	(*InstanceNetworkAutoConfig)(nil),                                         // 282: forge.InstanceNetworkAutoConfig
-	(*InstanceInfinibandConfig)(nil),                                          // 283: forge.InstanceInfinibandConfig
-	(*InstanceDpuExtensionServiceConfig)(nil),                                 // 284: forge.InstanceDpuExtensionServiceConfig
-	(*InstanceDpuExtensionServicesConfig)(nil),                                // 285: forge.InstanceDpuExtensionServicesConfig
-	(*InstanceNVLinkConfig)(nil),                                              // 286: forge.InstanceNVLinkConfig
-	(*InstanceSpxConfig)(nil),                                                 // 287: forge.InstanceSpxConfig
-	(*InstanceSpxAttachment)(nil),                                             // 288: forge.InstanceSpxAttachment
-	(*InstanceOperatingSystemUpdateRequest)(nil),                              // 289: forge.InstanceOperatingSystemUpdateRequest
-	(*InstanceConfigUpdateRequest)(nil),                                       // 290: forge.InstanceConfigUpdateRequest
-	(*InstanceStatus)(nil),                                                    // 291: forge.InstanceStatus
-	(*InstanceSpxStatus)(nil),                                                 // 292: forge.InstanceSpxStatus
-	(*InstanceSpxAttachmentStatus)(nil),                                       // 293: forge.InstanceSpxAttachmentStatus
-	(*InstanceNetworkStatus)(nil),                                             // 294: forge.InstanceNetworkStatus
-	(*InstanceInfinibandStatus)(nil),                                          // 295: forge.InstanceInfinibandStatus
-	(*DpuExtensionServiceStatus)(nil),                                         // 296: forge.DpuExtensionServiceStatus
-	(*InstanceDpuExtensionServiceStatus)(nil),                                 // 297: forge.InstanceDpuExtensionServiceStatus
-	(*InstanceDpuExtensionServicesStatus)(nil),                                // 298: forge.InstanceDpuExtensionServicesStatus
-	(*InstanceNVLinkStatus)(nil),                                              // 299: forge.InstanceNVLinkStatus
-	(*Instance)(nil),                                                          // 300: forge.Instance
-	(*InstanceUpdateStatus)(nil),                                              // 301: forge.InstanceUpdateStatus
-	(*InstanceInterfaceConfig)(nil),                                           // 302: forge.InstanceInterfaceConfig
-	(*InstanceInterfaceVpcSelection)(nil),                                     // 303: forge.InstanceInterfaceVpcSelection
-	(*InstanceInterfaceIpv6Config)(nil),                                       // 304: forge.InstanceInterfaceIpv6Config
-	(*InstanceInterfaceRoutingProfile)(nil),                                   // 305: forge.InstanceInterfaceRoutingProfile
-	(*InstanceIBInterfaceConfig)(nil),                                         // 306: forge.InstanceIBInterfaceConfig
-	(*InstanceInterfaceResolvedVpcPrefixes)(nil),                              // 307: forge.InstanceInterfaceResolvedVpcPrefixes
-	(*InstanceInterfaceStatus)(nil),                                           // 308: forge.InstanceInterfaceStatus
-	(*InstanceIBInterfaceStatus)(nil),                                         // 309: forge.InstanceIBInterfaceStatus
-	(*InstanceNVLinkGpuStatus)(nil),                                           // 310: forge.InstanceNVLinkGpuStatus
-	(*InstanceNVLinkGpuConfig)(nil),                                           // 311: forge.InstanceNVLinkGpuConfig
-	(*InstancePhoneHomeLastContactRequest)(nil),                               // 312: forge.InstancePhoneHomeLastContactRequest
-	(*InstancePhoneHomeLastContactResponse)(nil),                              // 313: forge.InstancePhoneHomeLastContactResponse
-	(*Issue)(nil),                                                             // 314: forge.Issue
-	(*DeleteInitiatedBy)(nil),                                                 // 315: forge.DeleteInitiatedBy
-	(*DeleteAttribution)(nil),                                                 // 316: forge.DeleteAttribution
-	(*InstanceReleaseRequest)(nil),                                            // 317: forge.InstanceReleaseRequest
-	(*InstanceReleaseResult)(nil),                                             // 318: forge.InstanceReleaseResult
-	(*MachinesByIdsRequest)(nil),                                              // 319: forge.MachinesByIdsRequest
-	(*MachineSearchConfig)(nil),                                               // 320: forge.MachineSearchConfig
-	(*MachineStateHistoriesRequest)(nil),                                      // 321: forge.MachineStateHistoriesRequest
-	(*MachineStateHistories)(nil),                                             // 322: forge.MachineStateHistories
-	(*MachineStateHistoryRecords)(nil),                                        // 323: forge.MachineStateHistoryRecords
-	(*MachineHealthHistoriesRequest)(nil),                                     // 324: forge.MachineHealthHistoriesRequest
-	(*HealthHistories)(nil),                                                   // 325: forge.HealthHistories
-	(*HealthHistoryRecords)(nil),                                              // 326: forge.HealthHistoryRecords
-	(*HealthHistoryRecord)(nil),                                               // 327: forge.HealthHistoryRecord
-	(*TenantByOrganizationIdsRequest)(nil),                                    // 328: forge.TenantByOrganizationIdsRequest
-	(*TenantSearchFilter)(nil),                                                // 329: forge.TenantSearchFilter
-	(*TenantList)(nil),                                                        // 330: forge.TenantList
-	(*TenantOrganizationIdList)(nil),                                          // 331: forge.TenantOrganizationIdList
-	(*InterfaceList)(nil),                                                     // 332: forge.InterfaceList
-	(*MachineList)(nil),                                                       // 333: forge.MachineList
-	(*InterfaceDeleteQuery)(nil),                                              // 334: forge.InterfaceDeleteQuery
-	(*InterfaceSearchQuery)(nil),                                              // 335: forge.InterfaceSearchQuery
-	(*AssignStaticAddressRequest)(nil),                                        // 336: forge.AssignStaticAddressRequest
-	(*AssignStaticAddressResponse)(nil),                                       // 337: forge.AssignStaticAddressResponse
-	(*RemoveStaticAddressRequest)(nil),                                        // 338: forge.RemoveStaticAddressRequest
-	(*RemoveStaticAddressResponse)(nil),                                       // 339: forge.RemoveStaticAddressResponse
-	(*FindInterfaceAddressesRequest)(nil),                                     // 340: forge.FindInterfaceAddressesRequest
-	(*InterfaceAddress)(nil),                                                  // 341: forge.InterfaceAddress
-	(*FindInterfaceAddressesResponse)(nil),                                    // 342: forge.FindInterfaceAddressesResponse
-	(*BmcInfo)(nil),                                                           // 343: forge.BmcInfo
-	(*SwitchNvosInfo)(nil),                                                    // 344: forge.SwitchNvosInfo
-	(*MachineConfig)(nil),                                                     // 345: forge.MachineConfig
-	(*MachineStatus)(nil),                                                     // 346: forge.MachineStatus
-	(*Machine)(nil),                                                           // 347: forge.Machine
-	(*DpfMachineState)(nil),                                                   // 348: forge.DpfMachineState
-	(*InstanceNetworkRestrictions)(nil),                                       // 349: forge.InstanceNetworkRestrictions
-	(*MachineMetadataUpdateRequest)(nil),                                      // 350: forge.MachineMetadataUpdateRequest
-	(*RackMetadataUpdateRequest)(nil),                                         // 351: forge.RackMetadataUpdateRequest
-	(*SwitchMetadataUpdateRequest)(nil),                                       // 352: forge.SwitchMetadataUpdateRequest
-	(*PowerShelfMetadataUpdateRequest)(nil),                                   // 353: forge.PowerShelfMetadataUpdateRequest
-	(*DpuAgentInventoryReport)(nil),                                           // 354: forge.DpuAgentInventoryReport
-	(*MachineComponentInventory)(nil),                                         // 355: forge.MachineComponentInventory
-	(*MachineInventorySoftwareComponent)(nil),                                 // 356: forge.MachineInventorySoftwareComponent
-	(*HealthSourceOrigin)(nil),                                                // 357: forge.HealthSourceOrigin
-	(*ControllerStateReason)(nil),                                             // 358: forge.ControllerStateReason
-	(*ControllerStateSourceReference)(nil),                                    // 359: forge.ControllerStateSourceReference
-	(*StateSla)(nil),                                                          // 360: forge.StateSla
-	(*InstanceTenantStatus)(nil),                                              // 361: forge.InstanceTenantStatus
-	(*MachineEvent)(nil),                                                      // 362: forge.MachineEvent
-	(*MachineInterface)(nil),                                                  // 363: forge.MachineInterface
-	(*InfinibandStatusObservation)(nil),                                       // 364: forge.InfinibandStatusObservation
-	(*MachineIbInterface)(nil),                                                // 365: forge.MachineIbInterface
-	(*DhcpDiscovery)(nil),                                                     // 366: forge.DhcpDiscovery
-	(*ExpireDhcpLeaseRequest)(nil),                                            // 367: forge.ExpireDhcpLeaseRequest
-	(*ExpireDhcpLeaseResponse)(nil),                                           // 368: forge.ExpireDhcpLeaseResponse
-	(*DhcpRecord)(nil),                                                        // 369: forge.DhcpRecord
-	(*NetworkSegmentList)(nil),                                                // 370: forge.NetworkSegmentList
-	(*SSHKeyValidationRequest)(nil),                                           // 371: forge.SSHKeyValidationRequest
-	(*SSHKeyValidationResponse)(nil),                                          // 372: forge.SSHKeyValidationResponse
-	(*GetBmcCredentialsRequest)(nil),                                          // 373: forge.GetBmcCredentialsRequest
-	(*GetSwitchNvosCredentialsRequest)(nil),                                   // 374: forge.GetSwitchNvosCredentialsRequest
-	(*GetBmcCredentialsResponse)(nil),                                         // 375: forge.GetBmcCredentialsResponse
-	(*BmcCredentials)(nil),                                                    // 376: forge.BmcCredentials
-	(*GetSiteExplorationRequest)(nil),                                         // 377: forge.GetSiteExplorationRequest
-	(*ClearSiteExplorationErrorRequest)(nil),                                  // 378: forge.ClearSiteExplorationErrorRequest
-	(*ReExploreEndpointRequest)(nil),                                          // 379: forge.ReExploreEndpointRequest
-	(*RefreshEndpointReportRequest)(nil),                                      // 380: forge.RefreshEndpointReportRequest
-	(*DeleteExploredEndpointRequest)(nil),                                     // 381: forge.DeleteExploredEndpointRequest
-	(*PauseExploredEndpointRemediationRequest)(nil),                           // 382: forge.PauseExploredEndpointRemediationRequest
-	(*DeleteExploredEndpointResponse)(nil),                                    // 383: forge.DeleteExploredEndpointResponse
-	(*BmcEndpointRequest)(nil),                                                // 384: forge.BmcEndpointRequest
-	(*SshTimeoutConfig)(nil),                                                  // 385: forge.SshTimeoutConfig
-	(*SshRequest)(nil),                                                        // 386: forge.SshRequest
-	(*CopyBfbToDpuRshimRequest)(nil),                                          // 387: forge.CopyBfbToDpuRshimRequest
-	(*UpdateMachineHardwareInfoRequest)(nil),                                  // 388: forge.UpdateMachineHardwareInfoRequest
-	(*MachineHardwareInfo)(nil),                                               // 389: forge.MachineHardwareInfo
-	(*ManagedHostNetworkConfigRequest)(nil),                                   // 390: forge.ManagedHostNetworkConfigRequest
-	(*ManagedHostNetworkConfigResponse)(nil),                                  // 391: forge.ManagedHostNetworkConfigResponse
-	(*TrafficInterceptConfig)(nil),                                            // 392: forge.TrafficInterceptConfig
-	(*TrafficInterceptBridging)(nil),                                          // 393: forge.TrafficInterceptBridging
-	(*ManagedHostDpuExtensionServiceConfig)(nil),                              // 394: forge.ManagedHostDpuExtensionServiceConfig
-	(*ManagedHostQuarantineState)(nil),                                        // 395: forge.ManagedHostQuarantineState
-	(*GetManagedHostQuarantineStateRequest)(nil),                              // 396: forge.GetManagedHostQuarantineStateRequest
-	(*GetManagedHostQuarantineStateResponse)(nil),                             // 397: forge.GetManagedHostQuarantineStateResponse
-	(*SetManagedHostQuarantineStateRequest)(nil),                              // 398: forge.SetManagedHostQuarantineStateRequest
-	(*SetManagedHostQuarantineStateResponse)(nil),                             // 399: forge.SetManagedHostQuarantineStateResponse
-	(*ClearManagedHostQuarantineStateRequest)(nil),                            // 400: forge.ClearManagedHostQuarantineStateRequest
-	(*ClearManagedHostQuarantineStateResponse)(nil),                           // 401: forge.ClearManagedHostQuarantineStateResponse
-	(*ManagedHostNetworkConfig)(nil),                                          // 402: forge.ManagedHostNetworkConfig
-	(*FlatInterfaceConfig)(nil),                                               // 403: forge.FlatInterfaceConfig
-	(*FlatInterfaceRoutingProfile)(nil),                                       // 404: forge.FlatInterfaceRoutingProfile
-	(*FlatInterfaceIpv6Config)(nil),                                           // 405: forge.FlatInterfaceIpv6Config
-	(*FlatInterfaceNetworkSecurityGroupConfig)(nil),                           // 406: forge.FlatInterfaceNetworkSecurityGroupConfig
-	(*ManagedHostNetworkStatusRequest)(nil),                                   // 407: forge.ManagedHostNetworkStatusRequest
-	(*ManagedHostNetworkStatusResponse)(nil),                                  // 408: forge.ManagedHostNetworkStatusResponse
-	(*DpuAgentUpgradeCheckRequest)(nil),                                       // 409: forge.DpuAgentUpgradeCheckRequest
-	(*DpuAgentUpgradeCheckResponse)(nil),                                      // 410: forge.DpuAgentUpgradeCheckResponse
-	(*DpuAgentUpgradePolicyRequest)(nil),                                      // 411: forge.DpuAgentUpgradePolicyRequest
-	(*DpuAgentUpgradePolicyResponse)(nil),                                     // 412: forge.DpuAgentUpgradePolicyResponse
-	(*AdminForceDeleteMachineRequest)(nil),                                    // 413: forge.AdminForceDeleteMachineRequest
-	(*AdminForceDeleteMachineResponse)(nil),                                   // 414: forge.AdminForceDeleteMachineResponse
-	(*DisableSecureBootResponse)(nil),                                         // 415: forge.DisableSecureBootResponse
-	(*LockdownRequest)(nil),                                                   // 416: forge.LockdownRequest
-	(*LockdownResponse)(nil),                                                  // 417: forge.LockdownResponse
-	(*LockdownStatusRequest)(nil),                                             // 418: forge.LockdownStatusRequest
-	(*MachineSetupStatusRequest)(nil),                                         // 419: forge.MachineSetupStatusRequest
-	(*MachineSetupRequest)(nil),                                               // 420: forge.MachineSetupRequest
-	(*MachineSetupResponse)(nil),                                              // 421: forge.MachineSetupResponse
-	(*SetDpuFirstBootOrderRequest)(nil),                                       // 422: forge.SetDpuFirstBootOrderRequest
-	(*SetDpuFirstBootOrderResponse)(nil),                                      // 423: forge.SetDpuFirstBootOrderResponse
-	(*AdminRebootRequest)(nil),                                                // 424: forge.AdminRebootRequest
-	(*AdminRebootResponse)(nil),                                               // 425: forge.AdminRebootResponse
-	(*AdminBmcResetRequest)(nil),                                              // 426: forge.AdminBmcResetRequest
-	(*AdminBmcResetResponse)(nil),                                             // 427: forge.AdminBmcResetResponse
-	(*EnableInfiniteBootRequest)(nil),                                         // 428: forge.EnableInfiniteBootRequest
-	(*EnableInfiniteBootResponse)(nil),                                        // 429: forge.EnableInfiniteBootResponse
-	(*IsInfiniteBootEnabledRequest)(nil),                                      // 430: forge.IsInfiniteBootEnabledRequest
-	(*IsInfiniteBootEnabledResponse)(nil),                                     // 431: forge.IsInfiniteBootEnabledResponse
-	(*BMCMetaDataGetRequest)(nil),                                             // 432: forge.BMCMetaDataGetRequest
-	(*BMCMetaDataGetResponse)(nil),                                            // 433: forge.BMCMetaDataGetResponse
-	(*MachineCredentialsUpdateRequest)(nil),                                   // 434: forge.MachineCredentialsUpdateRequest
-	(*MachineCredentialsUpdateResponse)(nil),                                  // 435: forge.MachineCredentialsUpdateResponse
-	(*ForgeAgentControlRequest)(nil),                                          // 436: forge.ForgeAgentControlRequest
-	(*ForgeAgentControlResponse)(nil),                                         // 437: forge.ForgeAgentControlResponse
-	(*MachineDiscoveryInfo)(nil),                                              // 438: forge.MachineDiscoveryInfo
-	(*MachineDiscoveryCompletedRequest)(nil),                                  // 439: forge.MachineDiscoveryCompletedRequest
-	(*MachineCleanupInfo)(nil),                                                // 440: forge.MachineCleanupInfo
-	(*MachineCertificate)(nil),                                                // 441: forge.MachineCertificate
-	(*MachineCertificateRenewRequest)(nil),                                    // 442: forge.MachineCertificateRenewRequest
-	(*MachineCertificateResult)(nil),                                          // 443: forge.MachineCertificateResult
-	(*MachineDiscoveryResult)(nil),                                            // 444: forge.MachineDiscoveryResult
-	(*MachineDiscoveryCompletedResponse)(nil),                                 // 445: forge.MachineDiscoveryCompletedResponse
-	(*MachineCleanupResult)(nil),                                              // 446: forge.MachineCleanupResult
-	(*ForgeScoutErrorReport)(nil),                                             // 447: forge.ForgeScoutErrorReport
-	(*ForgeScoutErrorReportResult)(nil),                                       // 448: forge.ForgeScoutErrorReportResult
-	(*PxeInstructionRequest)(nil),                                             // 449: forge.PxeInstructionRequest
-	(*PxeInstructions)(nil),                                                   // 450: forge.PxeInstructions
-	(*CloudInitDiscoveryInstructions)(nil),                                    // 451: forge.CloudInitDiscoveryInstructions
-	(*CloudInitMetaData)(nil),                                                 // 452: forge.CloudInitMetaData
-	(*CloudInitInstructionsRequest)(nil),                                      // 453: forge.CloudInitInstructionsRequest
-	(*CloudInitInstructions)(nil),                                             // 454: forge.CloudInitInstructions
-	(*DpuNetworkStatus)(nil),                                                  // 455: forge.DpuNetworkStatus
-	(*LastDhcpRequest)(nil),                                                   // 456: forge.LastDhcpRequest
-	(*DpuExtensionServiceStatusObservation)(nil),                              // 457: forge.DpuExtensionServiceStatusObservation
-	(*DpuExtensionServiceComponent)(nil),                                      // 458: forge.DpuExtensionServiceComponent
-	(*OptionalHealthReport)(nil),                                              // 459: forge.OptionalHealthReport
-	(*HealthReportEntry)(nil),                                                 // 460: forge.HealthReportEntry
-	(*InsertMachineHealthReportRequest)(nil),                                  // 461: forge.InsertMachineHealthReportRequest
-	(*InsertRackHealthReportRequest)(nil),                                     // 462: forge.InsertRackHealthReportRequest
-	(*RemoveRackHealthReportRequest)(nil),                                     // 463: forge.RemoveRackHealthReportRequest
-	(*ListRackHealthReportsRequest)(nil),                                      // 464: forge.ListRackHealthReportsRequest
-	(*InsertSwitchHealthReportRequest)(nil),                                   // 465: forge.InsertSwitchHealthReportRequest
-	(*RemoveSwitchHealthReportRequest)(nil),                                   // 466: forge.RemoveSwitchHealthReportRequest
-	(*ListSwitchHealthReportsRequest)(nil),                                    // 467: forge.ListSwitchHealthReportsRequest
-	(*InsertPowerShelfHealthReportRequest)(nil),                               // 468: forge.InsertPowerShelfHealthReportRequest
-	(*RemovePowerShelfHealthReportRequest)(nil),                               // 469: forge.RemovePowerShelfHealthReportRequest
-	(*ListPowerShelfHealthReportsRequest)(nil),                                // 470: forge.ListPowerShelfHealthReportsRequest
-	(*ListHealthReportResponse)(nil),                                          // 471: forge.ListHealthReportResponse
-	(*RemoveMachineHealthReportRequest)(nil),                                  // 472: forge.RemoveMachineHealthReportRequest
-	(*ListNVLinkDomainHealthReportsRequest)(nil),                              // 473: forge.ListNVLinkDomainHealthReportsRequest
-	(*InsertNVLinkDomainHealthReportRequest)(nil),                             // 474: forge.InsertNVLinkDomainHealthReportRequest
-	(*RemoveNVLinkDomainHealthReportRequest)(nil),                             // 475: forge.RemoveNVLinkDomainHealthReportRequest
-	(*InstanceInterfaceStatusObservation)(nil),                                // 476: forge.InstanceInterfaceStatusObservation
-	(*FabricInterfaceData)(nil),                                               // 477: forge.FabricInterfaceData
-	(*LinkData)(nil),                                                          // 478: forge.LinkData
-	(*Tenant)(nil),                                                            // 479: forge.Tenant
-	(*CreateTenantRequest)(nil),                                               // 480: forge.CreateTenantRequest
-	(*CreateTenantResponse)(nil),                                              // 481: forge.CreateTenantResponse
-	(*UpdateTenantRequest)(nil),                                               // 482: forge.UpdateTenantRequest
-	(*UpdateTenantResponse)(nil),                                              // 483: forge.UpdateTenantResponse
-	(*FindTenantRequest)(nil),                                                 // 484: forge.FindTenantRequest
-	(*FindTenantResponse)(nil),                                                // 485: forge.FindTenantResponse
-	(*TenantKeysetIdentifier)(nil),                                            // 486: forge.TenantKeysetIdentifier
-	(*TenantPublicKey)(nil),                                                   // 487: forge.TenantPublicKey
-	(*TenantKeysetContent)(nil),                                               // 488: forge.TenantKeysetContent
-	(*TenantKeyset)(nil),                                                      // 489: forge.TenantKeyset
-	(*CreateTenantKeysetRequest)(nil),                                         // 490: forge.CreateTenantKeysetRequest
-	(*CreateTenantKeysetResponse)(nil),                                        // 491: forge.CreateTenantKeysetResponse
-	(*TenantKeySetList)(nil),                                                  // 492: forge.TenantKeySetList
-	(*UpdateTenantKeysetRequest)(nil),                                         // 493: forge.UpdateTenantKeysetRequest
-	(*UpdateTenantKeysetResponse)(nil),                                        // 494: forge.UpdateTenantKeysetResponse
-	(*DeleteTenantKeysetRequest)(nil),                                         // 495: forge.DeleteTenantKeysetRequest
-	(*DeleteTenantKeysetResponse)(nil),                                        // 496: forge.DeleteTenantKeysetResponse
-	(*TenantKeysetSearchFilter)(nil),                                          // 497: forge.TenantKeysetSearchFilter
-	(*TenantKeysetIdList)(nil),                                                // 498: forge.TenantKeysetIdList
-	(*TenantKeysetsByIdsRequest)(nil),                                         // 499: forge.TenantKeysetsByIdsRequest
-	(*ValidateTenantPublicKeyRequest)(nil),                                    // 500: forge.ValidateTenantPublicKeyRequest
-	(*ValidateTenantPublicKeyResponse)(nil),                                   // 501: forge.ValidateTenantPublicKeyResponse
-	(*ListResourcePoolsRequest)(nil),                                          // 502: forge.ListResourcePoolsRequest
-	(*ResourcePools)(nil),                                                     // 503: forge.ResourcePools
-	(*ResourcePool)(nil),                                                      // 504: forge.ResourcePool
-	(*GrowResourcePoolRequest)(nil),                                           // 505: forge.GrowResourcePoolRequest
-	(*GrowResourcePoolResponse)(nil),                                          // 506: forge.GrowResourcePoolResponse
-	(*Range)(nil),                                                             // 507: forge.Range
-	(*MigrateVpcVniResponse)(nil),                                             // 508: forge.MigrateVpcVniResponse
-	(*MaintenanceRequest)(nil),                                                // 509: forge.MaintenanceRequest
-	(*SetDynamicConfigRequest)(nil),                                           // 510: forge.SetDynamicConfigRequest
-	(*FindIpAddressRequest)(nil),                                              // 511: forge.FindIpAddressRequest
-	(*FindIpAddressResponse)(nil),                                             // 512: forge.FindIpAddressResponse
-	(*IdentifyUuidRequest)(nil),                                               // 513: forge.IdentifyUuidRequest
-	(*IdentifyUuidResponse)(nil),                                              // 514: forge.IdentifyUuidResponse
-	(*FindBmcIpsRequest)(nil),                                                 // 515: forge.FindBmcIpsRequest
-	(*IdentifyMacRequest)(nil),                                                // 516: forge.IdentifyMacRequest
-	(*IdentifyMacResponse)(nil),                                               // 517: forge.IdentifyMacResponse
-	(*IdentifySerialRequest)(nil),                                             // 518: forge.IdentifySerialRequest
-	(*IdentifySerialResponse)(nil),                                            // 519: forge.IdentifySerialResponse
-	(*DpuReprovisioningRequest)(nil),                                          // 520: forge.DpuReprovisioningRequest
-	(*DpuReprovisioningListRequest)(nil),                                      // 521: forge.DpuReprovisioningListRequest
-	(*DpuReprovisioningListResponse)(nil),                                     // 522: forge.DpuReprovisioningListResponse
-	(*HostReprovisioningRequest)(nil),                                         // 523: forge.HostReprovisioningRequest
-	(*HostReprovisioningListRequest)(nil),                                     // 524: forge.HostReprovisioningListRequest
-	(*HostReprovisioningListResponse)(nil),                                    // 525: forge.HostReprovisioningListResponse
-	(*DpuOsOperationalState)(nil),                                             // 526: forge.DpuOsOperationalState
-	(*DpuRepresentorStatus)(nil),                                              // 527: forge.DpuRepresentorStatus
-	(*DpuInfoStatusObservation)(nil),                                          // 528: forge.DpuInfoStatusObservation
-	(*DpuInfo)(nil),                                                           // 529: forge.DpuInfo
-	(*GetDpuInfoListRequest)(nil),                                             // 530: forge.GetDpuInfoListRequest
-	(*GetDpuInfoListResponse)(nil),                                            // 531: forge.GetDpuInfoListResponse
-	(*IpAddressMatch)(nil),                                                    // 532: forge.IpAddressMatch
-	(*MachineBootOverride)(nil),                                               // 533: forge.MachineBootOverride
-	(*ConnectedDevice)(nil),                                                   // 534: forge.ConnectedDevice
-	(*ConnectedDeviceList)(nil),                                               // 535: forge.ConnectedDeviceList
-	(*BmcIpList)(nil),                                                         // 536: forge.BmcIpList
-	(*BmcIp)(nil),                                                             // 537: forge.BmcIp
-	(*MacAddressBmcIp)(nil),                                                   // 538: forge.MacAddressBmcIp
-	(*MachineIdBmcIpPairs)(nil),                                               // 539: forge.MachineIdBmcIpPairs
-	(*MachineIdBmcIp)(nil),                                                    // 540: forge.MachineIdBmcIp
-	(*NetworkDevice)(nil),                                                     // 541: forge.NetworkDevice
-	(*NetworkTopologyRequest)(nil),                                            // 542: forge.NetworkTopologyRequest
-	(*NetworkDeviceIdList)(nil),                                               // 543: forge.NetworkDeviceIdList
-	(*NetworkTopologyData)(nil),                                               // 544: forge.NetworkTopologyData
-	(*RouteServers)(nil),                                                      // 545: forge.RouteServers
-	(*RouteServerEntries)(nil),                                                // 546: forge.RouteServerEntries
-	(*RouteServer)(nil),                                                       // 547: forge.RouteServer
-	(*SetHostUefiPasswordRequest)(nil),                                        // 548: forge.SetHostUefiPasswordRequest
-	(*SetHostUefiPasswordResponse)(nil),                                       // 549: forge.SetHostUefiPasswordResponse
-	(*ClearHostUefiPasswordRequest)(nil),                                      // 550: forge.ClearHostUefiPasswordRequest
-	(*ClearHostUefiPasswordResponse)(nil),                                     // 551: forge.ClearHostUefiPasswordResponse
-	(*OsImageAttributes)(nil),                                                 // 552: forge.OsImageAttributes
-	(*OsImage)(nil),                                                           // 553: forge.OsImage
-	(*ListOsImageRequest)(nil),                                                // 554: forge.ListOsImageRequest
-	(*ListOsImageResponse)(nil),                                               // 555: forge.ListOsImageResponse
-	(*DeleteOsImageRequest)(nil),                                              // 556: forge.DeleteOsImageRequest
-	(*DeleteOsImageResponse)(nil),                                             // 557: forge.DeleteOsImageResponse
-	(*GetIpxeTemplateRequest)(nil),                                            // 558: forge.GetIpxeTemplateRequest
-	(*ListIpxeTemplatesRequest)(nil),                                          // 559: forge.ListIpxeTemplatesRequest
-	(*IpxeTemplateList)(nil),                                                  // 560: forge.IpxeTemplateList
-	(*ExpectedHostNic)(nil),                                                   // 561: forge.ExpectedHostNic
-	(*HostLifecycleProfile)(nil),                                              // 562: forge.HostLifecycleProfile
-	(*ExpectedMachine)(nil),                                                   // 563: forge.ExpectedMachine
-	(*ExpectedMachineRequest)(nil),                                            // 564: forge.ExpectedMachineRequest
-	(*ExpectedMachineList)(nil),                                               // 565: forge.ExpectedMachineList
-	(*LinkedExpectedMachineList)(nil),                                         // 566: forge.LinkedExpectedMachineList
-	(*LinkedExpectedMachine)(nil),                                             // 567: forge.LinkedExpectedMachine
-	(*UnexpectedMachineList)(nil),                                             // 568: forge.UnexpectedMachineList
-	(*UnexpectedMachine)(nil),                                                 // 569: forge.UnexpectedMachine
-	(*BatchExpectedMachineOperationRequest)(nil),                              // 570: forge.BatchExpectedMachineOperationRequest
-	(*ExpectedMachineOperationResult)(nil),                                    // 571: forge.ExpectedMachineOperationResult
-	(*BatchExpectedMachineOperationResponse)(nil),                             // 572: forge.BatchExpectedMachineOperationResponse
-	(*MachineRebootCompletedResponse)(nil),                                    // 573: forge.MachineRebootCompletedResponse
-	(*MachineRebootCompletedRequest)(nil),                                     // 574: forge.MachineRebootCompletedRequest
-	(*ScoutFirmwareUpgradeStatusRequest)(nil),                                 // 575: forge.ScoutFirmwareUpgradeStatusRequest
-	(*MachineValidationCompletedRequest)(nil),                                 // 576: forge.MachineValidationCompletedRequest
-	(*MachineValidationCompletedResponse)(nil),                                // 577: forge.MachineValidationCompletedResponse
-	(*MachineValidationResult)(nil),                                           // 578: forge.MachineValidationResult
-	(*MachineValidationResultPostRequest)(nil),                                // 579: forge.MachineValidationResultPostRequest
-	(*MachineValidationResultList)(nil),                                       // 580: forge.MachineValidationResultList
-	(*MachineValidationGetRequest)(nil),                                       // 581: forge.MachineValidationGetRequest
-	(*MachineValidationStatus)(nil),                                           // 582: forge.MachineValidationStatus
-	(*MachineValidationRun)(nil),                                              // 583: forge.MachineValidationRun
-	(*MachineSetAutoUpdateRequest)(nil),                                       // 584: forge.MachineSetAutoUpdateRequest
-	(*MachineSetAutoUpdateResponse)(nil),                                      // 585: forge.MachineSetAutoUpdateResponse
-	(*GetMachineValidationExternalConfigRequest)(nil),                         // 586: forge.GetMachineValidationExternalConfigRequest
-	(*MachineValidationExternalConfig)(nil),                                   // 587: forge.MachineValidationExternalConfig
-	(*GetMachineValidationExternalConfigResponse)(nil),                        // 588: forge.GetMachineValidationExternalConfigResponse
-	(*GetMachineValidationExternalConfigsRequest)(nil),                        // 589: forge.GetMachineValidationExternalConfigsRequest
-	(*GetMachineValidationExternalConfigsResponse)(nil),                       // 590: forge.GetMachineValidationExternalConfigsResponse
-	(*AddUpdateMachineValidationExternalConfigRequest)(nil),                   // 591: forge.AddUpdateMachineValidationExternalConfigRequest
-	(*RemoveMachineValidationExternalConfigRequest)(nil),                      // 592: forge.RemoveMachineValidationExternalConfigRequest
-	(*MachineValidationOnDemandRequest)(nil),                                  // 593: forge.MachineValidationOnDemandRequest
-	(*MachineValidationOnDemandResponse)(nil),                                 // 594: forge.MachineValidationOnDemandResponse
-	(*FirmwareUpgradeActivity)(nil),                                           // 595: forge.FirmwareUpgradeActivity
-	(*NvosUpdateActivity)(nil),                                                // 596: forge.NvosUpdateActivity
-	(*ConfigureNmxClusterActivity)(nil),                                       // 597: forge.ConfigureNmxClusterActivity
-	(*PowerSequenceActivity)(nil),                                             // 598: forge.PowerSequenceActivity
-	(*MaintenanceActivityConfig)(nil),                                         // 599: forge.MaintenanceActivityConfig
-	(*RackMaintenanceScope)(nil),                                              // 600: forge.RackMaintenanceScope
-	(*RackMaintenanceOnDemandRequest)(nil),                                    // 601: forge.RackMaintenanceOnDemandRequest
-	(*RackMaintenanceOnDemandResponse)(nil),                                   // 602: forge.RackMaintenanceOnDemandResponse
-	(*AdminPowerControlRequest)(nil),                                          // 603: forge.AdminPowerControlRequest
-	(*AdminPowerControlResponse)(nil),                                         // 604: forge.AdminPowerControlResponse
-	(*GetRedfishJobStateRequest)(nil),                                         // 605: forge.GetRedfishJobStateRequest
-	(*GetRedfishJobStateResponse)(nil),                                        // 606: forge.GetRedfishJobStateResponse
-	(*MachineValidationRunList)(nil),                                          // 607: forge.MachineValidationRunList
-	(*MachineValidationRunListGetRequest)(nil),                                // 608: forge.MachineValidationRunListGetRequest
-	(*MachineValidationRunItemSearchFilter)(nil),                              // 609: forge.MachineValidationRunItemSearchFilter
-	(*MachineValidationRunItemIdList)(nil),                                    // 610: forge.MachineValidationRunItemIdList
-	(*MachineValidationRunItemsByIdsRequest)(nil),                             // 611: forge.MachineValidationRunItemsByIdsRequest
-	(*MachineValidationRunItemList)(nil),                                      // 612: forge.MachineValidationRunItemList
-	(*MachineValidationRunItem)(nil),                                          // 613: forge.MachineValidationRunItem
-	(*MachineValidationAttemptGetRequest)(nil),                                // 614: forge.MachineValidationAttemptGetRequest
-	(*MachineValidationAttempt)(nil),                                          // 615: forge.MachineValidationAttempt
-	(*MachineValidationHeartbeatRequest)(nil),                                 // 616: forge.MachineValidationHeartbeatRequest
-	(*MachineValidationHeartbeatResponse)(nil),                                // 617: forge.MachineValidationHeartbeatResponse
-	(*IsBmcInManagedHostResponse)(nil),                                        // 618: forge.IsBmcInManagedHostResponse
-	(*BmcCredentialStatusResponse)(nil),                                       // 619: forge.BmcCredentialStatusResponse
-	(*MachineValidationTestsGetRequest)(nil),                                  // 620: forge.MachineValidationTestsGetRequest
-	(*MachineValidationTestUpdateRequest)(nil),                                // 621: forge.MachineValidationTestUpdateRequest
-	(*MachineValidationTestAddRequest)(nil),                                   // 622: forge.MachineValidationTestAddRequest
-	(*MachineValidationTestAddUpdateResponse)(nil),                            // 623: forge.MachineValidationTestAddUpdateResponse
-	(*MachineValidationTestsGetResponse)(nil),                                 // 624: forge.MachineValidationTestsGetResponse
-	(*MachineValidationTestVerfiedRequest)(nil),                               // 625: forge.MachineValidationTestVerfiedRequest
-	(*MachineValidationTestVerfiedResponse)(nil),                              // 626: forge.MachineValidationTestVerfiedResponse
-	(*MachineValidationTest)(nil),                                             // 627: forge.MachineValidationTest
-	(*MachineValidationTestNextVersionResponse)(nil),                          // 628: forge.MachineValidationTestNextVersionResponse
-	(*MachineValidationTestNextVersionRequest)(nil),                           // 629: forge.MachineValidationTestNextVersionRequest
-	(*MachineValidationTestEnableDisableTestRequest)(nil),                     // 630: forge.MachineValidationTestEnableDisableTestRequest
-	(*MachineValidationTestEnableDisableTestResponse)(nil),                    // 631: forge.MachineValidationTestEnableDisableTestResponse
-	(*MachineValidationRunRequest)(nil),                                       // 632: forge.MachineValidationRunRequest
-	(*MachineValidationRunResponse)(nil),                                      // 633: forge.MachineValidationRunResponse
-	(*MachineCapabilityAttributesCpu)(nil),                                    // 634: forge.MachineCapabilityAttributesCpu
-	(*MachineCapabilityAttributesGpu)(nil),                                    // 635: forge.MachineCapabilityAttributesGpu
-	(*MachineCapabilityAttributesMemory)(nil),                                 // 636: forge.MachineCapabilityAttributesMemory
-	(*MachineCapabilityAttributesStorage)(nil),                                // 637: forge.MachineCapabilityAttributesStorage
-	(*MachineCapabilityAttributesNetwork)(nil),                                // 638: forge.MachineCapabilityAttributesNetwork
-	(*MachineCapabilityAttributesInfiniband)(nil),                             // 639: forge.MachineCapabilityAttributesInfiniband
-	(*MachineCapabilityAttributesDpu)(nil),                                    // 640: forge.MachineCapabilityAttributesDpu
-	(*MachineCapabilitiesSet)(nil),                                            // 641: forge.MachineCapabilitiesSet
-	(*InstanceTypeAttributes)(nil),                                            // 642: forge.InstanceTypeAttributes
-	(*InstanceType)(nil),                                                      // 643: forge.InstanceType
-	(*InstanceTypeMachineCapabilityFilterAttributes)(nil),                     // 644: forge.InstanceTypeMachineCapabilityFilterAttributes
-	(*CreateInstanceTypeRequest)(nil),                                         // 645: forge.CreateInstanceTypeRequest
-	(*CreateInstanceTypeResponse)(nil),                                        // 646: forge.CreateInstanceTypeResponse
-	(*FindInstanceTypeIdsRequest)(nil),                                        // 647: forge.FindInstanceTypeIdsRequest
-	(*FindInstanceTypeIdsResponse)(nil),                                       // 648: forge.FindInstanceTypeIdsResponse
-	(*FindInstanceTypesByIdsRequest)(nil),                                     // 649: forge.FindInstanceTypesByIdsRequest
-	(*FindInstanceTypesByIdsResponse)(nil),                                    // 650: forge.FindInstanceTypesByIdsResponse
-	(*DeleteInstanceTypeRequest)(nil),                                         // 651: forge.DeleteInstanceTypeRequest
-	(*DeleteInstanceTypeResponse)(nil),                                        // 652: forge.DeleteInstanceTypeResponse
-	(*UpdateInstanceTypeResponse)(nil),                                        // 653: forge.UpdateInstanceTypeResponse
-	(*UpdateInstanceTypeRequest)(nil),                                         // 654: forge.UpdateInstanceTypeRequest
-	(*AssociateMachinesWithInstanceTypeRequest)(nil),                          // 655: forge.AssociateMachinesWithInstanceTypeRequest
-	(*AssociateMachinesWithInstanceTypeResponse)(nil),                         // 656: forge.AssociateMachinesWithInstanceTypeResponse
-	(*RemoveMachineInstanceTypeAssociationRequest)(nil),                       // 657: forge.RemoveMachineInstanceTypeAssociationRequest
-	(*RemoveMachineInstanceTypeAssociationResponse)(nil),                      // 658: forge.RemoveMachineInstanceTypeAssociationResponse
-	(*RedfishBrowseRequest)(nil),                                              // 659: forge.RedfishBrowseRequest
-	(*RedfishBrowseResponse)(nil),                                             // 660: forge.RedfishBrowseResponse
-	(*RedfishListActionsRequest)(nil),                                         // 661: forge.RedfishListActionsRequest
-	(*RedfishListActionsResponse)(nil),                                        // 662: forge.RedfishListActionsResponse
-	(*RedfishAction)(nil),                                                     // 663: forge.RedfishAction
-	(*OptionalRedfishActionResult)(nil),                                       // 664: forge.OptionalRedfishActionResult
-	(*RedfishActionResult)(nil),                                               // 665: forge.RedfishActionResult
-	(*RedfishCreateActionRequest)(nil),                                        // 666: forge.RedfishCreateActionRequest
-	(*RedfishCreateActionResponse)(nil),                                       // 667: forge.RedfishCreateActionResponse
-	(*RedfishActionID)(nil),                                                   // 668: forge.RedfishActionID
-	(*RedfishApproveActionResponse)(nil),                                      // 669: forge.RedfishApproveActionResponse
-	(*RedfishApplyActionResponse)(nil),                                        // 670: forge.RedfishApplyActionResponse
-	(*RedfishCancelActionResponse)(nil),                                       // 671: forge.RedfishCancelActionResponse
-	(*UfmBrowseRequest)(nil),                                                  // 672: forge.UfmBrowseRequest
-	(*UfmBrowseResponse)(nil),                                                 // 673: forge.UfmBrowseResponse
-	(*NetworkSecurityGroupAttributes)(nil),                                    // 674: forge.NetworkSecurityGroupAttributes
-	(*NetworkSecurityGroup)(nil),                                              // 675: forge.NetworkSecurityGroup
-	(*CreateNetworkSecurityGroupRequest)(nil),                                 // 676: forge.CreateNetworkSecurityGroupRequest
-	(*CreateNetworkSecurityGroupResponse)(nil),                                // 677: forge.CreateNetworkSecurityGroupResponse
-	(*FindNetworkSecurityGroupIdsRequest)(nil),                                // 678: forge.FindNetworkSecurityGroupIdsRequest
-	(*FindNetworkSecurityGroupIdsResponse)(nil),                               // 679: forge.FindNetworkSecurityGroupIdsResponse
-	(*FindNetworkSecurityGroupsByIdsRequest)(nil),                             // 680: forge.FindNetworkSecurityGroupsByIdsRequest
-	(*FindNetworkSecurityGroupsByIdsResponse)(nil),                            // 681: forge.FindNetworkSecurityGroupsByIdsResponse
-	(*UpdateNetworkSecurityGroupResponse)(nil),                                // 682: forge.UpdateNetworkSecurityGroupResponse
-	(*UpdateNetworkSecurityGroupRequest)(nil),                                 // 683: forge.UpdateNetworkSecurityGroupRequest
-	(*DeleteNetworkSecurityGroupRequest)(nil),                                 // 684: forge.DeleteNetworkSecurityGroupRequest
-	(*DeleteNetworkSecurityGroupResponse)(nil),                                // 685: forge.DeleteNetworkSecurityGroupResponse
-	(*NetworkSecurityGroupStatus)(nil),                                        // 686: forge.NetworkSecurityGroupStatus
-	(*NetworkSecurityGroupPropagationObjectStatus)(nil),                       // 687: forge.NetworkSecurityGroupPropagationObjectStatus
-	(*GetNetworkSecurityGroupPropagationStatusResponse)(nil),                  // 688: forge.GetNetworkSecurityGroupPropagationStatusResponse
-	(*NetworkSecurityGroupIdList)(nil),                                        // 689: forge.NetworkSecurityGroupIdList
-	(*GetNetworkSecurityGroupPropagationStatusRequest)(nil),                   // 690: forge.GetNetworkSecurityGroupPropagationStatusRequest
-	(*NetworkSecurityGroupRuleAttributes)(nil),                                // 691: forge.NetworkSecurityGroupRuleAttributes
-	(*ResolvedNetworkSecurityGroupRule)(nil),                                  // 692: forge.ResolvedNetworkSecurityGroupRule
-	(*GetNetworkSecurityGroupAttachmentsRequest)(nil),                         // 693: forge.GetNetworkSecurityGroupAttachmentsRequest
-	(*NetworkSecurityGroupAttachments)(nil),                                   // 694: forge.NetworkSecurityGroupAttachments
-	(*GetNetworkSecurityGroupAttachmentsResponse)(nil),                        // 695: forge.GetNetworkSecurityGroupAttachmentsResponse
-	(*GetDesiredFirmwareVersionsRequest)(nil),                                 // 696: forge.GetDesiredFirmwareVersionsRequest
-	(*GetDesiredFirmwareVersionsResponse)(nil),                                // 697: forge.GetDesiredFirmwareVersionsResponse
-	(*DesiredFirmwareVersionEntry)(nil),                                       // 698: forge.DesiredFirmwareVersionEntry
-	(*SkuComponentChassis)(nil),                                               // 699: forge.SkuComponentChassis
-	(*SkuComponentCpu)(nil),                                                   // 700: forge.SkuComponentCpu
-	(*SkuComponentGpu)(nil),                                                   // 701: forge.SkuComponentGpu
-	(*SkuComponentEthernetDevices)(nil),                                       // 702: forge.SkuComponentEthernetDevices
-	(*SkuComponentInfinibandDevices)(nil),                                     // 703: forge.SkuComponentInfinibandDevices
-	(*SkuComponentStorage)(nil),                                               // 704: forge.SkuComponentStorage
-	(*SkuComponentStorageController)(nil),                                     // 705: forge.SkuComponentStorageController
-	(*SkuComponentMemory)(nil),                                                // 706: forge.SkuComponentMemory
-	(*SkuComponentTpm)(nil),                                                   // 707: forge.SkuComponentTpm
-	(*SkuComponents)(nil),                                                     // 708: forge.SkuComponents
-	(*Sku)(nil),                                                               // 709: forge.Sku
-	(*SkuMachinePair)(nil),                                                    // 710: forge.SkuMachinePair
-	(*RemoveSkuRequest)(nil),                                                  // 711: forge.RemoveSkuRequest
-	(*SkuList)(nil),                                                           // 712: forge.SkuList
-	(*SkuIdList)(nil),                                                         // 713: forge.SkuIdList
-	(*SkuStatus)(nil),                                                         // 714: forge.SkuStatus
-	(*SkusByIdsRequest)(nil),                                                  // 715: forge.SkusByIdsRequest
-	(*SkuSearchFilter)(nil),                                                   // 716: forge.SkuSearchFilter
-	(*DpaInterface)(nil),                                                      // 717: forge.DpaInterface
-	(*DpaInterfaceCreationRequest)(nil),                                       // 718: forge.DpaInterfaceCreationRequest
-	(*DpaInterfaceIdList)(nil),                                                // 719: forge.DpaInterfaceIdList
-	(*DpaInterfacesByIdsRequest)(nil),                                         // 720: forge.DpaInterfacesByIdsRequest
-	(*DpaInterfaceList)(nil),                                                  // 721: forge.DpaInterfaceList
-	(*DpaNetworkObservationSetRequest)(nil),                                   // 722: forge.DpaNetworkObservationSetRequest
-	(*DpaInterfaceDeletionRequest)(nil),                                       // 723: forge.DpaInterfaceDeletionRequest
-	(*DpaInterfaceDeletionResult)(nil),                                        // 724: forge.DpaInterfaceDeletionResult
-	(*SkuUpdateMetadataRequest)(nil),                                          // 725: forge.SkuUpdateMetadataRequest
-	(*PowerOptionRequest)(nil),                                                // 726: forge.PowerOptionRequest
-	(*PowerOptionUpdateRequest)(nil),                                          // 727: forge.PowerOptionUpdateRequest
-	(*PowerOptions)(nil),                                                      // 728: forge.PowerOptions
-	(*PowerOptionResponse)(nil),                                               // 729: forge.PowerOptionResponse
-	(*ComputeAllocationAttributes)(nil),                                       // 730: forge.ComputeAllocationAttributes
-	(*ComputeAllocation)(nil),                                                 // 731: forge.ComputeAllocation
-	(*CreateComputeAllocationRequest)(nil),                                    // 732: forge.CreateComputeAllocationRequest
-	(*CreateComputeAllocationResponse)(nil),                                   // 733: forge.CreateComputeAllocationResponse
-	(*FindComputeAllocationIdsRequest)(nil),                                   // 734: forge.FindComputeAllocationIdsRequest
-	(*FindComputeAllocationIdsResponse)(nil),                                  // 735: forge.FindComputeAllocationIdsResponse
-	(*FindComputeAllocationsByIdsRequest)(nil),                                // 736: forge.FindComputeAllocationsByIdsRequest
-	(*FindComputeAllocationsByIdsResponse)(nil),                               // 737: forge.FindComputeAllocationsByIdsResponse
-	(*UpdateComputeAllocationResponse)(nil),                                   // 738: forge.UpdateComputeAllocationResponse
-	(*UpdateComputeAllocationRequest)(nil),                                    // 739: forge.UpdateComputeAllocationRequest
-	(*DeleteComputeAllocationRequest)(nil),                                    // 740: forge.DeleteComputeAllocationRequest
-	(*DeleteComputeAllocationResponse)(nil),                                   // 741: forge.DeleteComputeAllocationResponse
-	(*InstanceTypeAllocationStats)(nil),                                       // 742: forge.InstanceTypeAllocationStats
-	(*GetRackRequest)(nil),                                                    // 743: forge.GetRackRequest
-	(*GetRackResponse)(nil),                                                   // 744: forge.GetRackResponse
-	(*RackList)(nil),                                                          // 745: forge.RackList
-	(*RackSearchFilter)(nil),                                                  // 746: forge.RackSearchFilter
-	(*RackIdList)(nil),                                                        // 747: forge.RackIdList
-	(*RacksByIdsRequest)(nil),                                                 // 748: forge.RacksByIdsRequest
-	(*Rack)(nil),                                                              // 749: forge.Rack
-	(*RackConfig)(nil),                                                        // 750: forge.RackConfig
-	(*RackStatus)(nil),                                                        // 751: forge.RackStatus
-	(*RackStateHistoriesRequest)(nil),                                         // 752: forge.RackStateHistoriesRequest
-	(*DeleteRackRequest)(nil),                                                 // 753: forge.DeleteRackRequest
-	(*AdminForceDeleteRackRequest)(nil),                                       // 754: forge.AdminForceDeleteRackRequest
-	(*AdminForceDeleteRackResponse)(nil),                                      // 755: forge.AdminForceDeleteRackResponse
-	(*RackCapabilityCompute)(nil),                                             // 756: forge.RackCapabilityCompute
-	(*RackCapabilitySwitch)(nil),                                              // 757: forge.RackCapabilitySwitch
-	(*RackCapabilityPowerShelf)(nil),                                          // 758: forge.RackCapabilityPowerShelf
-	(*RackCapabilitiesSet)(nil),                                               // 759: forge.RackCapabilitiesSet
-	(*RackProfile)(nil),                                                       // 760: forge.RackProfile
-	(*GetRackProfileRequest)(nil),                                             // 761: forge.GetRackProfileRequest
-	(*GetRackProfileResponse)(nil),                                            // 762: forge.GetRackProfileResponse
-	(*RackManagerForgeRequest)(nil),                                           // 763: forge.RackManagerForgeRequest
-	(*RackManagerForgeResponse)(nil),                                          // 764: forge.RackManagerForgeResponse
-	(*MachineNVLinkInfo)(nil),                                                 // 765: forge.MachineNVLinkInfo
-	(*UpdateMachineNvLinkInfoRequest)(nil),                                    // 766: forge.UpdateMachineNvLinkInfoRequest
-	(*MachineSpxStatusObservation)(nil),                                       // 767: forge.MachineSpxStatusObservation
-	(*MachineSpxAttachmentStatusObservation)(nil),                             // 768: forge.MachineSpxAttachmentStatusObservation
-	(*AstraConfig)(nil),                                                       // 769: forge.AstraConfig
-	(*AstraAttachment)(nil),                                                   // 770: forge.AstraAttachment
-	(*AstraConfigStatus)(nil),                                                 // 771: forge.AstraConfigStatus
-	(*AstraAttachmentStatus)(nil),                                             // 772: forge.AstraAttachmentStatus
-	(*AstraStatus)(nil),                                                       // 773: forge.AstraStatus
-	(*NVLinkGpu)(nil),                                                         // 774: forge.NVLinkGpu
-	(*MachineNVLinkStatusObservation)(nil),                                    // 775: forge.MachineNVLinkStatusObservation
-	(*MachineNVLinkGpuStatusObservation)(nil),                                 // 776: forge.MachineNVLinkGpuStatusObservation
-	(*NmxcBrowseRequest)(nil),                                                 // 777: forge.NmxcBrowseRequest
-	(*NmxcBrowseResponse)(nil),                                                // 778: forge.NmxcBrowseResponse
-	(*NVLinkPartition)(nil),                                                   // 779: forge.NVLinkPartition
-	(*NVLinkPartitionList)(nil),                                               // 780: forge.NVLinkPartitionList
-	(*NVLinkPartitionSearchConfig)(nil),                                       // 781: forge.NVLinkPartitionSearchConfig
-	(*NVLinkPartitionQuery)(nil),                                              // 782: forge.NVLinkPartitionQuery
-	(*NVLinkPartitionSearchFilter)(nil),                                       // 783: forge.NVLinkPartitionSearchFilter
-	(*NVLinkPartitionsByIdsRequest)(nil),                                      // 784: forge.NVLinkPartitionsByIdsRequest
-	(*NVLinkPartitionIdList)(nil),                                             // 785: forge.NVLinkPartitionIdList
-	(*NVLinkFabricSearchFilter)(nil),                                          // 786: forge.NVLinkFabricSearchFilter
-	(*NVLinkLogicalPartitionConfig)(nil),                                      // 787: forge.NVLinkLogicalPartitionConfig
-	(*NVLinkLogicalPartitionStatus)(nil),                                      // 788: forge.NVLinkLogicalPartitionStatus
-	(*NVLinkLogicalPartition)(nil),                                            // 789: forge.NVLinkLogicalPartition
-	(*NVLinkLogicalPartitionList)(nil),                                        // 790: forge.NVLinkLogicalPartitionList
-	(*NVLinkLogicalPartitionCreationRequest)(nil),                             // 791: forge.NVLinkLogicalPartitionCreationRequest
-	(*NVLinkLogicalPartitionDeletionRequest)(nil),                             // 792: forge.NVLinkLogicalPartitionDeletionRequest
-	(*NVLinkLogicalPartitionDeletionResult)(nil),                              // 793: forge.NVLinkLogicalPartitionDeletionResult
-	(*NVLinkLogicalPartitionSearchFilter)(nil),                                // 794: forge.NVLinkLogicalPartitionSearchFilter
-	(*NVLinkLogicalPartitionsByIdsRequest)(nil),                               // 795: forge.NVLinkLogicalPartitionsByIdsRequest
-	(*NVLinkLogicalPartitionIdList)(nil),                                      // 796: forge.NVLinkLogicalPartitionIdList
-	(*NVLinkLogicalPartitionUpdateRequest)(nil),                               // 797: forge.NVLinkLogicalPartitionUpdateRequest
-	(*NVLinkLogicalPartitionUpdateResult)(nil),                                // 798: forge.NVLinkLogicalPartitionUpdateResult
-	(*CreateBmcUserRequest)(nil),                                              // 799: forge.CreateBmcUserRequest
-	(*CreateBmcUserResponse)(nil),                                             // 800: forge.CreateBmcUserResponse
-	(*DeleteBmcUserRequest)(nil),                                              // 801: forge.DeleteBmcUserRequest
-	(*DeleteBmcUserResponse)(nil),                                             // 802: forge.DeleteBmcUserResponse
-	(*SetBmcRootPasswordRequest)(nil),                                         // 803: forge.SetBmcRootPasswordRequest
-	(*SetBmcRootPasswordResponse)(nil),                                        // 804: forge.SetBmcRootPasswordResponse
-	(*ProbeBmcVendorRequest)(nil),                                             // 805: forge.ProbeBmcVendorRequest
-	(*ProbeBmcVendorResponse)(nil),                                            // 806: forge.ProbeBmcVendorResponse
-	(*SetFirmwareUpdateTimeWindowRequest)(nil),                                // 807: forge.SetFirmwareUpdateTimeWindowRequest
-	(*SetFirmwareUpdateTimeWindowResponse)(nil),                               // 808: forge.SetFirmwareUpdateTimeWindowResponse
-	(*UpsertHostFirmwareConfigRequest)(nil),                                   // 809: forge.UpsertHostFirmwareConfigRequest
-	(*DeleteHostFirmwareConfigRequest)(nil),                                   // 810: forge.DeleteHostFirmwareConfigRequest
-	(*UpsertHostFirmwareComponentConfig)(nil),                                 // 811: forge.UpsertHostFirmwareComponentConfig
-	(*HostFirmwareComponentConfigResponse)(nil),                               // 812: forge.HostFirmwareComponentConfigResponse
-	(*HostFirmwareVersionConfig)(nil),                                         // 813: forge.HostFirmwareVersionConfig
-	(*HostFirmwareArtifact)(nil),                                              // 814: forge.HostFirmwareArtifact
-	(*HostFirmwareConfigResponse)(nil),                                        // 815: forge.HostFirmwareConfigResponse
-	(*ListHostFirmwareRequest)(nil),                                           // 816: forge.ListHostFirmwareRequest
-	(*ListHostFirmwareResponse)(nil),                                          // 817: forge.ListHostFirmwareResponse
-	(*AvailableHostFirmware)(nil),                                             // 818: forge.AvailableHostFirmware
-	(*TrimTableRequest)(nil),                                                  // 819: forge.TrimTableRequest
-	(*TrimTableResponse)(nil),                                                 // 820: forge.TrimTableResponse
-	(*NvlinkNmxcEndpoint)(nil),                                                // 821: forge.NvlinkNmxcEndpoint
-	(*NvlinkNmxcEndpointList)(nil),                                            // 822: forge.NvlinkNmxcEndpointList
-	(*DeleteNvlinkNmxcEndpointRequest)(nil),                                   // 823: forge.DeleteNvlinkNmxcEndpointRequest
-	(*CreateRemediationRequest)(nil),                                          // 824: forge.CreateRemediationRequest
-	(*CreateRemediationResponse)(nil),                                         // 825: forge.CreateRemediationResponse
-	(*RemediationIdList)(nil),                                                 // 826: forge.RemediationIdList
-	(*RemediationList)(nil),                                                   // 827: forge.RemediationList
-	(*Remediation)(nil),                                                       // 828: forge.Remediation
-	(*ApproveRemediationRequest)(nil),                                         // 829: forge.ApproveRemediationRequest
-	(*RevokeRemediationRequest)(nil),                                          // 830: forge.RevokeRemediationRequest
-	(*EnableRemediationRequest)(nil),                                          // 831: forge.EnableRemediationRequest
-	(*DisableRemediationRequest)(nil),                                         // 832: forge.DisableRemediationRequest
-	(*FindAppliedRemediationIdsRequest)(nil),                                  // 833: forge.FindAppliedRemediationIdsRequest
-	(*AppliedRemediationIdList)(nil),                                          // 834: forge.AppliedRemediationIdList
-	(*FindAppliedRemediationsRequest)(nil),                                    // 835: forge.FindAppliedRemediationsRequest
-	(*AppliedRemediation)(nil),                                                // 836: forge.AppliedRemediation
-	(*AppliedRemediationList)(nil),                                            // 837: forge.AppliedRemediationList
-	(*GetNextRemediationForMachineRequest)(nil),                               // 838: forge.GetNextRemediationForMachineRequest
-	(*GetNextRemediationForMachineResponse)(nil),                              // 839: forge.GetNextRemediationForMachineResponse
-	(*RemediationAppliedRequest)(nil),                                         // 840: forge.RemediationAppliedRequest
-	(*RemediationApplicationStatus)(nil),                                      // 841: forge.RemediationApplicationStatus
-	(*SetPrimaryDpuRequest)(nil),                                              // 842: forge.SetPrimaryDpuRequest
-	(*SetPrimaryInterfaceRequest)(nil),                                        // 843: forge.SetPrimaryInterfaceRequest
-	(*UsernamePassword)(nil),                                                  // 844: forge.UsernamePassword
-	(*SessionToken)(nil),                                                      // 845: forge.SessionToken
-	(*DpuExtensionServiceCredential)(nil),                                     // 846: forge.DpuExtensionServiceCredential
-	(*DpuExtensionServiceVersionInfo)(nil),                                    // 847: forge.DpuExtensionServiceVersionInfo
-	(*DpuExtensionService)(nil),                                               // 848: forge.DpuExtensionService
-	(*CreateDpuExtensionServiceRequest)(nil),                                  // 849: forge.CreateDpuExtensionServiceRequest
-	(*UpdateDpuExtensionServiceRequest)(nil),                                  // 850: forge.UpdateDpuExtensionServiceRequest
-	(*DeleteDpuExtensionServiceRequest)(nil),                                  // 851: forge.DeleteDpuExtensionServiceRequest
-	(*DeleteDpuExtensionServiceResponse)(nil),                                 // 852: forge.DeleteDpuExtensionServiceResponse
-	(*DpuExtensionServiceSearchFilter)(nil),                                   // 853: forge.DpuExtensionServiceSearchFilter
-	(*DpuExtensionServiceIdList)(nil),                                         // 854: forge.DpuExtensionServiceIdList
-	(*DpuExtensionServicesByIdsRequest)(nil),                                  // 855: forge.DpuExtensionServicesByIdsRequest
-	(*DpuExtensionServiceList)(nil),                                           // 856: forge.DpuExtensionServiceList
-	(*GetDpuExtensionServiceVersionsInfoRequest)(nil),                         // 857: forge.GetDpuExtensionServiceVersionsInfoRequest
-	(*DpuExtensionServiceVersionInfoList)(nil),                                // 858: forge.DpuExtensionServiceVersionInfoList
-	(*FindInstancesByDpuExtensionServiceRequest)(nil),                         // 859: forge.FindInstancesByDpuExtensionServiceRequest
-	(*FindInstancesByDpuExtensionServiceResponse)(nil),                        // 860: forge.FindInstancesByDpuExtensionServiceResponse
-	(*InstanceDpuExtensionServiceInfo)(nil),                                   // 861: forge.InstanceDpuExtensionServiceInfo
-	(*DpuExtensionServiceObservabilityConfigPrometheus)(nil),                  // 862: forge.DpuExtensionServiceObservabilityConfigPrometheus
-	(*DpuExtensionServiceObservabilityConfigLogging)(nil),                     // 863: forge.DpuExtensionServiceObservabilityConfigLogging
-	(*DpuExtensionServiceObservabilityConfig)(nil),                            // 864: forge.DpuExtensionServiceObservabilityConfig
-	(*DpuExtensionServiceObservability)(nil),                                  // 865: forge.DpuExtensionServiceObservability
-	(*ScoutStreamApiBoundMessage)(nil),                                        // 866: forge.ScoutStreamApiBoundMessage
-	(*ScoutStreamScoutBoundMessage)(nil),                                      // 867: forge.ScoutStreamScoutBoundMessage
-	(*ScoutStreamInitRequest)(nil),                                            // 868: forge.ScoutStreamInitRequest
-	(*ScoutStreamShowConnectionsRequest)(nil),                                 // 869: forge.ScoutStreamShowConnectionsRequest
-	(*ScoutStreamShowConnectionsResponse)(nil),                                // 870: forge.ScoutStreamShowConnectionsResponse
-	(*ScoutStreamDisconnectRequest)(nil),                                      // 871: forge.ScoutStreamDisconnectRequest
-	(*ScoutStreamDisconnectResponse)(nil),                                     // 872: forge.ScoutStreamDisconnectResponse
-	(*ScoutStreamAdminPingRequest)(nil),                                       // 873: forge.ScoutStreamAdminPingRequest
-	(*ScoutStreamAdminPingResponse)(nil),                                      // 874: forge.ScoutStreamAdminPingResponse
-	(*ScoutStreamAgentPingRequest)(nil),                                       // 875: forge.ScoutStreamAgentPingRequest
-	(*ScoutStreamAgentPingResponse)(nil),                                      // 876: forge.ScoutStreamAgentPingResponse
-	(*ScoutStreamConnectionInfo)(nil),                                         // 877: forge.ScoutStreamConnectionInfo
-	(*ScoutStreamError)(nil),                                                  // 878: forge.ScoutStreamError
-	(*PrefixFilterPolicyEntry)(nil),                                           // 879: forge.PrefixFilterPolicyEntry
-	(*RoutingProfile)(nil),                                                    // 880: forge.RoutingProfile
-	(*DomainLegacy)(nil),                                                      // 881: forge.DomainLegacy
-	(*DomainListLegacy)(nil),                                                  // 882: forge.DomainListLegacy
-	(*DomainDeletionLegacy)(nil),                                              // 883: forge.DomainDeletionLegacy
-	(*DomainDeletionResultLegacy)(nil),                                        // 884: forge.DomainDeletionResultLegacy
-	(*DomainSearchQueryLegacy)(nil),                                           // 885: forge.DomainSearchQueryLegacy
-	(*PxeDomain)(nil),                                                         // 886: forge.PxeDomain
-	(*MachinePositionQuery)(nil),                                              // 887: forge.MachinePositionQuery
-	(*MachinePositionInfoList)(nil),                                           // 888: forge.MachinePositionInfoList
-	(*MachinePositionInfo)(nil),                                               // 889: forge.MachinePositionInfo
-	(*ModifyDPFStateRequest)(nil),                                             // 890: forge.ModifyDPFStateRequest
-	(*DPFStateResponse)(nil),                                                  // 891: forge.DPFStateResponse
-	(*GetDPFStateRequest)(nil),                                                // 892: forge.GetDPFStateRequest
-	(*GetDPFHostSnapshotRequest)(nil),                                         // 893: forge.GetDPFHostSnapshotRequest
-	(*DPFHostSnapshotResponse)(nil),                                           // 894: forge.DPFHostSnapshotResponse
-	(*GetDPFServiceVersionsRequest)(nil),                                      // 895: forge.GetDPFServiceVersionsRequest
-	(*DPFServiceVersion)(nil),                                                 // 896: forge.DPFServiceVersion
-	(*DPFServiceVersionsResponse)(nil),                                        // 897: forge.DPFServiceVersionsResponse
-	(*ComponentResult)(nil),                                                   // 898: forge.ComponentResult
-	(*SwitchIdList)(nil),                                                      // 899: forge.SwitchIdList
-	(*PowerShelfIdList)(nil),                                                  // 900: forge.PowerShelfIdList
-	(*GetComponentInventoryRequest)(nil),                                      // 901: forge.GetComponentInventoryRequest
-	(*ComponentInventoryEntry)(nil),                                           // 902: forge.ComponentInventoryEntry
-	(*GetComponentInventoryResponse)(nil),                                     // 903: forge.GetComponentInventoryResponse
-	(*ComponentPowerControlRequest)(nil),                                      // 904: forge.ComponentPowerControlRequest
-	(*ComponentPowerControlResponse)(nil),                                     // 905: forge.ComponentPowerControlResponse
-	(*ComponentConfigureSwitchCertificateRequest)(nil),                        // 906: forge.ComponentConfigureSwitchCertificateRequest
-	(*ComponentConfigureSwitchCertificateResponse)(nil),                       // 907: forge.ComponentConfigureSwitchCertificateResponse
-	(*FirmwareUpdateStatus)(nil),                                              // 908: forge.FirmwareUpdateStatus
-	(*UpdateComputeTrayFirmwareTarget)(nil),                                   // 909: forge.UpdateComputeTrayFirmwareTarget
-	(*UpdateSwitchFirmwareTarget)(nil),                                        // 910: forge.UpdateSwitchFirmwareTarget
-	(*UpdatePowerShelfFirmwareTarget)(nil),                                    // 911: forge.UpdatePowerShelfFirmwareTarget
-	(*UpdateFirmwareObjectTarget)(nil),                                        // 912: forge.UpdateFirmwareObjectTarget
-	(*UpdateComponentFirmwareRequest)(nil),                                    // 913: forge.UpdateComponentFirmwareRequest
-	(*UpdateComponentFirmwareResponse)(nil),                                   // 914: forge.UpdateComponentFirmwareResponse
-	(*GetComponentFirmwareStatusRequest)(nil),                                 // 915: forge.GetComponentFirmwareStatusRequest
-	(*GetComponentFirmwareStatusResponse)(nil),                                // 916: forge.GetComponentFirmwareStatusResponse
-	(*ListComponentFirmwareVersionsRequest)(nil),                              // 917: forge.ListComponentFirmwareVersionsRequest
-	(*ComputeTrayFirmwareVersions)(nil),                                       // 918: forge.ComputeTrayFirmwareVersions
-	(*DeviceFirmwareVersions)(nil),                                            // 919: forge.DeviceFirmwareVersions
-	(*ListComponentFirmwareVersionsResponse)(nil),                             // 920: forge.ListComponentFirmwareVersionsResponse
-	(*SpxPartitionCreationRequest)(nil),                                       // 921: forge.SpxPartitionCreationRequest
-	(*SpxPartition)(nil),                                                      // 922: forge.SpxPartition
-	(*SpxPartitionIdList)(nil),                                                // 923: forge.SpxPartitionIdList
-	(*SpxPartitionDeletionRequest)(nil),                                       // 924: forge.SpxPartitionDeletionRequest
-	(*SpxPartitionDeletionResult)(nil),                                        // 925: forge.SpxPartitionDeletionResult
-	(*SpxPartitionSearchFilter)(nil),                                          // 926: forge.SpxPartitionSearchFilter
-	(*SpxPartitionList)(nil),                                                  // 927: forge.SpxPartitionList
-	(*SpxPartitionsByIdsRequest)(nil),                                         // 928: forge.SpxPartitionsByIdsRequest
-	(*AdminForceDeleteSwitchRequest)(nil),                                     // 929: forge.AdminForceDeleteSwitchRequest
-	(*AdminForceDeleteSwitchResponse)(nil),                                    // 930: forge.AdminForceDeleteSwitchResponse
-	(*AdminForceDeletePowerShelfRequest)(nil),                                 // 931: forge.AdminForceDeletePowerShelfRequest
-	(*AdminForceDeletePowerShelfResponse)(nil),                                // 932: forge.AdminForceDeletePowerShelfResponse
-	(*OperatingSystem)(nil),                                                   // 933: forge.OperatingSystem
-	(*CreateOperatingSystemRequest)(nil),                                      // 934: forge.CreateOperatingSystemRequest
-	(*IpxeTemplateParameters)(nil),                                            // 935: forge.IpxeTemplateParameters
-	(*IpxeTemplateArtifacts)(nil),                                             // 936: forge.IpxeTemplateArtifacts
-	(*UpdateOperatingSystemRequest)(nil),                                      // 937: forge.UpdateOperatingSystemRequest
-	(*DeleteOperatingSystemRequest)(nil),                                      // 938: forge.DeleteOperatingSystemRequest
-	(*DeleteOperatingSystemResponse)(nil),                                     // 939: forge.DeleteOperatingSystemResponse
-	(*OperatingSystemSearchFilter)(nil),                                       // 940: forge.OperatingSystemSearchFilter
-	(*OperatingSystemIdList)(nil),                                             // 941: forge.OperatingSystemIdList
-	(*OperatingSystemsByIdsRequest)(nil),                                      // 942: forge.OperatingSystemsByIdsRequest
-	(*OperatingSystemList)(nil),                                               // 943: forge.OperatingSystemList
-	(*GetOperatingSystemCachableIpxeTemplateArtifactsRequest)(nil),            // 944: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	(*IpxeTemplateArtifactList)(nil),                                          // 945: forge.IpxeTemplateArtifactList
-	(*IpxeTemplateArtifactUpdateRequest)(nil),                                 // 946: forge.IpxeTemplateArtifactUpdateRequest
-	(*UpdateOperatingSystemIpxeTemplateArtifactRequest)(nil),                  // 947: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	(*HostRepresentorInterceptBridging)(nil),                                  // 948: forge.HostRepresentorInterceptBridging
-	(*ReWrapSecretsRequest)(nil),                                              // 949: forge.ReWrapSecretsRequest
-	(*ReWrapSecretsResponse)(nil),                                             // 950: forge.ReWrapSecretsResponse
-	(*GetMachineBootInterfacesRequest)(nil),                                   // 951: forge.GetMachineBootInterfacesRequest
-	(*MachineBootInterface)(nil),                                              // 952: forge.MachineBootInterface
-	(*MachineInterfaceBootInterface)(nil),                                     // 953: forge.MachineInterfaceBootInterface
-	(*PredictedBootInterface)(nil),                                            // 954: forge.PredictedBootInterface
-	(*ExploredBootInterface)(nil),                                             // 955: forge.ExploredBootInterface
-	(*RetainedBootInterface)(nil),                                             // 956: forge.RetainedBootInterface
-	(*GetMachineBootInterfacesResponse)(nil),                                  // 957: forge.GetMachineBootInterfacesResponse
-	(*GetContainerRegistryCredentialRequest)(nil),                             // 958: forge.GetContainerRegistryCredentialRequest
-	(*GetContainerRegistryCredentialResponse)(nil),                            // 959: forge.GetContainerRegistryCredentialResponse
-	(*SetContainerRegistryCredentialRequest)(nil),                             // 960: forge.SetContainerRegistryCredentialRequest
-	(*SitePrefix)(nil),                                                        // 961: forge.SitePrefix
-	(*SitePrefixConfig)(nil),                                                  // 962: forge.SitePrefixConfig
-	(*SitePrefixStatus)(nil),                                                  // 963: forge.SitePrefixStatus
-	(*SitePrefixSearchFilter)(nil),                                            // 964: forge.SitePrefixSearchFilter
-	(*SitePrefixesByIdsRequest)(nil),                                          // 965: forge.SitePrefixesByIdsRequest
-	(*SitePrefixIdList)(nil),                                                  // 966: forge.SitePrefixIdList
-	(*SitePrefixList)(nil),                                                    // 967: forge.SitePrefixList
-	nil,                                                                       // 968: forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
-	(*DNSMessage_DNSQuestion)(nil),                                            // 969: forge.DNSMessage.DNSQuestion
-	(*DNSMessage_DNSResponse)(nil),                                            // 970: forge.DNSMessage.DNSResponse
-	(*DNSMessage_DNSResponse_DNSRR)(nil),                                      // 971: forge.DNSMessage.DNSResponse.DNSRR
-	nil,                                                                       // 972: forge.FabricManagerConfig.ConfigMapEntry
-	nil,                                                                       // 973: forge.StateHistories.HistoriesEntry
-	nil,                                                                       // 974: forge.MachineStateHistories.HistoriesEntry
-	nil,                                                                       // 975: forge.HealthHistories.HistoriesEntry
-	nil,                                                                       // 976: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
-	(*MachineCredentialsUpdateRequest_Credentials)(nil),                       // 977: forge.MachineCredentialsUpdateRequest.Credentials
-	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo)(nil),              // 978: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
-	(*ForgeAgentControlResponse_Noop)(nil),                                    // 979: forge.ForgeAgentControlResponse.Noop
-	(*ForgeAgentControlResponse_Reset)(nil),                                   // 980: forge.ForgeAgentControlResponse.Reset
-	(*ForgeAgentControlResponse_Discovery)(nil),                               // 981: forge.ForgeAgentControlResponse.Discovery
-	(*ForgeAgentControlResponse_Rebuild)(nil),                                 // 982: forge.ForgeAgentControlResponse.Rebuild
-	(*ForgeAgentControlResponse_Retry)(nil),                                   // 983: forge.ForgeAgentControlResponse.Retry
-	(*ForgeAgentControlResponse_Measure)(nil),                                 // 984: forge.ForgeAgentControlResponse.Measure
-	(*ForgeAgentControlResponse_LogError)(nil),                                // 985: forge.ForgeAgentControlResponse.LogError
-	(*ForgeAgentControlResponse_MachineValidation)(nil),                       // 986: forge.ForgeAgentControlResponse.MachineValidation
-	(*ForgeAgentControlResponse_MachineValidationFilter)(nil),                 // 987: forge.ForgeAgentControlResponse.MachineValidationFilter
-	(*ForgeAgentControlResponse_MlxAction)(nil),                               // 988: forge.ForgeAgentControlResponse.MlxAction
-	(*ForgeAgentControlResponse_MlxDeviceAction)(nil),                         // 989: forge.ForgeAgentControlResponse.MlxDeviceAction
-	(*ForgeAgentControlResponse_MlxDeviceNoop)(nil),                           // 990: forge.ForgeAgentControlResponse.MlxDeviceNoop
-	(*ForgeAgentControlResponse_MlxDeviceLock)(nil),                           // 991: forge.ForgeAgentControlResponse.MlxDeviceLock
-	(*ForgeAgentControlResponse_MlxDeviceUnlock)(nil),                         // 992: forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	(*ForgeAgentControlResponse_MlxDeviceApplyProfile)(nil),                   // 993: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	(*ForgeAgentControlResponse_MlxDeviceApplyFirmware)(nil),                  // 994: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	(*ForgeAgentControlResponse_FirmwareUpgrade)(nil),                         // 995: forge.ForgeAgentControlResponse.FirmwareUpgrade
-	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair)(nil), // 996: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	(*MachineCleanupInfo_CleanupStepResult)(nil),                              // 997: forge.MachineCleanupInfo.CleanupStepResult
-	(*DpuReprovisioningListResponse_DpuReprovisioningListItem)(nil),           // 998: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
-	(*HostReprovisioningListResponse_HostReprovisioningListItem)(nil),         // 999: forge.HostReprovisioningListResponse.HostReprovisioningListItem
-	(*MachineValidationTestUpdateRequest_Payload)(nil),                        // 1000: forge.MachineValidationTestUpdateRequest.Payload
-	nil,                                                  // 1001: forge.RedfishBrowseResponse.HeadersEntry
-	nil,                                                  // 1002: forge.RedfishActionResult.HeadersEntry
-	nil,                                                  // 1003: forge.UfmBrowseResponse.HeadersEntry
-	nil,                                                  // 1004: forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
-	nil,                                                  // 1005: forge.NmxcBrowseResponse.HeadersEntry
-	(*DPFStateResponse_DPFState)(nil),                    // 1006: forge.DPFStateResponse.DPFState
-	(*MachineId)(nil),                                    // 1007: common.MachineId
-	(*timestamppb.Timestamp)(nil),                        // 1008: google.protobuf.Timestamp
-	(*VpcId)(nil),                                        // 1009: common.VpcId
-	(*NVLinkLogicalPartitionId)(nil),                     // 1010: common.NVLinkLogicalPartitionId
-	(*VpcPrefixId)(nil),                                  // 1011: common.VpcPrefixId
-	(*VpcPeeringId)(nil),                                 // 1012: common.VpcPeeringId
-	(*IBPartitionId)(nil),                                // 1013: common.IBPartitionId
-	(*HealthReport)(nil),                                 // 1014: health.HealthReport
-	(*PowerShelfId)(nil),                                 // 1015: common.PowerShelfId
-	(*RackId)(nil),                                       // 1016: common.RackId
-	(*UUID)(nil),                                         // 1017: common.UUID
-	(*SwitchId)(nil),                                     // 1018: common.SwitchId
-	(*RackProfileId)(nil),                                // 1019: common.RackProfileId
-	(*DomainId)(nil),                                     // 1020: common.DomainId
-	(*NetworkSegmentId)(nil),                             // 1021: common.NetworkSegmentId
-	(*NetworkPrefixId)(nil),                              // 1022: common.NetworkPrefixId
-	(*InstanceId)(nil),                                   // 1023: common.InstanceId
-	(*IpxeTemplateId)(nil),                               // 1024: common.IpxeTemplateId
-	(*OperatingSystemId)(nil),                            // 1025: common.OperatingSystemId
-	(*SpxPartitionId)(nil),                               // 1026: common.SpxPartitionId
-	(*NVLinkDomainId)(nil),                               // 1027: common.NVLinkDomainId
-	(*MachineInterfaceId)(nil),                           // 1028: common.MachineInterfaceId
-	(*DiscoveryInfo)(nil),                                // 1029: machine_discovery.DiscoveryInfo
-	(*durationpb.Duration)(nil),                          // 1030: google.protobuf.Duration
-	(*StringList)(nil),                                   // 1031: common.StringList
-	(*Gpu)(nil),                                          // 1032: machine_discovery.Gpu
-	(*RouteTarget)(nil),                                  // 1033: common.RouteTarget
-	(*MachineValidationId)(nil),                          // 1034: common.MachineValidationId
-	(*Uint32List)(nil),                                   // 1035: common.Uint32List
-	(*DpaInterfaceId)(nil),                               // 1036: common.DpaInterfaceId
-	(*ComputeAllocationId)(nil),                          // 1037: common.ComputeAllocationId
-	(*RackHardwareType)(nil),                             // 1038: common.RackHardwareType
-	(*NVLinkPartitionId)(nil),                            // 1039: common.NVLinkPartitionId
-	(*RemediationId)(nil),                                // 1040: common.RemediationId
-	(*MlxDeviceLockdownResponse)(nil),                    // 1041: mlx_device.MlxDeviceLockdownResponse
-	(*MlxDeviceProfileSyncResponse)(nil),                 // 1042: mlx_device.MlxDeviceProfileSyncResponse
-	(*MlxDeviceProfileCompareResponse)(nil),              // 1043: mlx_device.MlxDeviceProfileCompareResponse
-	(*MlxDeviceInfoDeviceResponse)(nil),                  // 1044: mlx_device.MlxDeviceInfoDeviceResponse
-	(*MlxDeviceInfoReportResponse)(nil),                  // 1045: mlx_device.MlxDeviceInfoReportResponse
-	(*MlxDeviceRegistryListResponse)(nil),                // 1046: mlx_device.MlxDeviceRegistryListResponse
-	(*MlxDeviceRegistryShowResponse)(nil),                // 1047: mlx_device.MlxDeviceRegistryShowResponse
-	(*MlxDeviceConfigQueryResponse)(nil),                 // 1048: mlx_device.MlxDeviceConfigQueryResponse
-	(*MlxDeviceConfigSetResponse)(nil),                   // 1049: mlx_device.MlxDeviceConfigSetResponse
-	(*MlxDeviceConfigSyncResponse)(nil),                  // 1050: mlx_device.MlxDeviceConfigSyncResponse
-	(*MlxDeviceConfigCompareResponse)(nil),               // 1051: mlx_device.MlxDeviceConfigCompareResponse
-	(*MlxDeviceLockdownLockRequest)(nil),                 // 1052: mlx_device.MlxDeviceLockdownLockRequest
-	(*MlxDeviceLockdownUnlockRequest)(nil),               // 1053: mlx_device.MlxDeviceLockdownUnlockRequest
-	(*MlxDeviceLockdownStatusRequest)(nil),               // 1054: mlx_device.MlxDeviceLockdownStatusRequest
-	(*MlxDeviceProfileSyncRequest)(nil),                  // 1055: mlx_device.MlxDeviceProfileSyncRequest
-	(*MlxDeviceProfileCompareRequest)(nil),               // 1056: mlx_device.MlxDeviceProfileCompareRequest
-	(*MlxDeviceInfoDeviceRequest)(nil),                   // 1057: mlx_device.MlxDeviceInfoDeviceRequest
-	(*MlxDeviceInfoReportRequest)(nil),                   // 1058: mlx_device.MlxDeviceInfoReportRequest
-	(*MlxDeviceRegistryListRequest)(nil),                 // 1059: mlx_device.MlxDeviceRegistryListRequest
-	(*MlxDeviceRegistryShowRequest)(nil),                 // 1060: mlx_device.MlxDeviceRegistryShowRequest
-	(*MlxDeviceConfigQueryRequest)(nil),                  // 1061: mlx_device.MlxDeviceConfigQueryRequest
-	(*MlxDeviceConfigSetRequest)(nil),                    // 1062: mlx_device.MlxDeviceConfigSetRequest
-	(*MlxDeviceConfigSyncRequest)(nil),                   // 1063: mlx_device.MlxDeviceConfigSyncRequest
-	(*MlxDeviceConfigCompareRequest)(nil),                // 1064: mlx_device.MlxDeviceConfigCompareRequest
-	(*Domain)(nil),                                       // 1065: dns.Domain
-	(*MachineIdList)(nil),                                // 1066: common.MachineIdList
-	(*EndpointExplorationReport)(nil),                    // 1067: site_explorer.EndpointExplorationReport
-	(SystemPowerControl)(0),                              // 1068: common.SystemPowerControl
-	(*SitePrefixId)(nil),                                 // 1069: common.SitePrefixId
-	(*SerializableMlxConfigProfile)(nil),                 // 1070: mlx_device.SerializableMlxConfigProfile
-	(*FirmwareFlasherProfile)(nil),                       // 1071: mlx_device.FirmwareFlasherProfile
-	(*ScoutFirmwareUpgradeTask)(nil),                     // 1072: scout_firmware_upgrade.ScoutFirmwareUpgradeTask
-	(*CreateDomainRequest)(nil),                          // 1073: dns.CreateDomainRequest
-	(*UpdateDomainRequest)(nil),                          // 1074: dns.UpdateDomainRequest
-	(*DomainDeletionRequest)(nil),                        // 1075: dns.DomainDeletionRequest
-	(*DomainSearchQuery)(nil),                            // 1076: dns.DomainSearchQuery
-	(*DnsResourceRecordLookupRequest)(nil),               // 1077: dns.DnsResourceRecordLookupRequest
-	(*GetAllDomainsRequest)(nil),                         // 1078: dns.GetAllDomainsRequest
-	(*DomainMetadataRequest)(nil),                        // 1079: dns.DomainMetadataRequest
-	(*emptypb.Empty)(nil),                                // 1080: google.protobuf.Empty
-	(*ExploredEndpointSearchFilter)(nil),                 // 1081: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointsByIdsRequest)(nil),                // 1082: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredManagedHostSearchFilter)(nil),              // 1083: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostsByIdsRequest)(nil),             // 1084: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1085: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1086: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*CreateMeasurementBundleRequest)(nil),               // 1087: measured_boot.CreateMeasurementBundleRequest
-	(*DeleteMeasurementBundleRequest)(nil),               // 1088: measured_boot.DeleteMeasurementBundleRequest
-	(*RenameMeasurementBundleRequest)(nil),               // 1089: measured_boot.RenameMeasurementBundleRequest
-	(*UpdateMeasurementBundleRequest)(nil),               // 1090: measured_boot.UpdateMeasurementBundleRequest
-	(*ShowMeasurementBundleRequest)(nil),                 // 1091: measured_boot.ShowMeasurementBundleRequest
-	(*ShowMeasurementBundlesRequest)(nil),                // 1092: measured_boot.ShowMeasurementBundlesRequest
-	(*ListMeasurementBundlesRequest)(nil),                // 1093: measured_boot.ListMeasurementBundlesRequest
-	(*ListMeasurementBundleMachinesRequest)(nil),         // 1094: measured_boot.ListMeasurementBundleMachinesRequest
-	(*FindClosestBundleMatchRequest)(nil),                // 1095: measured_boot.FindClosestBundleMatchRequest
-	(*DeleteMeasurementJournalRequest)(nil),              // 1096: measured_boot.DeleteMeasurementJournalRequest
-	(*ShowMeasurementJournalRequest)(nil),                // 1097: measured_boot.ShowMeasurementJournalRequest
-	(*ShowMeasurementJournalsRequest)(nil),               // 1098: measured_boot.ShowMeasurementJournalsRequest
-	(*ListMeasurementJournalRequest)(nil),                // 1099: measured_boot.ListMeasurementJournalRequest
-	(*AttestCandidateMachineRequest)(nil),                // 1100: measured_boot.AttestCandidateMachineRequest
-	(*ShowCandidateMachineRequest)(nil),                  // 1101: measured_boot.ShowCandidateMachineRequest
-	(*ShowCandidateMachinesRequest)(nil),                 // 1102: measured_boot.ShowCandidateMachinesRequest
-	(*ListCandidateMachinesRequest)(nil),                 // 1103: measured_boot.ListCandidateMachinesRequest
-	(*CreateMeasurementSystemProfileRequest)(nil),        // 1104: measured_boot.CreateMeasurementSystemProfileRequest
-	(*DeleteMeasurementSystemProfileRequest)(nil),        // 1105: measured_boot.DeleteMeasurementSystemProfileRequest
-	(*RenameMeasurementSystemProfileRequest)(nil),        // 1106: measured_boot.RenameMeasurementSystemProfileRequest
-	(*ShowMeasurementSystemProfileRequest)(nil),          // 1107: measured_boot.ShowMeasurementSystemProfileRequest
-	(*ShowMeasurementSystemProfilesRequest)(nil),         // 1108: measured_boot.ShowMeasurementSystemProfilesRequest
-	(*ListMeasurementSystemProfilesRequest)(nil),         // 1109: measured_boot.ListMeasurementSystemProfilesRequest
-	(*ListMeasurementSystemProfileBundlesRequest)(nil),   // 1110: measured_boot.ListMeasurementSystemProfileBundlesRequest
-	(*ListMeasurementSystemProfileMachinesRequest)(nil),  // 1111: measured_boot.ListMeasurementSystemProfileMachinesRequest
-	(*CreateMeasurementReportRequest)(nil),               // 1112: measured_boot.CreateMeasurementReportRequest
-	(*DeleteMeasurementReportRequest)(nil),               // 1113: measured_boot.DeleteMeasurementReportRequest
-	(*PromoteMeasurementReportRequest)(nil),              // 1114: measured_boot.PromoteMeasurementReportRequest
-	(*RevokeMeasurementReportRequest)(nil),               // 1115: measured_boot.RevokeMeasurementReportRequest
-	(*ShowMeasurementReportForIdRequest)(nil),            // 1116: measured_boot.ShowMeasurementReportForIdRequest
-	(*ShowMeasurementReportsForMachineRequest)(nil),      // 1117: measured_boot.ShowMeasurementReportsForMachineRequest
-	(*ShowMeasurementReportsRequest)(nil),                // 1118: measured_boot.ShowMeasurementReportsRequest
-	(*ListMeasurementReportRequest)(nil),                 // 1119: measured_boot.ListMeasurementReportRequest
-	(*MatchMeasurementReportRequest)(nil),                // 1120: measured_boot.MatchMeasurementReportRequest
-	(*ImportSiteMeasurementsRequest)(nil),                // 1121: measured_boot.ImportSiteMeasurementsRequest
-	(*ExportSiteMeasurementsRequest)(nil),                // 1122: measured_boot.ExportSiteMeasurementsRequest
-	(*AddMeasurementTrustedMachineRequest)(nil),          // 1123: measured_boot.AddMeasurementTrustedMachineRequest
-	(*RemoveMeasurementTrustedMachineRequest)(nil),       // 1124: measured_boot.RemoveMeasurementTrustedMachineRequest
-	(*AddMeasurementTrustedProfileRequest)(nil),          // 1125: measured_boot.AddMeasurementTrustedProfileRequest
-	(*RemoveMeasurementTrustedProfileRequest)(nil),       // 1126: measured_boot.RemoveMeasurementTrustedProfileRequest
-	(*ListMeasurementTrustedMachinesRequest)(nil),        // 1127: measured_boot.ListMeasurementTrustedMachinesRequest
-	(*ListMeasurementTrustedProfilesRequest)(nil),        // 1128: measured_boot.ListMeasurementTrustedProfilesRequest
-	(*ListAttestationSummaryRequest)(nil),                // 1129: measured_boot.ListAttestationSummaryRequest
-	(*PublishMlxDeviceReportRequest)(nil),                // 1130: mlx_device.PublishMlxDeviceReportRequest
-	(*PublishMlxObservationReportRequest)(nil),           // 1131: mlx_device.PublishMlxObservationReportRequest
-	(*MlxAdminProfileSyncRequest)(nil),                   // 1132: mlx_device.MlxAdminProfileSyncRequest
-	(*MlxAdminProfileShowRequest)(nil),                   // 1133: mlx_device.MlxAdminProfileShowRequest
-	(*MlxAdminProfileCompareRequest)(nil),                // 1134: mlx_device.MlxAdminProfileCompareRequest
-	(*MlxAdminProfileListRequest)(nil),                   // 1135: mlx_device.MlxAdminProfileListRequest
-	(*MlxAdminLockdownLockRequest)(nil),                  // 1136: mlx_device.MlxAdminLockdownLockRequest
-	(*MlxAdminLockdownUnlockRequest)(nil),                // 1137: mlx_device.MlxAdminLockdownUnlockRequest
-	(*MlxAdminLockdownStatusRequest)(nil),                // 1138: mlx_device.MlxAdminLockdownStatusRequest
-	(*MlxAdminDeviceInfoRequest)(nil),                    // 1139: mlx_device.MlxAdminDeviceInfoRequest
-	(*MlxAdminDeviceReportRequest)(nil),                  // 1140: mlx_device.MlxAdminDeviceReportRequest
-	(*MlxAdminRegistryListRequest)(nil),                  // 1141: mlx_device.MlxAdminRegistryListRequest
-	(*MlxAdminRegistryShowRequest)(nil),                  // 1142: mlx_device.MlxAdminRegistryShowRequest
-	(*MlxAdminConfigQueryRequest)(nil),                   // 1143: mlx_device.MlxAdminConfigQueryRequest
-	(*MlxAdminConfigSetRequest)(nil),                     // 1144: mlx_device.MlxAdminConfigSetRequest
-	(*MlxAdminConfigSyncRequest)(nil),                    // 1145: mlx_device.MlxAdminConfigSyncRequest
-	(*MlxAdminConfigCompareRequest)(nil),                 // 1146: mlx_device.MlxAdminConfigCompareRequest
-	(*DomainDeletionResult)(nil),                         // 1147: dns.DomainDeletionResult
-	(*DomainList)(nil),                                   // 1148: dns.DomainList
-	(*DnsResourceRecordLookupResponse)(nil),              // 1149: dns.DnsResourceRecordLookupResponse
-	(*GetAllDomainsResponse)(nil),                        // 1150: dns.GetAllDomainsResponse
-	(*DomainMetadataResponse)(nil),                       // 1151: dns.DomainMetadataResponse
-	(*SiteExplorationReport)(nil),                        // 1152: site_explorer.SiteExplorationReport
-	(*SiteExplorerLastRunResponse)(nil),                  // 1153: site_explorer.SiteExplorerLastRunResponse
-	(*ExploredEndpoint)(nil),                             // 1154: site_explorer.ExploredEndpoint
-	(*ExploredEndpointIdList)(nil),                       // 1155: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointList)(nil),                         // 1156: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostIdList)(nil),                    // 1157: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostList)(nil),                      // 1158: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDeviceHostIdList)(nil),                  // 1159: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDeviceList)(nil),                        // 1160: site_explorer.ExploredMlxDeviceList
-	(*CreateMeasurementBundleResponse)(nil),              // 1161: measured_boot.CreateMeasurementBundleResponse
-	(*DeleteMeasurementBundleResponse)(nil),              // 1162: measured_boot.DeleteMeasurementBundleResponse
-	(*RenameMeasurementBundleResponse)(nil),              // 1163: measured_boot.RenameMeasurementBundleResponse
-	(*UpdateMeasurementBundleResponse)(nil),              // 1164: measured_boot.UpdateMeasurementBundleResponse
-	(*ShowMeasurementBundleResponse)(nil),                // 1165: measured_boot.ShowMeasurementBundleResponse
-	(*ShowMeasurementBundlesResponse)(nil),               // 1166: measured_boot.ShowMeasurementBundlesResponse
-	(*ListMeasurementBundlesResponse)(nil),               // 1167: measured_boot.ListMeasurementBundlesResponse
-	(*ListMeasurementBundleMachinesResponse)(nil),        // 1168: measured_boot.ListMeasurementBundleMachinesResponse
-	(*DeleteMeasurementJournalResponse)(nil),             // 1169: measured_boot.DeleteMeasurementJournalResponse
-	(*ShowMeasurementJournalResponse)(nil),               // 1170: measured_boot.ShowMeasurementJournalResponse
-	(*ShowMeasurementJournalsResponse)(nil),              // 1171: measured_boot.ShowMeasurementJournalsResponse
-	(*ListMeasurementJournalResponse)(nil),               // 1172: measured_boot.ListMeasurementJournalResponse
-	(*AttestCandidateMachineResponse)(nil),               // 1173: measured_boot.AttestCandidateMachineResponse
-	(*ShowCandidateMachineResponse)(nil),                 // 1174: measured_boot.ShowCandidateMachineResponse
-	(*ShowCandidateMachinesResponse)(nil),                // 1175: measured_boot.ShowCandidateMachinesResponse
-	(*ListCandidateMachinesResponse)(nil),                // 1176: measured_boot.ListCandidateMachinesResponse
-	(*CreateMeasurementSystemProfileResponse)(nil),       // 1177: measured_boot.CreateMeasurementSystemProfileResponse
-	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1178: measured_boot.DeleteMeasurementSystemProfileResponse
-	(*RenameMeasurementSystemProfileResponse)(nil),       // 1179: measured_boot.RenameMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfileResponse)(nil),         // 1180: measured_boot.ShowMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1181: measured_boot.ShowMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfilesResponse)(nil),        // 1182: measured_boot.ListMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1183: measured_boot.ListMeasurementSystemProfileBundlesResponse
-	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1184: measured_boot.ListMeasurementSystemProfileMachinesResponse
-	(*CreateMeasurementReportResponse)(nil),              // 1185: measured_boot.CreateMeasurementReportResponse
-	(*DeleteMeasurementReportResponse)(nil),              // 1186: measured_boot.DeleteMeasurementReportResponse
-	(*PromoteMeasurementReportResponse)(nil),             // 1187: measured_boot.PromoteMeasurementReportResponse
-	(*RevokeMeasurementReportResponse)(nil),              // 1188: measured_boot.RevokeMeasurementReportResponse
-	(*ShowMeasurementReportForIdResponse)(nil),           // 1189: measured_boot.ShowMeasurementReportForIdResponse
-	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1190: measured_boot.ShowMeasurementReportsForMachineResponse
-	(*ShowMeasurementReportsResponse)(nil),               // 1191: measured_boot.ShowMeasurementReportsResponse
-	(*ListMeasurementReportResponse)(nil),                // 1192: measured_boot.ListMeasurementReportResponse
-	(*MatchMeasurementReportResponse)(nil),               // 1193: measured_boot.MatchMeasurementReportResponse
-	(*ImportSiteMeasurementsResponse)(nil),               // 1194: measured_boot.ImportSiteMeasurementsResponse
-	(*ExportSiteMeasurementsResponse)(nil),               // 1195: measured_boot.ExportSiteMeasurementsResponse
-	(*AddMeasurementTrustedMachineResponse)(nil),         // 1196: measured_boot.AddMeasurementTrustedMachineResponse
-	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1197: measured_boot.RemoveMeasurementTrustedMachineResponse
-	(*AddMeasurementTrustedProfileResponse)(nil),         // 1198: measured_boot.AddMeasurementTrustedProfileResponse
-	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1199: measured_boot.RemoveMeasurementTrustedProfileResponse
-	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1200: measured_boot.ListMeasurementTrustedMachinesResponse
-	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1201: measured_boot.ListMeasurementTrustedProfilesResponse
-	(*ListAttestationSummaryResponse)(nil),               // 1202: measured_boot.ListAttestationSummaryResponse
-	(*LockdownStatus)(nil),                               // 1203: site_explorer.LockdownStatus
-	(*PublishMlxDeviceReportResponse)(nil),               // 1204: mlx_device.PublishMlxDeviceReportResponse
-	(*PublishMlxObservationReportResponse)(nil),          // 1205: mlx_device.PublishMlxObservationReportResponse
-	(*MlxAdminProfileSyncResponse)(nil),                  // 1206: mlx_device.MlxAdminProfileSyncResponse
-	(*MlxAdminProfileShowResponse)(nil),                  // 1207: mlx_device.MlxAdminProfileShowResponse
-	(*MlxAdminProfileCompareResponse)(nil),               // 1208: mlx_device.MlxAdminProfileCompareResponse
-	(*MlxAdminProfileListResponse)(nil),                  // 1209: mlx_device.MlxAdminProfileListResponse
-	(*MlxAdminLockdownLockResponse)(nil),                 // 1210: mlx_device.MlxAdminLockdownLockResponse
-	(*MlxAdminLockdownUnlockResponse)(nil),               // 1211: mlx_device.MlxAdminLockdownUnlockResponse
-	(*MlxAdminLockdownStatusResponse)(nil),               // 1212: mlx_device.MlxAdminLockdownStatusResponse
-	(*MlxAdminDeviceInfoResponse)(nil),                   // 1213: mlx_device.MlxAdminDeviceInfoResponse
-	(*MlxAdminDeviceReportResponse)(nil),                 // 1214: mlx_device.MlxAdminDeviceReportResponse
-	(*MlxAdminRegistryListResponse)(nil),                 // 1215: mlx_device.MlxAdminRegistryListResponse
-	(*MlxAdminRegistryShowResponse)(nil),                 // 1216: mlx_device.MlxAdminRegistryShowResponse
-	(*MlxAdminConfigQueryResponse)(nil),                  // 1217: mlx_device.MlxAdminConfigQueryResponse
-	(*MlxAdminConfigSetResponse)(nil),                    // 1218: mlx_device.MlxAdminConfigSetResponse
-	(*MlxAdminConfigSyncResponse)(nil),                   // 1219: mlx_device.MlxAdminConfigSyncResponse
-	(*MlxAdminConfigCompareResponse)(nil),                // 1220: mlx_device.MlxAdminConfigCompareResponse
+	(JwksKind)(0),                                                  // 2: forge.JwksKind
+	(MachineIngestionState)(0),                                     // 3: forge.MachineIngestionState
+	(CredentialType)(0),                                            // 4: forge.CredentialType
+	(RotationCredentialType)(0),                                    // 5: forge.RotationCredentialType
+	(VpcVirtualizationType)(0),                                     // 6: forge.VpcVirtualizationType
+	(PrefixMatchType)(0),                                           // 7: forge.PrefixMatchType
+	(TenantState)(0),                                               // 8: forge.TenantState
+	(PowerShelfMaintenanceOperation)(0),                            // 9: forge.PowerShelfMaintenanceOperation
+	(DeletedFilter)(0),                                             // 10: forge.DeletedFilter
+	(FabricManagerState)(0),                                        // 11: forge.FabricManagerState
+	(NetworkSegmentType)(0),                                        // 12: forge.NetworkSegmentType
+	(NetworkSegmentFlag)(0),                                        // 13: forge.NetworkSegmentFlag
+	(IpxeTemplateArtifactCacheStrategy)(0),                         // 14: forge.IpxeTemplateArtifactCacheStrategy
+	(IpxeTemplateVisibility)(0),                                    // 15: forge.IpxeTemplateVisibility
+	(SpxAttachmentType)(0),                                         // 16: forge.SpxAttachmentType
+	(InstanceInterfaceIpFamilyMode)(0),                             // 17: forge.InstanceInterfaceIpFamilyMode
+	(IssueCategory)(0),                                             // 18: forge.IssueCategory
+	(AssignStaticAddressStatus)(0),                                 // 19: forge.AssignStaticAddressStatus
+	(RemoveStaticAddressStatus)(0),                                 // 20: forge.RemoveStaticAddressStatus
+	(MachineType)(0),                                               // 21: forge.MachineType
+	(InstanceNetworkSegmentMembershipType)(0),                      // 22: forge.InstanceNetworkSegmentMembershipType
+	(ControllerStateOutcome)(0),                                    // 23: forge.ControllerStateOutcome
+	(SyncState)(0),                                                 // 24: forge.SyncState
+	(MachineArchitecture)(0),                                       // 25: forge.MachineArchitecture
+	(InterfaceAssociationType)(0),                                  // 26: forge.InterfaceAssociationType
+	(InterfaceType)(0),                                             // 27: forge.InterfaceType
+	(AddressFamily)(0),                                             // 28: forge.AddressFamily
+	(MessageKind)(0),                                               // 29: forge.MessageKind
+	(ExpireDhcpLeaseStatus)(0),                                     // 30: forge.ExpireDhcpLeaseStatus
+	(UserRoles)(0),                                                 // 31: forge.UserRoles
+	(MachineHardwareInfoUpdateType)(0),                             // 32: forge.MachineHardwareInfoUpdateType
+	(ManagedHostQuarantineMode)(0),                                 // 33: forge.ManagedHostQuarantineMode
+	(VpcIsolationBehaviorType)(0),                                  // 34: forge.VpcIsolationBehaviorType
+	(AgentUpgradePolicy)(0),                                        // 35: forge.AgentUpgradePolicy
+	(LockdownAction)(0),                                            // 36: forge.LockdownAction
+	(BMCRequestType)(0),                                            // 37: forge.BMCRequestType
+	(MachineDiscoveryReporter)(0),                                  // 38: forge.MachineDiscoveryReporter
+	(BootstrapCaSource)(0),                                         // 39: forge.BootstrapCaSource
+	(InterfaceFunctionType)(0),                                     // 40: forge.InterfaceFunctionType
+	(HealthReportApplyMode)(0),                                     // 41: forge.HealthReportApplyMode
+	(ResourcePoolType)(0),                                          // 42: forge.ResourcePoolType
+	(MaintenanceOperation)(0),                                      // 43: forge.MaintenanceOperation
+	(ConfigSetting)(0),                                             // 44: forge.ConfigSetting
+	(UuidType)(0),                                                  // 45: forge.UuidType
+	(MacOwner)(0),                                                  // 46: forge.MacOwner
+	(UpdateInitiator)(0),                                           // 47: forge.UpdateInitiator
+	(IpType)(0),                                                    // 48: forge.IpType
+	(RouteServerSourceType)(0),                                     // 49: forge.RouteServerSourceType
+	(OsImageStatus)(0),                                             // 50: forge.OsImageStatus
+	(DpuMode)(0),                                                   // 51: forge.DpuMode
+	(BmcIpAllocationType)(0),                                       // 52: forge.BmcIpAllocationType
+	(MachineValidationStarted)(0),                                  // 53: forge.MachineValidationStarted
+	(MachineValidationInProgress)(0),                               // 54: forge.MachineValidationInProgress
+	(MachineValidationCompleted)(0),                                // 55: forge.MachineValidationCompleted
+	(MachineCapabilityDeviceType)(0),                               // 56: forge.MachineCapabilityDeviceType
+	(MachineCapabilityType)(0),                                     // 57: forge.MachineCapabilityType
+	(NetworkSecurityGroupSource)(0),                                // 58: forge.NetworkSecurityGroupSource
+	(NetworkSecurityGroupPropagationStatus)(0),                     // 59: forge.NetworkSecurityGroupPropagationStatus
+	(NetworkSecurityGroupRuleDirection)(0),                         // 60: forge.NetworkSecurityGroupRuleDirection
+	(NetworkSecurityGroupRuleProtocol)(0),                          // 61: forge.NetworkSecurityGroupRuleProtocol
+	(NetworkSecurityGroupRuleAction)(0),                            // 62: forge.NetworkSecurityGroupRuleAction
+	(DpaInterfaceType)(0),                                          // 63: forge.DpaInterfaceType
+	(PowerState)(0),                                                // 64: forge.PowerState
+	(RackHardwareTopology)(0),                                      // 65: forge.RackHardwareTopology
+	(RackProductFamily)(0),                                         // 66: forge.RackProductFamily
+	(RackHardwareClass)(0),                                         // 67: forge.RackHardwareClass
+	(RackManagerForgeCmd)(0),                                       // 68: forge.RackManagerForgeCmd
+	(AstraPhase)(0),                                                // 69: forge.AstraPhase
+	(NmxcBrowseOperation)(0),                                       // 70: forge.NmxcBrowseOperation
+	(HostFirmwareComponentType)(0),                                 // 71: forge.HostFirmwareComponentType
+	(TrimTableTarget)(0),                                           // 72: forge.TrimTableTarget
+	(DpuExtensionServiceType)(0),                                   // 73: forge.DpuExtensionServiceType
+	(DpuExtensionServiceDeploymentStatus)(0),                       // 74: forge.DpuExtensionServiceDeploymentStatus
+	(ScoutStreamErrorStatus)(0),                                    // 75: forge.ScoutStreamErrorStatus
+	(ComponentManagerStatusCode)(0),                                // 76: forge.ComponentManagerStatusCode
+	(FirmwareUpdateState)(0),                                       // 77: forge.FirmwareUpdateState
+	(NvSwitchComponent)(0),                                         // 78: forge.NvSwitchComponent
+	(PowerShelfComponent)(0),                                       // 79: forge.PowerShelfComponent
+	(ComputeTrayComponent)(0),                                      // 80: forge.ComputeTrayComponent
+	(OperatingSystemType)(0),                                       // 81: forge.OperatingSystemType
+	(ExpectedInterfaceRole)(0),                                     // 82: forge.ExpectedInterfaceRole
+	(ExpectedInterfaceIpAllocation)(0),                             // 83: forge.ExpectedInterfaceIpAllocation
+	(SitePrefixAuthority)(0),                                       // 84: forge.SitePrefixAuthority
+	(SitePrefixRoutingScope)(0),                                    // 85: forge.SitePrefixRoutingScope
+	(SitePrefixLifecycleState)(0),                                  // 86: forge.SitePrefixLifecycleState
+	(InstancePowerRequest_Operation)(0),                            // 87: forge.InstancePowerRequest.Operation
+	(InstanceUpdateStatus_Module)(0),                               // 88: forge.InstanceUpdateStatus.Module
+	(MachineCredentialsUpdateRequest_CredentialPurpose)(0),         // 89: forge.MachineCredentialsUpdateRequest.CredentialPurpose
+	(ForgeAgentControlResponse_LegacyAction)(0),                    // 90: forge.ForgeAgentControlResponse.LegacyAction
+	(MachineCleanupInfo_CleanupResult)(0),                          // 91: forge.MachineCleanupInfo.CleanupResult
+	(DpuReprovisioningRequest_Mode)(0),                             // 92: forge.DpuReprovisioningRequest.Mode
+	(HostReprovisioningRequest_Mode)(0),                            // 93: forge.HostReprovisioningRequest.Mode
+	(MachineSetAutoUpdateRequest_SetAutoupdateAction)(0),           // 94: forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
+	(MachineValidationOnDemandRequest_Action)(0),                   // 95: forge.MachineValidationOnDemandRequest.Action
+	(AdminPowerControlRequest_SystemPowerControl)(0),               // 96: forge.AdminPowerControlRequest.SystemPowerControl
+	(GetRedfishJobStateResponse_RedfishJobState)(0),                // 97: forge.GetRedfishJobStateResponse.RedfishJobState
+	(*LifecycleStatus)(nil),                                        // 98: forge.LifecycleStatus
+	(*SpdmMachineAttestationStatus)(nil),                           // 99: forge.SpdmMachineAttestationStatus
+	(*SpdmMachineAttestationTriggerResponse)(nil),                  // 100: forge.SpdmMachineAttestationTriggerResponse
+	(*SpdmAttestationDetails)(nil),                                 // 101: forge.SpdmAttestationDetails
+	(*SpdmGetAttestationMachineResponse)(nil),                      // 102: forge.SpdmGetAttestationMachineResponse
+	(*SpdmMachineAttestationTriggerRequest)(nil),                   // 103: forge.SpdmMachineAttestationTriggerRequest
+	(*SpdmListAttestationMachinesRequest)(nil),                     // 104: forge.SpdmListAttestationMachinesRequest
+	(*SpdmListAttestationMachinesResponse)(nil),                    // 105: forge.SpdmListAttestationMachinesResponse
+	(*MachineIdentityRequest)(nil),                                 // 106: forge.MachineIdentityRequest
+	(*MachineIdentityResponse)(nil),                                // 107: forge.MachineIdentityResponse
+	(*GetTenantIdentityConfigRequest)(nil),                         // 108: forge.GetTenantIdentityConfigRequest
+	(*TenantIdentitySigningKey)(nil),                               // 109: forge.TenantIdentitySigningKey
+	(*TenantIdentityConfig)(nil),                                   // 110: forge.TenantIdentityConfig
+	(*SetTenantIdentityConfigRequest)(nil),                         // 111: forge.SetTenantIdentityConfigRequest
+	(*TenantIdentityConfigResponse)(nil),                           // 112: forge.TenantIdentityConfigResponse
+	(*ClientSecretBasic)(nil),                                      // 113: forge.ClientSecretBasic
+	(*ClientSecretBasicResponse)(nil),                              // 114: forge.ClientSecretBasicResponse
+	(*TokenDelegationResponse)(nil),                                // 115: forge.TokenDelegationResponse
+	(*GetTokenDelegationRequest)(nil),                              // 116: forge.GetTokenDelegationRequest
+	(*TokenDelegation)(nil),                                        // 117: forge.TokenDelegation
+	(*TokenDelegationRequest)(nil),                                 // 118: forge.TokenDelegationRequest
+	(*ReencryptTenantIdentitySecretsRequest)(nil),                  // 119: forge.ReencryptTenantIdentitySecretsRequest
+	(*ReencryptTenantIdentityFailure)(nil),                         // 120: forge.ReencryptTenantIdentityFailure
+	(*ReencryptTenantIdentitySecretsResponse)(nil),                 // 121: forge.ReencryptTenantIdentitySecretsResponse
+	(*Jwks)(nil),                                                   // 122: forge.Jwks
+	(*OpenIdConfiguration)(nil),                                    // 123: forge.OpenIdConfiguration
+	(*JwksRequest)(nil),                                            // 124: forge.JwksRequest
+	(*OpenIdConfigRequest)(nil),                                    // 125: forge.OpenIdConfigRequest
+	(*MachineIngestionStateResponse)(nil),                          // 126: forge.MachineIngestionStateResponse
+	(*TpmCaAddedCaStatus)(nil),                                     // 127: forge.TpmCaAddedCaStatus
+	(*TpmCaCertId)(nil),                                            // 128: forge.TpmCaCertId
+	(*TpmEkCertStatus)(nil),                                        // 129: forge.TpmEkCertStatus
+	(*TpmEkCertStatusCollection)(nil),                              // 130: forge.TpmEkCertStatusCollection
+	(*TpmCaCert)(nil),                                              // 131: forge.TpmCaCert
+	(*TpmCaCertDetail)(nil),                                        // 132: forge.TpmCaCertDetail
+	(*TpmCaCertDetailCollection)(nil),                              // 133: forge.TpmCaCertDetailCollection
+	(*AttestKeyBindChallenge)(nil),                                 // 134: forge.AttestKeyBindChallenge
+	(*AttestQuoteRequest)(nil),                                     // 135: forge.AttestQuoteRequest
+	(*AttestQuoteResponse)(nil),                                    // 136: forge.AttestQuoteResponse
+	(*CredentialCreationRequest)(nil),                              // 137: forge.CredentialCreationRequest
+	(*CredentialDeletionRequest)(nil),                              // 138: forge.CredentialDeletionRequest
+	(*CredentialCreationResult)(nil),                               // 139: forge.CredentialCreationResult
+	(*CredentialDeletionResult)(nil),                               // 140: forge.CredentialDeletionResult
+	(*RotateCredentialRequest)(nil),                                // 141: forge.RotateCredentialRequest
+	(*RotateCredentialResult)(nil),                                 // 142: forge.RotateCredentialResult
+	(*CredentialRotationStatusRequest)(nil),                        // 143: forge.CredentialRotationStatusRequest
+	(*DeviceCredentialRotationStatus)(nil),                         // 144: forge.DeviceCredentialRotationStatus
+	(*CredentialRotationStatusResult)(nil),                         // 145: forge.CredentialRotationStatusResult
+	(*VersionRequest)(nil),                                         // 146: forge.VersionRequest
+	(*BuildInfo)(nil),                                              // 147: forge.BuildInfo
+	(*RuntimeConfig)(nil),                                          // 148: forge.RuntimeConfig
+	(*EchoRequest)(nil),                                            // 149: forge.EchoRequest
+	(*EchoResponse)(nil),                                           // 150: forge.EchoResponse
+	(*DNSMessage)(nil),                                             // 151: forge.DNSMessage
+	(*DnsRequest)(nil),                                             // 152: forge.DnsRequest
+	(*DnsReply)(nil),                                               // 153: forge.DnsReply
+	(*ConsoleInput)(nil),                                           // 154: forge.ConsoleInput
+	(*ConsoleOutput)(nil),                                          // 155: forge.ConsoleOutput
+	(*InstanceEvent)(nil),                                          // 156: forge.InstanceEvent
+	(*VpcSearchQuery)(nil),                                         // 157: forge.VpcSearchQuery
+	(*VpcSearchFilter)(nil),                                        // 158: forge.VpcSearchFilter
+	(*VpcIdList)(nil),                                              // 159: forge.VpcIdList
+	(*VpcsByIdsRequest)(nil),                                       // 160: forge.VpcsByIdsRequest
+	(*TenantSearchQuery)(nil),                                      // 161: forge.TenantSearchQuery
+	(*VpcConfig)(nil),                                              // 162: forge.VpcConfig
+	(*VpcStatus)(nil),                                              // 163: forge.VpcStatus
+	(*Vpc)(nil),                                                    // 164: forge.Vpc
+	(*VpcCreationRequest)(nil),                                     // 165: forge.VpcCreationRequest
+	(*VpcUpdateRequest)(nil),                                       // 166: forge.VpcUpdateRequest
+	(*VpcUpdateResult)(nil),                                        // 167: forge.VpcUpdateResult
+	(*VpcUpdateVirtualizationRequest)(nil),                         // 168: forge.VpcUpdateVirtualizationRequest
+	(*VpcUpdateVirtualizationResult)(nil),                          // 169: forge.VpcUpdateVirtualizationResult
+	(*VpcDeletionRequest)(nil),                                     // 170: forge.VpcDeletionRequest
+	(*VpcDeletionResult)(nil),                                      // 171: forge.VpcDeletionResult
+	(*VpcList)(nil),                                                // 172: forge.VpcList
+	(*VpcPrefix)(nil),                                              // 173: forge.VpcPrefix
+	(*VpcPrefixConfig)(nil),                                        // 174: forge.VpcPrefixConfig
+	(*VpcPrefixStatus)(nil),                                        // 175: forge.VpcPrefixStatus
+	(*VpcPrefixCreationRequest)(nil),                               // 176: forge.VpcPrefixCreationRequest
+	(*VpcPrefixSearchQuery)(nil),                                   // 177: forge.VpcPrefixSearchQuery
+	(*VpcPrefixGetRequest)(nil),                                    // 178: forge.VpcPrefixGetRequest
+	(*VpcPrefixIdList)(nil),                                        // 179: forge.VpcPrefixIdList
+	(*VpcPrefixList)(nil),                                          // 180: forge.VpcPrefixList
+	(*VpcPrefixUpdateRequest)(nil),                                 // 181: forge.VpcPrefixUpdateRequest
+	(*VpcPrefixDeletionRequest)(nil),                               // 182: forge.VpcPrefixDeletionRequest
+	(*VpcPrefixDeletionResult)(nil),                                // 183: forge.VpcPrefixDeletionResult
+	(*VpcPrefixStateHistoriesRequest)(nil),                         // 184: forge.VpcPrefixStateHistoriesRequest
+	(*VpcPeering)(nil),                                             // 185: forge.VpcPeering
+	(*VpcPeeringIdList)(nil),                                       // 186: forge.VpcPeeringIdList
+	(*VpcPeeringList)(nil),                                         // 187: forge.VpcPeeringList
+	(*VpcPeeringCreationRequest)(nil),                              // 188: forge.VpcPeeringCreationRequest
+	(*VpcPeeringSearchFilter)(nil),                                 // 189: forge.VpcPeeringSearchFilter
+	(*VpcPeeringsByIdsRequest)(nil),                                // 190: forge.VpcPeeringsByIdsRequest
+	(*VpcPeeringDeletionRequest)(nil),                              // 191: forge.VpcPeeringDeletionRequest
+	(*VpcPeeringDeletionResult)(nil),                               // 192: forge.VpcPeeringDeletionResult
+	(*IBPartitionConfig)(nil),                                      // 193: forge.IBPartitionConfig
+	(*IBPartitionStatus)(nil),                                      // 194: forge.IBPartitionStatus
+	(*IBPartition)(nil),                                            // 195: forge.IBPartition
+	(*IBPartitionList)(nil),                                        // 196: forge.IBPartitionList
+	(*IBPartitionCreationRequest)(nil),                             // 197: forge.IBPartitionCreationRequest
+	(*IBPartitionUpdateRequest)(nil),                               // 198: forge.IBPartitionUpdateRequest
+	(*IBPartitionDeletionRequest)(nil),                             // 199: forge.IBPartitionDeletionRequest
+	(*IBPartitionDeletionResult)(nil),                              // 200: forge.IBPartitionDeletionResult
+	(*IBPartitionSearchFilter)(nil),                                // 201: forge.IBPartitionSearchFilter
+	(*IBPartitionsByIdsRequest)(nil),                               // 202: forge.IBPartitionsByIdsRequest
+	(*IBPartitionIdList)(nil),                                      // 203: forge.IBPartitionIdList
+	(*PowerShelfConfig)(nil),                                       // 204: forge.PowerShelfConfig
+	(*PowerShelfStatus)(nil),                                       // 205: forge.PowerShelfStatus
+	(*PowerShelf)(nil),                                             // 206: forge.PowerShelf
+	(*PowerShelfList)(nil),                                         // 207: forge.PowerShelfList
+	(*PowerShelfCreationRequest)(nil),                              // 208: forge.PowerShelfCreationRequest
+	(*PowerShelfDeletionRequest)(nil),                              // 209: forge.PowerShelfDeletionRequest
+	(*PowerShelfDeletionResult)(nil),                               // 210: forge.PowerShelfDeletionResult
+	(*PowerShelfMaintenanceRequest)(nil),                           // 211: forge.PowerShelfMaintenanceRequest
+	(*PowerShelfStateHistoriesRequest)(nil),                        // 212: forge.PowerShelfStateHistoriesRequest
+	(*PowerShelfQuery)(nil),                                        // 213: forge.PowerShelfQuery
+	(*PowerShelfSearchFilter)(nil),                                 // 214: forge.PowerShelfSearchFilter
+	(*PowerShelvesByIdsRequest)(nil),                               // 215: forge.PowerShelvesByIdsRequest
+	(*ExpectedPowerShelf)(nil),                                     // 216: forge.ExpectedPowerShelf
+	(*ExpectedPowerShelfRequest)(nil),                              // 217: forge.ExpectedPowerShelfRequest
+	(*ExpectedPowerShelfList)(nil),                                 // 218: forge.ExpectedPowerShelfList
+	(*LinkedExpectedPowerShelfList)(nil),                           // 219: forge.LinkedExpectedPowerShelfList
+	(*LinkedExpectedPowerShelf)(nil),                               // 220: forge.LinkedExpectedPowerShelf
+	(*SwitchConfig)(nil),                                           // 221: forge.SwitchConfig
+	(*FabricManagerConfig)(nil),                                    // 222: forge.FabricManagerConfig
+	(*FabricManagerStatus)(nil),                                    // 223: forge.FabricManagerStatus
+	(*SwitchStatus)(nil),                                           // 224: forge.SwitchStatus
+	(*PlacementInRack)(nil),                                        // 225: forge.PlacementInRack
+	(*Switch)(nil),                                                 // 226: forge.Switch
+	(*SwitchList)(nil),                                             // 227: forge.SwitchList
+	(*SwitchCreationRequest)(nil),                                  // 228: forge.SwitchCreationRequest
+	(*SwitchDeletionRequest)(nil),                                  // 229: forge.SwitchDeletionRequest
+	(*SwitchDeletionResult)(nil),                                   // 230: forge.SwitchDeletionResult
+	(*StateHistoryRecord)(nil),                                     // 231: forge.StateHistoryRecord
+	(*StateHistoryRecords)(nil),                                    // 232: forge.StateHistoryRecords
+	(*SwitchStateHistoriesRequest)(nil),                            // 233: forge.SwitchStateHistoriesRequest
+	(*StateHistories)(nil),                                         // 234: forge.StateHistories
+	(*SwitchQuery)(nil),                                            // 235: forge.SwitchQuery
+	(*SwitchSearchFilter)(nil),                                     // 236: forge.SwitchSearchFilter
+	(*SwitchesByIdsRequest)(nil),                                   // 237: forge.SwitchesByIdsRequest
+	(*ExpectedSwitch)(nil),                                         // 238: forge.ExpectedSwitch
+	(*ExpectedSwitchRequest)(nil),                                  // 239: forge.ExpectedSwitchRequest
+	(*ExpectedSwitchList)(nil),                                     // 240: forge.ExpectedSwitchList
+	(*LinkedExpectedSwitchList)(nil),                               // 241: forge.LinkedExpectedSwitchList
+	(*LinkedExpectedSwitch)(nil),                                   // 242: forge.LinkedExpectedSwitch
+	(*ExpectedRack)(nil),                                           // 243: forge.ExpectedRack
+	(*ExpectedRackRequest)(nil),                                    // 244: forge.ExpectedRackRequest
+	(*ExpectedRackList)(nil),                                       // 245: forge.ExpectedRackList
+	(*IBFabricSearchFilter)(nil),                                   // 246: forge.IBFabricSearchFilter
+	(*IBFabricIdList)(nil),                                         // 247: forge.IBFabricIdList
+	(*NetworkSegmentStateHistory)(nil),                             // 248: forge.NetworkSegmentStateHistory
+	(*NetworkSegmentConfig)(nil),                                   // 249: forge.NetworkSegmentConfig
+	(*NetworkSegmentStatus)(nil),                                   // 250: forge.NetworkSegmentStatus
+	(*NetworkSegment)(nil),                                         // 251: forge.NetworkSegment
+	(*NetworkSegmentCreationRequest)(nil),                          // 252: forge.NetworkSegmentCreationRequest
+	(*NetworkSegmentDeletionRequest)(nil),                          // 253: forge.NetworkSegmentDeletionRequest
+	(*AttachNetworkSegmentToVpcRequest)(nil),                       // 254: forge.AttachNetworkSegmentToVpcRequest
+	(*NetworkSegmentDeletionResult)(nil),                           // 255: forge.NetworkSegmentDeletionResult
+	(*NetworkSegmentStateHistoriesRequest)(nil),                    // 256: forge.NetworkSegmentStateHistoriesRequest
+	(*NetworkSegmentSearchConfig)(nil),                             // 257: forge.NetworkSegmentSearchConfig
+	(*NetworkSegmentSearchFilter)(nil),                             // 258: forge.NetworkSegmentSearchFilter
+	(*NetworkSegmentIdList)(nil),                                   // 259: forge.NetworkSegmentIdList
+	(*NetworkSegmentsByIdsRequest)(nil),                            // 260: forge.NetworkSegmentsByIdsRequest
+	(*NetworkPrefix)(nil),                                          // 261: forge.NetworkPrefix
+	(*MachineState)(nil),                                           // 262: forge.MachineState
+	(*InstancePowerRequest)(nil),                                   // 263: forge.InstancePowerRequest
+	(*InstancePowerResult)(nil),                                    // 264: forge.InstancePowerResult
+	(*InstanceList)(nil),                                           // 265: forge.InstanceList
+	(*Label)(nil),                                                  // 266: forge.Label
+	(*Metadata)(nil),                                               // 267: forge.Metadata
+	(*InstanceSearchFilter)(nil),                                   // 268: forge.InstanceSearchFilter
+	(*InstanceIdList)(nil),                                         // 269: forge.InstanceIdList
+	(*InstancesByIdsRequest)(nil),                                  // 270: forge.InstancesByIdsRequest
+	(*InstanceAllocationRequest)(nil),                              // 271: forge.InstanceAllocationRequest
+	(*BatchInstanceAllocationRequest)(nil),                         // 272: forge.BatchInstanceAllocationRequest
+	(*BatchInstanceAllocationResponse)(nil),                        // 273: forge.BatchInstanceAllocationResponse
+	(*IpxeTemplateParameter)(nil),                                  // 274: forge.IpxeTemplateParameter
+	(*IpxeTemplateArtifact)(nil),                                   // 275: forge.IpxeTemplateArtifact
+	(*IpxeTemplate)(nil),                                           // 276: forge.IpxeTemplate
+	(*TenantConfig)(nil),                                           // 277: forge.TenantConfig
+	(*InstanceOperatingSystemConfig)(nil),                          // 278: forge.InstanceOperatingSystemConfig
+	(*InlineIpxe)(nil),                                             // 279: forge.InlineIpxe
+	(*InstanceConfig)(nil),                                         // 280: forge.InstanceConfig
+	(*InstanceNetworkConfig)(nil),                                  // 281: forge.InstanceNetworkConfig
+	(*InstanceNetworkAutoConfig)(nil),                              // 282: forge.InstanceNetworkAutoConfig
+	(*InstanceInfinibandConfig)(nil),                               // 283: forge.InstanceInfinibandConfig
+	(*InstanceDpuExtensionServiceConfig)(nil),                      // 284: forge.InstanceDpuExtensionServiceConfig
+	(*InstanceDpuExtensionServicesConfig)(nil),                     // 285: forge.InstanceDpuExtensionServicesConfig
+	(*InstanceNVLinkConfig)(nil),                                   // 286: forge.InstanceNVLinkConfig
+	(*InstanceSpxConfig)(nil),                                      // 287: forge.InstanceSpxConfig
+	(*InstanceSpxAttachment)(nil),                                  // 288: forge.InstanceSpxAttachment
+	(*InstanceOperatingSystemUpdateRequest)(nil),                   // 289: forge.InstanceOperatingSystemUpdateRequest
+	(*InstanceConfigUpdateRequest)(nil),                            // 290: forge.InstanceConfigUpdateRequest
+	(*InstanceStatus)(nil),                                         // 291: forge.InstanceStatus
+	(*InstanceSpxStatus)(nil),                                      // 292: forge.InstanceSpxStatus
+	(*InstanceSpxAttachmentStatus)(nil),                            // 293: forge.InstanceSpxAttachmentStatus
+	(*InstanceNetworkStatus)(nil),                                  // 294: forge.InstanceNetworkStatus
+	(*InstanceInfinibandStatus)(nil),                               // 295: forge.InstanceInfinibandStatus
+	(*DpuExtensionServiceStatus)(nil),                              // 296: forge.DpuExtensionServiceStatus
+	(*InstanceDpuExtensionServiceStatus)(nil),                      // 297: forge.InstanceDpuExtensionServiceStatus
+	(*InstanceDpuExtensionServicesStatus)(nil),                     // 298: forge.InstanceDpuExtensionServicesStatus
+	(*InstanceNVLinkStatus)(nil),                                   // 299: forge.InstanceNVLinkStatus
+	(*Instance)(nil),                                               // 300: forge.Instance
+	(*InstanceUpdateStatus)(nil),                                   // 301: forge.InstanceUpdateStatus
+	(*InstanceInterfaceConfig)(nil),                                // 302: forge.InstanceInterfaceConfig
+	(*InstanceInterfaceVpcSelection)(nil),                          // 303: forge.InstanceInterfaceVpcSelection
+	(*InstanceInterfaceIpv6Config)(nil),                            // 304: forge.InstanceInterfaceIpv6Config
+	(*InstanceInterfaceRoutingProfile)(nil),                        // 305: forge.InstanceInterfaceRoutingProfile
+	(*InstanceIBInterfaceConfig)(nil),                              // 306: forge.InstanceIBInterfaceConfig
+	(*InstanceInterfaceResolvedVpcPrefixes)(nil),                   // 307: forge.InstanceInterfaceResolvedVpcPrefixes
+	(*InstanceInterfaceStatus)(nil),                                // 308: forge.InstanceInterfaceStatus
+	(*InstanceIBInterfaceStatus)(nil),                              // 309: forge.InstanceIBInterfaceStatus
+	(*InstanceNVLinkGpuStatus)(nil),                                // 310: forge.InstanceNVLinkGpuStatus
+	(*InstanceNVLinkGpuConfig)(nil),                                // 311: forge.InstanceNVLinkGpuConfig
+	(*InstancePhoneHomeLastContactRequest)(nil),                    // 312: forge.InstancePhoneHomeLastContactRequest
+	(*InstancePhoneHomeLastContactResponse)(nil),                   // 313: forge.InstancePhoneHomeLastContactResponse
+	(*Issue)(nil),                                                  // 314: forge.Issue
+	(*DeleteInitiatedBy)(nil),                                      // 315: forge.DeleteInitiatedBy
+	(*DeleteAttribution)(nil),                                      // 316: forge.DeleteAttribution
+	(*InstanceReleaseRequest)(nil),                                 // 317: forge.InstanceReleaseRequest
+	(*InstanceReleaseResult)(nil),                                  // 318: forge.InstanceReleaseResult
+	(*MachinesByIdsRequest)(nil),                                   // 319: forge.MachinesByIdsRequest
+	(*MachineSearchConfig)(nil),                                    // 320: forge.MachineSearchConfig
+	(*MachineStateHistoriesRequest)(nil),                           // 321: forge.MachineStateHistoriesRequest
+	(*MachineStateHistories)(nil),                                  // 322: forge.MachineStateHistories
+	(*MachineStateHistoryRecords)(nil),                             // 323: forge.MachineStateHistoryRecords
+	(*MachineHealthHistoriesRequest)(nil),                          // 324: forge.MachineHealthHistoriesRequest
+	(*HealthHistories)(nil),                                        // 325: forge.HealthHistories
+	(*HealthHistoryRecords)(nil),                                   // 326: forge.HealthHistoryRecords
+	(*HealthHistoryRecord)(nil),                                    // 327: forge.HealthHistoryRecord
+	(*TenantByOrganizationIdsRequest)(nil),                         // 328: forge.TenantByOrganizationIdsRequest
+	(*TenantSearchFilter)(nil),                                     // 329: forge.TenantSearchFilter
+	(*TenantList)(nil),                                             // 330: forge.TenantList
+	(*TenantOrganizationIdList)(nil),                               // 331: forge.TenantOrganizationIdList
+	(*InterfaceList)(nil),                                          // 332: forge.InterfaceList
+	(*MachineList)(nil),                                            // 333: forge.MachineList
+	(*InterfaceDeleteQuery)(nil),                                   // 334: forge.InterfaceDeleteQuery
+	(*InterfaceSearchQuery)(nil),                                   // 335: forge.InterfaceSearchQuery
+	(*AssignStaticAddressRequest)(nil),                             // 336: forge.AssignStaticAddressRequest
+	(*AssignStaticAddressResponse)(nil),                            // 337: forge.AssignStaticAddressResponse
+	(*RemoveStaticAddressRequest)(nil),                             // 338: forge.RemoveStaticAddressRequest
+	(*RemoveStaticAddressResponse)(nil),                            // 339: forge.RemoveStaticAddressResponse
+	(*FindInterfaceAddressesRequest)(nil),                          // 340: forge.FindInterfaceAddressesRequest
+	(*InterfaceAddress)(nil),                                       // 341: forge.InterfaceAddress
+	(*FindInterfaceAddressesResponse)(nil),                         // 342: forge.FindInterfaceAddressesResponse
+	(*BmcInfo)(nil),                                                // 343: forge.BmcInfo
+	(*SwitchNvosInfo)(nil),                                         // 344: forge.SwitchNvosInfo
+	(*MachineConfig)(nil),                                          // 345: forge.MachineConfig
+	(*MachineStatus)(nil),                                          // 346: forge.MachineStatus
+	(*Machine)(nil),                                                // 347: forge.Machine
+	(*DpfMachineState)(nil),                                        // 348: forge.DpfMachineState
+	(*InstanceNetworkRestrictions)(nil),                            // 349: forge.InstanceNetworkRestrictions
+	(*MachineMetadataUpdateRequest)(nil),                           // 350: forge.MachineMetadataUpdateRequest
+	(*RackMetadataUpdateRequest)(nil),                              // 351: forge.RackMetadataUpdateRequest
+	(*SwitchMetadataUpdateRequest)(nil),                            // 352: forge.SwitchMetadataUpdateRequest
+	(*PowerShelfMetadataUpdateRequest)(nil),                        // 353: forge.PowerShelfMetadataUpdateRequest
+	(*DpuAgentInventoryReport)(nil),                                // 354: forge.DpuAgentInventoryReport
+	(*MachineComponentInventory)(nil),                              // 355: forge.MachineComponentInventory
+	(*MachineInventorySoftwareComponent)(nil),                      // 356: forge.MachineInventorySoftwareComponent
+	(*HealthSourceOrigin)(nil),                                     // 357: forge.HealthSourceOrigin
+	(*ControllerStateReason)(nil),                                  // 358: forge.ControllerStateReason
+	(*ControllerStateSourceReference)(nil),                         // 359: forge.ControllerStateSourceReference
+	(*StateSla)(nil),                                               // 360: forge.StateSla
+	(*InstanceTenantStatus)(nil),                                   // 361: forge.InstanceTenantStatus
+	(*MachineEvent)(nil),                                           // 362: forge.MachineEvent
+	(*MachineInterface)(nil),                                       // 363: forge.MachineInterface
+	(*InfinibandStatusObservation)(nil),                            // 364: forge.InfinibandStatusObservation
+	(*MachineIbInterface)(nil),                                     // 365: forge.MachineIbInterface
+	(*DhcpDiscovery)(nil),                                          // 366: forge.DhcpDiscovery
+	(*ExpireDhcpLeaseRequest)(nil),                                 // 367: forge.ExpireDhcpLeaseRequest
+	(*ExpireDhcpLeaseResponse)(nil),                                // 368: forge.ExpireDhcpLeaseResponse
+	(*DhcpRecord)(nil),                                             // 369: forge.DhcpRecord
+	(*NetworkSegmentList)(nil),                                     // 370: forge.NetworkSegmentList
+	(*SSHKeyValidationRequest)(nil),                                // 371: forge.SSHKeyValidationRequest
+	(*SSHKeyValidationResponse)(nil),                               // 372: forge.SSHKeyValidationResponse
+	(*GetBmcCredentialsRequest)(nil),                               // 373: forge.GetBmcCredentialsRequest
+	(*GetSwitchNvosCredentialsRequest)(nil),                        // 374: forge.GetSwitchNvosCredentialsRequest
+	(*GetBmcCredentialsResponse)(nil),                              // 375: forge.GetBmcCredentialsResponse
+	(*BmcCredentials)(nil),                                         // 376: forge.BmcCredentials
+	(*GetSiteExplorationRequest)(nil),                              // 377: forge.GetSiteExplorationRequest
+	(*ClearSiteExplorationErrorRequest)(nil),                       // 378: forge.ClearSiteExplorationErrorRequest
+	(*ReExploreEndpointRequest)(nil),                               // 379: forge.ReExploreEndpointRequest
+	(*RefreshEndpointReportRequest)(nil),                           // 380: forge.RefreshEndpointReportRequest
+	(*DeleteExploredEndpointRequest)(nil),                          // 381: forge.DeleteExploredEndpointRequest
+	(*PauseExploredEndpointRemediationRequest)(nil),                // 382: forge.PauseExploredEndpointRemediationRequest
+	(*DeleteExploredEndpointResponse)(nil),                         // 383: forge.DeleteExploredEndpointResponse
+	(*BmcEndpointRequest)(nil),                                     // 384: forge.BmcEndpointRequest
+	(*SshTimeoutConfig)(nil),                                       // 385: forge.SshTimeoutConfig
+	(*SshRequest)(nil),                                             // 386: forge.SshRequest
+	(*CopyBfbToDpuRshimRequest)(nil),                               // 387: forge.CopyBfbToDpuRshimRequest
+	(*UpdateMachineHardwareInfoRequest)(nil),                       // 388: forge.UpdateMachineHardwareInfoRequest
+	(*MachineHardwareInfo)(nil),                                    // 389: forge.MachineHardwareInfo
+	(*ManagedHostNetworkConfigRequest)(nil),                        // 390: forge.ManagedHostNetworkConfigRequest
+	(*ManagedHostNetworkConfigResponse)(nil),                       // 391: forge.ManagedHostNetworkConfigResponse
+	(*TrafficInterceptConfig)(nil),                                 // 392: forge.TrafficInterceptConfig
+	(*TrafficInterceptBridging)(nil),                               // 393: forge.TrafficInterceptBridging
+	(*ManagedHostDpuExtensionServiceConfig)(nil),                   // 394: forge.ManagedHostDpuExtensionServiceConfig
+	(*ManagedHostQuarantineState)(nil),                             // 395: forge.ManagedHostQuarantineState
+	(*GetManagedHostQuarantineStateRequest)(nil),                   // 396: forge.GetManagedHostQuarantineStateRequest
+	(*GetManagedHostQuarantineStateResponse)(nil),                  // 397: forge.GetManagedHostQuarantineStateResponse
+	(*SetManagedHostQuarantineStateRequest)(nil),                   // 398: forge.SetManagedHostQuarantineStateRequest
+	(*SetManagedHostQuarantineStateResponse)(nil),                  // 399: forge.SetManagedHostQuarantineStateResponse
+	(*ClearManagedHostQuarantineStateRequest)(nil),                 // 400: forge.ClearManagedHostQuarantineStateRequest
+	(*ClearManagedHostQuarantineStateResponse)(nil),                // 401: forge.ClearManagedHostQuarantineStateResponse
+	(*ManagedHostNetworkConfig)(nil),                               // 402: forge.ManagedHostNetworkConfig
+	(*FlatInterfaceConfig)(nil),                                    // 403: forge.FlatInterfaceConfig
+	(*FlatInterfaceRoutingProfile)(nil),                            // 404: forge.FlatInterfaceRoutingProfile
+	(*FlatInterfaceIpv6Config)(nil),                                // 405: forge.FlatInterfaceIpv6Config
+	(*FlatInterfaceNetworkSecurityGroupConfig)(nil),                // 406: forge.FlatInterfaceNetworkSecurityGroupConfig
+	(*ManagedHostNetworkStatusRequest)(nil),                        // 407: forge.ManagedHostNetworkStatusRequest
+	(*ManagedHostNetworkStatusResponse)(nil),                       // 408: forge.ManagedHostNetworkStatusResponse
+	(*DpuAgentUpgradeCheckRequest)(nil),                            // 409: forge.DpuAgentUpgradeCheckRequest
+	(*DpuAgentUpgradeCheckResponse)(nil),                           // 410: forge.DpuAgentUpgradeCheckResponse
+	(*DpuAgentUpgradePolicyRequest)(nil),                           // 411: forge.DpuAgentUpgradePolicyRequest
+	(*DpuAgentUpgradePolicyResponse)(nil),                          // 412: forge.DpuAgentUpgradePolicyResponse
+	(*AdminForceDeleteMachineRequest)(nil),                         // 413: forge.AdminForceDeleteMachineRequest
+	(*AdminForceDeleteMachineResponse)(nil),                        // 414: forge.AdminForceDeleteMachineResponse
+	(*DisableSecureBootResponse)(nil),                              // 415: forge.DisableSecureBootResponse
+	(*LockdownRequest)(nil),                                        // 416: forge.LockdownRequest
+	(*LockdownResponse)(nil),                                       // 417: forge.LockdownResponse
+	(*LockdownStatusRequest)(nil),                                  // 418: forge.LockdownStatusRequest
+	(*MachineSetupStatusRequest)(nil),                              // 419: forge.MachineSetupStatusRequest
+	(*MachineSetupRequest)(nil),                                    // 420: forge.MachineSetupRequest
+	(*MachineSetupResponse)(nil),                                   // 421: forge.MachineSetupResponse
+	(*SetDpuFirstBootOrderRequest)(nil),                            // 422: forge.SetDpuFirstBootOrderRequest
+	(*SetDpuFirstBootOrderResponse)(nil),                           // 423: forge.SetDpuFirstBootOrderResponse
+	(*AdminRebootRequest)(nil),                                     // 424: forge.AdminRebootRequest
+	(*AdminRebootResponse)(nil),                                    // 425: forge.AdminRebootResponse
+	(*AdminBmcResetRequest)(nil),                                   // 426: forge.AdminBmcResetRequest
+	(*AdminBmcResetResponse)(nil),                                  // 427: forge.AdminBmcResetResponse
+	(*EnableInfiniteBootRequest)(nil),                              // 428: forge.EnableInfiniteBootRequest
+	(*EnableInfiniteBootResponse)(nil),                             // 429: forge.EnableInfiniteBootResponse
+	(*IsInfiniteBootEnabledRequest)(nil),                           // 430: forge.IsInfiniteBootEnabledRequest
+	(*IsInfiniteBootEnabledResponse)(nil),                          // 431: forge.IsInfiniteBootEnabledResponse
+	(*BMCMetaDataGetRequest)(nil),                                  // 432: forge.BMCMetaDataGetRequest
+	(*BMCMetaDataGetResponse)(nil),                                 // 433: forge.BMCMetaDataGetResponse
+	(*MachineCredentialsUpdateRequest)(nil),                        // 434: forge.MachineCredentialsUpdateRequest
+	(*MachineCredentialsUpdateResponse)(nil),                       // 435: forge.MachineCredentialsUpdateResponse
+	(*ForgeAgentControlRequest)(nil),                               // 436: forge.ForgeAgentControlRequest
+	(*ForgeAgentControlResponse)(nil),                              // 437: forge.ForgeAgentControlResponse
+	(*MachineDiscoveryInfo)(nil),                                   // 438: forge.MachineDiscoveryInfo
+	(*MachineDiscoveryCompletedRequest)(nil),                       // 439: forge.MachineDiscoveryCompletedRequest
+	(*MachineCleanupInfo)(nil),                                     // 440: forge.MachineCleanupInfo
+	(*MachineCertificate)(nil),                                     // 441: forge.MachineCertificate
+	(*MachineCertificateRenewRequest)(nil),                         // 442: forge.MachineCertificateRenewRequest
+	(*MachineCertificateResult)(nil),                               // 443: forge.MachineCertificateResult
+	(*MachineDiscoveryResult)(nil),                                 // 444: forge.MachineDiscoveryResult
+	(*MachineDiscoveryCompletedResponse)(nil),                      // 445: forge.MachineDiscoveryCompletedResponse
+	(*MachineCleanupResult)(nil),                                   // 446: forge.MachineCleanupResult
+	(*ForgeScoutErrorReport)(nil),                                  // 447: forge.ForgeScoutErrorReport
+	(*ForgeScoutErrorReportResult)(nil),                            // 448: forge.ForgeScoutErrorReportResult
+	(*PxeInstructionRequest)(nil),                                  // 449: forge.PxeInstructionRequest
+	(*PxeInstructions)(nil),                                        // 450: forge.PxeInstructions
+	(*CloudInitDiscoveryInstructions)(nil),                         // 451: forge.CloudInitDiscoveryInstructions
+	(*CloudInitMetaData)(nil),                                      // 452: forge.CloudInitMetaData
+	(*CloudInitInstructionsRequest)(nil),                           // 453: forge.CloudInitInstructionsRequest
+	(*CloudInitInstructions)(nil),                                  // 454: forge.CloudInitInstructions
+	(*DpuNetworkStatus)(nil),                                       // 455: forge.DpuNetworkStatus
+	(*LastDhcpRequest)(nil),                                        // 456: forge.LastDhcpRequest
+	(*DpuExtensionServiceStatusObservation)(nil),                   // 457: forge.DpuExtensionServiceStatusObservation
+	(*DpuExtensionServiceComponent)(nil),                           // 458: forge.DpuExtensionServiceComponent
+	(*OptionalHealthReport)(nil),                                   // 459: forge.OptionalHealthReport
+	(*HealthReportEntry)(nil),                                      // 460: forge.HealthReportEntry
+	(*InsertMachineHealthReportRequest)(nil),                       // 461: forge.InsertMachineHealthReportRequest
+	(*InsertRackHealthReportRequest)(nil),                          // 462: forge.InsertRackHealthReportRequest
+	(*RemoveRackHealthReportRequest)(nil),                          // 463: forge.RemoveRackHealthReportRequest
+	(*ListRackHealthReportsRequest)(nil),                           // 464: forge.ListRackHealthReportsRequest
+	(*InsertSwitchHealthReportRequest)(nil),                        // 465: forge.InsertSwitchHealthReportRequest
+	(*RemoveSwitchHealthReportRequest)(nil),                        // 466: forge.RemoveSwitchHealthReportRequest
+	(*ListSwitchHealthReportsRequest)(nil),                         // 467: forge.ListSwitchHealthReportsRequest
+	(*InsertPowerShelfHealthReportRequest)(nil),                    // 468: forge.InsertPowerShelfHealthReportRequest
+	(*RemovePowerShelfHealthReportRequest)(nil),                    // 469: forge.RemovePowerShelfHealthReportRequest
+	(*ListPowerShelfHealthReportsRequest)(nil),                     // 470: forge.ListPowerShelfHealthReportsRequest
+	(*ListHealthReportResponse)(nil),                               // 471: forge.ListHealthReportResponse
+	(*RemoveMachineHealthReportRequest)(nil),                       // 472: forge.RemoveMachineHealthReportRequest
+	(*ListNVLinkDomainHealthReportsRequest)(nil),                   // 473: forge.ListNVLinkDomainHealthReportsRequest
+	(*InsertNVLinkDomainHealthReportRequest)(nil),                  // 474: forge.InsertNVLinkDomainHealthReportRequest
+	(*RemoveNVLinkDomainHealthReportRequest)(nil),                  // 475: forge.RemoveNVLinkDomainHealthReportRequest
+	(*InstanceInterfaceStatusObservation)(nil),                     // 476: forge.InstanceInterfaceStatusObservation
+	(*FabricInterfaceData)(nil),                                    // 477: forge.FabricInterfaceData
+	(*LinkData)(nil),                                               // 478: forge.LinkData
+	(*Tenant)(nil),                                                 // 479: forge.Tenant
+	(*CreateTenantRequest)(nil),                                    // 480: forge.CreateTenantRequest
+	(*CreateTenantResponse)(nil),                                   // 481: forge.CreateTenantResponse
+	(*UpdateTenantRequest)(nil),                                    // 482: forge.UpdateTenantRequest
+	(*UpdateTenantResponse)(nil),                                   // 483: forge.UpdateTenantResponse
+	(*FindTenantRequest)(nil),                                      // 484: forge.FindTenantRequest
+	(*FindTenantResponse)(nil),                                     // 485: forge.FindTenantResponse
+	(*TenantKeysetIdentifier)(nil),                                 // 486: forge.TenantKeysetIdentifier
+	(*TenantPublicKey)(nil),                                        // 487: forge.TenantPublicKey
+	(*TenantKeysetContent)(nil),                                    // 488: forge.TenantKeysetContent
+	(*TenantKeyset)(nil),                                           // 489: forge.TenantKeyset
+	(*CreateTenantKeysetRequest)(nil),                              // 490: forge.CreateTenantKeysetRequest
+	(*CreateTenantKeysetResponse)(nil),                             // 491: forge.CreateTenantKeysetResponse
+	(*TenantKeySetList)(nil),                                       // 492: forge.TenantKeySetList
+	(*UpdateTenantKeysetRequest)(nil),                              // 493: forge.UpdateTenantKeysetRequest
+	(*UpdateTenantKeysetResponse)(nil),                             // 494: forge.UpdateTenantKeysetResponse
+	(*DeleteTenantKeysetRequest)(nil),                              // 495: forge.DeleteTenantKeysetRequest
+	(*DeleteTenantKeysetResponse)(nil),                             // 496: forge.DeleteTenantKeysetResponse
+	(*TenantKeysetSearchFilter)(nil),                               // 497: forge.TenantKeysetSearchFilter
+	(*TenantKeysetIdList)(nil),                                     // 498: forge.TenantKeysetIdList
+	(*TenantKeysetsByIdsRequest)(nil),                              // 499: forge.TenantKeysetsByIdsRequest
+	(*ValidateTenantPublicKeyRequest)(nil),                         // 500: forge.ValidateTenantPublicKeyRequest
+	(*ValidateTenantPublicKeyResponse)(nil),                        // 501: forge.ValidateTenantPublicKeyResponse
+	(*ListResourcePoolsRequest)(nil),                               // 502: forge.ListResourcePoolsRequest
+	(*ResourcePools)(nil),                                          // 503: forge.ResourcePools
+	(*ResourcePool)(nil),                                           // 504: forge.ResourcePool
+	(*GrowResourcePoolRequest)(nil),                                // 505: forge.GrowResourcePoolRequest
+	(*GrowResourcePoolResponse)(nil),                               // 506: forge.GrowResourcePoolResponse
+	(*Range)(nil),                                                  // 507: forge.Range
+	(*MigrateVpcVniResponse)(nil),                                  // 508: forge.MigrateVpcVniResponse
+	(*MaintenanceRequest)(nil),                                     // 509: forge.MaintenanceRequest
+	(*SetDynamicConfigRequest)(nil),                                // 510: forge.SetDynamicConfigRequest
+	(*FindIpAddressRequest)(nil),                                   // 511: forge.FindIpAddressRequest
+	(*FindIpAddressResponse)(nil),                                  // 512: forge.FindIpAddressResponse
+	(*IdentifyUuidRequest)(nil),                                    // 513: forge.IdentifyUuidRequest
+	(*IdentifyUuidResponse)(nil),                                   // 514: forge.IdentifyUuidResponse
+	(*FindBmcIpsRequest)(nil),                                      // 515: forge.FindBmcIpsRequest
+	(*IdentifyMacRequest)(nil),                                     // 516: forge.IdentifyMacRequest
+	(*IdentifyMacResponse)(nil),                                    // 517: forge.IdentifyMacResponse
+	(*IdentifySerialRequest)(nil),                                  // 518: forge.IdentifySerialRequest
+	(*IdentifySerialResponse)(nil),                                 // 519: forge.IdentifySerialResponse
+	(*DpuReprovisioningRequest)(nil),                               // 520: forge.DpuReprovisioningRequest
+	(*DpuReprovisioningListRequest)(nil),                           // 521: forge.DpuReprovisioningListRequest
+	(*DpuReprovisioningListResponse)(nil),                          // 522: forge.DpuReprovisioningListResponse
+	(*HostReprovisioningRequest)(nil),                              // 523: forge.HostReprovisioningRequest
+	(*HostReprovisioningListRequest)(nil),                          // 524: forge.HostReprovisioningListRequest
+	(*HostReprovisioningListResponse)(nil),                         // 525: forge.HostReprovisioningListResponse
+	(*DpuOsOperationalState)(nil),                                  // 526: forge.DpuOsOperationalState
+	(*DpuRepresentorStatus)(nil),                                   // 527: forge.DpuRepresentorStatus
+	(*DpuInfoStatusObservation)(nil),                               // 528: forge.DpuInfoStatusObservation
+	(*DpuInfo)(nil),                                                // 529: forge.DpuInfo
+	(*GetDpuInfoListRequest)(nil),                                  // 530: forge.GetDpuInfoListRequest
+	(*GetDpuInfoListResponse)(nil),                                 // 531: forge.GetDpuInfoListResponse
+	(*IpAddressMatch)(nil),                                         // 532: forge.IpAddressMatch
+	(*MachineBootOverride)(nil),                                    // 533: forge.MachineBootOverride
+	(*ConnectedDevice)(nil),                                        // 534: forge.ConnectedDevice
+	(*ConnectedDeviceList)(nil),                                    // 535: forge.ConnectedDeviceList
+	(*BmcIpList)(nil),                                              // 536: forge.BmcIpList
+	(*BmcIp)(nil),                                                  // 537: forge.BmcIp
+	(*MacAddressBmcIp)(nil),                                        // 538: forge.MacAddressBmcIp
+	(*MachineIdBmcIpPairs)(nil),                                    // 539: forge.MachineIdBmcIpPairs
+	(*MachineIdBmcIp)(nil),                                         // 540: forge.MachineIdBmcIp
+	(*NetworkDevice)(nil),                                          // 541: forge.NetworkDevice
+	(*NetworkTopologyRequest)(nil),                                 // 542: forge.NetworkTopologyRequest
+	(*NetworkDeviceIdList)(nil),                                    // 543: forge.NetworkDeviceIdList
+	(*NetworkTopologyData)(nil),                                    // 544: forge.NetworkTopologyData
+	(*RouteServers)(nil),                                           // 545: forge.RouteServers
+	(*RouteServerEntries)(nil),                                     // 546: forge.RouteServerEntries
+	(*RouteServer)(nil),                                            // 547: forge.RouteServer
+	(*SetHostUefiPasswordRequest)(nil),                             // 548: forge.SetHostUefiPasswordRequest
+	(*SetHostUefiPasswordResponse)(nil),                            // 549: forge.SetHostUefiPasswordResponse
+	(*ClearHostUefiPasswordRequest)(nil),                           // 550: forge.ClearHostUefiPasswordRequest
+	(*ClearHostUefiPasswordResponse)(nil),                          // 551: forge.ClearHostUefiPasswordResponse
+	(*OsImageAttributes)(nil),                                      // 552: forge.OsImageAttributes
+	(*OsImage)(nil),                                                // 553: forge.OsImage
+	(*ListOsImageRequest)(nil),                                     // 554: forge.ListOsImageRequest
+	(*ListOsImageResponse)(nil),                                    // 555: forge.ListOsImageResponse
+	(*DeleteOsImageRequest)(nil),                                   // 556: forge.DeleteOsImageRequest
+	(*DeleteOsImageResponse)(nil),                                  // 557: forge.DeleteOsImageResponse
+	(*GetIpxeTemplateRequest)(nil),                                 // 558: forge.GetIpxeTemplateRequest
+	(*ListIpxeTemplatesRequest)(nil),                               // 559: forge.ListIpxeTemplatesRequest
+	(*IpxeTemplateList)(nil),                                       // 560: forge.IpxeTemplateList
+	(*ExpectedHostNic)(nil),                                        // 561: forge.ExpectedHostNic
+	(*HostLifecycleProfile)(nil),                                   // 562: forge.HostLifecycleProfile
+	(*ExpectedMachine)(nil),                                        // 563: forge.ExpectedMachine
+	(*ExpectedMachineRequest)(nil),                                 // 564: forge.ExpectedMachineRequest
+	(*ExpectedMachineList)(nil),                                    // 565: forge.ExpectedMachineList
+	(*LinkedExpectedMachineList)(nil),                              // 566: forge.LinkedExpectedMachineList
+	(*LinkedExpectedMachine)(nil),                                  // 567: forge.LinkedExpectedMachine
+	(*UnexpectedMachineList)(nil),                                  // 568: forge.UnexpectedMachineList
+	(*UnexpectedMachine)(nil),                                      // 569: forge.UnexpectedMachine
+	(*BatchExpectedMachineOperationRequest)(nil),                   // 570: forge.BatchExpectedMachineOperationRequest
+	(*ExpectedMachineOperationResult)(nil),                         // 571: forge.ExpectedMachineOperationResult
+	(*BatchExpectedMachineOperationResponse)(nil),                  // 572: forge.BatchExpectedMachineOperationResponse
+	(*MachineRebootCompletedResponse)(nil),                         // 573: forge.MachineRebootCompletedResponse
+	(*MachineRebootCompletedRequest)(nil),                          // 574: forge.MachineRebootCompletedRequest
+	(*ScoutFirmwareUpgradeStatusRequest)(nil),                      // 575: forge.ScoutFirmwareUpgradeStatusRequest
+	(*MachineValidationCompletedRequest)(nil),                      // 576: forge.MachineValidationCompletedRequest
+	(*MachineValidationCompletedResponse)(nil),                     // 577: forge.MachineValidationCompletedResponse
+	(*MachineValidationResult)(nil),                                // 578: forge.MachineValidationResult
+	(*MachineValidationResultPostRequest)(nil),                     // 579: forge.MachineValidationResultPostRequest
+	(*MachineValidationResultList)(nil),                            // 580: forge.MachineValidationResultList
+	(*MachineValidationGetRequest)(nil),                            // 581: forge.MachineValidationGetRequest
+	(*MachineValidationStatus)(nil),                                // 582: forge.MachineValidationStatus
+	(*MachineValidationRun)(nil),                                   // 583: forge.MachineValidationRun
+	(*MachineSetAutoUpdateRequest)(nil),                            // 584: forge.MachineSetAutoUpdateRequest
+	(*MachineSetAutoUpdateResponse)(nil),                           // 585: forge.MachineSetAutoUpdateResponse
+	(*GetMachineValidationExternalConfigRequest)(nil),              // 586: forge.GetMachineValidationExternalConfigRequest
+	(*MachineValidationExternalConfig)(nil),                        // 587: forge.MachineValidationExternalConfig
+	(*GetMachineValidationExternalConfigResponse)(nil),             // 588: forge.GetMachineValidationExternalConfigResponse
+	(*GetMachineValidationExternalConfigsRequest)(nil),             // 589: forge.GetMachineValidationExternalConfigsRequest
+	(*GetMachineValidationExternalConfigsResponse)(nil),            // 590: forge.GetMachineValidationExternalConfigsResponse
+	(*AddUpdateMachineValidationExternalConfigRequest)(nil),        // 591: forge.AddUpdateMachineValidationExternalConfigRequest
+	(*RemoveMachineValidationExternalConfigRequest)(nil),           // 592: forge.RemoveMachineValidationExternalConfigRequest
+	(*MachineValidationOnDemandRequest)(nil),                       // 593: forge.MachineValidationOnDemandRequest
+	(*MachineValidationOnDemandResponse)(nil),                      // 594: forge.MachineValidationOnDemandResponse
+	(*FirmwareUpgradeActivity)(nil),                                // 595: forge.FirmwareUpgradeActivity
+	(*NvosUpdateActivity)(nil),                                     // 596: forge.NvosUpdateActivity
+	(*ConfigureNmxClusterActivity)(nil),                            // 597: forge.ConfigureNmxClusterActivity
+	(*PowerSequenceActivity)(nil),                                  // 598: forge.PowerSequenceActivity
+	(*MaintenanceActivityConfig)(nil),                              // 599: forge.MaintenanceActivityConfig
+	(*RackMaintenanceScope)(nil),                                   // 600: forge.RackMaintenanceScope
+	(*RackMaintenanceOnDemandRequest)(nil),                         // 601: forge.RackMaintenanceOnDemandRequest
+	(*RackMaintenanceOnDemandResponse)(nil),                        // 602: forge.RackMaintenanceOnDemandResponse
+	(*AdminPowerControlRequest)(nil),                               // 603: forge.AdminPowerControlRequest
+	(*AdminPowerControlResponse)(nil),                              // 604: forge.AdminPowerControlResponse
+	(*GetRedfishJobStateRequest)(nil),                              // 605: forge.GetRedfishJobStateRequest
+	(*GetRedfishJobStateResponse)(nil),                             // 606: forge.GetRedfishJobStateResponse
+	(*MachineValidationRunList)(nil),                               // 607: forge.MachineValidationRunList
+	(*MachineValidationRunListGetRequest)(nil),                     // 608: forge.MachineValidationRunListGetRequest
+	(*MachineValidationRunItemSearchFilter)(nil),                   // 609: forge.MachineValidationRunItemSearchFilter
+	(*MachineValidationRunItemIdList)(nil),                         // 610: forge.MachineValidationRunItemIdList
+	(*MachineValidationRunItemsByIdsRequest)(nil),                  // 611: forge.MachineValidationRunItemsByIdsRequest
+	(*MachineValidationRunItemList)(nil),                           // 612: forge.MachineValidationRunItemList
+	(*MachineValidationRunItem)(nil),                               // 613: forge.MachineValidationRunItem
+	(*MachineValidationAttemptGetRequest)(nil),                     // 614: forge.MachineValidationAttemptGetRequest
+	(*MachineValidationAttempt)(nil),                               // 615: forge.MachineValidationAttempt
+	(*MachineValidationHeartbeatRequest)(nil),                      // 616: forge.MachineValidationHeartbeatRequest
+	(*MachineValidationHeartbeatResponse)(nil),                     // 617: forge.MachineValidationHeartbeatResponse
+	(*IsBmcInManagedHostResponse)(nil),                             // 618: forge.IsBmcInManagedHostResponse
+	(*BmcCredentialStatusResponse)(nil),                            // 619: forge.BmcCredentialStatusResponse
+	(*MachineValidationTestsGetRequest)(nil),                       // 620: forge.MachineValidationTestsGetRequest
+	(*MachineValidationTestUpdateRequest)(nil),                     // 621: forge.MachineValidationTestUpdateRequest
+	(*MachineValidationTestAddRequest)(nil),                        // 622: forge.MachineValidationTestAddRequest
+	(*MachineValidationTestAddUpdateResponse)(nil),                 // 623: forge.MachineValidationTestAddUpdateResponse
+	(*MachineValidationTestsGetResponse)(nil),                      // 624: forge.MachineValidationTestsGetResponse
+	(*MachineValidationTestVerfiedRequest)(nil),                    // 625: forge.MachineValidationTestVerfiedRequest
+	(*MachineValidationTestVerfiedResponse)(nil),                   // 626: forge.MachineValidationTestVerfiedResponse
+	(*MachineValidationTest)(nil),                                  // 627: forge.MachineValidationTest
+	(*MachineValidationTestNextVersionResponse)(nil),               // 628: forge.MachineValidationTestNextVersionResponse
+	(*MachineValidationTestNextVersionRequest)(nil),                // 629: forge.MachineValidationTestNextVersionRequest
+	(*MachineValidationTestEnableDisableTestRequest)(nil),          // 630: forge.MachineValidationTestEnableDisableTestRequest
+	(*MachineValidationTestEnableDisableTestResponse)(nil),         // 631: forge.MachineValidationTestEnableDisableTestResponse
+	(*MachineValidationRunRequest)(nil),                            // 632: forge.MachineValidationRunRequest
+	(*MachineValidationRunResponse)(nil),                           // 633: forge.MachineValidationRunResponse
+	(*MachineCapabilityAttributesCpu)(nil),                         // 634: forge.MachineCapabilityAttributesCpu
+	(*MachineCapabilityAttributesGpu)(nil),                         // 635: forge.MachineCapabilityAttributesGpu
+	(*MachineCapabilityAttributesMemory)(nil),                      // 636: forge.MachineCapabilityAttributesMemory
+	(*MachineCapabilityAttributesStorage)(nil),                     // 637: forge.MachineCapabilityAttributesStorage
+	(*MachineCapabilityAttributesNetwork)(nil),                     // 638: forge.MachineCapabilityAttributesNetwork
+	(*MachineCapabilityAttributesInfiniband)(nil),                  // 639: forge.MachineCapabilityAttributesInfiniband
+	(*MachineCapabilityAttributesDpu)(nil),                         // 640: forge.MachineCapabilityAttributesDpu
+	(*MachineCapabilitiesSet)(nil),                                 // 641: forge.MachineCapabilitiesSet
+	(*InstanceTypeAttributes)(nil),                                 // 642: forge.InstanceTypeAttributes
+	(*InstanceType)(nil),                                           // 643: forge.InstanceType
+	(*InstanceTypeMachineCapabilityFilterAttributes)(nil),          // 644: forge.InstanceTypeMachineCapabilityFilterAttributes
+	(*CreateInstanceTypeRequest)(nil),                              // 645: forge.CreateInstanceTypeRequest
+	(*CreateInstanceTypeResponse)(nil),                             // 646: forge.CreateInstanceTypeResponse
+	(*FindInstanceTypeIdsRequest)(nil),                             // 647: forge.FindInstanceTypeIdsRequest
+	(*FindInstanceTypeIdsResponse)(nil),                            // 648: forge.FindInstanceTypeIdsResponse
+	(*FindInstanceTypesByIdsRequest)(nil),                          // 649: forge.FindInstanceTypesByIdsRequest
+	(*FindInstanceTypesByIdsResponse)(nil),                         // 650: forge.FindInstanceTypesByIdsResponse
+	(*DeleteInstanceTypeRequest)(nil),                              // 651: forge.DeleteInstanceTypeRequest
+	(*DeleteInstanceTypeResponse)(nil),                             // 652: forge.DeleteInstanceTypeResponse
+	(*UpdateInstanceTypeResponse)(nil),                             // 653: forge.UpdateInstanceTypeResponse
+	(*UpdateInstanceTypeRequest)(nil),                              // 654: forge.UpdateInstanceTypeRequest
+	(*AssociateMachinesWithInstanceTypeRequest)(nil),               // 655: forge.AssociateMachinesWithInstanceTypeRequest
+	(*AssociateMachinesWithInstanceTypeResponse)(nil),              // 656: forge.AssociateMachinesWithInstanceTypeResponse
+	(*RemoveMachineInstanceTypeAssociationRequest)(nil),            // 657: forge.RemoveMachineInstanceTypeAssociationRequest
+	(*RemoveMachineInstanceTypeAssociationResponse)(nil),           // 658: forge.RemoveMachineInstanceTypeAssociationResponse
+	(*RedfishBrowseRequest)(nil),                                   // 659: forge.RedfishBrowseRequest
+	(*RedfishBrowseResponse)(nil),                                  // 660: forge.RedfishBrowseResponse
+	(*RedfishListActionsRequest)(nil),                              // 661: forge.RedfishListActionsRequest
+	(*RedfishListActionsResponse)(nil),                             // 662: forge.RedfishListActionsResponse
+	(*RedfishAction)(nil),                                          // 663: forge.RedfishAction
+	(*OptionalRedfishActionResult)(nil),                            // 664: forge.OptionalRedfishActionResult
+	(*RedfishActionResult)(nil),                                    // 665: forge.RedfishActionResult
+	(*RedfishCreateActionRequest)(nil),                             // 666: forge.RedfishCreateActionRequest
+	(*RedfishCreateActionResponse)(nil),                            // 667: forge.RedfishCreateActionResponse
+	(*RedfishActionID)(nil),                                        // 668: forge.RedfishActionID
+	(*RedfishApproveActionResponse)(nil),                           // 669: forge.RedfishApproveActionResponse
+	(*RedfishApplyActionResponse)(nil),                             // 670: forge.RedfishApplyActionResponse
+	(*RedfishCancelActionResponse)(nil),                            // 671: forge.RedfishCancelActionResponse
+	(*UfmBrowseRequest)(nil),                                       // 672: forge.UfmBrowseRequest
+	(*UfmBrowseResponse)(nil),                                      // 673: forge.UfmBrowseResponse
+	(*NetworkSecurityGroupAttributes)(nil),                         // 674: forge.NetworkSecurityGroupAttributes
+	(*NetworkSecurityGroup)(nil),                                   // 675: forge.NetworkSecurityGroup
+	(*CreateNetworkSecurityGroupRequest)(nil),                      // 676: forge.CreateNetworkSecurityGroupRequest
+	(*CreateNetworkSecurityGroupResponse)(nil),                     // 677: forge.CreateNetworkSecurityGroupResponse
+	(*FindNetworkSecurityGroupIdsRequest)(nil),                     // 678: forge.FindNetworkSecurityGroupIdsRequest
+	(*FindNetworkSecurityGroupIdsResponse)(nil),                    // 679: forge.FindNetworkSecurityGroupIdsResponse
+	(*FindNetworkSecurityGroupsByIdsRequest)(nil),                  // 680: forge.FindNetworkSecurityGroupsByIdsRequest
+	(*FindNetworkSecurityGroupsByIdsResponse)(nil),                 // 681: forge.FindNetworkSecurityGroupsByIdsResponse
+	(*UpdateNetworkSecurityGroupResponse)(nil),                     // 682: forge.UpdateNetworkSecurityGroupResponse
+	(*UpdateNetworkSecurityGroupRequest)(nil),                      // 683: forge.UpdateNetworkSecurityGroupRequest
+	(*DeleteNetworkSecurityGroupRequest)(nil),                      // 684: forge.DeleteNetworkSecurityGroupRequest
+	(*DeleteNetworkSecurityGroupResponse)(nil),                     // 685: forge.DeleteNetworkSecurityGroupResponse
+	(*NetworkSecurityGroupStatus)(nil),                             // 686: forge.NetworkSecurityGroupStatus
+	(*NetworkSecurityGroupPropagationObjectStatus)(nil),            // 687: forge.NetworkSecurityGroupPropagationObjectStatus
+	(*GetNetworkSecurityGroupPropagationStatusResponse)(nil),       // 688: forge.GetNetworkSecurityGroupPropagationStatusResponse
+	(*NetworkSecurityGroupIdList)(nil),                             // 689: forge.NetworkSecurityGroupIdList
+	(*GetNetworkSecurityGroupPropagationStatusRequest)(nil),        // 690: forge.GetNetworkSecurityGroupPropagationStatusRequest
+	(*NetworkSecurityGroupRuleAttributes)(nil),                     // 691: forge.NetworkSecurityGroupRuleAttributes
+	(*ResolvedNetworkSecurityGroupRule)(nil),                       // 692: forge.ResolvedNetworkSecurityGroupRule
+	(*GetNetworkSecurityGroupAttachmentsRequest)(nil),              // 693: forge.GetNetworkSecurityGroupAttachmentsRequest
+	(*NetworkSecurityGroupAttachments)(nil),                        // 694: forge.NetworkSecurityGroupAttachments
+	(*GetNetworkSecurityGroupAttachmentsResponse)(nil),             // 695: forge.GetNetworkSecurityGroupAttachmentsResponse
+	(*GetDesiredFirmwareVersionsRequest)(nil),                      // 696: forge.GetDesiredFirmwareVersionsRequest
+	(*GetDesiredFirmwareVersionsResponse)(nil),                     // 697: forge.GetDesiredFirmwareVersionsResponse
+	(*DesiredFirmwareVersionEntry)(nil),                            // 698: forge.DesiredFirmwareVersionEntry
+	(*SkuComponentChassis)(nil),                                    // 699: forge.SkuComponentChassis
+	(*SkuComponentCpu)(nil),                                        // 700: forge.SkuComponentCpu
+	(*SkuComponentGpu)(nil),                                        // 701: forge.SkuComponentGpu
+	(*SkuComponentEthernetDevices)(nil),                            // 702: forge.SkuComponentEthernetDevices
+	(*SkuComponentInfinibandDevices)(nil),                          // 703: forge.SkuComponentInfinibandDevices
+	(*SkuComponentStorage)(nil),                                    // 704: forge.SkuComponentStorage
+	(*SkuComponentStorageController)(nil),                          // 705: forge.SkuComponentStorageController
+	(*SkuComponentMemory)(nil),                                     // 706: forge.SkuComponentMemory
+	(*SkuComponentTpm)(nil),                                        // 707: forge.SkuComponentTpm
+	(*SkuComponents)(nil),                                          // 708: forge.SkuComponents
+	(*Sku)(nil),                                                    // 709: forge.Sku
+	(*SkuMachinePair)(nil),                                         // 710: forge.SkuMachinePair
+	(*RemoveSkuRequest)(nil),                                       // 711: forge.RemoveSkuRequest
+	(*SkuList)(nil),                                                // 712: forge.SkuList
+	(*SkuIdList)(nil),                                              // 713: forge.SkuIdList
+	(*SkuStatus)(nil),                                              // 714: forge.SkuStatus
+	(*SkusByIdsRequest)(nil),                                       // 715: forge.SkusByIdsRequest
+	(*SkuSearchFilter)(nil),                                        // 716: forge.SkuSearchFilter
+	(*DpaInterface)(nil),                                           // 717: forge.DpaInterface
+	(*DpaInterfaceCreationRequest)(nil),                            // 718: forge.DpaInterfaceCreationRequest
+	(*DpaInterfaceIdList)(nil),                                     // 719: forge.DpaInterfaceIdList
+	(*DpaInterfacesByIdsRequest)(nil),                              // 720: forge.DpaInterfacesByIdsRequest
+	(*DpaInterfaceList)(nil),                                       // 721: forge.DpaInterfaceList
+	(*DpaNetworkObservationSetRequest)(nil),                        // 722: forge.DpaNetworkObservationSetRequest
+	(*DpaInterfaceDeletionRequest)(nil),                            // 723: forge.DpaInterfaceDeletionRequest
+	(*DpaInterfaceDeletionResult)(nil),                             // 724: forge.DpaInterfaceDeletionResult
+	(*SkuUpdateMetadataRequest)(nil),                               // 725: forge.SkuUpdateMetadataRequest
+	(*PowerOptionRequest)(nil),                                     // 726: forge.PowerOptionRequest
+	(*PowerOptionUpdateRequest)(nil),                               // 727: forge.PowerOptionUpdateRequest
+	(*PowerOptions)(nil),                                           // 728: forge.PowerOptions
+	(*PowerOptionResponse)(nil),                                    // 729: forge.PowerOptionResponse
+	(*ComputeAllocationAttributes)(nil),                            // 730: forge.ComputeAllocationAttributes
+	(*ComputeAllocation)(nil),                                      // 731: forge.ComputeAllocation
+	(*CreateComputeAllocationRequest)(nil),                         // 732: forge.CreateComputeAllocationRequest
+	(*CreateComputeAllocationResponse)(nil),                        // 733: forge.CreateComputeAllocationResponse
+	(*FindComputeAllocationIdsRequest)(nil),                        // 734: forge.FindComputeAllocationIdsRequest
+	(*FindComputeAllocationIdsResponse)(nil),                       // 735: forge.FindComputeAllocationIdsResponse
+	(*FindComputeAllocationsByIdsRequest)(nil),                     // 736: forge.FindComputeAllocationsByIdsRequest
+	(*FindComputeAllocationsByIdsResponse)(nil),                    // 737: forge.FindComputeAllocationsByIdsResponse
+	(*UpdateComputeAllocationResponse)(nil),                        // 738: forge.UpdateComputeAllocationResponse
+	(*UpdateComputeAllocationRequest)(nil),                         // 739: forge.UpdateComputeAllocationRequest
+	(*DeleteComputeAllocationRequest)(nil),                         // 740: forge.DeleteComputeAllocationRequest
+	(*DeleteComputeAllocationResponse)(nil),                        // 741: forge.DeleteComputeAllocationResponse
+	(*InstanceTypeAllocationStats)(nil),                            // 742: forge.InstanceTypeAllocationStats
+	(*GetRackRequest)(nil),                                         // 743: forge.GetRackRequest
+	(*GetRackResponse)(nil),                                        // 744: forge.GetRackResponse
+	(*RackList)(nil),                                               // 745: forge.RackList
+	(*RackSearchFilter)(nil),                                       // 746: forge.RackSearchFilter
+	(*RackIdList)(nil),                                             // 747: forge.RackIdList
+	(*RacksByIdsRequest)(nil),                                      // 748: forge.RacksByIdsRequest
+	(*Rack)(nil),                                                   // 749: forge.Rack
+	(*RackConfig)(nil),                                             // 750: forge.RackConfig
+	(*RackStatus)(nil),                                             // 751: forge.RackStatus
+	(*RackStateHistoriesRequest)(nil),                              // 752: forge.RackStateHistoriesRequest
+	(*DeleteRackRequest)(nil),                                      // 753: forge.DeleteRackRequest
+	(*AdminForceDeleteRackRequest)(nil),                            // 754: forge.AdminForceDeleteRackRequest
+	(*AdminForceDeleteRackResponse)(nil),                           // 755: forge.AdminForceDeleteRackResponse
+	(*RackCapabilityCompute)(nil),                                  // 756: forge.RackCapabilityCompute
+	(*RackCapabilitySwitch)(nil),                                   // 757: forge.RackCapabilitySwitch
+	(*RackCapabilityPowerShelf)(nil),                               // 758: forge.RackCapabilityPowerShelf
+	(*RackCapabilitiesSet)(nil),                                    // 759: forge.RackCapabilitiesSet
+	(*RackProfile)(nil),                                            // 760: forge.RackProfile
+	(*GetRackProfileRequest)(nil),                                  // 761: forge.GetRackProfileRequest
+	(*GetRackProfileResponse)(nil),                                 // 762: forge.GetRackProfileResponse
+	(*RackManagerForgeRequest)(nil),                                // 763: forge.RackManagerForgeRequest
+	(*RackManagerForgeResponse)(nil),                               // 764: forge.RackManagerForgeResponse
+	(*MachineNVLinkInfo)(nil),                                      // 765: forge.MachineNVLinkInfo
+	(*UpdateMachineNvLinkInfoRequest)(nil),                         // 766: forge.UpdateMachineNvLinkInfoRequest
+	(*MachineSpxStatusObservation)(nil),                            // 767: forge.MachineSpxStatusObservation
+	(*MachineSpxAttachmentStatusObservation)(nil),                  // 768: forge.MachineSpxAttachmentStatusObservation
+	(*AstraConfig)(nil),                                            // 769: forge.AstraConfig
+	(*AstraAttachment)(nil),                                        // 770: forge.AstraAttachment
+	(*AstraConfigStatus)(nil),                                      // 771: forge.AstraConfigStatus
+	(*AstraAttachmentStatus)(nil),                                  // 772: forge.AstraAttachmentStatus
+	(*AstraStatus)(nil),                                            // 773: forge.AstraStatus
+	(*NVLinkGpu)(nil),                                              // 774: forge.NVLinkGpu
+	(*MachineNVLinkStatusObservation)(nil),                         // 775: forge.MachineNVLinkStatusObservation
+	(*MachineNVLinkGpuStatusObservation)(nil),                      // 776: forge.MachineNVLinkGpuStatusObservation
+	(*NmxcBrowseRequest)(nil),                                      // 777: forge.NmxcBrowseRequest
+	(*NmxcBrowseResponse)(nil),                                     // 778: forge.NmxcBrowseResponse
+	(*NVLinkPartition)(nil),                                        // 779: forge.NVLinkPartition
+	(*NVLinkPartitionList)(nil),                                    // 780: forge.NVLinkPartitionList
+	(*NVLinkPartitionSearchConfig)(nil),                            // 781: forge.NVLinkPartitionSearchConfig
+	(*NVLinkPartitionQuery)(nil),                                   // 782: forge.NVLinkPartitionQuery
+	(*NVLinkPartitionSearchFilter)(nil),                            // 783: forge.NVLinkPartitionSearchFilter
+	(*NVLinkPartitionsByIdsRequest)(nil),                           // 784: forge.NVLinkPartitionsByIdsRequest
+	(*NVLinkPartitionIdList)(nil),                                  // 785: forge.NVLinkPartitionIdList
+	(*NVLinkFabricSearchFilter)(nil),                               // 786: forge.NVLinkFabricSearchFilter
+	(*NVLinkLogicalPartitionConfig)(nil),                           // 787: forge.NVLinkLogicalPartitionConfig
+	(*NVLinkLogicalPartitionStatus)(nil),                           // 788: forge.NVLinkLogicalPartitionStatus
+	(*NVLinkLogicalPartition)(nil),                                 // 789: forge.NVLinkLogicalPartition
+	(*NVLinkLogicalPartitionList)(nil),                             // 790: forge.NVLinkLogicalPartitionList
+	(*NVLinkLogicalPartitionCreationRequest)(nil),                  // 791: forge.NVLinkLogicalPartitionCreationRequest
+	(*NVLinkLogicalPartitionDeletionRequest)(nil),                  // 792: forge.NVLinkLogicalPartitionDeletionRequest
+	(*NVLinkLogicalPartitionDeletionResult)(nil),                   // 793: forge.NVLinkLogicalPartitionDeletionResult
+	(*NVLinkLogicalPartitionSearchFilter)(nil),                     // 794: forge.NVLinkLogicalPartitionSearchFilter
+	(*NVLinkLogicalPartitionsByIdsRequest)(nil),                    // 795: forge.NVLinkLogicalPartitionsByIdsRequest
+	(*NVLinkLogicalPartitionIdList)(nil),                           // 796: forge.NVLinkLogicalPartitionIdList
+	(*NVLinkLogicalPartitionUpdateRequest)(nil),                    // 797: forge.NVLinkLogicalPartitionUpdateRequest
+	(*NVLinkLogicalPartitionUpdateResult)(nil),                     // 798: forge.NVLinkLogicalPartitionUpdateResult
+	(*CreateBmcUserRequest)(nil),                                   // 799: forge.CreateBmcUserRequest
+	(*CreateBmcUserResponse)(nil),                                  // 800: forge.CreateBmcUserResponse
+	(*DeleteBmcUserRequest)(nil),                                   // 801: forge.DeleteBmcUserRequest
+	(*DeleteBmcUserResponse)(nil),                                  // 802: forge.DeleteBmcUserResponse
+	(*SetBmcRootPasswordRequest)(nil),                              // 803: forge.SetBmcRootPasswordRequest
+	(*SetBmcRootPasswordResponse)(nil),                             // 804: forge.SetBmcRootPasswordResponse
+	(*ProbeBmcVendorRequest)(nil),                                  // 805: forge.ProbeBmcVendorRequest
+	(*ProbeBmcVendorResponse)(nil),                                 // 806: forge.ProbeBmcVendorResponse
+	(*SetFirmwareUpdateTimeWindowRequest)(nil),                     // 807: forge.SetFirmwareUpdateTimeWindowRequest
+	(*SetFirmwareUpdateTimeWindowResponse)(nil),                    // 808: forge.SetFirmwareUpdateTimeWindowResponse
+	(*UpsertHostFirmwareConfigRequest)(nil),                        // 809: forge.UpsertHostFirmwareConfigRequest
+	(*DeleteHostFirmwareConfigRequest)(nil),                        // 810: forge.DeleteHostFirmwareConfigRequest
+	(*UpsertHostFirmwareComponentConfig)(nil),                      // 811: forge.UpsertHostFirmwareComponentConfig
+	(*HostFirmwareComponentConfigResponse)(nil),                    // 812: forge.HostFirmwareComponentConfigResponse
+	(*HostFirmwareVersionConfig)(nil),                              // 813: forge.HostFirmwareVersionConfig
+	(*HostFirmwareArtifact)(nil),                                   // 814: forge.HostFirmwareArtifact
+	(*HostFirmwareConfigResponse)(nil),                             // 815: forge.HostFirmwareConfigResponse
+	(*ListHostFirmwareRequest)(nil),                                // 816: forge.ListHostFirmwareRequest
+	(*ListHostFirmwareResponse)(nil),                               // 817: forge.ListHostFirmwareResponse
+	(*AvailableHostFirmware)(nil),                                  // 818: forge.AvailableHostFirmware
+	(*TrimTableRequest)(nil),                                       // 819: forge.TrimTableRequest
+	(*TrimTableResponse)(nil),                                      // 820: forge.TrimTableResponse
+	(*NvlinkNmxcEndpoint)(nil),                                     // 821: forge.NvlinkNmxcEndpoint
+	(*NvlinkNmxcEndpointList)(nil),                                 // 822: forge.NvlinkNmxcEndpointList
+	(*DeleteNvlinkNmxcEndpointRequest)(nil),                        // 823: forge.DeleteNvlinkNmxcEndpointRequest
+	(*CreateRemediationRequest)(nil),                               // 824: forge.CreateRemediationRequest
+	(*CreateRemediationResponse)(nil),                              // 825: forge.CreateRemediationResponse
+	(*RemediationIdList)(nil),                                      // 826: forge.RemediationIdList
+	(*RemediationList)(nil),                                        // 827: forge.RemediationList
+	(*Remediation)(nil),                                            // 828: forge.Remediation
+	(*ApproveRemediationRequest)(nil),                              // 829: forge.ApproveRemediationRequest
+	(*RevokeRemediationRequest)(nil),                               // 830: forge.RevokeRemediationRequest
+	(*EnableRemediationRequest)(nil),                               // 831: forge.EnableRemediationRequest
+	(*DisableRemediationRequest)(nil),                              // 832: forge.DisableRemediationRequest
+	(*FindAppliedRemediationIdsRequest)(nil),                       // 833: forge.FindAppliedRemediationIdsRequest
+	(*AppliedRemediationIdList)(nil),                               // 834: forge.AppliedRemediationIdList
+	(*FindAppliedRemediationsRequest)(nil),                         // 835: forge.FindAppliedRemediationsRequest
+	(*AppliedRemediation)(nil),                                     // 836: forge.AppliedRemediation
+	(*AppliedRemediationList)(nil),                                 // 837: forge.AppliedRemediationList
+	(*GetNextRemediationForMachineRequest)(nil),                    // 838: forge.GetNextRemediationForMachineRequest
+	(*GetNextRemediationForMachineResponse)(nil),                   // 839: forge.GetNextRemediationForMachineResponse
+	(*RemediationAppliedRequest)(nil),                              // 840: forge.RemediationAppliedRequest
+	(*RemediationApplicationStatus)(nil),                           // 841: forge.RemediationApplicationStatus
+	(*SetPrimaryDpuRequest)(nil),                                   // 842: forge.SetPrimaryDpuRequest
+	(*SetPrimaryInterfaceRequest)(nil),                             // 843: forge.SetPrimaryInterfaceRequest
+	(*UsernamePassword)(nil),                                       // 844: forge.UsernamePassword
+	(*SessionToken)(nil),                                           // 845: forge.SessionToken
+	(*DpuExtensionServiceCredential)(nil),                          // 846: forge.DpuExtensionServiceCredential
+	(*DpuExtensionServiceVersionInfo)(nil),                         // 847: forge.DpuExtensionServiceVersionInfo
+	(*DpuExtensionService)(nil),                                    // 848: forge.DpuExtensionService
+	(*CreateDpuExtensionServiceRequest)(nil),                       // 849: forge.CreateDpuExtensionServiceRequest
+	(*UpdateDpuExtensionServiceRequest)(nil),                       // 850: forge.UpdateDpuExtensionServiceRequest
+	(*DeleteDpuExtensionServiceRequest)(nil),                       // 851: forge.DeleteDpuExtensionServiceRequest
+	(*DeleteDpuExtensionServiceResponse)(nil),                      // 852: forge.DeleteDpuExtensionServiceResponse
+	(*DpuExtensionServiceSearchFilter)(nil),                        // 853: forge.DpuExtensionServiceSearchFilter
+	(*DpuExtensionServiceIdList)(nil),                              // 854: forge.DpuExtensionServiceIdList
+	(*DpuExtensionServicesByIdsRequest)(nil),                       // 855: forge.DpuExtensionServicesByIdsRequest
+	(*DpuExtensionServiceList)(nil),                                // 856: forge.DpuExtensionServiceList
+	(*GetDpuExtensionServiceVersionsInfoRequest)(nil),              // 857: forge.GetDpuExtensionServiceVersionsInfoRequest
+	(*DpuExtensionServiceVersionInfoList)(nil),                     // 858: forge.DpuExtensionServiceVersionInfoList
+	(*FindInstancesByDpuExtensionServiceRequest)(nil),              // 859: forge.FindInstancesByDpuExtensionServiceRequest
+	(*FindInstancesByDpuExtensionServiceResponse)(nil),             // 860: forge.FindInstancesByDpuExtensionServiceResponse
+	(*InstanceDpuExtensionServiceInfo)(nil),                        // 861: forge.InstanceDpuExtensionServiceInfo
+	(*DpuExtensionServiceObservabilityConfigPrometheus)(nil),       // 862: forge.DpuExtensionServiceObservabilityConfigPrometheus
+	(*DpuExtensionServiceObservabilityConfigLogging)(nil),          // 863: forge.DpuExtensionServiceObservabilityConfigLogging
+	(*DpuExtensionServiceObservabilityConfig)(nil),                 // 864: forge.DpuExtensionServiceObservabilityConfig
+	(*DpuExtensionServiceObservability)(nil),                       // 865: forge.DpuExtensionServiceObservability
+	(*ScoutStreamApiBoundMessage)(nil),                             // 866: forge.ScoutStreamApiBoundMessage
+	(*ScoutStreamScoutBoundMessage)(nil),                           // 867: forge.ScoutStreamScoutBoundMessage
+	(*ScoutStreamInitRequest)(nil),                                 // 868: forge.ScoutStreamInitRequest
+	(*ScoutStreamShowConnectionsRequest)(nil),                      // 869: forge.ScoutStreamShowConnectionsRequest
+	(*ScoutStreamShowConnectionsResponse)(nil),                     // 870: forge.ScoutStreamShowConnectionsResponse
+	(*ScoutStreamDisconnectRequest)(nil),                           // 871: forge.ScoutStreamDisconnectRequest
+	(*ScoutStreamDisconnectResponse)(nil),                          // 872: forge.ScoutStreamDisconnectResponse
+	(*ScoutStreamAdminPingRequest)(nil),                            // 873: forge.ScoutStreamAdminPingRequest
+	(*ScoutStreamAdminPingResponse)(nil),                           // 874: forge.ScoutStreamAdminPingResponse
+	(*ScoutStreamAgentPingRequest)(nil),                            // 875: forge.ScoutStreamAgentPingRequest
+	(*ScoutStreamAgentPingResponse)(nil),                           // 876: forge.ScoutStreamAgentPingResponse
+	(*ScoutStreamConnectionInfo)(nil),                              // 877: forge.ScoutStreamConnectionInfo
+	(*ScoutStreamError)(nil),                                       // 878: forge.ScoutStreamError
+	(*PrefixFilterPolicyEntry)(nil),                                // 879: forge.PrefixFilterPolicyEntry
+	(*RoutingProfile)(nil),                                         // 880: forge.RoutingProfile
+	(*DomainLegacy)(nil),                                           // 881: forge.DomainLegacy
+	(*DomainListLegacy)(nil),                                       // 882: forge.DomainListLegacy
+	(*DomainDeletionLegacy)(nil),                                   // 883: forge.DomainDeletionLegacy
+	(*DomainDeletionResultLegacy)(nil),                             // 884: forge.DomainDeletionResultLegacy
+	(*DomainSearchQueryLegacy)(nil),                                // 885: forge.DomainSearchQueryLegacy
+	(*PxeDomain)(nil),                                              // 886: forge.PxeDomain
+	(*MachinePositionQuery)(nil),                                   // 887: forge.MachinePositionQuery
+	(*MachinePositionInfoList)(nil),                                // 888: forge.MachinePositionInfoList
+	(*MachinePositionInfo)(nil),                                    // 889: forge.MachinePositionInfo
+	(*ModifyDPFStateRequest)(nil),                                  // 890: forge.ModifyDPFStateRequest
+	(*DPFStateResponse)(nil),                                       // 891: forge.DPFStateResponse
+	(*GetDPFStateRequest)(nil),                                     // 892: forge.GetDPFStateRequest
+	(*GetDPFHostSnapshotRequest)(nil),                              // 893: forge.GetDPFHostSnapshotRequest
+	(*DPFHostSnapshotResponse)(nil),                                // 894: forge.DPFHostSnapshotResponse
+	(*GetDPFServiceVersionsRequest)(nil),                           // 895: forge.GetDPFServiceVersionsRequest
+	(*DPFServiceVersion)(nil),                                      // 896: forge.DPFServiceVersion
+	(*DPFServiceVersionsResponse)(nil),                             // 897: forge.DPFServiceVersionsResponse
+	(*ComponentResult)(nil),                                        // 898: forge.ComponentResult
+	(*SwitchIdList)(nil),                                           // 899: forge.SwitchIdList
+	(*PowerShelfIdList)(nil),                                       // 900: forge.PowerShelfIdList
+	(*GetComponentInventoryRequest)(nil),                           // 901: forge.GetComponentInventoryRequest
+	(*ComponentInventoryEntry)(nil),                                // 902: forge.ComponentInventoryEntry
+	(*GetComponentInventoryResponse)(nil),                          // 903: forge.GetComponentInventoryResponse
+	(*ComponentPowerControlRequest)(nil),                           // 904: forge.ComponentPowerControlRequest
+	(*ComponentPowerControlResponse)(nil),                          // 905: forge.ComponentPowerControlResponse
+	(*ComponentConfigureSwitchCertificateRequest)(nil),             // 906: forge.ComponentConfigureSwitchCertificateRequest
+	(*ComponentConfigureSwitchCertificateResponse)(nil),            // 907: forge.ComponentConfigureSwitchCertificateResponse
+	(*FirmwareUpdateStatus)(nil),                                   // 908: forge.FirmwareUpdateStatus
+	(*UpdateComputeTrayFirmwareTarget)(nil),                        // 909: forge.UpdateComputeTrayFirmwareTarget
+	(*UpdateSwitchFirmwareTarget)(nil),                             // 910: forge.UpdateSwitchFirmwareTarget
+	(*UpdatePowerShelfFirmwareTarget)(nil),                         // 911: forge.UpdatePowerShelfFirmwareTarget
+	(*UpdateFirmwareObjectTarget)(nil),                             // 912: forge.UpdateFirmwareObjectTarget
+	(*UpdateComponentFirmwareRequest)(nil),                         // 913: forge.UpdateComponentFirmwareRequest
+	(*UpdateComponentFirmwareResponse)(nil),                        // 914: forge.UpdateComponentFirmwareResponse
+	(*GetComponentFirmwareStatusRequest)(nil),                      // 915: forge.GetComponentFirmwareStatusRequest
+	(*GetComponentFirmwareStatusResponse)(nil),                     // 916: forge.GetComponentFirmwareStatusResponse
+	(*ListComponentFirmwareVersionsRequest)(nil),                   // 917: forge.ListComponentFirmwareVersionsRequest
+	(*ComputeTrayFirmwareVersions)(nil),                            // 918: forge.ComputeTrayFirmwareVersions
+	(*DeviceFirmwareVersions)(nil),                                 // 919: forge.DeviceFirmwareVersions
+	(*ListComponentFirmwareVersionsResponse)(nil),                  // 920: forge.ListComponentFirmwareVersionsResponse
+	(*SpxPartitionCreationRequest)(nil),                            // 921: forge.SpxPartitionCreationRequest
+	(*SpxPartition)(nil),                                           // 922: forge.SpxPartition
+	(*SpxPartitionIdList)(nil),                                     // 923: forge.SpxPartitionIdList
+	(*SpxPartitionDeletionRequest)(nil),                            // 924: forge.SpxPartitionDeletionRequest
+	(*SpxPartitionDeletionResult)(nil),                             // 925: forge.SpxPartitionDeletionResult
+	(*SpxPartitionSearchFilter)(nil),                               // 926: forge.SpxPartitionSearchFilter
+	(*SpxPartitionList)(nil),                                       // 927: forge.SpxPartitionList
+	(*SpxPartitionsByIdsRequest)(nil),                              // 928: forge.SpxPartitionsByIdsRequest
+	(*AdminForceDeleteSwitchRequest)(nil),                          // 929: forge.AdminForceDeleteSwitchRequest
+	(*AdminForceDeleteSwitchResponse)(nil),                         // 930: forge.AdminForceDeleteSwitchResponse
+	(*AdminForceDeletePowerShelfRequest)(nil),                      // 931: forge.AdminForceDeletePowerShelfRequest
+	(*AdminForceDeletePowerShelfResponse)(nil),                     // 932: forge.AdminForceDeletePowerShelfResponse
+	(*OperatingSystem)(nil),                                        // 933: forge.OperatingSystem
+	(*CreateOperatingSystemRequest)(nil),                           // 934: forge.CreateOperatingSystemRequest
+	(*IpxeTemplateParameters)(nil),                                 // 935: forge.IpxeTemplateParameters
+	(*IpxeTemplateArtifacts)(nil),                                  // 936: forge.IpxeTemplateArtifacts
+	(*UpdateOperatingSystemRequest)(nil),                           // 937: forge.UpdateOperatingSystemRequest
+	(*DeleteOperatingSystemRequest)(nil),                           // 938: forge.DeleteOperatingSystemRequest
+	(*DeleteOperatingSystemResponse)(nil),                          // 939: forge.DeleteOperatingSystemResponse
+	(*OperatingSystemSearchFilter)(nil),                            // 940: forge.OperatingSystemSearchFilter
+	(*OperatingSystemIdList)(nil),                                  // 941: forge.OperatingSystemIdList
+	(*OperatingSystemsByIdsRequest)(nil),                           // 942: forge.OperatingSystemsByIdsRequest
+	(*OperatingSystemList)(nil),                                    // 943: forge.OperatingSystemList
+	(*GetOperatingSystemCachableIpxeTemplateArtifactsRequest)(nil), // 944: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	(*IpxeTemplateArtifactList)(nil),                               // 945: forge.IpxeTemplateArtifactList
+	(*IpxeTemplateArtifactUpdateRequest)(nil),                      // 946: forge.IpxeTemplateArtifactUpdateRequest
+	(*UpdateOperatingSystemIpxeTemplateArtifactRequest)(nil),       // 947: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	(*HostRepresentorInterceptBridging)(nil),                       // 948: forge.HostRepresentorInterceptBridging
+	(*ReWrapSecretsRequest)(nil),                                   // 949: forge.ReWrapSecretsRequest
+	(*ReWrapSecretsResponse)(nil),                                  // 950: forge.ReWrapSecretsResponse
+	(*GetMachineBootInterfacesRequest)(nil),                        // 951: forge.GetMachineBootInterfacesRequest
+	(*MachineBootInterface)(nil),                                   // 952: forge.MachineBootInterface
+	(*MachineInterfaceBootInterface)(nil),                          // 953: forge.MachineInterfaceBootInterface
+	(*PredictedBootInterface)(nil),                                 // 954: forge.PredictedBootInterface
+	(*ExploredBootInterface)(nil),                                  // 955: forge.ExploredBootInterface
+	(*RetainedBootInterface)(nil),                                  // 956: forge.RetainedBootInterface
+	(*GetMachineBootInterfacesResponse)(nil),                       // 957: forge.GetMachineBootInterfacesResponse
+	(*GetContainerRegistryCredentialRequest)(nil),                  // 958: forge.GetContainerRegistryCredentialRequest
+	(*GetContainerRegistryCredentialResponse)(nil),                 // 959: forge.GetContainerRegistryCredentialResponse
+	(*SetContainerRegistryCredentialRequest)(nil),                  // 960: forge.SetContainerRegistryCredentialRequest
+	(*SitePrefix)(nil),                                             // 961: forge.SitePrefix
+	(*SitePrefixConfig)(nil),                                       // 962: forge.SitePrefixConfig
+	(*SitePrefixStatus)(nil),                                       // 963: forge.SitePrefixStatus
+	(*SitePrefixSearchFilter)(nil),                                 // 964: forge.SitePrefixSearchFilter
+	(*SitePrefixesByIdsRequest)(nil),                               // 965: forge.SitePrefixesByIdsRequest
+	(*SitePrefixIdList)(nil),                                       // 966: forge.SitePrefixIdList
+	(*SitePrefixList)(nil),                                         // 967: forge.SitePrefixList
+	(*EraseHostMetadataByBmcMacRequest)(nil),                       // 968: forge.EraseHostMetadataByBmcMacRequest
+	(*EraseHostMetadataByBmcMacResponse)(nil),                      // 969: forge.EraseHostMetadataByBmcMacResponse
+	nil,                                  // 970: forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
+	(*DNSMessage_DNSQuestion)(nil),       // 971: forge.DNSMessage.DNSQuestion
+	(*DNSMessage_DNSResponse)(nil),       // 972: forge.DNSMessage.DNSResponse
+	(*DNSMessage_DNSResponse_DNSRR)(nil), // 973: forge.DNSMessage.DNSResponse.DNSRR
+	nil,                                  // 974: forge.FabricManagerConfig.ConfigMapEntry
+	nil,                                  // 975: forge.StateHistories.HistoriesEntry
+	nil,                                  // 976: forge.MachineStateHistories.HistoriesEntry
+	nil,                                  // 977: forge.HealthHistories.HistoriesEntry
+	nil,                                  // 978: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
+	(*MachineCredentialsUpdateRequest_Credentials)(nil),                       // 979: forge.MachineCredentialsUpdateRequest.Credentials
+	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo)(nil),              // 980: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
+	(*ForgeAgentControlResponse_Noop)(nil),                                    // 981: forge.ForgeAgentControlResponse.Noop
+	(*ForgeAgentControlResponse_Reset)(nil),                                   // 982: forge.ForgeAgentControlResponse.Reset
+	(*ForgeAgentControlResponse_Discovery)(nil),                               // 983: forge.ForgeAgentControlResponse.Discovery
+	(*ForgeAgentControlResponse_Rebuild)(nil),                                 // 984: forge.ForgeAgentControlResponse.Rebuild
+	(*ForgeAgentControlResponse_Retry)(nil),                                   // 985: forge.ForgeAgentControlResponse.Retry
+	(*ForgeAgentControlResponse_Measure)(nil),                                 // 986: forge.ForgeAgentControlResponse.Measure
+	(*ForgeAgentControlResponse_LogError)(nil),                                // 987: forge.ForgeAgentControlResponse.LogError
+	(*ForgeAgentControlResponse_MachineValidation)(nil),                       // 988: forge.ForgeAgentControlResponse.MachineValidation
+	(*ForgeAgentControlResponse_MachineValidationFilter)(nil),                 // 989: forge.ForgeAgentControlResponse.MachineValidationFilter
+	(*ForgeAgentControlResponse_MlxAction)(nil),                               // 990: forge.ForgeAgentControlResponse.MlxAction
+	(*ForgeAgentControlResponse_MlxDeviceAction)(nil),                         // 991: forge.ForgeAgentControlResponse.MlxDeviceAction
+	(*ForgeAgentControlResponse_MlxDeviceNoop)(nil),                           // 992: forge.ForgeAgentControlResponse.MlxDeviceNoop
+	(*ForgeAgentControlResponse_MlxDeviceLock)(nil),                           // 993: forge.ForgeAgentControlResponse.MlxDeviceLock
+	(*ForgeAgentControlResponse_MlxDeviceUnlock)(nil),                         // 994: forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	(*ForgeAgentControlResponse_MlxDeviceApplyProfile)(nil),                   // 995: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	(*ForgeAgentControlResponse_MlxDeviceApplyFirmware)(nil),                  // 996: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	(*ForgeAgentControlResponse_FirmwareUpgrade)(nil),                         // 997: forge.ForgeAgentControlResponse.FirmwareUpgrade
+	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair)(nil), // 998: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	(*MachineCleanupInfo_CleanupStepResult)(nil),                              // 999: forge.MachineCleanupInfo.CleanupStepResult
+	(*DpuReprovisioningListResponse_DpuReprovisioningListItem)(nil),           // 1000: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
+	(*HostReprovisioningListResponse_HostReprovisioningListItem)(nil),         // 1001: forge.HostReprovisioningListResponse.HostReprovisioningListItem
+	(*MachineValidationTestUpdateRequest_Payload)(nil),                        // 1002: forge.MachineValidationTestUpdateRequest.Payload
+	nil,                                                  // 1003: forge.RedfishBrowseResponse.HeadersEntry
+	nil,                                                  // 1004: forge.RedfishActionResult.HeadersEntry
+	nil,                                                  // 1005: forge.UfmBrowseResponse.HeadersEntry
+	nil,                                                  // 1006: forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
+	nil,                                                  // 1007: forge.NmxcBrowseResponse.HeadersEntry
+	(*DPFStateResponse_DPFState)(nil),                    // 1008: forge.DPFStateResponse.DPFState
+	(*MachineId)(nil),                                    // 1009: common.MachineId
+	(*timestamppb.Timestamp)(nil),                        // 1010: google.protobuf.Timestamp
+	(*VpcId)(nil),                                        // 1011: common.VpcId
+	(*NVLinkLogicalPartitionId)(nil),                     // 1012: common.NVLinkLogicalPartitionId
+	(*VpcPrefixId)(nil),                                  // 1013: common.VpcPrefixId
+	(*VpcPeeringId)(nil),                                 // 1014: common.VpcPeeringId
+	(*IBPartitionId)(nil),                                // 1015: common.IBPartitionId
+	(*HealthReport)(nil),                                 // 1016: health.HealthReport
+	(*PowerShelfId)(nil),                                 // 1017: common.PowerShelfId
+	(*RackId)(nil),                                       // 1018: common.RackId
+	(*UUID)(nil),                                         // 1019: common.UUID
+	(*SwitchId)(nil),                                     // 1020: common.SwitchId
+	(*RackProfileId)(nil),                                // 1021: common.RackProfileId
+	(*DomainId)(nil),                                     // 1022: common.DomainId
+	(*NetworkSegmentId)(nil),                             // 1023: common.NetworkSegmentId
+	(*NetworkPrefixId)(nil),                              // 1024: common.NetworkPrefixId
+	(*InstanceId)(nil),                                   // 1025: common.InstanceId
+	(*IpxeTemplateId)(nil),                               // 1026: common.IpxeTemplateId
+	(*OperatingSystemId)(nil),                            // 1027: common.OperatingSystemId
+	(*SpxPartitionId)(nil),                               // 1028: common.SpxPartitionId
+	(*NVLinkDomainId)(nil),                               // 1029: common.NVLinkDomainId
+	(*MachineInterfaceId)(nil),                           // 1030: common.MachineInterfaceId
+	(*DiscoveryInfo)(nil),                                // 1031: machine_discovery.DiscoveryInfo
+	(*durationpb.Duration)(nil),                          // 1032: google.protobuf.Duration
+	(*StringList)(nil),                                   // 1033: common.StringList
+	(*Gpu)(nil),                                          // 1034: machine_discovery.Gpu
+	(*RouteTarget)(nil),                                  // 1035: common.RouteTarget
+	(*MachineValidationId)(nil),                          // 1036: common.MachineValidationId
+	(*Uint32List)(nil),                                   // 1037: common.Uint32List
+	(*DpaInterfaceId)(nil),                               // 1038: common.DpaInterfaceId
+	(*ComputeAllocationId)(nil),                          // 1039: common.ComputeAllocationId
+	(*RackHardwareType)(nil),                             // 1040: common.RackHardwareType
+	(*NVLinkPartitionId)(nil),                            // 1041: common.NVLinkPartitionId
+	(*RemediationId)(nil),                                // 1042: common.RemediationId
+	(*MlxDeviceLockdownResponse)(nil),                    // 1043: mlx_device.MlxDeviceLockdownResponse
+	(*MlxDeviceProfileSyncResponse)(nil),                 // 1044: mlx_device.MlxDeviceProfileSyncResponse
+	(*MlxDeviceProfileCompareResponse)(nil),              // 1045: mlx_device.MlxDeviceProfileCompareResponse
+	(*MlxDeviceInfoDeviceResponse)(nil),                  // 1046: mlx_device.MlxDeviceInfoDeviceResponse
+	(*MlxDeviceInfoReportResponse)(nil),                  // 1047: mlx_device.MlxDeviceInfoReportResponse
+	(*MlxDeviceRegistryListResponse)(nil),                // 1048: mlx_device.MlxDeviceRegistryListResponse
+	(*MlxDeviceRegistryShowResponse)(nil),                // 1049: mlx_device.MlxDeviceRegistryShowResponse
+	(*MlxDeviceConfigQueryResponse)(nil),                 // 1050: mlx_device.MlxDeviceConfigQueryResponse
+	(*MlxDeviceConfigSetResponse)(nil),                   // 1051: mlx_device.MlxDeviceConfigSetResponse
+	(*MlxDeviceConfigSyncResponse)(nil),                  // 1052: mlx_device.MlxDeviceConfigSyncResponse
+	(*MlxDeviceConfigCompareResponse)(nil),               // 1053: mlx_device.MlxDeviceConfigCompareResponse
+	(*MlxDeviceLockdownLockRequest)(nil),                 // 1054: mlx_device.MlxDeviceLockdownLockRequest
+	(*MlxDeviceLockdownUnlockRequest)(nil),               // 1055: mlx_device.MlxDeviceLockdownUnlockRequest
+	(*MlxDeviceLockdownStatusRequest)(nil),               // 1056: mlx_device.MlxDeviceLockdownStatusRequest
+	(*MlxDeviceProfileSyncRequest)(nil),                  // 1057: mlx_device.MlxDeviceProfileSyncRequest
+	(*MlxDeviceProfileCompareRequest)(nil),               // 1058: mlx_device.MlxDeviceProfileCompareRequest
+	(*MlxDeviceInfoDeviceRequest)(nil),                   // 1059: mlx_device.MlxDeviceInfoDeviceRequest
+	(*MlxDeviceInfoReportRequest)(nil),                   // 1060: mlx_device.MlxDeviceInfoReportRequest
+	(*MlxDeviceRegistryListRequest)(nil),                 // 1061: mlx_device.MlxDeviceRegistryListRequest
+	(*MlxDeviceRegistryShowRequest)(nil),                 // 1062: mlx_device.MlxDeviceRegistryShowRequest
+	(*MlxDeviceConfigQueryRequest)(nil),                  // 1063: mlx_device.MlxDeviceConfigQueryRequest
+	(*MlxDeviceConfigSetRequest)(nil),                    // 1064: mlx_device.MlxDeviceConfigSetRequest
+	(*MlxDeviceConfigSyncRequest)(nil),                   // 1065: mlx_device.MlxDeviceConfigSyncRequest
+	(*MlxDeviceConfigCompareRequest)(nil),                // 1066: mlx_device.MlxDeviceConfigCompareRequest
+	(*Domain)(nil),                                       // 1067: dns.Domain
+	(*MachineIdList)(nil),                                // 1068: common.MachineIdList
+	(*EndpointExplorationReport)(nil),                    // 1069: site_explorer.EndpointExplorationReport
+	(SystemPowerControl)(0),                              // 1070: common.SystemPowerControl
+	(*SitePrefixId)(nil),                                 // 1071: common.SitePrefixId
+	(*SerializableMlxConfigProfile)(nil),                 // 1072: mlx_device.SerializableMlxConfigProfile
+	(*FirmwareFlasherProfile)(nil),                       // 1073: mlx_device.FirmwareFlasherProfile
+	(*ScoutFirmwareUpgradeTask)(nil),                     // 1074: scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	(*CreateDomainRequest)(nil),                          // 1075: dns.CreateDomainRequest
+	(*UpdateDomainRequest)(nil),                          // 1076: dns.UpdateDomainRequest
+	(*DomainDeletionRequest)(nil),                        // 1077: dns.DomainDeletionRequest
+	(*DomainSearchQuery)(nil),                            // 1078: dns.DomainSearchQuery
+	(*DnsResourceRecordLookupRequest)(nil),               // 1079: dns.DnsResourceRecordLookupRequest
+	(*GetAllDomainsRequest)(nil),                         // 1080: dns.GetAllDomainsRequest
+	(*DomainMetadataRequest)(nil),                        // 1081: dns.DomainMetadataRequest
+	(*emptypb.Empty)(nil),                                // 1082: google.protobuf.Empty
+	(*ExploredEndpointSearchFilter)(nil),                 // 1083: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointsByIdsRequest)(nil),                // 1084: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredManagedHostSearchFilter)(nil),              // 1085: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostsByIdsRequest)(nil),             // 1086: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1087: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1088: site_explorer.ExploredMlxDevicesByIdsRequest
+	(*CreateMeasurementBundleRequest)(nil),               // 1089: measured_boot.CreateMeasurementBundleRequest
+	(*DeleteMeasurementBundleRequest)(nil),               // 1090: measured_boot.DeleteMeasurementBundleRequest
+	(*RenameMeasurementBundleRequest)(nil),               // 1091: measured_boot.RenameMeasurementBundleRequest
+	(*UpdateMeasurementBundleRequest)(nil),               // 1092: measured_boot.UpdateMeasurementBundleRequest
+	(*ShowMeasurementBundleRequest)(nil),                 // 1093: measured_boot.ShowMeasurementBundleRequest
+	(*ShowMeasurementBundlesRequest)(nil),                // 1094: measured_boot.ShowMeasurementBundlesRequest
+	(*ListMeasurementBundlesRequest)(nil),                // 1095: measured_boot.ListMeasurementBundlesRequest
+	(*ListMeasurementBundleMachinesRequest)(nil),         // 1096: measured_boot.ListMeasurementBundleMachinesRequest
+	(*FindClosestBundleMatchRequest)(nil),                // 1097: measured_boot.FindClosestBundleMatchRequest
+	(*DeleteMeasurementJournalRequest)(nil),              // 1098: measured_boot.DeleteMeasurementJournalRequest
+	(*ShowMeasurementJournalRequest)(nil),                // 1099: measured_boot.ShowMeasurementJournalRequest
+	(*ShowMeasurementJournalsRequest)(nil),               // 1100: measured_boot.ShowMeasurementJournalsRequest
+	(*ListMeasurementJournalRequest)(nil),                // 1101: measured_boot.ListMeasurementJournalRequest
+	(*AttestCandidateMachineRequest)(nil),                // 1102: measured_boot.AttestCandidateMachineRequest
+	(*ShowCandidateMachineRequest)(nil),                  // 1103: measured_boot.ShowCandidateMachineRequest
+	(*ShowCandidateMachinesRequest)(nil),                 // 1104: measured_boot.ShowCandidateMachinesRequest
+	(*ListCandidateMachinesRequest)(nil),                 // 1105: measured_boot.ListCandidateMachinesRequest
+	(*CreateMeasurementSystemProfileRequest)(nil),        // 1106: measured_boot.CreateMeasurementSystemProfileRequest
+	(*DeleteMeasurementSystemProfileRequest)(nil),        // 1107: measured_boot.DeleteMeasurementSystemProfileRequest
+	(*RenameMeasurementSystemProfileRequest)(nil),        // 1108: measured_boot.RenameMeasurementSystemProfileRequest
+	(*ShowMeasurementSystemProfileRequest)(nil),          // 1109: measured_boot.ShowMeasurementSystemProfileRequest
+	(*ShowMeasurementSystemProfilesRequest)(nil),         // 1110: measured_boot.ShowMeasurementSystemProfilesRequest
+	(*ListMeasurementSystemProfilesRequest)(nil),         // 1111: measured_boot.ListMeasurementSystemProfilesRequest
+	(*ListMeasurementSystemProfileBundlesRequest)(nil),   // 1112: measured_boot.ListMeasurementSystemProfileBundlesRequest
+	(*ListMeasurementSystemProfileMachinesRequest)(nil),  // 1113: measured_boot.ListMeasurementSystemProfileMachinesRequest
+	(*CreateMeasurementReportRequest)(nil),               // 1114: measured_boot.CreateMeasurementReportRequest
+	(*DeleteMeasurementReportRequest)(nil),               // 1115: measured_boot.DeleteMeasurementReportRequest
+	(*PromoteMeasurementReportRequest)(nil),              // 1116: measured_boot.PromoteMeasurementReportRequest
+	(*RevokeMeasurementReportRequest)(nil),               // 1117: measured_boot.RevokeMeasurementReportRequest
+	(*ShowMeasurementReportForIdRequest)(nil),            // 1118: measured_boot.ShowMeasurementReportForIdRequest
+	(*ShowMeasurementReportsForMachineRequest)(nil),      // 1119: measured_boot.ShowMeasurementReportsForMachineRequest
+	(*ShowMeasurementReportsRequest)(nil),                // 1120: measured_boot.ShowMeasurementReportsRequest
+	(*ListMeasurementReportRequest)(nil),                 // 1121: measured_boot.ListMeasurementReportRequest
+	(*MatchMeasurementReportRequest)(nil),                // 1122: measured_boot.MatchMeasurementReportRequest
+	(*ImportSiteMeasurementsRequest)(nil),                // 1123: measured_boot.ImportSiteMeasurementsRequest
+	(*ExportSiteMeasurementsRequest)(nil),                // 1124: measured_boot.ExportSiteMeasurementsRequest
+	(*AddMeasurementTrustedMachineRequest)(nil),          // 1125: measured_boot.AddMeasurementTrustedMachineRequest
+	(*RemoveMeasurementTrustedMachineRequest)(nil),       // 1126: measured_boot.RemoveMeasurementTrustedMachineRequest
+	(*AddMeasurementTrustedProfileRequest)(nil),          // 1127: measured_boot.AddMeasurementTrustedProfileRequest
+	(*RemoveMeasurementTrustedProfileRequest)(nil),       // 1128: measured_boot.RemoveMeasurementTrustedProfileRequest
+	(*ListMeasurementTrustedMachinesRequest)(nil),        // 1129: measured_boot.ListMeasurementTrustedMachinesRequest
+	(*ListMeasurementTrustedProfilesRequest)(nil),        // 1130: measured_boot.ListMeasurementTrustedProfilesRequest
+	(*ListAttestationSummaryRequest)(nil),                // 1131: measured_boot.ListAttestationSummaryRequest
+	(*PublishMlxDeviceReportRequest)(nil),                // 1132: mlx_device.PublishMlxDeviceReportRequest
+	(*PublishMlxObservationReportRequest)(nil),           // 1133: mlx_device.PublishMlxObservationReportRequest
+	(*MlxAdminProfileSyncRequest)(nil),                   // 1134: mlx_device.MlxAdminProfileSyncRequest
+	(*MlxAdminProfileShowRequest)(nil),                   // 1135: mlx_device.MlxAdminProfileShowRequest
+	(*MlxAdminProfileCompareRequest)(nil),                // 1136: mlx_device.MlxAdminProfileCompareRequest
+	(*MlxAdminProfileListRequest)(nil),                   // 1137: mlx_device.MlxAdminProfileListRequest
+	(*MlxAdminLockdownLockRequest)(nil),                  // 1138: mlx_device.MlxAdminLockdownLockRequest
+	(*MlxAdminLockdownUnlockRequest)(nil),                // 1139: mlx_device.MlxAdminLockdownUnlockRequest
+	(*MlxAdminLockdownStatusRequest)(nil),                // 1140: mlx_device.MlxAdminLockdownStatusRequest
+	(*MlxAdminDeviceInfoRequest)(nil),                    // 1141: mlx_device.MlxAdminDeviceInfoRequest
+	(*MlxAdminDeviceReportRequest)(nil),                  // 1142: mlx_device.MlxAdminDeviceReportRequest
+	(*MlxAdminRegistryListRequest)(nil),                  // 1143: mlx_device.MlxAdminRegistryListRequest
+	(*MlxAdminRegistryShowRequest)(nil),                  // 1144: mlx_device.MlxAdminRegistryShowRequest
+	(*MlxAdminConfigQueryRequest)(nil),                   // 1145: mlx_device.MlxAdminConfigQueryRequest
+	(*MlxAdminConfigSetRequest)(nil),                     // 1146: mlx_device.MlxAdminConfigSetRequest
+	(*MlxAdminConfigSyncRequest)(nil),                    // 1147: mlx_device.MlxAdminConfigSyncRequest
+	(*MlxAdminConfigCompareRequest)(nil),                 // 1148: mlx_device.MlxAdminConfigCompareRequest
+	(*DomainDeletionResult)(nil),                         // 1149: dns.DomainDeletionResult
+	(*DomainList)(nil),                                   // 1150: dns.DomainList
+	(*DnsResourceRecordLookupResponse)(nil),              // 1151: dns.DnsResourceRecordLookupResponse
+	(*GetAllDomainsResponse)(nil),                        // 1152: dns.GetAllDomainsResponse
+	(*DomainMetadataResponse)(nil),                       // 1153: dns.DomainMetadataResponse
+	(*SiteExplorationReport)(nil),                        // 1154: site_explorer.SiteExplorationReport
+	(*SiteExplorerLastRunResponse)(nil),                  // 1155: site_explorer.SiteExplorerLastRunResponse
+	(*ExploredEndpoint)(nil),                             // 1156: site_explorer.ExploredEndpoint
+	(*ExploredEndpointIdList)(nil),                       // 1157: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointList)(nil),                         // 1158: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostIdList)(nil),                    // 1159: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostList)(nil),                      // 1160: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDeviceHostIdList)(nil),                  // 1161: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDeviceList)(nil),                        // 1162: site_explorer.ExploredMlxDeviceList
+	(*CreateMeasurementBundleResponse)(nil),              // 1163: measured_boot.CreateMeasurementBundleResponse
+	(*DeleteMeasurementBundleResponse)(nil),              // 1164: measured_boot.DeleteMeasurementBundleResponse
+	(*RenameMeasurementBundleResponse)(nil),              // 1165: measured_boot.RenameMeasurementBundleResponse
+	(*UpdateMeasurementBundleResponse)(nil),              // 1166: measured_boot.UpdateMeasurementBundleResponse
+	(*ShowMeasurementBundleResponse)(nil),                // 1167: measured_boot.ShowMeasurementBundleResponse
+	(*ShowMeasurementBundlesResponse)(nil),               // 1168: measured_boot.ShowMeasurementBundlesResponse
+	(*ListMeasurementBundlesResponse)(nil),               // 1169: measured_boot.ListMeasurementBundlesResponse
+	(*ListMeasurementBundleMachinesResponse)(nil),        // 1170: measured_boot.ListMeasurementBundleMachinesResponse
+	(*DeleteMeasurementJournalResponse)(nil),             // 1171: measured_boot.DeleteMeasurementJournalResponse
+	(*ShowMeasurementJournalResponse)(nil),               // 1172: measured_boot.ShowMeasurementJournalResponse
+	(*ShowMeasurementJournalsResponse)(nil),              // 1173: measured_boot.ShowMeasurementJournalsResponse
+	(*ListMeasurementJournalResponse)(nil),               // 1174: measured_boot.ListMeasurementJournalResponse
+	(*AttestCandidateMachineResponse)(nil),               // 1175: measured_boot.AttestCandidateMachineResponse
+	(*ShowCandidateMachineResponse)(nil),                 // 1176: measured_boot.ShowCandidateMachineResponse
+	(*ShowCandidateMachinesResponse)(nil),                // 1177: measured_boot.ShowCandidateMachinesResponse
+	(*ListCandidateMachinesResponse)(nil),                // 1178: measured_boot.ListCandidateMachinesResponse
+	(*CreateMeasurementSystemProfileResponse)(nil),       // 1179: measured_boot.CreateMeasurementSystemProfileResponse
+	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1180: measured_boot.DeleteMeasurementSystemProfileResponse
+	(*RenameMeasurementSystemProfileResponse)(nil),       // 1181: measured_boot.RenameMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfileResponse)(nil),         // 1182: measured_boot.ShowMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1183: measured_boot.ShowMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfilesResponse)(nil),        // 1184: measured_boot.ListMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1185: measured_boot.ListMeasurementSystemProfileBundlesResponse
+	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1186: measured_boot.ListMeasurementSystemProfileMachinesResponse
+	(*CreateMeasurementReportResponse)(nil),              // 1187: measured_boot.CreateMeasurementReportResponse
+	(*DeleteMeasurementReportResponse)(nil),              // 1188: measured_boot.DeleteMeasurementReportResponse
+	(*PromoteMeasurementReportResponse)(nil),             // 1189: measured_boot.PromoteMeasurementReportResponse
+	(*RevokeMeasurementReportResponse)(nil),              // 1190: measured_boot.RevokeMeasurementReportResponse
+	(*ShowMeasurementReportForIdResponse)(nil),           // 1191: measured_boot.ShowMeasurementReportForIdResponse
+	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1192: measured_boot.ShowMeasurementReportsForMachineResponse
+	(*ShowMeasurementReportsResponse)(nil),               // 1193: measured_boot.ShowMeasurementReportsResponse
+	(*ListMeasurementReportResponse)(nil),                // 1194: measured_boot.ListMeasurementReportResponse
+	(*MatchMeasurementReportResponse)(nil),               // 1195: measured_boot.MatchMeasurementReportResponse
+	(*ImportSiteMeasurementsResponse)(nil),               // 1196: measured_boot.ImportSiteMeasurementsResponse
+	(*ExportSiteMeasurementsResponse)(nil),               // 1197: measured_boot.ExportSiteMeasurementsResponse
+	(*AddMeasurementTrustedMachineResponse)(nil),         // 1198: measured_boot.AddMeasurementTrustedMachineResponse
+	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1199: measured_boot.RemoveMeasurementTrustedMachineResponse
+	(*AddMeasurementTrustedProfileResponse)(nil),         // 1200: measured_boot.AddMeasurementTrustedProfileResponse
+	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1201: measured_boot.RemoveMeasurementTrustedProfileResponse
+	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1202: measured_boot.ListMeasurementTrustedMachinesResponse
+	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1203: measured_boot.ListMeasurementTrustedProfilesResponse
+	(*ListAttestationSummaryResponse)(nil),               // 1204: measured_boot.ListAttestationSummaryResponse
+	(*LockdownStatus)(nil),                               // 1205: site_explorer.LockdownStatus
+	(*PublishMlxDeviceReportResponse)(nil),               // 1206: mlx_device.PublishMlxDeviceReportResponse
+	(*PublishMlxObservationReportResponse)(nil),          // 1207: mlx_device.PublishMlxObservationReportResponse
+	(*MlxAdminProfileSyncResponse)(nil),                  // 1208: mlx_device.MlxAdminProfileSyncResponse
+	(*MlxAdminProfileShowResponse)(nil),                  // 1209: mlx_device.MlxAdminProfileShowResponse
+	(*MlxAdminProfileCompareResponse)(nil),               // 1210: mlx_device.MlxAdminProfileCompareResponse
+	(*MlxAdminProfileListResponse)(nil),                  // 1211: mlx_device.MlxAdminProfileListResponse
+	(*MlxAdminLockdownLockResponse)(nil),                 // 1212: mlx_device.MlxAdminLockdownLockResponse
+	(*MlxAdminLockdownUnlockResponse)(nil),               // 1213: mlx_device.MlxAdminLockdownUnlockResponse
+	(*MlxAdminLockdownStatusResponse)(nil),               // 1214: mlx_device.MlxAdminLockdownStatusResponse
+	(*MlxAdminDeviceInfoResponse)(nil),                   // 1215: mlx_device.MlxAdminDeviceInfoResponse
+	(*MlxAdminDeviceReportResponse)(nil),                 // 1216: mlx_device.MlxAdminDeviceReportResponse
+	(*MlxAdminRegistryListResponse)(nil),                 // 1217: mlx_device.MlxAdminRegistryListResponse
+	(*MlxAdminRegistryShowResponse)(nil),                 // 1218: mlx_device.MlxAdminRegistryShowResponse
+	(*MlxAdminConfigQueryResponse)(nil),                  // 1219: mlx_device.MlxAdminConfigQueryResponse
+	(*MlxAdminConfigSetResponse)(nil),                    // 1220: mlx_device.MlxAdminConfigSetResponse
+	(*MlxAdminConfigSyncResponse)(nil),                   // 1221: mlx_device.MlxAdminConfigSyncResponse
+	(*MlxAdminConfigCompareResponse)(nil),                // 1222: mlx_device.MlxAdminConfigCompareResponse
 }
 var file_nico_nico_proto_depIdxs = []int32{
 	358,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
 	360,  // 1: forge.LifecycleStatus.sla:type_name -> forge.StateSla
-	1007, // 2: forge.SpdmMachineAttestationStatus.machine_id:type_name -> common.MachineId
+	1009, // 2: forge.SpdmMachineAttestationStatus.machine_id:type_name -> common.MachineId
 	0,    // 3: forge.SpdmMachineAttestationStatus.attestation_status:type_name -> forge.SpdmAttestationStatus
-	1007, // 4: forge.SpdmMachineAttestationTriggerResponse.machine_id:type_name -> common.MachineId
-	1007, // 5: forge.SpdmAttestationDetails.machine_id:type_name -> common.MachineId
-	1008, // 6: forge.SpdmAttestationDetails.started_at:type_name -> google.protobuf.Timestamp
-	1008, // 7: forge.SpdmAttestationDetails.cancelled_at:type_name -> google.protobuf.Timestamp
-	1008, // 8: forge.SpdmAttestationDetails.completed_at:type_name -> google.protobuf.Timestamp
+	1009, // 4: forge.SpdmMachineAttestationTriggerResponse.machine_id:type_name -> common.MachineId
+	1009, // 5: forge.SpdmAttestationDetails.machine_id:type_name -> common.MachineId
+	1010, // 6: forge.SpdmAttestationDetails.started_at:type_name -> google.protobuf.Timestamp
+	1010, // 7: forge.SpdmAttestationDetails.cancelled_at:type_name -> google.protobuf.Timestamp
+	1010, // 8: forge.SpdmAttestationDetails.completed_at:type_name -> google.protobuf.Timestamp
 	101,  // 9: forge.SpdmGetAttestationMachineResponse.attestations_details:type_name -> forge.SpdmAttestationDetails
-	1007, // 10: forge.SpdmMachineAttestationTriggerRequest.machine_id:type_name -> common.MachineId
-	1007, // 11: forge.SpdmListAttestationMachinesRequest.machine_id:type_name -> common.MachineId
+	1009, // 10: forge.SpdmMachineAttestationTriggerRequest.machine_id:type_name -> common.MachineId
+	1009, // 11: forge.SpdmListAttestationMachinesRequest.machine_id:type_name -> common.MachineId
 	1,    // 12: forge.SpdmListAttestationMachinesRequest.selector:type_name -> forge.SpdmListAttestationMachinesRequestSelector
 	99,   // 13: forge.SpdmListAttestationMachinesResponse.statuses:type_name -> forge.SpdmMachineAttestationStatus
-	1008, // 14: forge.TenantIdentitySigningKey.expire_at:type_name -> google.protobuf.Timestamp
+	1010, // 14: forge.TenantIdentitySigningKey.expire_at:type_name -> google.protobuf.Timestamp
 	110,  // 15: forge.SetTenantIdentityConfigRequest.config:type_name -> forge.TenantIdentityConfig
 	110,  // 16: forge.TenantIdentityConfigResponse.config:type_name -> forge.TenantIdentityConfig
-	1008, // 17: forge.TenantIdentityConfigResponse.created_at:type_name -> google.protobuf.Timestamp
-	1008, // 18: forge.TenantIdentityConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
+	1010, // 17: forge.TenantIdentityConfigResponse.created_at:type_name -> google.protobuf.Timestamp
+	1010, // 18: forge.TenantIdentityConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
 	109,  // 19: forge.TenantIdentityConfigResponse.signing_keys:type_name -> forge.TenantIdentitySigningKey
 	114,  // 20: forge.TokenDelegationResponse.client_secret_basic:type_name -> forge.ClientSecretBasicResponse
-	1008, // 21: forge.TokenDelegationResponse.created_at:type_name -> google.protobuf.Timestamp
-	1008, // 22: forge.TokenDelegationResponse.updated_at:type_name -> google.protobuf.Timestamp
+	1010, // 21: forge.TokenDelegationResponse.created_at:type_name -> google.protobuf.Timestamp
+	1010, // 22: forge.TokenDelegationResponse.updated_at:type_name -> google.protobuf.Timestamp
 	113,  // 23: forge.TokenDelegation.client_secret_basic:type_name -> forge.ClientSecretBasic
 	117,  // 24: forge.TokenDelegationRequest.config:type_name -> forge.TokenDelegation
 	120,  // 25: forge.ReencryptTenantIdentitySecretsResponse.failures:type_name -> forge.ReencryptTenantIdentityFailure
 	2,    // 26: forge.JwksRequest.kind:type_name -> forge.JwksKind
 	3,    // 27: forge.MachineIngestionStateResponse.machine_ingestion_state:type_name -> forge.MachineIngestionState
 	128,  // 28: forge.TpmCaAddedCaStatus.id:type_name -> forge.TpmCaCertId
-	1007, // 29: forge.TpmEkCertStatus.machine_id:type_name -> common.MachineId
+	1009, // 29: forge.TpmEkCertStatus.machine_id:type_name -> common.MachineId
 	129,  // 30: forge.TpmEkCertStatusCollection.tpm_ek_cert_statuses:type_name -> forge.TpmEkCertStatus
 	132,  // 31: forge.TpmCaCertDetailCollection.tpm_ca_cert_details:type_name -> forge.TpmCaCertDetail
-	1007, // 32: forge.AttestQuoteRequest.machine_id:type_name -> common.MachineId
+	1009, // 32: forge.AttestQuoteRequest.machine_id:type_name -> common.MachineId
 	441,  // 33: forge.AttestQuoteResponse.machine_certificate:type_name -> forge.MachineCertificate
 	4,    // 34: forge.CredentialCreationRequest.credential_type:type_name -> forge.CredentialType
 	4,    // 35: forge.CredentialDeletionRequest.credential_type:type_name -> forge.CredentialType
 	5,    // 36: forge.RotateCredentialRequest.credential_type:type_name -> forge.RotationCredentialType
 	5,    // 37: forge.RotateCredentialResult.credential_type:type_name -> forge.RotationCredentialType
-	1008, // 38: forge.RotateCredentialResult.started_at:type_name -> google.protobuf.Timestamp
+	1010, // 38: forge.RotateCredentialResult.started_at:type_name -> google.protobuf.Timestamp
 	5,    // 39: forge.CredentialRotationStatusRequest.credential_type:type_name -> forge.RotationCredentialType
-	1008, // 40: forge.DeviceCredentialRotationStatus.quarantined_until:type_name -> google.protobuf.Timestamp
-	1008, // 41: forge.DeviceCredentialRotationStatus.last_attempt_at:type_name -> google.protobuf.Timestamp
-	1008, // 42: forge.CredentialRotationStatusResult.started_at:type_name -> google.protobuf.Timestamp
+	1010, // 40: forge.DeviceCredentialRotationStatus.quarantined_until:type_name -> google.protobuf.Timestamp
+	1010, // 41: forge.DeviceCredentialRotationStatus.last_attempt_at:type_name -> google.protobuf.Timestamp
+	1010, // 42: forge.CredentialRotationStatusResult.started_at:type_name -> google.protobuf.Timestamp
 	144,  // 43: forge.CredentialRotationStatusResult.device:type_name -> forge.DeviceCredentialRotationStatus
 	148,  // 44: forge.BuildInfo.runtime_config:type_name -> forge.RuntimeConfig
-	968,  // 45: forge.RuntimeConfig.dpu_nic_firmware_update_version:type_name -> forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
-	969,  // 46: forge.DNSMessage.question:type_name -> forge.DNSMessage.DNSQuestion
-	970,  // 47: forge.DNSMessage.response:type_name -> forge.DNSMessage.DNSResponse
-	1009, // 48: forge.VpcSearchQuery.id:type_name -> common.VpcId
+	970,  // 45: forge.RuntimeConfig.dpu_nic_firmware_update_version:type_name -> forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
+	971,  // 46: forge.DNSMessage.question:type_name -> forge.DNSMessage.DNSQuestion
+	972,  // 47: forge.DNSMessage.response:type_name -> forge.DNSMessage.DNSResponse
+	1011, // 48: forge.VpcSearchQuery.id:type_name -> common.VpcId
 	266,  // 49: forge.VpcSearchFilter.label:type_name -> forge.Label
-	1009, // 50: forge.VpcIdList.vpc_ids:type_name -> common.VpcId
-	1009, // 51: forge.VpcsByIdsRequest.vpc_ids:type_name -> common.VpcId
+	1011, // 50: forge.VpcIdList.vpc_ids:type_name -> common.VpcId
+	1011, // 51: forge.VpcsByIdsRequest.vpc_ids:type_name -> common.VpcId
 	6,    // 52: forge.VpcConfig.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1010, // 53: forge.VpcConfig.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1009, // 54: forge.Vpc.id:type_name -> common.VpcId
-	1008, // 55: forge.Vpc.created:type_name -> google.protobuf.Timestamp
-	1008, // 56: forge.Vpc.updated:type_name -> google.protobuf.Timestamp
-	1008, // 57: forge.Vpc.deleted:type_name -> google.protobuf.Timestamp
+	1012, // 53: forge.VpcConfig.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1011, // 54: forge.Vpc.id:type_name -> common.VpcId
+	1010, // 55: forge.Vpc.created:type_name -> google.protobuf.Timestamp
+	1010, // 56: forge.Vpc.updated:type_name -> google.protobuf.Timestamp
+	1010, // 57: forge.Vpc.deleted:type_name -> google.protobuf.Timestamp
 	6,    // 58: forge.Vpc.network_virtualization_type:type_name -> forge.VpcVirtualizationType
 	267,  // 59: forge.Vpc.metadata:type_name -> forge.Metadata
-	1010, // 60: forge.Vpc.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 60: forge.Vpc.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
 	163,  // 61: forge.Vpc.status:type_name -> forge.VpcStatus
 	162,  // 62: forge.Vpc.config:type_name -> forge.VpcConfig
 	6,    // 63: forge.VpcCreationRequest.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1009, // 64: forge.VpcCreationRequest.id:type_name -> common.VpcId
+	1011, // 64: forge.VpcCreationRequest.id:type_name -> common.VpcId
 	267,  // 65: forge.VpcCreationRequest.metadata:type_name -> forge.Metadata
-	1010, // 66: forge.VpcCreationRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1009, // 67: forge.VpcUpdateRequest.id:type_name -> common.VpcId
+	1012, // 66: forge.VpcCreationRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1011, // 67: forge.VpcUpdateRequest.id:type_name -> common.VpcId
 	267,  // 68: forge.VpcUpdateRequest.metadata:type_name -> forge.Metadata
-	1010, // 69: forge.VpcUpdateRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 69: forge.VpcUpdateRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
 	164,  // 70: forge.VpcUpdateResult.vpc:type_name -> forge.Vpc
-	1009, // 71: forge.VpcUpdateVirtualizationRequest.id:type_name -> common.VpcId
+	1011, // 71: forge.VpcUpdateVirtualizationRequest.id:type_name -> common.VpcId
 	6,    // 72: forge.VpcUpdateVirtualizationRequest.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1009, // 73: forge.VpcDeletionRequest.id:type_name -> common.VpcId
+	1011, // 73: forge.VpcDeletionRequest.id:type_name -> common.VpcId
 	164,  // 74: forge.VpcList.vpcs:type_name -> forge.Vpc
-	1011, // 75: forge.VpcPrefix.id:type_name -> common.VpcPrefixId
-	1009, // 76: forge.VpcPrefix.vpc_id:type_name -> common.VpcId
+	1013, // 75: forge.VpcPrefix.id:type_name -> common.VpcPrefixId
+	1011, // 76: forge.VpcPrefix.vpc_id:type_name -> common.VpcId
 	174,  // 77: forge.VpcPrefix.config:type_name -> forge.VpcPrefixConfig
 	175,  // 78: forge.VpcPrefix.status:type_name -> forge.VpcPrefixStatus
 	267,  // 79: forge.VpcPrefix.metadata:type_name -> forge.Metadata
 	98,   // 80: forge.VpcPrefixStatus.lifecycle:type_name -> forge.LifecycleStatus
 	8,    // 81: forge.VpcPrefixStatus.tenant_state:type_name -> forge.TenantState
-	1011, // 82: forge.VpcPrefixCreationRequest.id:type_name -> common.VpcPrefixId
-	1009, // 83: forge.VpcPrefixCreationRequest.vpc_id:type_name -> common.VpcId
+	1013, // 82: forge.VpcPrefixCreationRequest.id:type_name -> common.VpcPrefixId
+	1011, // 83: forge.VpcPrefixCreationRequest.vpc_id:type_name -> common.VpcId
 	174,  // 84: forge.VpcPrefixCreationRequest.config:type_name -> forge.VpcPrefixConfig
 	267,  // 85: forge.VpcPrefixCreationRequest.metadata:type_name -> forge.Metadata
-	1009, // 86: forge.VpcPrefixSearchQuery.vpc_id:type_name -> common.VpcId
-	1011, // 87: forge.VpcPrefixSearchQuery.tenant_prefix_id:type_name -> common.VpcPrefixId
+	1011, // 86: forge.VpcPrefixSearchQuery.vpc_id:type_name -> common.VpcId
+	1013, // 87: forge.VpcPrefixSearchQuery.tenant_prefix_id:type_name -> common.VpcPrefixId
 	7,    // 88: forge.VpcPrefixSearchQuery.prefix_match_type:type_name -> forge.PrefixMatchType
 	10,   // 89: forge.VpcPrefixSearchQuery.deleted:type_name -> forge.DeletedFilter
-	1011, // 90: forge.VpcPrefixGetRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1013, // 90: forge.VpcPrefixGetRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
 	10,   // 91: forge.VpcPrefixGetRequest.deleted:type_name -> forge.DeletedFilter
-	1011, // 92: forge.VpcPrefixIdList.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1013, // 92: forge.VpcPrefixIdList.vpc_prefix_ids:type_name -> common.VpcPrefixId
 	173,  // 93: forge.VpcPrefixList.vpc_prefixes:type_name -> forge.VpcPrefix
-	1011, // 94: forge.VpcPrefixUpdateRequest.id:type_name -> common.VpcPrefixId
+	1013, // 94: forge.VpcPrefixUpdateRequest.id:type_name -> common.VpcPrefixId
 	174,  // 95: forge.VpcPrefixUpdateRequest.config:type_name -> forge.VpcPrefixConfig
 	267,  // 96: forge.VpcPrefixUpdateRequest.metadata:type_name -> forge.Metadata
-	1011, // 97: forge.VpcPrefixDeletionRequest.id:type_name -> common.VpcPrefixId
-	1011, // 98: forge.VpcPrefixStateHistoriesRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
-	1012, // 99: forge.VpcPeering.id:type_name -> common.VpcPeeringId
-	1009, // 100: forge.VpcPeering.vpc_id:type_name -> common.VpcId
-	1009, // 101: forge.VpcPeering.peer_vpc_id:type_name -> common.VpcId
-	1012, // 102: forge.VpcPeeringIdList.vpc_peering_ids:type_name -> common.VpcPeeringId
+	1013, // 97: forge.VpcPrefixDeletionRequest.id:type_name -> common.VpcPrefixId
+	1013, // 98: forge.VpcPrefixStateHistoriesRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1014, // 99: forge.VpcPeering.id:type_name -> common.VpcPeeringId
+	1011, // 100: forge.VpcPeering.vpc_id:type_name -> common.VpcId
+	1011, // 101: forge.VpcPeering.peer_vpc_id:type_name -> common.VpcId
+	1014, // 102: forge.VpcPeeringIdList.vpc_peering_ids:type_name -> common.VpcPeeringId
 	185,  // 103: forge.VpcPeeringList.vpc_peerings:type_name -> forge.VpcPeering
-	1009, // 104: forge.VpcPeeringCreationRequest.vpc_id:type_name -> common.VpcId
-	1009, // 105: forge.VpcPeeringCreationRequest.peer_vpc_id:type_name -> common.VpcId
-	1012, // 106: forge.VpcPeeringCreationRequest.id:type_name -> common.VpcPeeringId
-	1009, // 107: forge.VpcPeeringSearchFilter.vpc_id:type_name -> common.VpcId
-	1012, // 108: forge.VpcPeeringsByIdsRequest.vpc_peering_ids:type_name -> common.VpcPeeringId
-	1012, // 109: forge.VpcPeeringDeletionRequest.id:type_name -> common.VpcPeeringId
+	1011, // 104: forge.VpcPeeringCreationRequest.vpc_id:type_name -> common.VpcId
+	1011, // 105: forge.VpcPeeringCreationRequest.peer_vpc_id:type_name -> common.VpcId
+	1014, // 106: forge.VpcPeeringCreationRequest.id:type_name -> common.VpcPeeringId
+	1011, // 107: forge.VpcPeeringSearchFilter.vpc_id:type_name -> common.VpcId
+	1014, // 108: forge.VpcPeeringsByIdsRequest.vpc_peering_ids:type_name -> common.VpcPeeringId
+	1014, // 109: forge.VpcPeeringDeletionRequest.id:type_name -> common.VpcPeeringId
 	8,    // 110: forge.IBPartitionStatus.state:type_name -> forge.TenantState
 	358,  // 111: forge.IBPartitionStatus.state_reason:type_name -> forge.ControllerStateReason
 	360,  // 112: forge.IBPartitionStatus.state_sla:type_name -> forge.StateSla
-	1013, // 113: forge.IBPartition.id:type_name -> common.IBPartitionId
+	1015, // 113: forge.IBPartition.id:type_name -> common.IBPartitionId
 	193,  // 114: forge.IBPartition.config:type_name -> forge.IBPartitionConfig
 	194,  // 115: forge.IBPartition.status:type_name -> forge.IBPartitionStatus
 	267,  // 116: forge.IBPartition.metadata:type_name -> forge.Metadata
 	195,  // 117: forge.IBPartitionList.ib_partitions:type_name -> forge.IBPartition
 	193,  // 118: forge.IBPartitionCreationRequest.config:type_name -> forge.IBPartitionConfig
-	1013, // 119: forge.IBPartitionCreationRequest.id:type_name -> common.IBPartitionId
+	1015, // 119: forge.IBPartitionCreationRequest.id:type_name -> common.IBPartitionId
 	267,  // 120: forge.IBPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1013, // 121: forge.IBPartitionUpdateRequest.id:type_name -> common.IBPartitionId
+	1015, // 121: forge.IBPartitionUpdateRequest.id:type_name -> common.IBPartitionId
 	193,  // 122: forge.IBPartitionUpdateRequest.config:type_name -> forge.IBPartitionConfig
 	267,  // 123: forge.IBPartitionUpdateRequest.metadata:type_name -> forge.Metadata
-	1013, // 124: forge.IBPartitionDeletionRequest.id:type_name -> common.IBPartitionId
-	1013, // 125: forge.IBPartitionsByIdsRequest.ib_partition_ids:type_name -> common.IBPartitionId
-	1013, // 126: forge.IBPartitionIdList.ib_partition_ids:type_name -> common.IBPartitionId
+	1015, // 124: forge.IBPartitionDeletionRequest.id:type_name -> common.IBPartitionId
+	1015, // 125: forge.IBPartitionsByIdsRequest.ib_partition_ids:type_name -> common.IBPartitionId
+	1015, // 126: forge.IBPartitionIdList.ib_partition_ids:type_name -> common.IBPartitionId
 	358,  // 127: forge.PowerShelfStatus.state_reason:type_name -> forge.ControllerStateReason
 	360,  // 128: forge.PowerShelfStatus.state_sla:type_name -> forge.StateSla
-	1014, // 129: forge.PowerShelfStatus.health:type_name -> health.HealthReport
+	1016, // 129: forge.PowerShelfStatus.health:type_name -> health.HealthReport
 	357,  // 130: forge.PowerShelfStatus.health_sources:type_name -> forge.HealthSourceOrigin
 	98,   // 131: forge.PowerShelfStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1015, // 132: forge.PowerShelf.id:type_name -> common.PowerShelfId
+	1017, // 132: forge.PowerShelf.id:type_name -> common.PowerShelfId
 	204,  // 133: forge.PowerShelf.config:type_name -> forge.PowerShelfConfig
 	205,  // 134: forge.PowerShelf.status:type_name -> forge.PowerShelfStatus
-	1008, // 135: forge.PowerShelf.deleted:type_name -> google.protobuf.Timestamp
+	1010, // 135: forge.PowerShelf.deleted:type_name -> google.protobuf.Timestamp
 	267,  // 136: forge.PowerShelf.metadata:type_name -> forge.Metadata
 	343,  // 137: forge.PowerShelf.bmc_info:type_name -> forge.BmcInfo
-	1016, // 138: forge.PowerShelf.rack_id:type_name -> common.RackId
+	1018, // 138: forge.PowerShelf.rack_id:type_name -> common.RackId
 	206,  // 139: forge.PowerShelfList.power_shelves:type_name -> forge.PowerShelf
 	204,  // 140: forge.PowerShelfCreationRequest.config:type_name -> forge.PowerShelfConfig
-	1015, // 141: forge.PowerShelfCreationRequest.id:type_name -> common.PowerShelfId
-	1015, // 142: forge.PowerShelfDeletionRequest.id:type_name -> common.PowerShelfId
-	1015, // 143: forge.PowerShelfMaintenanceRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	1017, // 141: forge.PowerShelfCreationRequest.id:type_name -> common.PowerShelfId
+	1017, // 142: forge.PowerShelfDeletionRequest.id:type_name -> common.PowerShelfId
+	1017, // 143: forge.PowerShelfMaintenanceRequest.power_shelf_ids:type_name -> common.PowerShelfId
 	9,    // 144: forge.PowerShelfMaintenanceRequest.operation:type_name -> forge.PowerShelfMaintenanceOperation
-	1015, // 145: forge.PowerShelfStateHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
-	1015, // 146: forge.PowerShelfQuery.power_shelf_id:type_name -> common.PowerShelfId
-	1016, // 147: forge.PowerShelfSearchFilter.rack_id:type_name -> common.RackId
+	1017, // 145: forge.PowerShelfStateHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	1017, // 146: forge.PowerShelfQuery.power_shelf_id:type_name -> common.PowerShelfId
+	1018, // 147: forge.PowerShelfSearchFilter.rack_id:type_name -> common.RackId
 	10,   // 148: forge.PowerShelfSearchFilter.deleted:type_name -> forge.DeletedFilter
-	1015, // 149: forge.PowerShelvesByIdsRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	1017, // 149: forge.PowerShelvesByIdsRequest.power_shelf_ids:type_name -> common.PowerShelfId
 	267,  // 150: forge.ExpectedPowerShelf.metadata:type_name -> forge.Metadata
-	1016, // 151: forge.ExpectedPowerShelf.rack_id:type_name -> common.RackId
-	1017, // 152: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
-	1017, // 153: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
+	1018, // 151: forge.ExpectedPowerShelf.rack_id:type_name -> common.RackId
+	1019, // 152: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	1019, // 153: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
 	216,  // 154: forge.ExpectedPowerShelfList.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
 	220,  // 155: forge.LinkedExpectedPowerShelfList.expected_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
-	1015, // 156: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
-	1017, // 157: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
-	1016, // 158: forge.LinkedExpectedPowerShelf.rack_id:type_name -> common.RackId
+	1017, // 156: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
+	1019, // 157: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	1018, // 158: forge.LinkedExpectedPowerShelf.rack_id:type_name -> common.RackId
 	222,  // 159: forge.SwitchConfig.fabric_manager_config:type_name -> forge.FabricManagerConfig
-	972,  // 160: forge.FabricManagerConfig.config_map:type_name -> forge.FabricManagerConfig.ConfigMapEntry
+	974,  // 160: forge.FabricManagerConfig.config_map:type_name -> forge.FabricManagerConfig.ConfigMapEntry
 	11,   // 161: forge.FabricManagerStatus.fabric_manager_state:type_name -> forge.FabricManagerState
 	358,  // 162: forge.SwitchStatus.state_reason:type_name -> forge.ControllerStateReason
 	360,  // 163: forge.SwitchStatus.state_sla:type_name -> forge.StateSla
-	1014, // 164: forge.SwitchStatus.health:type_name -> health.HealthReport
+	1016, // 164: forge.SwitchStatus.health:type_name -> health.HealthReport
 	357,  // 165: forge.SwitchStatus.health_sources:type_name -> forge.HealthSourceOrigin
 	98,   // 166: forge.SwitchStatus.lifecycle:type_name -> forge.LifecycleStatus
 	223,  // 167: forge.SwitchStatus.fabric_manager_status_details:type_name -> forge.FabricManagerStatus
-	1018, // 168: forge.Switch.id:type_name -> common.SwitchId
+	1020, // 168: forge.Switch.id:type_name -> common.SwitchId
 	221,  // 169: forge.Switch.config:type_name -> forge.SwitchConfig
 	224,  // 170: forge.Switch.status:type_name -> forge.SwitchStatus
-	1008, // 171: forge.Switch.deleted:type_name -> google.protobuf.Timestamp
+	1010, // 171: forge.Switch.deleted:type_name -> google.protobuf.Timestamp
 	343,  // 172: forge.Switch.bmc_info:type_name -> forge.BmcInfo
 	267,  // 173: forge.Switch.metadata:type_name -> forge.Metadata
-	1016, // 174: forge.Switch.rack_id:type_name -> common.RackId
+	1018, // 174: forge.Switch.rack_id:type_name -> common.RackId
 	225,  // 175: forge.Switch.placement_in_rack:type_name -> forge.PlacementInRack
 	344,  // 176: forge.Switch.nvos_info:type_name -> forge.SwitchNvosInfo
 	226,  // 177: forge.SwitchList.switches:type_name -> forge.Switch
 	221,  // 178: forge.SwitchCreationRequest.config:type_name -> forge.SwitchConfig
-	1017, // 179: forge.SwitchCreationRequest.id:type_name -> common.UUID
+	1019, // 179: forge.SwitchCreationRequest.id:type_name -> common.UUID
 	225,  // 180: forge.SwitchCreationRequest.placement_in_rack:type_name -> forge.PlacementInRack
-	1018, // 181: forge.SwitchDeletionRequest.id:type_name -> common.SwitchId
-	1008, // 182: forge.StateHistoryRecord.time:type_name -> google.protobuf.Timestamp
+	1020, // 181: forge.SwitchDeletionRequest.id:type_name -> common.SwitchId
+	1010, // 182: forge.StateHistoryRecord.time:type_name -> google.protobuf.Timestamp
 	231,  // 183: forge.StateHistoryRecords.records:type_name -> forge.StateHistoryRecord
-	1018, // 184: forge.SwitchStateHistoriesRequest.switch_ids:type_name -> common.SwitchId
-	973,  // 185: forge.StateHistories.histories:type_name -> forge.StateHistories.HistoriesEntry
-	1018, // 186: forge.SwitchQuery.switch_id:type_name -> common.SwitchId
-	1016, // 187: forge.SwitchSearchFilter.rack_id:type_name -> common.RackId
+	1020, // 184: forge.SwitchStateHistoriesRequest.switch_ids:type_name -> common.SwitchId
+	975,  // 185: forge.StateHistories.histories:type_name -> forge.StateHistories.HistoriesEntry
+	1020, // 186: forge.SwitchQuery.switch_id:type_name -> common.SwitchId
+	1018, // 187: forge.SwitchSearchFilter.rack_id:type_name -> common.RackId
 	10,   // 188: forge.SwitchSearchFilter.deleted:type_name -> forge.DeletedFilter
-	1018, // 189: forge.SwitchesByIdsRequest.switch_ids:type_name -> common.SwitchId
+	1020, // 189: forge.SwitchesByIdsRequest.switch_ids:type_name -> common.SwitchId
 	267,  // 190: forge.ExpectedSwitch.metadata:type_name -> forge.Metadata
-	1016, // 191: forge.ExpectedSwitch.rack_id:type_name -> common.RackId
-	1017, // 192: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
-	1017, // 193: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
+	1018, // 191: forge.ExpectedSwitch.rack_id:type_name -> common.RackId
+	1019, // 192: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	1019, // 193: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
 	238,  // 194: forge.ExpectedSwitchList.expected_switches:type_name -> forge.ExpectedSwitch
 	242,  // 195: forge.LinkedExpectedSwitchList.expected_switches:type_name -> forge.LinkedExpectedSwitch
-	1018, // 196: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId
-	1017, // 197: forge.LinkedExpectedSwitch.expected_switch_id:type_name -> common.UUID
-	1016, // 198: forge.LinkedExpectedSwitch.rack_id:type_name -> common.RackId
-	1016, // 199: forge.ExpectedRack.rack_id:type_name -> common.RackId
-	1019, // 200: forge.ExpectedRack.rack_profile_id:type_name -> common.RackProfileId
+	1020, // 196: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId
+	1019, // 197: forge.LinkedExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	1018, // 198: forge.LinkedExpectedSwitch.rack_id:type_name -> common.RackId
+	1018, // 199: forge.ExpectedRack.rack_id:type_name -> common.RackId
+	1021, // 200: forge.ExpectedRack.rack_profile_id:type_name -> common.RackProfileId
 	267,  // 201: forge.ExpectedRack.metadata:type_name -> forge.Metadata
 	243,  // 202: forge.ExpectedRackList.expected_racks:type_name -> forge.ExpectedRack
-	1008, // 203: forge.NetworkSegmentStateHistory.time:type_name -> google.protobuf.Timestamp
-	1009, // 204: forge.NetworkSegmentConfig.vpc_id:type_name -> common.VpcId
-	1020, // 205: forge.NetworkSegmentConfig.subdomain_id:type_name -> common.DomainId
+	1010, // 203: forge.NetworkSegmentStateHistory.time:type_name -> google.protobuf.Timestamp
+	1011, // 204: forge.NetworkSegmentConfig.vpc_id:type_name -> common.VpcId
+	1022, // 205: forge.NetworkSegmentConfig.subdomain_id:type_name -> common.DomainId
 	12,   // 206: forge.NetworkSegmentConfig.segment_type:type_name -> forge.NetworkSegmentType
 	261,  // 207: forge.NetworkSegmentConfig.prefixes:type_name -> forge.NetworkPrefix
 	13,   // 208: forge.NetworkSegmentStatus.flags:type_name -> forge.NetworkSegmentFlag
 	98,   // 209: forge.NetworkSegmentStatus.lifecycle:type_name -> forge.LifecycleStatus
 	8,    // 210: forge.NetworkSegmentStatus.tenant_state:type_name -> forge.TenantState
-	1021, // 211: forge.NetworkSegment.id:type_name -> common.NetworkSegmentId
-	1009, // 212: forge.NetworkSegment.vpc_id:type_name -> common.VpcId
-	1020, // 213: forge.NetworkSegment.subdomain_id:type_name -> common.DomainId
+	1023, // 211: forge.NetworkSegment.id:type_name -> common.NetworkSegmentId
+	1011, // 212: forge.NetworkSegment.vpc_id:type_name -> common.VpcId
+	1022, // 213: forge.NetworkSegment.subdomain_id:type_name -> common.DomainId
 	261,  // 214: forge.NetworkSegment.prefixes:type_name -> forge.NetworkPrefix
-	1008, // 215: forge.NetworkSegment.created:type_name -> google.protobuf.Timestamp
-	1008, // 216: forge.NetworkSegment.updated:type_name -> google.protobuf.Timestamp
-	1008, // 217: forge.NetworkSegment.deleted:type_name -> google.protobuf.Timestamp
+	1010, // 215: forge.NetworkSegment.created:type_name -> google.protobuf.Timestamp
+	1010, // 216: forge.NetworkSegment.updated:type_name -> google.protobuf.Timestamp
+	1010, // 217: forge.NetworkSegment.deleted:type_name -> google.protobuf.Timestamp
 	12,   // 218: forge.NetworkSegment.segment_type:type_name -> forge.NetworkSegmentType
 	13,   // 219: forge.NetworkSegment.flags:type_name -> forge.NetworkSegmentFlag
 	249,  // 220: forge.NetworkSegment.config:type_name -> forge.NetworkSegmentConfig
@@ -69648,37 +69800,37 @@ var file_nico_nico_proto_depIdxs = []int32{
 	248,  // 224: forge.NetworkSegment.history:type_name -> forge.NetworkSegmentStateHistory
 	358,  // 225: forge.NetworkSegment.state_reason:type_name -> forge.ControllerStateReason
 	360,  // 226: forge.NetworkSegment.state_sla:type_name -> forge.StateSla
-	1009, // 227: forge.NetworkSegmentCreationRequest.vpc_id:type_name -> common.VpcId
-	1020, // 228: forge.NetworkSegmentCreationRequest.subdomain_id:type_name -> common.DomainId
+	1011, // 227: forge.NetworkSegmentCreationRequest.vpc_id:type_name -> common.VpcId
+	1022, // 228: forge.NetworkSegmentCreationRequest.subdomain_id:type_name -> common.DomainId
 	261,  // 229: forge.NetworkSegmentCreationRequest.prefixes:type_name -> forge.NetworkPrefix
 	12,   // 230: forge.NetworkSegmentCreationRequest.segment_type:type_name -> forge.NetworkSegmentType
-	1021, // 231: forge.NetworkSegmentCreationRequest.id:type_name -> common.NetworkSegmentId
-	1021, // 232: forge.NetworkSegmentDeletionRequest.id:type_name -> common.NetworkSegmentId
-	1021, // 233: forge.AttachNetworkSegmentToVpcRequest.network_segment_id:type_name -> common.NetworkSegmentId
-	1009, // 234: forge.AttachNetworkSegmentToVpcRequest.vpc_id:type_name -> common.VpcId
-	1021, // 235: forge.NetworkSegmentStateHistoriesRequest.network_segment_ids:type_name -> common.NetworkSegmentId
-	1021, // 236: forge.NetworkSegmentIdList.network_segments_ids:type_name -> common.NetworkSegmentId
-	1021, // 237: forge.NetworkSegmentsByIdsRequest.network_segments_ids:type_name -> common.NetworkSegmentId
-	1022, // 238: forge.NetworkPrefix.id:type_name -> common.NetworkPrefixId
+	1023, // 231: forge.NetworkSegmentCreationRequest.id:type_name -> common.NetworkSegmentId
+	1023, // 232: forge.NetworkSegmentDeletionRequest.id:type_name -> common.NetworkSegmentId
+	1023, // 233: forge.AttachNetworkSegmentToVpcRequest.network_segment_id:type_name -> common.NetworkSegmentId
+	1011, // 234: forge.AttachNetworkSegmentToVpcRequest.vpc_id:type_name -> common.VpcId
+	1023, // 235: forge.NetworkSegmentStateHistoriesRequest.network_segment_ids:type_name -> common.NetworkSegmentId
+	1023, // 236: forge.NetworkSegmentIdList.network_segments_ids:type_name -> common.NetworkSegmentId
+	1023, // 237: forge.NetworkSegmentsByIdsRequest.network_segments_ids:type_name -> common.NetworkSegmentId
+	1024, // 238: forge.NetworkPrefix.id:type_name -> common.NetworkPrefixId
 	87,   // 239: forge.InstancePowerRequest.operation:type_name -> forge.InstancePowerRequest.Operation
-	1023, // 240: forge.InstancePowerRequest.instance_id:type_name -> common.InstanceId
+	1025, // 240: forge.InstancePowerRequest.instance_id:type_name -> common.InstanceId
 	300,  // 241: forge.InstanceList.instances:type_name -> forge.Instance
 	266,  // 242: forge.Metadata.labels:type_name -> forge.Label
 	266,  // 243: forge.InstanceSearchFilter.label:type_name -> forge.Label
-	1023, // 244: forge.InstanceIdList.instance_ids:type_name -> common.InstanceId
-	1023, // 245: forge.InstancesByIdsRequest.instance_ids:type_name -> common.InstanceId
-	1007, // 246: forge.InstanceAllocationRequest.machine_id:type_name -> common.MachineId
+	1025, // 244: forge.InstanceIdList.instance_ids:type_name -> common.InstanceId
+	1025, // 245: forge.InstancesByIdsRequest.instance_ids:type_name -> common.InstanceId
+	1009, // 246: forge.InstanceAllocationRequest.machine_id:type_name -> common.MachineId
 	280,  // 247: forge.InstanceAllocationRequest.config:type_name -> forge.InstanceConfig
-	1023, // 248: forge.InstanceAllocationRequest.instance_id:type_name -> common.InstanceId
+	1025, // 248: forge.InstanceAllocationRequest.instance_id:type_name -> common.InstanceId
 	267,  // 249: forge.InstanceAllocationRequest.metadata:type_name -> forge.Metadata
 	271,  // 250: forge.BatchInstanceAllocationRequest.instance_requests:type_name -> forge.InstanceAllocationRequest
 	300,  // 251: forge.BatchInstanceAllocationResponse.instances:type_name -> forge.Instance
 	14,   // 252: forge.IpxeTemplateArtifact.cache_strategy:type_name -> forge.IpxeTemplateArtifactCacheStrategy
-	1024, // 253: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
+	1026, // 253: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
 	15,   // 254: forge.IpxeTemplate.visibility:type_name -> forge.IpxeTemplateVisibility
 	279,  // 255: forge.InstanceOperatingSystemConfig.ipxe:type_name -> forge.InlineIpxe
-	1017, // 256: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
-	1025, // 257: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId
+	1019, // 256: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
+	1027, // 257: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId
 	277,  // 258: forge.InstanceConfig.tenant:type_name -> forge.TenantConfig
 	278,  // 259: forge.InstanceConfig.os:type_name -> forge.InstanceOperatingSystemConfig
 	281,  // 260: forge.InstanceConfig.network:type_name -> forge.InstanceNetworkConfig
@@ -69688,16 +69840,16 @@ var file_nico_nico_proto_depIdxs = []int32{
 	287,  // 264: forge.InstanceConfig.spxconfig:type_name -> forge.InstanceSpxConfig
 	302,  // 265: forge.InstanceNetworkConfig.interfaces:type_name -> forge.InstanceInterfaceConfig
 	282,  // 266: forge.InstanceNetworkConfig.auto_config:type_name -> forge.InstanceNetworkAutoConfig
-	1009, // 267: forge.InstanceNetworkAutoConfig.vpc_id:type_name -> common.VpcId
+	1011, // 267: forge.InstanceNetworkAutoConfig.vpc_id:type_name -> common.VpcId
 	306,  // 268: forge.InstanceInfinibandConfig.ib_interfaces:type_name -> forge.InstanceIBInterfaceConfig
 	284,  // 269: forge.InstanceDpuExtensionServicesConfig.service_configs:type_name -> forge.InstanceDpuExtensionServiceConfig
 	311,  // 270: forge.InstanceNVLinkConfig.gpu_configs:type_name -> forge.InstanceNVLinkGpuConfig
 	288,  // 271: forge.InstanceSpxConfig.spx_attachments:type_name -> forge.InstanceSpxAttachment
-	1026, // 272: forge.InstanceSpxAttachment.spx_partition_id:type_name -> common.SpxPartitionId
+	1028, // 272: forge.InstanceSpxAttachment.spx_partition_id:type_name -> common.SpxPartitionId
 	16,   // 273: forge.InstanceSpxAttachment.attachment_type:type_name -> forge.SpxAttachmentType
-	1023, // 274: forge.InstanceOperatingSystemUpdateRequest.instance_id:type_name -> common.InstanceId
+	1025, // 274: forge.InstanceOperatingSystemUpdateRequest.instance_id:type_name -> common.InstanceId
 	278,  // 275: forge.InstanceOperatingSystemUpdateRequest.os:type_name -> forge.InstanceOperatingSystemConfig
-	1023, // 276: forge.InstanceConfigUpdateRequest.instance_id:type_name -> common.InstanceId
+	1025, // 276: forge.InstanceConfigUpdateRequest.instance_id:type_name -> common.InstanceId
 	280,  // 277: forge.InstanceConfigUpdateRequest.config:type_name -> forge.InstanceConfig
 	267,  // 278: forge.InstanceConfigUpdateRequest.metadata:type_name -> forge.Metadata
 	361,  // 279: forge.InstanceStatus.tenant:type_name -> forge.InstanceTenantStatus
@@ -69711,12 +69863,12 @@ var file_nico_nico_proto_depIdxs = []int32{
 	293,  // 287: forge.InstanceSpxStatus.attachment_statuses:type_name -> forge.InstanceSpxAttachmentStatus
 	24,   // 288: forge.InstanceSpxStatus.configs_synced:type_name -> forge.SyncState
 	16,   // 289: forge.InstanceSpxAttachmentStatus.attachment_type:type_name -> forge.SpxAttachmentType
-	1026, // 290: forge.InstanceSpxAttachmentStatus.spx_partition_id:type_name -> common.SpxPartitionId
+	1028, // 290: forge.InstanceSpxAttachmentStatus.spx_partition_id:type_name -> common.SpxPartitionId
 	308,  // 291: forge.InstanceNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatus
 	24,   // 292: forge.InstanceNetworkStatus.configs_synced:type_name -> forge.SyncState
 	309,  // 293: forge.InstanceInfinibandStatus.ib_interfaces:type_name -> forge.InstanceIBInterfaceStatus
 	24,   // 294: forge.InstanceInfinibandStatus.configs_synced:type_name -> forge.SyncState
-	1007, // 295: forge.DpuExtensionServiceStatus.dpu_machine_id:type_name -> common.MachineId
+	1009, // 295: forge.DpuExtensionServiceStatus.dpu_machine_id:type_name -> common.MachineId
 	74,   // 296: forge.DpuExtensionServiceStatus.status:type_name -> forge.DpuExtensionServiceDeploymentStatus
 	458,  // 297: forge.DpuExtensionServiceStatus.components:type_name -> forge.DpuExtensionServiceComponent
 	74,   // 298: forge.InstanceDpuExtensionServiceStatus.deployment_status:type_name -> forge.DpuExtensionServiceDeploymentStatus
@@ -69725,78 +69877,78 @@ var file_nico_nico_proto_depIdxs = []int32{
 	24,   // 301: forge.InstanceDpuExtensionServicesStatus.configs_synced:type_name -> forge.SyncState
 	310,  // 302: forge.InstanceNVLinkStatus.gpu_statuses:type_name -> forge.InstanceNVLinkGpuStatus
 	24,   // 303: forge.InstanceNVLinkStatus.configs_synced:type_name -> forge.SyncState
-	1023, // 304: forge.Instance.id:type_name -> common.InstanceId
-	1007, // 305: forge.Instance.machine_id:type_name -> common.MachineId
+	1025, // 304: forge.Instance.id:type_name -> common.InstanceId
+	1009, // 305: forge.Instance.machine_id:type_name -> common.MachineId
 	267,  // 306: forge.Instance.metadata:type_name -> forge.Metadata
 	280,  // 307: forge.Instance.config:type_name -> forge.InstanceConfig
 	291,  // 308: forge.Instance.status:type_name -> forge.InstanceStatus
 	88,   // 309: forge.InstanceUpdateStatus.module:type_name -> forge.InstanceUpdateStatus.Module
-	1008, // 310: forge.InstanceUpdateStatus.trigger_received_at:type_name -> google.protobuf.Timestamp
-	1008, // 311: forge.InstanceUpdateStatus.update_triggered_at:type_name -> google.protobuf.Timestamp
+	1010, // 310: forge.InstanceUpdateStatus.trigger_received_at:type_name -> google.protobuf.Timestamp
+	1010, // 311: forge.InstanceUpdateStatus.update_triggered_at:type_name -> google.protobuf.Timestamp
 	40,   // 312: forge.InstanceInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	1021, // 313: forge.InstanceInterfaceConfig.network_segment_id:type_name -> common.NetworkSegmentId
-	1021, // 314: forge.InstanceInterfaceConfig.segment_id:type_name -> common.NetworkSegmentId
-	1011, // 315: forge.InstanceInterfaceConfig.vpc_prefix_id:type_name -> common.VpcPrefixId
+	1023, // 313: forge.InstanceInterfaceConfig.network_segment_id:type_name -> common.NetworkSegmentId
+	1023, // 314: forge.InstanceInterfaceConfig.segment_id:type_name -> common.NetworkSegmentId
+	1013, // 315: forge.InstanceInterfaceConfig.vpc_prefix_id:type_name -> common.VpcPrefixId
 	303,  // 316: forge.InstanceInterfaceConfig.vpc:type_name -> forge.InstanceInterfaceVpcSelection
 	304,  // 317: forge.InstanceInterfaceConfig.ipv6_interface_config:type_name -> forge.InstanceInterfaceIpv6Config
 	305,  // 318: forge.InstanceInterfaceConfig.routing_profile:type_name -> forge.InstanceInterfaceRoutingProfile
-	1009, // 319: forge.InstanceInterfaceVpcSelection.vpc_id:type_name -> common.VpcId
+	1011, // 319: forge.InstanceInterfaceVpcSelection.vpc_id:type_name -> common.VpcId
 	17,   // 320: forge.InstanceInterfaceVpcSelection.family_mode:type_name -> forge.InstanceInterfaceIpFamilyMode
-	1011, // 321: forge.InstanceInterfaceIpv6Config.vpc_prefix_id:type_name -> common.VpcPrefixId
+	1013, // 321: forge.InstanceInterfaceIpv6Config.vpc_prefix_id:type_name -> common.VpcPrefixId
 	879,  // 322: forge.InstanceInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	40,   // 323: forge.InstanceIBInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	1013, // 324: forge.InstanceIBInterfaceConfig.ib_partition_id:type_name -> common.IBPartitionId
-	1011, // 325: forge.InstanceInterfaceResolvedVpcPrefixes.ipv4_vpc_prefix_id:type_name -> common.VpcPrefixId
-	1011, // 326: forge.InstanceInterfaceResolvedVpcPrefixes.ipv6_vpc_prefix_id:type_name -> common.VpcPrefixId
-	1009, // 327: forge.InstanceInterfaceStatus.vpc_id:type_name -> common.VpcId
+	1015, // 324: forge.InstanceIBInterfaceConfig.ib_partition_id:type_name -> common.IBPartitionId
+	1013, // 325: forge.InstanceInterfaceResolvedVpcPrefixes.ipv4_vpc_prefix_id:type_name -> common.VpcPrefixId
+	1013, // 326: forge.InstanceInterfaceResolvedVpcPrefixes.ipv6_vpc_prefix_id:type_name -> common.VpcPrefixId
+	1011, // 327: forge.InstanceInterfaceStatus.vpc_id:type_name -> common.VpcId
 	307,  // 328: forge.InstanceInterfaceStatus.resolved_vpc_prefixes:type_name -> forge.InstanceInterfaceResolvedVpcPrefixes
-	1027, // 329: forge.InstanceNVLinkGpuStatus.domain_id:type_name -> common.NVLinkDomainId
-	1010, // 330: forge.InstanceNVLinkGpuStatus.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1010, // 331: forge.InstanceNVLinkGpuConfig.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1023, // 332: forge.InstancePhoneHomeLastContactRequest.instance_id:type_name -> common.InstanceId
-	1008, // 333: forge.InstancePhoneHomeLastContactResponse.timestamp:type_name -> google.protobuf.Timestamp
+	1029, // 329: forge.InstanceNVLinkGpuStatus.domain_id:type_name -> common.NVLinkDomainId
+	1012, // 330: forge.InstanceNVLinkGpuStatus.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 331: forge.InstanceNVLinkGpuConfig.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1025, // 332: forge.InstancePhoneHomeLastContactRequest.instance_id:type_name -> common.InstanceId
+	1010, // 333: forge.InstancePhoneHomeLastContactResponse.timestamp:type_name -> google.protobuf.Timestamp
 	18,   // 334: forge.Issue.category:type_name -> forge.IssueCategory
 	315,  // 335: forge.DeleteAttribution.initiated_by:type_name -> forge.DeleteInitiatedBy
-	1023, // 336: forge.InstanceReleaseRequest.id:type_name -> common.InstanceId
+	1025, // 336: forge.InstanceReleaseRequest.id:type_name -> common.InstanceId
 	314,  // 337: forge.InstanceReleaseRequest.issue:type_name -> forge.Issue
 	316,  // 338: forge.InstanceReleaseRequest.delete_attribution:type_name -> forge.DeleteAttribution
-	1007, // 339: forge.MachinesByIdsRequest.machine_ids:type_name -> common.MachineId
-	1016, // 340: forge.MachineSearchConfig.rack_id:type_name -> common.RackId
-	1007, // 341: forge.MachineStateHistoriesRequest.machine_ids:type_name -> common.MachineId
-	974,  // 342: forge.MachineStateHistories.histories:type_name -> forge.MachineStateHistories.HistoriesEntry
+	1009, // 339: forge.MachinesByIdsRequest.machine_ids:type_name -> common.MachineId
+	1018, // 340: forge.MachineSearchConfig.rack_id:type_name -> common.RackId
+	1009, // 341: forge.MachineStateHistoriesRequest.machine_ids:type_name -> common.MachineId
+	976,  // 342: forge.MachineStateHistories.histories:type_name -> forge.MachineStateHistories.HistoriesEntry
 	362,  // 343: forge.MachineStateHistoryRecords.records:type_name -> forge.MachineEvent
-	1007, // 344: forge.MachineHealthHistoriesRequest.machine_ids:type_name -> common.MachineId
-	1008, // 345: forge.MachineHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	1008, // 346: forge.MachineHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	975,  // 347: forge.HealthHistories.histories:type_name -> forge.HealthHistories.HistoriesEntry
+	1009, // 344: forge.MachineHealthHistoriesRequest.machine_ids:type_name -> common.MachineId
+	1010, // 345: forge.MachineHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	1010, // 346: forge.MachineHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	977,  // 347: forge.HealthHistories.histories:type_name -> forge.HealthHistories.HistoriesEntry
 	327,  // 348: forge.HealthHistoryRecords.records:type_name -> forge.HealthHistoryRecord
-	1014, // 349: forge.HealthHistoryRecord.health:type_name -> health.HealthReport
-	1008, // 350: forge.HealthHistoryRecord.time:type_name -> google.protobuf.Timestamp
+	1016, // 349: forge.HealthHistoryRecord.health:type_name -> health.HealthReport
+	1010, // 350: forge.HealthHistoryRecord.time:type_name -> google.protobuf.Timestamp
 	479,  // 351: forge.TenantList.tenants:type_name -> forge.Tenant
 	363,  // 352: forge.InterfaceList.interfaces:type_name -> forge.MachineInterface
 	347,  // 353: forge.MachineList.machines:type_name -> forge.Machine
-	1028, // 354: forge.InterfaceDeleteQuery.id:type_name -> common.MachineInterfaceId
-	1028, // 355: forge.InterfaceSearchQuery.id:type_name -> common.MachineInterfaceId
-	1028, // 356: forge.AssignStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
-	1028, // 357: forge.AssignStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 354: forge.InterfaceDeleteQuery.id:type_name -> common.MachineInterfaceId
+	1030, // 355: forge.InterfaceSearchQuery.id:type_name -> common.MachineInterfaceId
+	1030, // 356: forge.AssignStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 357: forge.AssignStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
 	19,   // 358: forge.AssignStaticAddressResponse.status:type_name -> forge.AssignStaticAddressStatus
-	1028, // 359: forge.RemoveStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
-	1028, // 360: forge.RemoveStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 359: forge.RemoveStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 360: forge.RemoveStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
 	20,   // 361: forge.RemoveStaticAddressResponse.status:type_name -> forge.RemoveStaticAddressStatus
-	1028, // 362: forge.FindInterfaceAddressesRequest.interface_id:type_name -> common.MachineInterfaceId
-	1028, // 363: forge.FindInterfaceAddressesResponse.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 362: forge.FindInterfaceAddressesRequest.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 363: forge.FindInterfaceAddressesResponse.interface_id:type_name -> common.MachineInterfaceId
 	341,  // 364: forge.FindInterfaceAddressesResponse.addresses:type_name -> forge.InterfaceAddress
-	1028, // 365: forge.BmcInfo.machine_interface_id:type_name -> common.MachineInterfaceId
-	1008, // 366: forge.MachineConfig.maintenance_start_time:type_name -> google.protobuf.Timestamp
+	1030, // 365: forge.BmcInfo.machine_interface_id:type_name -> common.MachineInterfaceId
+	1010, // 366: forge.MachineConfig.maintenance_start_time:type_name -> google.protobuf.Timestamp
 	348,  // 367: forge.MachineConfig.dpf:type_name -> forge.DpfMachineState
 	363,  // 368: forge.MachineStatus.interfaces:type_name -> forge.MachineInterface
-	1029, // 369: forge.MachineStatus.discovery_info:type_name -> machine_discovery.DiscoveryInfo
-	1008, // 370: forge.MachineStatus.last_reboot_time:type_name -> google.protobuf.Timestamp
-	1008, // 371: forge.MachineStatus.last_observation_time:type_name -> google.protobuf.Timestamp
-	1007, // 372: forge.MachineStatus.associated_host_machine_id:type_name -> common.MachineId
-	1007, // 373: forge.MachineStatus.associated_dpu_machine_ids:type_name -> common.MachineId
-	1008, // 374: forge.MachineStatus.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
-	1014, // 375: forge.MachineStatus.health:type_name -> health.HealthReport
+	1031, // 369: forge.MachineStatus.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	1010, // 370: forge.MachineStatus.last_reboot_time:type_name -> google.protobuf.Timestamp
+	1010, // 371: forge.MachineStatus.last_observation_time:type_name -> google.protobuf.Timestamp
+	1009, // 372: forge.MachineStatus.associated_host_machine_id:type_name -> common.MachineId
+	1009, // 373: forge.MachineStatus.associated_dpu_machine_ids:type_name -> common.MachineId
+	1010, // 374: forge.MachineStatus.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
+	1016, // 375: forge.MachineStatus.health:type_name -> health.HealthReport
 	357,  // 376: forge.MachineStatus.health_sources:type_name -> forge.HealthSourceOrigin
 	364,  // 377: forge.MachineStatus.infiniband:type_name -> forge.InfinibandStatusObservation
 	641,  // 378: forge.MachineStatus.capabilities:type_name -> forge.MachineCapabilitiesSet
@@ -69807,22 +69959,22 @@ var file_nico_nico_proto_depIdxs = []int32{
 	767,  // 383: forge.MachineStatus.spx:type_name -> forge.MachineSpxStatusObservation
 	349,  // 384: forge.MachineStatus.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
 	98,   // 385: forge.MachineStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1007, // 386: forge.Machine.id:type_name -> common.MachineId
+	1009, // 386: forge.Machine.id:type_name -> common.MachineId
 	358,  // 387: forge.Machine.state_reason:type_name -> forge.ControllerStateReason
 	360,  // 388: forge.Machine.state_sla:type_name -> forge.StateSla
 	362,  // 389: forge.Machine.events:type_name -> forge.MachineEvent
 	363,  // 390: forge.Machine.interfaces:type_name -> forge.MachineInterface
-	1029, // 391: forge.Machine.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	1031, // 391: forge.Machine.discovery_info:type_name -> machine_discovery.DiscoveryInfo
 	21,   // 392: forge.Machine.machine_type:type_name -> forge.MachineType
 	343,  // 393: forge.Machine.bmc_info:type_name -> forge.BmcInfo
-	1008, // 394: forge.Machine.last_reboot_time:type_name -> google.protobuf.Timestamp
-	1008, // 395: forge.Machine.last_observation_time:type_name -> google.protobuf.Timestamp
-	1008, // 396: forge.Machine.maintenance_start_time:type_name -> google.protobuf.Timestamp
-	1007, // 397: forge.Machine.associated_host_machine_id:type_name -> common.MachineId
+	1010, // 394: forge.Machine.last_reboot_time:type_name -> google.protobuf.Timestamp
+	1010, // 395: forge.Machine.last_observation_time:type_name -> google.protobuf.Timestamp
+	1010, // 396: forge.Machine.maintenance_start_time:type_name -> google.protobuf.Timestamp
+	1009, // 397: forge.Machine.associated_host_machine_id:type_name -> common.MachineId
 	355,  // 398: forge.Machine.inventory:type_name -> forge.MachineComponentInventory
-	1008, // 399: forge.Machine.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
-	1007, // 400: forge.Machine.associated_dpu_machine_ids:type_name -> common.MachineId
-	1014, // 401: forge.Machine.health:type_name -> health.HealthReport
+	1010, // 399: forge.Machine.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
+	1009, // 400: forge.Machine.associated_dpu_machine_ids:type_name -> common.MachineId
+	1016, // 401: forge.Machine.health:type_name -> health.HealthReport
 	357,  // 402: forge.Machine.health_sources:type_name -> forge.HealthSourceOrigin
 	364,  // 403: forge.Machine.ib_status:type_name -> forge.InfinibandStatusObservation
 	267,  // 404: forge.Machine.metadata:type_name -> forge.Metadata
@@ -69832,93 +69984,93 @@ var file_nico_nico_proto_depIdxs = []int32{
 	395,  // 408: forge.Machine.quarantine_state:type_name -> forge.ManagedHostQuarantineState
 	765,  // 409: forge.Machine.nvlink_info:type_name -> forge.MachineNVLinkInfo
 	775,  // 410: forge.Machine.nvlink_status_observation:type_name -> forge.MachineNVLinkStatusObservation
-	1016, // 411: forge.Machine.rack_id:type_name -> common.RackId
+	1018, // 411: forge.Machine.rack_id:type_name -> common.RackId
 	225,  // 412: forge.Machine.placement_in_rack:type_name -> forge.PlacementInRack
 	767,  // 413: forge.Machine.spx_status_observation:type_name -> forge.MachineSpxStatusObservation
 	348,  // 414: forge.Machine.dpf:type_name -> forge.DpfMachineState
 	345,  // 415: forge.Machine.config:type_name -> forge.MachineConfig
 	346,  // 416: forge.Machine.status:type_name -> forge.MachineStatus
 	22,   // 417: forge.InstanceNetworkRestrictions.network_segment_membership_type:type_name -> forge.InstanceNetworkSegmentMembershipType
-	1021, // 418: forge.InstanceNetworkRestrictions.network_segment_ids:type_name -> common.NetworkSegmentId
-	1007, // 419: forge.MachineMetadataUpdateRequest.machine_id:type_name -> common.MachineId
+	1023, // 418: forge.InstanceNetworkRestrictions.network_segment_ids:type_name -> common.NetworkSegmentId
+	1009, // 419: forge.MachineMetadataUpdateRequest.machine_id:type_name -> common.MachineId
 	267,  // 420: forge.MachineMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1016, // 421: forge.RackMetadataUpdateRequest.rack_id:type_name -> common.RackId
+	1018, // 421: forge.RackMetadataUpdateRequest.rack_id:type_name -> common.RackId
 	267,  // 422: forge.RackMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1018, // 423: forge.SwitchMetadataUpdateRequest.switch_id:type_name -> common.SwitchId
+	1020, // 423: forge.SwitchMetadataUpdateRequest.switch_id:type_name -> common.SwitchId
 	267,  // 424: forge.SwitchMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1015, // 425: forge.PowerShelfMetadataUpdateRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1017, // 425: forge.PowerShelfMetadataUpdateRequest.power_shelf_id:type_name -> common.PowerShelfId
 	267,  // 426: forge.PowerShelfMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1007, // 427: forge.DpuAgentInventoryReport.machine_id:type_name -> common.MachineId
+	1009, // 427: forge.DpuAgentInventoryReport.machine_id:type_name -> common.MachineId
 	355,  // 428: forge.DpuAgentInventoryReport.inventory:type_name -> forge.MachineComponentInventory
 	356,  // 429: forge.MachineComponentInventory.components:type_name -> forge.MachineInventorySoftwareComponent
 	41,   // 430: forge.HealthSourceOrigin.mode:type_name -> forge.HealthReportApplyMode
 	23,   // 431: forge.ControllerStateReason.outcome:type_name -> forge.ControllerStateOutcome
 	359,  // 432: forge.ControllerStateReason.source_ref:type_name -> forge.ControllerStateSourceReference
-	1030, // 433: forge.StateSla.sla:type_name -> google.protobuf.Duration
+	1032, // 433: forge.StateSla.sla:type_name -> google.protobuf.Duration
 	8,    // 434: forge.InstanceTenantStatus.state:type_name -> forge.TenantState
-	1008, // 435: forge.MachineEvent.time:type_name -> google.protobuf.Timestamp
-	1028, // 436: forge.MachineInterface.id:type_name -> common.MachineInterfaceId
-	1007, // 437: forge.MachineInterface.attached_dpu_machine_id:type_name -> common.MachineId
-	1007, // 438: forge.MachineInterface.machine_id:type_name -> common.MachineId
-	1021, // 439: forge.MachineInterface.segment_id:type_name -> common.NetworkSegmentId
-	1020, // 440: forge.MachineInterface.domain_id:type_name -> common.DomainId
-	1008, // 441: forge.MachineInterface.created:type_name -> google.protobuf.Timestamp
-	1008, // 442: forge.MachineInterface.last_dhcp:type_name -> google.protobuf.Timestamp
-	1015, // 443: forge.MachineInterface.power_shelf_id:type_name -> common.PowerShelfId
-	1018, // 444: forge.MachineInterface.switch_id:type_name -> common.SwitchId
+	1010, // 435: forge.MachineEvent.time:type_name -> google.protobuf.Timestamp
+	1030, // 436: forge.MachineInterface.id:type_name -> common.MachineInterfaceId
+	1009, // 437: forge.MachineInterface.attached_dpu_machine_id:type_name -> common.MachineId
+	1009, // 438: forge.MachineInterface.machine_id:type_name -> common.MachineId
+	1023, // 439: forge.MachineInterface.segment_id:type_name -> common.NetworkSegmentId
+	1022, // 440: forge.MachineInterface.domain_id:type_name -> common.DomainId
+	1010, // 441: forge.MachineInterface.created:type_name -> google.protobuf.Timestamp
+	1010, // 442: forge.MachineInterface.last_dhcp:type_name -> google.protobuf.Timestamp
+	1017, // 443: forge.MachineInterface.power_shelf_id:type_name -> common.PowerShelfId
+	1020, // 444: forge.MachineInterface.switch_id:type_name -> common.SwitchId
 	26,   // 445: forge.MachineInterface.association_type:type_name -> forge.InterfaceAssociationType
 	27,   // 446: forge.MachineInterface.interface_type:type_name -> forge.InterfaceType
 	365,  // 447: forge.InfinibandStatusObservation.ib_interfaces:type_name -> forge.MachineIbInterface
-	1008, // 448: forge.InfinibandStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	1031, // 449: forge.MachineIbInterface.associated_pkeys:type_name -> common.StringList
-	1031, // 450: forge.MachineIbInterface.associated_partition_ids:type_name -> common.StringList
+	1010, // 448: forge.InfinibandStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1033, // 449: forge.MachineIbInterface.associated_pkeys:type_name -> common.StringList
+	1033, // 450: forge.MachineIbInterface.associated_partition_ids:type_name -> common.StringList
 	28,   // 451: forge.DhcpDiscovery.address_family:type_name -> forge.AddressFamily
 	29,   // 452: forge.DhcpDiscovery.message_kind:type_name -> forge.MessageKind
 	30,   // 453: forge.ExpireDhcpLeaseResponse.status:type_name -> forge.ExpireDhcpLeaseStatus
-	1007, // 454: forge.DhcpRecord.machine_id:type_name -> common.MachineId
-	1028, // 455: forge.DhcpRecord.machine_interface_id:type_name -> common.MachineInterfaceId
-	1021, // 456: forge.DhcpRecord.segment_id:type_name -> common.NetworkSegmentId
-	1020, // 457: forge.DhcpRecord.subdomain_id:type_name -> common.DomainId
-	1008, // 458: forge.DhcpRecord.last_invalidation_time:type_name -> google.protobuf.Timestamp
+	1009, // 454: forge.DhcpRecord.machine_id:type_name -> common.MachineId
+	1030, // 455: forge.DhcpRecord.machine_interface_id:type_name -> common.MachineInterfaceId
+	1023, // 456: forge.DhcpRecord.segment_id:type_name -> common.NetworkSegmentId
+	1022, // 457: forge.DhcpRecord.subdomain_id:type_name -> common.DomainId
+	1010, // 458: forge.DhcpRecord.last_invalidation_time:type_name -> google.protobuf.Timestamp
 	251,  // 459: forge.NetworkSegmentList.network_segments:type_name -> forge.NetworkSegment
 	31,   // 460: forge.SSHKeyValidationResponse.role:type_name -> forge.UserRoles
-	1018, // 461: forge.GetSwitchNvosCredentialsRequest.switch_id:type_name -> common.SwitchId
+	1020, // 461: forge.GetSwitchNvosCredentialsRequest.switch_id:type_name -> common.SwitchId
 	376,  // 462: forge.GetBmcCredentialsResponse.credentials:type_name -> forge.BmcCredentials
 	844,  // 463: forge.BmcCredentials.username_password:type_name -> forge.UsernamePassword
 	845,  // 464: forge.BmcCredentials.session_token:type_name -> forge.SessionToken
 	384,  // 465: forge.SshRequest.endpoint_request:type_name -> forge.BmcEndpointRequest
 	386,  // 466: forge.CopyBfbToDpuRshimRequest.ssh_request:type_name -> forge.SshRequest
-	1007, // 467: forge.UpdateMachineHardwareInfoRequest.machine_id:type_name -> common.MachineId
+	1009, // 467: forge.UpdateMachineHardwareInfoRequest.machine_id:type_name -> common.MachineId
 	389,  // 468: forge.UpdateMachineHardwareInfoRequest.info:type_name -> forge.MachineHardwareInfo
 	32,   // 469: forge.UpdateMachineHardwareInfoRequest.update_type:type_name -> forge.MachineHardwareInfoUpdateType
-	1032, // 470: forge.MachineHardwareInfo.gpus:type_name -> machine_discovery.Gpu
-	1007, // 471: forge.ManagedHostNetworkConfigRequest.dpu_machine_id:type_name -> common.MachineId
+	1034, // 470: forge.MachineHardwareInfo.gpus:type_name -> machine_discovery.Gpu
+	1009, // 471: forge.ManagedHostNetworkConfigRequest.dpu_machine_id:type_name -> common.MachineId
 	402,  // 472: forge.ManagedHostNetworkConfigResponse.managed_host_config:type_name -> forge.ManagedHostNetworkConfig
 	403,  // 473: forge.ManagedHostNetworkConfigResponse.admin_interface:type_name -> forge.FlatInterfaceConfig
 	403,  // 474: forge.ManagedHostNetworkConfigResponse.tenant_interfaces:type_name -> forge.FlatInterfaceConfig
-	1023, // 475: forge.ManagedHostNetworkConfigResponse.instance_id:type_name -> common.InstanceId
+	1025, // 475: forge.ManagedHostNetworkConfigResponse.instance_id:type_name -> common.InstanceId
 	6,    // 476: forge.ManagedHostNetworkConfigResponse.network_virtualization_type:type_name -> forge.VpcVirtualizationType
 	34,   // 477: forge.ManagedHostNetworkConfigResponse.vpc_isolation_behavior:type_name -> forge.VpcIsolationBehaviorType
 	300,  // 478: forge.ManagedHostNetworkConfigResponse.instance:type_name -> forge.Instance
-	1033, // 479: forge.ManagedHostNetworkConfigResponse.common_internal_route_target:type_name -> common.RouteTarget
-	1033, // 480: forge.ManagedHostNetworkConfigResponse.additional_route_target_imports:type_name -> common.RouteTarget
+	1035, // 479: forge.ManagedHostNetworkConfigResponse.common_internal_route_target:type_name -> common.RouteTarget
+	1035, // 480: forge.ManagedHostNetworkConfigResponse.additional_route_target_imports:type_name -> common.RouteTarget
 	692,  // 481: forge.ManagedHostNetworkConfigResponse.network_security_policy_overrides:type_name -> forge.ResolvedNetworkSecurityGroupRule
 	394,  // 482: forge.ManagedHostNetworkConfigResponse.dpu_extension_services:type_name -> forge.ManagedHostDpuExtensionServiceConfig
 	392,  // 483: forge.ManagedHostNetworkConfigResponse.traffic_intercept_config:type_name -> forge.TrafficInterceptConfig
 	880,  // 484: forge.ManagedHostNetworkConfigResponse.routing_profile:type_name -> forge.RoutingProfile
 	769,  // 485: forge.ManagedHostNetworkConfigResponse.astra_config:type_name -> forge.AstraConfig
 	393,  // 486: forge.TrafficInterceptConfig.bridging:type_name -> forge.TrafficInterceptBridging
-	976,  // 487: forge.TrafficInterceptBridging.host_representor_intercept_bridging:type_name -> forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
+	978,  // 487: forge.TrafficInterceptBridging.host_representor_intercept_bridging:type_name -> forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry
 	73,   // 488: forge.ManagedHostDpuExtensionServiceConfig.service_type:type_name -> forge.DpuExtensionServiceType
 	846,  // 489: forge.ManagedHostDpuExtensionServiceConfig.credential:type_name -> forge.DpuExtensionServiceCredential
 	865,  // 490: forge.ManagedHostDpuExtensionServiceConfig.observability:type_name -> forge.DpuExtensionServiceObservability
 	33,   // 491: forge.ManagedHostQuarantineState.mode:type_name -> forge.ManagedHostQuarantineMode
-	1007, // 492: forge.GetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	1009, // 492: forge.GetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
 	395,  // 493: forge.GetManagedHostQuarantineStateResponse.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	1007, // 494: forge.SetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	1009, // 494: forge.SetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
 	395,  // 495: forge.SetManagedHostQuarantineStateRequest.quarantine_state:type_name -> forge.ManagedHostQuarantineState
 	395,  // 496: forge.SetManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	1007, // 497: forge.ClearManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	1009, // 497: forge.ClearManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
 	395,  // 498: forge.ClearManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
 	395,  // 499: forge.ManagedHostNetworkConfig.quarantine_state:type_name -> forge.ManagedHostQuarantineState
 	40,   // 500: forge.FlatInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
@@ -69926,19 +70078,19 @@ var file_nico_nico_proto_depIdxs = []int32{
 	880,  // 502: forge.FlatInterfaceConfig.vpc_routing_profile:type_name -> forge.RoutingProfile
 	404,  // 503: forge.FlatInterfaceConfig.interface_routing_profile:type_name -> forge.FlatInterfaceRoutingProfile
 	406,  // 504: forge.FlatInterfaceConfig.network_security_group:type_name -> forge.FlatInterfaceNetworkSecurityGroupConfig
-	1017, // 505: forge.FlatInterfaceConfig.internal_uuid:type_name -> common.UUID
+	1019, // 505: forge.FlatInterfaceConfig.internal_uuid:type_name -> common.UUID
 	879,  // 506: forge.FlatInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	58,   // 507: forge.FlatInterfaceNetworkSecurityGroupConfig.source:type_name -> forge.NetworkSecurityGroupSource
 	692,  // 508: forge.FlatInterfaceNetworkSecurityGroupConfig.rules:type_name -> forge.ResolvedNetworkSecurityGroupRule
 	455,  // 509: forge.ManagedHostNetworkStatusResponse.all:type_name -> forge.DpuNetworkStatus
-	1008, // 510: forge.DpuAgentUpgradeCheckRequest.binary_mtime:type_name -> google.protobuf.Timestamp
+	1010, // 510: forge.DpuAgentUpgradeCheckRequest.binary_mtime:type_name -> google.protobuf.Timestamp
 	35,   // 511: forge.DpuAgentUpgradePolicyRequest.new_policy:type_name -> forge.AgentUpgradePolicy
 	35,   // 512: forge.DpuAgentUpgradePolicyResponse.active_policy:type_name -> forge.AgentUpgradePolicy
 	384,  // 513: forge.LockdownRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1007, // 514: forge.LockdownRequest.machine_id:type_name -> common.MachineId
+	1009, // 514: forge.LockdownRequest.machine_id:type_name -> common.MachineId
 	36,   // 515: forge.LockdownRequest.action:type_name -> forge.LockdownAction
 	384,  // 516: forge.LockdownStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1007, // 517: forge.LockdownStatusRequest.machine_id:type_name -> common.MachineId
+	1009, // 517: forge.LockdownStatusRequest.machine_id:type_name -> common.MachineId
 	384,  // 518: forge.MachineSetupStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 519: forge.MachineSetupRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 520: forge.SetDpuFirstBootOrderRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
@@ -69946,89 +70098,89 @@ var file_nico_nico_proto_depIdxs = []int32{
 	384,  // 522: forge.AdminBmcResetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 523: forge.EnableInfiniteBootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 524: forge.IsInfiniteBootEnabledRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1007, // 525: forge.BMCMetaDataGetRequest.machine_id:type_name -> common.MachineId
+	1009, // 525: forge.BMCMetaDataGetRequest.machine_id:type_name -> common.MachineId
 	31,   // 526: forge.BMCMetaDataGetRequest.role:type_name -> forge.UserRoles
 	37,   // 527: forge.BMCMetaDataGetRequest.request_type:type_name -> forge.BMCRequestType
 	384,  // 528: forge.BMCMetaDataGetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1007, // 529: forge.MachineCredentialsUpdateRequest.machine_id:type_name -> common.MachineId
-	977,  // 530: forge.MachineCredentialsUpdateRequest.credentials:type_name -> forge.MachineCredentialsUpdateRequest.Credentials
-	1007, // 531: forge.ForgeAgentControlRequest.machine_id:type_name -> common.MachineId
+	1009, // 529: forge.MachineCredentialsUpdateRequest.machine_id:type_name -> common.MachineId
+	979,  // 530: forge.MachineCredentialsUpdateRequest.credentials:type_name -> forge.MachineCredentialsUpdateRequest.Credentials
+	1009, // 531: forge.ForgeAgentControlRequest.machine_id:type_name -> common.MachineId
 	90,   // 532: forge.ForgeAgentControlResponse.legacy_action:type_name -> forge.ForgeAgentControlResponse.LegacyAction
-	978,  // 533: forge.ForgeAgentControlResponse.data:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
-	979,  // 534: forge.ForgeAgentControlResponse.noop:type_name -> forge.ForgeAgentControlResponse.Noop
-	980,  // 535: forge.ForgeAgentControlResponse.reset:type_name -> forge.ForgeAgentControlResponse.Reset
-	981,  // 536: forge.ForgeAgentControlResponse.discovery:type_name -> forge.ForgeAgentControlResponse.Discovery
-	982,  // 537: forge.ForgeAgentControlResponse.rebuild:type_name -> forge.ForgeAgentControlResponse.Rebuild
-	983,  // 538: forge.ForgeAgentControlResponse.retry:type_name -> forge.ForgeAgentControlResponse.Retry
-	984,  // 539: forge.ForgeAgentControlResponse.measure:type_name -> forge.ForgeAgentControlResponse.Measure
-	985,  // 540: forge.ForgeAgentControlResponse.log_error:type_name -> forge.ForgeAgentControlResponse.LogError
-	986,  // 541: forge.ForgeAgentControlResponse.machine_validation:type_name -> forge.ForgeAgentControlResponse.MachineValidation
-	988,  // 542: forge.ForgeAgentControlResponse.mlx_action:type_name -> forge.ForgeAgentControlResponse.MlxAction
-	995,  // 543: forge.ForgeAgentControlResponse.firmware_upgrade:type_name -> forge.ForgeAgentControlResponse.FirmwareUpgrade
-	1028, // 544: forge.MachineDiscoveryInfo.machine_interface_id:type_name -> common.MachineInterfaceId
-	1029, // 545: forge.MachineDiscoveryInfo.info:type_name -> machine_discovery.DiscoveryInfo
+	980,  // 533: forge.ForgeAgentControlResponse.data:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
+	981,  // 534: forge.ForgeAgentControlResponse.noop:type_name -> forge.ForgeAgentControlResponse.Noop
+	982,  // 535: forge.ForgeAgentControlResponse.reset:type_name -> forge.ForgeAgentControlResponse.Reset
+	983,  // 536: forge.ForgeAgentControlResponse.discovery:type_name -> forge.ForgeAgentControlResponse.Discovery
+	984,  // 537: forge.ForgeAgentControlResponse.rebuild:type_name -> forge.ForgeAgentControlResponse.Rebuild
+	985,  // 538: forge.ForgeAgentControlResponse.retry:type_name -> forge.ForgeAgentControlResponse.Retry
+	986,  // 539: forge.ForgeAgentControlResponse.measure:type_name -> forge.ForgeAgentControlResponse.Measure
+	987,  // 540: forge.ForgeAgentControlResponse.log_error:type_name -> forge.ForgeAgentControlResponse.LogError
+	988,  // 541: forge.ForgeAgentControlResponse.machine_validation:type_name -> forge.ForgeAgentControlResponse.MachineValidation
+	990,  // 542: forge.ForgeAgentControlResponse.mlx_action:type_name -> forge.ForgeAgentControlResponse.MlxAction
+	997,  // 543: forge.ForgeAgentControlResponse.firmware_upgrade:type_name -> forge.ForgeAgentControlResponse.FirmwareUpgrade
+	1030, // 544: forge.MachineDiscoveryInfo.machine_interface_id:type_name -> common.MachineInterfaceId
+	1031, // 545: forge.MachineDiscoveryInfo.info:type_name -> machine_discovery.DiscoveryInfo
 	38,   // 546: forge.MachineDiscoveryInfo.discovery_reporter:type_name -> forge.MachineDiscoveryReporter
-	1007, // 547: forge.MachineDiscoveryCompletedRequest.machine_id:type_name -> common.MachineId
-	1007, // 548: forge.MachineCleanupInfo.machine_id:type_name -> common.MachineId
-	997,  // 549: forge.MachineCleanupInfo.nvme:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	997,  // 550: forge.MachineCleanupInfo.ram:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	997,  // 551: forge.MachineCleanupInfo.mem_overwrite:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	997,  // 552: forge.MachineCleanupInfo.ib:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	997,  // 553: forge.MachineCleanupInfo.hdd:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	1009, // 547: forge.MachineDiscoveryCompletedRequest.machine_id:type_name -> common.MachineId
+	1009, // 548: forge.MachineCleanupInfo.machine_id:type_name -> common.MachineId
+	999,  // 549: forge.MachineCleanupInfo.nvme:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	999,  // 550: forge.MachineCleanupInfo.ram:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	999,  // 551: forge.MachineCleanupInfo.mem_overwrite:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	999,  // 552: forge.MachineCleanupInfo.ib:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	999,  // 553: forge.MachineCleanupInfo.hdd:type_name -> forge.MachineCleanupInfo.CleanupStepResult
 	91,   // 554: forge.MachineCleanupInfo.result:type_name -> forge.MachineCleanupInfo.CleanupResult
 	441,  // 555: forge.MachineCertificateResult.machine_certificate:type_name -> forge.MachineCertificate
-	1007, // 556: forge.MachineDiscoveryResult.machine_id:type_name -> common.MachineId
+	1009, // 556: forge.MachineDiscoveryResult.machine_id:type_name -> common.MachineId
 	441,  // 557: forge.MachineDiscoveryResult.machine_certificate:type_name -> forge.MachineCertificate
 	134,  // 558: forge.MachineDiscoveryResult.attest_key_challenge:type_name -> forge.AttestKeyBindChallenge
-	1028, // 559: forge.MachineDiscoveryResult.machine_interface_id:type_name -> common.MachineInterfaceId
-	1007, // 560: forge.ForgeScoutErrorReport.machine_id:type_name -> common.MachineId
-	1028, // 561: forge.ForgeScoutErrorReport.machine_interface_id:type_name -> common.MachineInterfaceId
+	1030, // 559: forge.MachineDiscoveryResult.machine_interface_id:type_name -> common.MachineInterfaceId
+	1009, // 560: forge.ForgeScoutErrorReport.machine_id:type_name -> common.MachineId
+	1030, // 561: forge.ForgeScoutErrorReport.machine_interface_id:type_name -> common.MachineInterfaceId
 	25,   // 562: forge.PxeInstructionRequest.arch:type_name -> forge.MachineArchitecture
-	1028, // 563: forge.PxeInstructionRequest.interface_id:type_name -> common.MachineInterfaceId
+	1030, // 563: forge.PxeInstructionRequest.interface_id:type_name -> common.MachineInterfaceId
 	363,  // 564: forge.CloudInitDiscoveryInstructions.machine_interface:type_name -> forge.MachineInterface
 	886,  // 565: forge.CloudInitDiscoveryInstructions.domain:type_name -> forge.PxeDomain
 	39,   // 566: forge.CloudInitDiscoveryInstructions.bootstrap_ca_source:type_name -> forge.BootstrapCaSource
 	451,  // 567: forge.CloudInitInstructions.discovery_instructions:type_name -> forge.CloudInitDiscoveryInstructions
 	452,  // 568: forge.CloudInitInstructions.metadata:type_name -> forge.CloudInitMetaData
-	1007, // 569: forge.DpuNetworkStatus.dpu_machine_id:type_name -> common.MachineId
-	1008, // 570: forge.DpuNetworkStatus.observed_at:type_name -> google.protobuf.Timestamp
+	1009, // 569: forge.DpuNetworkStatus.dpu_machine_id:type_name -> common.MachineId
+	1010, // 570: forge.DpuNetworkStatus.observed_at:type_name -> google.protobuf.Timestamp
 	476,  // 571: forge.DpuNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatusObservation
-	1023, // 572: forge.DpuNetworkStatus.instance_id:type_name -> common.InstanceId
-	1014, // 573: forge.DpuNetworkStatus.dpu_health:type_name -> health.HealthReport
+	1025, // 572: forge.DpuNetworkStatus.instance_id:type_name -> common.InstanceId
+	1016, // 573: forge.DpuNetworkStatus.dpu_health:type_name -> health.HealthReport
 	477,  // 574: forge.DpuNetworkStatus.fabric_interfaces:type_name -> forge.FabricInterfaceData
 	456,  // 575: forge.DpuNetworkStatus.last_dhcp_requests:type_name -> forge.LastDhcpRequest
 	457,  // 576: forge.DpuNetworkStatus.dpu_extension_services:type_name -> forge.DpuExtensionServiceStatusObservation
 	771,  // 577: forge.DpuNetworkStatus.astra_config_status:type_name -> forge.AstraConfigStatus
-	1028, // 578: forge.LastDhcpRequest.host_interface_id:type_name -> common.MachineInterfaceId
+	1030, // 578: forge.LastDhcpRequest.host_interface_id:type_name -> common.MachineInterfaceId
 	73,   // 579: forge.DpuExtensionServiceStatusObservation.service_type:type_name -> forge.DpuExtensionServiceType
 	74,   // 580: forge.DpuExtensionServiceStatusObservation.state:type_name -> forge.DpuExtensionServiceDeploymentStatus
 	458,  // 581: forge.DpuExtensionServiceStatusObservation.components:type_name -> forge.DpuExtensionServiceComponent
-	1014, // 582: forge.OptionalHealthReport.report:type_name -> health.HealthReport
-	1014, // 583: forge.HealthReportEntry.report:type_name -> health.HealthReport
+	1016, // 582: forge.OptionalHealthReport.report:type_name -> health.HealthReport
+	1016, // 583: forge.HealthReportEntry.report:type_name -> health.HealthReport
 	41,   // 584: forge.HealthReportEntry.mode:type_name -> forge.HealthReportApplyMode
-	1007, // 585: forge.InsertMachineHealthReportRequest.machine_id:type_name -> common.MachineId
+	1009, // 585: forge.InsertMachineHealthReportRequest.machine_id:type_name -> common.MachineId
 	460,  // 586: forge.InsertMachineHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1016, // 587: forge.InsertRackHealthReportRequest.rack_id:type_name -> common.RackId
+	1018, // 587: forge.InsertRackHealthReportRequest.rack_id:type_name -> common.RackId
 	460,  // 588: forge.InsertRackHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1016, // 589: forge.RemoveRackHealthReportRequest.rack_id:type_name -> common.RackId
-	1016, // 590: forge.ListRackHealthReportsRequest.rack_id:type_name -> common.RackId
-	1018, // 591: forge.InsertSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
+	1018, // 589: forge.RemoveRackHealthReportRequest.rack_id:type_name -> common.RackId
+	1018, // 590: forge.ListRackHealthReportsRequest.rack_id:type_name -> common.RackId
+	1020, // 591: forge.InsertSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
 	460,  // 592: forge.InsertSwitchHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1018, // 593: forge.RemoveSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
-	1018, // 594: forge.ListSwitchHealthReportsRequest.switch_id:type_name -> common.SwitchId
-	1015, // 595: forge.InsertPowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1020, // 593: forge.RemoveSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
+	1020, // 594: forge.ListSwitchHealthReportsRequest.switch_id:type_name -> common.SwitchId
+	1017, // 595: forge.InsertPowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
 	460,  // 596: forge.InsertPowerShelfHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1015, // 597: forge.RemovePowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1015, // 598: forge.ListPowerShelfHealthReportsRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1017, // 597: forge.RemovePowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1017, // 598: forge.ListPowerShelfHealthReportsRequest.power_shelf_id:type_name -> common.PowerShelfId
 	460,  // 599: forge.ListHealthReportResponse.health_report_entries:type_name -> forge.HealthReportEntry
-	1007, // 600: forge.RemoveMachineHealthReportRequest.machine_id:type_name -> common.MachineId
-	1027, // 601: forge.ListNVLinkDomainHealthReportsRequest.domain_id:type_name -> common.NVLinkDomainId
-	1027, // 602: forge.InsertNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
+	1009, // 600: forge.RemoveMachineHealthReportRequest.machine_id:type_name -> common.MachineId
+	1029, // 601: forge.ListNVLinkDomainHealthReportsRequest.domain_id:type_name -> common.NVLinkDomainId
+	1029, // 602: forge.InsertNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
 	460,  // 603: forge.InsertNVLinkDomainHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1027, // 604: forge.RemoveNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
+	1029, // 604: forge.RemoveNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
 	40,   // 605: forge.InstanceInterfaceStatusObservation.function_type:type_name -> forge.InterfaceFunctionType
 	686,  // 606: forge.InstanceInterfaceStatusObservation.network_security_group:type_name -> forge.NetworkSecurityGroupStatus
-	1017, // 607: forge.InstanceInterfaceStatusObservation.internal_uuid:type_name -> common.UUID
+	1019, // 607: forge.InstanceInterfaceStatusObservation.internal_uuid:type_name -> common.UUID
 	478,  // 608: forge.FabricInterfaceData.link_data:type_name -> forge.LinkData
 	267,  // 609: forge.Tenant.metadata:type_name -> forge.Metadata
 	267,  // 610: forge.CreateTenantRequest.metadata:type_name -> forge.Metadata
@@ -70050,135 +70202,135 @@ var file_nico_nico_proto_depIdxs = []int32{
 	486,  // 626: forge.TenantKeysetsByIdsRequest.keyset_ids:type_name -> forge.TenantKeysetIdentifier
 	504,  // 627: forge.ResourcePools.pools:type_name -> forge.ResourcePool
 	43,   // 628: forge.MaintenanceRequest.operation:type_name -> forge.MaintenanceOperation
-	1007, // 629: forge.MaintenanceRequest.host_id:type_name -> common.MachineId
+	1009, // 629: forge.MaintenanceRequest.host_id:type_name -> common.MachineId
 	44,   // 630: forge.SetDynamicConfigRequest.setting:type_name -> forge.ConfigSetting
 	532,  // 631: forge.FindIpAddressResponse.matches:type_name -> forge.IpAddressMatch
-	1017, // 632: forge.IdentifyUuidRequest.uuid:type_name -> common.UUID
-	1017, // 633: forge.IdentifyUuidResponse.uuid:type_name -> common.UUID
+	1019, // 632: forge.IdentifyUuidRequest.uuid:type_name -> common.UUID
+	1019, // 633: forge.IdentifyUuidResponse.uuid:type_name -> common.UUID
 	45,   // 634: forge.IdentifyUuidResponse.object_type:type_name -> forge.UuidType
 	46,   // 635: forge.IdentifyMacResponse.object_type:type_name -> forge.MacOwner
-	1007, // 636: forge.IdentifySerialResponse.machine_id:type_name -> common.MachineId
-	1007, // 637: forge.DpuReprovisioningRequest.dpu_id:type_name -> common.MachineId
+	1009, // 636: forge.IdentifySerialResponse.machine_id:type_name -> common.MachineId
+	1009, // 637: forge.DpuReprovisioningRequest.dpu_id:type_name -> common.MachineId
 	92,   // 638: forge.DpuReprovisioningRequest.mode:type_name -> forge.DpuReprovisioningRequest.Mode
 	47,   // 639: forge.DpuReprovisioningRequest.initiator:type_name -> forge.UpdateInitiator
-	1007, // 640: forge.DpuReprovisioningRequest.machine_id:type_name -> common.MachineId
-	998,  // 641: forge.DpuReprovisioningListResponse.dpus:type_name -> forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
-	1007, // 642: forge.HostReprovisioningRequest.machine_id:type_name -> common.MachineId
+	1009, // 640: forge.DpuReprovisioningRequest.machine_id:type_name -> common.MachineId
+	1000, // 641: forge.DpuReprovisioningListResponse.dpus:type_name -> forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
+	1009, // 642: forge.HostReprovisioningRequest.machine_id:type_name -> common.MachineId
 	93,   // 643: forge.HostReprovisioningRequest.mode:type_name -> forge.HostReprovisioningRequest.Mode
 	47,   // 644: forge.HostReprovisioningRequest.initiator:type_name -> forge.UpdateInitiator
-	999,  // 645: forge.HostReprovisioningListResponse.hosts:type_name -> forge.HostReprovisioningListResponse.HostReprovisioningListItem
+	1001, // 645: forge.HostReprovisioningListResponse.hosts:type_name -> forge.HostReprovisioningListResponse.HostReprovisioningListItem
 	526,  // 646: forge.DpuInfoStatusObservation.os_operational_state:type_name -> forge.DpuOsOperationalState
 	527,  // 647: forge.DpuInfoStatusObservation.representors:type_name -> forge.DpuRepresentorStatus
-	1008, // 648: forge.DpuInfoStatusObservation.last_heartbeat:type_name -> google.protobuf.Timestamp
+	1010, // 648: forge.DpuInfoStatusObservation.last_heartbeat:type_name -> google.protobuf.Timestamp
 	528,  // 649: forge.DpuInfo.observed_status:type_name -> forge.DpuInfoStatusObservation
 	529,  // 650: forge.GetDpuInfoListResponse.dpu_list:type_name -> forge.DpuInfo
 	48,   // 651: forge.IpAddressMatch.ip_type:type_name -> forge.IpType
-	1028, // 652: forge.MachineBootOverride.machine_interface_id:type_name -> common.MachineInterfaceId
-	1007, // 653: forge.ConnectedDevice.id:type_name -> common.MachineId
+	1030, // 652: forge.MachineBootOverride.machine_interface_id:type_name -> common.MachineInterfaceId
+	1009, // 653: forge.ConnectedDevice.id:type_name -> common.MachineId
 	534,  // 654: forge.ConnectedDeviceList.connected_devices:type_name -> forge.ConnectedDevice
 	540,  // 655: forge.MachineIdBmcIpPairs.pairs:type_name -> forge.MachineIdBmcIp
-	1007, // 656: forge.MachineIdBmcIp.machine_id:type_name -> common.MachineId
+	1009, // 656: forge.MachineIdBmcIp.machine_id:type_name -> common.MachineId
 	534,  // 657: forge.NetworkDevice.devices:type_name -> forge.ConnectedDevice
 	541,  // 658: forge.NetworkTopologyData.network_devices:type_name -> forge.NetworkDevice
 	49,   // 659: forge.RouteServers.source_type:type_name -> forge.RouteServerSourceType
 	547,  // 660: forge.RouteServerEntries.route_servers:type_name -> forge.RouteServer
 	49,   // 661: forge.RouteServer.source_type:type_name -> forge.RouteServerSourceType
-	1007, // 662: forge.SetHostUefiPasswordRequest.host_id:type_name -> common.MachineId
-	1007, // 663: forge.ClearHostUefiPasswordRequest.host_id:type_name -> common.MachineId
-	1017, // 664: forge.OsImageAttributes.id:type_name -> common.UUID
+	1009, // 662: forge.SetHostUefiPasswordRequest.host_id:type_name -> common.MachineId
+	1009, // 663: forge.ClearHostUefiPasswordRequest.host_id:type_name -> common.MachineId
+	1019, // 664: forge.OsImageAttributes.id:type_name -> common.UUID
 	552,  // 665: forge.OsImage.attributes:type_name -> forge.OsImageAttributes
 	50,   // 666: forge.OsImage.status:type_name -> forge.OsImageStatus
 	553,  // 667: forge.ListOsImageResponse.images:type_name -> forge.OsImage
-	1017, // 668: forge.DeleteOsImageRequest.id:type_name -> common.UUID
-	1024, // 669: forge.GetIpxeTemplateRequest.id:type_name -> common.IpxeTemplateId
+	1019, // 668: forge.DeleteOsImageRequest.id:type_name -> common.UUID
+	1026, // 669: forge.GetIpxeTemplateRequest.id:type_name -> common.IpxeTemplateId
 	276,  // 670: forge.IpxeTemplateList.templates:type_name -> forge.IpxeTemplate
 	12,   // 671: forge.ExpectedHostNic.network_segment_type:type_name -> forge.NetworkSegmentType
 	82,   // 672: forge.ExpectedHostNic.role:type_name -> forge.ExpectedInterfaceRole
 	83,   // 673: forge.ExpectedHostNic.ip_allocation:type_name -> forge.ExpectedInterfaceIpAllocation
 	267,  // 674: forge.ExpectedMachine.metadata:type_name -> forge.Metadata
-	1017, // 675: forge.ExpectedMachine.id:type_name -> common.UUID
+	1019, // 675: forge.ExpectedMachine.id:type_name -> common.UUID
 	561,  // 676: forge.ExpectedMachine.host_nics:type_name -> forge.ExpectedHostNic
-	1016, // 677: forge.ExpectedMachine.rack_id:type_name -> common.RackId
+	1018, // 677: forge.ExpectedMachine.rack_id:type_name -> common.RackId
 	51,   // 678: forge.ExpectedMachine.dpu_mode:type_name -> forge.DpuMode
 	562,  // 679: forge.ExpectedMachine.host_lifecycle_profile:type_name -> forge.HostLifecycleProfile
 	52,   // 680: forge.ExpectedMachine.bmc_ip_allocation:type_name -> forge.BmcIpAllocationType
-	1017, // 681: forge.ExpectedMachineRequest.id:type_name -> common.UUID
+	1019, // 681: forge.ExpectedMachineRequest.id:type_name -> common.UUID
 	563,  // 682: forge.ExpectedMachineList.expected_machines:type_name -> forge.ExpectedMachine
 	567,  // 683: forge.LinkedExpectedMachineList.expected_machines:type_name -> forge.LinkedExpectedMachine
-	1007, // 684: forge.LinkedExpectedMachine.machine_id:type_name -> common.MachineId
-	1017, // 685: forge.LinkedExpectedMachine.expected_machine_id:type_name -> common.UUID
+	1009, // 684: forge.LinkedExpectedMachine.machine_id:type_name -> common.MachineId
+	1019, // 685: forge.LinkedExpectedMachine.expected_machine_id:type_name -> common.UUID
 	569,  // 686: forge.UnexpectedMachineList.unexpected_machines:type_name -> forge.UnexpectedMachine
-	1007, // 687: forge.UnexpectedMachine.machine_id:type_name -> common.MachineId
+	1009, // 687: forge.UnexpectedMachine.machine_id:type_name -> common.MachineId
 	565,  // 688: forge.BatchExpectedMachineOperationRequest.expected_machines:type_name -> forge.ExpectedMachineList
-	1017, // 689: forge.ExpectedMachineOperationResult.id:type_name -> common.UUID
+	1019, // 689: forge.ExpectedMachineOperationResult.id:type_name -> common.UUID
 	563,  // 690: forge.ExpectedMachineOperationResult.expected_machine:type_name -> forge.ExpectedMachine
 	571,  // 691: forge.BatchExpectedMachineOperationResponse.results:type_name -> forge.ExpectedMachineOperationResult
-	1007, // 692: forge.MachineRebootCompletedRequest.machine_id:type_name -> common.MachineId
-	1007, // 693: forge.ScoutFirmwareUpgradeStatusRequest.machine_id:type_name -> common.MachineId
-	1007, // 694: forge.MachineValidationCompletedRequest.machine_id:type_name -> common.MachineId
-	1034, // 695: forge.MachineValidationCompletedRequest.validation_id:type_name -> common.MachineValidationId
-	1008, // 696: forge.MachineValidationResult.start_time:type_name -> google.protobuf.Timestamp
-	1008, // 697: forge.MachineValidationResult.end_time:type_name -> google.protobuf.Timestamp
-	1034, // 698: forge.MachineValidationResult.validation_id:type_name -> common.MachineValidationId
+	1009, // 692: forge.MachineRebootCompletedRequest.machine_id:type_name -> common.MachineId
+	1009, // 693: forge.ScoutFirmwareUpgradeStatusRequest.machine_id:type_name -> common.MachineId
+	1009, // 694: forge.MachineValidationCompletedRequest.machine_id:type_name -> common.MachineId
+	1036, // 695: forge.MachineValidationCompletedRequest.validation_id:type_name -> common.MachineValidationId
+	1010, // 696: forge.MachineValidationResult.start_time:type_name -> google.protobuf.Timestamp
+	1010, // 697: forge.MachineValidationResult.end_time:type_name -> google.protobuf.Timestamp
+	1036, // 698: forge.MachineValidationResult.validation_id:type_name -> common.MachineValidationId
 	578,  // 699: forge.MachineValidationResultPostRequest.result:type_name -> forge.MachineValidationResult
 	578,  // 700: forge.MachineValidationResultList.results:type_name -> forge.MachineValidationResult
-	1007, // 701: forge.MachineValidationGetRequest.machine_id:type_name -> common.MachineId
-	1034, // 702: forge.MachineValidationGetRequest.validation_id:type_name -> common.MachineValidationId
+	1009, // 701: forge.MachineValidationGetRequest.machine_id:type_name -> common.MachineId
+	1036, // 702: forge.MachineValidationGetRequest.validation_id:type_name -> common.MachineValidationId
 	53,   // 703: forge.MachineValidationStatus.started:type_name -> forge.MachineValidationStarted
 	54,   // 704: forge.MachineValidationStatus.in_progress:type_name -> forge.MachineValidationInProgress
 	55,   // 705: forge.MachineValidationStatus.completed:type_name -> forge.MachineValidationCompleted
-	1034, // 706: forge.MachineValidationRun.validation_id:type_name -> common.MachineValidationId
-	1007, // 707: forge.MachineValidationRun.machine_id:type_name -> common.MachineId
-	1008, // 708: forge.MachineValidationRun.start_time:type_name -> google.protobuf.Timestamp
-	1008, // 709: forge.MachineValidationRun.end_time:type_name -> google.protobuf.Timestamp
+	1036, // 706: forge.MachineValidationRun.validation_id:type_name -> common.MachineValidationId
+	1009, // 707: forge.MachineValidationRun.machine_id:type_name -> common.MachineId
+	1010, // 708: forge.MachineValidationRun.start_time:type_name -> google.protobuf.Timestamp
+	1010, // 709: forge.MachineValidationRun.end_time:type_name -> google.protobuf.Timestamp
 	582,  // 710: forge.MachineValidationRun.status:type_name -> forge.MachineValidationStatus
-	1030, // 711: forge.MachineValidationRun.duration_to_complete:type_name -> google.protobuf.Duration
-	1008, // 712: forge.MachineValidationRun.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1007, // 713: forge.MachineSetAutoUpdateRequest.machine_id:type_name -> common.MachineId
+	1032, // 711: forge.MachineValidationRun.duration_to_complete:type_name -> google.protobuf.Duration
+	1010, // 712: forge.MachineValidationRun.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1009, // 713: forge.MachineSetAutoUpdateRequest.machine_id:type_name -> common.MachineId
 	94,   // 714: forge.MachineSetAutoUpdateRequest.action:type_name -> forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
-	1008, // 715: forge.MachineValidationExternalConfig.timestamp:type_name -> google.protobuf.Timestamp
+	1010, // 715: forge.MachineValidationExternalConfig.timestamp:type_name -> google.protobuf.Timestamp
 	587,  // 716: forge.GetMachineValidationExternalConfigResponse.config:type_name -> forge.MachineValidationExternalConfig
 	587,  // 717: forge.GetMachineValidationExternalConfigsResponse.configs:type_name -> forge.MachineValidationExternalConfig
-	1007, // 718: forge.MachineValidationOnDemandRequest.machine_id:type_name -> common.MachineId
+	1009, // 718: forge.MachineValidationOnDemandRequest.machine_id:type_name -> common.MachineId
 	95,   // 719: forge.MachineValidationOnDemandRequest.action:type_name -> forge.MachineValidationOnDemandRequest.Action
-	1034, // 720: forge.MachineValidationOnDemandResponse.validation_id:type_name -> common.MachineValidationId
+	1036, // 720: forge.MachineValidationOnDemandResponse.validation_id:type_name -> common.MachineValidationId
 	595,  // 721: forge.MaintenanceActivityConfig.firmware_upgrade:type_name -> forge.FirmwareUpgradeActivity
 	597,  // 722: forge.MaintenanceActivityConfig.configure_nmx_cluster:type_name -> forge.ConfigureNmxClusterActivity
 	598,  // 723: forge.MaintenanceActivityConfig.power_sequence:type_name -> forge.PowerSequenceActivity
 	596,  // 724: forge.MaintenanceActivityConfig.nvos_update:type_name -> forge.NvosUpdateActivity
 	599,  // 725: forge.RackMaintenanceScope.activities:type_name -> forge.MaintenanceActivityConfig
-	1016, // 726: forge.RackMaintenanceOnDemandRequest.rack_id:type_name -> common.RackId
+	1018, // 726: forge.RackMaintenanceOnDemandRequest.rack_id:type_name -> common.RackId
 	600,  // 727: forge.RackMaintenanceOnDemandRequest.scope:type_name -> forge.RackMaintenanceScope
 	384,  // 728: forge.AdminPowerControlRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	96,   // 729: forge.AdminPowerControlRequest.action:type_name -> forge.AdminPowerControlRequest.SystemPowerControl
-	1007, // 730: forge.GetRedfishJobStateRequest.machine_id:type_name -> common.MachineId
+	1009, // 730: forge.GetRedfishJobStateRequest.machine_id:type_name -> common.MachineId
 	97,   // 731: forge.GetRedfishJobStateResponse.job_state:type_name -> forge.GetRedfishJobStateResponse.RedfishJobState
 	583,  // 732: forge.MachineValidationRunList.runs:type_name -> forge.MachineValidationRun
-	1007, // 733: forge.MachineValidationRunListGetRequest.machine_id:type_name -> common.MachineId
-	1034, // 734: forge.MachineValidationRunItemSearchFilter.validation_id:type_name -> common.MachineValidationId
-	1017, // 735: forge.MachineValidationRunItemIdList.run_item_ids:type_name -> common.UUID
-	1017, // 736: forge.MachineValidationRunItemsByIdsRequest.run_item_ids:type_name -> common.UUID
+	1009, // 733: forge.MachineValidationRunListGetRequest.machine_id:type_name -> common.MachineId
+	1036, // 734: forge.MachineValidationRunItemSearchFilter.validation_id:type_name -> common.MachineValidationId
+	1019, // 735: forge.MachineValidationRunItemIdList.run_item_ids:type_name -> common.UUID
+	1019, // 736: forge.MachineValidationRunItemsByIdsRequest.run_item_ids:type_name -> common.UUID
 	613,  // 737: forge.MachineValidationRunItemList.run_items:type_name -> forge.MachineValidationRunItem
-	1017, // 738: forge.MachineValidationRunItem.run_item_id:type_name -> common.UUID
-	1034, // 739: forge.MachineValidationRunItem.validation_id:type_name -> common.MachineValidationId
-	1030, // 740: forge.MachineValidationRunItem.timeout:type_name -> google.protobuf.Duration
-	1008, // 741: forge.MachineValidationRunItem.started_at:type_name -> google.protobuf.Timestamp
-	1008, // 742: forge.MachineValidationRunItem.ended_at:type_name -> google.protobuf.Timestamp
-	1008, // 743: forge.MachineValidationRunItem.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1017, // 744: forge.MachineValidationRunItem.current_attempt_id:type_name -> common.UUID
-	1017, // 745: forge.MachineValidationAttemptGetRequest.attempt_id:type_name -> common.UUID
-	1017, // 746: forge.MachineValidationAttempt.attempt_id:type_name -> common.UUID
-	1017, // 747: forge.MachineValidationAttempt.run_item_id:type_name -> common.UUID
-	1008, // 748: forge.MachineValidationAttempt.started_at:type_name -> google.protobuf.Timestamp
-	1008, // 749: forge.MachineValidationAttempt.ended_at:type_name -> google.protobuf.Timestamp
-	1008, // 750: forge.MachineValidationAttempt.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1034, // 751: forge.MachineValidationHeartbeatRequest.validation_id:type_name -> common.MachineValidationId
-	1017, // 752: forge.MachineValidationHeartbeatRequest.run_item_id:type_name -> common.UUID
-	1017, // 753: forge.MachineValidationHeartbeatRequest.attempt_id:type_name -> common.UUID
-	1000, // 754: forge.MachineValidationTestUpdateRequest.payload:type_name -> forge.MachineValidationTestUpdateRequest.Payload
+	1019, // 738: forge.MachineValidationRunItem.run_item_id:type_name -> common.UUID
+	1036, // 739: forge.MachineValidationRunItem.validation_id:type_name -> common.MachineValidationId
+	1032, // 740: forge.MachineValidationRunItem.timeout:type_name -> google.protobuf.Duration
+	1010, // 741: forge.MachineValidationRunItem.started_at:type_name -> google.protobuf.Timestamp
+	1010, // 742: forge.MachineValidationRunItem.ended_at:type_name -> google.protobuf.Timestamp
+	1010, // 743: forge.MachineValidationRunItem.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1019, // 744: forge.MachineValidationRunItem.current_attempt_id:type_name -> common.UUID
+	1019, // 745: forge.MachineValidationAttemptGetRequest.attempt_id:type_name -> common.UUID
+	1019, // 746: forge.MachineValidationAttempt.attempt_id:type_name -> common.UUID
+	1019, // 747: forge.MachineValidationAttempt.run_item_id:type_name -> common.UUID
+	1010, // 748: forge.MachineValidationAttempt.started_at:type_name -> google.protobuf.Timestamp
+	1010, // 749: forge.MachineValidationAttempt.ended_at:type_name -> google.protobuf.Timestamp
+	1010, // 750: forge.MachineValidationAttempt.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1036, // 751: forge.MachineValidationHeartbeatRequest.validation_id:type_name -> common.MachineValidationId
+	1019, // 752: forge.MachineValidationHeartbeatRequest.run_item_id:type_name -> common.UUID
+	1019, // 753: forge.MachineValidationHeartbeatRequest.attempt_id:type_name -> common.UUID
+	1002, // 754: forge.MachineValidationTestUpdateRequest.payload:type_name -> forge.MachineValidationTestUpdateRequest.Payload
 	627,  // 755: forge.MachineValidationTestsGetResponse.tests:type_name -> forge.MachineValidationTest
-	1034, // 756: forge.MachineValidationRunRequest.validation_id:type_name -> common.MachineValidationId
-	1030, // 757: forge.MachineValidationRunRequest.duration_to_complete:type_name -> google.protobuf.Duration
+	1036, // 756: forge.MachineValidationRunRequest.validation_id:type_name -> common.MachineValidationId
+	1032, // 757: forge.MachineValidationRunRequest.duration_to_complete:type_name -> google.protobuf.Duration
 	627,  // 758: forge.MachineValidationRunRequest.selected_tests:type_name -> forge.MachineValidationTest
 	56,   // 759: forge.MachineCapabilityAttributesGpu.device_type:type_name -> forge.MachineCapabilityDeviceType
 	56,   // 760: forge.MachineCapabilityAttributesNetwork.device_type:type_name -> forge.MachineCapabilityDeviceType
@@ -70194,7 +70346,7 @@ var file_nico_nico_proto_depIdxs = []int32{
 	267,  // 770: forge.InstanceType.metadata:type_name -> forge.Metadata
 	742,  // 771: forge.InstanceType.allocation_stats:type_name -> forge.InstanceTypeAllocationStats
 	57,   // 772: forge.InstanceTypeMachineCapabilityFilterAttributes.capability_type:type_name -> forge.MachineCapabilityType
-	1035, // 773: forge.InstanceTypeMachineCapabilityFilterAttributes.inactive_devices:type_name -> common.Uint32List
+	1037, // 773: forge.InstanceTypeMachineCapabilityFilterAttributes.inactive_devices:type_name -> common.Uint32List
 	56,   // 774: forge.InstanceTypeMachineCapabilityFilterAttributes.device_type:type_name -> forge.MachineCapabilityDeviceType
 	267,  // 775: forge.CreateInstanceTypeRequest.metadata:type_name -> forge.Metadata
 	642,  // 776: forge.CreateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
@@ -70203,15 +70355,15 @@ var file_nico_nico_proto_depIdxs = []int32{
 	643,  // 779: forge.UpdateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
 	267,  // 780: forge.UpdateInstanceTypeRequest.metadata:type_name -> forge.Metadata
 	642,  // 781: forge.UpdateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
-	1001, // 782: forge.RedfishBrowseResponse.headers:type_name -> forge.RedfishBrowseResponse.HeadersEntry
+	1003, // 782: forge.RedfishBrowseResponse.headers:type_name -> forge.RedfishBrowseResponse.HeadersEntry
 	663,  // 783: forge.RedfishListActionsResponse.actions:type_name -> forge.RedfishAction
-	1008, // 784: forge.RedfishAction.approver_dates:type_name -> google.protobuf.Timestamp
-	1008, // 785: forge.RedfishAction.applied_at:type_name -> google.protobuf.Timestamp
+	1010, // 784: forge.RedfishAction.approver_dates:type_name -> google.protobuf.Timestamp
+	1010, // 785: forge.RedfishAction.applied_at:type_name -> google.protobuf.Timestamp
 	664,  // 786: forge.RedfishAction.results:type_name -> forge.OptionalRedfishActionResult
 	665,  // 787: forge.OptionalRedfishActionResult.result:type_name -> forge.RedfishActionResult
-	1002, // 788: forge.RedfishActionResult.headers:type_name -> forge.RedfishActionResult.HeadersEntry
-	1008, // 789: forge.RedfishActionResult.completed_at:type_name -> google.protobuf.Timestamp
-	1003, // 790: forge.UfmBrowseResponse.headers:type_name -> forge.UfmBrowseResponse.HeadersEntry
+	1004, // 788: forge.RedfishActionResult.headers:type_name -> forge.RedfishActionResult.HeadersEntry
+	1010, // 789: forge.RedfishActionResult.completed_at:type_name -> google.protobuf.Timestamp
+	1005, // 790: forge.UfmBrowseResponse.headers:type_name -> forge.UfmBrowseResponse.HeadersEntry
 	691,  // 791: forge.NetworkSecurityGroupAttributes.rules:type_name -> forge.NetworkSecurityGroupRuleAttributes
 	267,  // 792: forge.NetworkSecurityGroup.metadata:type_name -> forge.Metadata
 	674,  // 793: forge.NetworkSecurityGroup.attributes:type_name -> forge.NetworkSecurityGroupAttributes
@@ -70233,7 +70385,7 @@ var file_nico_nico_proto_depIdxs = []int32{
 	691,  // 809: forge.ResolvedNetworkSecurityGroupRule.rule:type_name -> forge.NetworkSecurityGroupRuleAttributes
 	694,  // 810: forge.GetNetworkSecurityGroupAttachmentsResponse.attachments:type_name -> forge.NetworkSecurityGroupAttachments
 	698,  // 811: forge.GetDesiredFirmwareVersionsResponse.entries:type_name -> forge.DesiredFirmwareVersionEntry
-	1004, // 812: forge.DesiredFirmwareVersionEntry.component_versions:type_name -> forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
+	1006, // 812: forge.DesiredFirmwareVersionEntry.component_versions:type_name -> forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
 	699,  // 813: forge.SkuComponents.chassis:type_name -> forge.SkuComponentChassis
 	700,  // 814: forge.SkuComponents.cpus:type_name -> forge.SkuComponentCpu
 	701,  // 815: forge.SkuComponents.gpus:type_name -> forge.SkuComponentGpu
@@ -70242,96 +70394,96 @@ var file_nico_nico_proto_depIdxs = []int32{
 	704,  // 818: forge.SkuComponents.storage:type_name -> forge.SkuComponentStorage
 	706,  // 819: forge.SkuComponents.memory:type_name -> forge.SkuComponentMemory
 	707,  // 820: forge.SkuComponents.tpm:type_name -> forge.SkuComponentTpm
-	1008, // 821: forge.Sku.created:type_name -> google.protobuf.Timestamp
+	1010, // 821: forge.Sku.created:type_name -> google.protobuf.Timestamp
 	708,  // 822: forge.Sku.components:type_name -> forge.SkuComponents
-	1007, // 823: forge.Sku.associated_machine_ids:type_name -> common.MachineId
-	1007, // 824: forge.SkuMachinePair.machine_id:type_name -> common.MachineId
-	1007, // 825: forge.RemoveSkuRequest.machine_id:type_name -> common.MachineId
+	1009, // 823: forge.Sku.associated_machine_ids:type_name -> common.MachineId
+	1009, // 824: forge.SkuMachinePair.machine_id:type_name -> common.MachineId
+	1009, // 825: forge.RemoveSkuRequest.machine_id:type_name -> common.MachineId
 	709,  // 826: forge.SkuList.skus:type_name -> forge.Sku
-	1008, // 827: forge.SkuStatus.verify_request_time:type_name -> google.protobuf.Timestamp
-	1008, // 828: forge.SkuStatus.last_match_attempt:type_name -> google.protobuf.Timestamp
-	1008, // 829: forge.SkuStatus.last_generate_attempt:type_name -> google.protobuf.Timestamp
-	1036, // 830: forge.DpaInterface.id:type_name -> common.DpaInterfaceId
-	1007, // 831: forge.DpaInterface.machine_id:type_name -> common.MachineId
-	1008, // 832: forge.DpaInterface.created:type_name -> google.protobuf.Timestamp
-	1008, // 833: forge.DpaInterface.updated:type_name -> google.protobuf.Timestamp
-	1008, // 834: forge.DpaInterface.deleted:type_name -> google.protobuf.Timestamp
+	1010, // 827: forge.SkuStatus.verify_request_time:type_name -> google.protobuf.Timestamp
+	1010, // 828: forge.SkuStatus.last_match_attempt:type_name -> google.protobuf.Timestamp
+	1010, // 829: forge.SkuStatus.last_generate_attempt:type_name -> google.protobuf.Timestamp
+	1038, // 830: forge.DpaInterface.id:type_name -> common.DpaInterfaceId
+	1009, // 831: forge.DpaInterface.machine_id:type_name -> common.MachineId
+	1010, // 832: forge.DpaInterface.created:type_name -> google.protobuf.Timestamp
+	1010, // 833: forge.DpaInterface.updated:type_name -> google.protobuf.Timestamp
+	1010, // 834: forge.DpaInterface.deleted:type_name -> google.protobuf.Timestamp
 	231,  // 835: forge.DpaInterface.history:type_name -> forge.StateHistoryRecord
-	1008, // 836: forge.DpaInterface.last_hb_time:type_name -> google.protobuf.Timestamp
+	1010, // 836: forge.DpaInterface.last_hb_time:type_name -> google.protobuf.Timestamp
 	63,   // 837: forge.DpaInterface.interface_type:type_name -> forge.DpaInterfaceType
-	1007, // 838: forge.DpaInterfaceCreationRequest.machine_id:type_name -> common.MachineId
+	1009, // 838: forge.DpaInterfaceCreationRequest.machine_id:type_name -> common.MachineId
 	63,   // 839: forge.DpaInterfaceCreationRequest.interface_type:type_name -> forge.DpaInterfaceType
-	1036, // 840: forge.DpaInterfaceIdList.ids:type_name -> common.DpaInterfaceId
-	1036, // 841: forge.DpaInterfacesByIdsRequest.ids:type_name -> common.DpaInterfaceId
+	1038, // 840: forge.DpaInterfaceIdList.ids:type_name -> common.DpaInterfaceId
+	1038, // 841: forge.DpaInterfacesByIdsRequest.ids:type_name -> common.DpaInterfaceId
 	717,  // 842: forge.DpaInterfaceList.interfaces:type_name -> forge.DpaInterface
-	1036, // 843: forge.DpaNetworkObservationSetRequest.id:type_name -> common.DpaInterfaceId
-	1036, // 844: forge.DpaInterfaceDeletionRequest.id:type_name -> common.DpaInterfaceId
-	1007, // 845: forge.PowerOptionRequest.machine_id:type_name -> common.MachineId
-	1007, // 846: forge.PowerOptionUpdateRequest.machine_id:type_name -> common.MachineId
+	1038, // 843: forge.DpaNetworkObservationSetRequest.id:type_name -> common.DpaInterfaceId
+	1038, // 844: forge.DpaInterfaceDeletionRequest.id:type_name -> common.DpaInterfaceId
+	1009, // 845: forge.PowerOptionRequest.machine_id:type_name -> common.MachineId
+	1009, // 846: forge.PowerOptionUpdateRequest.machine_id:type_name -> common.MachineId
 	64,   // 847: forge.PowerOptionUpdateRequest.power_state:type_name -> forge.PowerState
 	64,   // 848: forge.PowerOptions.desired_state:type_name -> forge.PowerState
-	1008, // 849: forge.PowerOptions.desired_state_updated_at:type_name -> google.protobuf.Timestamp
+	1010, // 849: forge.PowerOptions.desired_state_updated_at:type_name -> google.protobuf.Timestamp
 	64,   // 850: forge.PowerOptions.actual_state:type_name -> forge.PowerState
-	1008, // 851: forge.PowerOptions.actual_state_updated_at:type_name -> google.protobuf.Timestamp
-	1007, // 852: forge.PowerOptions.host_id:type_name -> common.MachineId
-	1008, // 853: forge.PowerOptions.next_power_state_fetch_at:type_name -> google.protobuf.Timestamp
-	1008, // 854: forge.PowerOptions.tried_triggering_on_at:type_name -> google.protobuf.Timestamp
-	1008, // 855: forge.PowerOptions.wait_until_time_before_performing_next_power_action:type_name -> google.protobuf.Timestamp
+	1010, // 851: forge.PowerOptions.actual_state_updated_at:type_name -> google.protobuf.Timestamp
+	1009, // 852: forge.PowerOptions.host_id:type_name -> common.MachineId
+	1010, // 853: forge.PowerOptions.next_power_state_fetch_at:type_name -> google.protobuf.Timestamp
+	1010, // 854: forge.PowerOptions.tried_triggering_on_at:type_name -> google.protobuf.Timestamp
+	1010, // 855: forge.PowerOptions.wait_until_time_before_performing_next_power_action:type_name -> google.protobuf.Timestamp
 	728,  // 856: forge.PowerOptionResponse.response:type_name -> forge.PowerOptions
-	1037, // 857: forge.ComputeAllocation.id:type_name -> common.ComputeAllocationId
+	1039, // 857: forge.ComputeAllocation.id:type_name -> common.ComputeAllocationId
 	730,  // 858: forge.ComputeAllocation.attributes:type_name -> forge.ComputeAllocationAttributes
 	267,  // 859: forge.ComputeAllocation.metadata:type_name -> forge.Metadata
-	1037, // 860: forge.CreateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	1039, // 860: forge.CreateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
 	267,  // 861: forge.CreateComputeAllocationRequest.metadata:type_name -> forge.Metadata
 	730,  // 862: forge.CreateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
 	731,  // 863: forge.CreateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
-	1037, // 864: forge.FindComputeAllocationIdsResponse.ids:type_name -> common.ComputeAllocationId
-	1037, // 865: forge.FindComputeAllocationsByIdsRequest.ids:type_name -> common.ComputeAllocationId
+	1039, // 864: forge.FindComputeAllocationIdsResponse.ids:type_name -> common.ComputeAllocationId
+	1039, // 865: forge.FindComputeAllocationsByIdsRequest.ids:type_name -> common.ComputeAllocationId
 	731,  // 866: forge.FindComputeAllocationsByIdsResponse.allocations:type_name -> forge.ComputeAllocation
 	731,  // 867: forge.UpdateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
-	1037, // 868: forge.UpdateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	1039, // 868: forge.UpdateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
 	267,  // 869: forge.UpdateComputeAllocationRequest.metadata:type_name -> forge.Metadata
 	730,  // 870: forge.UpdateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
-	1037, // 871: forge.DeleteComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	1039, // 871: forge.DeleteComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
 	749,  // 872: forge.GetRackResponse.rack:type_name -> forge.Rack
 	749,  // 873: forge.RackList.racks:type_name -> forge.Rack
 	266,  // 874: forge.RackSearchFilter.label:type_name -> forge.Label
-	1016, // 875: forge.RackIdList.rack_ids:type_name -> common.RackId
-	1016, // 876: forge.RacksByIdsRequest.rack_ids:type_name -> common.RackId
-	1016, // 877: forge.Rack.id:type_name -> common.RackId
-	1008, // 878: forge.Rack.created:type_name -> google.protobuf.Timestamp
-	1008, // 879: forge.Rack.updated:type_name -> google.protobuf.Timestamp
-	1008, // 880: forge.Rack.deleted:type_name -> google.protobuf.Timestamp
+	1018, // 875: forge.RackIdList.rack_ids:type_name -> common.RackId
+	1018, // 876: forge.RacksByIdsRequest.rack_ids:type_name -> common.RackId
+	1018, // 877: forge.Rack.id:type_name -> common.RackId
+	1010, // 878: forge.Rack.created:type_name -> google.protobuf.Timestamp
+	1010, // 879: forge.Rack.updated:type_name -> google.protobuf.Timestamp
+	1010, // 880: forge.Rack.deleted:type_name -> google.protobuf.Timestamp
 	267,  // 881: forge.Rack.metadata:type_name -> forge.Metadata
 	750,  // 882: forge.Rack.config:type_name -> forge.RackConfig
 	751,  // 883: forge.Rack.status:type_name -> forge.RackStatus
-	1014, // 884: forge.RackStatus.health:type_name -> health.HealthReport
+	1016, // 884: forge.RackStatus.health:type_name -> health.HealthReport
 	357,  // 885: forge.RackStatus.health_sources:type_name -> forge.HealthSourceOrigin
 	98,   // 886: forge.RackStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1016, // 887: forge.RackStateHistoriesRequest.rack_ids:type_name -> common.RackId
-	1016, // 888: forge.AdminForceDeleteRackRequest.rack_id:type_name -> common.RackId
+	1018, // 887: forge.RackStateHistoriesRequest.rack_ids:type_name -> common.RackId
+	1018, // 888: forge.AdminForceDeleteRackRequest.rack_id:type_name -> common.RackId
 	756,  // 889: forge.RackCapabilitiesSet.compute:type_name -> forge.RackCapabilityCompute
 	757,  // 890: forge.RackCapabilitiesSet.switch:type_name -> forge.RackCapabilitySwitch
 	758,  // 891: forge.RackCapabilitiesSet.power_shelf:type_name -> forge.RackCapabilityPowerShelf
-	1038, // 892: forge.RackProfile.rack_hardware_type:type_name -> common.RackHardwareType
+	1040, // 892: forge.RackProfile.rack_hardware_type:type_name -> common.RackHardwareType
 	65,   // 893: forge.RackProfile.rack_hardware_topology:type_name -> forge.RackHardwareTopology
 	67,   // 894: forge.RackProfile.rack_hardware_class:type_name -> forge.RackHardwareClass
 	759,  // 895: forge.RackProfile.capabilities:type_name -> forge.RackCapabilitiesSet
 	66,   // 896: forge.RackProfile.product_family:type_name -> forge.RackProductFamily
-	1016, // 897: forge.GetRackProfileRequest.rack_id:type_name -> common.RackId
-	1016, // 898: forge.GetRackProfileResponse.rack_id:type_name -> common.RackId
-	1019, // 899: forge.GetRackProfileResponse.rack_profile_id:type_name -> common.RackProfileId
+	1018, // 897: forge.GetRackProfileRequest.rack_id:type_name -> common.RackId
+	1018, // 898: forge.GetRackProfileResponse.rack_id:type_name -> common.RackId
+	1021, // 899: forge.GetRackProfileResponse.rack_profile_id:type_name -> common.RackProfileId
 	760,  // 900: forge.GetRackProfileResponse.profile:type_name -> forge.RackProfile
 	68,   // 901: forge.RackManagerForgeRequest.cmd:type_name -> forge.RackManagerForgeCmd
-	1027, // 902: forge.MachineNVLinkInfo.domain_uuid:type_name -> common.NVLinkDomainId
+	1029, // 902: forge.MachineNVLinkInfo.domain_uuid:type_name -> common.NVLinkDomainId
 	774,  // 903: forge.MachineNVLinkInfo.gpus:type_name -> forge.NVLinkGpu
-	1007, // 904: forge.UpdateMachineNvLinkInfoRequest.machine_id:type_name -> common.MachineId
+	1009, // 904: forge.UpdateMachineNvLinkInfoRequest.machine_id:type_name -> common.MachineId
 	765,  // 905: forge.UpdateMachineNvLinkInfoRequest.nvlink_info:type_name -> forge.MachineNVLinkInfo
 	768,  // 906: forge.MachineSpxStatusObservation.attachment_status:type_name -> forge.MachineSpxAttachmentStatusObservation
-	1008, // 907: forge.MachineSpxStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	1026, // 908: forge.MachineSpxAttachmentStatusObservation.partition_id:type_name -> common.SpxPartitionId
+	1010, // 907: forge.MachineSpxStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1028, // 908: forge.MachineSpxAttachmentStatusObservation.partition_id:type_name -> common.SpxPartitionId
 	16,   // 909: forge.MachineSpxAttachmentStatusObservation.attachment_type:type_name -> forge.SpxAttachmentType
-	1008, // 910: forge.MachineSpxAttachmentStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1010, // 910: forge.MachineSpxAttachmentStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
 	770,  // 911: forge.AstraConfig.astra_attachments:type_name -> forge.AstraAttachment
 	16,   // 912: forge.AstraAttachment.attachment_type:type_name -> forge.SpxAttachmentType
 	772,  // 913: forge.AstraConfigStatus.astra_attachments_status:type_name -> forge.AstraAttachmentStatus
@@ -70339,40 +70491,40 @@ var file_nico_nico_proto_depIdxs = []int32{
 	773,  // 915: forge.AstraAttachmentStatus.status:type_name -> forge.AstraStatus
 	69,   // 916: forge.AstraStatus.phase:type_name -> forge.AstraPhase
 	776,  // 917: forge.MachineNVLinkStatusObservation.gpu_status:type_name -> forge.MachineNVLinkGpuStatusObservation
-	1039, // 918: forge.MachineNVLinkGpuStatusObservation.partition_id:type_name -> common.NVLinkPartitionId
-	1010, // 919: forge.MachineNVLinkGpuStatusObservation.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1027, // 920: forge.MachineNVLinkGpuStatusObservation.domain_id:type_name -> common.NVLinkDomainId
+	1041, // 918: forge.MachineNVLinkGpuStatusObservation.partition_id:type_name -> common.NVLinkPartitionId
+	1012, // 919: forge.MachineNVLinkGpuStatusObservation.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1029, // 920: forge.MachineNVLinkGpuStatusObservation.domain_id:type_name -> common.NVLinkDomainId
 	70,   // 921: forge.NmxcBrowseRequest.operation:type_name -> forge.NmxcBrowseOperation
-	1005, // 922: forge.NmxcBrowseResponse.headers:type_name -> forge.NmxcBrowseResponse.HeadersEntry
-	1039, // 923: forge.NVLinkPartition.id:type_name -> common.NVLinkPartitionId
-	1027, // 924: forge.NVLinkPartition.domain_uuid:type_name -> common.NVLinkDomainId
-	1010, // 925: forge.NVLinkPartition.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1007, // 922: forge.NmxcBrowseResponse.headers:type_name -> forge.NmxcBrowseResponse.HeadersEntry
+	1041, // 923: forge.NVLinkPartition.id:type_name -> common.NVLinkPartitionId
+	1029, // 924: forge.NVLinkPartition.domain_uuid:type_name -> common.NVLinkDomainId
+	1012, // 925: forge.NVLinkPartition.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
 	779,  // 926: forge.NVLinkPartitionList.partitions:type_name -> forge.NVLinkPartition
-	1017, // 927: forge.NVLinkPartitionQuery.id:type_name -> common.UUID
+	1019, // 927: forge.NVLinkPartitionQuery.id:type_name -> common.UUID
 	781,  // 928: forge.NVLinkPartitionQuery.search_config:type_name -> forge.NVLinkPartitionSearchConfig
-	1039, // 929: forge.NVLinkPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkPartitionId
-	1039, // 930: forge.NVLinkPartitionIdList.partition_ids:type_name -> common.NVLinkPartitionId
+	1041, // 929: forge.NVLinkPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkPartitionId
+	1041, // 930: forge.NVLinkPartitionIdList.partition_ids:type_name -> common.NVLinkPartitionId
 	267,  // 931: forge.NVLinkLogicalPartitionConfig.metadata:type_name -> forge.Metadata
 	8,    // 932: forge.NVLinkLogicalPartitionStatus.state:type_name -> forge.TenantState
-	1010, // 933: forge.NVLinkLogicalPartition.id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 933: forge.NVLinkLogicalPartition.id:type_name -> common.NVLinkLogicalPartitionId
 	787,  // 934: forge.NVLinkLogicalPartition.config:type_name -> forge.NVLinkLogicalPartitionConfig
 	788,  // 935: forge.NVLinkLogicalPartition.status:type_name -> forge.NVLinkLogicalPartitionStatus
-	1008, // 936: forge.NVLinkLogicalPartition.created:type_name -> google.protobuf.Timestamp
+	1010, // 936: forge.NVLinkLogicalPartition.created:type_name -> google.protobuf.Timestamp
 	789,  // 937: forge.NVLinkLogicalPartitionList.partitions:type_name -> forge.NVLinkLogicalPartition
 	787,  // 938: forge.NVLinkLogicalPartitionCreationRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	1010, // 939: forge.NVLinkLogicalPartitionCreationRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	1010, // 940: forge.NVLinkLogicalPartitionDeletionRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	1010, // 941: forge.NVLinkLogicalPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkLogicalPartitionId
-	1010, // 942: forge.NVLinkLogicalPartitionIdList.partition_ids:type_name -> common.NVLinkLogicalPartitionId
-	1010, // 943: forge.NVLinkLogicalPartitionUpdateRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 939: forge.NVLinkLogicalPartitionCreationRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 940: forge.NVLinkLogicalPartitionDeletionRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 941: forge.NVLinkLogicalPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 942: forge.NVLinkLogicalPartitionIdList.partition_ids:type_name -> common.NVLinkLogicalPartitionId
+	1012, // 943: forge.NVLinkLogicalPartitionUpdateRequest.id:type_name -> common.NVLinkLogicalPartitionId
 	787,  // 944: forge.NVLinkLogicalPartitionUpdateRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
 	384,  // 945: forge.CreateBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 946: forge.DeleteBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 947: forge.SetBmcRootPasswordRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	384,  // 948: forge.ProbeBmcVendorRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1007, // 949: forge.SetFirmwareUpdateTimeWindowRequest.machine_ids:type_name -> common.MachineId
-	1008, // 950: forge.SetFirmwareUpdateTimeWindowRequest.start_timestamp:type_name -> google.protobuf.Timestamp
-	1008, // 951: forge.SetFirmwareUpdateTimeWindowRequest.end_timestamp:type_name -> google.protobuf.Timestamp
+	1009, // 949: forge.SetFirmwareUpdateTimeWindowRequest.machine_ids:type_name -> common.MachineId
+	1010, // 950: forge.SetFirmwareUpdateTimeWindowRequest.start_timestamp:type_name -> google.protobuf.Timestamp
+	1010, // 951: forge.SetFirmwareUpdateTimeWindowRequest.end_timestamp:type_name -> google.protobuf.Timestamp
 	811,  // 952: forge.UpsertHostFirmwareConfigRequest.components:type_name -> forge.UpsertHostFirmwareComponentConfig
 	71,   // 953: forge.UpsertHostFirmwareConfigRequest.ordering:type_name -> forge.HostFirmwareComponentType
 	71,   // 954: forge.UpsertHostFirmwareComponentConfig.type:type_name -> forge.HostFirmwareComponentType
@@ -70382,43 +70534,43 @@ var file_nico_nico_proto_depIdxs = []int32{
 	814,  // 958: forge.HostFirmwareVersionConfig.artifacts:type_name -> forge.HostFirmwareArtifact
 	812,  // 959: forge.HostFirmwareConfigResponse.components:type_name -> forge.HostFirmwareComponentConfigResponse
 	71,   // 960: forge.HostFirmwareConfigResponse.ordering:type_name -> forge.HostFirmwareComponentType
-	1008, // 961: forge.HostFirmwareConfigResponse.created_at:type_name -> google.protobuf.Timestamp
-	1008, // 962: forge.HostFirmwareConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
+	1010, // 961: forge.HostFirmwareConfigResponse.created_at:type_name -> google.protobuf.Timestamp
+	1010, // 962: forge.HostFirmwareConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
 	818,  // 963: forge.ListHostFirmwareResponse.available:type_name -> forge.AvailableHostFirmware
 	72,   // 964: forge.TrimTableRequest.target:type_name -> forge.TrimTableTarget
 	821,  // 965: forge.NvlinkNmxcEndpointList.entries:type_name -> forge.NvlinkNmxcEndpoint
 	267,  // 966: forge.CreateRemediationRequest.metadata:type_name -> forge.Metadata
-	1040, // 967: forge.CreateRemediationResponse.remediation_id:type_name -> common.RemediationId
-	1040, // 968: forge.RemediationIdList.remediation_ids:type_name -> common.RemediationId
+	1042, // 967: forge.CreateRemediationResponse.remediation_id:type_name -> common.RemediationId
+	1042, // 968: forge.RemediationIdList.remediation_ids:type_name -> common.RemediationId
 	828,  // 969: forge.RemediationList.remediations:type_name -> forge.Remediation
-	1040, // 970: forge.Remediation.id:type_name -> common.RemediationId
+	1042, // 970: forge.Remediation.id:type_name -> common.RemediationId
 	267,  // 971: forge.Remediation.metadata:type_name -> forge.Metadata
-	1008, // 972: forge.Remediation.creation_time:type_name -> google.protobuf.Timestamp
-	1040, // 973: forge.ApproveRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1040, // 974: forge.RevokeRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1040, // 975: forge.EnableRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1040, // 976: forge.DisableRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1040, // 977: forge.FindAppliedRemediationIdsRequest.remediation_id:type_name -> common.RemediationId
-	1007, // 978: forge.FindAppliedRemediationIdsRequest.dpu_machine_id:type_name -> common.MachineId
-	1040, // 979: forge.AppliedRemediationIdList.remediation_ids:type_name -> common.RemediationId
-	1007, // 980: forge.AppliedRemediationIdList.dpu_machine_ids:type_name -> common.MachineId
-	1040, // 981: forge.FindAppliedRemediationsRequest.remediation_id:type_name -> common.RemediationId
-	1007, // 982: forge.FindAppliedRemediationsRequest.dpu_machine_id:type_name -> common.MachineId
-	1040, // 983: forge.AppliedRemediation.remediation_id:type_name -> common.RemediationId
-	1007, // 984: forge.AppliedRemediation.dpu_machine_id:type_name -> common.MachineId
-	1008, // 985: forge.AppliedRemediation.applied_time:type_name -> google.protobuf.Timestamp
+	1010, // 972: forge.Remediation.creation_time:type_name -> google.protobuf.Timestamp
+	1042, // 973: forge.ApproveRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1042, // 974: forge.RevokeRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1042, // 975: forge.EnableRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1042, // 976: forge.DisableRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1042, // 977: forge.FindAppliedRemediationIdsRequest.remediation_id:type_name -> common.RemediationId
+	1009, // 978: forge.FindAppliedRemediationIdsRequest.dpu_machine_id:type_name -> common.MachineId
+	1042, // 979: forge.AppliedRemediationIdList.remediation_ids:type_name -> common.RemediationId
+	1009, // 980: forge.AppliedRemediationIdList.dpu_machine_ids:type_name -> common.MachineId
+	1042, // 981: forge.FindAppliedRemediationsRequest.remediation_id:type_name -> common.RemediationId
+	1009, // 982: forge.FindAppliedRemediationsRequest.dpu_machine_id:type_name -> common.MachineId
+	1042, // 983: forge.AppliedRemediation.remediation_id:type_name -> common.RemediationId
+	1009, // 984: forge.AppliedRemediation.dpu_machine_id:type_name -> common.MachineId
+	1010, // 985: forge.AppliedRemediation.applied_time:type_name -> google.protobuf.Timestamp
 	267,  // 986: forge.AppliedRemediation.metadata:type_name -> forge.Metadata
 	836,  // 987: forge.AppliedRemediationList.applied_remediations:type_name -> forge.AppliedRemediation
-	1007, // 988: forge.GetNextRemediationForMachineRequest.dpu_machine_id:type_name -> common.MachineId
-	1040, // 989: forge.GetNextRemediationForMachineResponse.remediation_id:type_name -> common.RemediationId
-	1040, // 990: forge.RemediationAppliedRequest.remediation_id:type_name -> common.RemediationId
-	1007, // 991: forge.RemediationAppliedRequest.dpu_machine_id:type_name -> common.MachineId
+	1009, // 988: forge.GetNextRemediationForMachineRequest.dpu_machine_id:type_name -> common.MachineId
+	1042, // 989: forge.GetNextRemediationForMachineResponse.remediation_id:type_name -> common.RemediationId
+	1042, // 990: forge.RemediationAppliedRequest.remediation_id:type_name -> common.RemediationId
+	1009, // 991: forge.RemediationAppliedRequest.dpu_machine_id:type_name -> common.MachineId
 	841,  // 992: forge.RemediationAppliedRequest.status:type_name -> forge.RemediationApplicationStatus
 	267,  // 993: forge.RemediationApplicationStatus.metadata:type_name -> forge.Metadata
-	1007, // 994: forge.SetPrimaryDpuRequest.host_machine_id:type_name -> common.MachineId
-	1007, // 995: forge.SetPrimaryDpuRequest.dpu_machine_id:type_name -> common.MachineId
-	1007, // 996: forge.SetPrimaryInterfaceRequest.host_machine_id:type_name -> common.MachineId
-	1028, // 997: forge.SetPrimaryInterfaceRequest.interface_id:type_name -> common.MachineInterfaceId
+	1009, // 994: forge.SetPrimaryDpuRequest.host_machine_id:type_name -> common.MachineId
+	1009, // 995: forge.SetPrimaryDpuRequest.dpu_machine_id:type_name -> common.MachineId
+	1009, // 996: forge.SetPrimaryInterfaceRequest.host_machine_id:type_name -> common.MachineId
+	1030, // 997: forge.SetPrimaryInterfaceRequest.interface_id:type_name -> common.MachineInterfaceId
 	844,  // 998: forge.DpuExtensionServiceCredential.username_password:type_name -> forge.UsernamePassword
 	865,  // 999: forge.DpuExtensionServiceVersionInfo.observability:type_name -> forge.DpuExtensionServiceObservability
 	73,   // 1000: forge.DpuExtensionService.service_type:type_name -> forge.DpuExtensionServiceType
@@ -70435,86 +70587,86 @@ var file_nico_nico_proto_depIdxs = []int32{
 	862,  // 1011: forge.DpuExtensionServiceObservabilityConfig.prometheus:type_name -> forge.DpuExtensionServiceObservabilityConfigPrometheus
 	863,  // 1012: forge.DpuExtensionServiceObservabilityConfig.logging:type_name -> forge.DpuExtensionServiceObservabilityConfigLogging
 	864,  // 1013: forge.DpuExtensionServiceObservability.configs:type_name -> forge.DpuExtensionServiceObservabilityConfig
-	1017, // 1014: forge.ScoutStreamApiBoundMessage.flow_uuid:type_name -> common.UUID
+	1019, // 1014: forge.ScoutStreamApiBoundMessage.flow_uuid:type_name -> common.UUID
 	868,  // 1015: forge.ScoutStreamApiBoundMessage.init:type_name -> forge.ScoutStreamInitRequest
-	1041, // 1016: forge.ScoutStreamApiBoundMessage.mlx_device_lockdown_response:type_name -> mlx_device.MlxDeviceLockdownResponse
-	1042, // 1017: forge.ScoutStreamApiBoundMessage.mlx_device_profile_sync_response:type_name -> mlx_device.MlxDeviceProfileSyncResponse
-	1043, // 1018: forge.ScoutStreamApiBoundMessage.mlx_device_profile_compare_response:type_name -> mlx_device.MlxDeviceProfileCompareResponse
-	1044, // 1019: forge.ScoutStreamApiBoundMessage.mlx_device_info_device_response:type_name -> mlx_device.MlxDeviceInfoDeviceResponse
-	1045, // 1020: forge.ScoutStreamApiBoundMessage.mlx_device_info_report_response:type_name -> mlx_device.MlxDeviceInfoReportResponse
-	1046, // 1021: forge.ScoutStreamApiBoundMessage.mlx_device_registry_list_response:type_name -> mlx_device.MlxDeviceRegistryListResponse
-	1047, // 1022: forge.ScoutStreamApiBoundMessage.mlx_device_registry_show_response:type_name -> mlx_device.MlxDeviceRegistryShowResponse
-	1048, // 1023: forge.ScoutStreamApiBoundMessage.mlx_device_config_query_response:type_name -> mlx_device.MlxDeviceConfigQueryResponse
-	1049, // 1024: forge.ScoutStreamApiBoundMessage.mlx_device_config_set_response:type_name -> mlx_device.MlxDeviceConfigSetResponse
-	1050, // 1025: forge.ScoutStreamApiBoundMessage.mlx_device_config_sync_response:type_name -> mlx_device.MlxDeviceConfigSyncResponse
-	1051, // 1026: forge.ScoutStreamApiBoundMessage.mlx_device_config_compare_response:type_name -> mlx_device.MlxDeviceConfigCompareResponse
+	1043, // 1016: forge.ScoutStreamApiBoundMessage.mlx_device_lockdown_response:type_name -> mlx_device.MlxDeviceLockdownResponse
+	1044, // 1017: forge.ScoutStreamApiBoundMessage.mlx_device_profile_sync_response:type_name -> mlx_device.MlxDeviceProfileSyncResponse
+	1045, // 1018: forge.ScoutStreamApiBoundMessage.mlx_device_profile_compare_response:type_name -> mlx_device.MlxDeviceProfileCompareResponse
+	1046, // 1019: forge.ScoutStreamApiBoundMessage.mlx_device_info_device_response:type_name -> mlx_device.MlxDeviceInfoDeviceResponse
+	1047, // 1020: forge.ScoutStreamApiBoundMessage.mlx_device_info_report_response:type_name -> mlx_device.MlxDeviceInfoReportResponse
+	1048, // 1021: forge.ScoutStreamApiBoundMessage.mlx_device_registry_list_response:type_name -> mlx_device.MlxDeviceRegistryListResponse
+	1049, // 1022: forge.ScoutStreamApiBoundMessage.mlx_device_registry_show_response:type_name -> mlx_device.MlxDeviceRegistryShowResponse
+	1050, // 1023: forge.ScoutStreamApiBoundMessage.mlx_device_config_query_response:type_name -> mlx_device.MlxDeviceConfigQueryResponse
+	1051, // 1024: forge.ScoutStreamApiBoundMessage.mlx_device_config_set_response:type_name -> mlx_device.MlxDeviceConfigSetResponse
+	1052, // 1025: forge.ScoutStreamApiBoundMessage.mlx_device_config_sync_response:type_name -> mlx_device.MlxDeviceConfigSyncResponse
+	1053, // 1026: forge.ScoutStreamApiBoundMessage.mlx_device_config_compare_response:type_name -> mlx_device.MlxDeviceConfigCompareResponse
 	876,  // 1027: forge.ScoutStreamApiBoundMessage.scout_stream_agent_ping_response:type_name -> forge.ScoutStreamAgentPingResponse
-	1017, // 1028: forge.ScoutStreamScoutBoundMessage.flow_uuid:type_name -> common.UUID
-	1052, // 1029: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_lock_request:type_name -> mlx_device.MlxDeviceLockdownLockRequest
-	1053, // 1030: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_unlock_request:type_name -> mlx_device.MlxDeviceLockdownUnlockRequest
-	1054, // 1031: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_status_request:type_name -> mlx_device.MlxDeviceLockdownStatusRequest
-	1055, // 1032: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_sync_request:type_name -> mlx_device.MlxDeviceProfileSyncRequest
-	1056, // 1033: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_compare_request:type_name -> mlx_device.MlxDeviceProfileCompareRequest
-	1057, // 1034: forge.ScoutStreamScoutBoundMessage.mlx_device_info_device_request:type_name -> mlx_device.MlxDeviceInfoDeviceRequest
-	1058, // 1035: forge.ScoutStreamScoutBoundMessage.mlx_device_info_report_request:type_name -> mlx_device.MlxDeviceInfoReportRequest
-	1059, // 1036: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_list_request:type_name -> mlx_device.MlxDeviceRegistryListRequest
-	1060, // 1037: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_show_request:type_name -> mlx_device.MlxDeviceRegistryShowRequest
-	1061, // 1038: forge.ScoutStreamScoutBoundMessage.mlx_device_config_query_request:type_name -> mlx_device.MlxDeviceConfigQueryRequest
-	1062, // 1039: forge.ScoutStreamScoutBoundMessage.mlx_device_config_set_request:type_name -> mlx_device.MlxDeviceConfigSetRequest
-	1063, // 1040: forge.ScoutStreamScoutBoundMessage.mlx_device_config_sync_request:type_name -> mlx_device.MlxDeviceConfigSyncRequest
-	1064, // 1041: forge.ScoutStreamScoutBoundMessage.mlx_device_config_compare_request:type_name -> mlx_device.MlxDeviceConfigCompareRequest
+	1019, // 1028: forge.ScoutStreamScoutBoundMessage.flow_uuid:type_name -> common.UUID
+	1054, // 1029: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_lock_request:type_name -> mlx_device.MlxDeviceLockdownLockRequest
+	1055, // 1030: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_unlock_request:type_name -> mlx_device.MlxDeviceLockdownUnlockRequest
+	1056, // 1031: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_status_request:type_name -> mlx_device.MlxDeviceLockdownStatusRequest
+	1057, // 1032: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_sync_request:type_name -> mlx_device.MlxDeviceProfileSyncRequest
+	1058, // 1033: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_compare_request:type_name -> mlx_device.MlxDeviceProfileCompareRequest
+	1059, // 1034: forge.ScoutStreamScoutBoundMessage.mlx_device_info_device_request:type_name -> mlx_device.MlxDeviceInfoDeviceRequest
+	1060, // 1035: forge.ScoutStreamScoutBoundMessage.mlx_device_info_report_request:type_name -> mlx_device.MlxDeviceInfoReportRequest
+	1061, // 1036: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_list_request:type_name -> mlx_device.MlxDeviceRegistryListRequest
+	1062, // 1037: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_show_request:type_name -> mlx_device.MlxDeviceRegistryShowRequest
+	1063, // 1038: forge.ScoutStreamScoutBoundMessage.mlx_device_config_query_request:type_name -> mlx_device.MlxDeviceConfigQueryRequest
+	1064, // 1039: forge.ScoutStreamScoutBoundMessage.mlx_device_config_set_request:type_name -> mlx_device.MlxDeviceConfigSetRequest
+	1065, // 1040: forge.ScoutStreamScoutBoundMessage.mlx_device_config_sync_request:type_name -> mlx_device.MlxDeviceConfigSyncRequest
+	1066, // 1041: forge.ScoutStreamScoutBoundMessage.mlx_device_config_compare_request:type_name -> mlx_device.MlxDeviceConfigCompareRequest
 	875,  // 1042: forge.ScoutStreamScoutBoundMessage.scout_stream_agent_ping_request:type_name -> forge.ScoutStreamAgentPingRequest
-	1007, // 1043: forge.ScoutStreamInitRequest.machine_id:type_name -> common.MachineId
+	1009, // 1043: forge.ScoutStreamInitRequest.machine_id:type_name -> common.MachineId
 	877,  // 1044: forge.ScoutStreamShowConnectionsResponse.scout_stream_connections:type_name -> forge.ScoutStreamConnectionInfo
-	1007, // 1045: forge.ScoutStreamDisconnectRequest.machine_id:type_name -> common.MachineId
-	1007, // 1046: forge.ScoutStreamDisconnectResponse.machine_id:type_name -> common.MachineId
-	1007, // 1047: forge.ScoutStreamAdminPingRequest.machine_id:type_name -> common.MachineId
+	1009, // 1045: forge.ScoutStreamDisconnectRequest.machine_id:type_name -> common.MachineId
+	1009, // 1046: forge.ScoutStreamDisconnectResponse.machine_id:type_name -> common.MachineId
+	1009, // 1047: forge.ScoutStreamAdminPingRequest.machine_id:type_name -> common.MachineId
 	878,  // 1048: forge.ScoutStreamAgentPingResponse.error:type_name -> forge.ScoutStreamError
-	1007, // 1049: forge.ScoutStreamConnectionInfo.machine_id:type_name -> common.MachineId
+	1009, // 1049: forge.ScoutStreamConnectionInfo.machine_id:type_name -> common.MachineId
 	75,   // 1050: forge.ScoutStreamError.status:type_name -> forge.ScoutStreamErrorStatus
-	1033, // 1051: forge.RoutingProfile.route_target_imports:type_name -> common.RouteTarget
-	1033, // 1052: forge.RoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
+	1035, // 1051: forge.RoutingProfile.route_target_imports:type_name -> common.RouteTarget
+	1035, // 1052: forge.RoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
 	879,  // 1053: forge.RoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
 	879,  // 1054: forge.RoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
-	1020, // 1055: forge.DomainLegacy.id:type_name -> common.DomainId
-	1008, // 1056: forge.DomainLegacy.created:type_name -> google.protobuf.Timestamp
-	1008, // 1057: forge.DomainLegacy.updated:type_name -> google.protobuf.Timestamp
-	1008, // 1058: forge.DomainLegacy.deleted:type_name -> google.protobuf.Timestamp
+	1022, // 1055: forge.DomainLegacy.id:type_name -> common.DomainId
+	1010, // 1056: forge.DomainLegacy.created:type_name -> google.protobuf.Timestamp
+	1010, // 1057: forge.DomainLegacy.updated:type_name -> google.protobuf.Timestamp
+	1010, // 1058: forge.DomainLegacy.deleted:type_name -> google.protobuf.Timestamp
 	881,  // 1059: forge.DomainListLegacy.domains:type_name -> forge.DomainLegacy
-	1020, // 1060: forge.DomainDeletionLegacy.id:type_name -> common.DomainId
-	1020, // 1061: forge.DomainSearchQueryLegacy.id:type_name -> common.DomainId
-	1065, // 1062: forge.PxeDomain.new_domain:type_name -> dns.Domain
+	1022, // 1060: forge.DomainDeletionLegacy.id:type_name -> common.DomainId
+	1022, // 1061: forge.DomainSearchQueryLegacy.id:type_name -> common.DomainId
+	1067, // 1062: forge.PxeDomain.new_domain:type_name -> dns.Domain
 	881,  // 1063: forge.PxeDomain.legacy_domain:type_name -> forge.DomainLegacy
-	1007, // 1064: forge.MachinePositionQuery.machine_ids:type_name -> common.MachineId
+	1009, // 1064: forge.MachinePositionQuery.machine_ids:type_name -> common.MachineId
 	889,  // 1065: forge.MachinePositionInfoList.machine_position_info:type_name -> forge.MachinePositionInfo
-	1007, // 1066: forge.MachinePositionInfo.machine_id:type_name -> common.MachineId
-	1018, // 1067: forge.MachinePositionInfo.switch_id:type_name -> common.SwitchId
-	1015, // 1068: forge.MachinePositionInfo.power_shelf_id:type_name -> common.PowerShelfId
-	1007, // 1069: forge.ModifyDPFStateRequest.machine_id:type_name -> common.MachineId
-	1006, // 1070: forge.DPFStateResponse.dpf_states:type_name -> forge.DPFStateResponse.DPFState
-	1007, // 1071: forge.GetDPFStateRequest.machine_ids:type_name -> common.MachineId
-	1007, // 1072: forge.GetDPFHostSnapshotRequest.host_machine_id:type_name -> common.MachineId
+	1009, // 1066: forge.MachinePositionInfo.machine_id:type_name -> common.MachineId
+	1020, // 1067: forge.MachinePositionInfo.switch_id:type_name -> common.SwitchId
+	1017, // 1068: forge.MachinePositionInfo.power_shelf_id:type_name -> common.PowerShelfId
+	1009, // 1069: forge.ModifyDPFStateRequest.machine_id:type_name -> common.MachineId
+	1008, // 1070: forge.DPFStateResponse.dpf_states:type_name -> forge.DPFStateResponse.DPFState
+	1009, // 1071: forge.GetDPFStateRequest.machine_ids:type_name -> common.MachineId
+	1009, // 1072: forge.GetDPFHostSnapshotRequest.host_machine_id:type_name -> common.MachineId
 	896,  // 1073: forge.DPFServiceVersionsResponse.services:type_name -> forge.DPFServiceVersion
 	76,   // 1074: forge.ComponentResult.status:type_name -> forge.ComponentManagerStatusCode
-	1018, // 1075: forge.SwitchIdList.ids:type_name -> common.SwitchId
-	1015, // 1076: forge.PowerShelfIdList.ids:type_name -> common.PowerShelfId
-	1066, // 1077: forge.GetComponentInventoryRequest.machine_ids:type_name -> common.MachineIdList
+	1020, // 1075: forge.SwitchIdList.ids:type_name -> common.SwitchId
+	1017, // 1076: forge.PowerShelfIdList.ids:type_name -> common.PowerShelfId
+	1068, // 1077: forge.GetComponentInventoryRequest.machine_ids:type_name -> common.MachineIdList
 	899,  // 1078: forge.GetComponentInventoryRequest.switch_ids:type_name -> forge.SwitchIdList
 	900,  // 1079: forge.GetComponentInventoryRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
 	898,  // 1080: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
-	1067, // 1081: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
+	1069, // 1081: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
 	902,  // 1082: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
-	1066, // 1083: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
+	1068, // 1083: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
 	899,  // 1084: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
 	900,  // 1085: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	1068, // 1086: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
+	1070, // 1086: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
 	898,  // 1087: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
 	899,  // 1088: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
 	898,  // 1089: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
 	898,  // 1090: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
 	77,   // 1091: forge.FirmwareUpdateStatus.state:type_name -> forge.FirmwareUpdateState
-	1008, // 1092: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
-	1066, // 1093: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
+	1010, // 1092: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
+	1068, // 1093: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
 	80,   // 1094: forge.UpdateComputeTrayFirmwareTarget.components:type_name -> forge.ComputeTrayComponent
 	899,  // 1095: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
 	78,   // 1096: forge.UpdateSwitchFirmwareTarget.components:type_name -> forge.NvSwitchComponent
@@ -70526,12 +70678,12 @@ var file_nico_nico_proto_depIdxs = []int32{
 	911,  // 1102: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
 	912,  // 1103: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
 	898,  // 1104: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
-	1066, // 1105: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
+	1068, // 1105: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
 	899,  // 1106: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
 	900,  // 1107: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
 	747,  // 1108: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
 	908,  // 1109: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
-	1066, // 1110: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
+	1068, // 1110: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
 	899,  // 1111: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
 	900,  // 1112: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
 	747,  // 1113: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
@@ -70540,56 +70692,56 @@ var file_nico_nico_proto_depIdxs = []int32{
 	918,  // 1116: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
 	919,  // 1117: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
 	267,  // 1118: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1026, // 1119: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
+	1028, // 1119: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
 	267,  // 1120: forge.SpxPartition.metadata:type_name -> forge.Metadata
-	1026, // 1121: forge.SpxPartition.id:type_name -> common.SpxPartitionId
-	1026, // 1122: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
-	1026, // 1123: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
+	1028, // 1121: forge.SpxPartition.id:type_name -> common.SpxPartitionId
+	1028, // 1122: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
+	1028, // 1123: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
 	266,  // 1124: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
 	922,  // 1125: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
-	1026, // 1126: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
-	1018, // 1127: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
-	1015, // 1128: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1025, // 1129: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
+	1028, // 1126: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
+	1020, // 1127: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
+	1017, // 1128: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1027, // 1129: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
 	81,   // 1130: forge.OperatingSystem.type:type_name -> forge.OperatingSystemType
 	8,    // 1131: forge.OperatingSystem.status:type_name -> forge.TenantState
-	1024, // 1132: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
+	1026, // 1132: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
 	274,  // 1133: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
 	275,  // 1134: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	1025, // 1135: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1024, // 1136: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	1027, // 1135: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1026, // 1136: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
 	274,  // 1137: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
 	275,  // 1138: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
 	274,  // 1139: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
 	275,  // 1140: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
-	1025, // 1141: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1024, // 1142: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	1027, // 1141: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1026, // 1142: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
 	935,  // 1143: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
 	936,  // 1144: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
-	1025, // 1145: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1025, // 1146: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
-	1025, // 1147: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
+	1027, // 1145: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1027, // 1146: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
+	1027, // 1147: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
 	933,  // 1148: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
-	1025, // 1149: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
+	1027, // 1149: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
 	275,  // 1150: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
-	1025, // 1151: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
+	1027, // 1151: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
 	946,  // 1152: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
-	1007, // 1153: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
-	1028, // 1154: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
-	1008, // 1155: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
-	1007, // 1156: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
+	1009, // 1153: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
+	1030, // 1154: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
+	1010, // 1155: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
+	1009, // 1156: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
 	953,  // 1157: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
 	954,  // 1158: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
 	955,  // 1159: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
 	956,  // 1160: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
 	952,  // 1161: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
 	952,  // 1162: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
-	1069, // 1163: forge.SitePrefix.id:type_name -> common.SitePrefixId
+	1071, // 1163: forge.SitePrefix.id:type_name -> common.SitePrefixId
 	962,  // 1164: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
 	963,  // 1165: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
 	267,  // 1166: forge.SitePrefix.metadata:type_name -> forge.Metadata
-	1008, // 1167: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
-	1008, // 1168: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
+	1010, // 1167: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
+	1010, // 1168: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
 	85,   // 1169: forge.SitePrefixConfig.routing_scope:type_name -> forge.SitePrefixRoutingScope
 	84,   // 1170: forge.SitePrefixStatus.authority:type_name -> forge.SitePrefixAuthority
 	86,   // 1171: forge.SitePrefixStatus.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
@@ -70597,41 +70749,41 @@ var file_nico_nico_proto_depIdxs = []int32{
 	85,   // 1173: forge.SitePrefixSearchFilter.routing_scope:type_name -> forge.SitePrefixRoutingScope
 	86,   // 1174: forge.SitePrefixSearchFilter.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
 	7,    // 1175: forge.SitePrefixSearchFilter.prefix_match_type:type_name -> forge.PrefixMatchType
-	1069, // 1176: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
-	1069, // 1177: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
+	1071, // 1176: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
+	1071, // 1177: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
 	961,  // 1178: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
-	971,  // 1179: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
+	973,  // 1179: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
 	232,  // 1180: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
 	323,  // 1181: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
 	326,  // 1182: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
 	948,  // 1183: forge.TrafficInterceptBridging.HostRepresentorInterceptBridgingEntry.value:type_name -> forge.HostRepresentorInterceptBridging
 	89,   // 1184: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
-	996,  // 1185: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	1034, // 1186: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
-	987,  // 1187: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
-	1031, // 1188: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
-	989,  // 1189: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
-	990,  // 1190: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
-	991,  // 1191: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
-	992,  // 1192: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	993,  // 1193: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	994,  // 1194: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	1070, // 1195: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
-	1071, // 1196: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
-	1072, // 1197: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	998,  // 1185: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	1036, // 1186: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
+	989,  // 1187: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
+	1033, // 1188: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
+	991,  // 1189: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
+	992,  // 1190: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
+	993,  // 1191: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
+	994,  // 1192: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	995,  // 1193: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	996,  // 1194: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	1072, // 1195: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
+	1073, // 1196: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
+	1074, // 1197: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
 	91,   // 1198: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
-	1007, // 1199: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
-	1008, // 1200: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1008, // 1201: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	1007, // 1202: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
-	1008, // 1203: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1008, // 1204: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	1007, // 1205: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
+	1009, // 1199: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
+	1010, // 1200: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1010, // 1201: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	1009, // 1202: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
+	1010, // 1203: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1010, // 1204: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	1009, // 1205: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
 	146,  // 1206: forge.Forge.Version:input_type -> forge.VersionRequest
-	1073, // 1207: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
-	1074, // 1208: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
-	1075, // 1209: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
-	1076, // 1210: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
+	1075, // 1207: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
+	1076, // 1208: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
+	1077, // 1209: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
+	1078, // 1210: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
 	881,  // 1211: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
 	881,  // 1212: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
 	883,  // 1213: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
@@ -70688,10 +70840,10 @@ var file_nico_nico_proto_depIdxs = []int32{
 	290,  // 1264: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
 	268,  // 1265: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
 	270,  // 1266: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
-	1007, // 1267: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
+	1009, // 1267: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
 	390,  // 1268: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
 	455,  // 1269: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
-	1007, // 1270: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
+	1009, // 1270: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
 	461,  // 1271: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
 	472,  // 1272: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
 	464,  // 1273: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
@@ -70706,14 +70858,14 @@ var file_nico_nico_proto_depIdxs = []int32{
 	473,  // 1282: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
 	474,  // 1283: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
 	475,  // 1284: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
-	1007, // 1285: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
+	1009, // 1285: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
 	461,  // 1286: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
 	472,  // 1287: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
 	409,  // 1288: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
 	411,  // 1289: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
-	1077, // 1290: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
-	1078, // 1291: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
-	1079, // 1292: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
+	1079, // 1290: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
+	1080, // 1291: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
+	1081, // 1292: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
 	263,  // 1293: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
 	436,  // 1294: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
 	438,  // 1295: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
@@ -70740,7 +70892,7 @@ var file_nico_nico_proto_depIdxs = []int32{
 	184,  // 1316: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
 	329,  // 1317: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
 	328,  // 1318: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
-	1066, // 1319: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
+	1068, // 1319: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
 	536,  // 1320: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
 	537,  // 1321: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
 	515,  // 1322: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
@@ -70765,7 +70917,7 @@ var file_nico_nico_proto_depIdxs = []int32{
 	374,  // 1341: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
 	407,  // 1342: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
 	377,  // 1343: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
-	1080, // 1344: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
+	1082, // 1344: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
 	378,  // 1345: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
 	384,  // 1346: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
 	384,  // 1347: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
@@ -70774,795 +70926,797 @@ var file_nico_nico_proto_depIdxs = []int32{
 	380,  // 1350: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
 	381,  // 1351: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
 	382,  // 1352: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
-	1081, // 1353: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
-	1082, // 1354: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
-	1083, // 1355: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
-	1084, // 1356: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
-	1085, // 1357: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
-	1086, // 1358: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
+	1083, // 1353: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
+	1084, // 1354: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
+	1085, // 1355: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
+	1086, // 1356: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
+	1087, // 1357: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
+	1088, // 1358: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
 	388,  // 1359: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
 	413,  // 1360: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
-	502,  // 1361: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
-	505,  // 1362: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
-	350,  // 1363: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
-	351,  // 1364: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
-	352,  // 1365: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
-	353,  // 1366: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
-	766,  // 1367: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
-	509,  // 1368: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
-	510,  // 1369: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
-	520,  // 1370: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
-	521,  // 1371: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
-	523,  // 1372: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
-	524,  // 1373: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
-	1007, // 1374: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
-	575,  // 1375: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
-	530,  // 1376: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
-	1028, // 1377: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
-	533,  // 1378: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
-	1028, // 1379: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
-	951,  // 1380: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
-	542,  // 1381: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
-	543,  // 1382: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
-	137,  // 1383: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
-	138,  // 1384: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
-	141,  // 1385: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
-	143,  // 1386: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
-	958,  // 1387: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
-	960,  // 1388: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
-	1080, // 1389: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
-	545,  // 1390: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
-	545,  // 1391: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
-	545,  // 1392: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
-	354,  // 1393: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
-	312,  // 1394: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
-	548,  // 1395: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
-	550,  // 1396: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
-	563,  // 1397: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
-	564,  // 1398: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	563,  // 1399: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
-	564,  // 1400: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	1080, // 1401: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
-	565,  // 1402: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
-	1080, // 1403: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
-	1080, // 1404: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
-	1080, // 1405: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
-	570,  // 1406: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	570,  // 1407: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	216,  // 1408: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	217,  // 1409: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	216,  // 1410: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	217,  // 1411: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	1080, // 1412: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	218,  // 1413: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
-	1080, // 1414: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	1080, // 1415: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
-	238,  // 1416: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
-	239,  // 1417: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	238,  // 1418: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
-	239,  // 1419: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	1080, // 1420: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
-	240,  // 1421: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
-	1080, // 1422: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
-	1080, // 1423: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
-	243,  // 1424: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
-	244,  // 1425: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
-	243,  // 1426: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
-	244,  // 1427: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
-	1080, // 1428: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
-	245,  // 1429: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
-	1080, // 1430: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
-	135,  // 1431: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
-	645,  // 1432: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
-	647,  // 1433: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
-	649,  // 1434: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
-	654,  // 1435: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
-	651,  // 1436: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
-	655,  // 1437: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
-	657,  // 1438: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
-	1087, // 1439: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
-	1088, // 1440: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
-	1089, // 1441: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
-	1090, // 1442: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
-	1091, // 1443: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
-	1092, // 1444: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
-	1093, // 1445: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
-	1094, // 1446: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
-	1095, // 1447: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
-	1096, // 1448: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
-	1097, // 1449: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
-	1098, // 1450: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
-	1099, // 1451: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
-	1100, // 1452: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
-	1101, // 1453: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
-	1102, // 1454: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
-	1103, // 1455: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
-	1104, // 1456: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
-	1105, // 1457: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
-	1106, // 1458: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
-	1107, // 1459: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
-	1108, // 1460: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
-	1109, // 1461: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
-	1110, // 1462: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
-	1111, // 1463: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
-	1112, // 1464: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
-	1113, // 1465: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
-	1114, // 1466: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
-	1115, // 1467: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
-	1116, // 1468: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
-	1117, // 1469: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
-	1118, // 1470: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
-	1119, // 1471: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
-	1120, // 1472: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
-	1121, // 1473: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
-	1122, // 1474: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
-	1123, // 1475: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
-	1124, // 1476: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
-	1125, // 1477: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
-	1126, // 1478: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
-	1127, // 1479: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
-	1128, // 1480: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
-	1129, // 1481: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
-	676,  // 1482: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
-	678,  // 1483: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
-	680,  // 1484: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
-	683,  // 1485: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
-	684,  // 1486: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
-	690,  // 1487: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
-	693,  // 1488: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
-	552,  // 1489: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
-	556,  // 1490: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
-	554,  // 1491: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
-	1017, // 1492: forge.Forge.GetOsImage:input_type -> common.UUID
-	552,  // 1493: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
-	558,  // 1494: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
-	559,  // 1495: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
-	574,  // 1496: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
-	579,  // 1497: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
-	581,  // 1498: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
-	576,  // 1499: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
-	584,  // 1500: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
-	586,  // 1501: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
-	589,  // 1502: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
-	591,  // 1503: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
-	608,  // 1504: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
-	609,  // 1505: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
-	611,  // 1506: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
-	614,  // 1507: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
-	616,  // 1508: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
-	592,  // 1509: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
-	620,  // 1510: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
-	622,  // 1511: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
-	621,  // 1512: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
-	625,  // 1513: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
-	629,  // 1514: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
-	630,  // 1515: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
-	632,  // 1516: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
-	426,  // 1517: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
-	603,  // 1518: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
-	384,  // 1519: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
-	416,  // 1520: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
-	418,  // 1521: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
-	420,  // 1522: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
-	422,  // 1523: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
-	799,  // 1524: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
-	801,  // 1525: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
-	803,  // 1526: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
-	805,  // 1527: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
-	428,  // 1528: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
-	430,  // 1529: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
-	593,  // 1530: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
-	601,  // 1531: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
-	131,  // 1532: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
-	1080, // 1533: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
-	1080, // 1534: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
-	128,  // 1535: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
-	659,  // 1536: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
-	661,  // 1537: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
-	666,  // 1538: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
-	668,  // 1539: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
-	668,  // 1540: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
-	668,  // 1541: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
-	672,  // 1542: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
-	696,  // 1543: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
-	809,  // 1544: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
-	810,  // 1545: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
-	712,  // 1546: forge.Forge.CreateSku:input_type -> forge.SkuList
-	1007, // 1547: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
-	1007, // 1548: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
-	710,  // 1549: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
-	711,  // 1550: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
-	713,  // 1551: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
-	1080, // 1552: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
-	715,  // 1553: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
-	725,  // 1554: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
-	709,  // 1555: forge.Forge.ReplaceSku:input_type -> forge.Sku
-	396,  // 1556: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
-	398,  // 1557: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
-	400,  // 1558: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
-	1007, // 1559: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
-	387,  // 1560: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
-	1080, // 1561: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
-	720,  // 1562: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
-	718,  // 1563: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	718,  // 1564: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	723,  // 1565: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
-	726,  // 1566: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
-	727,  // 1567: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
-	384,  // 1568: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
-	384,  // 1569: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
-	746,  // 1570: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
-	748,  // 1571: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
-	743,  // 1572: forge.Forge.GetRack:input_type -> forge.GetRackRequest
-	753,  // 1573: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
-	754,  // 1574: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
-	761,  // 1575: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
-	732,  // 1576: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
-	734,  // 1577: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
-	736,  // 1578: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
-	739,  // 1579: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
-	740,  // 1580: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
-	807,  // 1581: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
-	816,  // 1582: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
-	1130, // 1583: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
-	1131, // 1584: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
-	819,  // 1585: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
-	1080, // 1586: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
-	821,  // 1587: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	821,  // 1588: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	823,  // 1589: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
-	824,  // 1590: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
-	829,  // 1591: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
-	830,  // 1592: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
-	831,  // 1593: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
-	832,  // 1594: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
-	1080, // 1595: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
-	826,  // 1596: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
-	833,  // 1597: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
-	835,  // 1598: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
-	838,  // 1599: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
-	840,  // 1600: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
-	842,  // 1601: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
-	843,  // 1602: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
-	849,  // 1603: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
-	850,  // 1604: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
-	851,  // 1605: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
-	853,  // 1606: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
-	855,  // 1607: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
-	857,  // 1608: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
-	859,  // 1609: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
-	103,  // 1610: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
-	1007, // 1611: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
-	104,  // 1612: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
-	1007, // 1613: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
-	106,  // 1614: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
-	108,  // 1615: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	111,  // 1616: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
-	108,  // 1617: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	116,  // 1618: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	118,  // 1619: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
-	116,  // 1620: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	119,  // 1621: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
-	124,  // 1622: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
-	125,  // 1623: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
-	866,  // 1624: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
-	869,  // 1625: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
-	871,  // 1626: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
-	873,  // 1627: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
-	1132, // 1628: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
-	1133, // 1629: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
-	1134, // 1630: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
-	1135, // 1631: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
-	1136, // 1632: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
-	1137, // 1633: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
-	1138, // 1634: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
-	1139, // 1635: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
-	1140, // 1636: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
-	1141, // 1637: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
-	1142, // 1638: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
-	1143, // 1639: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
-	1144, // 1640: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
-	1145, // 1641: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
-	1146, // 1642: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
-	783,  // 1643: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
-	784,  // 1644: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
-	161,  // 1645: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	794,  // 1646: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
-	795,  // 1647: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
-	791,  // 1648: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
-	797,  // 1649: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
-	792,  // 1650: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
-	161,  // 1651: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	887,  // 1652: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
-	777,  // 1653: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
-	890,  // 1654: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
-	892,  // 1655: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
-	893,  // 1656: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
-	895,  // 1657: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
-	904,  // 1658: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
-	906,  // 1659: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
-	901,  // 1660: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
-	913,  // 1661: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
-	915,  // 1662: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
-	917,  // 1663: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
-	934,  // 1664: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
-	1025, // 1665: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
-	937,  // 1666: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
-	938,  // 1667: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
-	940,  // 1668: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
-	942,  // 1669: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
-	944,  // 1670: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	947,  // 1671: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	949,  // 1672: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
-	147,  // 1673: forge.Forge.Version:output_type -> forge.BuildInfo
-	1065, // 1674: forge.Forge.CreateDomain:output_type -> dns.Domain
-	1065, // 1675: forge.Forge.UpdateDomain:output_type -> dns.Domain
-	1147, // 1676: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
-	1148, // 1677: forge.Forge.FindDomain:output_type -> dns.DomainList
-	881,  // 1678: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
-	881,  // 1679: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
-	884,  // 1680: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
-	882,  // 1681: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
-	164,  // 1682: forge.Forge.CreateVpc:output_type -> forge.Vpc
-	167,  // 1683: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
-	169,  // 1684: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
-	171,  // 1685: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
-	159,  // 1686: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
-	172,  // 1687: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
-	922,  // 1688: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
-	925,  // 1689: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
-	923,  // 1690: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
-	927,  // 1691: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
-	173,  // 1692: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
-	179,  // 1693: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
-	180,  // 1694: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
-	173,  // 1695: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
-	183,  // 1696: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
-	966,  // 1697: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
-	967,  // 1698: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
-	185,  // 1699: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
-	186,  // 1700: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
-	187,  // 1701: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
-	192,  // 1702: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
-	259,  // 1703: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
-	370,  // 1704: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
-	251,  // 1705: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
-	251,  // 1706: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
-	255,  // 1707: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
-	370,  // 1708: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
-	203,  // 1709: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
-	196,  // 1710: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
-	195,  // 1711: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
-	195,  // 1712: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
-	200,  // 1713: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
-	196,  // 1714: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
-	207,  // 1715: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
-	900,  // 1716: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
-	207,  // 1717: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
-	210,  // 1718: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
-	932,  // 1719: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
-	1080, // 1720: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
-	227,  // 1721: forge.Forge.FindSwitches:output_type -> forge.SwitchList
-	899,  // 1722: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
-	227,  // 1723: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
-	230,  // 1724: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
-	930,  // 1725: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
-	247,  // 1726: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
-	300,  // 1727: forge.Forge.AllocateInstance:output_type -> forge.Instance
-	273,  // 1728: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
-	318,  // 1729: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
-	300,  // 1730: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
-	300,  // 1731: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
-	269,  // 1732: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
-	265,  // 1733: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
-	265,  // 1734: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
-	391,  // 1735: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
-	1080, // 1736: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
-	471,  // 1737: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
-	1080, // 1738: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
-	1080, // 1739: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
-	471,  // 1740: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
-	1080, // 1741: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
-	1080, // 1742: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
-	471,  // 1743: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
-	1080, // 1744: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
-	1080, // 1745: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
-	471,  // 1746: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
-	1080, // 1747: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
-	1080, // 1748: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
-	471,  // 1749: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
-	1080, // 1750: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	1080, // 1751: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	471,  // 1752: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
-	1080, // 1753: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
-	1080, // 1754: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
-	410,  // 1755: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
-	412,  // 1756: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
-	1149, // 1757: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
-	1150, // 1758: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
-	1151, // 1759: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
-	264,  // 1760: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
-	437,  // 1761: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
-	444,  // 1762: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
-	443,  // 1763: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
-	445,  // 1764: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
-	446,  // 1765: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
-	448,  // 1766: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
-	369,  // 1767: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
-	368,  // 1768: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
-	337,  // 1769: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
-	339,  // 1770: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
-	342,  // 1771: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
-	332,  // 1772: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
-	1080, // 1773: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
-	512,  // 1774: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
-	1066, // 1775: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
-	333,  // 1776: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
-	322,  // 1777: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
-	325,  // 1778: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
-	234,  // 1779: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
-	234,  // 1780: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
-	234,  // 1781: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
-	234,  // 1782: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
-	234,  // 1783: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
-	331,  // 1784: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
-	330,  // 1785: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
-	535,  // 1786: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
-	539,  // 1787: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
-	538,  // 1788: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
-	536,  // 1789: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
-	514,  // 1790: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
-	517,  // 1791: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
-	519,  // 1792: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
-	433,  // 1793: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
-	435,  // 1794: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
-	450,  // 1795: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
-	454,  // 1796: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
-	150,  // 1797: forge.Forge.Echo:output_type -> forge.EchoResponse
-	481,  // 1798: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
-	485,  // 1799: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
-	483,  // 1800: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
-	491,  // 1801: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
-	498,  // 1802: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
-	492,  // 1803: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
-	494,  // 1804: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
-	496,  // 1805: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
-	501,  // 1806: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
-	375,  // 1807: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
-	375,  // 1808: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
-	408,  // 1809: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
-	1152, // 1810: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
-	1153, // 1811: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
-	1080, // 1812: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
-	618,  // 1813: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
-	619,  // 1814: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
-	1067, // 1815: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
-	1080, // 1816: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
-	1154, // 1817: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
-	383,  // 1818: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
-	1080, // 1819: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
-	1155, // 1820: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
-	1156, // 1821: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
-	1157, // 1822: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
-	1158, // 1823: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
-	1159, // 1824: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
-	1160, // 1825: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
-	1080, // 1826: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
-	414,  // 1827: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
-	503,  // 1828: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
-	506,  // 1829: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
-	1080, // 1830: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
-	1080, // 1831: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
-	1080, // 1832: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
-	1080, // 1833: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
-	1080, // 1834: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
-	1080, // 1835: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
-	1080, // 1836: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
-	1080, // 1837: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
-	522,  // 1838: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
-	1080, // 1839: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
-	525,  // 1840: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
-	1080, // 1841: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
-	1080, // 1842: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
-	531,  // 1843: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
-	533,  // 1844: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
-	1080, // 1845: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
-	1080, // 1846: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
-	957,  // 1847: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
-	544,  // 1848: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
-	544,  // 1849: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
-	139,  // 1850: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
-	140,  // 1851: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
-	142,  // 1852: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
-	145,  // 1853: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
-	959,  // 1854: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
-	1080, // 1855: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
-	546,  // 1856: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
-	1080, // 1857: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
-	1080, // 1858: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
-	1080, // 1859: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
-	1080, // 1860: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
-	313,  // 1861: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
-	549,  // 1862: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
-	551,  // 1863: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
-	1080, // 1864: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
-	1080, // 1865: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
-	1080, // 1866: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
-	563,  // 1867: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
-	565,  // 1868: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
-	1080, // 1869: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
-	1080, // 1870: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
-	566,  // 1871: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
-	568,  // 1872: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
-	572,  // 1873: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	572,  // 1874: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	1080, // 1875: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1080, // 1876: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1080, // 1877: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
-	216,  // 1878: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
-	218,  // 1879: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
-	1080, // 1880: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	1080, // 1881: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	219,  // 1882: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
-	1080, // 1883: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
-	1080, // 1884: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
-	1080, // 1885: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
-	238,  // 1886: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
-	240,  // 1887: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
-	1080, // 1888: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
-	1080, // 1889: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
-	241,  // 1890: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
-	1080, // 1891: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
-	1080, // 1892: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
-	1080, // 1893: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
-	243,  // 1894: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
-	245,  // 1895: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
-	1080, // 1896: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
-	1080, // 1897: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
-	136,  // 1898: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
-	646,  // 1899: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
-	648,  // 1900: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
-	650,  // 1901: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
-	653,  // 1902: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
-	652,  // 1903: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
-	656,  // 1904: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
-	658,  // 1905: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
-	1161, // 1906: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
-	1162, // 1907: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
-	1163, // 1908: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
-	1164, // 1909: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
-	1165, // 1910: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1166, // 1911: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
-	1167, // 1912: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
-	1168, // 1913: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
-	1165, // 1914: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1169, // 1915: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
-	1170, // 1916: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
-	1171, // 1917: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
-	1172, // 1918: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
-	1173, // 1919: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
-	1174, // 1920: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
-	1175, // 1921: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
-	1176, // 1922: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
-	1177, // 1923: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
-	1178, // 1924: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
-	1179, // 1925: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
-	1180, // 1926: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
-	1181, // 1927: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
-	1182, // 1928: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
-	1183, // 1929: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
-	1184, // 1930: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
-	1185, // 1931: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
-	1186, // 1932: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
-	1187, // 1933: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
-	1188, // 1934: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
-	1189, // 1935: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
-	1190, // 1936: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
-	1191, // 1937: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
-	1192, // 1938: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
-	1193, // 1939: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
-	1194, // 1940: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
-	1195, // 1941: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
-	1196, // 1942: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
-	1197, // 1943: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
-	1198, // 1944: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
-	1199, // 1945: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
-	1200, // 1946: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
-	1201, // 1947: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
-	1202, // 1948: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
-	677,  // 1949: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
-	679,  // 1950: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
-	681,  // 1951: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
-	682,  // 1952: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
-	685,  // 1953: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
-	688,  // 1954: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
-	695,  // 1955: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
-	553,  // 1956: forge.Forge.CreateOsImage:output_type -> forge.OsImage
-	557,  // 1957: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
-	555,  // 1958: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
-	553,  // 1959: forge.Forge.GetOsImage:output_type -> forge.OsImage
-	553,  // 1960: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
-	276,  // 1961: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
-	560,  // 1962: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
-	573,  // 1963: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
-	1080, // 1964: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
-	580,  // 1965: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
-	577,  // 1966: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
-	585,  // 1967: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
-	588,  // 1968: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
-	590,  // 1969: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
-	1080, // 1970: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	607,  // 1971: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
-	610,  // 1972: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
-	612,  // 1973: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
-	615,  // 1974: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
-	617,  // 1975: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
-	1080, // 1976: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	624,  // 1977: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
-	623,  // 1978: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	623,  // 1979: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	626,  // 1980: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
-	628,  // 1981: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
-	631,  // 1982: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
-	633,  // 1983: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
-	427,  // 1984: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
-	604,  // 1985: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
-	415,  // 1986: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
-	417,  // 1987: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
-	1203, // 1988: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
-	421,  // 1989: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
-	423,  // 1990: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
-	800,  // 1991: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
-	802,  // 1992: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
-	804,  // 1993: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
-	806,  // 1994: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
-	429,  // 1995: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
-	431,  // 1996: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
-	594,  // 1997: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
-	602,  // 1998: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
-	127,  // 1999: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
-	133,  // 2000: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
-	130,  // 2001: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
-	1080, // 2002: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
-	660,  // 2003: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
-	662,  // 2004: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
-	667,  // 2005: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
-	669,  // 2006: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
-	670,  // 2007: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
-	671,  // 2008: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
-	673,  // 2009: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
-	697,  // 2010: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
-	815,  // 2011: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
-	1080, // 2012: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
-	713,  // 2013: forge.Forge.CreateSku:output_type -> forge.SkuIdList
-	709,  // 2014: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
-	1080, // 2015: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
-	1080, // 2016: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
-	1080, // 2017: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
-	1080, // 2018: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
-	713,  // 2019: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
-	712,  // 2020: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
-	1080, // 2021: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
-	709,  // 2022: forge.Forge.ReplaceSku:output_type -> forge.Sku
-	397,  // 2023: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
-	399,  // 2024: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
-	401,  // 2025: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
-	1080, // 2026: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
-	1080, // 2027: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
-	719,  // 2028: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
-	721,  // 2029: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
-	717,  // 2030: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
-	717,  // 2031: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
-	724,  // 2032: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
-	729,  // 2033: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
-	729,  // 2034: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
-	1080, // 2035: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
-	126,  // 2036: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
-	747,  // 2037: forge.Forge.FindRackIds:output_type -> forge.RackIdList
-	745,  // 2038: forge.Forge.FindRacksByIds:output_type -> forge.RackList
-	744,  // 2039: forge.Forge.GetRack:output_type -> forge.GetRackResponse
-	1080, // 2040: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
-	755,  // 2041: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
-	762,  // 2042: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
-	733,  // 2043: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
-	735,  // 2044: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
-	737,  // 2045: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
-	738,  // 2046: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
-	741,  // 2047: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
-	808,  // 2048: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
-	817,  // 2049: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
-	1204, // 2050: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
-	1205, // 2051: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
-	820,  // 2052: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
-	822,  // 2053: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
-	821,  // 2054: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	821,  // 2055: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	1080, // 2056: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
-	825,  // 2057: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
-	1080, // 2058: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
-	1080, // 2059: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
-	1080, // 2060: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
-	1080, // 2061: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
-	826,  // 2062: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
-	827,  // 2063: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
-	834,  // 2064: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
-	837,  // 2065: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
-	839,  // 2066: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
-	1080, // 2067: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
-	1080, // 2068: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
-	1080, // 2069: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
-	848,  // 2070: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
-	848,  // 2071: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
-	852,  // 2072: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
-	854,  // 2073: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
-	856,  // 2074: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
-	858,  // 2075: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
-	860,  // 2076: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
-	100,  // 2077: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
-	1080, // 2078: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
-	105,  // 2079: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
-	102,  // 2080: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
-	107,  // 2081: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
-	112,  // 2082: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	112,  // 2083: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	1080, // 2084: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
-	115,  // 2085: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	115,  // 2086: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	1080, // 2087: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
-	121,  // 2088: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
-	122,  // 2089: forge.Forge.GetJWKS:output_type -> forge.Jwks
-	123,  // 2090: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
-	867,  // 2091: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
-	870,  // 2092: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
-	872,  // 2093: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
-	874,  // 2094: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
-	1206, // 2095: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
-	1207, // 2096: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
-	1208, // 2097: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
-	1209, // 2098: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
-	1210, // 2099: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
-	1211, // 2100: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
-	1212, // 2101: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
-	1213, // 2102: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
-	1214, // 2103: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
-	1215, // 2104: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
-	1216, // 2105: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
-	1217, // 2106: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
-	1218, // 2107: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
-	1219, // 2108: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
-	1220, // 2109: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
-	785,  // 2110: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
-	780,  // 2111: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
-	780,  // 2112: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
-	796,  // 2113: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
-	790,  // 2114: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
-	789,  // 2115: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
-	798,  // 2116: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
-	793,  // 2117: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
-	790,  // 2118: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
-	888,  // 2119: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
-	778,  // 2120: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
-	1080, // 2121: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
-	891,  // 2122: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
-	894,  // 2123: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
-	897,  // 2124: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
-	905,  // 2125: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
-	907,  // 2126: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
-	903,  // 2127: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
-	914,  // 2128: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
-	916,  // 2129: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
-	920,  // 2130: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
-	933,  // 2131: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
-	933,  // 2132: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
-	933,  // 2133: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
-	939,  // 2134: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
-	941,  // 2135: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
-	943,  // 2136: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
-	945,  // 2137: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	945,  // 2138: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	950,  // 2139: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
-	1673, // [1673:2140] is the sub-list for method output_type
-	1206, // [1206:1673] is the sub-list for method input_type
+	968,  // 1361: forge.Forge.EraseHostMetadataByBmcMac:input_type -> forge.EraseHostMetadataByBmcMacRequest
+	502,  // 1362: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
+	505,  // 1363: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
+	350,  // 1364: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
+	351,  // 1365: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
+	352,  // 1366: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
+	353,  // 1367: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
+	766,  // 1368: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
+	509,  // 1369: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
+	510,  // 1370: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
+	520,  // 1371: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
+	521,  // 1372: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
+	523,  // 1373: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
+	524,  // 1374: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
+	1009, // 1375: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
+	575,  // 1376: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
+	530,  // 1377: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
+	1030, // 1378: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
+	533,  // 1379: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
+	1030, // 1380: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
+	951,  // 1381: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
+	542,  // 1382: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
+	543,  // 1383: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
+	137,  // 1384: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
+	138,  // 1385: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
+	141,  // 1386: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
+	143,  // 1387: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
+	958,  // 1388: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
+	960,  // 1389: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
+	1082, // 1390: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
+	545,  // 1391: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
+	545,  // 1392: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
+	545,  // 1393: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
+	354,  // 1394: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
+	312,  // 1395: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
+	548,  // 1396: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
+	550,  // 1397: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
+	563,  // 1398: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
+	564,  // 1399: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	563,  // 1400: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
+	564,  // 1401: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	1082, // 1402: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
+	565,  // 1403: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
+	1082, // 1404: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
+	1082, // 1405: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
+	1082, // 1406: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
+	570,  // 1407: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	570,  // 1408: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	216,  // 1409: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	217,  // 1410: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	216,  // 1411: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	217,  // 1412: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	1082, // 1413: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	218,  // 1414: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
+	1082, // 1415: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	1082, // 1416: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
+	238,  // 1417: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
+	239,  // 1418: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	238,  // 1419: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
+	239,  // 1420: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	1082, // 1421: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
+	240,  // 1422: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
+	1082, // 1423: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
+	1082, // 1424: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
+	243,  // 1425: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
+	244,  // 1426: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
+	243,  // 1427: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
+	244,  // 1428: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
+	1082, // 1429: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
+	245,  // 1430: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
+	1082, // 1431: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
+	135,  // 1432: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
+	645,  // 1433: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
+	647,  // 1434: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
+	649,  // 1435: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
+	654,  // 1436: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
+	651,  // 1437: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
+	655,  // 1438: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
+	657,  // 1439: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
+	1089, // 1440: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
+	1090, // 1441: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
+	1091, // 1442: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
+	1092, // 1443: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
+	1093, // 1444: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
+	1094, // 1445: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
+	1095, // 1446: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
+	1096, // 1447: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
+	1097, // 1448: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
+	1098, // 1449: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
+	1099, // 1450: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
+	1100, // 1451: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
+	1101, // 1452: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
+	1102, // 1453: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
+	1103, // 1454: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
+	1104, // 1455: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
+	1105, // 1456: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
+	1106, // 1457: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
+	1107, // 1458: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
+	1108, // 1459: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
+	1109, // 1460: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
+	1110, // 1461: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
+	1111, // 1462: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
+	1112, // 1463: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
+	1113, // 1464: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
+	1114, // 1465: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
+	1115, // 1466: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
+	1116, // 1467: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
+	1117, // 1468: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
+	1118, // 1469: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
+	1119, // 1470: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
+	1120, // 1471: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
+	1121, // 1472: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
+	1122, // 1473: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
+	1123, // 1474: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
+	1124, // 1475: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
+	1125, // 1476: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
+	1126, // 1477: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
+	1127, // 1478: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
+	1128, // 1479: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
+	1129, // 1480: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
+	1130, // 1481: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
+	1131, // 1482: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
+	676,  // 1483: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
+	678,  // 1484: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
+	680,  // 1485: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
+	683,  // 1486: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
+	684,  // 1487: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
+	690,  // 1488: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
+	693,  // 1489: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
+	552,  // 1490: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
+	556,  // 1491: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
+	554,  // 1492: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
+	1019, // 1493: forge.Forge.GetOsImage:input_type -> common.UUID
+	552,  // 1494: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
+	558,  // 1495: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
+	559,  // 1496: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
+	574,  // 1497: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
+	579,  // 1498: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
+	581,  // 1499: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
+	576,  // 1500: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
+	584,  // 1501: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
+	586,  // 1502: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
+	589,  // 1503: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
+	591,  // 1504: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
+	608,  // 1505: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
+	609,  // 1506: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
+	611,  // 1507: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
+	614,  // 1508: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
+	616,  // 1509: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
+	592,  // 1510: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
+	620,  // 1511: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
+	622,  // 1512: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
+	621,  // 1513: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
+	625,  // 1514: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
+	629,  // 1515: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
+	630,  // 1516: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
+	632,  // 1517: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
+	426,  // 1518: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
+	603,  // 1519: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
+	384,  // 1520: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
+	416,  // 1521: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
+	418,  // 1522: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
+	420,  // 1523: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
+	422,  // 1524: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
+	799,  // 1525: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
+	801,  // 1526: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
+	803,  // 1527: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
+	805,  // 1528: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
+	428,  // 1529: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
+	430,  // 1530: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
+	593,  // 1531: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
+	601,  // 1532: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
+	131,  // 1533: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
+	1082, // 1534: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
+	1082, // 1535: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
+	128,  // 1536: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
+	659,  // 1537: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
+	661,  // 1538: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
+	666,  // 1539: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
+	668,  // 1540: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
+	668,  // 1541: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
+	668,  // 1542: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
+	672,  // 1543: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
+	696,  // 1544: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
+	809,  // 1545: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
+	810,  // 1546: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
+	712,  // 1547: forge.Forge.CreateSku:input_type -> forge.SkuList
+	1009, // 1548: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
+	1009, // 1549: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
+	710,  // 1550: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
+	711,  // 1551: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
+	713,  // 1552: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
+	1082, // 1553: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
+	715,  // 1554: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
+	725,  // 1555: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
+	709,  // 1556: forge.Forge.ReplaceSku:input_type -> forge.Sku
+	396,  // 1557: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
+	398,  // 1558: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
+	400,  // 1559: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
+	1009, // 1560: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
+	387,  // 1561: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
+	1082, // 1562: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
+	720,  // 1563: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
+	718,  // 1564: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	718,  // 1565: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	723,  // 1566: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
+	726,  // 1567: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
+	727,  // 1568: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
+	384,  // 1569: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
+	384,  // 1570: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
+	746,  // 1571: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
+	748,  // 1572: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
+	743,  // 1573: forge.Forge.GetRack:input_type -> forge.GetRackRequest
+	753,  // 1574: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
+	754,  // 1575: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
+	761,  // 1576: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
+	732,  // 1577: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
+	734,  // 1578: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
+	736,  // 1579: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
+	739,  // 1580: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
+	740,  // 1581: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
+	807,  // 1582: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
+	816,  // 1583: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
+	1132, // 1584: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
+	1133, // 1585: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
+	819,  // 1586: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
+	1082, // 1587: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
+	821,  // 1588: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	821,  // 1589: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	823,  // 1590: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
+	824,  // 1591: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
+	829,  // 1592: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
+	830,  // 1593: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
+	831,  // 1594: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
+	832,  // 1595: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
+	1082, // 1596: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
+	826,  // 1597: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
+	833,  // 1598: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
+	835,  // 1599: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
+	838,  // 1600: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
+	840,  // 1601: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
+	842,  // 1602: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
+	843,  // 1603: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
+	849,  // 1604: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
+	850,  // 1605: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
+	851,  // 1606: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
+	853,  // 1607: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
+	855,  // 1608: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
+	857,  // 1609: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
+	859,  // 1610: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
+	103,  // 1611: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
+	1009, // 1612: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
+	104,  // 1613: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
+	1009, // 1614: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
+	106,  // 1615: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
+	108,  // 1616: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	111,  // 1617: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
+	108,  // 1618: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	116,  // 1619: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	118,  // 1620: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
+	116,  // 1621: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	119,  // 1622: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
+	124,  // 1623: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
+	125,  // 1624: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
+	866,  // 1625: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
+	869,  // 1626: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
+	871,  // 1627: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
+	873,  // 1628: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
+	1134, // 1629: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
+	1135, // 1630: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
+	1136, // 1631: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
+	1137, // 1632: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
+	1138, // 1633: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
+	1139, // 1634: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
+	1140, // 1635: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
+	1141, // 1636: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
+	1142, // 1637: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
+	1143, // 1638: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
+	1144, // 1639: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
+	1145, // 1640: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
+	1146, // 1641: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
+	1147, // 1642: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
+	1148, // 1643: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
+	783,  // 1644: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
+	784,  // 1645: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
+	161,  // 1646: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	794,  // 1647: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
+	795,  // 1648: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
+	791,  // 1649: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
+	797,  // 1650: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
+	792,  // 1651: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
+	161,  // 1652: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	887,  // 1653: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
+	777,  // 1654: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
+	890,  // 1655: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
+	892,  // 1656: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
+	893,  // 1657: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
+	895,  // 1658: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
+	904,  // 1659: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
+	906,  // 1660: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
+	901,  // 1661: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
+	913,  // 1662: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
+	915,  // 1663: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
+	917,  // 1664: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
+	934,  // 1665: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
+	1027, // 1666: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
+	937,  // 1667: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
+	938,  // 1668: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
+	940,  // 1669: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
+	942,  // 1670: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
+	944,  // 1671: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	947,  // 1672: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	949,  // 1673: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
+	147,  // 1674: forge.Forge.Version:output_type -> forge.BuildInfo
+	1067, // 1675: forge.Forge.CreateDomain:output_type -> dns.Domain
+	1067, // 1676: forge.Forge.UpdateDomain:output_type -> dns.Domain
+	1149, // 1677: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
+	1150, // 1678: forge.Forge.FindDomain:output_type -> dns.DomainList
+	881,  // 1679: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
+	881,  // 1680: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
+	884,  // 1681: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
+	882,  // 1682: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
+	164,  // 1683: forge.Forge.CreateVpc:output_type -> forge.Vpc
+	167,  // 1684: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
+	169,  // 1685: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
+	171,  // 1686: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
+	159,  // 1687: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
+	172,  // 1688: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
+	922,  // 1689: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
+	925,  // 1690: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
+	923,  // 1691: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
+	927,  // 1692: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
+	173,  // 1693: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
+	179,  // 1694: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
+	180,  // 1695: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
+	173,  // 1696: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
+	183,  // 1697: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
+	966,  // 1698: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
+	967,  // 1699: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
+	185,  // 1700: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
+	186,  // 1701: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
+	187,  // 1702: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
+	192,  // 1703: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
+	259,  // 1704: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
+	370,  // 1705: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
+	251,  // 1706: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
+	251,  // 1707: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
+	255,  // 1708: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
+	370,  // 1709: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
+	203,  // 1710: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
+	196,  // 1711: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
+	195,  // 1712: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
+	195,  // 1713: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
+	200,  // 1714: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
+	196,  // 1715: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
+	207,  // 1716: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
+	900,  // 1717: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
+	207,  // 1718: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
+	210,  // 1719: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
+	932,  // 1720: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
+	1082, // 1721: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
+	227,  // 1722: forge.Forge.FindSwitches:output_type -> forge.SwitchList
+	899,  // 1723: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
+	227,  // 1724: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
+	230,  // 1725: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
+	930,  // 1726: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
+	247,  // 1727: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
+	300,  // 1728: forge.Forge.AllocateInstance:output_type -> forge.Instance
+	273,  // 1729: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
+	318,  // 1730: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
+	300,  // 1731: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
+	300,  // 1732: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
+	269,  // 1733: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
+	265,  // 1734: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
+	265,  // 1735: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
+	391,  // 1736: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
+	1082, // 1737: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
+	471,  // 1738: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
+	1082, // 1739: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
+	1082, // 1740: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1741: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
+	1082, // 1742: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
+	1082, // 1743: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1744: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
+	1082, // 1745: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
+	1082, // 1746: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1747: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
+	1082, // 1748: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
+	1082, // 1749: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1750: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
+	1082, // 1751: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	1082, // 1752: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	471,  // 1753: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
+	1082, // 1754: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
+	1082, // 1755: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
+	410,  // 1756: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
+	412,  // 1757: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
+	1151, // 1758: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
+	1152, // 1759: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
+	1153, // 1760: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
+	264,  // 1761: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
+	437,  // 1762: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
+	444,  // 1763: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
+	443,  // 1764: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
+	445,  // 1765: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
+	446,  // 1766: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
+	448,  // 1767: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
+	369,  // 1768: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
+	368,  // 1769: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
+	337,  // 1770: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
+	339,  // 1771: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
+	342,  // 1772: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
+	332,  // 1773: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
+	1082, // 1774: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
+	512,  // 1775: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
+	1068, // 1776: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
+	333,  // 1777: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
+	322,  // 1778: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
+	325,  // 1779: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
+	234,  // 1780: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
+	234,  // 1781: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
+	234,  // 1782: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
+	234,  // 1783: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
+	234,  // 1784: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
+	331,  // 1785: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
+	330,  // 1786: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
+	535,  // 1787: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
+	539,  // 1788: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
+	538,  // 1789: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
+	536,  // 1790: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
+	514,  // 1791: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
+	517,  // 1792: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
+	519,  // 1793: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
+	433,  // 1794: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
+	435,  // 1795: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
+	450,  // 1796: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
+	454,  // 1797: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
+	150,  // 1798: forge.Forge.Echo:output_type -> forge.EchoResponse
+	481,  // 1799: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
+	485,  // 1800: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
+	483,  // 1801: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
+	491,  // 1802: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
+	498,  // 1803: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
+	492,  // 1804: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
+	494,  // 1805: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
+	496,  // 1806: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
+	501,  // 1807: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
+	375,  // 1808: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
+	375,  // 1809: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
+	408,  // 1810: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
+	1154, // 1811: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
+	1155, // 1812: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
+	1082, // 1813: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
+	618,  // 1814: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
+	619,  // 1815: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
+	1069, // 1816: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
+	1082, // 1817: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
+	1156, // 1818: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
+	383,  // 1819: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
+	1082, // 1820: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
+	1157, // 1821: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
+	1158, // 1822: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
+	1159, // 1823: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
+	1160, // 1824: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
+	1161, // 1825: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
+	1162, // 1826: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
+	1082, // 1827: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
+	414,  // 1828: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
+	969,  // 1829: forge.Forge.EraseHostMetadataByBmcMac:output_type -> forge.EraseHostMetadataByBmcMacResponse
+	503,  // 1830: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
+	506,  // 1831: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
+	1082, // 1832: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
+	1082, // 1833: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
+	1082, // 1834: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
+	1082, // 1835: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
+	1082, // 1836: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
+	1082, // 1837: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
+	1082, // 1838: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
+	1082, // 1839: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
+	522,  // 1840: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
+	1082, // 1841: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
+	525,  // 1842: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
+	1082, // 1843: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
+	1082, // 1844: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
+	531,  // 1845: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
+	533,  // 1846: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
+	1082, // 1847: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
+	1082, // 1848: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
+	957,  // 1849: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
+	544,  // 1850: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
+	544,  // 1851: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
+	139,  // 1852: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
+	140,  // 1853: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
+	142,  // 1854: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
+	145,  // 1855: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
+	959,  // 1856: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
+	1082, // 1857: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
+	546,  // 1858: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
+	1082, // 1859: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
+	1082, // 1860: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
+	1082, // 1861: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
+	1082, // 1862: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
+	313,  // 1863: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
+	549,  // 1864: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
+	551,  // 1865: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
+	1082, // 1866: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
+	1082, // 1867: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
+	1082, // 1868: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
+	563,  // 1869: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
+	565,  // 1870: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
+	1082, // 1871: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
+	1082, // 1872: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
+	566,  // 1873: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
+	568,  // 1874: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
+	572,  // 1875: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	572,  // 1876: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	1082, // 1877: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1082, // 1878: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1082, // 1879: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
+	216,  // 1880: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
+	218,  // 1881: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
+	1082, // 1882: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	1082, // 1883: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	219,  // 1884: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
+	1082, // 1885: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
+	1082, // 1886: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
+	1082, // 1887: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
+	238,  // 1888: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
+	240,  // 1889: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
+	1082, // 1890: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
+	1082, // 1891: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
+	241,  // 1892: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
+	1082, // 1893: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
+	1082, // 1894: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
+	1082, // 1895: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
+	243,  // 1896: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
+	245,  // 1897: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
+	1082, // 1898: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
+	1082, // 1899: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
+	136,  // 1900: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
+	646,  // 1901: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
+	648,  // 1902: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
+	650,  // 1903: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
+	653,  // 1904: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
+	652,  // 1905: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
+	656,  // 1906: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
+	658,  // 1907: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
+	1163, // 1908: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
+	1164, // 1909: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
+	1165, // 1910: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
+	1166, // 1911: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
+	1167, // 1912: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1168, // 1913: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
+	1169, // 1914: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
+	1170, // 1915: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
+	1167, // 1916: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1171, // 1917: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
+	1172, // 1918: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
+	1173, // 1919: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
+	1174, // 1920: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
+	1175, // 1921: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
+	1176, // 1922: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
+	1177, // 1923: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
+	1178, // 1924: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
+	1179, // 1925: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
+	1180, // 1926: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
+	1181, // 1927: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
+	1182, // 1928: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
+	1183, // 1929: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
+	1184, // 1930: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
+	1185, // 1931: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
+	1186, // 1932: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
+	1187, // 1933: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
+	1188, // 1934: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
+	1189, // 1935: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
+	1190, // 1936: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
+	1191, // 1937: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
+	1192, // 1938: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
+	1193, // 1939: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
+	1194, // 1940: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
+	1195, // 1941: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
+	1196, // 1942: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
+	1197, // 1943: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
+	1198, // 1944: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
+	1199, // 1945: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
+	1200, // 1946: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
+	1201, // 1947: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
+	1202, // 1948: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
+	1203, // 1949: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
+	1204, // 1950: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
+	677,  // 1951: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
+	679,  // 1952: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
+	681,  // 1953: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
+	682,  // 1954: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
+	685,  // 1955: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
+	688,  // 1956: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
+	695,  // 1957: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
+	553,  // 1958: forge.Forge.CreateOsImage:output_type -> forge.OsImage
+	557,  // 1959: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
+	555,  // 1960: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
+	553,  // 1961: forge.Forge.GetOsImage:output_type -> forge.OsImage
+	553,  // 1962: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
+	276,  // 1963: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
+	560,  // 1964: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
+	573,  // 1965: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
+	1082, // 1966: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
+	580,  // 1967: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
+	577,  // 1968: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
+	585,  // 1969: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
+	588,  // 1970: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
+	590,  // 1971: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
+	1082, // 1972: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	607,  // 1973: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
+	610,  // 1974: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
+	612,  // 1975: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
+	615,  // 1976: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
+	617,  // 1977: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
+	1082, // 1978: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	624,  // 1979: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
+	623,  // 1980: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	623,  // 1981: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	626,  // 1982: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
+	628,  // 1983: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
+	631,  // 1984: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
+	633,  // 1985: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
+	427,  // 1986: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
+	604,  // 1987: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
+	415,  // 1988: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
+	417,  // 1989: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
+	1205, // 1990: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
+	421,  // 1991: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
+	423,  // 1992: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
+	800,  // 1993: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
+	802,  // 1994: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
+	804,  // 1995: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
+	806,  // 1996: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
+	429,  // 1997: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
+	431,  // 1998: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
+	594,  // 1999: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
+	602,  // 2000: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
+	127,  // 2001: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
+	133,  // 2002: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
+	130,  // 2003: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
+	1082, // 2004: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
+	660,  // 2005: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
+	662,  // 2006: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
+	667,  // 2007: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
+	669,  // 2008: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
+	670,  // 2009: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
+	671,  // 2010: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
+	673,  // 2011: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
+	697,  // 2012: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
+	815,  // 2013: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
+	1082, // 2014: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
+	713,  // 2015: forge.Forge.CreateSku:output_type -> forge.SkuIdList
+	709,  // 2016: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
+	1082, // 2017: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
+	1082, // 2018: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
+	1082, // 2019: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
+	1082, // 2020: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
+	713,  // 2021: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
+	712,  // 2022: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
+	1082, // 2023: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
+	709,  // 2024: forge.Forge.ReplaceSku:output_type -> forge.Sku
+	397,  // 2025: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
+	399,  // 2026: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
+	401,  // 2027: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
+	1082, // 2028: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
+	1082, // 2029: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
+	719,  // 2030: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
+	721,  // 2031: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
+	717,  // 2032: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
+	717,  // 2033: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
+	724,  // 2034: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
+	729,  // 2035: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
+	729,  // 2036: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
+	1082, // 2037: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
+	126,  // 2038: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
+	747,  // 2039: forge.Forge.FindRackIds:output_type -> forge.RackIdList
+	745,  // 2040: forge.Forge.FindRacksByIds:output_type -> forge.RackList
+	744,  // 2041: forge.Forge.GetRack:output_type -> forge.GetRackResponse
+	1082, // 2042: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
+	755,  // 2043: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
+	762,  // 2044: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
+	733,  // 2045: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
+	735,  // 2046: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
+	737,  // 2047: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
+	738,  // 2048: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
+	741,  // 2049: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
+	808,  // 2050: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
+	817,  // 2051: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
+	1206, // 2052: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
+	1207, // 2053: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
+	820,  // 2054: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
+	822,  // 2055: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
+	821,  // 2056: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	821,  // 2057: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	1082, // 2058: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
+	825,  // 2059: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
+	1082, // 2060: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
+	1082, // 2061: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
+	1082, // 2062: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
+	1082, // 2063: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
+	826,  // 2064: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
+	827,  // 2065: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
+	834,  // 2066: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
+	837,  // 2067: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
+	839,  // 2068: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
+	1082, // 2069: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
+	1082, // 2070: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
+	1082, // 2071: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
+	848,  // 2072: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
+	848,  // 2073: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
+	852,  // 2074: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
+	854,  // 2075: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
+	856,  // 2076: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
+	858,  // 2077: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
+	860,  // 2078: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
+	100,  // 2079: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
+	1082, // 2080: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
+	105,  // 2081: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
+	102,  // 2082: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
+	107,  // 2083: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
+	112,  // 2084: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	112,  // 2085: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	1082, // 2086: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
+	115,  // 2087: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	115,  // 2088: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	1082, // 2089: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
+	121,  // 2090: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
+	122,  // 2091: forge.Forge.GetJWKS:output_type -> forge.Jwks
+	123,  // 2092: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
+	867,  // 2093: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
+	870,  // 2094: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
+	872,  // 2095: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
+	874,  // 2096: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
+	1208, // 2097: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
+	1209, // 2098: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
+	1210, // 2099: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
+	1211, // 2100: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
+	1212, // 2101: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
+	1213, // 2102: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
+	1214, // 2103: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
+	1215, // 2104: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
+	1216, // 2105: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
+	1217, // 2106: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
+	1218, // 2107: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
+	1219, // 2108: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
+	1220, // 2109: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
+	1221, // 2110: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
+	1222, // 2111: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
+	785,  // 2112: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
+	780,  // 2113: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
+	780,  // 2114: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
+	796,  // 2115: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
+	790,  // 2116: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
+	789,  // 2117: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
+	798,  // 2118: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
+	793,  // 2119: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
+	790,  // 2120: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
+	888,  // 2121: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
+	778,  // 2122: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
+	1082, // 2123: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
+	891,  // 2124: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
+	894,  // 2125: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
+	897,  // 2126: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
+	905,  // 2127: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
+	907,  // 2128: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
+	903,  // 2129: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
+	914,  // 2130: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
+	916,  // 2131: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
+	920,  // 2132: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
+	933,  // 2133: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
+	933,  // 2134: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
+	933,  // 2135: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
+	939,  // 2136: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
+	941,  // 2137: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
+	943,  // 2138: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
+	945,  // 2139: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	945,  // 2140: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	950,  // 2141: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
+	1674, // [1674:2142] is the sub-list for method output_type
+	1206, // [1206:1674] is the sub-list for method input_type
 	1206, // [1206:1206] is the sub-list for extension type_name
 	1206, // [1206:1206] is the sub-list for extension extendee
 	0,    // [0:1206] is the sub-list for field type_name
@@ -71999,28 +72153,28 @@ func file_nico_nico_proto_init() {
 	file_nico_nico_proto_msgTypes[859].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[864].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[866].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[871].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[873].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[889].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[891].OneofWrappers = []any{
+	file_nico_nico_proto_msgTypes[875].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[891].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[893].OneofWrappers = []any{
 		(*ForgeAgentControlResponse_MlxDeviceAction_Noop)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_Lock)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_Unlock)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_ApplyProfile)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_ApplyFirmware)(nil),
 	}
-	file_nico_nico_proto_msgTypes[895].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[896].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[900].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[901].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[897].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[898].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[902].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[903].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[904].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_nico_nico_proto_rawDesc), len(file_nico_nico_proto_rawDesc)),
 			NumEnums:      98,
-			NumMessages:   909,
+			NumMessages:   911,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
@@ -178,6 +178,7 @@ const (
 	Forge_FindExploredMlxDevicesByIds_FullMethodName                        = "/forge.Forge/FindExploredMlxDevicesByIds"
 	Forge_UpdateMachineHardwareInfo_FullMethodName                          = "/forge.Forge/UpdateMachineHardwareInfo"
 	Forge_AdminForceDeleteMachine_FullMethodName                            = "/forge.Forge/AdminForceDeleteMachine"
+	Forge_EraseHostMetadataByBmcMac_FullMethodName                          = "/forge.Forge/EraseHostMetadataByBmcMac"
 	Forge_AdminListResourcePools_FullMethodName                             = "/forge.Forge/AdminListResourcePools"
 	Forge_AdminGrowResourcePool_FullMethodName                              = "/forge.Forge/AdminGrowResourcePool"
 	Forge_UpdateMachineMetadata_FullMethodName                              = "/forge.Forge/UpdateMachineMetadata"
@@ -764,6 +765,26 @@ type ForgeClient interface {
 	// AdminForceDeleteMachine is a lower level admin tool for cases where there is no
 	// appropriate customer-facing workflow available or where those workflows fail.
 	AdminForceDeleteMachine(ctx context.Context, in *AdminForceDeleteMachineRequest, opts ...grpc.CallOption) (*AdminForceDeleteMachineResponse, error)
+	// EraseHostMetadataByBmcMac removes all NICo-owned site records tied to a
+	// server BMC MAC address -- machine interfaces (and their addresses/DHCP
+	// entries/boot overrides), retained boot rows, site-explorer exploration
+	// reports, explored managed hosts and the BMC credentials in vault -- so an
+	// operator has a clean slate to re-ingest a replacement host. Deletion is
+	// MAC-driven from cached state (no live BMC call), so an off/relocated host is
+	// still cleaned. It intentionally does NOT touch expected machines, which NICo
+	// does not own.
+	//
+	// Refusals and protections:
+	//   - Refuses when any interface for the MAC is still owned by a live device
+	//     (machine, DPU, switch or power shelf), or when a candidate BMC IP still
+	//     belongs to an ingested machine -- use AdminForceDeleteMachine for those.
+	//   - Preserves an exploration endpoint or explored-managed-host row whose BMC
+	//     (Redfish Manager) advertises a *different* MAC, so a reused IP now owned by
+	//     another host is never taken down.
+	//
+	// Set dry_run to report which records (and whether BMC credentials) would be
+	// erased without deleting anything.
+	EraseHostMetadataByBmcMac(ctx context.Context, in *EraseHostMetadataByBmcMacRequest, opts ...grpc.CallOption) (*EraseHostMetadataByBmcMacResponse, error)
 	// List existing resource pools and their stats
 	AdminListResourcePools(ctx context.Context, in *ListResourcePoolsRequest, opts ...grpc.CallOption) (*ResourcePools, error)
 	// Add capacity to a resource pool
@@ -2863,6 +2884,16 @@ func (c *forgeClient) AdminForceDeleteMachine(ctx context.Context, in *AdminForc
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AdminForceDeleteMachineResponse)
 	err := c.cc.Invoke(ctx, Forge_AdminForceDeleteMachine_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *forgeClient) EraseHostMetadataByBmcMac(ctx context.Context, in *EraseHostMetadataByBmcMacRequest, opts ...grpc.CallOption) (*EraseHostMetadataByBmcMacResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(EraseHostMetadataByBmcMacResponse)
+	err := c.cc.Invoke(ctx, Forge_EraseHostMetadataByBmcMac_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -6264,6 +6295,26 @@ type ForgeServer interface {
 	// AdminForceDeleteMachine is a lower level admin tool for cases where there is no
 	// appropriate customer-facing workflow available or where those workflows fail.
 	AdminForceDeleteMachine(context.Context, *AdminForceDeleteMachineRequest) (*AdminForceDeleteMachineResponse, error)
+	// EraseHostMetadataByBmcMac removes all NICo-owned site records tied to a
+	// server BMC MAC address -- machine interfaces (and their addresses/DHCP
+	// entries/boot overrides), retained boot rows, site-explorer exploration
+	// reports, explored managed hosts and the BMC credentials in vault -- so an
+	// operator has a clean slate to re-ingest a replacement host. Deletion is
+	// MAC-driven from cached state (no live BMC call), so an off/relocated host is
+	// still cleaned. It intentionally does NOT touch expected machines, which NICo
+	// does not own.
+	//
+	// Refusals and protections:
+	//   - Refuses when any interface for the MAC is still owned by a live device
+	//     (machine, DPU, switch or power shelf), or when a candidate BMC IP still
+	//     belongs to an ingested machine -- use AdminForceDeleteMachine for those.
+	//   - Preserves an exploration endpoint or explored-managed-host row whose BMC
+	//     (Redfish Manager) advertises a *different* MAC, so a reused IP now owned by
+	//     another host is never taken down.
+	//
+	// Set dry_run to report which records (and whether BMC credentials) would be
+	// erased without deleting anything.
+	EraseHostMetadataByBmcMac(context.Context, *EraseHostMetadataByBmcMacRequest) (*EraseHostMetadataByBmcMacResponse, error)
 	// List existing resource pools and their stats
 	AdminListResourcePools(context.Context, *ListResourcePoolsRequest) (*ResourcePools, error)
 	// Add capacity to a resource pool
@@ -7275,6 +7326,9 @@ func (UnimplementedForgeServer) UpdateMachineHardwareInfo(context.Context, *Upda
 }
 func (UnimplementedForgeServer) AdminForceDeleteMachine(context.Context, *AdminForceDeleteMachineRequest) (*AdminForceDeleteMachineResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AdminForceDeleteMachine not implemented")
+}
+func (UnimplementedForgeServer) EraseHostMetadataByBmcMac(context.Context, *EraseHostMetadataByBmcMacRequest) (*EraseHostMetadataByBmcMacResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method EraseHostMetadataByBmcMac not implemented")
 }
 func (UnimplementedForgeServer) AdminListResourcePools(context.Context, *ListResourcePoolsRequest) (*ResourcePools, error) {
 	return nil, status.Error(codes.Unimplemented, "method AdminListResourcePools not implemented")
@@ -11018,6 +11072,24 @@ func _Forge_AdminForceDeleteMachine_Handler(srv interface{}, ctx context.Context
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ForgeServer).AdminForceDeleteMachine(ctx, req.(*AdminForceDeleteMachineRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Forge_EraseHostMetadataByBmcMac_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(EraseHostMetadataByBmcMacRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ForgeServer).EraseHostMetadataByBmcMac(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Forge_EraseHostMetadataByBmcMac_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ForgeServer).EraseHostMetadataByBmcMac(ctx, req.(*EraseHostMetadataByBmcMacRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -17253,6 +17325,10 @@ var Forge_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AdminForceDeleteMachine",
 			Handler:    _Forge_AdminForceDeleteMachine_Handler,
+		},
+		{
+			MethodName: "EraseHostMetadataByBmcMac",
+			Handler:    _Forge_EraseHostMetadataByBmcMac_Handler,
 		},
 		{
 			MethodName: "AdminListResourcePools",

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -340,6 +340,27 @@ service Forge {
   // appropriate customer-facing workflow available or where those workflows fail.
   rpc AdminForceDeleteMachine(AdminForceDeleteMachineRequest) returns (AdminForceDeleteMachineResponse);
 
+  // EraseHostMetadataByBmcMac removes all NICo-owned site records tied to a
+  // server BMC MAC address -- machine interfaces (and their addresses/DHCP
+  // entries/boot overrides), retained boot rows, site-explorer exploration
+  // reports, explored managed hosts and the BMC credentials in vault -- so an
+  // operator has a clean slate to re-ingest a replacement host. Deletion is
+  // MAC-driven from cached state (no live BMC call), so an off/relocated host is
+  // still cleaned. It intentionally does NOT touch expected machines, which NICo
+  // does not own.
+  //
+  // Refusals and protections:
+  //   * Refuses when any interface for the MAC is still owned by a live device
+  //     (machine, DPU, switch or power shelf), or when a candidate BMC IP still
+  //     belongs to an ingested machine -- use AdminForceDeleteMachine for those.
+  //   * Preserves an exploration endpoint or explored-managed-host row whose BMC
+  //     (Redfish Manager) advertises a *different* MAC, so a reused IP now owned by
+  //     another host is never taken down.
+  //
+  // Set dry_run to report which records (and whether BMC credentials) would be
+  // erased without deleting anything.
+  rpc EraseHostMetadataByBmcMac(EraseHostMetadataByBmcMacRequest) returns (EraseHostMetadataByBmcMacResponse);
+
   // List existing resource pools and their stats
   rpc AdminListResourcePools(ListResourcePoolsRequest) returns (ResourcePools);
 
@@ -9528,4 +9549,34 @@ message SitePrefixIdList {
 
 message SitePrefixList {
   repeated SitePrefix site_prefixes = 1;
+}
+
+// Request to erase all NICo-owned site records for a server BMC MAC address.
+message EraseHostMetadataByBmcMacRequest {
+  // The server BMC MAC address whose lingering records should be erased.
+  string bmc_mac = 1;
+
+  // When true, report the records that would be erased without deleting them.
+  bool dry_run = 2;
+}
+
+// Response describing the records that were erased (or, in dry-run mode, that
+// would be erased) for the requested BMC MAC address.
+message EraseHostMetadataByBmcMacResponse {
+  // Echoes the request: true when nothing was actually deleted.
+  bool dry_run = 1;
+
+  // IDs of the machine interfaces erased for this MAC.
+  repeated string machine_interface_ids = 2;
+
+  // BMC IP addresses of the site-explorer exploration reports erased.
+  repeated string explored_endpoint_ips = 3;
+
+  // Host BMC IP addresses of the explored managed host records erased.
+  repeated string explored_managed_host_ips = 4;
+
+  // In a real run, true when the BMC credentials in vault (and the convergence
+  // markers keyed by this MAC) were cleared. In dry-run mode, true when such BMC
+  // credentials exist and would be cleared.
+  bool bmc_credentials_cleared = 5;
 }


### PR DESCRIPTION
Implements #3046: `nico-admin-cli managed-host erase-metadata --bmc-mac <MAC> [--dry-run] [--confirm]` removes all NICo-owned records for a server BMC MAC (machine interfaces + addresses/DHCP/boot-override, retained boot rows, site-explorer exploration reports, explored managed hosts, vault BMC credentials + convergence markers), giving an operator a clean slate to re-ingest a replacement host.

Deletion is MAC-driven from cached state (no live BMC call), so an off/relocated host is still cleaned. Refuses when an interface is still owned by a live device (machine, DPU, switch, power shelf) or a BMC IP still belongs to an ingested machine; protects a managed-host row or exploration endpoint whose BMC advertises a different MAC. Safety is dry-run + explicit --confirm. Expected machines are never touched.

11 integration tests added (verified 10/10 locally against Postgres before adding the endpoint-protection test). Draft: relying on CI for the full test suite + clippy-flow; generated CLI docs to follow from CI's canonical output.