### PR TITLE
feat(api-core): count BMC session cleanup failures

### DIFF
--- a/crates/api-core/src/credentials/bmc_session_manager.rs
+++ b/crates/api-core/src/credentials/bmc_session_manager.rs
@@ -170,6 +170,109 @@ impl fmt::Debug for BmcAuthMaterial {
     }
 }
 
+/// Which best-effort BMC session cleanup step failed.
+///
+/// `operation` is the only metric label. BMCs, callers, sessions, and errors
+/// stay on the log record instead of creating a new series for each failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+enum BmcSessionCleanupOperation {
+    RevokePriorSession,
+    ListSessionsForRevoke,
+    RevokeUnpersistedSession,
+    DeleteSessionRows,
+}
+
+/// The prior session was still present on the BMC, but its revoke failed.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "bmc_session_prior_revoke_failed",
+    metric_name = "carbide_bmc_session_cleanup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "failed to revoke prior BMC session; continuing with new session creation",
+    describe = "Number of BMC session cleanup failures, by operation."
+)]
+struct BmcSessionPriorRevokeFailed {
+    #[label]
+    operation: BmcSessionCleanupOperation,
+    #[context]
+    bmc_mac_address: MacAddress,
+    #[context(value)]
+    spiffe_service_id: String,
+    #[context]
+    session: ODataId,
+    #[context]
+    error: String,
+}
+
+/// The BMC session collection could not be listed before the prior revoke.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "bmc_session_prior_revoke_list_failed",
+    metric_name = "carbide_bmc_session_cleanup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "failed to list BMC sessions for prior-session revoke; continuing",
+    describe = "Number of BMC session cleanup failures, by operation."
+)]
+struct BmcSessionPriorRevokeListFailed {
+    #[label]
+    operation: BmcSessionCleanupOperation,
+    #[context]
+    bmc_mac_address: MacAddress,
+    #[context(value)]
+    spiffe_service_id: String,
+    #[context]
+    error: String,
+}
+
+/// Session metadata could not be stored, and rolling back the new BMC session
+/// failed too.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "bmc_session_unpersisted_revoke_failed",
+    metric_name = "carbide_bmc_session_cleanup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "failed to revoke just-created session after store upsert failed; it will leak until BMC idle timeout",
+    describe = "Number of BMC session cleanup failures, by operation."
+)]
+struct BmcSessionUnpersistedRevokeFailed {
+    #[label]
+    operation: BmcSessionCleanupOperation,
+    #[context]
+    bmc_mac_address: MacAddress,
+    #[context(value)]
+    spiffe_service_id: String,
+    #[context]
+    session: ODataId,
+    #[context]
+    error: String,
+}
+
+/// `flush_mac` could not delete the persisted session rows for a BMC.
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "bmc_session_store_flush_failed",
+    metric_name = "carbide_bmc_session_cleanup_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = "failed to delete BMC session rows during flush_mac; continuing",
+    describe = "Number of BMC session cleanup failures, by operation."
+)]
+struct BmcSessionStoreFlushFailed {
+    #[label]
+    operation: BmcSessionCleanupOperation,
+    #[context]
+    bmc_mac_address: MacAddress,
+    #[context]
+    error: String,
+}
+
 /// The actual lockout-avoidance state change, as the bounded `transition`
 /// label shared by the trip and clear Events below.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
@@ -418,14 +521,13 @@ impl BmcSessionManager {
                         .find(|m| m.raw().odata_id() == &prior_id)
                     {
                         if let Err(err) = prior_session.delete().await {
-                            tracing::warn!(
-                                error = ?err,
-                                bmc_mac_address = %bmc_mac,
-                                spiffe_service_id,
-                                session = %prior_id,
-                                "failed to revoke prior BMC session; \
-                                 continuing with new session creation"
-                            );
+                            carbide_instrument::emit(BmcSessionPriorRevokeFailed {
+                                operation: BmcSessionCleanupOperation::RevokePriorSession,
+                                bmc_mac_address: bmc_mac,
+                                spiffe_service_id: spiffe_service_id.to_owned(),
+                                session: prior_id,
+                                error: format!("{err:?}"),
+                            });
                         }
                     } else {
                         tracing::info!(
@@ -438,12 +540,12 @@ impl BmcSessionManager {
                     }
                 }
                 Err(err) => {
-                    tracing::warn!(
-                        error = ?err,
-                        bmc_mac_address = %bmc_mac,
-                        spiffe_service_id,
-                        "failed to list BMC sessions for prior-session revoke; continuing"
-                    );
+                    carbide_instrument::emit(BmcSessionPriorRevokeListFailed {
+                        operation: BmcSessionCleanupOperation::ListSessionsForRevoke,
+                        bmc_mac_address: bmc_mac,
+                        spiffe_service_id: spiffe_service_id.to_owned(),
+                        error: format!("{err:?}"),
+                    });
                 }
             }
         }
