### PR TITLE
feat(rack-controller): count maintenance token cleanup failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,7 @@ dependencies = [
  "carbide-api-db",
  "carbide-api-model",
  "carbide-health-metrics",
+ "carbide-instrument",
  "carbide-rack",
  "carbide-secrets",
  "carbide-test-support",
@@ -2822,6 +2823,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "state-controller",
+ "tokio",
  "tonic",
  "tracing",
 ]

--- a/crates/rack-controller/Cargo.toml
+++ b/crates/rack-controller/Cargo.toml
@@ -25,6 +25,7 @@ authors.workspace = true
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-api-model = { path = "../api-model", default-features = false }
 carbide-health-metrics = { path = "../health-metrics", default-features = false }
+carbide-instrument = { path = "../instrument" }
 carbide-rack = { path = "../rack", default-features = false }
 carbide-secrets = { path = "../secrets", default-features = false }
 carbide-utils = { path = "../utils", default-features = false }
@@ -47,7 +48,10 @@ tracing = { workspace = true }
 tonic = { workspace = true }
 
 [dev-dependencies]
+carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-secrets = { path = "../secrets", features = ["test-support"] }
 carbide-test-support = { path = "../test-support" }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -17,6 +17,7 @@
 
 //! Handler for RackState::Maintenance.
 
