### PR TITLE
fix(measured-boot): reject overflowing PCR ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,6 +2509,7 @@ dependencies = [
 name = "carbide-measured-boot"
 version = "0.0.0"
 dependencies = [
+ "carbide-test-support",
  "carbide-uuid",
  "chrono",
  "clap",

--- a/crates/measured-boot/Cargo.toml
+++ b/crates/measured-boot/Cargo.toml
@@ -40,5 +40,8 @@ eyre = { optional = true, workspace = true }
 serde = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/measured-boot/src/bundle.rs
+++ b/crates/measured-boot/src/bundle.rs
@@ -99,3 +99,57 @@ impl ToTable for MeasurementBundle {
         Ok(table.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use chrono::{DateTime, Utc};
+
+    use super::*;
+
+    fn bundle_value(pcr_register: i16, sha_any: &str) -> MeasurementBundleValueRecord {
+        MeasurementBundleValueRecord {
+            pcr_register,
+            sha_any: sha_any.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pcr_value_projection_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty bundle",
+                    input: vec![],
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "populated bundle preserves record order",
+                    input: vec![bundle_value(0, "sha-0"), bundle_value(7, "sha-7")],
+                    expect: vec![
+                        PcrRegisterValue {
+                            pcr_register: 0,
+                            sha_any: "sha-0".to_string(),
+                        },
+                        PcrRegisterValue {
+                            pcr_register: 7,
+                            sha_any: "sha-7".to_string(),
+                        },
+                    ],
+                },
+            ],
+            |values| {
+                MeasurementBundle {
+                    bundle_id: MeasurementBundleId::new(),
+                    profile_id: MeasurementSystemProfileId::new(),
+                    name: "test bundle".to_string(),
+                    state: MeasurementBundleState::Active,
+                    values,
+                    ts: DateTime::<Utc>::UNIX_EPOCH,
+                }
+                .pcr_values()
+            },
+        );
+    }
+}

--- a/crates/measured-boot/src/pcr.rs
+++ b/crates/measured-boot/src/pcr.rs
@@ -152,6 +152,12 @@ pub fn parse_range(arg: &str) -> super::Result<PcrRange> {
         )));
     }
 
