### PR TITLE
test(rpc): cover site explorer conversions

### DIFF
--- a/crates/api-core/tests/integration/explored_mlx_devices.rs
+++ b/crates/api-core/tests/integration/explored_mlx_devices.rs
@@ -117,9 +117,7 @@ async fn test_find_explored_mlx_devices(pool: PgPool) -> Result<(), Box<dyn std:
     assert_eq!(devices.len(), 1);
     let device = &devices[0];
     assert_eq!(device.host_bmc_ip, "192.0.2.20");
-    assert_eq!(device.part_number.as_deref(), Some("900-9D3B4-00EN-EA0"));
     assert_eq!(device.firmware_version.as_deref(), Some("32.38.1002"));
-    assert_eq!(device.serial_number.as_deref(), Some("MT2403X00984"));
     assert_eq!(
         device.device_kind,
         ::rpc::site_explorer::MlxDeviceKind::Bf3NicMode as i32

--- a/crates/rpc/src/model/site_explorer.rs
+++ b/crates/rpc/src/model/site_explorer.rs
@@ -428,33 +428,1054 @@ impl From<OperatorErrorSchema> for rpc::site_explorer::OperatorErrorSchema {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use carbide_test_support::value_scenarios;
-    use model::site_explorer::EndpointExplorationError;
+    use carbide_uuid::machine::MachineId;
+    use chrono::{DateTime, TimeZone as _, Utc};
+    use model::firmware::FirmwareComponentType;
+    use model::site_explorer::{EndpointExplorationError, EndpointType, PreingestionState};
     use prost::Message;
 
     use super::*;
 
-    #[test]
-    fn endpoint_report_propagates_operator_error_schema_to_rpc() {
-        let error = EndpointExplorationError::MissingVendor { observed: None };
-        let expected_schema = error.operator_error_schema();
+    const MACHINE_ID: &str = "fm100htv4fu8fpktl0e0qrg4dl58g2bc2g7naq0l6c15ruc22po1i5rfsq0";
+    const NO_TIMESTAMP: &str = "no timestamp available";
 
-        let report =
-            rpc::site_explorer::EndpointExplorationReport::from(EndpointExplorationReport {
-                last_exploration_error: Some(error),
-                ..Default::default()
+    fn timestamp(second: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 23, 12, 0, second)
+            .single()
+            .expect("valid test timestamp")
+    }
+
+    fn explored_dpu(address: &str, mac_address: Option<&str>) -> ExploredDpu {
+        ExploredDpu {
+            bmc_ip: address.parse().expect("valid DPU BMC IP"),
+            host_pf_mac_address: mac_address.map(|mac| mac.parse().expect("valid test MAC")),
+            report: Arc::new(EndpointExplorationReport::default()),
+        }
+    }
+
+    fn minimal_endpoint(address: &str) -> ExploredEndpoint {
+        ExploredEndpoint {
+            address: address.parse().expect("valid endpoint IP"),
+            report: EndpointExplorationReport::default(),
+            report_version: "V1-T0".parse().expect("valid config version"),
+            preingestion_state: PreingestionState::Initial,
+            waiting_for_explorer_refresh: false,
+            exploration_requested: false,
+            last_redfish_bmc_reset: None,
+            last_ipmitool_bmc_reset: None,
+            last_redfish_reboot: None,
+            last_redfish_powercycle: None,
+            pause_ingestion_and_poweron: false,
+            pause_remediation: false,
+            boot_interface_mac: None,
+            boot_interface_id: None,
+        }
+    }
+
+    fn successful_last_run() -> SiteExplorerLastRun {
+        SiteExplorerLastRun {
+            started_at: timestamp(0),
+            finished_at: timestamp(1),
+            success: true,
+            error: None,
+            failure_category: None,
+            endpoint_explorations: 2,
+            endpoint_explorations_success: 2,
+            endpoint_explorations_failed: 0,
+            last_successful_finished_at: Some(timestamp(1)),
+            last_failed_finished_at: None,
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct EndpointSummary {
+        address: String,
+        report_version: String,
+        report_type: Option<String>,
+        vendor: Option<String>,
+        exploration_requested: bool,
+        preingestion_state: String,
+        last_redfish_bmc_reset: String,
+        last_ipmitool_bmc_reset: String,
+        last_redfish_reboot: String,
+        last_redfish_powercycle: String,
+        pause_remediation: bool,
+    }
+
+    fn summarize_endpoint(endpoint: ExploredEndpoint) -> EndpointSummary {
+        let endpoint = rpc::site_explorer::ExploredEndpoint::from(endpoint);
+        EndpointSummary {
+            address: endpoint.address,
+            report_version: endpoint.report_version,
+            report_type: endpoint
+                .report
+                .as_ref()
+                .map(|report| report.endpoint_type.clone()),
+            vendor: endpoint.report.and_then(|report| report.vendor),
+            exploration_requested: endpoint.exploration_requested,
+            preingestion_state: endpoint.preingestion_state,
+            last_redfish_bmc_reset: endpoint.last_redfish_bmc_reset,
+            last_ipmitool_bmc_reset: endpoint.last_ipmitool_bmc_reset,
+            last_redfish_reboot: endpoint.last_redfish_reboot,
+            last_redfish_powercycle: endpoint.last_redfish_powercycle,
+            pause_remediation: endpoint.pause_remediation,
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ErrorSchemaSummary {
+        error_code: String,
+        mitigation: Option<String>,
+        text: String,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ManagerSummary {
+        id: String,
+        interface_count: usize,
+        interface_id: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct SystemSummary {
+        id: String,
+        manufacturer: Option<String>,
+        model: Option<String>,
+        serial_number: Option<String>,
+        nic_mode: Option<i32>,
+        interface_count: usize,
+        interface_id: Option<String>,
+        pcie_device_count: usize,
+        pcie_id: Option<String>,
+        power_state: i32,
+        boot_option_count: usize,
+        boot_option_id: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ChassisSummary {
+        id: String,
+        manufacturer: Option<String>,
+        model: Option<String>,
+        part_number: Option<String>,
+        serial_number: Option<String>,
+        adapter_count: usize,
+        adapter_id: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ServiceSummary {
+        id: String,
+        inventory_count: usize,
+        inventory_id: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct MachineSetupSummary {
+        is_done: bool,
+        diff_count: usize,
+        diff_key: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct EndpointReportSummary {
+        endpoint_type: String,
+        serialized_error: Option<EndpointExplorationError>,
+        error_schema: Option<ErrorSchemaSummary>,
+        latency: Option<(i64, i32)>,
+        machine_id: Option<String>,
+        vendor: Option<String>,
+        child_counts: (usize, usize, usize, usize),
+        manager: Option<ManagerSummary>,
+        system: Option<SystemSummary>,
+        chassis: Option<ChassisSummary>,
+        service: Option<ServiceSummary>,
+        machine_setup: Option<MachineSetupSummary>,
+        secure_boot_enabled: Option<bool>,
+        lockdown: Option<(i32, String)>,
+        firmware_versions: HashMap<String, String>,
+    }
+
+    fn summarize_endpoint_report(report: EndpointExplorationReport) -> EndpointReportSummary {
+        let report = rpc::site_explorer::EndpointExplorationReport::from(report);
+        let manager = report.managers.first().map(|manager| {
+            let interface = manager.ethernet_interfaces.first();
+            ManagerSummary {
+                id: manager.id.clone(),
+                interface_count: manager.ethernet_interfaces.len(),
+                interface_id: interface.and_then(|interface| interface.id.clone()),
+            }
+        });
+        let system = report.systems.first().map(|system| {
+            let pcie_device = system.pcie_devices.first();
+            SystemSummary {
+                id: system.id.clone(),
+                manufacturer: system.manufacturer.clone(),
+                model: system.model.clone(),
+                serial_number: system.serial_number.clone(),
+                nic_mode: system
+                    .attributes
+                    .as_ref()
+                    .and_then(|attributes| attributes.nic_mode),
+                interface_count: system.ethernet_interfaces.len(),
+                interface_id: system
+                    .ethernet_interfaces
+                    .first()
+                    .and_then(|interface| interface.id.clone()),
+                pcie_device_count: system.pcie_devices.len(),
+                pcie_id: pcie_device.and_then(|device| device.id.clone()),
+                power_state: system.power_state,
+                boot_option_count: system
+                    .boot_order
+                    .as_ref()
+                    .map_or(0, |order| order.boot_order.len()),
+                boot_option_id: system
+                    .boot_order
+                    .as_ref()
+                    .and_then(|order| order.boot_order.first())
+                    .map(|option| option.id.clone()),
+            }
+        });
+        let chassis = report.chassis.first().map(|chassis| ChassisSummary {
+            id: chassis.id.clone(),
+            manufacturer: chassis.manufacturer.clone(),
+            model: chassis.model.clone(),
+            part_number: chassis.part_number.clone(),
+            serial_number: chassis.serial_number.clone(),
+            adapter_count: chassis.network_adapters.len(),
+            adapter_id: chassis
+                .network_adapters
+                .first()
+                .map(|adapter| adapter.id.clone()),
+        });
+        let service = report.service.first().map(|service| ServiceSummary {
+            id: service.id.clone(),
+            inventory_count: service.inventories.len(),
+            inventory_id: service
+                .inventories
+                .first()
+                .map(|inventory| inventory.id.clone()),
+        });
+        let machine_setup =
+            report
+                .machine_setup_status
+                .as_ref()
+                .map(|status| MachineSetupSummary {
+                    is_done: status.is_done,
+                    diff_count: status.diffs.len(),
+                    diff_key: status.diffs.first().map(|diff| diff.key.clone()),
+                });
+        let serialized_error = report.last_exploration_error.map(|error| {
+            serde_json::from_str(&error).expect("RPC error remains serialized model JSON")
+        });
+        let error_schema = report
+            .last_exploration_error_schema
+            .map(|schema| ErrorSchemaSummary {
+                error_code: schema.error_code,
+                mitigation: schema.mitigation,
+                text: schema.text,
             });
 
-        let actual_schema = report
-            .last_exploration_error_schema
-            .expect("report contains operator error schema");
-        assert_eq!(
-            actual_schema.error_code,
-            expected_schema.error_code.to_string()
+        EndpointReportSummary {
+            endpoint_type: report.endpoint_type,
+            serialized_error,
+            error_schema,
+            latency: report
+                .last_exploration_latency
+                .map(|duration| (duration.seconds, duration.nanos)),
+            machine_id: report.machine_id,
+            vendor: report.vendor,
+            child_counts: (
+                report.managers.len(),
+                report.systems.len(),
+                report.chassis.len(),
+                report.service.len(),
+            ),
+            manager,
+            system,
+            chassis,
+            service,
+            machine_setup,
+            secure_boot_enabled: report.secure_boot_status.map(|status| status.is_enabled),
+            lockdown: report
+                .lockdown_status
+                .map(|status| (status.status, status.message)),
+            firmware_versions: report.firmware_versions,
+        }
+    }
+
+    #[test]
+    fn endpoint_search_filters_convert_to_model() {
+        value_scenarios!(
+            run = |filter| {
+                let _: ExploredEndpointSearchFilter = filter.into();
+            };
+            "empty endpoint filter" {
+                rpc::site_explorer::ExploredEndpointSearchFilter {} => (),
+            }
         );
-        assert_eq!(actual_schema.text, expected_schema.text);
-        assert_eq!(actual_schema.mitigation, expected_schema.mitigation);
-        assert!(report.last_exploration_error.is_some());
+    }
+
+    #[test]
+    fn managed_host_search_filters_convert_to_model() {
+        value_scenarios!(
+            run = |filter| {
+                let _: ExploredManagedHostSearchFilter = filter.into();
+            };
+            "empty managed-host filter" {
+                rpc::site_explorer::ExploredManagedHostSearchFilter {} => (),
+            }
+        );
+    }
+
+    #[test]
+    fn mlx_device_kinds_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::MlxDeviceKind::from;
+            "BlueField-3 NIC-mode SKU" {
+                MlxDeviceKind::Bf3NicMode => rpc::site_explorer::MlxDeviceKind::Bf3NicMode,
+            }
+
+            "BlueField-3 DPU-mode SKU" {
+                MlxDeviceKind::Bf3DpuMode => rpc::site_explorer::MlxDeviceKind::Bf3DpuMode,
+            }
+
+            "BlueField-3 SuperNIC SKU" {
+                MlxDeviceKind::Bf3SuperNic => rpc::site_explorer::MlxDeviceKind::Bf3SuperNic,
+            }
+
+            "BlueField-2 DPU" {
+                MlxDeviceKind::Bf2Dpu => rpc::site_explorer::MlxDeviceKind::Bf2Dpu,
+            }
+
+            "unknown device kind" {
+                MlxDeviceKind::Unknown => rpc::site_explorer::MlxDeviceKind::Unknown,
+            }
+        );
+    }
+
+    #[test]
+    fn bluefield_operating_modes_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::BlueFieldOperatingMode::from;
+            "DPU mode" {
+                BlueFieldOperatingMode::Dpu => rpc::site_explorer::BlueFieldOperatingMode::Dpu,
+            }
+
+            "NIC mode" {
+                BlueFieldOperatingMode::Nic => rpc::site_explorer::BlueFieldOperatingMode::Nic,
+            }
+        );
+    }
+
+    #[test]
+    fn power_states_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::PowerState::from;
+            "off" {
+                PowerState::Off => rpc::site_explorer::PowerState::Off,
+            }
+
+            "on" {
+                PowerState::On => rpc::site_explorer::PowerState::On,
+            }
+
+            "powering off" {
+                PowerState::PoweringOff => rpc::site_explorer::PowerState::PoweringOff,
+            }
+
+            "powering on" {
+                PowerState::PoweringOn => rpc::site_explorer::PowerState::PoweringOn,
+            }
+
+            "paused" {
+                PowerState::Paused => rpc::site_explorer::PowerState::Paused,
+            }
+
+            "unknown" {
+                PowerState::Unknown => rpc::site_explorer::PowerState::Unknown,
+            }
+        );
+    }
+
+    #[test]
+    fn lockdown_states_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::InternalLockdownStatus::from;
+            "enabled" {
+                InternalLockdownStatus::Enabled => rpc::site_explorer::InternalLockdownStatus::Enabled,
+            }
+
+            "partial" {
+                InternalLockdownStatus::Partial => rpc::site_explorer::InternalLockdownStatus::Partial,
+            }
+
+            "disabled" {
+                InternalLockdownStatus::Disabled => rpc::site_explorer::InternalLockdownStatus::Disabled,
+            }
+        );
+    }
+
+    #[test]
+    fn managed_hosts_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::ExploredManagedHost::from;
+            "no DPUs" {
+                ExploredManagedHost {
+                    host_bmc_ip: "192.0.2.10".parse().unwrap(),
+                    dpus: vec![],
+                } => rpc::site_explorer::ExploredManagedHost {
+                    host_bmc_ip: "192.0.2.10".to_string(),
+                    dpu_bmc_ip: String::new(),
+                    host_pf_mac_address: None,
+                    dpus: vec![],
+                },
+            }
+
+            "one DPU populates the repeated and legacy fields" {
+                ExploredManagedHost {
+                    host_bmc_ip: "192.0.2.11".parse().unwrap(),
+                    dpus: vec![explored_dpu(
+                        "192.0.2.21",
+                        Some("02:00:00:00:00:01"),
+                    )],
+                } => rpc::site_explorer::ExploredManagedHost {
+                    host_bmc_ip: "192.0.2.11".to_string(),
+                    dpu_bmc_ip: "192.0.2.21".to_string(),
+                    host_pf_mac_address: Some("02:00:00:00:00:01".to_string()),
+                    dpus: vec![rpc::site_explorer::ExploredDpu {
+                        bmc_ip: "192.0.2.21".to_string(),
+                        host_pf_mac_address: Some("02:00:00:00:00:01".to_string()),
+                    }],
+                },
+            }
+
+            "multiple DPUs preserve every DPU and derive legacy fields from the first" {
+                ExploredManagedHost {
+                    host_bmc_ip: "192.0.2.12".parse().unwrap(),
+                    dpus: vec![
+                        explored_dpu("192.0.2.22", None),
+                        explored_dpu("192.0.2.23", Some("02:00:00:00:00:03")),
+                    ],
+                } => rpc::site_explorer::ExploredManagedHost {
+                    host_bmc_ip: "192.0.2.12".to_string(),
+                    dpu_bmc_ip: "192.0.2.22".to_string(),
+                    host_pf_mac_address: None,
+                    dpus: vec![
+                        rpc::site_explorer::ExploredDpu {
+                            bmc_ip: "192.0.2.22".to_string(),
+                            host_pf_mac_address: None,
+                        },
+                        rpc::site_explorer::ExploredDpu {
+                            bmc_ip: "192.0.2.23".to_string(),
+                            host_pf_mac_address: Some("02:00:00:00:00:03".to_string()),
+                        },
+                    ],
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn explored_endpoints_convert_to_rpc() {
+        let sparse_version: config_version::ConfigVersion =
+            "V2-T0".parse().expect("valid config version");
+        let sparse = ExploredEndpoint {
+            report_version: sparse_version,
+            ..minimal_endpoint("192.0.2.30")
+        };
+
+        let reset = timestamp(2);
+        let ipmi_reset = timestamp(3);
+        let reboot = timestamp(4);
+        let powercycle = timestamp(5);
+        let populated_version: config_version::ConfigVersion =
+            "V9-T1000000".parse().expect("valid config version");
+        let populated = ExploredEndpoint {
+            address: "2001:db8::30".parse().unwrap(),
+            report: EndpointExplorationReport {
+                endpoint_type: EndpointType::Bmc,
+                vendor: Some("nvidia".into()),
+                ..Default::default()
+            },
+            report_version: populated_version,
+            preingestion_state: PreingestionState::RecheckVersions,
+            waiting_for_explorer_refresh: false,
+            exploration_requested: true,
+            last_redfish_bmc_reset: Some(reset),
+            last_ipmitool_bmc_reset: Some(ipmi_reset),
+            last_redfish_reboot: Some(reboot),
+            last_redfish_powercycle: Some(powercycle),
+            pause_ingestion_and_poweron: false,
+            pause_remediation: true,
+            boot_interface_mac: None,
+            boot_interface_id: None,
+        };
+
+        value_scenarios!(run = summarize_endpoint;
+            "absent timestamps use the existing sentinel" {
+                sparse => EndpointSummary {
+                    address: "192.0.2.30".to_string(),
+                    report_version: sparse_version.to_string(),
+                    report_type: Some("Unknown".to_string()),
+                    vendor: None,
+                    exploration_requested: false,
+                    preingestion_state: "Initial".to_string(),
+                    last_redfish_bmc_reset: NO_TIMESTAMP.to_string(),
+                    last_ipmitool_bmc_reset: NO_TIMESTAMP.to_string(),
+                    last_redfish_reboot: NO_TIMESTAMP.to_string(),
+                    last_redfish_powercycle: NO_TIMESTAMP.to_string(),
+                    pause_remediation: false,
+                },
+            }
+
+            "populated endpoint metadata" {
+                populated => EndpointSummary {
+                    address: "2001:db8::30".to_string(),
+                    report_version: populated_version.to_string(),
+                    report_type: Some("Bmc".to_string()),
+                    vendor: Some("nvidia".to_string()),
+                    exploration_requested: true,
+                    preingestion_state: "RecheckVersions".to_string(),
+                    last_redfish_bmc_reset: reset.to_string(),
+                    last_ipmitool_bmc_reset: ipmi_reset.to_string(),
+                    last_redfish_reboot: reboot.to_string(),
+                    last_redfish_powercycle: powercycle.to_string(),
+                    pause_remediation: true,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn explored_mlx_devices_convert_to_rpc() {
+        let machine_id: MachineId = MACHINE_ID.parse().expect("valid machine ID");
+
+        value_scenarios!(run = rpc::site_explorer::ExploredMlxDevice::from;
+            "optional fields absent" {
+                ExploredMlxDevice {
+                    host_bmc_ip: "192.0.2.40".parse().unwrap(),
+                    machine_id: None,
+                    device_kind: MlxDeviceKind::Unknown,
+                    pcie_id: None,
+                    part_number: None,
+                    serial_number: None,
+                    firmware_version: None,
+                    description: None,
+                    dpu_bmc_ip: None,
+                    nic_mode: None,
+                } => rpc::site_explorer::ExploredMlxDevice {
+                    host_bmc_ip: "192.0.2.40".to_string(),
+                    machine_id: None,
+                    device_kind: rpc::site_explorer::MlxDeviceKind::Unknown as i32,
+                    pcie_id: None,
+                    part_number: None,
+                    serial_number: None,
+                    firmware_version: None,
+                    description: None,
+                    dpu_bmc_ip: None,
+                    nic_mode: None,
+                },
+            }
+
+            "optional fields populated" {
+                ExploredMlxDevice {
+                    host_bmc_ip: "2001:db8::40".parse().unwrap(),
+                    machine_id: Some(machine_id),
+                    device_kind: MlxDeviceKind::Bf3DpuMode,
+                    pcie_id: Some("188-0".to_string()),
+                    part_number: Some("900-9D3B6-00CN-PA0".to_string()),
+                    serial_number: Some("MT2403X00984".to_string()),
+                    firmware_version: Some("32.42.1000".to_string()),
+                    description: Some("NVIDIA BlueField-3 DPU".to_string()),
+                    dpu_bmc_ip: Some("2001:db8::41".parse().unwrap()),
+                    nic_mode: Some(BlueFieldOperatingMode::Nic),
+                } => rpc::site_explorer::ExploredMlxDevice {
+                    host_bmc_ip: "2001:db8::40".to_string(),
+                    machine_id: Some(MACHINE_ID.to_string()),
+                    device_kind: rpc::site_explorer::MlxDeviceKind::Bf3DpuMode as i32,
+                    pcie_id: Some("188-0".to_string()),
+                    part_number: Some("900-9D3B6-00CN-PA0".to_string()),
+                    serial_number: Some("MT2403X00984".to_string()),
+                    firmware_version: Some("32.42.1000".to_string()),
+                    description: Some("NVIDIA BlueField-3 DPU".to_string()),
+                    dpu_bmc_ip: Some("2001:db8::41".to_string()),
+                    nic_mode: Some(rpc::site_explorer::BlueFieldOperatingMode::Nic as i32),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn ethernet_interfaces_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::EthernetInterface::from;
+            "optional fields absent" {
+                EthernetInterface::default() => rpc::site_explorer::EthernetInterface::default(),
+            }
+
+            "optional fields populated" {
+                EthernetInterface {
+                    id: Some("ethernet-1".to_string()),
+                    description: Some("host interface".to_string()),
+                    interface_enabled: Some(true),
+                    mac_address: Some("02:00:00:00:20:01".parse().expect("valid test MAC")),
+                    link_status: Some("LinkUp".to_string()),
+                    ..Default::default()
+                } => rpc::site_explorer::EthernetInterface {
+                    id: Some("ethernet-1".to_string()),
+                    description: Some("host interface".to_string()),
+                    interface_enabled: Some(true),
+                    mac_address: Some("02:00:00:00:20:01".to_string()),
+                    link_status: Some("LinkUp".to_string()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn pcie_devices_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::PcIeDevice::from;
+            "optional fields absent" {
+                PCIeDevice {
+                    description: None,
+                    firmware_version: None,
+                    gpu_vendor: None,
+                    id: None,
+                    manufacturer: None,
+                    name: None,
+                    part_number: None,
+                    serial_number: None,
+                    status: None,
+                } => rpc::site_explorer::PcIeDevice {
+                    description: None,
+                    firmware_version: None,
+                    gpu_vendor: None,
+                    id: None,
+                    manufacturer: None,
+                    name: None,
+                    part_number: None,
+                    serial_number: None,
+                    status: None,
+                },
+            }
+
+            "optional fields and status populated" {
+                PCIeDevice {
+                    description: Some("BlueField adapter".to_string()),
+                    firmware_version: Some("32.42.1000".to_string()),
+                    gpu_vendor: Some("GPU vendor".to_string()),
+                    id: Some("188-0".to_string()),
+                    manufacturer: Some("PCIe manufacturer".to_string()),
+                    name: Some("Network Adapter".to_string()),
+                    part_number: Some("900-9D3B6".to_string()),
+                    serial_number: Some("PCIE-SERIAL".to_string()),
+                    status: Some(SystemStatus {
+                        health: Some("OK".to_string()),
+                        health_rollup: Some("Warning".to_string()),
+                        state: "Enabled".to_string(),
+                    }),
+                } => rpc::site_explorer::PcIeDevice {
+                    description: Some("BlueField adapter".to_string()),
+                    firmware_version: Some("32.42.1000".to_string()),
+                    gpu_vendor: Some("GPU vendor".to_string()),
+                    id: Some("188-0".to_string()),
+                    manufacturer: Some("PCIe manufacturer".to_string()),
+                    name: Some("Network Adapter".to_string()),
+                    part_number: Some("900-9D3B6".to_string()),
+                    serial_number: Some("PCIE-SERIAL".to_string()),
+                    status: Some(rpc::site_explorer::SystemStatus {
+                        health: Some("OK".to_string()),
+                        health_rollup: Some("Warning".to_string()),
+                        state: "Enabled".to_string(),
+                    }),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn boot_options_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::BootOption::from;
+            "optional fields absent" {
+                BootOption::default() => rpc::site_explorer::BootOption::default(),
+            }
+
+            "optional fields populated" {
+                BootOption {
+                    display_name: "PXE".to_string(),
+                    id: "Boot0001".to_string(),
+                    boot_option_enabled: Some(true),
+                    uefi_device_path: Some("PciRoot(0x0)".to_string()),
+                } => rpc::site_explorer::BootOption {
+                    display_name: "PXE".to_string(),
+                    id: "Boot0001".to_string(),
+                    boot_option_enabled: Some(true),
+                    uefi_device_path: Some("PciRoot(0x0)".to_string()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn network_adapters_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::NetworkAdapter::from;
+            "optional fields absent" {
+                NetworkAdapter::default() => rpc::site_explorer::NetworkAdapter::default(),
+            }
+
+            "optional fields populated" {
+                NetworkAdapter {
+                    id: "adapter-1".to_string(),
+                    manufacturer: Some("NVIDIA".to_string()),
+                    model: Some("ConnectX-7".to_string()),
+                    part_number: Some("ADAPTER-PN".to_string()),
+                    serial_number: Some("ADAPTER-SERIAL".to_string()),
+                } => rpc::site_explorer::NetworkAdapter {
+                    id: "adapter-1".to_string(),
+                    manufacturer: Some("NVIDIA".to_string()),
+                    model: Some("ConnectX-7".to_string()),
+                    part_number: Some("ADAPTER-PN".to_string()),
+                    serial_number: Some("ADAPTER-SERIAL".to_string()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn inventories_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::Inventory::from;
+            "optional fields absent" {
+                Inventory::default() => rpc::site_explorer::Inventory::default(),
+            }
+
+            "optional fields populated" {
+                Inventory {
+                    id: "inventory-1".to_string(),
+                    description: Some("BMC firmware".to_string()),
+                    version: Some("25.06-2".to_string()),
+                    release_date: Some("2026-06-01".to_string()),
+                } => rpc::site_explorer::Inventory {
+                    id: "inventory-1".to_string(),
+                    description: Some("BMC firmware".to_string()),
+                    version: Some("25.06-2".to_string()),
+                    release_date: Some("2026-06-01".to_string()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn machine_setup_diffs_convert_to_rpc() {
+        value_scenarios!(run = rpc::site_explorer::MachineSetupDiff::from;
+            "empty fields" {
+                MachineSetupDiff::default() => rpc::site_explorer::MachineSetupDiff::default(),
+            }
+
+            "distinct fields" {
+                MachineSetupDiff {
+                    key: "boot-order".to_string(),
+                    expected: "PXE".to_string(),
+                    actual: "Disk".to_string(),
+                } => rpc::site_explorer::MachineSetupDiff {
+                    key: "boot-order".to_string(),
+                    expected: "PXE".to_string(),
+                    actual: "Disk".to_string(),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn endpoint_reports_convert_to_rpc() {
+        let error = EndpointExplorationError::MissingVendor { observed: None };
+        let expected_schema = error.operator_error_schema();
+        let machine_id: MachineId = MACHINE_ID.parse().expect("valid machine ID");
+        let manager_mac = "02:00:00:00:10:01".parse().expect("valid test MAC");
+        let system_mac = "02:00:00:00:10:02".parse().expect("valid test MAC");
+
+        let populated = EndpointExplorationReport {
+            endpoint_type: EndpointType::Bmc,
+            last_exploration_error: Some(error),
+            last_exploration_latency: Some(std::time::Duration::from_millis(1250)),
+            vendor: Some("nvidia".into()),
+            managers: vec![Manager {
+                id: "manager-1".to_string(),
+                ethernet_interfaces: vec![EthernetInterface {
+                    id: Some("manager-eth-1".to_string()),
+                    description: Some("manager interface".to_string()),
+                    interface_enabled: Some(true),
+                    mac_address: Some(manager_mac),
+                    link_status: Some("LinkUp".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            systems: vec![ComputerSystem {
+                id: "system-1".to_string(),
+                manufacturer: Some("NVIDIA".to_string()),
+                model: Some("DGX".to_string()),
+                serial_number: Some("HOST-SERIAL".to_string()),
+                ethernet_interfaces: vec![EthernetInterface {
+                    id: Some("system-eth-1".to_string()),
+                    description: Some("host interface".to_string()),
+                    interface_enabled: Some(false),
+                    mac_address: Some(system_mac),
+                    link_status: Some("NoLink".to_string()),
+                    ..Default::default()
+                }],
+                attributes: ComputerSystemAttributes {
+                    nic_mode: Some(BlueFieldOperatingMode::Dpu),
+                    is_infinite_boot_enabled: Some(true),
+                },
+                pcie_devices: vec![PCIeDevice {
+                    description: Some("BlueField adapter".to_string()),
+                    firmware_version: Some("32.42.1000".to_string()),
+                    gpu_vendor: Some("GPU vendor".to_string()),
+                    id: Some("188-0".to_string()),
+                    manufacturer: Some("PCIe manufacturer".to_string()),
+                    name: Some("Network Adapter".to_string()),
+                    part_number: Some("900-9D3B6".to_string()),
+                    serial_number: Some("PCIE-SERIAL".to_string()),
+                    status: Some(SystemStatus {
+                        health: Some("OK".to_string()),
+                        health_rollup: Some("Warning".to_string()),
+                        state: "Enabled".to_string(),
+                    }),
+                }],
+                power_state: PowerState::PoweringOn,
+                boot_order: Some(BootOrder {
+                    boot_order: vec![BootOption {
+                        display_name: "PXE".to_string(),
+                        id: "Boot0001".to_string(),
+                        boot_option_enabled: Some(true),
+                        uefi_device_path: Some("PciRoot(0x0)".to_string()),
+                    }],
+                }),
+                ..Default::default()
+            }],
+            chassis: vec![Chassis {
+                id: "chassis-1".to_string(),
+                manufacturer: Some("NVIDIA".to_string()),
+                model: Some("GB200".to_string()),
+                part_number: Some("CHASSIS-PN".to_string()),
+                serial_number: Some("CHASSIS-SERIAL".to_string()),
+                network_adapters: vec![NetworkAdapter {
+                    id: "adapter-1".to_string(),
+                    manufacturer: Some("NVIDIA".to_string()),
+                    model: Some("ConnectX-7".to_string()),
+                    part_number: Some("ADAPTER-PN".to_string()),
+                    serial_number: Some("ADAPTER-SERIAL".to_string()),
+                }],
+                ..Default::default()
+            }],
+            service: vec![Service {
+                id: "update-service".to_string(),
+                inventories: vec![Inventory {
+                    id: "inventory-1".to_string(),
+                    description: Some("BMC firmware".to_string()),
+                    version: Some("25.06-2".to_string()),
+                    release_date: Some("2026-06-01".to_string()),
+                }],
+            }],
+            machine_id: Some(machine_id),
+            versions: HashMap::from([(FirmwareComponentType::Bmc, "25.06-2".to_string())]),
+            machine_setup_status: Some(MachineSetupStatus {
+                is_done: true,
+                diffs: vec![MachineSetupDiff {
+                    key: "boot-order".to_string(),
+                    expected: "PXE".to_string(),
+                    actual: "Disk".to_string(),
+                }],
+            }),
+            secure_boot_status: Some(SecureBootStatus { is_enabled: true }),
+            lockdown_status: Some(LockdownStatus {
+                status: InternalLockdownStatus::Partial,
+                message: "one setting remains".to_string(),
+            }),
+            ..Default::default()
+        };
+
+        value_scenarios!(run = summarize_endpoint_report;
+            "sparse report" {
+                EndpointExplorationReport::default() => EndpointReportSummary {
+                    endpoint_type: "Unknown".to_string(),
+                    serialized_error: None,
+                    error_schema: None,
+                    latency: None,
+                    machine_id: None,
+                    vendor: None,
+                    child_counts: (0, 0, 0, 0),
+                    manager: None,
+                    system: None,
+                    chassis: None,
+                    service: None,
+                    machine_setup: None,
+                    secure_boot_enabled: None,
+                    lockdown: None,
+                    firmware_versions: HashMap::new(),
+                },
+            }
+
+            "populated report invokes each Redfish child conversion" {
+                populated => EndpointReportSummary {
+                    endpoint_type: "Bmc".to_string(),
+                    serialized_error: Some(EndpointExplorationError::MissingVendor {
+                        observed: None,
+                    }),
+                    error_schema: Some(ErrorSchemaSummary {
+                        error_code: "NICO-SITEEXPLORER-122".to_string(),
+                        mitigation: expected_schema.mitigation,
+                        text: expected_schema.text,
+                    }),
+                    latency: Some((1, 250_000_000)),
+                    machine_id: Some(MACHINE_ID.to_string()),
+                    vendor: Some("nvidia".to_string()),
+                    child_counts: (1, 1, 1, 1),
+                    manager: Some(ManagerSummary {
+                        id: "manager-1".to_string(),
+                        interface_count: 1,
+                        interface_id: Some("manager-eth-1".to_string()),
+                    }),
+                    system: Some(SystemSummary {
+                        id: "system-1".to_string(),
+                        manufacturer: Some("NVIDIA".to_string()),
+                        model: Some("DGX".to_string()),
+                        serial_number: Some("HOST-SERIAL".to_string()),
+                        nic_mode: Some(
+                            rpc::site_explorer::BlueFieldOperatingMode::Dpu as i32,
+                        ),
+                        interface_count: 1,
+                        interface_id: Some("system-eth-1".to_string()),
+                        pcie_device_count: 1,
+                        pcie_id: Some("188-0".to_string()),
+                        power_state: rpc::site_explorer::PowerState::PoweringOn as i32,
+                        boot_option_count: 1,
+                        boot_option_id: Some("Boot0001".to_string()),
+                    }),
+                    chassis: Some(ChassisSummary {
+                        id: "chassis-1".to_string(),
+                        manufacturer: Some("NVIDIA".to_string()),
+                        model: Some("GB200".to_string()),
+                        part_number: Some("CHASSIS-PN".to_string()),
+                        serial_number: Some("CHASSIS-SERIAL".to_string()),
+                        adapter_count: 1,
+                        adapter_id: Some("adapter-1".to_string()),
+                    }),
+                    service: Some(ServiceSummary {
+                        id: "update-service".to_string(),
+                        inventory_count: 1,
+                        inventory_id: Some("inventory-1".to_string()),
+                    }),
+                    machine_setup: Some(MachineSetupSummary {
+                        is_done: true,
+                        diff_count: 1,
+                        diff_key: Some("boot-order".to_string()),
+                    }),
+                    secure_boot_enabled: Some(true),
+                    lockdown: Some((
+                        rpc::site_explorer::InternalLockdownStatus::Partial as i32,
+                        "one setting remains".to_string(),
+                    )),
+                    firmware_versions: HashMap::from([(
+                        "bmc".to_string(),
+                        "25.06-2".to_string(),
+                    )]),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn last_runs_convert_to_rpc() {
+        let success_started = timestamp(10);
+        let success_finished = timestamp(11);
+        let failed_started = timestamp(12);
+        let failed_finished = timestamp(13);
+
+        value_scenarios!(run = rpc::site_explorer::SiteExplorerLastRun::from;
+            "successful run" {
+                SiteExplorerLastRun {
+                    started_at: success_started,
+                    finished_at: success_finished,
+                    success: true,
+                    error: None,
+                    failure_category: None,
+                    endpoint_explorations: 4,
+                    endpoint_explorations_success: 4,
+                    endpoint_explorations_failed: 0,
+                    last_successful_finished_at: Some(success_finished),
+                    last_failed_finished_at: None,
+                } => rpc::site_explorer::SiteExplorerLastRun {
+                    started_at: success_started.to_rfc3339(),
+                    finished_at: success_finished.to_rfc3339(),
+                    success: true,
+                    error: None,
+                    endpoint_explorations: 4,
+                    endpoint_explorations_success: 4,
+                    endpoint_explorations_failed: 0,
+                    failure_category: None,
+                    last_successful_finished_at: Some(success_finished.to_rfc3339()),
+                    last_failed_finished_at: None,
+                },
+            }
+
+            "failed run" {
+                SiteExplorerLastRun {
+                    started_at: failed_started,
+                    finished_at: failed_finished,
+                    success: false,
+                    error: Some("endpoint timed out".to_string()),
+                    failure_category: Some("exploration".to_string()),
+                    endpoint_explorations: 3,
+                    endpoint_explorations_success: 2,
+                    endpoint_explorations_failed: 1,
+                    last_successful_finished_at: None,
+                    last_failed_finished_at: Some(failed_finished),
+                } => rpc::site_explorer::SiteExplorerLastRun {
+                    started_at: failed_started.to_rfc3339(),
+                    finished_at: failed_finished.to_rfc3339(),
+                    success: false,
+                    error: Some("endpoint timed out".to_string()),
+                    endpoint_explorations: 3,
+                    endpoint_explorations_success: 2,
+                    endpoint_explorations_failed: 1,
+                    failure_category: Some("exploration".to_string()),
+                    last_successful_finished_at: None,
+                    last_failed_finished_at: Some(failed_finished.to_rfc3339()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn site_reports_convert_to_rpc() {
+        value_scenarios!(
+            run = |report| {
+                let report = rpc::site_explorer::SiteExplorationReport::from(report);
+                (
+                    report.last_run.is_some(),
+                    report.endpoints.len(),
+                    report.managed_hosts.len(),
+                )
+            };
+            "empty site report" {
+                SiteExplorationReport {
+                    last_run: None,
+                    endpoints: vec![],
+                    managed_hosts: vec![],
+                } => (false, 0, 0),
+            }
+
+            "populated site report" {
+                SiteExplorationReport {
+                    last_run: Some(successful_last_run()),
+                    endpoints: vec![minimal_endpoint("192.0.2.50")],
+                    managed_hosts: vec![ExploredManagedHost {
+                        host_bmc_ip: "192.0.2.51".parse().unwrap(),
+                        dpus: vec![explored_dpu("192.0.2.52", None)],
+                    }],
+                } => (true, 1, 1),
+            }
+        );
     }
 
     /// Reflection-backed and generated clients retain the legacy protobuf type
@@ -501,16 +1522,6 @@ mod tests {
         assert_eq!(
             rpc::site_explorer::BlueFieldOperatingMode::Nic.as_str_name(),
             "NIC"
-        );
-        value_scenarios!(
-            run = rpc::site_explorer::BlueFieldOperatingMode::from;
-            "DPU mode" {
-                BlueFieldOperatingMode::Dpu => rpc::site_explorer::BlueFieldOperatingMode::Dpu,
-            }
-
-            "NIC mode" {
-                BlueFieldOperatingMode::Nic => rpc::site_explorer::BlueFieldOperatingMode::Nic,
-            }
         );
     }
 }

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -44,9 +44,7 @@ use model::site_explorer::{
 };
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::GetSiteExplorationRequest;
-use rpc::site_explorer::{
-    ExploredDpu as RpcExploredDpu, ExploredManagedHost as RpcExploredManagedHost,
-};
+use rpc::site_explorer::ExploredDpu as RpcExploredDpu;
 use tonic::Request;
 
 use crate::env::{self, Env};
@@ -1513,28 +1511,17 @@ async fn test_site_explorer_main(pool: PgPool) -> Result<(), Box<dyn std::error:
         .expect("Should have found one managed host with zero DPUs")
         .clone();
 
+    assert_eq!(managed_host_1.host_bmc_ip, machines[1].ip);
     assert_eq!(
-        managed_host_1,
-        RpcExploredManagedHost {
-            host_bmc_ip: machines[1].ip.clone(),
-            dpu_bmc_ip: machines[0].ip.clone(),
+        managed_host_1.dpus,
+        vec![RpcExploredDpu {
+            bmc_ip: machines[0].ip.clone(),
             host_pf_mac_address: Some(mock_dpu.host_mac_address.to_string()),
-            dpus: vec![RpcExploredDpu {
-                bmc_ip: machines[0].ip.clone(),
-                host_pf_mac_address: Some(mock_dpu.host_mac_address.to_string()),
-            }]
-        }
+        }]
     );
 
-    assert_eq!(
-        managed_host_2,
-        RpcExploredManagedHost {
-            host_bmc_ip: machines[2].ip.clone(),
-            dpu_bmc_ip: "".to_string(),
-            host_pf_mac_address: None,
-            dpus: vec![],
-        }
-    );
+    assert_eq!(managed_host_2.host_bmc_ip, machines[2].ip);
+    assert!(managed_host_2.dpus.is_empty());
 
     assert_eq!(
         test_meter


### PR DESCRIPTION
## Summary

- Add focused table-driven coverage for Site Explorer enums, search filters, Redfish child records, endpoint reports, managed hosts, explored devices, and site reports.
- Exercise all 30 production conversion implementations with sparse and populated values, exact operator error transport, and compatibility behavior.
- Remove four direct field assertions already owned by model/RPC tests while retaining integration coverage for persistence, selection, association, classification, joins, and the firmware database round trip.

## Coverage

Production code in `crates/rpc/src/model/site_explorer.rs`:

| Metric | Before | After |
| --- | ---: | ---: |
| Functions | 5 / 55 (9.09%) | 54 / 55 (98.18%) |
| Lines | 38 / 283 (13.43%) | 283 / 283 (100%) |
| Regions | 60 / 325 (18.46%) | 323 / 325 (99.38%) |

The model-feature RPC suite grows from 117 to 134 tests. The new coverage is organized as 18 table-driven tests with 43 named cases, plus the existing protobuf descriptor compatibility test.

The only uncovered production function and two regions are the fallback closure for serializing an `EndpointExplorationError`. Its fixed variants contain only infallibly serializable fields; the containing conversion and exact decoded error payload are covered.

## Validation

- `cargo test -p carbide-rpc --features model site_explorer::tests --lib`
- `cargo test -p carbide-rpc --all-features --lib`
- `cargo test -p carbide-api-core --test integration explored_mlx_devices::test_find_explored_mlx_devices`
- `cargo test -p carbide-site-explorer --test integration site_explorer::test_site_explorer_main`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Independent agent review, local CodeRabbit review, and local Claude review

Closes #4038
