### PR TITLE
test(bmc): consolidate vendor ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "bmc-vendor",
  "carbide-api-model",
  "carbide-network",
+ "carbide-test-support",
  "itertools 0.14.0",
  "lazy_static",
  "mac_address",
@@ -920,6 +921,7 @@ dependencies = [
 name = "bmc-vendor"
 version = "0.1.0"
 dependencies = [
+ "carbide-test-support",
  "clap",
  "serde",
 ]
@@ -3727,6 +3729,7 @@ name = "component-manager"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bmc-vendor",
  "carbide-api-db",
  "carbide-api-model",
  "carbide-api-test-helper",

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -1233,17 +1233,6 @@ async fn resolve_power_shelf_endpoints(
     })
 }
 
-fn map_bmc_vendor_to_compute_tray(vendor: bmc_vendor::BMCVendor) -> ComputeTrayVendor {
-    match vendor {
-        bmc_vendor::BMCVendor::Dell => ComputeTrayVendor::Dell,
-        bmc_vendor::BMCVendor::Hpe => ComputeTrayVendor::Hpe,
-        bmc_vendor::BMCVendor::Lenovo => ComputeTrayVendor::Lenovo,
-        bmc_vendor::BMCVendor::Supermicro => ComputeTrayVendor::Supermicro,
-        bmc_vendor::BMCVendor::Nvidia => ComputeTrayVendor::Nvidia,
-        _ => ComputeTrayVendor::Unknown,
-    }
-}
-
 struct ResolvedComputeTrayEndpoints {
     endpoints: Vec<ComputeTrayEndpoint>,
     ip_to_machine_id: HashMap<IpAddr, carbide_uuid::machine::MachineId>,
@@ -1313,7 +1302,7 @@ async fn resolve_compute_tray_endpoints(
             }
         };
 
