### PR TITLE
fix(redfish): pass complete boot-interface targets once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6778,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.44.22#53c0b12569d6de1ecccde826d495618ff987d8c6"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.45.0#7cdf76cfa974db4062c6e7418d9609110bd1f2f3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = ["NVIDIA Carbide Engineering <carbide-dev@exchange.nvidia.com>"]
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.44.22" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.45.0" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -46,8 +46,8 @@ use crate::handlers::utils::resolve_bmc_address;
 /// `pick_boot_interface` selects the machine's primary interface -- the same
 /// row the machine-controller configures boot from -- and the row's own
 /// captured id completes the [`MachineBootInterface`], or the action targets
-/// the MAC alone ([`BootInterfaceTarget::MacOnly`], no id fallback), exactly
-/// like the controller's `boot_interface_target`.
+/// only the MAC ([`BootInterfaceTarget::MacOnly`]), exactly like the
+/// controller's `boot_interface_target`.
 ///
 /// A machine with no `machine_interfaces` rows yet (a zero-DPU/NIC-mode
 /// machine awaiting its first DHCP lease) resolves from its
@@ -94,8 +94,8 @@ fn resolve_admin_boot_interface_target(
                     .and_then(PredictedMachineInterface::boot_interface)
             })
     };
-    // Resolution chose `mac`; its `MachineBootInterface` is the target, or the
-    // MAC alone when no interface id has been captured (no id fallback).
+    // Resolution chose `mac`; use its `MachineBootInterface` when known, or
+    // `BootInterfaceTarget::MacOnly` when no `interface_id` has been captured.
     let target_for = |mac: MacAddress, pair: Option<MachineBootInterface>| -> BootInterfaceTarget {
         pair.map_or(BootInterfaceTarget::MacOnly(mac), BootInterfaceTarget::Pair)
     };

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -255,9 +255,9 @@ async fn set_primary_interface_core(
 
     txn.rollback().await?;
 
-    // Set the boot device. The new primary interface row already stores its
-    // Redfish interface id, so send the complete (MAC + id) pair when present,
-    // allowing for interface ID fallback (and target the MAC alone otherwise).
+    // The new primary row already stores `boot_interface_id`, so give
+    // `libredfish` both identifiers as one target. Rows without an ID still
+    // target the MAC alone.
     let boot_target = match boot_interface_id {
         Some(interface_id) => BootInterfaceTarget::Pair(MachineBootInterface {
             mac_address: primary_interface_mac_address,

--- a/crates/api-model/src/machine_boot_interface.rs
+++ b/crates/api-model/src/machine_boot_interface.rs
@@ -23,14 +23,13 @@ use serde::{Deserialize, Serialize};
 ///
 /// Both fields are always present: a `MachineBootInterface` is only ever
 /// constructed from a fully-populated pair, captured while the MAC was still
-/// reported by Redfish. Carrying both identifiers is what makes boot-interface
-/// operations resilient -- callers target the MAC first and fall back to the
-/// [stable] `interface_id`, so the boot interface stays addressable even if one
-/// identifier becomes unavailable. That happens, for example, after a BlueField
-/// operating-mode flip from DPU to NIC: some vendor BIOSes stop probing the
-/// adapter and the MAC drops out of `NetworkDeviceFunctions` /
-/// `EthernetInterfaces` / `NetworkAdapters`, leaving the `interface_id` as the
-/// reliable handle.
+/// reported by Redfish. When this complete pair is available, boot-interface
+/// callers pass both identifiers to `libredfish` as one `BootInterfaceRef::Pair`;
+/// callers without an `interface_id` target the MAC alone. This allows each
+/// vendor to use the identifier its implementation expects. Dell uses
+/// `interface_id` directly, which keeps the boot interface addressable after a
+/// BlueField operating-mode flip removes its MAC from `NetworkDeviceFunctions`,
+/// `EthernetInterfaces`, and `NetworkAdapters`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct MachineBootInterface {

--- a/crates/api-web/src/explored_endpoint.rs
+++ b/crates/api-web/src/explored_endpoint.rs
@@ -1234,9 +1234,8 @@ pub async fn set_dpu_first_boot_order(
 /// interface the same way every other flow does -- the owning machine's
 /// designated interface (`primary_interface` + its captured Redfish interface
 /// id) once a machine owns this endpoint, or site-explorer's automatic default
-/// for a not-yet-managed endpoint -- and set it boot-first via the usual
-/// MAC-first / interface-id fallback. One click to put the BMC's boot order
-/// back in line with what Carbide would target.
+/// for a not-yet-managed endpoint. One click puts the BMC's boot order back in
+/// line with what Carbide would target.
 pub async fn restore_boot_interface(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,

--- a/crates/machine-controller/src/boot_interface.rs
+++ b/crates/machine-controller/src/boot_interface.rs
@@ -25,10 +25,10 @@ use model::predicted_machine_interface::PredictedMachineInterface;
 /// Resolve how to target this host's boot interface for Redfish setup calls.
 ///
 /// The host's own `machine_interface` row wins the moment it exists: when that
-/// row has a captured Redfish interface id, the full pair is returned (enabling
-/// the MAC-first / interface-id fallback); otherwise it targets the MAC alone.
-/// Both come from the same row, so the pair can never name a different interface
-/// than the MAC.
+/// row has a captured `boot_interface_id`, the full pair is supplied to
+/// `libredfish` in one operation; otherwise the target contains only the MAC.
+/// Both identifiers come from the same row, so the pair cannot name a different
+/// interface than the MAC.
 ///
 /// Before that first DHCP lease creates a row -- the window a zero-DPU or
 /// NIC-mode host sits in, since it gets no primary row at ingestion -- the host's

--- a/crates/redfish/src/boot_interface.rs
+++ b/crates/redfish/src/boot_interface.rs
@@ -14,8 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//! Helpers for running boot-interface-targeted Redfish operations with a
-//! MAC-first / interface-id-fallback strategy.
+//! Helpers for running boot-interface-targeted Redfish operations.
 
 use std::future::Future;
 
@@ -26,22 +25,21 @@ use model::machine_boot_interface::MachineBootInterface;
 /// How to target a host's boot interface for a Redfish setup operation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BootInterfaceTarget {
-    /// A fully-captured boot interface (MAC + Redfish interface id). The MAC is
-    /// tried first; on failure the [stable] interface id is used as a fallback
-    /// (see [`with_boot_interface_fallback`]). Carrying both keeps the boot
-    /// interface addressable even when the MAC is no longer resolvable in
-    /// Redfish.
+    /// A fully captured boot interface (MAC + Redfish `interface_id`). Core
+    /// supplies both identifiers to `libredfish` as one
+    /// [`BootInterfaceRef::Pair`], allowing each vendor to use its native
+    /// identifier.
     Pair(MachineBootInterface),
     /// Only a MAC is known -- the boot interface has never been captured with an
-    /// interface id (e.g. a host last explored before id capture, or never
-    /// reported with a resolvable interface id). No id fallback is possible.
+    /// `interface_id` (e.g. a host last explored before id capture, or never
+    /// reported with a resolvable `interface_id`).
     MacOnly(MacAddress),
 }
 
 impl BootInterfaceTarget {
     /// Runs `op` against this boot interface. For [`BootInterfaceTarget::Pair`]
-    /// the MAC is tried first and the interface id is used as a fallback; for
-    /// [`BootInterfaceTarget::MacOnly`] only the MAC is attempted.
+    /// both identifiers are supplied in one call; for
+    /// [`BootInterfaceTarget::MacOnly`] only the MAC is supplied.
     ///
     /// `op` is invoked with a [`BootInterfaceRef`] and should call the desired
     /// Redfish trait method with it, e.g.
@@ -49,16 +47,15 @@ impl BootInterfaceTarget {
     /// `|bi| client.is_bios_setup(Some(bi))`.
     pub async fn run<'s, T, F, Fut>(&'s self, op: F) -> Result<T, RedfishError>
     where
-        F: Fn(BootInterfaceRef<'s>) -> Fut,
+        F: FnOnce(BootInterfaceRef<'s>) -> Fut,
         Fut: Future<Output = Result<T, RedfishError>>,
     {
         match self {
             BootInterfaceTarget::Pair(boot_interface) => {
-                with_boot_interface_fallback(
-                    boot_interface.mac_address,
-                    &boot_interface.interface_id,
-                    op,
-                )
+                op(BootInterfaceRef::Pair {
+                    mac_address: boot_interface.mac_address,
+                    interface_id: &boot_interface.interface_id,
+                })
                 .await
             }
             BootInterfaceTarget::MacOnly(mac) => op(BootInterfaceRef::Mac(*mac)).await,
@@ -74,46 +71,6 @@ impl BootInterfaceTarget {
     }
 }
 
-/// Runs a Redfish operation that targets a host's boot interface, trying the
-/// MAC first and falling back to the [stable] vendor-native Redfish interface
-/// id if the MAC attempt fails.
-///
-/// `op` is invoked with a [`BootInterfaceRef`] and should call the desired
-/// Redfish trait method with it (e.g. `|bi| client.set_boot_order_dpu_first(bi)`
-/// or `|bi| client.is_bios_setup(Some(bi))`).
-///
-/// The fallback is deliberately *not* gated on a specific error variant: a MAC
-/// that can no longer be mapped to an interface surfaces as a vendor-specific /
-/// generic Redfish error (e.g. Dell's "could not find network device function
-/// for ..."), so pattern-matching it would be brittle across vendors. Retrying
-/// with the interface id is safe -- the MAC lookup fails before any mutation --
-/// and the id is the canonical Redfish-standard resolver
-/// (`Systems/{}/EthernetInterfaces/{id}`), so it is also the attempt most likely
-/// to succeed. In particular it covers the case where the MAC has dropped out of
-/// Redfish entirely (e.g. after a BlueField operating-mode flip from DPU to NIC),
-/// where the MAC-keyed calls can no longer locate the interface.
-pub async fn with_boot_interface_fallback<'a, T, F, Fut>(
-    mac_address: MacAddress,
-    interface_id: &'a str,
-    op: F,
-) -> Result<T, RedfishError>
-where
-    F: Fn(BootInterfaceRef<'a>) -> Fut,
-    Fut: Future<Output = Result<T, RedfishError>>,
-{
-    match op(BootInterfaceRef::Mac(mac_address)).await {
-        Ok(value) => Ok(value),
-        Err(mac_error) => {
-            tracing::warn!(
-                error = %mac_error,
-                %interface_id,
-                "boot-interface Redfish operation failed targeting the MAC; retrying by interface id"
-            );
-            op(BootInterfaceRef::InterfaceId(interface_id)).await
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -125,64 +82,33 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fallback_retries_by_interface_id_when_mac_fails() {
+    async fn pair_target_runs_once_when_operation_fails() {
         let attempts = AtomicUsize::new(0);
-        let result: Result<&str, RedfishError> =
-            with_boot_interface_fallback(mac(), "NIC.Slot.7-1-1", |bi| {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                async move {
-                    match bi {
-                        // Simulate a MAC that no longer resolves to an interface.
-                        BootInterfaceRef::Mac(_) => Err(RedfishError::NoContent),
-                        BootInterfaceRef::InterfaceId(id) => {
-                            assert_eq!(id, "NIC.Slot.7-1-1");
-                            Ok("recovered")
-                        }
-                    }
-                }
-            })
-            .await;
-
-        assert_eq!(result.unwrap(), "recovered");
-        assert_eq!(
-            attempts.load(Ordering::SeqCst),
-            2,
-            "should try the MAC first, then fall back to the interface id"
-        );
-    }
-
-    #[tokio::test]
-    async fn fallback_does_not_retry_when_mac_succeeds() {
-        let attempts = AtomicUsize::new(0);
-        let result: Result<&str, RedfishError> =
-            with_boot_interface_fallback(mac(), "NIC.Slot.7-1-1", |bi| {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                async move {
-                    assert!(matches!(bi, BootInterfaceRef::Mac(_)));
-                    Ok("ok")
-                }
-            })
-            .await;
-
-        assert_eq!(result.unwrap(), "ok");
-        assert_eq!(attempts.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn pair_target_runs_with_fallback() {
         let target = BootInterfaceTarget::Pair(MachineBootInterface {
             mac_address: mac(),
             interface_id: "NIC.Slot.7-1-1".to_string(),
         });
-        let result: Result<bool, RedfishError> = target
-            .run(|bi| async move {
-                match bi {
-                    BootInterfaceRef::Mac(_) => Err(RedfishError::NoContent),
-                    BootInterfaceRef::InterfaceId(_) => Ok(true),
+        let result: Result<(), RedfishError> = target
+            .run(|boot_interface| {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    match boot_interface {
+                        BootInterfaceRef::Pair {
+                            mac_address,
+                            interface_id,
+                        } => {
+                            assert_eq!(mac_address, mac());
+                            assert_eq!(interface_id, "NIC.Slot.7-1-1");
+                        }
+                        _ => panic!("paired target must supply both identifiers"),
+                    }
+                    Err(RedfishError::NoContent)
                 }
             })
             .await;
-        assert!(result.unwrap());
+
+        assert!(matches!(result, Err(RedfishError::NoContent)));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -434,10 +434,15 @@ impl RedfishSimActions {
 
 /// Stringifies a [`libredfish::BootInterfaceRef`] for recording in
 /// [`RedfishSimAction`], so tests can assert on the targeted boot interface
-/// regardless of which variant was used.
+/// regardless of which variant was used. Paired targets use their MAC because
+/// the simulator action fields and existing assertions model boot-interface
+/// targets as MAC strings.
 fn boot_interface_ref_to_string(boot_interface: libredfish::BootInterfaceRef<'_>) -> String {
     match boot_interface {
-        libredfish::BootInterfaceRef::Mac(mac) => mac.to_string(),
+        libredfish::BootInterfaceRef::Mac(mac)
+        | libredfish::BootInterfaceRef::Pair {
+            mac_address: mac, ..
+        } => mac.to_string(),
         libredfish::BootInterfaceRef::InterfaceId(id) => id.to_string(),
     }
 }

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -524,7 +524,7 @@ impl RedfishClient {
             .map_err(map_redfish_client_creation_error)?;
 
         // We will be redoing machine_setup later and can worry about getting the profile right then.
-        // Bind the empty profiles outside the fallback closure so they outlive both attempts.
+        // Keep `empty_profiles` outside the closure so the returned future can borrow it.
         let empty_profiles: libredfish::BiosProfileVendor = HashMap::default();
         let result = match boot_interface {
             Some(target) => {


### PR DESCRIPTION
A complete `MachineBootInterface` was being split into a MAC operation and an interface-ID retry after any error. That could repeat mutations and made Core decide which identifier each vendor should use.

So, this bumps `libredfish` to `v0.45.0` and passes the MAC and interface ID together as one `BootInterfaceRef::Pair`. Each vendor can use the identifier its implementation expects, while `BootInterfaceTarget::MacOnly` still handles interfaces whose ID has not been captured.

`BootInterfaceTarget::run` now accepts its operation as `FnOnce`, and the error-path test proves a paired target invokes it once with both identifiers.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4008.

Part of https://github.com/NVIDIA/infra-controller/issues/2660.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The branch passed the full local formatting, lint, and dependency gates before the rebase. Those full-workspace checks required temporarily applying the `StaticMachineEndpoint::id` fixture correction that later merged in #4030; that unrelated edit was never committed. After rebasing onto the repaired `main`, the focused tests and affected call-site compile checks passed again.

```text
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
cargo make check-workspace-deps
cargo make check-licenses
cargo make check-bans
cargo check --locked -p carbide-redfish --all-targets --features test-support
cargo check --locked -p carbide-api-core -p carbide-machine-controller -p carbide-site-explorer -p carbide-api-web
cargo test --locked -p carbide-redfish --lib --features test-support boot_interface::tests -- --nocapture
git diff --check
```

## Additional Notes

This intentionally leaves Site Explorer's periodic MAC-only setup observation unchanged. Persisting a target-correlated observation across `libredfish`, `NvRedfish`, and `CompareResult` remains the next separate #2660 child so its data contract and backend behavior can be reviewed together.

Closes #4008
