### PR TITLE
refactor(component-manager): reuse loaded machines for endpoint resolution

### DIFF
--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -721,25 +721,25 @@ fn is_rack_scale_server(machine: &Machine) -> bool {
         .is_some_and(|hw| hw.is_mnnvl_capable())
 }
 
-/// Splits the requested compute machines into two lists: rack-scale and standalone servers.
-/// Rack-scale systems go through the rack-level state controller maintenance flow
-//  Standalone servers use the existing host reprovisioning firmware path.
-async fn partition_compute_machines_by_rack_scale(
-    api: &Api,
+/// Splits already-loaded compute machines into rack-scale and standalone lists.
+/// Rack-scale systems go through the rack-level state controller maintenance flow.
+/// Standalone servers use the existing host reprovisioning firmware path.
+///
+/// Unknown ids are a hard error here (firmware path); power control collects
+/// them as per-machine results instead via [`machine_is_rack_scale`].
+fn partition_loaded_compute_machines_by_rack_scale(
+    machines_by_id: &HashMap<MachineId, Machine>,
     machine_ids: &[MachineId],
 ) -> Result<(Vec<MachineId>, Vec<MachineId>), Status> {
-    let machines_by_id = load_machines_by_id(api, machine_ids).await?;
-
     let mut rack_scale = Vec::new();
     let mut standalone = Vec::new();
     for &machine_id in machine_ids {
-        if machine_is_rack_scale(&machines_by_id, machine_id)? {
+        if machine_is_rack_scale(machines_by_id, machine_id)? {
             rack_scale.push(machine_id);
         } else {
             standalone.push(machine_id);
         }
     }
-
     Ok((rack_scale, standalone))
 }
 
@@ -1254,26 +1254,21 @@ struct ComputeTrayEndpoints {
     unresolved: Vec<UnresolvedDevice<carbide_uuid::machine::MachineId>>,
 }
 
-async fn resolve_compute_tray_endpoints(
-    api: &Api,
-    machine_ids: &[carbide_uuid::machine::MachineId],
-) -> Result<ComputeTrayEndpoints, Status> {
-    let machines = db::machine::find(
-        api.db_reader().as_mut(),
-        db::ObjectFilter::List(machine_ids),
-        MachineSearchConfig::default(),
-    )
-    .await
-    .map_err(|e| Status::internal(format!("failed to look up machines: {e}")))?;
-
-    let machine_by_id: HashMap<_, _> = machines.into_iter().map(|m| (m.id, m)).collect();
-
+/// Resolve BMC endpoints from an already-loaded machine map.
+///
+/// Callers that previously loaded machines for classification (power / firmware
+/// partition) reuse that map here so the machine table is not queried again.
+async fn resolve_compute_tray_endpoints_from_machines(
+    credential_manager: &dyn CredentialManager,
+    machines_by_id: &HashMap<MachineId, Machine>,
+    machine_ids: &[MachineId],
+) -> ComputeTrayEndpoints {
     let mut endpoints = Vec::with_capacity(machine_ids.len());
     let mut ip_to_machine_id = HashMap::with_capacity(machine_ids.len());
     let mut unresolved = Vec::new();
 
     for &machine_id in machine_ids {
-        let Some(machine) = machine_by_id.get(&machine_id) else {
+        let Some(machine) = machines_by_id.get(&machine_id) else {
             unresolved.push(UnresolvedDevice {
                 id: machine_id,
                 reason: "machine not found in database".into(),
@@ -1297,21 +1292,17 @@ async fn resolve_compute_tray_endpoints(
             continue;
         };
 
-        let bmc_credentials = match fetch_compute_tray_bmc_credentials(
-            api.credential_manager.as_ref(),
-            bmc_mac,
-        )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                unresolved.push(UnresolvedDevice {
-                    id: machine_id,
-                    reason: format!("BMC credentials unavailable: {e}"),
-                });
-                continue;
-            }
-        };
+        let bmc_credentials =
+            match fetch_compute_tray_bmc_credentials(credential_manager, bmc_mac).await {
+                Ok(c) => c,
+                Err(e) => {
+                    unresolved.push(UnresolvedDevice {
+                        id: machine_id,
+                        reason: format!("BMC credentials unavailable: {e}"),
+                    });
+                    continue;
+                }
+            };
 
         let vendor = map_bmc_vendor_to_compute_tray(machine.bmc_vendor());
 
@@ -1330,13 +1321,13 @@ async fn resolve_compute_tray_endpoints(
         );
     }
 
-    Ok(ComputeTrayEndpoints {
+    ComputeTrayEndpoints {
         resolved: ResolvedComputeTrayEndpoints {
             endpoints,
             ip_to_machine_id,
         },
         unresolved,
-    })
+    }
 }
 
 fn switch_mac_to_id_str(mac: &MacAddress, mac_to_id: &HashMap<MacAddress, SwitchId>) -> String {
@@ -1770,6 +1761,7 @@ pub(crate) async fn component_power_control(
                     match dispatch_compute_tray_power_control(
                         api,
                         cm.compute_tray.as_ref(),
+                        &machines_by_id,
                         &rack_scale_ids,
                         action,
                     )
@@ -1794,6 +1786,7 @@ pub(crate) async fn component_power_control(
                 match dispatch_compute_tray_power_control(
                     api,
                     &core_backend,
+                    &machines_by_id,
                     &standalone_ids,
                     action,
                 )
@@ -1839,20 +1832,26 @@ fn partition_error_results(
         .collect()
 }
 
-/// Resolve BMC endpoints for `machine_ids`, issue power control through
-/// `backend`, and return per-machine results (keyed by machine id via the
-/// resolved `ip_to_machine_id` map) alongside the BMC IPs that were dispatched
-/// to, so the caller can request site re-exploration for them.
+/// Resolve BMC endpoints for `machine_ids` from an already-loaded machine map,
+/// issue power control through `backend`, and return per-machine results (keyed
+/// by machine id via the resolved `ip_to_machine_id` map) alongside the BMC IPs
+/// that were dispatched to, so the caller can request site re-exploration.
 ///
 /// Shared by the rack-scale synchronous path (configured backend, e.g. RMS) and
 /// the standalone path (always NICo-core's Redfish backend).
 async fn dispatch_compute_tray_power_control(
     api: &Api,
     backend: &dyn ComputeTrayManager,
+    machines_by_id: &HashMap<MachineId, Machine>,
     machine_ids: &[MachineId],
     action: PowerAction,
 ) -> Result<(Vec<rpc::ComponentResult>, Vec<IpAddr>), Status> {
-    let resolved = resolve_compute_tray_endpoints(api, machine_ids).await?;
+    let resolved = resolve_compute_tray_endpoints_from_machines(
+        api.credential_manager.as_ref(),
+        machines_by_id,
+        machine_ids,
+    )
+    .await;
 
     let mut results: Vec<rpc::ComponentResult> = resolved
         .unresolved
@@ -2277,8 +2276,9 @@ pub(crate) async fn update_component_firmware(
             // systems (currently GB200 NVL, backed by RMS via the
             // ComputeTrayManager interface) can choose between the rack-level
             // state controller maintenance flow and a direct backend dispatch.
+            let machines_by_id = load_machines_by_id(api, &list.machine_ids).await?;
             let (rack_scale_ids, standalone_ids) =
-                partition_compute_machines_by_rack_scale(api, &list.machine_ids).await?;
+                partition_loaded_compute_machines_by_rack_scale(&machines_by_id, &list.machine_ids)?;
 
             let mut results = Vec::new();
 
@@ -2309,7 +2309,12 @@ pub(crate) async fn update_component_firmware(
                 } else {
                     reject_firmware_object_json_for_direct_dispatch("compute tray", &access_token)?;
                     let components = map_compute_tray_components(&t.components)?;
-                    let resolved = resolve_compute_tray_endpoints(api, &rack_scale_ids).await?;
+                    let resolved = resolve_compute_tray_endpoints_from_machines(
+                        api.credential_manager.as_ref(),
+                        &machines_by_id,
+                        &rack_scale_ids,
+                    )
+                    .await;
 
                     results.extend(
                         resolved
@@ -2724,7 +2729,13 @@ pub(crate) async fn list_component_firmware_versions(
                 return Err(unsupported_from_json_firmware_versions("compute tray"));
             }
 
-            let resolved = resolve_compute_tray_endpoints(api, &list.machine_ids).await?;
+            let machines_by_id = load_machines_by_id(api, &list.machine_ids).await?;
+            let resolved = resolve_compute_tray_endpoints_from_machines(
+                api.credential_manager.as_ref(),
+                &machines_by_id,
+                &list.machine_ids,
+            )
+            .await;
 
             let mut devices: Vec<rpc::DeviceFirmwareVersions> = resolved
                 .unresolved

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -2277,8 +2277,10 @@ pub(crate) async fn update_component_firmware(
             // ComputeTrayManager interface) can choose between the rack-level
             // state controller maintenance flow and a direct backend dispatch.
             let machines_by_id = load_machines_by_id(api, &list.machine_ids).await?;
-            let (rack_scale_ids, standalone_ids) =
-                partition_loaded_compute_machines_by_rack_scale(&machines_by_id, &list.machine_ids)?;
+            let (rack_scale_ids, standalone_ids) = partition_loaded_compute_machines_by_rack_scale(
+                &machines_by_id,
+                &list.machine_ids,
+            )?;
 
             let mut results = Vec::new();
 
@@ -3785,8 +3787,7 @@ mod tests {
     fn all_rack_scale_batch_uses_only_rack_partition() {
         let id = host_machine_id();
         let machines = HashMap::from([(id, rack_scale_machine())]);
-        let (rack, standalone, results) =
-            prepare_dispatch_lists(&machines, &[id], &HashMap::new());
+        let (rack, standalone, results) = prepare_dispatch_lists(&machines, &[id], &HashMap::new());
         assert!(results.is_empty());
         assert_eq!(rack, vec![id]);
         assert!(standalone.is_empty());
@@ -3796,8 +3797,7 @@ mod tests {
     fn all_standalone_batch_uses_only_standalone_partition() {
         let id = host_machine_id();
         let machines = HashMap::from([(id, standalone_machine())]);
-        let (rack, standalone, results) =
-            prepare_dispatch_lists(&machines, &[id], &HashMap::new());
+        let (rack, standalone, results) = prepare_dispatch_lists(&machines, &[id], &HashMap::new());
         assert!(results.is_empty());
         assert!(rack.is_empty());
         assert_eq!(standalone, vec![id]);
@@ -3924,15 +3924,11 @@ mod tests {
             password: "secret".into(),
         });
 
-        let resolved =
-            resolve_compute_tray_endpoints_from_machines(&creds, &machines, &[id]).await;
+        let resolved = resolve_compute_tray_endpoints_from_machines(&creds, &machines, &[id]).await;
 
         assert!(resolved.unresolved.is_empty());
         assert_eq!(resolved.resolved.endpoints.len(), 1);
         assert_eq!(resolved.resolved.endpoints[0].bmc_ip, bmc_ip);
-        assert_eq!(
-            resolved.resolved.ip_to_machine_id.get(&bmc_ip),
-            Some(&id)
-        );
+        assert_eq!(resolved.resolved.ip_to_machine_id.get(&bmc_ip), Some(&id));
     }
 }

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -3651,6 +3651,8 @@ mod tests {
 
     // ---- compute power-control (MachineIds) decision logic ----
 
+    use carbide_secrets::credentials::Credentials;
+    use carbide_secrets::test_support::credentials::TestCredentialManager;
     use model::hardware_info::{Gpu, GpuPlatformInfo, HardwareInfo};
     use model::test_support::machine_snapshot::{dpu_machine_id, host_machine, host_machine_id};
 
@@ -3683,6 +3685,11 @@ mod tests {
         machine
     }
 
+    fn machine_with_id(mut machine: Machine, id: MachineId) -> Machine {
+        machine.id = id;
+        machine
+    }
+
     /// Rack-scale: at least one MNNVL-capable GPU.
     fn rack_scale_machine() -> Machine {
         machine_with_hardware(Some(HardwareInfo {
@@ -3694,6 +3701,42 @@ mod tests {
     /// Standalone: no MNNVL-capable GPU.
     fn standalone_machine() -> Machine {
         machine_with_hardware(Some(HardwareInfo::default()))
+    }
+
+    /// Mirror the MachineIds power path's classify → power-option gate → partition
+    /// loop without a database: unknown ids become per-machine NotFound results,
+    /// and only machines with a successful power-option update join a partition.
+    fn prepare_dispatch_lists(
+        machines_by_id: &HashMap<MachineId, Machine>,
+        machine_ids: &[MachineId],
+        power_option_ok: &HashMap<MachineId, bool>,
+    ) -> (Vec<MachineId>, Vec<MachineId>, Vec<rpc::ComponentResult>) {
+        let mut results = Vec::new();
+        let mut rack_scale_ids = Vec::new();
+        let mut standalone_ids = Vec::new();
+        for &machine_id in machine_ids {
+            let is_rack_scale = match machine_is_rack_scale(machines_by_id, machine_id) {
+                Ok(v) => v,
+                Err(status) => {
+                    results.push(status_result(&machine_id.to_string(), status));
+                    continue;
+                }
+            };
+            let ok = power_option_ok.get(&machine_id).copied().unwrap_or(true);
+            if !ok {
+                results.push(error_result(
+                    &machine_id.to_string(),
+                    "failed to update power option: precondition".into(),
+                ));
+                continue;
+            }
+            if is_rack_scale {
+                rack_scale_ids.push(machine_id);
+            } else {
+                standalone_ids.push(machine_id);
+            }
+        }
+        (rack_scale_ids, standalone_ids, results)
     }
 
     #[test]
@@ -3719,6 +3762,90 @@ mod tests {
     }
 
     #[test]
+    fn mixed_batch_routes_rack_to_rack_partition_and_standalone_to_core_partition() {
+        let rack_id = host_machine_id();
+        let standalone_id = dpu_machine_id(0);
+        let machines = HashMap::from([
+            (rack_id, machine_with_id(rack_scale_machine(), rack_id)),
+            (
+                standalone_id,
+                machine_with_id(standalone_machine(), standalone_id),
+            ),
+        ]);
+
+        let (rack, standalone, results) =
+            prepare_dispatch_lists(&machines, &[rack_id, standalone_id], &HashMap::new());
+
+        assert!(results.is_empty());
+        assert_eq!(rack, vec![rack_id]);
+        assert_eq!(standalone, vec![standalone_id]);
+    }
+
+    #[test]
+    fn all_rack_scale_batch_uses_only_rack_partition() {
+        let id = host_machine_id();
+        let machines = HashMap::from([(id, rack_scale_machine())]);
+        let (rack, standalone, results) =
+            prepare_dispatch_lists(&machines, &[id], &HashMap::new());
+        assert!(results.is_empty());
+        assert_eq!(rack, vec![id]);
+        assert!(standalone.is_empty());
+    }
+
+    #[test]
+    fn all_standalone_batch_uses_only_standalone_partition() {
+        let id = host_machine_id();
+        let machines = HashMap::from([(id, standalone_machine())]);
+        let (rack, standalone, results) =
+            prepare_dispatch_lists(&machines, &[id], &HashMap::new());
+        assert!(results.is_empty());
+        assert!(rack.is_empty());
+        assert_eq!(standalone, vec![id]);
+    }
+
+    #[test]
+    fn unknown_machine_id_is_not_found_and_does_not_abort_rest_of_batch() {
+        let known = host_machine_id();
+        let unknown = dpu_machine_id(1);
+        let machines = HashMap::from([(known, standalone_machine())]);
+
+        let (rack, standalone, results) =
+            prepare_dispatch_lists(&machines, &[unknown, known], &HashMap::new());
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].component_id, unknown.to_string());
+        assert_eq!(
+            results[0].status,
+            rpc::ComponentManagerStatusCode::NotFound as i32
+        );
+        assert!(rack.is_empty());
+        assert_eq!(standalone, vec![known]);
+    }
+
+    #[test]
+    fn power_option_failure_is_not_dispatched_while_siblings_are() {
+        let ok_id = host_machine_id();
+        let fail_id = dpu_machine_id(0);
+        let machines = HashMap::from([
+            (ok_id, machine_with_id(rack_scale_machine(), ok_id)),
+            (fail_id, machine_with_id(standalone_machine(), fail_id)),
+        ]);
+        let power_ok = HashMap::from([(ok_id, true), (fail_id, false)]);
+
+        let (rack, standalone, results) =
+            prepare_dispatch_lists(&machines, &[ok_id, fail_id], &power_ok);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].component_id, fail_id.to_string());
+        assert!(results[0].error.contains("failed to update power option"));
+        assert_eq!(rack, vec![ok_id]);
+        assert!(
+            standalone.is_empty(),
+            "power-option failure must not join a dispatch partition"
+        );
+    }
+
+    #[test]
     fn partition_error_results_reports_one_error_per_machine() {
         let ids = [host_machine_id(), dpu_machine_id(0)];
         let status = Status::unavailable("backend down");
@@ -3735,5 +3862,77 @@ mod tests {
             );
             assert!(result.error.contains("backend down"));
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_from_machines_reports_missing_id_and_bmc_gaps() {
+        let missing_id = dpu_machine_id(0);
+        let no_mac_id = host_machine_id();
+        let no_ip_id = dpu_machine_id(1);
+
+        let mut no_mac = standalone_machine();
+        no_mac.id = no_mac_id;
+        no_mac.status.bmc_info.mac = None;
+
+        let mut no_ip = standalone_machine();
+        no_ip.id = no_ip_id;
+        no_ip.status.bmc_info.ip = None;
+
+        let machines = HashMap::from([(no_mac_id, no_mac), (no_ip_id, no_ip)]);
+        let creds = TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "u".into(),
+            password: "p".into(),
+        });
+
+        let resolved = resolve_compute_tray_endpoints_from_machines(
+            &creds,
+            &machines,
+            &[missing_id, no_mac_id, no_ip_id],
+        )
+        .await;
+
+        assert!(resolved.resolved.endpoints.is_empty());
+        assert_eq!(resolved.unresolved.len(), 3);
+        assert!(
+            resolved
+                .unresolved
+                .iter()
+                .any(|u| u.id == missing_id && u.reason.contains("machine not found"))
+        );
+        assert!(
+            resolved
+                .unresolved
+                .iter()
+                .any(|u| u.id == no_mac_id && u.reason.contains("BMC MAC"))
+        );
+        assert!(
+            resolved
+                .unresolved
+                .iter()
+                .any(|u| u.id == no_ip_id && u.reason.contains("BMC IP"))
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_from_machines_builds_endpoint_when_bmc_and_creds_present() {
+        let id = host_machine_id();
+        let machine = standalone_machine();
+        let bmc_ip = machine.status.bmc_info.ip.expect("fixture has BMC IP");
+        let machines = HashMap::from([(id, machine)]);
+        let creds = TestCredentialManager::new(Credentials::UsernamePassword {
+            username: "root".into(),
+            password: "secret".into(),
+        });
+
+        let resolved =
+            resolve_compute_tray_endpoints_from_machines(&creds, &machines, &[id]).await;
+
+        assert!(resolved.unresolved.is_empty());
+        assert_eq!(resolved.resolved.endpoints.len(), 1);
+        assert_eq!(resolved.resolved.endpoints[0].bmc_ip, bmc_ip);
+        assert_eq!(
+            resolved.resolved.ip_to_machine_id.get(&bmc_ip),
+            Some(&id)
+        );
     }
 }


### PR DESCRIPTION
## Description:  
- Reuse the machine map already loaded for rack-scale and standalone classification when resolving compute-tray endpoints.
- Apply the shared resolution path to compute power control and firmware operations, avoiding redundant database queries.
- Add coverage for mixed routing, unknown machine IDs, power-option failures, and endpoint-resolution errors as a patch for #3873.


## Related issues
#3873

## Type of Change 
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes 
- [ ] **This PR contains breaking changes**

## Testing 
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 

