### PR TITLE
test(site-explorer): centralize endpoint error behavior

### DIFF
--- a/crates/admin-cli/src/site_explorer/get_report/cmd.rs
+++ b/crates/admin-cli/src/site_explorer/get_report/cmd.rs
@@ -18,9 +18,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use ::rpc::admin_cli::OutputFormat;
-use ::rpc::site_explorer::{
-    EndpointExplorationReport, ExploredEndpoint, ExploredManagedHost, SiteExplorationReport,
-};
+use ::rpc::site_explorer::{ExploredEndpoint, ExploredManagedHost, SiteExplorationReport};
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use prettytable::{Cell, Row, Table, format, row};
 
@@ -52,23 +50,6 @@ fn get_endpoints_for_managed_host<'ep>(
             }
         })
         .collect::<HashMap<&str, &ExploredEndpoint>>()
-}
-
-fn last_exploration_error_display(report: &EndpointExplorationReport) -> String {
-    report
-        .last_exploration_error_schema
-        .as_ref()
-        .map(|schema| serde_json::to_string_pretty(schema).unwrap_or_else(|_| schema.text.clone()))
-        .or_else(|| report.last_exploration_error.clone())
-        .unwrap_or_default()
-}
-
-fn has_last_exploration_error(report: &EndpointExplorationReport) -> bool {
-    report.last_exploration_error_schema.is_some()
-        || report
-            .last_exploration_error
-            .as_deref()
-            .is_some_and(|error| !error.is_empty())
 }
 
 fn convert_managed_host_to_nice_table(
@@ -365,7 +346,7 @@ fn filter_endpoints(
                     .report
                     .as_ref()
                     .map(|x| {
-                        let has_error = has_last_exploration_error(x);
+                        let has_error = x.has_last_exploration_error();
                         if erroronly {
                             has_error
                         } else if successonly {
@@ -500,7 +481,7 @@ fn endpoint_to_row(endpoint: &ExploredEndpoint) -> Row {
 
     let last_error = report
         .as_ref()
-        .map(last_exploration_error_display)
+        .map(|report| report.last_exploration_error_display())
         .unwrap_or_default();
 
     let error_segmented = last_error
@@ -577,7 +558,7 @@ async fn display_endpoint(
     table.add_row(row!["Preingestion State", endpoint.preingestion_state]);
     let last_error = report
         .as_ref()
-        .map(last_exploration_error_display)
+        .map(|report| report.last_exploration_error_display())
         .unwrap_or_default();
 
     let error_segmented = last_error
@@ -694,10 +675,10 @@ async fn display_endpoint(
 
 #[cfg(test)]
 mod tests {
-    use ::rpc::site_explorer::{EndpointExplorationReport, OperatorErrorSchema};
+    use ::rpc::site_explorer::{EndpointExplorationReport, ExploredEndpoint, OperatorErrorSchema};
     use carbide_test_support::{Check, check_values};
 
-    use super::{has_last_exploration_error, last_exploration_error_display};
+    use super::{convert_endpoints_to_nice_table, filter_endpoints};
 
     fn operator_error_schema() -> OperatorErrorSchema {
         OperatorErrorSchema {
@@ -707,51 +688,60 @@ mod tests {
         }
     }
 
-    fn report(
-        schema: Option<OperatorErrorSchema>,
-        legacy: Option<&str>,
-    ) -> EndpointExplorationReport {
-        EndpointExplorationReport {
-            last_exploration_error: legacy.map(str::to_string),
-            last_exploration_error_schema: schema,
+    fn endpoint(address: &str, report: EndpointExplorationReport) -> ExploredEndpoint {
+        ExploredEndpoint {
+            address: address.to_string(),
+            report: Some(report),
             ..Default::default()
         }
     }
 
     #[test]
-    fn last_exploration_error_display_and_presence_are_schema_aware() {
-        let schema_display =
-            serde_json::to_string_pretty(&operator_error_schema()).expect("schema serializes");
+    fn endpoint_error_filter_and_table_rendering_use_structured_errors() {
+        let error = endpoint(
+            "192.0.2.10",
+            EndpointExplorationReport {
+                last_exploration_error_schema: Some(operator_error_schema()),
+                ..Default::default()
+            },
+        );
+        let clear = endpoint("192.0.2.11", EndpointExplorationReport::default());
+        let endpoints = vec![error.clone(), clear];
 
         check_values(
             [
                 Check {
-                    scenario: "schema takes precedence over legacy error",
-                    input: report(Some(operator_error_schema()), Some("legacy error")),
-                    expect: (schema_display.clone(), true),
+                    scenario: "error-only",
+                    input: (true, false),
+                    expect: vec!["192.0.2.10".to_string()],
                 },
                 Check {
-                    scenario: "legacy error remains a fallback",
-                    input: report(None, Some("legacy error")),
-                    expect: ("legacy error".to_string(), true),
+                    scenario: "success-only",
+                    input: (false, true),
+                    expect: vec!["192.0.2.11".to_string()],
                 },
                 Check {
-                    scenario: "schema-only report is an error",
-                    input: report(Some(operator_error_schema()), None),
-                    expect: (schema_display, true),
-                },
-                Check {
-                    scenario: "report without either field has no error",
-                    input: report(None, None),
-                    expect: (String::new(), false),
+                    scenario: "all endpoints",
+                    input: (false, false),
+                    expect: vec!["192.0.2.10".to_string(), "192.0.2.11".to_string()],
                 },
             ],
-            |report| {
-                (
-                    last_exploration_error_display(&report),
-                    has_last_exploration_error(&report),
+            |(error_only, success_only)| {
+                filter_endpoints(
+                    endpoints.clone(),
+                    error_only,
+                    success_only,
+                    Vec::new(),
+                    None,
                 )
+                .into_iter()
+                .map(|endpoint| endpoint.address)
+                .collect::<Vec<_>>()
             },
         );
+
+        let rendered = convert_endpoints_to_nice_table(&[error]).to_string();
+        assert!(rendered.contains("NICO-SITEEXPLORER-122"));
+        assert!(rendered.contains("BMC vendor missing"));
     }
 }

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1330,8 +1330,8 @@ impl EndpointExplorationError {
 
 impl OperatorError for EndpointExplorationError {
     fn operator_error_code(&self) -> ErrorCode {
-        // Every code in this module is a site-explorer code, so the subsystem is
-        // assumed rather than repeated per arm.
+        // Most variants use Site Explorer codes; the DPU BIOS variant below
+        // keeps its existing DPU-specific code.
         use ErrorSubsystem::SiteExplorer;
         match self {
             EndpointExplorationError::ConnectionTimeout { .. } => {
@@ -2510,7 +2510,9 @@ mod explored_mlx_device_tests {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
+    use carbide_test_support::{
+        Case, Check, check_cases, check_values, scenarios, value_scenarios,
+    };
 
     use super::*;
     use crate::firmware::FirmwareComponent;
@@ -2603,6 +2605,334 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum MitigationGroup {
+        Network,
+        HardwareCompatibility,
+        Credentials,
+        IntermittentCredentials,
+        DpuRecovery,
+        DgxRetry,
+        NoMitigation,
+    }
+
+    impl MitigationGroup {
+        fn from_mitigation(mitigation: Option<&str>) -> Self {
+            match mitigation {
+                None => Self::NoMitigation,
+                Some(mitigation) if mitigation.contains("force-restarts the DPU") => {
+                    Self::DpuRecovery
+                }
+                Some(mitigation)
+                    if mitigation.contains("general DGX H100/H200 Redfish API information") =>
+                {
+                    Self::DgxRetry
+                }
+                Some(mitigation) if mitigation.starts_with("Transient:") => {
+                    Self::IntermittentCredentials
+                }
+                Some(mitigation)
+                    if mitigation.contains("PUT /v2/org/{org}/nico/credential/bmc") =>
+                {
+                    Self::Credentials
+                }
+                Some(mitigation) if mitigation.contains("Hardware Compatibility List") => {
+                    Self::HardwareCompatibility
+                }
+                Some(mitigation) if mitigation.contains("network reachability") => Self::Network,
+                Some(mitigation) => panic!("unclassified mitigation: {mitigation}"),
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct EndpointErrorBehavior {
+        code: ErrorCode,
+        unauthorized: bool,
+        unreachable: bool,
+        redfish: bool,
+        invalid_dpu_bios_response: bool,
+        intermittent_unauthorized_count: Option<u32>,
+        mitigation_group: MitigationGroup,
+    }
+
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+    struct EndpointPredicates {
+        unauthorized: bool,
+        unreachable: bool,
+        redfish: bool,
+        invalid_dpu_bios_response: bool,
+    }
+
+    fn expected_error_behavior(
+        code: ErrorCode,
+        predicates: EndpointPredicates,
+        intermittent_unauthorized_count: Option<u32>,
+        mitigation_group: MitigationGroup,
+    ) -> EndpointErrorBehavior {
+        let EndpointPredicates {
+            unauthorized,
+            unreachable,
+            redfish,
+            invalid_dpu_bios_response,
+        } = predicates;
+        EndpointErrorBehavior {
+            code,
+            unauthorized,
+            unreachable,
+            redfish,
+            invalid_dpu_bios_response,
+            intermittent_unauthorized_count,
+            mitigation_group,
+        }
+    }
+
+    #[test]
+    fn endpoint_exploration_error_behavior_is_stable() {
+        use ErrorSubsystem::SiteExplorer;
+        use MitigationGroup::*;
+
+        check_values(
+            [
+                Check {
+                    scenario: "connection timeout",
+                    input: EndpointExplorationError::ConnectionTimeout {
+                        details: "timeout".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 100),
+                        EndpointPredicates {
+                            unreachable: true,
+                            ..Default::default()
+                        },
+                        None,
+                        Network,
+                    ),
+                },
+                Check {
+                    scenario: "connection refused",
+                    input: EndpointExplorationError::ConnectionRefused {
+                        details: "refused".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 101),
+                        EndpointPredicates {
+                            unreachable: true,
+                            ..Default::default()
+                        },
+                        None,
+                        Network,
+                    ),
+                },
+                Check {
+                    scenario: "unreachable",
+                    input: EndpointExplorationError::Unreachable {
+                        details: Some("network".to_string()),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 102),
+                        EndpointPredicates {
+                            unreachable: true,
+                            ..Default::default()
+                        },
+                        None,
+                        Network,
+                    ),
+                },
+                Check {
+                    scenario: "unsupported vendor",
+                    input: EndpointExplorationError::UnsupportedVendor {
+                        vendor: "unknown".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 120),
+                        EndpointPredicates::default(),
+                        None,
+                        HardwareCompatibility,
+                    ),
+                },
+                Check {
+                    scenario: "missing redfish",
+                    input: EndpointExplorationError::MissingRedfish { uri: None },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 121),
+                        EndpointPredicates::default(),
+                        None,
+                        NoMitigation,
+                    ),
+                },
+                Check {
+                    scenario: "missing vendor",
+                    input: EndpointExplorationError::MissingVendor { observed: None },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 122),
+                        EndpointPredicates::default(),
+                        None,
+                        HardwareCompatibility,
+                    ),
+                },
+                Check {
+                    scenario: "redfish error",
+                    input: EndpointExplorationError::RedfishError {
+                        details: "request failed".to_string(),
+                        response_body: None,
+                        response_code: Some(500),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 130),
+                        EndpointPredicates {
+                            redfish: true,
+                            ..Default::default()
+                        },
+                        None,
+                        NoMitigation,
+                    ),
+                },
+                Check {
+                    scenario: "DGX firmware inventory forbidden",
+                    input: EndpointExplorationError::VikingFWInventoryForbiddenError {
+                        details: "forbidden".to_string(),
+                        response_body: None,
+                        response_code: Some(403),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 131),
+                        EndpointPredicates::default(),
+                        None,
+                        DgxRetry,
+                    ),
+                },
+                Check {
+                    scenario: "unauthorized",
+                    input: EndpointExplorationError::Unauthorized {
+                        details: "unauthorized".to_string(),
+                        response_body: None,
+                        response_code: Some(401),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 140),
+                        EndpointPredicates {
+                            unauthorized: true,
+                            ..Default::default()
+                        },
+                        None,
+                        Credentials,
+                    ),
+                },
+                Check {
+                    scenario: "missing credentials",
+                    input: EndpointExplorationError::MissingCredentials {
+                        key: "bmc".to_string(),
+                        cause: "missing".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 141),
+                        EndpointPredicates::default(),
+                        None,
+                        Credentials,
+                    ),
+                },
+                Check {
+                    scenario: "secrets engine",
+                    input: EndpointExplorationError::SecretsEngineError {
+                        cause: "unavailable".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 142),
+                        EndpointPredicates::default(),
+                        None,
+                        Credentials,
+                    ),
+                },
+                Check {
+                    scenario: "set credentials",
+                    input: EndpointExplorationError::SetCredentials {
+                        key: "bmc".to_string(),
+                        cause: "failed".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 143),
+                        EndpointPredicates::default(),
+                        None,
+                        Credentials,
+                    ),
+                },
+                Check {
+                    scenario: "avoid lockout",
+                    input: EndpointExplorationError::AvoidLockout,
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 144),
+                        EndpointPredicates {
+                            unauthorized: true,
+                            ..Default::default()
+                        },
+                        None,
+                        Credentials,
+                    ),
+                },
+                Check {
+                    scenario: "intermittent unauthorized",
+                    input: EndpointExplorationError::IntermittentUnauthorized {
+                        details: "temporary unauthorized response".to_string(),
+                        response_body: None,
+                        response_code: Some(401),
+                        consecutive_count: 3,
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 145),
+                        EndpointPredicates::default(),
+                        Some(3),
+                        IntermittentCredentials,
+                    ),
+                },
+                Check {
+                    scenario: "other",
+                    input: EndpointExplorationError::Other {
+                        details: "unexpected".to_string(),
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 199),
+                        EndpointPredicates::default(),
+                        None,
+                        NoMitigation,
+                    ),
+                },
+                Check {
+                    scenario: "invalid DPU BIOS response",
+                    input: EndpointExplorationError::InvalidDpuRedfishBiosResponse {
+                        details: "attributes not ready".to_string(),
+                        response_body: None,
+                        response_code: None,
+                    },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(ErrorSubsystem::Dpu, 134),
+                        EndpointPredicates {
+                            redfish: true,
+                            invalid_dpu_bios_response: true,
+                            ..Default::default()
+                        },
+                        None,
+                        DpuRecovery,
+                    ),
+                },
+            ],
+            |error| {
+                let schema = error.operator_error_schema();
+                EndpointErrorBehavior {
+                    code: schema.error_code,
+                    unauthorized: error.is_unauthorized(),
+                    unreachable: error.is_unreachable(),
+                    redfish: error.is_redfish(),
+                    invalid_dpu_bios_response: error.is_dpu_redfish_bios_response_invalid(),
+                    intermittent_unauthorized_count: error.intermittent_unauthorized_count(),
+                    mitigation_group: MitigationGroup::from_mitigation(
+                        schema.mitigation.as_deref(),
+                    ),
+                }
+            },
+        );
+    }
+
     #[test]
     fn dpu_bios_error_schema_contains_operator_action() {
         let error = EndpointExplorationError::InvalidDpuRedfishBiosResponse {
@@ -2612,15 +2942,13 @@ mod tests {
         };
 
         let schema = error.operator_error_schema();
+        let mitigation = schema
+            .mitigation
+            .as_deref()
+            .expect("DPU BIOS errors have recovery guidance");
 
-        assert_eq!(
-            schema.error_code,
-            EndpointExplorationError::INVALID_DPU_REDFISH_BIOS_RESPONSE_CODE
-        );
-        assert_eq!(
-            schema.mitigation.as_deref(),
-            Some(EndpointExplorationError::INVALID_DPU_REDFISH_BIOS_RESPONSE_MITIGATION)
-        );
+        assert!(mitigation.contains("force-restarts the DPU"));
+        assert!(mitigation.contains("BMC reset"));
         assert!(
             schema
                 .text

--- a/crates/api-web/src/explored_endpoint.rs
+++ b/crates/api-web/src/explored_endpoint.rs
@@ -28,8 +28,8 @@ use hyper::http::StatusCode;
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{self as forgerpc, BmcEndpointRequest, admin_power_control_request};
 use rpc::site_explorer::{
-    EndpointExplorationReport, ExploredEndpoint, InternalLockdownStatus, LockdownStatus,
-    MachineSetupStatus, SecureBootStatus, SiteExplorationReport,
+    ExploredEndpoint, InternalLockdownStatus, LockdownStatus, MachineSetupStatus, SecureBootStatus,
+    SiteExplorationReport,
 };
 use serde::Deserialize;
 
@@ -164,13 +164,13 @@ impl From<&ExploredEndpoint> for ExploredEndpointDisplay {
                 .map(|report| report.endpoint_type.clone())
                 .unwrap_or_default(),
             last_exploration_error: report_ref
-                .map(last_exploration_error_display)
+                .map(|report| report.last_exploration_error_display())
                 .unwrap_or_default(),
             last_exploration_latency: report_ref
                 .and_then(|report| report.last_exploration_latency.as_ref())
                 .map(|latency| latency.seconds),
             has_exploration_error: report_ref
-                .map(has_last_exploration_error)
+                .map(|report| report.has_last_exploration_error())
                 .unwrap_or_default(),
             bmc_mac_addrs: report_ref
                 .map(|report| {
@@ -212,23 +212,6 @@ impl From<&ExploredEndpoint> for ExploredEndpointDisplay {
                 .unwrap_or_default(),
         }
     }
-}
-
-fn last_exploration_error_display(report: &EndpointExplorationReport) -> String {
-    report
-        .last_exploration_error_schema
-        .as_ref()
-        .map(|schema| serde_json::to_string_pretty(schema).unwrap_or_else(|_| schema.text.clone()))
-        .or_else(|| report.last_exploration_error.clone())
-        .unwrap_or_default()
-}
-
-fn has_last_exploration_error(report: &EndpointExplorationReport) -> bool {
-    report.last_exploration_error_schema.is_some()
-        || report
-            .last_exploration_error
-            .as_deref()
-            .is_some_and(|error| !error.is_empty())
 }
 
 /// List explored endpoints
@@ -494,10 +477,10 @@ impl From<ExploredEndpointInfo> for ExploredEndpointDetail<'_> {
 
         Self {
             last_exploration_error: report_ref
-                .map(last_exploration_error_display)
+                .map(|report| report.last_exploration_error_display())
                 .unwrap_or_default(),
             has_exploration_error: report_ref
-                .map(has_last_exploration_error)
+                .map(|report| report.has_last_exploration_error())
                 .unwrap_or_default(),
             machine_setup_status: machine_setup_status_to_string(
                 report_ref.and_then(|report| report.machine_setup_status.as_ref()),
@@ -702,7 +685,7 @@ pub async fn refresh_endpoint(
             let has_error = ep
                 .report
                 .as_ref()
-                .map(has_last_exploration_error)
+                .map(|report| report.has_last_exploration_error())
                 .unwrap_or_default();
             (
                 StatusCode::OK,
@@ -786,7 +769,7 @@ fn query_filter_for(
         .and_then(|v| v.parse::<bool>().ok())
         .unwrap_or(false)
     {
-        Box::new(|ep: &ExploredEndpointDisplay| !ep.last_exploration_error.is_empty())
+        Box::new(|ep: &ExploredEndpointDisplay| ep.has_exploration_error)
     } else {
         Box::new(|_| true)
     };
@@ -1361,64 +1344,62 @@ impl<'a> super::Base for ExploredEndpointDetail<'a> {}
 
 #[cfg(test)]
 mod tests {
-    use carbide_test_support::{Check, check_values};
-    use rpc::site_explorer::{EndpointExplorationReport, OperatorErrorSchema};
+    use std::collections::HashMap;
 
-    use super::{has_last_exploration_error, last_exploration_error_display};
+    use askama::Template;
+    use rpc::site_explorer::{EndpointExplorationReport, ExploredEndpoint, OperatorErrorSchema};
 
-    fn operator_error_schema() -> OperatorErrorSchema {
-        OperatorErrorSchema {
-            error_code: "NICO-SITEEXPLORER-122".to_string(),
-            mitigation: Some("Check the HCL".to_string()),
-            text: "BMC vendor missing".to_string(),
-        }
-    }
+    use super::{ExploredEndpointDisplay, ExploredEndpointsShow, query_filter_for};
+    use crate::pagination::PageContext;
 
-    fn report(
-        schema: Option<OperatorErrorSchema>,
-        legacy: Option<&str>,
-    ) -> EndpointExplorationReport {
-        EndpointExplorationReport {
-            last_exploration_error: legacy.map(str::to_string),
-            last_exploration_error_schema: schema,
+    fn endpoint(address: &str, schema: Option<OperatorErrorSchema>) -> ExploredEndpoint {
+        ExploredEndpoint {
+            address: address.to_string(),
+            report: Some(EndpointExplorationReport {
+                last_exploration_error_schema: schema,
+                ..Default::default()
+            }),
             ..Default::default()
         }
     }
 
     #[test]
-    fn last_exploration_error_display_and_presence_are_schema_aware() {
-        let schema_display =
-            serde_json::to_string_pretty(&operator_error_schema()).expect("schema serializes");
-
-        check_values(
-            [
-                Check {
-                    scenario: "schema takes precedence over legacy error",
-                    input: report(Some(operator_error_schema()), Some("legacy error")),
-                    expect: (schema_display.clone(), true),
-                },
-                Check {
-                    scenario: "legacy error remains a fallback",
-                    input: report(None, Some("legacy error")),
-                    expect: ("legacy error".to_string(), true),
-                },
-                Check {
-                    scenario: "schema-only report is an error",
-                    input: report(Some(operator_error_schema()), None),
-                    expect: (schema_display, true),
-                },
-                Check {
-                    scenario: "report without either field has no error",
-                    input: report(None, None),
-                    expect: (String::new(), false),
-                },
-            ],
-            |report| {
-                (
-                    last_exploration_error_display(&report),
-                    has_last_exploration_error(&report),
-                )
-            },
+    fn endpoint_error_html_and_filter_render_structured_and_clear_reports() {
+        let error = endpoint(
+            "192.0.2.20",
+            Some(OperatorErrorSchema {
+                error_code: "NICO-SITEEXPLORER-122".to_string(),
+                mitigation: Some("Check the HCL".to_string()),
+                text: "BMC vendor missing".to_string(),
+            }),
         );
+        let clear = endpoint("192.0.2.21", None);
+        let error = ExploredEndpointDisplay::from(&error);
+        let clear = ExploredEndpointDisplay::from(&clear);
+
+        let errors_only = query_filter_for(HashMap::from([(
+            "errors-only".to_string(),
+            "true".to_string(),
+        )]));
+        assert!(errors_only(&error));
+        assert!(!errors_only(&clear));
+
+        let rendered = ExploredEndpointsShow {
+            last_run: None,
+            vendors: Vec::new(),
+            endpoints: vec![error, clear],
+            filter_name: "All",
+            active_vendor_filter: "all".to_string(),
+            is_errors_only: false,
+            page: PageContext::all(2, "/admin/explored-endpoint"),
+            missing_default_credentials: Vec::new(),
+        }
+        .render()
+        .expect("template renders");
+
+        assert!(rendered.contains("NICO-SITEEXPLORER-122"));
+        assert!(rendered.contains("192.0.2.20"));
+        assert!(rendered.contains("192.0.2.21"));
+        assert_eq!(rendered.matches("clearlasterror_action").count(), 1);
     }
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -67,6 +67,7 @@ pub mod measured_boot;
 pub mod network;
 pub mod protos;
 pub mod secrets;
+mod site_explorer_report;
 pub mod utils;
 
 #[cfg(feature = "model")]

--- a/crates/rpc/src/site_explorer_report.rs
+++ b/crates/rpc/src/site_explorer_report.rs
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::site_explorer::EndpointExplorationReport;
+
+impl EndpointExplorationReport {
+    /// Formats the structured operator error when available, falling back to
+    /// the legacy error string stored by older controllers.
+    pub fn last_exploration_error_display(&self) -> String {
+        self.last_exploration_error_schema
+            .as_ref()
+            .map(|schema| {
+                serde_json::to_string_pretty(schema).unwrap_or_else(|_| schema.text.clone())
+            })
+            .or_else(|| self.last_exploration_error.clone())
+            .unwrap_or_default()
+    }
+
+    /// Reports whether the endpoint has either a structured operator error or
+    /// a non-empty legacy error string.
+    pub fn has_last_exploration_error(&self) -> bool {
+        self.last_exploration_error_schema.is_some()
+            || self
+                .last_exploration_error
+                .as_deref()
+                .is_some_and(|error| !error.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+    use crate::site_explorer::OperatorErrorSchema;
+
+    fn operator_error_schema() -> OperatorErrorSchema {
+        OperatorErrorSchema {
+            error_code: "NICO-SITEEXPLORER-122".to_string(),
+            mitigation: Some("Check the HCL".to_string()),
+            text: "BMC vendor missing".to_string(),
+        }
+    }
+
+    fn report(
+        schema: Option<OperatorErrorSchema>,
+        legacy: Option<&str>,
+    ) -> EndpointExplorationReport {
+        EndpointExplorationReport {
+            last_exploration_error: legacy.map(str::to_string),
+            last_exploration_error_schema: schema,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn error_display_and_presence_are_schema_aware() {
+        let schema_display =
+            serde_json::to_string_pretty(&operator_error_schema()).expect("schema serializes");
+
+        check_values(
+            [
+                Check {
+                    scenario: "schema takes precedence over legacy error",
+                    input: report(Some(operator_error_schema()), Some("legacy error")),
+                    expect: (schema_display.clone(), true),
+                },
+                Check {
+                    scenario: "legacy error remains a fallback",
+                    input: report(None, Some("legacy error")),
+                    expect: ("legacy error".to_string(), true),
+                },
+                Check {
+                    scenario: "schema-only report is an error",
+                    input: report(Some(operator_error_schema()), None),
+                    expect: (schema_display, true),
+                },
+                Check {
+                    scenario: "report without either field has no error",
+                    input: report(None, None),
+                    expect: (String::new(), false),
+                },
+                Check {
+                    scenario: "empty legacy error is not an error",
+                    input: report(None, Some("")),
+                    expect: (String::new(), false),
+                },
+            ],
+            |report| {
+                (
+                    report.last_exploration_error_display(),
+                    report.has_last_exploration_error(),
+                )
+            },
+        );
+    }
+}


### PR DESCRIPTION
`EndpointExplorationError` has 16 variants, but direct tests sampled only part of the code, predicate, retry, and mitigation behavior. The admin CLI and API web also maintained copies of the same report display and presence helpers, with duplicate tests that stopped before their presentation boundaries.

So, this adds one 16-row model table for the complete error contract and keeps the DPU recovery guidance check focused on operator-facing text. It moves report display and presence handling into `carbide-rpc`, replaces the copied helper tests with one five-row owner table, and retains thin CLI and web tests for filtering and rendering.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4039

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Focused endpoint error table -- 16 rows passed
- Focused DPU recovery guidance test -- 1 passed
- Shared RPC report table -- 5 rows passed with default features and `--no-default-features`
- Admin CLI filtering table and renderer boundary -- passed
- API-web filter and template boundary -- passed
- `cargo test -p carbide-api-model --lib` -- 374 passed
- `cargo test -p carbide-rpc --lib` -- 15 passed
- `cargo test -p nico-admin-cli` -- 393 passed
- `cargo test -p carbide-api-web --lib -- --test-threads=1` -- 46 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

| Production evidence | Original | Expanded |
|---|---:|---:|
| Error mapping lines | 42/75 | 75/75 |
| Error mapping regions | 29/69 | 69/69 |
| Selected RPC and presentation lines | 30/216 | 169/204 |
| Selected RPC and presentation regions | 42/324 | 238/310 |

The selected RPC and presentation denominators fall because the copied CLI and web helper code is deleted. The shared table adds the empty legacy-error boundary, while the consumer tests exercise structured-error filtering and rendering through their real interfaces.

Local CodeRabbit review reported no findings. Claude found no correctness or build defects; its three low-severity observations were accepted as deliberate contract and table-design choices.