@@ -478,14 +580,13 @@ impl BmcSessionManager {
             .await
         {
             if let Err(revoke_err) = created.delete().await {
-                tracing::warn!(
-                    error = ?revoke_err,
-                    bmc_mac_address = %bmc_mac,
-                    spiffe_service_id,
-                    session = %location,
-                    "failed to revoke just-created session after store upsert failed; \
-                     it will leak until BMC idle timeout"
-                );
+                carbide_instrument::emit(BmcSessionUnpersistedRevokeFailed {
+                    operation: BmcSessionCleanupOperation::RevokeUnpersistedSession,
+                    bmc_mac_address: bmc_mac,
+                    spiffe_service_id: spiffe_service_id.to_owned(),
+                    session: location,
+                    error: format!("{revoke_err:?}"),
+                });
             }
             return Err(store_err);
         }
@@ -555,11 +656,11 @@ impl BmcSessionManager {
     /// Drop all session rows for `bmc_mac` and clear any lockout state.
     pub async fn flush_mac(&self, bmc_mac: MacAddress) {
         if let Err(err) = self.store.delete_by_mac(bmc_mac).await {
-            tracing::warn!(
-                error = %err,
-                bmc_mac_address = %bmc_mac,
-                "failed to delete BMC session rows during flush_mac; continuing"
-            );
+            carbide_instrument::emit(BmcSessionStoreFlushFailed {
+                operation: BmcSessionCleanupOperation::DeleteSessionRows,
+                bmc_mac_address: bmc_mac,
+                error: err.to_string(),
+            });
         }
         self.clear_lockout(bmc_mac).await;
         self.clear_no_session_service(bmc_mac).await;
@@ -699,18 +800,23 @@ mod tests {
         Credentials,
     };
     use carbide_secrets::test_support::credentials::TestCredentialManager;
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::{Check, check_values, value_scenarios};
     use mac_address::MacAddress;
     use sqlx::types::chrono::Utc;
     use tokio::sync::Mutex;
 
-    use super::{BmcSessionError, BmcSessionManager, BmcSessionStore, StoredSession};
+    use super::{
+        BmcSessionCleanupOperation, BmcSessionError, BmcSessionManager,
+        BmcSessionPriorRevokeFailed, BmcSessionPriorRevokeListFailed, BmcSessionStore,
+        BmcSessionStoreFlushFailed, BmcSessionUnpersistedRevokeFailed, StoredSession,
+    };
 
     fn mac(byte: u8) -> MacAddress {
         MacAddress::from([byte, 0, 0, 0, 0, 1])
     }
 
     const TEST_LOCKOUT_THRESHOLD: u32 = 3;
+    const CLEANUP_FAILURE_METRIC: &str = "carbide_bmc_session_cleanup_failures_total";
 
     #[derive(Default)]
     struct InMemoryBmcSessionStore {
@@ -759,6 +865,34 @@ mod tests {
         async fn delete_by_mac(&self, bmc_mac: MacAddress) -> Result<(), BmcSessionError> {
             self.rows.lock().await.retain(|(_, m), _| *m != bmc_mac);
             Ok(())
+        }
+    }
+
+    struct DeleteFailingBmcSessionStore;
+
+    #[async_trait]
+    impl BmcSessionStore for DeleteFailingBmcSessionStore {
+        async fn get(
+            &self,
+            _spiffe_service_id: &str,
+            _bmc_mac: MacAddress,
+        ) -> Result<Option<StoredSession>, BmcSessionError> {
+            Ok(None)
+        }
+
+        async fn upsert(
+            &self,
+            _spiffe_service_id: &str,
+            _bmc_mac: MacAddress,
+            _session_odata_id: &str,
+        ) -> Result<(), BmcSessionError> {
+            Ok(())
+        }
+
+        async fn delete_by_mac(&self, _bmc_mac: MacAddress) -> Result<(), BmcSessionError> {
+            Err(BmcSessionError::Store(
+                "injected session-row deletion failure".to_string(),
+            ))
         }
     }
 
@@ -835,6 +969,78 @@ mod tests {
         drop(rows);
         // lockout was cleared along with the rows.
         assert!(manager.check_not_locked_out(mac_a).await.is_none());
+    }
+
+    #[test]
+    fn flush_mac_counts_store_delete_failure_and_still_clears_cached_state() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime");
+        let bmc_proxy = Arc::new(ArcSwap::new(Arc::new(None)));
+        let redfish_pool = carbide_redfish::nv_redfish::new_pool(bmc_proxy);
+        let credential_manager =
+            Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
+                username: "root".to_string(),
+                password: "password".to_string(),
+            }));
+        let manager = Arc::new(BmcSessionManager::new(
+            redfish_pool,
+            credential_manager,
+            Arc::new(DeleteFailingBmcSessionStore),
+            TEST_LOCKOUT_THRESHOLD,
+            false,
+        ));
+        let bmc_mac = mac(0xAF);
+
+        runtime.block_on(async {
+            manager.force_trip_for_test(bmc_mac, 3, 401).await;
+            manager.no_session_service.lock().await.insert(bmc_mac);
+        });
+
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| runtime.block_on(manager.flush_mac(bmc_mac)));
+        let cleanup_logs = logs
+            .iter()
+            .filter(|log| log.field("metric_name") == Some(CLEANUP_FAILURE_METRIC))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            cleanup_logs.len(),
+            1,
+            "the injected store failure should emit one cleanup Event"
+        );
+        let log = cleanup_logs[0];
+        let bmc_mac_address = bmc_mac.to_string();
+        assert_eq!(log.level, tracing::Level::WARN);
+        assert_eq!(log.metadata_name, "bmc_session_store_flush_failed");
+        assert_eq!(
+            log.message,
+            "failed to delete BMC session rows during flush_mac; continuing"
+        );
+        assert_eq!(log.field("operation"), Some("delete_session_rows"));
+        assert_eq!(log.field("bmc_mac_address"), Some(bmc_mac_address.as_str()));
+        assert_eq!(
+            log.field("error"),
+            Some("BMC session store error: injected session-row deletion failure")
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                CLEANUP_FAILURE_METRIC,
+                &[("operation", "delete_session_rows")]
+            ),
+            1.0
+        );
+
+        runtime.block_on(async {
+            assert!(
+                manager.check_not_locked_out(bmc_mac).await.is_none(),
+                "`flush_mac` should clear the breaker after a store failure"
+            );
+            assert!(
+                !manager.no_session_service.lock().await.contains(&bmc_mac),
+                "`flush_mac` should clear the SessionService cache after a store failure"
+            );
+        });
     }
 
     #[tokio::test]
