### PR TITLE
test(health): cover inventory and entity metric projections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,7 @@ version = "0.0.1"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "axum",
  "base64",
  "bmc-mock",
  "bytes",

--- a/crates/health/Cargo.toml
+++ b/crates/health/Cargo.toml
@@ -108,6 +108,7 @@ tonic-prost-build = { workspace = true }
 bench-hooks = []
 
 [dev-dependencies]
+axum = { workspace = true }
 bmc-mock = { path = "../bmc-mock" }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }

--- a/crates/health/src/collectors/entity_metrics.rs
+++ b/crates/health/src/collectors/entity_metrics.rs
@@ -542,152 +542,714 @@ impl<B: Bmc + 'static> MetricsCollector<B> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::convert::Infallible;
+    use std::sync::Mutex as StdMutex;
 
+    use carbide_test_support::Outcome::Yields;
+    use carbide_test_support::{Case, Check, check_cases_async, check_values};
     use serde_json::json;
 
     use super::*;
+    use crate::collectors::projection_test_support::{ProjectionFixture, TestBmc, TestEntity};
+    use crate::endpoint::test_support::{mac, test_endpoint};
 
-    fn by_type(fields: &[MetricField]) -> HashMap<String, (&'static str, f64)> {
+    #[derive(Clone, Copy)]
+    enum Projection {
+        Processor,
+        Memory,
+        Drive,
+        PowerSupply,
+    }
+
+    struct ProjectionCase {
+        projection: Projection,
+        metrics: serde_json::Value,
+    }
+
+    type ProjectedMetric = (String, &'static str, f64);
+
+    fn sort_projected_metrics(mut fields: Vec<ProjectedMetric>) -> Vec<ProjectedMetric> {
+        fields.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then(left.1.cmp(right.1))
+                .then(left.2.total_cmp(&right.2))
+        });
         fields
-            .iter()
-            .map(|f| (f.metric_type.to_string(), (f.unit, f.value)))
-            .collect()
+    }
+
+    fn project(case: ProjectionCase) -> Vec<ProjectedMetric> {
+        let fields = match case.projection {
+            Projection::Processor => processor_metric_fields(
+                &serde_json::from_value(case.metrics)
+                    .expect("processor metrics should deserialize"),
+            ),
+            Projection::Memory => memory_metric_fields(
+                &serde_json::from_value(case.metrics).expect("memory metrics should deserialize"),
+            ),
+            Projection::Drive => drive_metric_fields(
+                &serde_json::from_value(case.metrics).expect("drive metrics should deserialize"),
+            ),
+            Projection::PowerSupply => power_supply_metric_fields(
+                &serde_json::from_value(case.metrics)
+                    .expect("power supply metrics should deserialize"),
+            ),
+        };
+
+        sort_projected_metrics(
+            fields
+                .into_iter()
+                .map(|field| (field.metric_type.into_owned(), field.unit, field.value))
+                .collect(),
+        )
+    }
+
+    fn expected(
+        fields: impl IntoIterator<Item = (&'static str, &'static str, f64)>,
+    ) -> Vec<ProjectedMetric> {
+        sort_projected_metrics(
+            fields
+                .into_iter()
+                .map(|(metric_type, unit, value)| (metric_type.to_string(), unit, value))
+                .collect(),
+        )
     }
 
     #[test]
