### PR TITLE
feat(machine-validation): require SHA256 digest on container images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7463,6 +7463,7 @@ dependencies = [
  "csv",
  "eyre",
  "futures",
+ "hex",
  "ipnet",
  "libredfish",
  "librms",

--- a/crates/admin-cli/Cargo.toml
+++ b/crates/admin-cli/Cargo.toml
@@ -77,6 +77,7 @@ urlencoding = { workspace = true }
 uuid = { workspace = true }
 x509-parser = { features = ["validate"], workspace = true }
 zip = { workspace = true, default-features = false, features = ["deflate"] }
+hex.workspace = true
 
 [dev-dependencies]
 carbide-test-support = { path = "../test-support" }

--- a/crates/admin-cli/src/machine_validation/tests.rs
+++ b/crates/admin-cli/src/machine_validation/tests.rs
@@ -241,6 +241,115 @@ fn parse_tests_subcommands() {
     );
 }
 
+// img_name requires a pinned sha256 digest; the tag is optional.
+const VALID_DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; // 64 hex chars
+
+#[test]
+fn parse_tests_add_img_name_validation() {
+    let valid_img = format!("nvcr.io/foo/bar:v1.0@sha256:{VALID_DIGEST}");
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Tests(tests_cmd::Args::Add(args)) => args.img_name,
+                    _ => panic!("expected Tests Add variant"),
+                })
+                .map_err(drop)
+        };
+        "add accepts a pinned digest" {
+            &[
+                "machine-validation", "tests", "add",
+                "--name", "my-test",
+                "--command", "/bin/test",
+                "--args", "--verbose",
+                "--img-name", valid_img.as_str(),
+            ][..] => Yields(Some(valid_img.clone())),
+        }
+        "add accepts :latest tag when digest is present" {
+            &[
+                "machine-validation", "tests", "add",
+                "--name", "my-test",
+                "--command", "/bin/test",
+                "--args", "--verbose",
+                "--img-name", &format!("nvcr.io/foo/bar:latest@sha256:{VALID_DIGEST}"),
+            ][..] => Yields(Some(format!("nvcr.io/foo/bar:latest@sha256:{VALID_DIGEST}"))),
+        }
+        "add rejects missing digest" {
+            &[
+                "machine-validation", "tests", "add",
+                "--name", "my-test",
+                "--command", "/bin/test",
+                "--args", "--verbose",
+                "--img-name", "nvcr.io/foo/bar:v1.0",
+            ][..] => Fails,
+        }
+        "add rejects empty name before @" {
+            &[
+                "machine-validation", "tests", "add",
+                "--name", "my-test",
+                "--command", "/bin/test",
+                "--args", "--verbose",
+                "--img-name", &format!("@sha256:{VALID_DIGEST}"),
+            ][..] => Fails,
+        }
+        "add without img_name is fine" {
+            &[
+                "machine-validation", "tests", "add",
+                "--name", "my-test",
+                "--command", "/bin/test",
+                "--args", "--verbose",
+            ][..] => Yields(None),
+        }
+    );
+}
+
+#[test]
+fn parse_tests_update_img_name_validation() {
+    let valid_img = format!("nvcr.io/foo/bar:v1.0@sha256:{VALID_DIGEST}");
+    scenarios!(
+        run = |argv| {
+            Cmd::try_parse_from(argv.iter().copied())
+                .map(|cmd| match cmd {
+                    Cmd::Tests(tests_cmd::Args::Update(args)) => args.img_name,
+                    _ => panic!("expected Tests Update variant"),
+                })
+                .map_err(drop)
+        };
+        "update accepts a pinned digest" {
+            &[
+                "machine-validation", "tests", "update",
+                "--test-id", "my-test",
+                "--version", "v1",
+                "--img-name", valid_img.as_str(),
+            ][..] => Yields(Some(valid_img.clone())),
+        }
+        "update accepts :latest tag when digest is present" {
+            &[
+                "machine-validation", "tests", "update",
+                "--test-id", "my-test",
+                "--version", "v1",
+                "--img-name", &format!("nvcr.io/foo/bar:latest@sha256:{VALID_DIGEST}"),
+            ][..] => Yields(Some(format!("nvcr.io/foo/bar:latest@sha256:{VALID_DIGEST}"))),
+        }
+        "update rejects missing digest" {
+            &[
+                "machine-validation", "tests", "update",
+                "--test-id", "my-test",
+                "--version", "v1",
+                "--img-name", "nvcr.io/foo/bar:v1.0",
+            ][..] => Fails,
+        }
+        "update rejects empty name before @" {
+            &[
+                "machine-validation", "tests", "update",
+                "--test-id", "my-test",
+                "--version", "v1",
+                "--img-name", &format!("@sha256:{VALID_DIGEST}"),
+            ][..] => Fails,
+        }
+    );
+}
+
 // Malformed invocations are rejected at parse time -- results show with none of
 // its required filters cannot parse.
 #[test]