@@ -1171,6 +1377,177 @@ mod tests {
         assert!(
             follow_up.is_none(),
             "second AvoidLockout should not be emitted from record_unauthorized"
+        );
+    }
+
+    const TEST_SPIFFE_SERVICE_ID: &str = "spiffe://example.test/service";
+    const TEST_SESSION_ID: &str = "/redfish/v1/SessionService/Sessions/42";
+
+    #[derive(Debug)]
+    enum CleanupFailureCase {
+        RevokePriorSession,
+        ListSessionsForRevoke,
+        RevokeUnpersistedSession,
+        DeleteSessionRows,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct CleanupFailureObservation {
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        operation: Option<String>,
+        bmc_mac_address: Option<String>,
+        spiffe_service_id: Option<String>,
+        session: Option<String>,
+        error: Option<String>,
+        spiffe_service_id_kind: Option<CapturedFieldKind>,
+        error_kind: Option<CapturedFieldKind>,
+        counter_delta: f64,
+    }
+
+    fn observe_cleanup_failure(case: CleanupFailureCase) -> CleanupFailureObservation {
+        let bmc_mac = mac(0xBC);
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| match case {
+            CleanupFailureCase::RevokePriorSession => {
+                carbide_instrument::emit(BmcSessionPriorRevokeFailed {
+                    operation: BmcSessionCleanupOperation::RevokePriorSession,
+                    bmc_mac_address: bmc_mac,
+                    spiffe_service_id: TEST_SPIFFE_SERVICE_ID.to_string(),
+                    session: nv_redfish::core::ODataId::from(TEST_SESSION_ID.to_string()),
+                    error: "DeleteError { status: 500 }".to_string(),
+                });
+            }
+            CleanupFailureCase::ListSessionsForRevoke => {
+                carbide_instrument::emit(BmcSessionPriorRevokeListFailed {
+                    operation: BmcSessionCleanupOperation::ListSessionsForRevoke,
+                    bmc_mac_address: bmc_mac,
+                    spiffe_service_id: TEST_SPIFFE_SERVICE_ID.to_string(),
+                    error: "ListError { status: 503 }".to_string(),
+                });
+            }
+            CleanupFailureCase::RevokeUnpersistedSession => {
+                carbide_instrument::emit(BmcSessionUnpersistedRevokeFailed {
+                    operation: BmcSessionCleanupOperation::RevokeUnpersistedSession,
+                    bmc_mac_address: bmc_mac,
+                    spiffe_service_id: TEST_SPIFFE_SERVICE_ID.to_string(),
+                    session: nv_redfish::core::ODataId::from(TEST_SESSION_ID.to_string()),
+                    error: "DeleteError { status: 500 }".to_string(),
+                });
+            }
+            CleanupFailureCase::DeleteSessionRows => {
+                carbide_instrument::emit(BmcSessionStoreFlushFailed {
+                    operation: BmcSessionCleanupOperation::DeleteSessionRows,
+                    bmc_mac_address: bmc_mac,
+                    error: "BMC session store error: database unavailable".to_string(),
+                });
+            }
+        });
+        assert_eq!(
+            logs.len(),
+            1,
+            "each cleanup failure should write one record"
+        );
+        let log = logs.first().expect("cleanup failure Event did not log");
+        let operation = log.field("operation").map(str::to_string);
+
+        CleanupFailureObservation {
+            level: log.level,
+            metadata_name: log.metadata_name.clone(),
+            message: log.message.clone(),
+            event_name: log.field("event_name").map(str::to_string),
+            metric_name: log.field("metric_name").map(str::to_string),
+            operation: operation.clone(),
+            bmc_mac_address: log.field("bmc_mac_address").map(str::to_string),
+            spiffe_service_id: log.field("spiffe_service_id").map(str::to_string),
+            session: log.field("session").map(str::to_string),
+            error: log.field("error").map(str::to_string),
+            spiffe_service_id_kind: log.field_kind("spiffe_service_id"),
+            error_kind: log.field_kind("error"),
+            counter_delta: metrics.counter_delta(
+                CLEANUP_FAILURE_METRIC,
+                &[(
+                    "operation",
+                    operation
+                        .as_deref()
+                        .expect("cleanup failure Event should label its operation"),
+                )],
+            ),
+        }
+    }
+
+    fn expected_cleanup_failure(
+        event_name: &str,
+        message: &str,
+        operation: &str,
+        spiffe_service_id: Option<&str>,
+        session: Option<&str>,
+        error: &str,
+    ) -> CleanupFailureObservation {
+        CleanupFailureObservation {
+            level: tracing::Level::WARN,
+            metadata_name: event_name.to_string(),
+            message: message.to_string(),
+            event_name: Some(event_name.to_string()),
+            metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
+            operation: Some(operation.to_string()),
+            bmc_mac_address: Some(mac(0xBC).to_string()),
+            spiffe_service_id: spiffe_service_id.map(str::to_string),
+            session: session.map(str::to_string),
+            error: Some(error.to_string()),
+            spiffe_service_id_kind: spiffe_service_id.map(|_| CapturedFieldKind::String),
+            error_kind: Some(CapturedFieldKind::Debug),
+            counter_delta: 1.0,
+        }
+    }
+
+    #[test]
+    fn cleanup_failures_log_and_count_by_operation() {
+        value_scenarios!(
+            run = observe_cleanup_failure;
+            "prior session revoke fails" {
+                CleanupFailureCase::RevokePriorSession => expected_cleanup_failure(
+                    "bmc_session_prior_revoke_failed",
+                    "failed to revoke prior BMC session; continuing with new session creation",
+                    "revoke_prior_session",
+                    Some(TEST_SPIFFE_SERVICE_ID),
+                    Some(TEST_SESSION_ID),
+                    "DeleteError { status: 500 }",
+                ),
+            }
+            "session listing for prior revoke fails" {
+                CleanupFailureCase::ListSessionsForRevoke => expected_cleanup_failure(
+                    "bmc_session_prior_revoke_list_failed",
+                    "failed to list BMC sessions for prior-session revoke; continuing",
+                    "list_sessions_for_revoke",
+                    Some(TEST_SPIFFE_SERVICE_ID),
+                    None,
+                    "ListError { status: 503 }",
+                ),
+            }
+            "unpersisted session rollback revoke fails" {
+                CleanupFailureCase::RevokeUnpersistedSession => expected_cleanup_failure(
+                    "bmc_session_unpersisted_revoke_failed",
+                    "failed to revoke just-created session after store upsert failed; it will leak until BMC idle timeout",
+                    "revoke_unpersisted_session",
+                    Some(TEST_SPIFFE_SERVICE_ID),
+                    Some(TEST_SESSION_ID),
+                    "DeleteError { status: 500 }",
+                ),
+            }
+            "flush store deletion fails" {
+                CleanupFailureCase::DeleteSessionRows => expected_cleanup_failure(
+                    "bmc_session_store_flush_failed",
+                    "failed to delete BMC session rows during flush_mac; continuing",
+                    "delete_session_rows",
+                    None,
+                    None,
+                    "BMC session store error: database unavailable",
+                ),
+            }
         );
     }
 

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -37,6 +37,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_bmc_proxy_tls_connection_fail_total</td><td>counter</td><td>Number of failed inbound connections, by failure reason</td></tr>
 <tr><td>carbide_bmc_proxy_tls_connection_success_total</td><td>counter</td><td>Number of successful TLS connections</td></tr>
 <tr><td>carbide_bmc_proxy_upstream_request_duration_milliseconds</td><td>histogram</td><td>Duration of requests the proxy forwarded to BMCs, by HTTP method and upstream status class; the _count series, split by status, gives the request and outcome rates.</td></tr>