+    for endpoint in &range {
+        i16::try_from(*endpoint).map_err(|_| {
+            super::Error::Parse(format!("pcr range endpoint is out of bounds: {endpoint}"))
+        })?;
+    }
+
     if range[0] > range[1] {
         return Err(super::Error::Parse(String::from(
             "end must be greater than start",
@@ -201,5 +207,249 @@ impl From<Vec<String>> for PcrRegisterValueVec {
             })
             .collect();
         PcrRegisterValueVec(pcr_register_values)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
+
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct RangeSummary {
+        start: usize,
+        end: usize,
+        display: String,
+    }
+
+    #[test]
+    fn parse_range_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "equal endpoints form a singleton range",
+                    input: "4-4",
+                    expect: Yields(RangeSummary {
+                        start: 4,
+                        end: 4,
+                        display: "4-4".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "ascending endpoints form an inclusive range",
+                    input: "0-23",
+                    expect: Yields(RangeSummary {
+                        start: 0,
+                        end: 23,
+                        display: "0-23".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "maximum i16 endpoints are accepted",
+                    input: "32767-32767",
+                    expect: Yields(RangeSummary {
+                        start: 32767,
+                        end: 32767,
+                        display: "32767-32767".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "reversed endpoints are rejected",
+                    input: "5-4",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "more than two endpoints are rejected",
+                    input: "1-2-3",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "nonnumeric endpoints are rejected",
+                    input: "one-2",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "overflowing start endpoint is rejected",
+                    input: "32768-32768",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "overflowing end endpoint is rejected",
+                    input: "0-32768",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrapped zero endpoint is rejected",
+                    input: "65536-65536",
+                    expect: Fails,
+                },
+            ],
+            |input| {
+                parse_range(input)
+                    .map(|range| {
+                        let display = range.to_string();
+                        RangeSummary {
+                            start: range.start,
+                            end: range.end,
+                            display,
+                        }
+                    })
+                    .map_err(drop)
+            },
+        );
+    }
+
+    #[test]
+    fn parse_pcr_index_input_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "singleton",
+                    input: "7",
+                    expect: Yields(vec![7]),
+                },
+                Case {
+                    scenario: "inclusive range",
+                    input: "2-5",
+                    expect: Yields(vec![2, 3, 4, 5]),
+                },
+                Case {
+                    scenario: "mixed singletons and range",
+                    input: "0,2-4,7",
+                    expect: Yields(vec![0, 2, 3, 4, 7]),
+                },
+                Case {
+                    scenario: "values are sorted and deduplicated",
+                    input: "4,2,4,2-3",
+                    expect: Yields(vec![2, 3, 4]),
+                },
+                Case {
+                    scenario: "maximum i16 singleton",
+                    input: "32767",
+                    expect: Yields(vec![32767]),
+                },
+                Case {
+                    scenario: "empty input is rejected",
+                    input: "",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "malformed range is rejected",
+                    input: "1-2-3",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "nonnumeric singleton is rejected",
+                    input: "one",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "overflowing singleton is rejected",
+                    input: "32768",
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "overflowing range is rejected before expansion",
+                    input: "32768-32768",
+                    expect: Fails,
+                },
+            ],
+            |input| parse_pcr_index_input(input).map(|set| set.0).map_err(drop),
+        );
+    }
+
+    enum SetConstruction {
+        New,
+        Default,
+        Values(Vec<i16>),
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct SetSummary {
+        iter: Vec<i16>,
+        borrowed: Vec<i16>,
+        owned: Vec<i16>,
+        display: String,
+    }
+
+    #[test]
+    fn pcr_set_iteration_and_display_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "new set is empty",
+                    input: SetConstruction::New,
+                    expect: SetSummary {
+                        iter: vec![],
+                        borrowed: vec![],
+                        owned: vec![],
+                        display: String::new(),
+                    },
+                },
+                Check {
+                    scenario: "default set is empty",
+                    input: SetConstruction::Default,
+                    expect: SetSummary {
+                        iter: vec![],
+                        borrowed: vec![],
+                        owned: vec![],
+                        display: String::new(),
+                    },
+                },
+                Check {
+                    scenario: "custom set retains order in every iterator",
+                    input: SetConstruction::Values(vec![0, 7, 23]),
+                    expect: SetSummary {
+                        iter: vec![0, 7, 23],
+                        borrowed: vec![0, 7, 23],
+                        owned: vec![0, 7, 23],
+                        display: "0,7,23".to_string(),
+                    },
+                },
+            ],
+            |construction| {
+                let set = match construction {
+                    SetConstruction::New => PcrSet::new(),
+                    SetConstruction::Default => PcrSet::default(),
+                    SetConstruction::Values(values) => PcrSet(values),
+                };
+                SetSummary {
+                    iter: set.iter().copied().collect(),
+                    borrowed: (&set).into_iter().copied().collect(),
+                    owned: set.clone().into_iter().collect(),
+                    display: set.to_string(),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn string_vector_projection_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty values",
+                    input: vec![],
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "values receive sequential PCR indexes",
+                    input: vec!["sha-0".to_string(), "sha-1".to_string()],
+                    expect: vec![
+                        PcrRegisterValue {
+                            pcr_register: 0,
+                            sha_any: "sha-0".to_string(),
+                        },
+                        PcrRegisterValue {
+                            pcr_register: 1,
+                            sha_any: "sha-1".to_string(),
+                        },
+                    ],
+                },
+            ],
+            |values| PcrRegisterValueVec::from(values).0,
+        );
     }
 }

