### PR TITLE
refactor(api-core,api-db): wrap the session-lock connection in a guard

### DIFF
--- a/crates/api-core/src/run.rs
+++ b/crates/api-core/src/run.rs
@@ -517,13 +517,6 @@ fn build_kms_backend(
 /// where they are stranded. Site-explorer credential rotation is the writer
 /// to worry about; keep it disabled until the whole fleet runs a consistent
 /// config.
-// Custom-lint exception for #2665 (@chet): this function intentionally keeps a
-// dedicated detached connection alive across awaits because the Vault import
-// lock is session-scoped and releases when that connection closes. The custom
-// lint also classifies bare `PgConnection`s as transactions, but no transaction
-// is open here: Vault reads and Postgres writes use separate pool connections so
-// the importer cannot block itself on pool capacity.
-#[allow(txn_held_across_await)]
 async fn import_vault_secrets_once(
     db_pool: &PgPool,
     secrets_config: &SecretsConfig,
@@ -538,22 +531,18 @@ async fn import_vault_secrets_once(
 
     // Several replicas can boot against the same empty database at once.
     // The marker path's advisory lock lets one of them import while the
-    // rest wait here, re-check the marker, and move on. It is a session
-    // lock on a dedicated connection rather than a transaction-scoped one:
-    // the import awaits Vault enumeration and pool-backed writes, and
-    // holding a transaction across those would trip `txn_held_across_await`
-    // and, under concurrent startup, risk waiters starving the pool the
-    // importer itself needs. Detaching the connection guarantees the lock
-    // releases when it drops, including on an early error return.
-    let mut lock_conn = db_pool
-        .acquire()
-        .await
-        .wrap_err("acquire vault import lock connection")?
-        .detach();
-    db::secrets::lock_path_session(&mut lock_conn, crate::secrets::VAULT_IMPORT_MARKER_PATH)
-        .await
-        .map_err(eyre::Report::new)
-        .wrap_err("acquire vault import lock")?;
+    // rest wait here, re-check the marker, and move on. `SessionLock` holds
+    // it on a dedicated detached connection rather than in a transaction: the
+    // import awaits Vault enumeration and pool-backed writes, and holding a
+    // transaction across those would trip `txn_held_across_await` and, under
+    // concurrent startup, risk waiters starving the pool the importer itself
+    // needs. `_import_lock` releases when it drops at the end of the function,
+    // including on an early error return.
+    let _import_lock =
+        db::secrets::SessionLock::acquire(db_pool, crate::secrets::VAULT_IMPORT_MARKER_PATH)
+            .await
+            .map_err(eyre::Report::new)
+            .wrap_err("acquire vault import lock")?;
 
     if is_import_complete(db_pool).await? {
         tracing::info!("Vault import completed by another replica");
@@ -606,7 +595,7 @@ async fn import_vault_secrets_once(
         .wrap_err("mark vault import complete")?;
     tracing::info!("Vault import marked complete");
 
-    // lock_conn drops here, closing the connection and releasing the
+    // `_import_lock` drops here, closing the connection and releasing the
     // session advisory lock.
     Ok(())
 }

--- a/crates/api-core/src/secrets/re_wrap.rs
+++ b/crates/api-core/src/secrets/re_wrap.rs
@@ -60,13 +60,6 @@ struct PendingReWrap {
 /// Historical journal entries are re-wrapped too: they must stay
 /// decryptable, and re-wrapping them is what lets an old KEK be retired
 /// completely.
-// Custom-lint exception for #2665 (@chet): this function intentionally keeps a
-// dedicated detached connection alive across awaits because the re-wrap lock is
-// session-scoped and releases when that connection closes. The custom lint
-// classifies bare `PgConnection`s as transactions, but no transaction is open on
-// this connection; batch reads, KMS work, and batch-write transactions use
-// separate pool connections.
-#[allow(txn_held_across_await)]
 pub async fn re_wrap_stale(
     pool: &PgPool,
     kms: &dyn KmsBackend,
@@ -74,20 +67,15 @@ pub async fn re_wrap_stale(
     batch_size: i64,
 ) -> Result<ReWrapStaleResult, PgSecretsError> {
     // One re-wrap at a time: a second concurrent run would double every
-    // KMS round-trip for no benefit. The guard is a session advisory lock
-    // held on a dedicated connection, not a transaction -- the walk awaits
-    // Vault/KMS and opens a transaction per batch, and a lock transaction
-    // held across all of that would trip `txn_held_across_await` and could
-    // starve the pool. Detaching the connection guarantees the lock
-    // releases when it drops, including on an early error return.
-    let mut lock_conn = pool
-        .acquire()
-        .await
-        .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?
-        .detach();
-    if !db::secrets::try_lock_path_session(&mut lock_conn, RE_WRAP_LOCK_PATH).await? {
-        return Err(PgSecretsError::ReWrapInProgress);
-    }
+    // KMS round-trip for no benefit. `SessionLock` holds a session advisory
+    // lock on its own detached connection -- not a transaction -- so the walk
+    // can await Vault/KMS and open a transaction per batch without holding
+    // anything across those awaits. `_lock` releases when it drops at the end
+    // of the function, including on an early `?` return.
+    let _lock = match db::secrets::SessionLock::try_acquire(pool, RE_WRAP_LOCK_PATH).await? {
+        Some(lock) => lock,
+        None => return Err(PgSecretsError::ReWrapInProgress),
+    };
 
     let mut result = ReWrapStaleResult {
         re_wrapped: 0,

--- a/crates/api-db/src/secrets.rs
+++ b/crates/api-db/src/secrets.rs
@@ -29,7 +29,7 @@
 
 use carbide_uuid::secret::SecretId;
 use model::secrets::SecretRow;
-use sqlx::{PgConnection, PgTransaction};
+use sqlx::{PgConnection, PgPool, PgTransaction};
 
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
@@ -155,6 +155,59 @@ pub async fn unlock_path_session(conn: &mut PgConnection, path: &str) -> Databas
         .await
         .map_err(|e| DatabaseError::query(sql, e))?;
     Ok(())
+}
+
+/// A Postgres *session* advisory lock held on its own dedicated connection.
+///
+/// The lock lives as long as this guard: it is taken on a dedicated connection
+/// detached from the pool, and Postgres releases it when that connection is
+/// torn down. Dropping the guard drops the connection and starts that teardown,
+/// so the release follows the drop closely but is not synchronous with it --
+/// fine for the single-flight callers here, where a racing re-run just waits on
+/// `acquire` or sees the lock still held via `try_acquire`. Because the
+/// connection is detached, holding it never counts against pool capacity, so a
+/// caller can guard a long operation (awaiting Vault/KMS, opening a transaction
+/// per batch) without keeping a *transaction* open across those awaits.
+///
+/// That last point is why this type exists rather than a bare `PgConnection`:
+/// the value a caller holds across its awaits is a `SessionLock` -- a lock
+/// holder, not a transaction -- so `txn_held_across_await` is not tripped, and
+/// no connection is held open as a transaction here.
+#[must_use = "dropping a SessionLock releases the session advisory lock"]
+pub struct SessionLock {
+    // Held only for its lifetime: dropping it closes the connection, which
+    // releases the lock. Nothing reads it back, hence the leading underscore.
+    _conn: PgConnection,
+}
+
+impl SessionLock {
+    /// Take `path`'s session advisory lock on a dedicated connection, waiting
+    /// until it is free (see [`lock_path_session`]).
+    pub async fn acquire(pool: &PgPool, path: &str) -> DatabaseResult<Self> {
+        let mut conn = pool
+            .acquire()
+            .await
+            .map_err(DatabaseError::acquire)?
+            .detach();
+        lock_path_session(&mut conn, path).await?;
+        Ok(Self { _conn: conn })
+    }
+
+    /// Try to take `path`'s session advisory lock on a dedicated connection
+    /// without waiting. `Ok(None)` means another session already holds it (see
+    /// [`try_lock_path_session`]).
+    pub async fn try_acquire(pool: &PgPool, path: &str) -> DatabaseResult<Option<Self>> {
+        let mut conn = pool
+            .acquire()
+            .await
+            .map_err(DatabaseError::acquire)?
+            .detach();
+        if try_lock_path_session(&mut conn, path).await? {
+            Ok(Some(Self { _conn: conn }))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// Whether any entries exist for the path.


### PR DESCRIPTION
Vault import and secret re-wrap each need to hold a lock for their whole run -- one importer at a time, one re-wrap at a time -- while they await Vault/KMS and open a transaction per batch. Both do it the same way: take a Postgres *session* advisory lock on a connection they `detach()` from the pool, and let dropping that connection release the lock. No transaction is ever open on it. It's the right design, but #3872 (which restored `txn_held_across_await` on `api-core`) can't tell a bare `PgConnection` holding only a session lock from a real transaction, so both had been parked behind `#[allow(txn_held_across_await)]`.

So, this gives the pattern a name. `db::secrets::SessionLock` -- living next to the lock primitives it wraps -- owns the detached connection and releases on drop, with `acquire` (waits) and `try_acquire` (returns `None` when another session holds it). It's `#[must_use]`, so you can't accidentally drop the lock the instant you take it. The value held across the awaits is now a `SessionLock`, a lock holder rather than a connection, so the lint is satisfied for the true reason: nothing here is a transaction.

Primary callouts are:
- `import_vault_secrets_once` and `re_wrap_stale` each collapse to a one-line `SessionLock::{acquire,try_acquire}`, and both `#[allow(txn_held_across_await)]` go away.
- The "why we detach a dedicated connection" explanation moves to the guard's doc, instead of being re-explained at each call site.

No behavior change -- the guard does exactly what the hand-rolled `acquire().detach()` + lock did, releasing on drop the same way (including on an early `?` return).

## Related issues
This supports https://github.com/NVIDIA/infra-controller/issues/4002

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

No behavior change. The existing `re_wrap_stale` tests exercise the new `SessionLock::try_acquire` path; the change is lint-green (`clippy` + `carbide-lints`) and passed a clean cross-model (Codex) and local CodeRabbit review.

## Additional Notes
Follow-up to #3872, which restored the lint and parked these two cases behind `#[allow(txn_held_across_await)]` + `TODO(#2665)`. Companion to the #2991 UEFI-credential follow-up from the same PR.