--- a/crates/admin-cli/src/machine_validation/tests_cmd/args.rs
+++ b/crates/admin-cli/src/machine_validation/tests_cmd/args.rs
@@ -17,6 +17,32 @@
 
 use clap::Parser;
 
+/// Require a pinned SHA256 digest on container image references.
+///
+/// Tags are mutable; a digest is the only guarantee of reproducibility.
+fn parse_img_name(s: &str) -> Result<String, String> {
+    let (name_part, digest_part) = s
+        .split_once('@')
+        .ok_or("must include a SHA256 digest (e.g. image:tag@sha256:<digest>)")?;
+    if name_part.is_empty() {
+        return Err("image name before '@' must not be empty".into());
+    }
+    if digest_part.contains('@') {
+        return Err("must contain exactly one '@sha256:<digest>' suffix".into());
+    }
+    let hex_str = digest_part
+        .strip_prefix("sha256:")
+        .ok_or("digest must use the 'sha256:' algorithm prefix")?;
+    let decoded = hex::decode(hex_str).map_err(|e| format!("digest is not valid hex: {e}"))?;
+    if decoded.len() != 32 {
+        return Err(format!(
+            "SHA256 digest must decode to 32 bytes, got {}",
+            decoded.len()
+        ));
+    }
+    Ok(s.to_string())
+}
+
 #[derive(Parser, Debug)]
 #[command(after_long_help = "\
 EXAMPLES:
@@ -91,7 +117,8 @@ pub struct UpdateTestOptions {
     #[clap(long, help = "List of contexts")]
     pub contexts: Vec<String>,
 
-    #[clap(long, help = "Container image name")]
+    #[clap(long, help = "Container image name (must include @sha256:<digest>)",
+           value_parser = parse_img_name)]
     pub img_name: Option<String>,
 
     #[clap(long, help = "Run command using chroot in case of container")]
@@ -151,7 +178,8 @@ pub struct AddTestOptions {
     #[clap(long, help = "List of contexts")]
     pub contexts: Vec<String>,
 
-    #[clap(long, help = "Container image name")]
+    #[clap(long, help = "Container image name (must include @sha256:<digest>)",
+           value_parser = parse_img_name)]
     pub img_name: Option<String>,
 
     #[clap(long, help = "Run command using chroot in case of container")]

--- a/crates/api-core/src/handlers/machine_validation.rs
+++ b/crates/api-core/src/handlers/machine_validation.rs
@@ -803,6 +803,43 @@ pub(crate) async fn remove_machine_validation_external_config(
     Ok(tonic::Response::new(()))
 }
 