-    fn processor_scalars_and_pcie_errors_are_flattened() {
-        let metrics: ProcessorMetrics = serde_json::from_value(json!({
-            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
-            "Id": "ProcessorMetrics",
-            "Name": "Processor Metrics",
-            "BandwidthPercent": 42.5,
-            "OperatingSpeedMHz": 3200,
-            "CorrectableCoreErrorCount": 7,
-            "UncorrectableCoreErrorCount": 0,
-            "PCIeErrors": {
-                "CorrectableErrorCount": 3,
-                "FatalErrorCount": 1
+    fn child_metric_projection_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "processor scalars, durations, and PCIe errors",
+                    input: ProjectionCase {
+                        projection: Projection::Processor,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
+                            "Id": "ProcessorMetrics",
+                            "Name": "Processor Metrics",
+                            "BandwidthPercent": 42.5,
+                            "OperatingSpeedMHz": 3200,
+                            "CorrectableCoreErrorCount": 7,
+                            "UncorrectableCoreErrorCount": 0,
+                            "PCIeErrors": {
+                                "CorrectableErrorCount": 3,
+                                "FatalErrorCount": 1
+                            },
+                            "PowerLimitThrottleDuration": "PT0S",
+                            "ThermalLimitThrottleDuration": "PT1M30S"
+                        }),
+                    },
+                    expect: expected([
+                        ("bandwidth", "percent", 42.5),
+                        ("operating_speed", "mhz", 3200.0),
+                        ("correctable_core_errors", "count", 7.0),
+                        ("uncorrectable_core_errors", "count", 0.0),
+                        ("power_limit_throttle", "seconds", 0.0),
+                        ("thermal_limit_throttle", "seconds", 90.0),
+                        ("pcie_correctable_errors", "count", 3.0),
+                        ("pcie_fatal_errors", "count", 1.0),
+                    ]),
+                },
+                Check {
+                    scenario: "processor sensor-backed excerpt is ignored",
+                    input: ProjectionCase {
+                        projection: Projection::Processor,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
+                            "Id": "ProcessorMetrics",
+                            "Name": "Processor Metrics",
+                            "CoreVoltage": {
+                                "DataSourceUri": "/redfish/v1/Chassis/1/Sensors/CPU0_Voltage",
+                                "Reading": 1.2
+                            }
+                        }),
+                    },
+                    expect: expected([]),
+                },
+                Check {
+                    scenario: "processor inline excerpt is emitted",
+                    input: ProjectionCase {
+                        projection: Projection::Processor,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
+                            "Id": "ProcessorMetrics",
+                            "Name": "Processor Metrics",
+                            "CoreVoltage": { "Reading": 1.05 }
+                        }),
+                    },
+                    expect: expected([("core_voltage", "volts", 1.05)]),
+                },
+                Check {
+                    scenario: "remaining processor scalars and PCIe counters",
+                    input: ProjectionCase {
+                        projection: Projection::Processor,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
+                            "Id": "ProcessorMetrics",
+                            "Name": "Processor Metrics",
+                            "AverageFrequencyMHz": 2800.5,
+                            "ThrottlingCelsius": 95.0,
+                            "TemperatureCelsius": 65.0,
+                            "ConsumedPowerWatt": 250.0,
+                            "FrequencyRatio": 0.75,
+                            "LocalMemoryBandwidthBytes": 1000,
+                            "RemoteMemoryBandwidthBytes": 2000,
+                            "KernelPercent": 4.5,
+                            "UserPercent": 10.5,
+                            "CorrectableOtherErrorCount": 2,
+                            "UncorrectableOtherErrorCount": 3,
+                            "PCIeErrors": {
+                                "NonFatalErrorCount": 1,
+                                "L0ToRecoveryCount": 2,
+                                "ReplayCount": 3,
+                                "ReplayRolloverCount": 4,
+                                "NAKSentCount": 5,
+                                "NAKReceivedCount": 6,
+                                "UnsupportedRequestCount": 7,
+                                "BadTLPCount": 8,
+                                "BadDLLPCount": 9,
+                                "FlowControlTimeoutErrors": 10
+                            }
+                        }),
+                    },
+                    expect: expected([
+                        ("average_frequency", "mhz", 2800.5),
+                        ("throttling", "celsius", 95.0),
+                        ("temperature", "celsius", 65.0),
+                        ("consumed_power", "watts", 250.0),
+                        ("frequency_ratio", "ratio", 0.75),
+                        ("local_memory_bandwidth", "bytes", 1000.0),
+                        ("remote_memory_bandwidth", "bytes", 2000.0),
+                        ("kernel_time", "percent", 4.5),
+                        ("user_time", "percent", 10.5),
+                        ("correctable_other_errors", "count", 2.0),
+                        ("uncorrectable_other_errors", "count", 3.0),
+                        ("pcie_non_fatal_errors", "count", 1.0),
+                        ("pcie_l0_to_recovery", "count", 2.0),
+                        ("pcie_replay", "count", 3.0),
+                        ("pcie_replay_rollover", "count", 4.0),
+                        ("pcie_nak_sent", "count", 5.0),
+                        ("pcie_nak_received", "count", 6.0),
+                        ("pcie_unsupported_request", "count", 7.0),
+                        ("pcie_bad_tlp", "count", 8.0),
+                        ("pcie_bad_dllp", "count", 9.0),
+                        ("pcie_flow_control_timeout", "count", 10.0),
+                    ]),
+                },
+                Check {
+                    scenario: "sparse processor metrics",
+                    input: ProjectionCase {
+                        projection: Projection::Processor,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
+                            "Id": "ProcessorMetrics",
+                            "Name": "Processor Metrics",
+                            "BandwidthPercent": null,
+                            "PowerLimitThrottleDuration": null
+                        }),
+                    },
+                    expect: expected([]),
+                },
+                Check {
+                    scenario: "memory nested periods use distinct prefixes",
+                    input: ProjectionCase {
+                        projection: Projection::Memory,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM0/MemoryMetrics",
+                            "Id": "MemoryMetrics",
+                            "Name": "Memory Metrics",
+                            "CorrectedVolatileErrorCount": 2,
+                            "CurrentPeriod": { "CorrectableECCErrorCount": 5 },
+                            "LifeTime": { "UncorrectableECCErrorCount": 9 }
+                        }),
+                    },
+                    expect: expected([
+                        ("corrected_volatile_errors", "count", 2.0),
+                        ("current_correctable_ecc_errors", "count", 5.0),
+                        ("lifetime_uncorrectable_ecc_errors", "count", 9.0),
+                    ]),
+                },
+                Check {
+                    scenario: "remaining memory scalars and period counters",
+                    input: ProjectionCase {
+                        projection: Projection::Memory,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM0/MemoryMetrics",
+                            "Id": "MemoryMetrics",
+                            "Name": "Memory Metrics",
+                            "BlockSizeBytes": 4096,
+                            "BandwidthPercent": 72.5,
+                            "OperatingSpeedMHz": 6400,
+                            "CorrectedPersistentErrorCount": 3,
+                            "DirtyShutdownCount": 4,
+                            "CapacityUtilizationPercent": 81.0,
+                            "CurrentPeriod": {
+                                "UncorrectableECCErrorCount": 5,
+                                "IndeterminateCorrectableErrorCount": 6,
+                                "IndeterminateUncorrectableErrorCount": 7
+                            },
+                            "LifeTime": {
+                                "CorrectableECCErrorCount": 8,
+                                "IndeterminateCorrectableErrorCount": 9,
+                                "IndeterminateUncorrectableErrorCount": 10
+                            }
+                        }),
+                    },
+                    expect: expected([
+                        ("block_size", "bytes", 4096.0),
+                        ("bandwidth", "percent", 72.5),
+                        ("operating_speed", "mhz", 6400.0),
+                        ("corrected_persistent_errors", "count", 3.0),
+                        ("dirty_shutdown", "count", 4.0),
+                        ("capacity_utilization", "percent", 81.0),
+                        ("current_uncorrectable_ecc_errors", "count", 5.0),
+                        ("current_indeterminate_correctable_errors", "count", 6.0),
+                        ("current_indeterminate_uncorrectable_errors", "count", 7.0),
+                        ("lifetime_correctable_ecc_errors", "count", 8.0),
+                        ("lifetime_indeterminate_correctable_errors", "count", 9.0),
+                        ("lifetime_indeterminate_uncorrectable_errors", "count", 10.0),
+                    ]),
+                },
+                Check {
+                    scenario: "sparse memory metrics",
+                    input: ProjectionCase {
+                        projection: Projection::Memory,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM0/MemoryMetrics",
+                            "Id": "MemoryMetrics",
+                            "Name": "Memory Metrics"
+                        }),
+                    },
+                    expect: expected([]),
+                },
+                Check {
+                    scenario: "drive error and lifetime counters",
+                    input: ProjectionCase {
+                        projection: Projection::Drive,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Storage/1/Drives/D0/Metrics",
+                            "Id": "DriveMetrics",
+                            "Name": "Drive Metrics",
+                            "BadBlockCount": 4,
+                            "CorrectableIOReadErrorCount": 11,
+                            "PowerOnHours": 12345.0
+                        }),
+                    },
+                    expect: expected([
+                        ("correctable_io_read_errors", "count", 11.0),
+                        ("bad_block", "count", 4.0),
+                        ("power_on_hours", "hours", 12345.0),
+                    ]),
+                },
+                Check {
+                    scenario: "remaining drive counters",
+                    input: ProjectionCase {
+                        projection: Projection::Drive,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Storage/1/Drives/D0/Metrics",
+                            "Id": "DriveMetrics",
+                            "Name": "Drive Metrics",
+                            "CorrectableIOWriteErrorCount": 1,
+                            "UncorrectableIOReadErrorCount": 2,
+                            "UncorrectableIOWriteErrorCount": 3,
+                            "NativeCommandQueueDepth": 4,
+                            "ReadIOKiBytes": 5,
+                            "WriteIOKiBytes": 6
+                        }),
+                    },
+                    expect: expected([
+                        ("correctable_io_write_errors", "count", 1.0),
+                        ("uncorrectable_io_read_errors", "count", 2.0),
+                        ("uncorrectable_io_write_errors", "count", 3.0),
+                        ("native_command_queue_depth", "count", 4.0),
+                        ("read_io", "kibibytes", 5.0),
+                        ("write_io", "kibibytes", 6.0),
+                    ]),
+                },
+                Check {
+                    scenario: "sparse drive metrics",
+                    input: ProjectionCase {
+                        projection: Projection::Drive,
+                        metrics: json!({
+                            "@odata.id": "/redfish/v1/Systems/1/Storage/1/Drives/D0/Metrics",
+                            "Id": "DriveMetrics",
+                            "Name": "Drive Metrics"
+                        }),
+                    },
+                    expect: expected([]),
+                },
+                Check {
+                    scenario: "power supply ignores sensor-backed and emits inline excerpts",
+                    input: ProjectionCase {
+                        projection: Projection::PowerSupply,
+                        metrics: json!({
+                            "@odata.id":
+                                "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/PSU0/Metrics",
+                            "Id": "PowerSupplyMetrics",
+                            "Name": "Power Supply Metrics",
+                            "InputVoltage": {
+                                "DataSourceUri": "/redfish/v1/Chassis/1/Sensors/PSU0_Vin",
+                                "Reading": 230.0
+                            },
+                            "InputPowerWatts": {
+                                "DataSourceUri": null,
+                                "Reading": 450.0
+                            },
+                            "OutputPowerWatts": {
+                                "DataSourceUri": null,
+                                "Reading": 500.0
+                            }
+                        }),
+                    },
+                    expect: expected([
+                        ("input_power", "watts", 450.0),
+                        ("output_power", "watts", 500.0),
+                    ]),
+                },
+                Check {
+                    scenario: "remaining power supply excerpts",
+                    input: ProjectionCase {
+                        projection: Projection::PowerSupply,
+                        metrics: json!({
+                            "@odata.id":
+                                "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/PSU0/Metrics",
+                            "Id": "PowerSupplyMetrics",
+                            "Name": "Power Supply Metrics",
+                            "InputVoltage": { "Reading": 230.0 },
+                            "InputCurrentAmps": {
+                                "DataSourceUri": null,
+                                "Reading": 2.0
+                            },
+                            "InputPowerWatts": { "Reading": null },
+                            "EnergykWh": {
+                                "DataSourceUri": null,
+                                "Reading": 2.5
+                            },
+                            "FrequencyHz": {
+                                "DataSourceUri": null,
+                                "Reading": 60.0
+                            },
+                            "TemperatureCelsius": {
+                                "DataSourceUri": null,
+                                "Reading": 35.0
+                            },
+                            "FanSpeedPercent": {
+                                "DataSourceUri": null,
+                                "Reading": 50.0
+                            }
+                        }),
+                    },
+                    expect: expected([
+                        ("input_voltage", "volts", 230.0),
+                        ("input_current", "amperes", 2.0),
+                        ("energy", "kilowatt_hours", 2.5),
+                        ("frequency", "hertz", 60.0),
+                        ("temperature", "celsius", 35.0),
+                        ("fan_speed", "percent", 50.0),
+                    ]),
+                },
+            ],
+            project,
+        );
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ObservedMetric {
+        key: String,
+        name: String,
+        metric_type: String,
+        unit: String,
+        value: f64,
+        labels: Vec<(String, String)>,
+        has_context: bool,
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum ObservedEvent {
+        CollectionStart,
+        Metric(ObservedMetric),
+        CollectionEnd,
+        CollectorRemoved,
+        Log,
+        Firmware,
+        HealthReport,
+    }
+
+    #[derive(Default)]
+    struct CapturingSink {
+        events: StdMutex<Vec<ObservedEvent>>,
+    }
+
+    impl DataSink for CapturingSink {
+        fn sink_type(&self) -> &'static str {
+            "capturing_sink"
+        }
+
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), HealthError> {
+            let observed = match event {
+                CollectorEvent::MetricCollectionStart => ObservedEvent::CollectionStart,
+                CollectorEvent::Metric(sample) => ObservedEvent::Metric(ObservedMetric {
+                    key: sample.key.clone(),
+                    name: sample.name.clone(),
+                    metric_type: sample.metric_type.clone(),
+                    unit: sample.unit.clone(),
+                    value: sample.value,
+                    labels: sample
+                        .labels
+                        .iter()
+                        .map(|(key, value)| (key.to_string(), value.clone()))
+                        .collect(),
+                    has_context: sample.context.is_some(),
+                }),
+                CollectorEvent::MetricCollectionEnd => ObservedEvent::CollectionEnd,
+                CollectorEvent::CollectorRemoved => ObservedEvent::CollectorRemoved,
+                CollectorEvent::Log(_) => ObservedEvent::Log,
+                CollectorEvent::Firmware(_) => ObservedEvent::Firmware,
+                CollectorEvent::HealthReport(_) => ObservedEvent::HealthReport,
+            };
+            self.events.lock().unwrap().push(observed);
+            Ok(())
+        }
+    }
+
+    struct CollectionCase {
+        bmc: Arc<TestBmc>,
+        entity: DiscoveredEntity<TestBmc>,
+        with_sink: bool,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ObservedCollection {
+        field_count: usize,
+        fetch_failures: usize,
+        events: Vec<ObservedEvent>,
+    }
+
+    async fn collect(case: CollectionCase) -> Result<ObservedCollection, Infallible> {
+        let capture = Arc::new(CapturingSink::default());
+        let data_sink = case.with_sink.then(|| capture.clone() as Arc<dyn DataSink>);
+        let collector = MetricsCollector::new_runner(
+            case.bmc,
+            Arc::new(test_endpoint(mac("00:11:22:33:44:55"))),
+            MetricsCollectorConfig {
+                data_sink,
+                shared: Arc::new(arc_swap::ArcSwapOption::empty()),
+                fetch_concurrency: 1,
             },
-            "PowerLimitThrottleDuration": "PT0S",
-            "ThermalLimitThrottleDuration": "PT1M30S"
-        }))
-        .expect("processor metrics should deserialize");
+        )
+        .expect("metrics collector should build");
+        let fetch_failures = AtomicUsize::new(0);
+        let field_count = collector
+            .collect_entity(&case.entity, &fetch_failures)
+            .await;
+        let events = capture.events.lock().unwrap().clone();
 
