### PR TITLE
fix(api-core): don't hold a db connection across the host UEFI credential read

### DIFF
--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -35,27 +35,32 @@ use crate::api::{Api, log_machine_id, log_request_data};
 use crate::auth::AuthContext;
 use crate::handlers::utils::convert_and_log_machine_id;
 
-// TODO(#2991, @spydaNVIDIA): avoid holding this transaction while the
-// credential reader may perform a remote Vault request. Keep the allowance on
-// this small helper rather than the full force-delete handler.
-#[allow(txn_held_across_await)]
+/// Resolve the host UEFI credential to authenticate a *clear* with while
+/// force-deleting a machine, keyed by the password the device currently holds
+/// (see `host_uefi_clear_credential_key`). Best effort: any failure returns
+/// `None`, so the force-delete skips the clear rather than aborting.
+///
+/// Resolve the key while the txn is open, commit, then read the secret -- the
+/// remote reader (Vault) request must not run while we hold the connection.
 async fn resolve_host_uefi_clear_credentials(
     api: &Api,
     bmc_mac_address: mac_address::MacAddress,
 ) -> Option<Credentials> {
-    match api.txn_begin().await {
-        Ok(mut txn) => {
-            let credentials = crate::handlers::uefi::host_uefi_clear_credentials(
-                &mut txn,
-                api.redfish_pool.credential_reader(),
-                bmc_mac_address,
-            )
-            .await;
-            let _ = txn.commit().await;
-            credentials.ok()
-        }
-        Err(_) => None,
+    let mut txn = api.txn_begin().await.ok()?;
+    let key =
+        crate::handlers::uefi::host_uefi_clear_credential_key(&mut txn, bmc_mac_address).await;
+    if let Err(err) = txn.commit().await {
+        tracing::warn!(
+            %bmc_mac_address,
+            error = %err,
+            "Failed to commit while resolving host UEFI clear credentials; skipping clear"
+        );
+        return None;
     }
+    let clear_key = key.ok()?;
+    crate::handlers::uefi::read_uefi_credentials(api.redfish_pool.credential_reader(), &clear_key)
+        .await
+        .ok()
 }
 
 pub(crate) async fn find_machine_ids(

--- a/crates/api-core/src/handlers/uefi.rs
+++ b/crates/api-core/src/handlers/uefi.rs
@@ -89,7 +89,11 @@ async fn host_uefi_device_version(
 /// Read the host UEFI credential at `key`, mapping a store error or a missing
 /// secret to a `CarbideError`. Used to resolve the password the low-level
 /// `redfish` UEFI calls apply (they no longer read the store themselves).
-async fn read_uefi_credentials(
+///
+/// Takes no database connection: the reader can be Vault-backed, so callers
+/// resolve the version-to-`key` half against the DB first, commit, then call
+/// this -- the remote read must not run while a connection is held.
+pub(crate) async fn read_uefi_credentials(
     reader: &dyn CredentialReader,
     key: &CredentialKey,
 ) -> Result<Credentials, CarbideError> {
@@ -107,37 +111,39 @@ async fn read_uefi_credentials(
         })
 }
 
-/// Resolve the site-wide host UEFI credential to *set* on a device: the secret
-/// at the current `host_uefi` target version (table-driven; v0 = the legacy
-/// unversioned site-default).
-// TODO(#2991, @spydaNVIDIA): do not hold the database connection while the
-// credential reader may perform a remote Vault request.
-#[allow(txn_held_across_await)]
-pub(crate) async fn host_uefi_set_credentials(
+/// The `CredentialKey` for the site-wide host UEFI password to *set* on a
+/// device: the secret at the current `host_uefi` target version (table-driven;
+/// v0 = the legacy unversioned site-default).
+///
+/// This is the database half of resolving the credential -- it reads only the
+/// version and returns the key. The caller reads the secret with
+/// `read_uefi_credentials` after committing, so no connection is held across the
+/// remote reader (Vault) request.
+pub(crate) async fn host_uefi_set_credential_key(
     conn: &mut sqlx::PgConnection,
-    reader: &dyn CredentialReader,
-) -> Result<Credentials, CarbideError> {
+) -> Result<CredentialKey, CarbideError> {
     let version = host_uefi_target_version(conn).await.map_err(|e| {
         CarbideError::internal(format!("failed to read host UEFI target version: {e}"))
     })?;
-    read_uefi_credentials(reader, &CredentialKey::host_uefi_site_default(version)).await
+    Ok(CredentialKey::host_uefi_site_default(version))
 }
 
-/// Resolve the host UEFI credential a device currently carries, to authenticate
-/// a *clear* against its existing password (the device's converged version; see
-/// [`host_uefi_device_version`]).
-// TODO(#2991, @spydaNVIDIA): do not hold the database connection while the
-// credential reader may perform a remote Vault request.
-#[allow(txn_held_across_await)]
-pub(crate) async fn host_uefi_clear_credentials(
+/// The `CredentialKey` for the host UEFI password a device currently holds, to
+/// authenticate a *clear* against its existing password (the device's converged
+/// version; see [`host_uefi_device_version`]).
+///
+/// Like `host_uefi_set_credential_key`, this is only the database half: it reads
+/// the device version and returns the key. The caller reads the secret with
+/// `read_uefi_credentials` after committing, so no connection is held across the
+/// remote reader (Vault) request.
+pub(crate) async fn host_uefi_clear_credential_key(
     conn: &mut sqlx::PgConnection,
-    reader: &dyn CredentialReader,
     bmc_mac: mac_address::MacAddress,
-) -> Result<Credentials, CarbideError> {
+) -> Result<CredentialKey, CarbideError> {
     let version = host_uefi_device_version(conn, bmc_mac).await.map_err(|e| {
         CarbideError::internal(format!("failed to read host UEFI device version: {e}"))
     })?;
-    read_uefi_credentials(reader, &CredentialKey::host_uefi_site_default(version)).await
+    Ok(CredentialKey::host_uefi_site_default(version))
 }
 
 pub(crate) async fn clear_host_uefi_password(
@@ -231,16 +237,17 @@ pub(crate) async fn clear_host_uefi_password(
         db::machine_interface::lookup_bmc_access_info(&mut txn, addr.ip(), Some(addr.port()))
             .await?;
 
-    // Resolve the credential the device currently carries so the clear
-    // authenticates with the right password (table-driven; see
-    // `host_uefi_clear_credentials`). Done before the commit while the txn is
-    // open.
-    let clear_credentials =
-        host_uefi_clear_credentials(&mut txn, api.redfish_pool.credential_reader(), bmc_mac)
-            .await?;
+    // Resolve which credential the clear must authenticate with -- the password
+    // the device currently holds, keyed by its converged version (table-driven;
+    // see `host_uefi_clear_credential_key`). This is the DB half; do it while the
+    // txn is open.
+    let clear_key = host_uefi_clear_credential_key(&mut txn, bmc_mac).await?;
 
-    // Don't hold the transaction across an await point
+    // Commit before the remote reader (Vault) request so the connection is not
+    // held across it, then read the actual secret.
     txn.commit().await?;
+    let clear_credentials =
+        read_uefi_credentials(api.redfish_pool.credential_reader(), &clear_key).await?;
 
     let redfish_client = api
         .redfish_pool
@@ -346,13 +353,16 @@ pub(crate) async fn set_host_uefi_password(
         db::machine_interface::lookup_bmc_access_info(&mut txn, addr.ip(), Some(addr.port()))
             .await?;
 
-    // Resolve the site-wide host UEFI credential to set (table-driven; v0 = the
-    // legacy unversioned site-default). Resolved before the commit.
-    let host_uefi_credentials =
-        host_uefi_set_credentials(&mut txn, api.redfish_pool.credential_reader()).await?;
+    // Resolve the site-wide host UEFI credential key to set (table-driven; v0 =
+    // the legacy unversioned site-default). This is the DB half; do it while the
+    // txn is open.
+    let host_uefi_key = host_uefi_set_credential_key(&mut txn).await?;
 
-    // Let txn drop so we don't hold it across a redfish request
+    // Commit before the remote reader (Vault) request and the redfish call so the
+    // connection is not held across them, then read the actual secret.
     txn.commit().await?;
+    let host_uefi_credentials =
+        read_uefi_credentials(api.redfish_pool.credential_reader(), &host_uefi_key).await?;
 
     let redfish_client = api
         .redfish_pool


### PR DESCRIPTION
Setting or clearing a host's UEFI password resolves the credential in two steps: read the target/device version out of Postgres, then fetch the secret at that version from the credential reader. With the Vault-backed reader that second step is a remote network call -- and we were making it with the database connection still in hand. #3872 restored the `txn_held_across_await` lint on `api-core` (it had been silenced since the #2054 crate split) and this was one of the cases it caught. The surrounding code even *claimed* it committed first -- a `// Don't hold the transaction across an await point` sits right above the commit -- but the vault read happened before it.

So, the version is the only thing the reader needs from the DB. This splits "resolve the credential *key*" (the DB half) from "read the secret" (the reader half): `host_uefi_{set,clear}_credentials` become `host_uefi_{set,clear}_credential_key`, and every caller resolves the key while the txn is open, commits, then calls `read_uefi_credentials` on nobody's connection. The three `#[allow(txn_held_across_await)]` + TODOs go away with them.

It's behavior-preserving -- same reads, same order -- the commit just finally lands before the remote read like the comment always said. Both handler transactions are read-only (the actual writes live in separate later transactions), so moving the read past the commit is safe. The force-delete helper stays best effort: it returns `None` and skips the clear on any failure -- now including a failed commit, which it warns about rather than silently ignoring.

## Related issues
This supports https://github.com/NVIDIA/infra-controller/issues/4001

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Behavior-preserving restructure -- same reads, same order, with the remote reader call moved past the commit. The existing `credential_rotation` integration tests exercise the set/clear paths; the change is lint-green (`clippy` + `carbide-lints`) and passed a clean cross-model (Codex) and local CodeRabbit review.

## Additional Notes
Follow-up to #3872, which restored the lint and parked this case behind `#[allow(txn_held_across_await)]` + a `TODO(#2991)`. Companion to the #2665 `SessionLock` follow-up from the same PR.


Closes #4001