+use carbide_instrument::{Event, emit};
 use carbide_rack::firmware_object::{
     ANY_RACK_HARDWARE_TYPE, profile_hardware_type_wire_value, rack_maintenance_access_token_key,
     rms_access_token_or_noauth,
@@ -289,6 +290,23 @@ async fn load_rack_maintenance_access_token(
     Ok(password)
 }
 
+#[derive(Event)]
+#[event(
+    event_name = "rack_maintenance_access_token_cleanup_failed",
+    metric_name = "carbide_rack_maintenance_access_token_cleanup_failures_total",
+    component = "rack-controller",
+    log = warn,
+    metric = counter,
+    message = "failed to delete rack maintenance access token",
+    describe = "Number of rack maintenance access token cleanup failures"
+)]
+struct RackMaintenanceAccessTokenCleanupFailed {
+    #[context]
+    rack_id: RackId,
+    #[context]
+    error: String,
+}
+
 async fn delete_rack_maintenance_access_token(
     credential_manager: &dyn CredentialManager,
     rack_id: &RackId,
@@ -297,11 +315,10 @@ async fn delete_rack_maintenance_access_token(
         .delete_credentials(&rack_maintenance_access_token_key(rack_id))
         .await
     {
-        tracing::warn!(
-            rack_id = %rack_id,
-            error = %error,
-            "failed to delete rack maintenance access token",
-        );
+        emit(RackMaintenanceAccessTokenCleanupFailed {
+            rack_id: rack_id.clone(),
+            error: error.to_string(),
+        });
     }
 }
 
@@ -2466,8 +2483,10 @@ pub async fn handle_maintenance(
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_rack::firmware_update::RackFirmwareInventory;
     use carbide_rack::rms_node_type::switch_node_identity_for_profile;
+    use carbide_secrets::test_support::credentials::TestCredentialManager;
     use carbide_test_support::{Check, check_values};
     use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
     use carbide_uuid::rack::RackId;
@@ -2480,9 +2499,10 @@ mod tests {
     use model::rack_type::{RackHardwareType, RackProductFamily, RackProfile};
 
     use super::{
-        build_switch_device_info_request, filter_inventory_by_scope, firmware_device_status,
-        first_maintenance_state, next_state_after_configure, next_state_after_firmware,
-        next_state_after_nvos, profile_hardware_type_or_any,
+        build_switch_device_info_request, delete_rack_maintenance_access_token,
+        filter_inventory_by_scope, firmware_device_status, first_maintenance_state,
+        next_state_after_configure, next_state_after_firmware, next_state_after_nvos,
+        profile_hardware_type_or_any,
     };
 
     fn test_machine_id(seed: u8) -> MachineId {
@@ -2524,6 +2544,100 @@ mod tests {
             switch_ids: vec![switch_a, switch_b],
             switches: vec![test_device_info(switch_a), test_device_info(switch_b)],
         }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AccessTokenCleanupObservation {
+        counter_delta: f64,
+        log_count: usize,
+        level: Option<tracing::Level>,
+        metadata_name: Option<String>,
+        message: Option<String>,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        rack_id: Option<String>,
+        error: Option<String>,
+    }
+
+    #[test]
+    fn rack_maintenance_access_token_cleanup_emits_only_on_failure() {
+        const METRIC_NAME: &str = "carbide_rack_maintenance_access_token_cleanup_failures_total";
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime");
+        let rack_id = RackId::from("rack-1");
+
+        carbide_test_support::value_scenarios!(
+            run = |delete_fails: bool| {
+                let credential_manager = TestCredentialManager::default();
+                credential_manager.set_delete_credentials_failure(delete_fails);
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| {
+                    runtime.block_on(delete_rack_maintenance_access_token(
+                        &credential_manager,
+                        &rack_id,
+                    ));
+                })
+                .into_iter()
+                .filter(|log| {
+                    log.field("event_name")
+                        == Some("rack_maintenance_access_token_cleanup_failed")
+                })
+                .collect::<Vec<_>>();
+                let log = logs.first();
+
+                AccessTokenCleanupObservation {
+                    counter_delta: metrics.counter_delta(METRIC_NAME, &[]),
+                    log_count: logs.len(),
+                    level: log.map(|log| log.level),
+                    metadata_name: log.map(|log| log.metadata_name.clone()),
+                    message: log.map(|log| log.message.clone()),
+                    event_name: log
+                        .and_then(|log| log.field("event_name"))
+                        .map(str::to_string),
+                    metric_name: log
+                        .and_then(|log| log.field("metric_name"))
+                        .map(str::to_string),
+                    rack_id: log
+                        .and_then(|log| log.field("rack_id"))
+                        .map(str::to_string),
+                    error: log.and_then(|log| log.field("error")).map(str::to_string),
+                }
+            };
+            "credential cleanup outcome" {
+                false => AccessTokenCleanupObservation {
+                    counter_delta: 0.0,
+                    log_count: 0,
+                    level: None,
+                    metadata_name: None,
+                    message: None,
+                    event_name: None,
+                    metric_name: None,
+                    rack_id: None,
+                    error: None,
+                },
+                true => AccessTokenCleanupObservation {
+                    counter_delta: 1.0,
+                    log_count: 1,
+                    level: Some(tracing::Level::WARN),
+                    metadata_name: Some(
+                        "rack_maintenance_access_token_cleanup_failed".to_string(),
+                    ),
+                    message: Some(
+                        "failed to delete rack maintenance access token".to_string(),
+                    ),
+                    event_name: Some(
+                        "rack_maintenance_access_token_cleanup_failed".to_string(),
+                    ),
+                    metric_name: Some(METRIC_NAME.to_string()),
+                    rack_id: Some("rack-1".to_string()),
+                    error: Some(
+                        "Secrets operation failed: test credential delete failure".to_string(),
+                    ),
+                },
+            }
+        );
     }
 
     #[test]

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -201,6 +201,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_preingestion_waiting_download</td><td>gauge</td><td>Number of machines that are waiting for firmware downloads on other machines to complete before doing their own</td></tr>
 <tr><td>carbide_preingestion_waiting_installation</td><td>gauge</td><td>Number of machines which have had firmware uploaded to them and are currently in the process of installing that firmware</td></tr>
 <tr><td>carbide_pxe_boot_outcomes_total</td><td>counter</td><td>Number of PXE boot-path outcomes served, by endpoint and reason.</td></tr>
+<tr><td>carbide_rack_maintenance_access_token_cleanup_failures_total</td><td>counter</td><td>Number of rack maintenance access token cleanup failures</td></tr>
 <tr><td>carbide_racks_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_racks in the system</td></tr>
 <tr><td>carbide_racks_health_overrides_count</td><td>gauge</td><td>Number of health overrides configured in the site</td></tr>
 <tr><td>carbide_racks_health_status_count</td><td>gauge</td><td>Number of racks in the system that have reported either a healthy or not healthy status - based on the presence of health probe alerts</td></tr>


### PR DESCRIPTION
Rack maintenance removes its temporary Vault access token when the workflow finishes, but a failed deletion was only visible as a warning. Since cleanup is intentionally best-effort, maintenance continues even though a credential may have been left behind.

So, the existing failure branch now emits `RackMaintenanceAccessTokenCleanupFailed`. It preserves the warning and continuation behavior while incrementing `carbide_rack_maintenance_access_token_cleanup_failures_total`; `rack_id` and the deletion error stay log-only, and no credential data is recorded.

The table-driven test exercises successful and failed deletion through `TestCredentialManager` and verifies that only the failure writes a log and increments the counter.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4076

Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-rack-controller --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo xtask check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

Closes #4076