-        let fields = by_type(&processor_metric_fields(&metrics));
-        assert_eq!(fields.get("bandwidth"), Some(&("percent", 42.5)));
-        assert_eq!(fields.get("operating_speed"), Some(&("mhz", 3200.0)));
-        assert_eq!(fields.get("correctable_core_errors"), Some(&("count", 7.0)));
-        assert_eq!(
-            fields.get("uncorrectable_core_errors"),
-            Some(&("count", 0.0))
-        );
-        assert_eq!(fields.get("pcie_correctable_errors"), Some(&("count", 3.0)));
-        assert_eq!(fields.get("pcie_fatal_errors"), Some(&("count", 1.0)));
-        // ISO 8601 durations are emitted as seconds.
-        assert_eq!(fields.get("power_limit_throttle"), Some(&("seconds", 0.0)));
-        assert_eq!(
-            fields.get("thermal_limit_throttle"),
-            Some(&("seconds", 90.0))
-        );
+        Ok(ObservedCollection {
+            field_count,
+            fetch_failures: fetch_failures.load(Ordering::Relaxed),
+            events,
+        })
     }
 
-    #[test]
-    fn sensor_backed_excerpt_is_skipped_but_inline_excerpt_is_emitted() {
-        // CoreVoltage carrying a DataSourceUri is already published as hw_sensor
-        // and must NOT be re-emitted here.
-        let linked: ProcessorMetrics = serde_json::from_value(json!({
-            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
-            "Id": "ProcessorMetrics",
-            "Name": "Processor Metrics",
-            "CoreVoltage": {
-                "DataSourceUri": "/redfish/v1/Chassis/1/Sensors/CPU0_Voltage",
-                "Reading": 1.2
-            }
-        }))
-        .expect("deserialize");
-        assert!(!by_type(&processor_metric_fields(&linked)).contains_key("core_voltage"));
-
-        // Without a DataSourceUri the inline reading is emitted.
-        let inline: ProcessorMetrics = serde_json::from_value(json!({
-            "@odata.id": "/redfish/v1/Systems/1/Processors/CPU0/ProcessorMetrics",
-            "Id": "ProcessorMetrics",
-            "Name": "Processor Metrics",
-            "CoreVoltage": { "Reading": 1.05 }
-        }))
-        .expect("deserialize");
-        assert_eq!(
-            by_type(&processor_metric_fields(&inline)).get("core_voltage"),
-            Some(&("volts", 1.05))
-        );
+    fn metric(
+        key: &str,
+        metric_type: &str,
+        unit: &str,
+        value: f64,
+        labels: &[(&str, &str)],
+    ) -> ObservedEvent {
+        ObservedEvent::Metric(ObservedMetric {
+            key: key.to_string(),
+            name: "hw_metric".to_string(),
+            metric_type: metric_type.to_string(),
+            unit: unit.to_string(),
+            value,
+            labels: labels
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                .collect(),
+            has_context: false,
+        })
     }
 
-    #[test]
-    fn memory_nested_periods_are_flattened_with_prefixes() {
-        let metrics: MemoryMetrics = serde_json::from_value(json!({
-            "@odata.id": "/redfish/v1/Systems/1/Memory/DIMM0/MemoryMetrics",
-            "Id": "MemoryMetrics",
-            "Name": "Memory Metrics",
-            "CorrectedVolatileErrorCount": 2,
-            "CurrentPeriod": { "CorrectableECCErrorCount": 5 },
-            "LifeTime": { "UncorrectableECCErrorCount": 9 }
-        }))
-        .expect("memory metrics should deserialize");
+    #[tokio::test]
+    async fn collect_entity_cases() {
+        let fixture = ProjectionFixture::new().await;
 
-        let fields = by_type(&memory_metric_fields(&metrics));
-        assert_eq!(
-            fields.get("corrected_volatile_errors"),
-            Some(&("count", 2.0))
-        );
-        assert_eq!(
-            fields.get("current_correctable_ecc_errors"),
-            Some(&("count", 5.0))
-        );
-        assert_eq!(
-            fields.get("lifetime_uncorrectable_ecc_errors"),
-            Some(&("count", 9.0))
-        );
-    }
-
-    #[test]
-    fn drive_io_error_counters_are_emitted() {
-        let metrics: nv_redfish::schema::drive_metrics::DriveMetrics =
-            serde_json::from_value(json!({
-                "@odata.id": "/redfish/v1/Systems/1/Storage/1/Drives/D0/Metrics",
-                "Id": "DriveMetrics",
-                "Name": "Drive Metrics",
-                "BadBlockCount": 4,
-                "CorrectableIOReadErrorCount": 11,
-                "PowerOnHours": 12345.0
-            }))
-            .expect("drive metrics should deserialize");
-
-        let fields = by_type(&drive_metric_fields(&metrics));
-        assert_eq!(fields.get("bad_block"), Some(&("count", 4.0)));
-        assert_eq!(
-            fields.get("correctable_io_read_errors"),
-            Some(&("count", 11.0))
-        );
-        assert_eq!(fields.get("power_on_hours"), Some(&("hours", 12345.0)));
-    }
-
-    #[test]
-    fn power_supply_metrics_skip_sensor_backed_excerpts() {
-        let metrics: PowerSupplyMetrics = serde_json::from_value(json!({
-            "@odata.id": "/redfish/v1/Chassis/1/PowerSubsystem/PowerSupplies/PSU0/Metrics",
-            "Id": "PowerSupplyMetrics",
-            "Name": "Power Supply Metrics",
-            "InputVoltage": {
-                "DataSourceUri": "/redfish/v1/Chassis/1/Sensors/PSU0_Vin",
-                "Reading": 230.0
-            },
-            "OutputPowerWatts": { "Reading": 500.0 }
-        }))
-        .expect("power supply metrics should deserialize");
-
-        let fields = by_type(&power_supply_metric_fields(&metrics));
-        // Sensor-backed input voltage is skipped; inline output power is kept.
-        assert!(!fields.contains_key("input_voltage"));
-        assert_eq!(fields.get("output_power"), Some(&("watts", 500.0)));
+        check_cases_async(
+            [
+                Case {
+                    scenario: "processor metric",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::Processor).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 1,
+                        fetch_failures: 0,
+                        events: vec![metric(
+                            "/redfish/v1/Systems/SYS0/Processors/CPU0/bandwidth",
+                            "bandwidth",
+                            "percent",
+                            42.0,
+                            &[
+                                ("processor_id", "CPU0"),
+                                ("system_id", "SYS0"),
+                                ("processor_type", "cpu"),
+                                ("model", "Grace"),
+                            ],
+                        )],
+                    }),
+                },
+                Case {
+                    scenario: "memory metric",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::Memory).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 1,
+                        fetch_failures: 0,
+                        events: vec![metric(
+                            "/redfish/v1/Systems/SYS0/Memory/DIMM0/block_size",
+                            "block_size",
+                            "bytes",
+                            4096.0,
+                            &[
+                                ("memory_id", "DIMM0"),
+                                ("system_id", "SYS0"),
+                                ("device_type", "ddr5"),
+                                ("model", "HMCG94AGBRA"),
+                            ],
+                        )],
+                    }),
+                },
+                Case {
+                    scenario: "drive metric",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::Drive).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 1,
+                        fetch_failures: 0,
+                        events: vec![metric(
+                            "/redfish/v1/Systems/SYS0/Storage/ST0/Drives/D0/bad_block",
+                            "bad_block",
+                            "count",
+                            4.0,
+                            &[
+                                ("drive_id", "D0"),
+                                ("storage_id", "ST0"),
+                                ("system_id", "SYS0"),
+                                ("model", "NVMe-1"),
+                            ],
+                        )],
+                    }),
+                },
+                Case {
+                    scenario: "power supply metric",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::PowerSupply).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 1,
+                        fetch_failures: 0,
+                        events: vec![metric(
+                            concat!(
+                                "/redfish/v1/Chassis/CH0/PowerSubsystem/PowerSupplies/PS0/",
+                                "output_power"
+                            ),
+                            "output_power",
+                            "watts",
+                            500.0,
+                            &[
+                                ("powersupply_id", "PS0"),
+                                ("chassis_id", "CH0"),
+                                ("model", "PSU-3KW"),
+                            ],
+                        )],
+                    }),
+                },
+                Case {
+                    scenario: "chassis is ignored",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::Chassis).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 0,
+                        fetch_failures: 0,
+                        events: vec![],
+                    }),
+                },
+                Case {
+                    scenario: "missing metrics link",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::SparseProcessor).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 0,
+                        fetch_failures: 0,
+                        events: vec![],
+                    }),
+                },
+                Case {
+                    scenario: "empty metrics resource",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::ProcessorWithEmptyMetrics).await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 0,
+                        fetch_failures: 0,
+                        events: vec![],
+                    }),
+                },
+                Case {
+                    scenario: "malformed metrics response",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture
+                            .entity(TestEntity::ProcessorWithMalformedMetrics)
+                            .await,
+                        with_sink: true,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 0,
+                        fetch_failures: 1,
+                        events: vec![],
+                    }),
+                },
+                Case {
+                    scenario: "metric projection without a sink",
+                    input: CollectionCase {
+                        bmc: fixture.bmc(),
+                        entity: fixture.entity(TestEntity::Processor).await,
+                        with_sink: false,
+                    },
+                    expect: Yields(ObservedCollection {
+                        field_count: 1,
+                        fetch_failures: 0,
+                        events: vec![],
+                    }),
+                },
+            ],
+            collect,
+        )
+        .await;
     }
 }

