### PR TITLE
fix(pxe): Make ovs port moves tolerant to OVS failures

### DIFF
--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -660,6 +660,13 @@ mod tests {
             )
             .unwrap();
 
+        // Verify unavailable representors do not abort the remaining cloud-init work.
+        assert!(rendered.contains(
+            r#"set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}' || true"#
+        ));
+        assert!(rendered.contains(
+            r#"ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport) || true"#
+        ));
         assert!(rendered.contains("ovs-vsctl get bridge br-sfc external_ids"));
         assert!(rendered.contains("ovs-vsctl --may-exist add-port br-sfc"));
         assert!(rendered.contains(

--- a/pxe/templates/user-data
+++ b/pxe/templates/user-data
@@ -621,11 +621,12 @@ write_files:
           # Adjust the sfc.conf to insert our patch port where the host representor used to be
           sed -i "s#{{ forge_hbn_bridge }}~${host_representor}~${host_representor}_if_r~${host_representor}_if~${host_representor}_if_r#{{ forge_hbn_bridge }}~${host_intercept_hbn_port}~${host_representor}_if_r~${host_representor}_if~${host_representor}_if_r#" /etc/mellanox/sfc.conf
 
+          # Keep the OVSDB move when its backing host PF/VF is not available yet.
           # Now pop the host representor off of br-hbn and attach it to the host intercept bridge
           ovs-vsctl --if-exists del-port "${host_representor}" -- \
             --may-exist add-port "${host_intercept_bridge_name}" "${host_representor}" -- \
-            set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}'
-          ovs-vsctl set interface "${host_representor}" ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport)
+            set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}' || true
+          ovs-vsctl set interface "${host_representor}" ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport) || true
 
           # Add the detail about the "uplink" for this bridge to external ids for the bridge
           ovs-vsctl br-set-external-id "${host_intercept_bridge_name}" bridge-uplink "${host_intercept_bridge_port}"


### PR DESCRIPTION
Allow DPU provisioning to continue when a host VF representor has not materialized yet.

OVS configuration and ofport_request synchronization are still attempted normally, preserving the working PF path, while expected transient failures no longer terminate cloud-init before service restart and Scout execution

## Related issues

https://github.com/NVIDIA/infra-controller/issues/4028

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Closes https://github.com/NVIDIA/infra-controller/issues/4028

