### PR TITLE
feat(rack): count dropped BMS DSX commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2761,6 +2761,7 @@ dependencies = [
  "carbide-api-db",
  "carbide-api-model",
  "carbide-health-report",
+ "carbide-instrument",
  "carbide-mqtt-common",
  "carbide-secrets",
  "carbide-test-support",

--- a/crates/rack/Cargo.toml
+++ b/crates/rack/Cargo.toml
@@ -30,6 +30,7 @@ bms-dsx-exchange = { path = "../bms-dsx-exchange", default-features = false }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
 carbide-health-report = { path = "../health-report", default-features = false }
+carbide-instrument = { path = "../instrument" }
 carbide-mqtt-common = { path = "../mqtt-common", default-features = false }
 carbide-secrets = { path = "../secrets", default-features = false }
 carbide-uuid = { path = "../uuid", default-features = false }
@@ -52,6 +53,7 @@ tokio-util = { workspace = true }
 tonic = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
 
 [lints]

--- a/crates/rack/src/bms_client.rs
+++ b/crates/rack/src/bms_client.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bms_dsx_exchange::{BmsDsxExchangePublisher, Publication, PublisherConfig, SourceUpdate};
+use carbide_instrument::{Event, LabelValue, emit};
 use carbide_mqtt_common::hook::MqttPublisher;
 use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
 use carbide_uuid::rack::RackId;
@@ -58,6 +59,38 @@ impl RawMessageType for BmsMetadataMessage {
 enum Command {
     Metadata { topic: String, payload: Vec<u8> },
     SourceUpdate(SourceUpdate),
+}
+
+impl Command {
+    fn kind(&self) -> CommandKind {
+        match self {
+            Self::Metadata { .. } => CommandKind::Metadata,
+            Self::SourceUpdate(_) => CommandKind::SourceUpdate,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum CommandKind {
+    Metadata,
+    SourceUpdate,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "bms_dsx_exchange_command_dropped",
+    metric_name = "carbide_bms_dsx_commands_dropped_total",
+    component = "carbide-rack",
+    log = warn,
+    metric = counter,
+    message = "BMS DSX Exchange command dropped because the worker stopped",
+    describe = "Number of BMS DSX Exchange commands dropped because the worker stopped, by command kind."
+)]
+struct BmsDsxExchangeCommandDropped {
+    #[label]
+    command_kind: CommandKind,
+    #[context]
+    error: String,
 }
 
 pub struct BmsDsxExchangeHandle {
@@ -123,11 +156,12 @@ impl BmsDsxExchangeHandle {
     }
 
     async fn send(&self, command: Command) {
+        let command_kind = command.kind();
         if let Err(error) = self.sender.send(command).await {
-            tracing::warn!(
-                ?error,
-                "BMS DSX Exchange command dropped because the worker stopped"
-            );
+            emit(BmsDsxExchangeCommandDropped {
+                command_kind,
+                error: format!("{error:?}"),
+            });
         }
     }
 
@@ -277,6 +311,8 @@ async fn seed_current_rack_state(
 mod tests {
     use std::sync::Arc;
 
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::value_scenarios;
     use carbide_uuid::rack::RackId;
     use mqttea::MqtteaClientError;
     use opentelemetry::global;
@@ -285,6 +321,8 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::*;
+
+    const DROPPED_COMMAND_METRIC: &str = "carbide_bms_dsx_commands_dropped_total";
 
     #[derive(Default)]
     struct RecordingPublisher {
@@ -420,6 +458,134 @@ mod tests {
     async fn shutdown(mut join_set: JoinSet<()>, cancel_token: CancellationToken) {
         cancel_token.cancel();
         while join_set.join_next().await.is_some() {}
+    }
+
+    #[derive(Debug)]
+    enum DroppedCommandCase {
+        Metadata,
+        SourceUpdate,
+        RackLeakState,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct DroppedCommandObservation {
+        log_count: usize,
+        command_kinds: Vec<String>,
+        metadata_count: f64,
+        source_update_count: f64,
+    }
+
+    #[test]
+    fn commands_dropped_after_the_worker_stops_log_and_count_by_kind() {
+        value_scenarios!(
+            run = |case| {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("test runtime");
+                let (sender, receiver) = mpsc::channel(1);
+                drop(receiver);
+                let handle = BmsDsxExchangeHandle { sender };
+                let metrics = MetricsCapture::start();
+
+                let logs: Vec<_> = capture_logs(|| {
+                    runtime.block_on(async {
+                        match case {
+                            DroppedCommandCase::Metadata => {
+                                handle
+                                    .handle_metadata(
+                                        "BMS/v1/PUB/Metadata/private-topic".to_string(),
+                                        b"private payload".to_vec(),
+                                    )
+                                    .await;
+                            }
+                            DroppedCommandCase::SourceUpdate => {
+                                handle
+                                    .send(Command::SourceUpdate(
+                                        SourceUpdate::liquid_isolation_request(
+                                            "private-rack".to_string(),
+                                            true,
+                                        ),
+                                    ))
+                                    .await;
+                            }
+                            DroppedCommandCase::RackLeakState => {
+                                handle
+                                    .set_rack_leak_state(&RackId::new("private-rack"), true)
+                                    .await;
+                            }
+                        }
+                    });
+                })
+                .into_iter()
+                .filter(|log| log.metadata_name == "bms_dsx_exchange_command_dropped")
+                .collect();
+
+                for log in &logs {
+                    assert_eq!(log.level, tracing::Level::WARN);
+                    assert_eq!(
+                        log.metadata_name,
+                        "bms_dsx_exchange_command_dropped"
+                    );
+                    assert_eq!(
+                        log.message,
+                        "BMS DSX Exchange command dropped because the worker stopped"
+                    );
+                    assert_eq!(
+                        log.field("event_name"),
+                        Some("bms_dsx_exchange_command_dropped")
+                    );
+                    assert_eq!(log.field("metric_name"), Some(DROPPED_COMMAND_METRIC));
+                    assert_eq!(log.field("error"), Some("SendError { .. }"));
+                    for private_field in ["topic", "payload", "rack_id", "source_update"] {
+                        assert_eq!(log.field(private_field), None);
+                    }
+                }
+
+                DroppedCommandObservation {
+                    log_count: logs.len(),
+                    command_kinds: logs
+                        .iter()
+                        .map(|log| {
+                            log.field("command_kind")
+                                .expect("dropped command kind")
+                                .to_string()
+                        })
+                        .collect(),
+                    metadata_count: metrics
+                        .counter_delta(DROPPED_COMMAND_METRIC, &[("command_kind", "metadata")]),
+                    source_update_count: metrics.counter_delta(
+                        DROPPED_COMMAND_METRIC,
+                        &[("command_kind", "source_update")],
+                    ),
+                }
+            };
+            "one command is dropped" {
+                DroppedCommandCase::Metadata => DroppedCommandObservation {
+                    log_count: 1,
+                    command_kinds: vec!["metadata".to_string()],
+                    metadata_count: 1.0,
+                    source_update_count: 0.0,
+                },
+                DroppedCommandCase::SourceUpdate => DroppedCommandObservation {
+                    log_count: 1,
+                    command_kinds: vec!["source_update".to_string()],
+                    metadata_count: 0.0,
+                    source_update_count: 1.0,
+                },
+            }
+            "`set_rack_leak_state` drops both isolation requests" {
+                DroppedCommandCase::RackLeakState => DroppedCommandObservation {
+                    log_count: 2,
+                    command_kinds: vec![
+                        "source_update".to_string(),
+                        "source_update".to_string(),
+                    ],
+                    metadata_count: 0.0,
+                    source_update_count: 2.0,
+                },
+            }
+        );
     }
 
     #[test]

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -38,6 +38,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_bmc_proxy_tls_connection_success_total</td><td>counter</td><td>Number of successful TLS connections</td></tr>
 <tr><td>carbide_bmc_proxy_upstream_request_duration_milliseconds</td><td>histogram</td><td>Duration of requests the proxy forwarded to BMCs, by HTTP method and upstream status class; the _count series, split by status, gives the request and outcome rates.</td></tr>
 <tr><td>carbide_bmc_session_lockout_breaker_transitions_total</td><td>counter</td><td>Number of BMC session lockout-avoidance breaker transitions.</td></tr>
+<tr><td>carbide_bms_dsx_commands_dropped_total</td><td>counter</td><td>Number of BMS DSX Exchange commands dropped because the worker stopped, by command kind.</td></tr>
 <tr><td>carbide_certs_renewals_total</td><td>counter</td><td>Number of client certificate renewal attempts, by outcome</td></tr>
 <tr><td>carbide_client_tcp_connect_attempts_total</td><td>counter</td><td>Number of outbound TCP connect attempts across all HTTP connectors</td></tr>
 <tr><td>carbide_client_tcp_connect_errors_total</td><td>counter</td><td>Number of failed outbound TCP connect attempts across all HTTP connectors</td></tr>


### PR DESCRIPTION
Once the BMS DSX worker's receiver stops, commands sent through `BmsDsxExchangeHandle` disappear before the broker-side publish metrics can see them. So, the existing warning now comes from an `Event` backed by `carbide_bms_dsx_commands_dropped_total`, with a closed `command_kind` label separating metadata from source updates.

Key updates include:

- The WARN message, `SendError` Debug rendering, and best-effort API behavior stay intact.
- Topics, payloads, rack IDs, and source-update contents never enter the metric or log record.
- Table-driven tests cover both command kinds and the two-command `set_rack_leak_state` path.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4018

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-rack --lib`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo xtask check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

The metric unit is commands, so one failed `set_rack_leak_state` call records two `source_update` drops. `docs/observability/core_metrics.md` is the generated metric catalogue and stays with the code change.

Closes #4018