+/// Require a pinned SHA256 digest on container image references.
+///
+/// Tags are mutable and can silently point to different content between
+/// pulls; only a digest guarantees the same image executes each time.
+fn validate_img_name(img_name: &str) -> Result<(), CarbideError> {
+    let (name_part, digest_part) = img_name.split_once('@').ok_or_else(|| {
+        CarbideError::InvalidArgument(
+            "img_name must include a SHA256 digest (e.g. image:tag@sha256:<digest>)".into(),
+        )
+    })?;
+    if name_part.is_empty() {
+        return Err(CarbideError::InvalidArgument(
+            "img_name image name before '@' must not be empty".into(),
+        ));
+    }
+    if digest_part.contains('@') {
+        return Err(CarbideError::InvalidArgument(
+            "img_name must contain exactly one '@sha256:<digest>' suffix".into(),
+        ));
+    }
+    let hex_str = digest_part.strip_prefix("sha256:").ok_or_else(|| {
+        CarbideError::InvalidArgument(
+            "img_name digest must use the 'sha256:' algorithm prefix".into(),
+        )
+    })?;
+    let decoded = hex::decode(hex_str).map_err(|e| {
+        CarbideError::InvalidArgument(format!("img_name digest is not valid hex: {e}"))
+    })?;
+    if decoded.len() != 32 {
+        return Err(CarbideError::InvalidArgument(format!(
+            "img_name SHA256 digest must decode to 32 bytes, got {}",
+            decoded.len()
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) async fn update_machine_validation_test(
     api: &Api,
     request: tonic::Request<rpc::MachineValidationTestUpdateRequest>,
@@ -815,6 +852,11 @@ pub(crate) async fn update_machine_validation_test(
     }
 
     let req = request.into_inner();
+
+    if let Some(img_name) = req.payload.as_ref().and_then(|p| p.img_name.as_deref()) {
+        validate_img_name(img_name).map_err(Status::from)?;
+    }
+
     let mut txn = api.txn_begin().await?;
 
     // let existing = machine_validation_suites::find(
@@ -857,6 +899,11 @@ pub(crate) async fn add_machine_validation_test(
     }
 
     let req = request.into_inner();
+
+    if let Some(img_name) = req.img_name.as_deref() {
+        validate_img_name(img_name).map_err(Status::from)?;
+    }
+
     let mut txn = api.txn_begin().await?;
 
     let model_req: ModelTestAddRequest = req.into();
@@ -1233,5 +1280,77 @@ mod tests {
             assert_eq!(event.validation_id, validation_id, "{}", case.scenario);
             assert_eq!(event.error, case.expect_error, "{}", case.scenario);
         }
+    }
+}
+
+#[cfg(test)]
+mod img_name_validation_tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases};
+
+    use super::validate_img_name;
+
+    // A 64-character hex string encoding 32 bytes — the canonical valid digest.
+    const VALID_HEX: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    #[test]
+    fn img_name_validation() {
+        check_cases(
+            [
+                Case {
+                    scenario: "tag with digest",
+                    input: format!("nvcr.io/foo/bar:v1.0@sha256:{VALID_HEX}"),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "no tag",
+                    input: format!("nvcr.io/foo/bar@sha256:{VALID_HEX}"),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "latest tag with digest",
+                    input: format!("nvcr.io/foo/bar:latest@sha256:{VALID_HEX}"),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "missing digest",
+                    input: "nvcr.io/foo/bar:v1.0".to_string(),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "multiple at-signs",
+                    input: format!("nvcr.io/foo/bar:v1.0@sha256:{VALID_HEX}@extra"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "wrong algorithm prefix",
+                    input: format!("nvcr.io/foo/bar:v1.0@md5:{VALID_HEX}"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "non-hex digest",
+                    input: "nvcr.io/foo/bar:v1.0@sha256:not-hex-at-all-!!!!".to_string(),
+                    expect: Fails,
+                },
+                Case {
+                    // 62 hex chars = 31 bytes, not 32.
+                    scenario: "digest too short",
+                    input: "nvcr.io/foo/bar:v1.0@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+                    expect: Fails,
+                },
+                Case {
+                    // 66 hex chars = 33 bytes, not 32.
+                    scenario: "digest too long",
+                    input: format!("nvcr.io/foo/bar:v1.0@sha256:{VALID_HEX}aa"),
+                    expect: Fails,
+                },
+                Case {
+                    scenario: "empty name before @",
+                    input: format!("@sha256:{VALID_HEX}"),
+                    expect: Fails,
+                },
+            ],
+            |img| validate_img_name(&img).map_err(|_| ()),
+        );
     }
 }


### PR DESCRIPTION
Reject any img_name that lacks a pinned @sha256:<digest> component. Any tag value (including :latest) is accepted as long as a valid digest is present. Validation runs at two layers:

- Handler (add/update): validate_img_name verifies the digest is exactly 32 bytes and that the reference has exactly one '@' segment.
- Admin CLI: mirrors the same rules via a clap value_parser on the img_name field.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/2962
https://github.com/NVIDIA/infra-controller/issues/3655

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