--- a/crates/measured-boot/src/records.rs
+++ b/crates/measured-boot/src/records.rs
@@ -710,3 +710,225 @@ impl ToTable for MeasurementApprovedProfileRecord {
         Ok(table.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Case, check_cases};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum RecordEnum {
+        BundleState,
+        MachineState,
+        ApprovalType,
+    }
+
+    struct EnumInput {
+        enum_type: RecordEnum,
+        value: &'static str,
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum ParsedRecordEnum {
+        BundleState(MeasurementBundleState),
+        MachineState(MeasurementMachineState),
+        ApprovalType(MeasurementApprovedType),
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct EnumSummary {
+        parsed: ParsedRecordEnum,
+        display: String,
+    }
+
+    #[test]
+    fn enum_parse_and_display_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "pending bundle",
+                    input: EnumInput {
+                        enum_type: RecordEnum::BundleState,
+                        value: "Pending",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::BundleState(MeasurementBundleState::Pending),
+                        display: "Pending".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "active bundle",
+                    input: EnumInput {
+                        enum_type: RecordEnum::BundleState,
+                        value: "Active",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::BundleState(MeasurementBundleState::Active),
+                        display: "Active".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "obsolete bundle",
+                    input: EnumInput {
+                        enum_type: RecordEnum::BundleState,
+                        value: "Obsolete",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::BundleState(MeasurementBundleState::Obsolete),
+                        display: "Obsolete".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "retired bundle",
+                    input: EnumInput {
+                        enum_type: RecordEnum::BundleState,
+                        value: "Retired",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::BundleState(MeasurementBundleState::Retired),
+                        display: "Retired".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "revoked bundle",
+                    input: EnumInput {
+                        enum_type: RecordEnum::BundleState,
+                        value: "Revoked",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::BundleState(MeasurementBundleState::Revoked),
+                        display: "Revoked".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "unknown bundle state",
+                    input: EnumInput {
+                        enum_type: RecordEnum::BundleState,
+                        value: "Unknown",
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "discovered machine",
+                    input: EnumInput {
+                        enum_type: RecordEnum::MachineState,
+                        value: "Discovered",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::MachineState(MeasurementMachineState::Discovered),
+                        display: "Discovered".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "machine pending bundle",
+                    input: EnumInput {
+                        enum_type: RecordEnum::MachineState,
+                        value: "PendingBundle",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::MachineState(
+                            MeasurementMachineState::PendingBundle,
+                        ),
+                        display: "PendingBundle".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "measured machine",
+                    input: EnumInput {
+                        enum_type: RecordEnum::MachineState,
+                        value: "Measured",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::MachineState(MeasurementMachineState::Measured),
+                        display: "Measured".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "failed measurement",
+                    input: EnumInput {
+                        enum_type: RecordEnum::MachineState,
+                        value: "MeasuringFailed",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::MachineState(
+                            MeasurementMachineState::MeasuringFailed,
+                        ),
+                        display: "MeasuringFailed".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "unknown machine state",
+                    input: EnumInput {
+                        enum_type: RecordEnum::MachineState,
+                        value: "Unknown",
+                    },
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "one-shot approval",
+                    input: EnumInput {
+                        enum_type: RecordEnum::ApprovalType,
+                        value: "Oneshot",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::ApprovalType(MeasurementApprovedType::Oneshot),
+                        display: "Oneshot".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "persistent approval",
+                    input: EnumInput {
+                        enum_type: RecordEnum::ApprovalType,
+                        value: "Persist",
+                    },
+                    expect: Yields(EnumSummary {
+                        parsed: ParsedRecordEnum::ApprovalType(MeasurementApprovedType::Persist),
+                        display: "Persist".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "unknown approval type",
+                    input: EnumInput {
+                        enum_type: RecordEnum::ApprovalType,
+                        value: "Unknown",
+                    },
+                    expect: Fails,
+                },
+            ],
+            |input| {
+                match input.enum_type {
+                    RecordEnum::BundleState => {
+                        input
+                            .value
+                            .parse::<MeasurementBundleState>()
+                            .map(|value| EnumSummary {
+                                display: value.to_string(),
+                                parsed: ParsedRecordEnum::BundleState(value),
+                            })
+                    }
+                    RecordEnum::MachineState => {
+                        input
+                            .value
+                            .parse::<MeasurementMachineState>()
+                            .map(|value| EnumSummary {
+                                display: value.to_string(),
+                                parsed: ParsedRecordEnum::MachineState(value),
+                            })
+                    }
+                    RecordEnum::ApprovalType => {
+                        input
+                            .value
+                            .parse::<MeasurementApprovedType>()
+                            .map(|value| EnumSummary {
+                                display: value.to_string(),
+                                parsed: ParsedRecordEnum::ApprovalType(value),
+                            })
+                    }
+                }
+                .map_err(drop)
+            },
+        );
+    }
+}

--- a/crates/measured-boot/src/report.rs
+++ b/crates/measured-boot/src/report.rs
@@ -76,3 +76,59 @@ impl ToTable for MeasurementReport {
         Ok(table.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use carbide_uuid::machine::{MachineIdSource, MachineType};
+    use carbide_uuid::measured_boot::MeasurementReportValueId;
+    use chrono::DateTime;
+
+    use super::*;
+
+    fn report_value(pcr_register: i16, sha_any: &str) -> MeasurementReportValueRecord {
+        MeasurementReportValueRecord {
+            value_id: MeasurementReportValueId::new(),
+            report_id: MeasurementReportId::new(),
+            pcr_register,
+            sha_any: sha_any.to_string(),
+            ts: DateTime::<Utc>::UNIX_EPOCH,
+        }
+    }
+
+    #[test]
+    fn pcr_value_projection_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "empty report",
+                    input: vec![],
+                    expect: vec![],
+                },
+                Check {
+                    scenario: "populated report preserves record order",
+                    input: vec![report_value(2, "sha-2"), report_value(11, "sha-11")],
+                    expect: vec![
+                        PcrRegisterValue {
+                            pcr_register: 2,
+                            sha_any: "sha-2".to_string(),
+                        },
+                        PcrRegisterValue {
+                            pcr_register: 11,
+                            sha_any: "sha-11".to_string(),
+                        },
+                    ],
+                },
+            ],
+            |values| {
+                MeasurementReport {
+                    report_id: MeasurementReportId::new(),
+                    machine_id: MachineId::new(MachineIdSource::Tpm, [0x11; 32], MachineType::Host),
+                    ts: DateTime::<Utc>::UNIX_EPOCH,
+                    values,
+                }
+                .pcr_values()
+            },
+        );
+    }
+}


### PR DESCRIPTION
`parse_range` parsed endpoints as `usize`, expanded them, and then
narrowed each index with `as i16`. That let `32768-32768` become
`-32768`, let `65536-65536` become zero, and allowed large ranges to
allocate before rejection. The measured-boot crate also had no local
tests, leaving its parser, iterator, projection, and public enum
contracts to downstream persistence and state-machine suites.

This validates both range endpoints with `i16::try_from` before reversal
checks, expansion, or narrowing. Seven owner tables now cover PCR
ranges and lists, every `PcrSet` iterator form, string-vector projection,
bundle and report projection, and exact public enum variants plus their
display strings.

The stable checkpoint adds 38 rows without changing production. Four
expanded rows pin overflowing start and end points, wrapped-zero input,
and aggregate parser rejection. Downstream API-core and API-db tests
remain because they own persistence, approvals, journals, selection,
and state-machine wiring. SPDM policy and the separate string-vector
index cast remain outside this change.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4034

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Original `carbide-measured-boot --lib` coverage run -- 0 tests
- Stable-table `carbide-measured-boot --lib` coverage run -- 7 passed
- Expanded `carbide-measured-boot --lib` coverage run -- 7 passed
- `cargo test -p carbide-measured-boot --lib` -- 7 passed
- `cargo test -p carbide-measured-boot --all-features` -- 7 passed; doc-tests passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

Primary values come from LLVM's per-function report and exclude inline
test code:

| Production contract | Original lines/regions | Stable-table lines/regions | Expanded lines/regions |
|---|---:|---:|---:|
| `parse_range` | 0/20, 0/18 | 20/20, 18/18 | 23/23, 24/24 |
| `parse_pcr_index_input` | 0/15, 0/35 | 15/15, 35/35 | 15/15, 35/35 |
| `PcrSet` construction, iteration, and display | 0/28, 0/38 | 28/28, 38/38 | 28/28, 38/38 |
| Bundle/report/PCR-value projections | 0/28, 0/29 | 28/28, 29/29 | 28/28, 29/29 |
| Public record enum parsing and display | 0/32, 0/46 | 32/32, 46/46 | 32/32, 46/46 |

The crate moves from zero tests to seven table entries and 42 final
rows. Raw totals, which include inline test code, move from 0/220 lines
and 0/269 regions to 614/692 lines and 409/488 regions.

Closes #4034