-        let vendor = map_bmc_vendor_to_compute_tray(machine.bmc_vendor());
+        let vendor = ComputeTrayVendor::from(machine.bmc_vendor());
 
         ip_to_machine_id.insert(bmc_ip, machine_id);
         endpoints.push(ComputeTrayEndpoint {

--- a/crates/api-core/src/handlers/firmware.rs
+++ b/crates/api-core/src/handlers/firmware.rs
@@ -853,6 +853,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_vendor_trims_and_rejects_invalid_values() {
+        scenarios!(run = |input| parse_vendor(input).map_err(drop);
+            "trimmed canonical vendors are accepted" {
+                " Dell " => Yields(bmc_vendor::BMCVendor::Dell),
+            }
+
+            "invalid vendors are rejected" {
+                "   " => Fails,
+                "Acme" => Fails,
+            }
+        );
+    }
+
+    #[test]
     fn parse_preingest_upgrade_when_below_trims_and_rejects_empty_values() {
         assert_eq!(
             parse_preingest_upgrade_when_below(FirmwareComponentType::Bmc, Some(" 7.20.10.50 "))

--- a/crates/api-model/src/hardware_info.rs
+++ b/crates/api-model/src/hardware_info.rs
@@ -872,23 +872,11 @@ mod tests {
         );
     }
 
-    // `bmc_vendor()` maps the DMI `sys_vendor` string through `from_udev_dmi`, and
-    // falls back to `Unknown` when there is no DMI data at all.
     #[test]
     fn hardware_info_bmc_vendor() {
         value_scenarios!(
             run = |info| info.bmc_vendor();
-            "lenovo sys vendor" {
-                info_with_dmi(
-                    CpuArchitecture::X86_64,
-                    DmiData {
-                        sys_vendor: "Lenovo".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Lenovo,
-            }
-
-            "dell sys vendor" {
+            "DMI data delegates to BMCVendor" {
                 info_with_dmi(
                     CpuArchitecture::X86_64,
                     DmiData {
@@ -898,67 +886,7 @@ mod tests {
                 ) => bmc_vendor::BMCVendor::Dell,
             }
 
-            "nvidia sys vendor" {
-                info_with_dmi(
-                    CpuArchitecture::Aarch64,
-                    DmiData {
-                        sys_vendor: "NVIDIA".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Nvidia,
-            }
-
-            "mellanox url maps to nvidia" {
-                info_with_dmi(
-                    CpuArchitecture::Aarch64,
-                    DmiData {
-                        sys_vendor: "https://www.mellanox.com".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Nvidia,
-            }
-
-            "supermicro sys vendor" {
-                info_with_dmi(
-                    CpuArchitecture::X86_64,
-                    DmiData {
-                        sys_vendor: "Supermicro".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Supermicro,
-            }
-
-            "hpe sys vendor" {
-                info_with_dmi(
-                    CpuArchitecture::X86_64,
-                    DmiData {
-                        sys_vendor: "HPE".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Hpe,
-            }
-
-            "unrecognized sys vendor is unknown" {
-                info_with_dmi(
-                    CpuArchitecture::X86_64,
-                    DmiData {
-                        sys_vendor: "Acme Corp".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Unknown,
-            }
-
-            "case-sensitive: lowercase dell is unknown" {
-                info_with_dmi(
-                    CpuArchitecture::X86_64,
-                    DmiData {
-                        sys_vendor: "dell inc.".to_string(),
-                        ..Default::default()
-                    },
-                ) => bmc_vendor::BMCVendor::Unknown,
-            }
-
-            "no dmi data is unknown" {
+            "missing DMI data falls back to unknown" {
                 HardwareInfo::default() => bmc_vendor::BMCVendor::Unknown,
             }
         );

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -3059,7 +3059,9 @@ mod tests {
     use carbide_test_support::{Check, check_values, scenarios};
 
     use super::*;
-    use crate::test_support::machine_snapshot::{dpu_machine, managed_host_state_snapshot};
+    use crate::test_support::machine_snapshot::{
+        dpu_machine, host_machine, managed_host_state_snapshot,
+    };
 
     #[derive(Clone, Copy)]
     struct DpuProvisioningInput {
@@ -3091,6 +3093,37 @@ mod tests {
         firmware_version: Some("BF4-26.04"),
         reprovision_requested: false,
     };
+
+    #[test]
+    fn machine_bmc_vendor_delegates_to_hardware_info() {
+        let mut with_hardware_info = host_machine();
+        with_hardware_info
+            .status
+            .hardware_info
+            .as_mut()
+            .and_then(|hardware_info| hardware_info.dmi_data.as_mut())
+            .expect("fixture host has DMI data")
+            .sys_vendor = "Dell Inc.".to_string();
+
+        let mut without_hardware_info = host_machine();
+        without_hardware_info.status.hardware_info = None;
+
+        check_values(
+            [
+                Check {
+                    scenario: "hardware info delegates to its DMI vendor",
+                    input: with_hardware_info,
+                    expect: bmc_vendor::BMCVendor::Dell,
+                },
+                Check {
+                    scenario: "missing hardware info falls back to unknown",
+                    input: without_hardware_info,
+                    expect: bmc_vendor::BMCVendor::Unknown,
+                },
+            ],
+            |machine| machine.bmc_vendor(),
+        );
+    }
 
     #[derive(Clone, Copy)]
     struct DpfProvisioningInput {

--- a/crates/bmc-explorer/Cargo.toml
+++ b/crates/bmc-explorer/Cargo.toml
@@ -82,6 +82,7 @@ bmc-mock = { path = "../bmc-mock" }
 # Self dev-dependency so the crate's own integration tests get the test-support
 # helpers; applies only to test/bench targets, never the production library.
 bmc-explorer = { path = ".", features = ["test-support"] }
+carbide-test-support = { path = "../test-support" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -156,3 +156,38 @@ impl fmt::Display for BiosAttrValue<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bmc_vendor::BMCVendor;
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[test]
+    fn hw_type_bmc_vendor_maps_each_variant() {
+        value_scenarios!(run = |hardware_type: HwType| hardware_type.bmc_vendor();
+            "generic AMI has no canonical vendor" {
+                HwType::Ami => None,
+            }
+
+            "hardware types map to canonical vendors" {
+                HwType::Bluefield => Some(BMCVendor::Nvidia),
+                HwType::Dell => Some(BMCVendor::Dell),
+                HwType::Gb200 => Some(BMCVendor::Nvidia),
+                HwType::DgxGb300 => Some(BMCVendor::Nvidia),
+                HwType::Hpe => Some(BMCVendor::Hpe),
+                HwType::Lenovo => Some(BMCVendor::Lenovo),
+                HwType::LenovoAmi => Some(BMCVendor::LenovoAMI),
+                HwType::LenovoGb300 => Some(BMCVendor::LenovoAMI),
+                HwType::SupermicroGb300 => Some(BMCVendor::Supermicro),
+                HwType::Supermicro => Some(BMCVendor::Supermicro),
+                HwType::Viking => Some(BMCVendor::Nvidia),
+                HwType::LiteonPowerShelf => Some(BMCVendor::Liteon),
+                HwType::DeltaPowerShelf => Some(BMCVendor::Delta),
+                HwType::NvSwitch => Some(BMCVendor::Nvidia),
+                HwType::VeraRubin => Some(BMCVendor::Nvidia),
+            }
+        );
+    }
+}

--- a/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
@@ -59,7 +59,6 @@ async fn explore_bluefield3_without_system_eth_interfaces() {
         .await
         .unwrap();
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
-    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
     assert_eq!(
         report
             .systems
@@ -250,7 +249,6 @@ async fn explore_bluefield3_ignores_500_on_bios_fetch() {
         .expect("exploration must succeed when BlueField BIOS fetch returns 500");
 
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
-    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
     assert!(
         report
             .machine_setup_status

--- a/crates/bmc-explorer/tests/integration/powershelf_explore.rs
+++ b/crates/bmc-explorer/tests/integration/powershelf_explore.rs
@@ -104,7 +104,6 @@ async fn explore_delta_power_shelf_all_off() {
         .await
         .unwrap();
 
-    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Delta));
     assert!(!report.systems.is_empty(), "a system must be synthesized");
     assert!(
         report
@@ -127,7 +126,6 @@ async fn explore_delta_power_shelf_mixed() {
         .await
         .unwrap();
 
-    assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Delta));
     assert!(!report.systems.is_empty(), "a system must be synthesized");
     assert!(
         report

--- a/crates/bmc-vendor/Cargo.toml
+++ b/crates/bmc-vendor/Cargo.toml
@@ -25,5 +25,8 @@ authors.workspace = true
 clap = { workspace = true }
 serde = { features = ["derive"], workspace = true }
 
+[dev-dependencies]
+carbide-test-support = { path = "../test-support" }
+
 [lints]
 workspace = true

--- a/crates/bmc-vendor/src/lib.rs
+++ b/crates/bmc-vendor/src/lib.rs
@@ -169,19 +169,6 @@ impl BMCVendor {
         }
     }
 
-    /// BMC vendors issue their own TLS certs. Match on the Organization in that cert.
-    pub fn from_tls_issuer(s: &str) -> BMCVendor {
-        match s {
-            "Lenovo" => BMCVendor::Lenovo,
-            "Dell Inc." => BMCVendor::Dell,
-            "Super Micro Computer" => BMCVendor::Supermicro,
-            "Hewlett Packard Enterprise" => BMCVendor::Hpe,
-            "American Megatrends International LLC (AMI)" => BMCVendor::Nvidia,
-            "OpenBMC" => BMCVendor::Nvidia,
-            _ => BMCVendor::Unknown,
-        }
-    }
-
     /// to_pascalcase converts to StringLikeThis to match serialization
     pub fn to_pascalcase(self) -> String {
         match self {
@@ -201,10 +188,6 @@ impl BMCVendor {
         *self == Self::Lenovo
     }
 
-    pub fn is_lenovo_ami(&self) -> bool {
-        *self == Self::LenovoAMI
-    }
-
     pub fn is_supermicro(&self) -> bool {
         *self == Self::Supermicro
     }
@@ -217,19 +200,156 @@ impl BMCVendor {
         *self == Self::Dell
     }
 
-    pub fn is_hpe(&self) -> bool {
-        *self == Self::Hpe
-    }
-
-    pub fn is_liteon(&self) -> bool {
-        *self == Self::Liteon
-    }
-
-    pub fn is_delta(&self) -> bool {
-        *self == Self::Delta
-    }
-
     pub fn is_unknown(&self) -> bool {
         *self == Self::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct VendorPredicates {
+        is_lenovo: bool,
+        is_supermicro: bool,
+        is_nvidia: bool,
+        is_dell: bool,
+        is_unknown: bool,
+    }
+
+    #[test]
+    fn bmc_vendor_canonical_forms_cover_all_variants() {
+        value_scenarios!(
+            run = |input: &str| {
+                let vendor = BMCVendor::from(input);
+                (
+                    vendor,
+                    vendor.to_string(),
+                    vendor.to_pascalcase(),
+                    VendorPredicates {
+                        is_lenovo: vendor.is_lenovo(),
+                        is_supermicro: vendor.is_supermicro(),
+                        is_nvidia: vendor.is_nvidia(),
+                        is_dell: vendor.is_dell(),
+                        is_unknown: vendor.is_unknown(),
+                    },
+                )
+            };
+
+            "canonical names are case insensitive" {
+                "LeNoVo" => (
+                    BMCVendor::Lenovo,
+                    "lenovo".to_string(),
+                    "Lenovo".to_string(),
+                    VendorPredicates {
+                        is_lenovo: true,
+                        ..Default::default()
+                    },
+                ),
+                "LeNoVoAmI" => (
+                    BMCVendor::LenovoAMI,
+                    "lenovoami".to_string(),
+                    "LenovoAMI".to_string(),
+                    VendorPredicates::default(),
+                ),
+                "DELL" => (
+                    BMCVendor::Dell,
+                    "dell".to_string(),
+                    "Dell".to_string(),
+                    VendorPredicates {
+                        is_dell: true,
+                        ..Default::default()
+                    },
+                ),
+                "SuPeRmIcRo" => (
+                    BMCVendor::Supermicro,
+                    "supermicro".to_string(),
+                    "Supermicro".to_string(),
+                    VendorPredicates {
+                        is_supermicro: true,
+                        ..Default::default()
+                    },
+                ),
+                "HPE" => (
+                    BMCVendor::Hpe,
+                    "hpe".to_string(),
+                    "Hpe".to_string(),
+                    VendorPredicates::default(),
+                ),
+                "NVIDIA" => (
+                    BMCVendor::Nvidia,
+                    "nvidia".to_string(),
+                    "Nvidia".to_string(),
+                    VendorPredicates {
+                        is_nvidia: true,
+                        ..Default::default()
+                    },
+                ),
+                "LiTeOn" => (
+                    BMCVendor::Liteon,
+                    "liteon".to_string(),
+                    "Liteon".to_string(),
+                    VendorPredicates::default(),
+                ),
+                "DeLtA" => (
+                    BMCVendor::Delta,
+                    "delta".to_string(),
+                    "Delta".to_string(),
+                    VendorPredicates::default(),
+                ),
+                "unknown" => (
+                    BMCVendor::Unknown,
+                    "unknown".to_string(),
+                    "Unknown".to_string(),
+                    VendorPredicates {
+                        is_unknown: true,
+                        ..Default::default()
+                    },
+                ),
+            }
+
+            "noncanonical names are unknown" {
+                "Acme" => (
+                    BMCVendor::Unknown,
+                    "unknown".to_string(),
+                    "Unknown".to_string(),
+                    VendorPredicates {
+                        is_unknown: true,
+                        ..Default::default()
+                    },
+                ),
+                " dell " => (
+                    BMCVendor::Unknown,
+                    "unknown".to_string(),
+                    "Unknown".to_string(),
+                    VendorPredicates {
+                        is_unknown: true,
+                        ..Default::default()
+                    },
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn bmc_vendor_from_udev_dmi_classifies_system_vendors() {
+        value_scenarios!(BMCVendor::from_udev_dmi:
+            "known system vendors" {
+                "Lenovo" => BMCVendor::Lenovo,
+                "Dell Inc." => BMCVendor::Dell,
+                "https://www.mellanox.com" => BMCVendor::Nvidia,
+                "NVIDIA" => BMCVendor::Nvidia,
+                "Supermicro" => BMCVendor::Supermicro,
+                "HPE" => BMCVendor::Hpe,
+            }
+
+            "unknown system vendors" {
+                "Acme Corp" => BMCVendor::Unknown,
+                "dell inc." => BMCVendor::Unknown,
+            }
+        );
     }
 }

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -23,6 +23,7 @@ authors.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model" }
 carbide-instrument = { path = "../instrument" }

--- a/crates/component-manager/src/compute_tray_manager.rs
+++ b/crates/component-manager/src/compute_tray_manager.rs
@@ -29,6 +29,22 @@ pub enum ComputeTrayVendor {
     Nvidia,
 }
 
+impl From<bmc_vendor::BMCVendor> for ComputeTrayVendor {
+    fn from(vendor: bmc_vendor::BMCVendor) -> Self {
+        match vendor {
+            bmc_vendor::BMCVendor::Dell => Self::Dell,
+            bmc_vendor::BMCVendor::Hpe => Self::Hpe,
+            bmc_vendor::BMCVendor::Lenovo => Self::Lenovo,
+            bmc_vendor::BMCVendor::Supermicro => Self::Supermicro,
+            bmc_vendor::BMCVendor::Nvidia => Self::Nvidia,
+            bmc_vendor::BMCVendor::LenovoAMI
+            | bmc_vendor::BMCVendor::Liteon
+            | bmc_vendor::BMCVendor::Delta
+            | bmc_vendor::BMCVendor::Unknown => Self::Unknown,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComputeTrayModel {
     Unknown,
@@ -102,4 +118,32 @@ pub trait ComputeTrayManager: Send + Sync + Debug + 'static {
     ) -> Result<Vec<ComputeTrayFirmwareUpdateStatus>, ComponentManagerError>;
 
     async fn list_firmware_bundles(&self) -> Result<Vec<String>, ComponentManagerError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use bmc_vendor::BMCVendor;
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[test]
+    fn bmc_vendor_maps_to_compute_tray_vendor() {
+        value_scenarios!(run = ComputeTrayVendor::from;
+            "supported compute tray vendors" {
+                BMCVendor::Dell => ComputeTrayVendor::Dell,
+                BMCVendor::Hpe => ComputeTrayVendor::Hpe,
+                BMCVendor::Lenovo => ComputeTrayVendor::Lenovo,
+                BMCVendor::Supermicro => ComputeTrayVendor::Supermicro,
+                BMCVendor::Nvidia => ComputeTrayVendor::Nvidia,
+            }
+
+            "unsupported compute tray vendors" {
+                BMCVendor::LenovoAMI => ComputeTrayVendor::Unknown,
+                BMCVendor::Liteon => ComputeTrayVendor::Unknown,
+                BMCVendor::Delta => ComputeTrayVendor::Unknown,
+                BMCVendor::Unknown => ComputeTrayVendor::Unknown,
+            }
+        );
+    }
 }

--- a/crates/component-manager/src/core_compute_manager.rs
+++ b/crates/component-manager/src/core_compute_manager.rs
@@ -134,3 +134,28 @@ impl crate::compute_tray_manager::ComputeTrayManager for CoreComputeTrayManager 
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use libredfish::model::service_root::RedfishVendor;
+
+    use super::*;
+
+    #[test]
+    fn compute_tray_vendor_maps_to_redfish_vendor() {
+        value_scenarios!(map_vendor:
+            "supported Redfish vendors" {
+                ComputeTrayVendor::Dell => Some(RedfishVendor::Dell),
+                ComputeTrayVendor::Hpe => Some(RedfishVendor::Hpe),
+                ComputeTrayVendor::Lenovo => Some(RedfishVendor::Lenovo),
+                ComputeTrayVendor::Supermicro => Some(RedfishVendor::Supermicro),
+            }
+
+            "vendors without a Redfish adapter" {
+                ComputeTrayVendor::Nvidia => None,
+                ComputeTrayVendor::Unknown => None,
+            }
+        );
+    }
+}

--- a/crates/machine-controller/src/handler/maintenance.rs
+++ b/crates/machine-controller/src/handler/maintenance.rs
@@ -22,9 +22,7 @@ use carbide_secrets::credentials::{
 };
 use carbide_uuid::machine::MachineId;
 use chrono::Utc;
-use component_manager::compute_tray_manager::{
-    ComputeTrayEndpoint, ComputeTrayResult, ComputeTrayVendor,
-};
+use component_manager::compute_tray_manager::{ComputeTrayEndpoint, ComputeTrayResult};
 use db::machine as db_machine;
 use mac_address::MacAddress;
 use model::component_manager::PowerAction;
@@ -231,21 +229,10 @@ pub(super) async fn build_compute_tray_endpoint(
     let credentials = lookup_bmc_credentials(credential_manager, bmc_mac).await?;
 
     Ok(ComputeTrayEndpoint {
-        vendor: map_bmc_vendor_to_compute_tray(machine.bmc_vendor()),
+        vendor: machine.bmc_vendor().into(),
         bmc_ip,
         bmc_credentials: credentials,
     })
-}
-
-fn map_bmc_vendor_to_compute_tray(vendor: bmc_vendor::BMCVendor) -> ComputeTrayVendor {
-    match vendor {
-        bmc_vendor::BMCVendor::Dell => ComputeTrayVendor::Dell,
-        bmc_vendor::BMCVendor::Hpe => ComputeTrayVendor::Hpe,
-        bmc_vendor::BMCVendor::Lenovo => ComputeTrayVendor::Lenovo,
-        bmc_vendor::BMCVendor::Supermicro => ComputeTrayVendor::Supermicro,
-        bmc_vendor::BMCVendor::Nvidia => ComputeTrayVendor::Nvidia,
-        _ => ComputeTrayVendor::Unknown,
-    }
 }
 
 async fn lookup_bmc_credentials(

--- a/crates/redfish/src/libredfish/conv.rs
+++ b/crates/redfish/src/libredfish/conv.rs
@@ -195,3 +195,38 @@ impl IntoModel<Evidence> for libredfish::model::component_integrity::Evidence {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use libredfish::model::service_root::RedfishVendor;
+
+    use super::*;
+
+    #[test]
+    fn redfish_vendors_map_to_bmc_vendors() {
+        value_scenarios!(bmc_vendor:
+            "NVIDIA Redfish implementations" {
+                RedfishVendor::AMI => BMCVendor::Nvidia,
+                RedfishVendor::NvidiaDpu => BMCVendor::Nvidia,
+                RedfishVendor::NvidiaGBx00 => BMCVendor::Nvidia,
+                RedfishVendor::NvidiaGH200 => BMCVendor::Nvidia,
+                RedfishVendor::NvidiaGBSwitch => BMCVendor::Nvidia,
+                RedfishVendor::P3809 => BMCVendor::Nvidia,
+                RedfishVendor::VeraRubin => BMCVendor::Nvidia,
+            }
+
+            "vendor-specific Redfish implementations" {
+                RedfishVendor::Dell => BMCVendor::Dell,
+                RedfishVendor::Hpe => BMCVendor::Hpe,
+                RedfishVendor::Lenovo => BMCVendor::Lenovo,
+                RedfishVendor::LenovoAMI => BMCVendor::LenovoAMI,
+                RedfishVendor::LenovoGB300 => BMCVendor::LenovoAMI,
+                RedfishVendor::LiteOnPowerShelf => BMCVendor::Liteon,
+                RedfishVendor::DeltaPowerShelf => BMCVendor::Delta,
+                RedfishVendor::Supermicro => BMCVendor::Supermicro,
+                RedfishVendor::Unknown => BMCVendor::Unknown,
+            }
+        );
+    }
+}

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -122,8 +122,6 @@ impl BmcVendor {
 
 #[derive(thiserror::Error, Debug)]
 pub enum BmcVendorDetectionError {
-    #[error("machine has no DMI data")]
-    MissingDmiData,
     #[error("unknown or unsupported sys_vendor string: {sys_vendor}")]
     UnknownSysVendor { sys_vendor: String },
 }
@@ -355,7 +353,8 @@ impl EscapeSequence {
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{scenarios, value_scenarios};
+    use carbide_test_support::{Check, check_values, scenarios, value_scenarios};
+    use carbide_uuid::machine::{MachineIdSource, MachineType};
 
     use super::*;
 
@@ -471,6 +470,18 @@ mod tests {
         vendor: BmcVendor,
     }
 
+    #[derive(Clone, Copy)]
+    enum VendorSerdeInput {
+        RoundTrip(BmcVendor),
+        Deserialize(&'static str),
+    }
+
+    #[derive(Clone, Copy)]
+    struct VendorDetectionInput {
+        vendor_string: &'static str,
+        machine_id: MachineId,
+    }
+
     const ALL_VENDORS: [(BmcVendor, &str); 7] = [
         (BmcVendor::Ssh(SshBmcVendor::Dell), "dell"),
         (BmcVendor::Ssh(SshBmcVendor::Lenovo), "lenovo"),
@@ -485,23 +496,20 @@ mod tests {
     ];
 
     #[test]
-    fn bmc_vendor_config_string_names_each_variant() {
-        // Driven from `ALL_VENDORS` so a new variant is covered by adding one row there.
-        for (vendor, config_string) in ALL_VENDORS {
-            assert_eq!(vendor.config_string(), config_string, "{vendor:?}");
-        }
-    }
-
-    #[test]
-    fn bmc_vendor_from_config_string_parses_each_variant() {
-        // Driven from `ALL_VENDORS` so a new variant is covered by adding one row there.
-        for (vendor, config_string) in ALL_VENDORS {
-            assert_eq!(
-                BmcVendor::from_config_string(config_string),
-                Some(vendor),
-                "{config_string:?}",
-            );
-        }
+    fn bmc_vendor_config_strings_map_both_directions() {
+        check_values(
+            ALL_VENDORS.map(|(vendor, config_string)| Check {
+                scenario: config_string,
+                input: (vendor, config_string),
+                expect: (config_string, Some(vendor)),
+            }),
+            |(vendor, config_string)| {
+                (
+                    vendor.config_string(),
+                    BmcVendor::from_config_string(config_string),
+                )
+            },
+        );
 
         value_scenarios!(
             run = |s: &str| BmcVendor::from_config_string(s);
@@ -514,32 +522,79 @@ mod tests {
     }
 
     #[test]
-    fn bmc_vendor_config_string_round_trips() {
-        // config_string -> from_config_string returns the same vendor for every variant.
-        for (vendor, _) in ALL_VENDORS {
-            assert_eq!(
-                BmcVendor::from_config_string(vendor.config_string()),
-                Some(vendor),
-                "{vendor:?}",
-            );
-        }
+    fn bmc_vendor_serde_uses_config_strings() {
+        scenarios!(
+            run = |input| match input {
+                VendorSerdeInput::RoundTrip(vendor) => {
+                    let serialized =
+                        toml::to_string(&Wrap { vendor }).map_err(|error| error.to_string())?;
+                    let deserialized =
+                        toml::from_str(&serialized).map_err(|error| error.to_string())?;
+                    Ok((Some(serialized), deserialized))
+                }
+                VendorSerdeInput::Deserialize(serialized) => toml::from_str(serialized)
+                    .map(|vendor| (None, vendor))
+                    .map_err(|error| error.to_string()),
+            };
+
+            "representative transports round trip" {
+                VendorSerdeInput::RoundTrip(BmcVendor::Ssh(SshBmcVendor::Dell)) => Yields((
+                    Some("vendor = \"dell\"\n".to_string()),
+                    Wrap { vendor: BmcVendor::Ssh(SshBmcVendor::Dell) },
+                )),
+                VendorSerdeInput::RoundTrip(BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking)) => Yields((
+                    Some("vendor = \"nvidia_viking\"\n".to_string()),
+                    Wrap { vendor: BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking) },
+                )),
+            }
+
+            "invalid config values are rejected" {
+                VendorSerdeInput::Deserialize("vendor = \"bogus\"") => Fails,
+                VendorSerdeInput::Deserialize("vendor = 7") => Fails,
+            }
+        );
     }
 
     #[test]
-    fn bmc_vendor_serde_round_trips_through_toml() {
-        // The custom Serialize/Deserialize go through a real TOML (de)serializer.
-        for (vendor, config_string) in ALL_VENDORS {
-            let label = format!("{vendor:?}");
-            let wrap = Wrap { vendor };
-            let serialized = toml::to_string(&wrap).expect("serialize");
-            assert_eq!(
-                serialized,
-                format!("vendor = \"{config_string}\"\n"),
-                "{label}"
-            );
-            let deserialized: Wrap = toml::from_str(&serialized).expect("deserialize");
-            assert_eq!(deserialized, wrap, "{label}");
-        }
+    fn bmc_vendor_detect_from_api_vendor_maps_hosts_and_dpus() {
+        let host_id = MachineId::new(MachineIdSource::Tpm, [1; 32], MachineType::Host);
+        let dpu_id = MachineId::new(MachineIdSource::Tpm, [2; 32], MachineType::Dpu);
+
+        scenarios!(
+            run = |VendorDetectionInput { vendor_string, machine_id }| {
+                BmcVendor::detect_from_api_vendor(vendor_string, &machine_id)
+                    .map_err(|error| error.to_string())
+            };
+
+            "DPU identity takes priority over the API vendor" {
+                VendorDetectionInput { vendor_string: "", machine_id: dpu_id } =>
+                    Yields(BmcVendor::Ssh(SshBmcVendor::Dpu)),
+            }
+
+            "supported host vendors select their transport" {
+                VendorDetectionInput { vendor_string: "lenovo", machine_id: host_id } =>
+                    Yields(BmcVendor::Ssh(SshBmcVendor::Lenovo)),
+                VendorDetectionInput { vendor_string: "lenovoami", machine_id: host_id } =>
+                    Yields(BmcVendor::Ssh(SshBmcVendor::LenovoAmi)),
+                VendorDetectionInput { vendor_string: "dell", machine_id: host_id } =>
+                    Yields(BmcVendor::Ssh(SshBmcVendor::Dell)),
+                VendorDetectionInput { vendor_string: "supermicro", machine_id: host_id } =>
+                    Yields(BmcVendor::Ipmi(IpmiBmcVendor::Supermicro)),
+                VendorDetectionInput { vendor_string: "hpe", machine_id: host_id } =>
+                    Yields(BmcVendor::Ssh(SshBmcVendor::Hpe)),
+                VendorDetectionInput { vendor_string: "nvidia", machine_id: host_id } =>
+                    Yields(BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking)),
+            }
+
+            "unsupported host vendors preserve the API text in the error" {
+                VendorDetectionInput { vendor_string: "liteon", machine_id: host_id } =>
+                    FailsWith("unknown or unsupported sys_vendor string: liteon".to_string()),
+                VendorDetectionInput { vendor_string: "delta", machine_id: host_id } =>
+                    FailsWith("unknown or unsupported sys_vendor string: delta".to_string()),
+                VendorDetectionInput { vendor_string: "Acme BMC", machine_id: host_id } =>
+                    FailsWith("unknown or unsupported sys_vendor string: Acme BMC".to_string()),
+            }
+        );
     }
 
     #[test]
@@ -607,22 +662,6 @@ mod tests {
                     output: b"connect com2\r\nready",
                     skip_data_read_len: b"connect com2".len(),
                 } => true,
-            }
-        );
-    }
-
-    #[test]
-    fn bmc_vendor_deserialize_rejects_an_unknown_string() {
-        scenarios!(
-            run = |s: &str| toml::from_str::<Wrap>(&format!("vendor = \"{s}\"")).map_err(|e| e.to_string());
-
-            "valid config strings deserialize" {
-                "dell" => Yields(Wrap { vendor: BmcVendor::Ssh(SshBmcVendor::Dell) }),
-                "nvidia_viking" => Yields(Wrap { vendor: BmcVendor::Ipmi(IpmiBmcVendor::NvidiaViking) }),
-            }
-
-            "an unknown string is rejected" {
-                "bogus" => Fails,
             }
         );
     }

--- a/docs/development/new_hardware_support.md
+++ b/docs/development/new_hardware_support.md
@@ -177,7 +177,7 @@ NICo has its own `BMCVendor` enum, distinct from libredfish's `RedfishVendor`. I
 
 1. **Update the** `bmc_vendor()` **mapping** in `crates/redfish/src/libredfish/conv.rs` so libredfish's vendor detection flows into NICo's enum.
 
-1. **Extend parsing** in `From<&str>`, `from_udev_dmi()`, and `from_tls_issuer()` as applicable.
+1. **Extend parsing** in `From<&str>` and `from_udev_dmi()` as applicable.
 
 ### `HwType` enum (`crates/bmc-explorer/src/hw/mod.rs`)
 
@@ -386,4 +386,3 @@ To add one:
 1. Wire the variant through `crates/bmc-mock/src/machine_info.rs`: DPU count and type, vendor and product identity, Redfish version, manager, system, chassis, discovery, firmware inventory, and OEM behavior should match the live BMC responses relevant to the test.
 
 1. Add focused tests for the behavior the hardware contribution changes, such as vendor detection, inventory, NIC-mode detection, or provisioning.
-


### PR DESCRIPTION
Canonical BMC vendor rules were spread across direct owners, wrapper tests, duplicate compute-tray adapters, and repeated integration assertions. This moves each matrix beside the production code it verifies, removes proven copies and unused helpers, and fills the vendor boundaries that had no direct coverage.

## Related issues

Closes #4069.

Part of #3914.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Post-rebase `cargo llvm-cov` union across the nine focused package/filter invocations -- 44 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Independent diff review -- no code findings
- Local CodeRabbit review -- no findings
- Local Claude review -- no correctness or compile defects

## Additional Notes

### Ownership and duplicate control

- `bmc-vendor` now owns complete parsing, DMI classification, display, Pascal-case, and retained predicate tables.
- Two byte-identical `BMCVendor -> ComputeTrayVendor` functions become one exhaustive `From` implementation beside `ComputeTrayVendor`.
- API-model retains one delegation row and each missing-data fallback instead of repeating the owner's DMI matrix.
- SSH's five overlapping config, round-trip, and serde entries become two owner tables plus one detection table.
- Four repeated integration assertions are removed only from secondary cases; representative vendor assertions remain for each distinct hardware route.
- Six unused selected functions and one never-constructed error variant are removed instead of receiving artificial tests.
- The live Redfish converter remains in production and now has a complete 16-row table; site-explorer calls it when populating endpoint exploration reports.
- The developer guide drops its reference to the removed TLS helper in the same change, so it does not describe an API that no longer exists.

### Coverage

The measurements select the production vendor owners and adapters across `bmc-vendor`, API-model, component-manager, SSH-console, BMC-explorer, Redfish, and API-core.

| Checkpoint | Functions | Lines | Regions | Focused executions |
| --- | ---: | ---: | ---: | ---: |
| Original | 10/30 | 76/213 | 100/264 | 38 |
| Converted | 10/24 | 76/182 | 100/227 | 36 |
| Expanded | 24/24 | 182/182 | 227/227 | 44 |

The converted checkpoint preserves every covered production line and region while duplicate/dead production removal reduces the selected denominator by six functions, 31 lines, and 37 regions. The expanded tables then add 106 covered lines and 127 covered regions, reaching every selected production function, line, and region.

The final expanded union was rerun after rebasing onto `b01a70adf`, which already contains #4030, and produced the same 24/24 function, 182/182 line, and 227/227 region totals.