+<tr><td>carbide_bmc_session_cleanup_failures_total</td><td>counter</td><td>Number of BMC session cleanup failures, by operation.</td></tr>
 <tr><td>carbide_bmc_session_lockout_breaker_transitions_total</td><td>counter</td><td>Number of BMC session lockout-avoidance breaker transitions.</td></tr>
 <tr><td>carbide_certs_renewals_total</td><td>counter</td><td>Number of client certificate renewal attempts, by outcome</td></tr>
 <tr><td>carbide_client_tcp_connect_attempts_total</td><td>counter</td><td>Number of outbound TCP connect attempts across all HTTP connectors</td></tr>


### PR DESCRIPTION
The BMC session manager treats cleanup as best effort, so a failed revoke or session-row deletion can leave stale state behind while the caller continues. So, the four warning paths now emit `Event`s through `carbide_bmc_session_cleanup_failures_total`, with a closed `operation` label showing which cleanup step failed.

Key updates include:

- Every existing WARN message, field rendering, and continue/return decision stays intact.
- BMC MACs, SPIFFE IDs, session IDs, and errors remain log-only context, and this counter stays separate from the lockout-breaker metric.
- Table-driven coverage pins all four contracts, and the `flush_mac` test proves both caches are still cleared after store deletion fails.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4017

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-api-core credentials::bmc_session_manager::tests --lib`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`

## Additional Notes

`docs/observability/core_metrics.md` is the generated metric catalogue and stays with the code change.

Closes #4017
