### PR TITLE
fix(api-model): reject empty DPU provisioning sets

### DIFF
--- a/crates/api-model/src/bmc_info.rs
+++ b/crates/api-model/src/bmc_info.rs
@@ -108,6 +108,8 @@ impl FromStr for UserRoles {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     fn bmc_with_firmware(version: Option<&str>) -> BmcInfo {
@@ -118,27 +120,46 @@ mod tests {
     }
 
     #[test]
-    fn supports_bfb_install_bf4() {
-        // BF4 firmware is year-based (>= 26.x) and clears the 24.10 gate.
-        // In the real flow `dpu_bmc_version` strips the "bf4-" prefix, so the
-        // stored version is numeric; a raw "BF4-…" string works too.
-        assert!(bmc_with_firmware(Some("26.04-8")).supports_bfb_install());
-        assert!(bmc_with_firmware(Some("BF4-26.04-8")).supports_bfb_install());
-    }
-
-    #[test]
-    fn supports_bfb_install_bf3_gated_on_version() {
-        // BF3 firmware "BF-<ver>" is supported at/after 24.10.
-        assert!(bmc_with_firmware(Some("BF-25.10-9")).supports_bfb_install());
-        assert!(bmc_with_firmware(Some("BF-24.10-0")).supports_bfb_install());
-        // Already-stripped numeric form (as dpu_bmc_version returns) also works.
-        assert!(bmc_with_firmware(Some("25.10-9")).supports_bfb_install());
-        // Older BF3 firmware is not supported.
-        assert!(!bmc_with_firmware(Some("BF-24.04-1")).supports_bfb_install());
-    }
-
-    #[test]
-    fn supports_bfb_install_absent_firmware_is_false() {
-        assert!(!bmc_with_firmware(None).supports_bfb_install());
+    fn supports_bfb_install_firmware_matrix() {
+        check_values(
+            [
+                Check {
+                    scenario: "normalized BF4 firmware clears the minimum",
+                    input: Some("26.04-8"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "raw BF4 firmware clears the minimum",
+                    input: Some("BF4-26.04-8"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "newer raw BF3 firmware clears the minimum",
+                    input: Some("BF-25.10-9"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "BF3 firmware at the minimum is supported",
+                    input: Some("BF-24.10-0"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "normalized BF3 firmware clears the minimum",
+                    input: Some("25.10-9"),
+                    expect: true,
+                },
+                Check {
+                    scenario: "older BF3 firmware is unsupported",
+                    input: Some("BF-24.04-1"),
+                    expect: false,
+                },
+                Check {
+                    scenario: "absent firmware is unsupported",
+                    input: None,
+                    expect: false,
+                },
+            ],
+            |version| bmc_with_firmware(version).supports_bfb_install(),
+        );
     }
 }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1465,13 +1465,10 @@ impl NextStateBFBSupport<ReprovisionState> for ReprovisionState {
 }
 
 fn bfb_install_support(dpu_snapshots: &[Machine]) -> bool {
-    let bfb_install_support_ = |dpu_snapshots: &[Machine]| -> bool {
-        dpu_snapshots
+    !dpu_snapshots.is_empty()
+        && dpu_snapshots
             .iter()
             .all(|m| m.status.bmc_info.supports_bfb_install())
-    };
-
-    bfb_install_support_(dpu_snapshots)
 }
 
 /// MeasuringState contains states used for host attestion (or
@@ -2980,6 +2977,14 @@ pub fn dpf_based_dpu_provisioning_possible(
         return false;
     }
 
+    if state.dpu_snapshots.is_empty() {
+        tracing::info!(
+            machine_id = %state.host_snapshot.id,
+            "DPF based DPU provisioning is not possible because the host has no DPUs.",
+        );
+        return false;
+    }
+
     // if it is reprovisioning case, initial ingestion should be done with dpf
     // to continue or we should be trying to reprovision all the dpus (switching
     // to DPF). Reprovisioning only a subset of DPUs cannot flip the host to DPF.
@@ -3051,9 +3056,347 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::scenarios;
+    use carbide_test_support::{Check, check_values, scenarios};
 
     use super::*;
+    use crate::test_support::machine_snapshot::{dpu_machine, managed_host_state_snapshot};
+
+    #[derive(Clone, Copy)]
+    struct DpuProvisioningInput {
+        part_number: &'static str,
+        firmware_version: Option<&'static str>,
+        reprovision_requested: bool,
+    }
+
+    const BF2_SUPPORTED: DpuProvisioningInput = DpuProvisioningInput {
+        part_number: "MBF2M516C",
+        firmware_version: Some("BF-24.10"),
+        reprovision_requested: false,
+    };
+    const BF3_SUPPORTED: DpuProvisioningInput = DpuProvisioningInput {
+        part_number: "900-9D3B6",
+        firmware_version: Some("BF-24.10"),
+        reprovision_requested: false,
+    };
+    const BF3_REQUESTED: DpuProvisioningInput = DpuProvisioningInput {
+        reprovision_requested: true,
+        ..BF3_SUPPORTED
+    };
+    const BF3_UNSUPPORTED_BFB: DpuProvisioningInput = DpuProvisioningInput {
+        firmware_version: Some("BF-24.04"),
+        ..BF3_SUPPORTED
+    };
+    const BF4_SUPPORTED: DpuProvisioningInput = DpuProvisioningInput {
+        part_number: "900-9D4B4",
+        firmware_version: Some("BF4-26.04"),
+        reprovision_requested: false,
+    };
+
+    #[derive(Clone, Copy)]
+    struct DpfProvisioningInput {
+        dpf_enabled_at_site: bool,
+        dpf_enabled_for_host: bool,
+        used_for_ingestion: bool,
+        reprovisioning_case: bool,
+        dpus: &'static [DpuProvisioningInput],
+    }
+
+    fn dpf_input(dpus: &'static [DpuProvisioningInput]) -> DpfProvisioningInput {
+        DpfProvisioningInput {
+            dpf_enabled_at_site: true,
+            dpf_enabled_for_host: true,
+            used_for_ingestion: false,
+            reprovisioning_case: false,
+            dpus,
+        }
+    }
+
+    fn provisioning_state(input: DpfProvisioningInput) -> ManagedHostStateSnapshot {
+        let mut state = managed_host_state_snapshot();
+        state.host_snapshot.config.dpf = Dpf {
+            enabled: input.dpf_enabled_for_host,
+            used_for_ingestion: input.used_for_ingestion,
+        };
+        state.dpu_snapshots = input
+            .dpus
+            .iter()
+            .enumerate()
+            .map(|(index, input)| {
+                let mut dpu = dpu_machine(index as u8);
+                dpu.status.bmc_info.firmware_version = input.firmware_version.map(str::to_string);
+                dpu.status
+                    .hardware_info
+                    .as_mut()
+                    .expect("fixture DPU has hardware info")
+                    .dpu_info
+                    .as_mut()
+                    .expect("fixture DPU has DPU info")
+                    .part_number = input.part_number.to_string();
+                dpu.reprovision_requested =
+                    input.reprovision_requested.then(|| ReprovisionRequest {
+                        requested_at: DateTime::<Utc>::UNIX_EPOCH,
+                        initiator: "test".to_string(),
+                        update_firmware: false,
+                        started_at: None,
+                        user_approval_received: false,
+                        restart_reprovision_requested_at: DateTime::<Utc>::UNIX_EPOCH,
+                    });
+                dpu
+            })
+            .collect();
+        state
+    }
+
+    #[test]
+    fn dpf_provisioning_policy_matrix() {
+        check_values(
+            [
+                Check {
+                    scenario: "site flag disables DPF provisioning",
+                    input: DpfProvisioningInput {
+                        dpf_enabled_at_site: false,
+                        ..dpf_input(&[BF3_SUPPORTED])
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "host flag disables DPF provisioning",
+                    input: DpfProvisioningInput {
+                        dpf_enabled_for_host: false,
+                        ..dpf_input(&[BF3_SUPPORTED])
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "initial BF3 provisioning is eligible",
+                    input: dpf_input(&[BF3_SUPPORTED]),
+                    expect: true,
+                },
+                Check {
+                    scenario: "legacy ingestion can switch when every DPU is requested",
+                    input: DpfProvisioningInput {
+                        reprovisioning_case: true,
+                        dpus: &[BF3_REQUESTED, BF3_REQUESTED],
+                        ..dpf_input(&[])
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "legacy ingestion cannot switch a requested subset",
+                    input: DpfProvisioningInput {
+                        reprovisioning_case: true,
+                        dpus: &[BF3_REQUESTED, BF3_SUPPORTED],
+                        ..dpf_input(&[])
+                    },
+                    expect: false,
+                },
+                Check {
+                    scenario: "DPF ingestion permits a requested subset",
+                    input: DpfProvisioningInput {
+                        used_for_ingestion: true,
+                        reprovisioning_case: true,
+                        dpus: &[BF3_REQUESTED, BF3_SUPPORTED],
+                        ..dpf_input(&[])
+                    },
+                    expect: true,
+                },
+                Check {
+                    scenario: "a BF2 DPU prevents DPF provisioning",
+                    input: dpf_input(&[BF3_SUPPORTED, BF2_SUPPORTED]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "BF4 provisioning is eligible",
+                    input: dpf_input(&[BF4_SUPPORTED]),
+                    expect: true,
+                },
+                Check {
+                    scenario: "unsupported BFB firmware prevents DPF provisioning",
+                    input: dpf_input(&[BF3_UNSUPPORTED_BFB]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "mixed BFB support prevents DPF provisioning",
+                    input: dpf_input(&[BF3_SUPPORTED, BF3_UNSUPPORTED_BFB]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "a host without DPUs is ineligible",
+                    input: dpf_input(&[]),
+                    expect: false,
+                },
+            ],
+            |input| {
+                let state = provisioning_state(input);
+                dpf_based_dpu_provisioning_possible(
+                    &state,
+                    input.dpf_enabled_at_site,
+                    input.reprovisioning_case,
+                )
+            },
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    struct DpuProvisioningRouteInput {
+        dpf: DpfProvisioningInput,
+        enable_secure_boot: bool,
+    }
+
+    #[test]
+    fn dpu_provisioning_route_matrix() {
+        check_values(
+            [
+                Check {
+                    scenario: "DPF takes priority over secure boot",
+                    input: DpuProvisioningRouteInput {
+                        dpf: DpfProvisioningInput {
+                            used_for_ingestion: true,
+                            ..dpf_input(&[BF3_SUPPORTED])
+                        },
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::DisableSecureBoot {
+                            count: 0,
+                            disable_secure_boot_state: Some(
+                                SetSecureBootState::CheckSecureBootStatus,
+                            ),
+                        },
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::Reprovisioning,
+                        },
+                    ),
+                },
+                Check {
+                    scenario: "Redfish BFB is selected when site DPF is disabled",
+                    input: DpuProvisioningRouteInput {
+                        dpf: DpfProvisioningInput {
+                            dpf_enabled_at_site: false,
+                            ..dpf_input(&[BF3_SUPPORTED])
+                        },
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::EnableSecureBoot {
+                            count: 0,
+                            enable_secure_boot_state: SetSecureBootState::CheckSecureBootStatus,
+                        },
+                        ReprovisionState::InstallDpuOs {
+                            substate: InstallDpuOsState::InstallingBFB,
+                        },
+                    ),
+                },
+                Check {
+                    scenario: "secure boot disabled bypasses Redfish BFB",
+                    input: DpuProvisioningRouteInput {
+                        dpf: DpfProvisioningInput {
+                            dpf_enabled_at_site: false,
+                            ..dpf_input(&[BF3_SUPPORTED])
+                        },
+                        enable_secure_boot: false,
+                    },
+                    expect: (
+                        DpuDiscoveringState::DisableSecureBoot {
+                            count: 0,
+                            disable_secure_boot_state: Some(
+                                SetSecureBootState::CheckSecureBootStatus,
+                            ),
+                        },
+                        ReprovisionState::WaitingForNetworkInstall,
+                    ),
+                },
+                Check {
+                    scenario: "mixed BFB support uses network installation",
+                    input: DpuProvisioningRouteInput {
+                        dpf: DpfProvisioningInput {
+                            dpf_enabled_at_site: false,
+                            dpus: &[BF3_SUPPORTED, BF3_UNSUPPORTED_BFB],
+                            ..dpf_input(&[])
+                        },
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::DisableSecureBoot {
+                            count: 0,
+                            disable_secure_boot_state: Some(
+                                SetSecureBootState::CheckSecureBootStatus,
+                            ),
+                        },
+                        ReprovisionState::WaitingForNetworkInstall,
+                    ),
+                },
+                Check {
+                    scenario: "legacy subset only blocks the reprovision DPF route",
+                    input: DpuProvisioningRouteInput {
+                        dpf: DpfProvisioningInput {
+                            dpus: &[BF3_REQUESTED, BF3_SUPPORTED],
+                            ..dpf_input(&[])
+                        },
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::DisableSecureBoot {
+                            count: 0,
+                            disable_secure_boot_state: Some(
+                                SetSecureBootState::CheckSecureBootStatus,
+                            ),
+                        },
+                        ReprovisionState::InstallDpuOs {
+                            substate: InstallDpuOsState::InstallingBFB,
+                        },
+                    ),
+                },
+                Check {
+                    scenario: "BF2 falls back to Redfish BFB installation",
+                    input: DpuProvisioningRouteInput {
+                        dpf: dpf_input(&[BF2_SUPPORTED]),
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::EnableSecureBoot {
+                            count: 0,
+                            enable_secure_boot_state: SetSecureBootState::CheckSecureBootStatus,
+                        },
+                        ReprovisionState::InstallDpuOs {
+                            substate: InstallDpuOsState::InstallingBFB,
+                        },
+                    ),
+                },
+                Check {
+                    scenario: "an empty DPU set cannot select aggregate routes",
+                    input: DpuProvisioningRouteInput {
+                        dpf: dpf_input(&[]),
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::DisableSecureBoot {
+                            count: 0,
+                            disable_secure_boot_state: Some(
+                                SetSecureBootState::CheckSecureBootStatus,
+                            ),
+                        },
+                        ReprovisionState::WaitingForNetworkInstall,
+                    ),
+                },
+            ],
+            |input| {
+                let state = provisioning_state(input.dpf);
+                (
+                    DpuDiscoveringState::next_substate_based_on_bfb_support(
+                        input.enable_secure_boot,
+                        &state,
+                        input.dpf.dpf_enabled_at_site,
+                    ),
+                    ReprovisionState::next_substate_based_on_bfb_support(
+                        input.enable_secure_boot,
+                        &state,
+                        input.dpf.dpf_enabled_at_site,
+                    ),
+                )
+            },
+        );
+    }
 
     // Deserializing a `FailureDetails` JSON blob: the parsed value must match the
     // expected struct (cause + failed_at + source). The type is PartialEq, so we


### PR DESCRIPTION
An empty DPU slice satisfies `Iterator::all`, so `bfb_install_support`
and `dpf_based_dpu_provisioning_possible` could treat a host with no
DPUs as eligible for aggregate provisioning. Those helpers and both
`NextStateBFBSupport` implementations also had no direct unit coverage,
leaving their route decisions to callers to exercise indirectly.

This requires a non-empty DPU set before either aggregate decision can
succeed. One policy table now walks the site and host flags, ingestion
and reprovision rules, BF2/BF3/BF4 handling, firmware gates, mixed DPU
sets, and the empty-set boundary. A second table checks DPF priority,
Redfish BFB installation, network fallback, legacy subsets, BF2, and
empty-set routing across both state implementations.

The existing BMC firmware tests are folded into one seven-row table
without changing their production coverage. `DpuProvisioningRouteInput`
also names the secure-boot and DPF inputs, so the route table no longer
hides policy behind positional booleans. No public signatures or
serialized models change.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4033

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Original `carbide-api-model --lib` coverage run -- 373 passed
- Converted `carbide-api-model --lib` coverage run -- 371 passed
- Expanded `carbide-api-model --lib` coverage run -- 373 passed
- `cargo test --locked --package carbide-api-model --lib` -- 373 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

Focused production coverage excludes test code and external macro
bodies:

| Production code | Original lines/regions | Converted lines/regions | Expanded lines/regions |
|---|---:|---:|---:|
| `BmcInfo::supports_bfb_install` | 6/6, 15/15 | 6/6, 15/15 | 6/6, 15/15 |
| `bfb_install_support` | 0/8, 0/10 | 0/8, 0/10 | 6/6, 7/7 |
| DPU-discovery `NextStateBFBSupport` | 0/19, 0/12 | 0/19, 0/12 | 19/19, 12/12 |
| Reprovision `NextStateBFBSupport` | 0/19, 0/16 | 0/19, 0/16 | 19/19, 16/16 |
| `dpf_based_dpu_provisioning_possible` | 0/45, 0/46 | 0/45, 0/46 | 49/49, 51/51 |
| **Selected production total** | **6/97, 15/99** | **6/97, 15/99** | **99/99, 101/101** |

The BMC conversion preserves all seven existing cases while reducing
three libtest entries to one. The two new policy tables bring the final
library count back to 373.

Raw package totals include unrelated production and test code:

| Checkpoint | Lines | Regions |
|---|---:|---:|
| Original | 13,163/18,853 (69.8191%) | 14,739/22,652 (65.0671%) |
| Converted | 13,191/18,881 (69.8639%) | 14,725/22,638 (65.0455%) |
| Expanded | 13,704/19,161 (71.5203%) | 15,070/22,735 (66.2855%) |

Closes #4033