--- a/crates/health/src/collectors/inventory.rs
+++ b/crates/health/src/collectors/inventory.rs
@@ -220,3 +220,251 @@ pub(crate) struct EntityInventory<B: Bmc> {
 }
 
 pub(crate) type SharedInventory<B> = Arc<ArcSwapOption<EntityInventory<B>>>;
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+    use crate::collectors::projection_test_support::{ProjectionFixture, TestBmc, TestEntity};
+
+    #[derive(Debug, PartialEq)]
+    struct ObservedDerivedMetric {
+        metric_type: &'static str,
+        unit: &'static str,
+        value: f64,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ObservedEntity {
+        sensor_ids: Vec<String>,
+        entity_type: &'static str,
+        physical_context: &'static str,
+        base_attributes: Vec<(String, String)>,
+        entity_specific_attributes: Vec<(String, String)>,
+        key: String,
+        derived_metrics: Vec<ObservedDerivedMetric>,
+    }
+
+    fn observe(entity: DiscoveredEntity<TestBmc>) -> ObservedEntity {
+        ObservedEntity {
+            sensor_ids: entity
+                .sensors()
+                .iter()
+                .map(|sensor| sensor.odata_id().to_string())
+                .collect(),
+            entity_type: entity.entity_type(),
+            physical_context: entity.physical_context_fallback(),
+            base_attributes: entity
+                .base_attributes()
+                .into_iter()
+                .map(|(key, value)| (key.into_owned(), value))
+                .collect(),
+            entity_specific_attributes: entity
+                .entity_specific_attributes()
+                .into_iter()
+                .map(|(key, value)| (key.into_owned(), value))
+                .collect(),
+            key: entity.key(),
+            derived_metrics: entity
+                .derived_metrics()
+                .into_iter()
+                .map(|metric| ObservedDerivedMetric {
+                    metric_type: metric.metric_type,
+                    unit: metric.unit,
+                    value: metric.value,
+                })
+                .collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn inventory_projection_cases() {
+        let fixture = ProjectionFixture::new().await;
+
+        check_values(
+            [
+                Check {
+                    scenario: "populated processor",
+                    input: fixture.entity(TestEntity::Processor).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![
+                            "/redfish/v1/Chassis/CH0/Sensors/CPU0_Voltage".to_string(),
+                        ],
+                        entity_type: "processor",
+                        physical_context: "cpu",
+                        base_attributes: vec![
+                            ("processor_id".to_string(), "CPU0".to_string()),
+                            ("system_id".to_string(), "SYS0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![
+                            ("processor_type".to_string(), "cpu".to_string()),
+                            ("model".to_string(), "Grace".to_string()),
+                        ],
+                        key: "/redfish/v1/Systems/SYS0/Processors/CPU0".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "sparse processor",
+                    input: fixture.entity(TestEntity::SparseProcessor).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "processor",
+                        physical_context: "cpu",
+                        base_attributes: vec![
+                            ("processor_id".to_string(), "CPU-sparse".to_string()),
+                            ("system_id".to_string(), "SYS0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![],
+                        key: "/redfish/v1/Systems/SYS0/Processors/CPU-sparse".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "populated memory",
+                    input: fixture.entity(TestEntity::Memory).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "memory",
+                        physical_context: "memory",
+                        base_attributes: vec![
+                            ("memory_id".to_string(), "DIMM0".to_string()),
+                            ("system_id".to_string(), "SYS0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![
+                            ("device_type".to_string(), "ddr5".to_string()),
+                            ("model".to_string(), "HMCG94AGBRA".to_string()),
+                        ],
+                        key: "/redfish/v1/Systems/SYS0/Memory/DIMM0".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "sparse memory",
+                    input: fixture.entity(TestEntity::SparseMemory).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "memory",
+                        physical_context: "memory",
+                        base_attributes: vec![
+                            ("memory_id".to_string(), "DIMM-sparse".to_string()),
+                            ("system_id".to_string(), "SYS0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![],
+                        key: "/redfish/v1/Systems/SYS0/Memory/DIMM-sparse".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "populated drive",
+                    input: fixture.entity(TestEntity::Drive).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "drive",
+                        physical_context: "storage_device",
+                        base_attributes: vec![
+                            ("drive_id".to_string(), "D0".to_string()),
+                            ("storage_id".to_string(), "ST0".to_string()),
+                            ("system_id".to_string(), "SYS0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![(
+                            "model".to_string(),
+                            "NVMe-1".to_string(),
+                        )],
+                        key: "/redfish/v1/Systems/SYS0/Storage/ST0/Drives/D0".to_string(),
+                        derived_metrics: vec![ObservedDerivedMetric {
+                            metric_type: "drive_predicted_media_life_left",
+                            unit: "percentage",
+                            value: 80.0,
+                        }],
+                    },
+                },
+                Check {
+                    scenario: "sparse drive",
+                    input: fixture.entity(TestEntity::SparseDrive).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "drive",
+                        physical_context: "storage_device",
+                        base_attributes: vec![
+                            ("drive_id".to_string(), "D-sparse".to_string()),
+                            ("storage_id".to_string(), "ST0".to_string()),
+                            ("system_id".to_string(), "SYS0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![],
+                        key: "/redfish/v1/Systems/SYS0/Storage/ST0/Drives/D-sparse".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "populated power supply",
+                    input: fixture.entity(TestEntity::PowerSupply).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "powersupply",
+                        physical_context: "power_supply",
+                        base_attributes: vec![
+                            ("powersupply_id".to_string(), "PS0".to_string()),
+                            ("chassis_id".to_string(), "CH0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![(
+                            "model".to_string(),
+                            "PSU-3KW".to_string(),
+                        )],
+                        key: "/redfish/v1/Chassis/CH0/PowerSubsystem/PowerSupplies/PS0".to_string(),
+                        derived_metrics: vec![ObservedDerivedMetric {
+                            metric_type: "powersupply_capacity",
+                            unit: "watts",
+                            value: 3000.0,
+                        }],
+                    },
+                },
+                Check {
+                    scenario: "sparse power supply",
+                    input: fixture.entity(TestEntity::SparsePowerSupply).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "powersupply",
+                        physical_context: "power_supply",
+                        base_attributes: vec![
+                            ("powersupply_id".to_string(), "PS-sparse".to_string()),
+                            ("chassis_id".to_string(), "CH0".to_string()),
+                        ],
+                        entity_specific_attributes: vec![],
+                        key: "/redfish/v1/Chassis/CH0/PowerSubsystem/PowerSupplies/PS-sparse"
+                            .to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "populated chassis",
+                    input: fixture.entity(TestEntity::Chassis).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "chassis",
+                        physical_context: "chassis",
+                        base_attributes: vec![("chassis_id".to_string(), "CH0".to_string())],
+                        entity_specific_attributes: vec![("model".to_string(), "HGX".to_string())],
+                        key: "/redfish/v1/Chassis/CH0".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+                Check {
+                    scenario: "sparse chassis",
+                    input: fixture.entity(TestEntity::SparseChassis).await,
+                    expect: ObservedEntity {
+                        sensor_ids: vec![],
+                        entity_type: "chassis",
+                        physical_context: "chassis",
+                        base_attributes: vec![("chassis_id".to_string(), "CH-sparse".to_string())],
+                        entity_specific_attributes: vec![],
+                        key: "/redfish/v1/Chassis/CH-sparse".to_string(),
+                        derived_metrics: vec![],
+                    },
+                },
+            ],
+            observe,
+        );
+    }
+}

--- a/crates/health/src/collectors/mod.rs
+++ b/crates/health/src/collectors/mod.rs
@@ -25,6 +25,8 @@ mod logs;
 mod nmxc;
 mod nmxt;
 mod nvue;
+#[cfg(test)]
+pub(in crate::collectors) mod projection_test_support;
 mod runtime;
 mod sensors;
 

--- a/crates/health/src/collectors/projection_test_support.rs
+++ b/crates/health/src/collectors/projection_test_support.rs
@@ -1,0 +1,675 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{OriginalUri, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::{Json, Router};
+pub(in crate::collectors) use bmc_mock::test_support::TestBmc;
+use bmc_mock::test_support::axum_http_client::AxumRouterHttpClient;
+use nv_redfish::ServiceRoot;
+use nv_redfish::bmc_http::{BmcCredentials, CacheSettings};
+use nv_redfish::chassis::{Chassis, PowerSupply};
+use nv_redfish::computer_system::{ComputerSystem, Drive, Memory, Processor, Storage};
+use serde_json::{Value, json};
+use url::Url;
+
+use super::inventory::DiscoveredEntity;
+
+#[derive(Clone)]
+enum MockResponse {
+    Json(Value),
+    Malformed,
+}
+
+async fn resource_response(
+    State(resources): State<Arc<HashMap<String, MockResponse>>>,
+    OriginalUri(uri): OriginalUri,
+) -> Response {
+    match resources.get(uri.path()) {
+        Some(MockResponse::Json(value)) => Json(value.clone()).into_response(),
+        Some(MockResponse::Malformed) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "application/json")],
+            "not valid JSON",
+        )
+            .into_response(),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+fn resource(path: &str, odata_type: &str, id: &str, name: &str, attributes: Value) -> Value {
+    let Value::Object(mut attributes) = attributes else {
+        panic!("test resource attributes must be an object");
+    };
+    attributes.insert("@odata.id".to_string(), Value::String(path.to_string()));
+    attributes.insert(
+        "@odata.type".to_string(),
+        Value::String(odata_type.to_string()),
+    );
+    attributes.insert("Id".to_string(), Value::String(id.to_string()));
+    attributes.insert("Name".to_string(), Value::String(name.to_string()));
+    Value::Object(attributes)
+}
+
+fn collection(path: &str, odata_type: &str, name: &str, members: &[&str]) -> Value {
+    json!({
+        "@odata.id": path,
+        "@odata.type": odata_type,
+        "Name": name,
+        "Members": members
+            .iter()
+            .map(|member| json!({ "@odata.id": member }))
+            .collect::<Vec<_>>()
+    })
+}
+
+fn insert(resources: &mut HashMap<String, MockResponse>, path: &str, value: Value) {
+    resources.insert(path.to_string(), MockResponse::Json(value));
+}
+
+fn insert_resource(
+    resources: &mut HashMap<String, MockResponse>,
+    path: &str,
+    odata_type: &str,
+    id: &str,
+    name: &str,
+    attributes: Value,
+) {
+    insert(
+        resources,
+        path,
+        resource(path, odata_type, id, name, attributes),
+    );
+}
+
+fn reference(path: &str) -> Value {
+    json!({ "@odata.id": path })
+}
+
+fn mock_resources() -> HashMap<String, MockResponse> {
+    const SYSTEM: &str = "/redfish/v1/Systems/SYS0";
+    const PROCESSORS: &str = "/redfish/v1/Systems/SYS0/Processors";
+    const MEMORY: &str = "/redfish/v1/Systems/SYS0/Memory";
+    const STORAGE: &str = "/redfish/v1/Systems/SYS0/Storage";
+    const CHASSIS: &str = "/redfish/v1/Chassis/CH0";
+    const POWER_SUBSYSTEM: &str = "/redfish/v1/Chassis/CH0/PowerSubsystem";
+    const POWER_SUPPLIES: &str = "/redfish/v1/Chassis/CH0/PowerSubsystem/PowerSupplies";
+
+    let processor = |id: &str| format!("{PROCESSORS}/{id}");
+    let memory = |id: &str| format!("{MEMORY}/{id}");
+    let storage = |id: &str| format!("{STORAGE}/{id}");
+    let drive = |id: &str| format!("{STORAGE}/ST0/Drives/{id}");
+    let chassis = |id: &str| format!("/redfish/v1/Chassis/{id}");
+    let power_supply = |id: &str| format!("{POWER_SUPPLIES}/{id}");
+
+    let mut resources = HashMap::new();
+    insert_resource(
+        &mut resources,
+        "/redfish/v1",
+        "#ServiceRoot.v1_15_0.ServiceRoot",
+        "RootService",
+        "Root Service",
+        json!({
+            "Links": {
+                "Sessions": reference("/redfish/v1/SessionService/Sessions")
+            },
+            "Systems": reference("/redfish/v1/Systems"),
+            "Chassis": reference("/redfish/v1/Chassis")
+        }),
+    );
+    insert(
+        &mut resources,
+        "/redfish/v1/Systems",
+        collection(
+            "/redfish/v1/Systems",
+            "#ComputerSystemCollection.ComputerSystemCollection",
+            "Systems",
+            &[SYSTEM],
+        ),
+    );
+    insert_resource(
+        &mut resources,
+        SYSTEM,
+        "#ComputerSystem.v1_20_1.ComputerSystem",
+        "SYS0",
+        "Test system",
+        json!({
+            "Processors": reference(PROCESSORS),
+            "Memory": reference(MEMORY),
+            "Storage": reference(STORAGE)
+        }),
+    );
+
+    let processor_paths = [
+        processor("CPU0"),
+        processor("CPU-sparse"),
+        processor("CPU-empty"),
+        processor("CPU-malformed"),
+    ];
+    let processor_members: Vec<_> = processor_paths.iter().map(String::as_str).collect();
+    insert(
+        &mut resources,
+        PROCESSORS,
+        collection(
+            PROCESSORS,
+            "#ProcessorCollection.ProcessorCollection",
+            "Processors",
+            &processor_members,
+        ),
+    );
+    let cpu = processor("CPU0");
+    let cpu_metrics = format!("{cpu}/Metrics");
+    insert_resource(
+        &mut resources,
+        &cpu,
+        "#Processor.v1_20_0.Processor",
+        "CPU0",
+        "Processor",
+        json!({
+            "ProcessorType": "CPU",
+            "Model": "Grace",
+            "Metrics": reference(&cpu_metrics)
+        }),
+    );
+    insert_resource(
+        &mut resources,
+        &cpu_metrics,
+        "#ProcessorMetrics.v1_6_1.ProcessorMetrics",
+        "Metrics",
+        "Processor metrics",
+        json!({
+            "BandwidthPercent": 42.0,
+            "CoreVoltage": {
+                "DataSourceUri": "/redfish/v1/Chassis/CH0/Sensors/CPU0_Voltage",
+                "Reading": 1.2
+            }
+        }),
+    );
+    #[derive(Clone, Copy)]
+    enum ProcessorMetricsResource {
+        Missing,
+        Empty,
+        Malformed,
+    }
+
+    for (id, metrics) in [
+        ("CPU-sparse", ProcessorMetricsResource::Missing),
+        ("CPU-empty", ProcessorMetricsResource::Empty),
+        ("CPU-malformed", ProcessorMetricsResource::Malformed),
+    ] {
+        let path = processor(id);
+        let metrics_path = format!("{path}/Metrics");
+        let attributes = match metrics {
+            ProcessorMetricsResource::Missing => json!({}),
+            ProcessorMetricsResource::Empty | ProcessorMetricsResource::Malformed => {
+                json!({ "Metrics": reference(&metrics_path) })
+            }
+        };
+        insert_resource(
+            &mut resources,
+            &path,
+            "#Processor.v1_20_0.Processor",
+            id,
+            "Test processor",
+            attributes,
+        );
+        match metrics {
+            ProcessorMetricsResource::Empty => insert_resource(
+                &mut resources,
+                &metrics_path,
+                "#ProcessorMetrics.v1_6_1.ProcessorMetrics",
+                "Metrics",
+                "Empty processor metrics",
+                json!({}),
+            ),
+            ProcessorMetricsResource::Malformed => {
+                resources.insert(metrics_path, MockResponse::Malformed);
+            }
+            ProcessorMetricsResource::Missing => {}
+        }
+    }
+
+    let memory_paths = [memory("DIMM0"), memory("DIMM-sparse")];
+    let memory_members: Vec<_> = memory_paths.iter().map(String::as_str).collect();
+    insert(
+        &mut resources,
+        MEMORY,
+        collection(
+            MEMORY,
+            "#MemoryCollection.MemoryCollection",
+            "Memory",
+            &memory_members,
+        ),
+    );
+    let dimm = memory("DIMM0");
+    let dimm_metrics = format!("{dimm}/Metrics");
+    insert_resource(
+        &mut resources,
+        &dimm,
+        "#Memory.v1_20_0.Memory",
+        "DIMM0",
+        "Memory",
+        json!({
+            "MemoryDeviceType": "DDR5",
+            "Model": "HMCG94AGBRA",
+            "Metrics": reference(&dimm_metrics)
+        }),
+    );
+    insert_resource(
+        &mut resources,
+        &dimm_metrics,
+        "#MemoryMetrics.v1_7_0.MemoryMetrics",
+        "Metrics",
+        "Memory metrics",
+        json!({ "BlockSizeBytes": 4096 }),
+    );
+    let sparse_memory = memory("DIMM-sparse");
+    insert_resource(
+        &mut resources,
+        &sparse_memory,
+        "#Memory.v1_20_0.Memory",
+        "DIMM-sparse",
+        "Sparse memory",
+        json!({}),
+    );
+
+    let storage_controller = storage("ST0");
+    insert(
+        &mut resources,
+        STORAGE,
+        collection(
+            STORAGE,
+            "#StorageCollection.StorageCollection",
+            "Storage",
+            &[&storage_controller],
+        ),
+    );
+    let drive_paths = [drive("D0"), drive("D-sparse")];
+    insert_resource(
+        &mut resources,
+        &storage_controller,
+        "#Storage.v1_15_0.Storage",
+        "ST0",
+        "Storage",
+        json!({
+            "Drives": drive_paths.iter().map(|path| reference(path)).collect::<Vec<_>>()
+        }),
+    );
+    let disk = drive("D0");
+    let disk_metrics = format!("{disk}/Metrics");
+    insert_resource(
+        &mut resources,
+        &disk,
+        "#Drive.v1_19_0.Drive",
+        "D0",
+        "Drive",
+        json!({
+            "Model": "NVMe-1",
+            "PredictedMediaLifeLeftPercent": 80.0,
+            "Metrics": reference(&disk_metrics)
+        }),
+    );
+    insert_resource(
+        &mut resources,
+        &disk_metrics,
+        "#DriveMetrics.v1_2_0.DriveMetrics",
+        "Metrics",
+        "Drive metrics",
+        json!({ "BadBlockCount": 4 }),
+    );
+    let sparse_drive = drive("D-sparse");
+    insert_resource(
+        &mut resources,
+        &sparse_drive,
+        "#Drive.v1_19_0.Drive",
+        "D-sparse",
+        "Sparse drive",
+        json!({}),
+    );
+
+    let sparse_chassis = chassis("CH-sparse");
+    insert(
+        &mut resources,
+        "/redfish/v1/Chassis",
+        collection(
+            "/redfish/v1/Chassis",
+            "#ChassisCollection.ChassisCollection",
+            "Chassis",
+            &[CHASSIS, &sparse_chassis],
+        ),
+    );
+    insert_resource(
+        &mut resources,
+        CHASSIS,
+        "#Chassis.v1_27_0.Chassis",
+        "CH0",
+        "Chassis",
+        json!({
+            "ChassisType": "RackMount",
+            "Model": "HGX",
+            "PowerSubsystem": reference(POWER_SUBSYSTEM)
+        }),
+    );
+    insert_resource(
+        &mut resources,
+        &sparse_chassis,
+        "#Chassis.v1_27_0.Chassis",
+        "CH-sparse",
+        "Sparse chassis",
+        json!({ "ChassisType": "RackMount" }),
+    );
+    insert_resource(
+        &mut resources,
+        POWER_SUBSYSTEM,
+        "#PowerSubsystem.v1_1_0.PowerSubsystem",
+        "PowerSubsystem",
+        "Power subsystem",
+        json!({ "PowerSupplies": reference(POWER_SUPPLIES) }),
+    );
+
+    let power_supply_paths = [power_supply("PS0"), power_supply("PS-sparse")];
+    let power_supply_members: Vec<_> = power_supply_paths.iter().map(String::as_str).collect();
+    insert(
+        &mut resources,
+        POWER_SUPPLIES,
+        collection(
+            POWER_SUPPLIES,
+            "#PowerSupplyCollection.PowerSupplyCollection",
+            "Power supplies",
+            &power_supply_members,
+        ),
+    );
+    let psu = power_supply("PS0");
+    let psu_metrics = format!("{psu}/Metrics");
+    insert_resource(
+        &mut resources,
+        &psu,
+        "#PowerSupply.v1_5_0.PowerSupply",
+        "PS0",
+        "Power supply",
+        json!({
+            "Model": "PSU-3KW",
+            "PowerCapacityWatts": 3000.0,
+            "Metrics": reference(&psu_metrics)
+        }),
+    );
+    insert_resource(
+        &mut resources,
+        &psu_metrics,
+        "#PowerSupplyMetrics.v1_0_0.PowerSupplyMetrics",
+        "Metrics",
+        "Power supply metrics",
+        json!({ "OutputPowerWatts": { "Reading": 500.0 } }),
+    );
+    let sparse_psu = power_supply("PS-sparse");
+    insert_resource(
+        &mut resources,
+        &sparse_psu,
+        "#PowerSupply.v1_5_0.PowerSupply",
+        "PS-sparse",
+        "Sparse power supply",
+        json!({}),
+    );
+
+    resources
+}
+
+#[derive(Clone, Copy)]
+pub(in crate::collectors) enum TestEntity {
+    Processor,
+    SparseProcessor,
+    ProcessorWithEmptyMetrics,
+    ProcessorWithMalformedMetrics,
+    Memory,
+    SparseMemory,
+    Drive,
+    SparseDrive,
+    PowerSupply,
+    SparsePowerSupply,
+    Chassis,
+    SparseChassis,
+}
+
+pub(in crate::collectors) struct ProjectionFixture {
+    bmc: Arc<TestBmc>,
+    system: Arc<ComputerSystem<TestBmc>>,
+    storage: Arc<Storage<TestBmc>>,
+    processors: HashMap<String, Arc<Processor<TestBmc>>>,
+    memory: HashMap<String, Arc<Memory<TestBmc>>>,
+    drives: HashMap<String, Arc<Drive<TestBmc>>>,
+    chassis: HashMap<String, Arc<Chassis<TestBmc>>>,
+    power_supplies: HashMap<String, Arc<PowerSupply<TestBmc>>>,
+}
+
+impl ProjectionFixture {
+    pub(in crate::collectors) async fn new() -> Self {
+        let resources = Arc::new(mock_resources());
+        let router = Router::new()
+            .fallback(resource_response)
+            .with_state(resources);
+        let bmc = Arc::new(TestBmc::new(
+            AxumRouterHttpClient::new(router),
+            Url::parse("https://projection-test.local").expect("test URL should parse"),
+            BmcCredentials::new("root".to_string(), "password".to_string()),
+            CacheSettings::with_capacity(64),
+        ));
+        let root = ServiceRoot::new(bmc.clone())
+            .await
+            .expect("test service root should load");
+
+        let system = Arc::new(
+            root.systems()
+                .await
+                .expect("systems should load")
+                .expect("systems link should exist")
+                .members()
+                .await
+                .expect("system members should load")
+                .into_iter()
+                .next()
+                .expect("test system should exist"),
+        );
+        let processors = system
+            .processors()
+            .await
+            .expect("processors should load")
+            .expect("processors link should exist")
+            .into_iter()
+            .map(|entity| (entity.raw().base.id.clone(), Arc::new(entity)))
+            .collect();
+        let memory = system
+            .memory_modules()
+            .await
+            .expect("memory should load")
+            .expect("memory link should exist")
+            .into_iter()
+            .map(|entity| (entity.raw().base.id.clone(), Arc::new(entity)))
+            .collect();
+        let storage = Arc::new(
+            system
+                .storage_controllers()
+                .await
+                .expect("storage should load")
+                .expect("storage link should exist")
+                .into_iter()
+                .next()
+                .expect("test storage should exist"),
+        );
+        let drives = storage
+            .drives()
+            .await
+            .expect("drives should load")
+            .expect("drives should exist")
+            .into_iter()
+            .map(|entity| (entity.raw().base.id.clone(), Arc::new(entity)))
+            .collect();
+
+        let chassis: HashMap<_, _> = root
+            .chassis()
+            .await
+            .expect("chassis should load")
+            .expect("chassis link should exist")
+            .members()
+            .await
+            .expect("chassis members should load")
+            .into_iter()
+            .map(|entity| (entity.raw().base.id.clone(), Arc::new(entity)))
+            .collect();
+        let parent_chassis = chassis
+            .get("CH0")
+            .expect("parent chassis should exist")
+            .clone();
+        let power_supplies = parent_chassis
+            .power_supplies()
+            .await
+            .expect("power supplies should load")
+            .into_iter()
+            .map(|entity| (entity.raw().base.id.clone(), Arc::new(entity)))
+            .collect();
+
+        Self {
+            bmc,
+            system,
+            storage,
+            processors,
+            memory,
+            drives,
+            chassis,
+            power_supplies,
+        }
+    }
+
+    pub(in crate::collectors) fn bmc(&self) -> Arc<TestBmc> {
+        self.bmc.clone()
+    }
+
+    fn processor(&self, id: &str) -> Arc<Processor<TestBmc>> {
+        self.processors
+            .get(id)
+            .unwrap_or_else(|| panic!("processor {id} should exist"))
+            .clone()
+    }
+
+    fn memory(&self, id: &str) -> Arc<Memory<TestBmc>> {
+        self.memory
+            .get(id)
+            .unwrap_or_else(|| panic!("memory {id} should exist"))
+            .clone()
+    }
+
+    fn drive(&self, id: &str) -> Arc<Drive<TestBmc>> {
+        self.drives
+            .get(id)
+            .unwrap_or_else(|| panic!("drive {id} should exist"))
+            .clone()
+    }
+
+    fn chassis(&self, id: &str) -> Arc<Chassis<TestBmc>> {
+        self.chassis
+            .get(id)
+            .unwrap_or_else(|| panic!("chassis {id} should exist"))
+            .clone()
+    }
+
+    fn power_supply(&self, id: &str) -> Arc<PowerSupply<TestBmc>> {
+        self.power_supplies
+            .get(id)
+            .unwrap_or_else(|| panic!("power supply {id} should exist"))
+            .clone()
+    }
+
+    pub(in crate::collectors) async fn entity(
+        &self,
+        entity: TestEntity,
+    ) -> DiscoveredEntity<TestBmc> {
+        match entity {
+            TestEntity::Processor => {
+                let entity = self.processor("CPU0");
+                // Inventory receives the sensor links that discovery already combined.
+                // One metric-linked sensor is enough to exercise that projection boundary.
+                let sensors = entity
+                    .metrics_sensor_links()
+                    .await
+                    .expect("processor sensors should load");
+                DiscoveredEntity::Processor {
+                    entity,
+                    system: self.system.clone(),
+                    sensors,
+                }
+            }
+            TestEntity::SparseProcessor => DiscoveredEntity::Processor {
+                entity: self.processor("CPU-sparse"),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::ProcessorWithEmptyMetrics => DiscoveredEntity::Processor {
+                entity: self.processor("CPU-empty"),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::ProcessorWithMalformedMetrics => DiscoveredEntity::Processor {
+                entity: self.processor("CPU-malformed"),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::Memory => DiscoveredEntity::Memory {
+                entity: self.memory("DIMM0"),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::SparseMemory => DiscoveredEntity::Memory {
+                entity: self.memory("DIMM-sparse"),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::Drive => DiscoveredEntity::Drive {
+                entity: self.drive("D0"),
+                storage: self.storage.clone(),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::SparseDrive => DiscoveredEntity::Drive {
+                entity: self.drive("D-sparse"),
+                storage: self.storage.clone(),
+                system: self.system.clone(),
+                sensors: Vec::new(),
+            },
+            TestEntity::PowerSupply => DiscoveredEntity::PowerSupply {
+                entity: self.power_supply("PS0"),
+                chassis: self.chassis("CH0"),
+                sensors: Vec::new(),
+            },
+            TestEntity::SparsePowerSupply => DiscoveredEntity::PowerSupply {
+                entity: self.power_supply("PS-sparse"),
+                chassis: self.chassis("CH0"),
+                sensors: Vec::new(),
+            },
+            TestEntity::Chassis => DiscoveredEntity::Chassis {
+                entity: self.chassis("CH0"),
+                sensors: Vec::new(),
+            },
+            TestEntity::SparseChassis => DiscoveredEntity::Chassis {
+                entity: self.chassis("CH-sparse"),
+                sensors: Vec::new(),
+            },
+        }
+    }
+}


### PR DESCRIPTION
Health's inventory projection had no direct coverage, and the child metric tests stopped before `MetricsCollector::collect_entity`.

So, this replaces five standalone entries with one table and adds owner tables for every `DiscoveredEntity` variant plus representative collection behavior. A `#[cfg(test)]` in-process Redfish fixture lets the same rows cover populated, sparse, null, malformed, ignored, and sinkless paths without repeating setup.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4075

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo test -p carbide-health --lib`

`cargo make format-nightly`

`cargo make clippy`

`cargo make carbide-lints`

## Additional Notes

Production behavior is unchanged. The selected projection code now measures:

| Checkpoint | Functions | Lines | Regions | Health test entries |
| --- | ---: | ---: | ---: | ---: |
| Original | 7/30 | 104/339 | 129/534 | 405 |
| Converted | 7/30 | 104/339 | 129/534 | 401 |
| Expanded | 30/30 | 335/339 | 509/534 | 403 |

The four uncovered source lines are three repeated generic miss arms for the non-processor entity types and one lazy tracing field. Processor rows already exercise the missing-resource and malformed-fetch behavior. Sensor projection remains separate for the next focused change.
