### PR TITLE
feat(firmware): count artifacts unavailable before download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "sha2 0.11.0",
  "sqlx",
  "temp-dir",
+ "tempfile",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",

--- a/crates/firmware/Cargo.toml
+++ b/crates/firmware/Cargo.toml
@@ -41,6 +41,7 @@ carbide-macros = { path = "../macros" }
 carbide-api-db = { path = "../api-db", default-features = false }
 sqlx = { workspace = true }
 carbide-sqlx-testing = { path = "../sqlx-testing", default-features = false }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/firmware/src/downloader.rs
+++ b/crates/firmware/src/downloader.rs
@@ -29,6 +29,54 @@ use reqwest_middleware::ClientWithMiddleware as Client;
 use sha2::{Digest, Sha256};
 use tokio::fs::File;
 
+/// `ArtifactUnavailableReason` names the bounded blocker that kept an
+/// artifact from reaching the download path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ArtifactUnavailableReason {
+    MissingUrl,
+    StaleCacheRemovalFailed,
+}
+
+// Both failures increment the same counter, but their existing log fields
+// differ. Separate Event types keep each record intact instead of adding empty
+// context. Their descriptions must stay identical so OpenTelemetry treats them
+// as one instrument.
+#[derive(Event)]
+#[event(
+    event_name = "firmware_artifact_missing_url",
+    metric_name = "carbide_firmware_artifact_unavailable_total",
+    component = "carbide-firmware",
+    log = error,
+    metric = counter,
+    message = "Firmware artifact is missing and has no URL",
+    describe = "Number of firmware artifacts unavailable before download, by reason."
+)]
+pub(crate) struct FirmwareArtifactMissingUrl {
+    #[label]
+    pub reason: ArtifactUnavailableReason,
+    #[context]
+    pub firmware_path: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "firmware_stale_cached_artifact_removal_failed",
+    metric_name = "carbide_firmware_artifact_unavailable_total",
+    component = "carbide-firmware",
+    log = error,
+    metric = counter,
+    message = "Failed to remove stale cached firmware artifact",
+    describe = "Number of firmware artifacts unavailable before download, by reason."
+)]
+pub(crate) struct FirmwareStaleCachedArtifactRemovalFailed {
+    #[label]
+    pub reason: ArtifactUnavailableReason,
+    #[context]
+    pub filename: String,
+    #[context]
+    pub error: String,
+}
+
 /// How a background firmware download attempt ended, as a bounded metric
 /// label.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
@@ -160,10 +208,10 @@ impl FirmwareDownloader {
         }
 
         if url.is_empty() {
-            tracing::error!(
-                firmware_path = ?filename,
-                "Firmware artifact is missing and has no URL",
-            );
+            emit(FirmwareArtifactMissingUrl {
+                reason: ArtifactUnavailableReason::MissingUrl,
+                firmware_path: format!("{filename:?}"),
+            });
             return false;
         }
 
@@ -283,11 +331,11 @@ fn cached_file_status(filename: &Path, sha256: &str) -> CachedFileStatus {
             );
 
             if let Err(err) = std::fs::remove_file(filename) {
-                tracing::error!(
-                    filename = %filename.display(),
-                    error = %err,
-                    "Failed to remove stale cached firmware artifact",
-                );
+                emit(FirmwareStaleCachedArtifactRemovalFailed {
+                    reason: ArtifactUnavailableReason::StaleCacheRemovalFailed,
+                    filename: filename.display().to_string(),
+                    error: err.to_string(),
+                });
                 return CachedFileStatus::Unusable;
             }
 

--- a/crates/firmware/src/tests/downloader.rs
+++ b/crates/firmware/src/tests/downloader.rs
@@ -27,6 +27,7 @@ use tokio::io::AsyncWriteExt;
 
 use crate::downloader::*;
 
+const ARTIFACT_UNAVAILABLE_METRIC: &str = "carbide_firmware_artifact_unavailable_total";
 const DOWNLOAD_DURATION_METRIC: &str = "carbide_firmware_download_duration_seconds";
 
 #[test]
@@ -226,6 +227,170 @@ async fn test_available_fetch_failure_counts() -> Result<(), std::io::Error> {
 
     assert!(!filename.exists());
     Ok(())
+}
+
+#[test]
+fn artifact_unavailable_events_preserve_log_contracts_and_count_reasons() {
+    #[derive(Clone, Copy)]
+    enum Fixture {
+        MissingUrl,
+        StaleCacheRemovalFailed,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct Contract {
+        event_name: String,
+        message: String,
+        metric_name: Option<String>,
+        reason: Option<String>,
+        firmware_path: Option<String>,
+        filename: Option<String>,
+        error: Option<String>,
+        counter_delta: f64,
+    }
+
+    let metrics = MetricsCapture::start();
+    check_values(
+        [
+            Check {
+                scenario: "missing URL retains firmware_path context",
+                input: Fixture::MissingUrl,
+                expect: Contract {
+                    event_name: "firmware_artifact_missing_url".to_string(),
+                    message: "Firmware artifact is missing and has no URL".to_string(),
+                    metric_name: Some(ARTIFACT_UNAVAILABLE_METRIC.to_string()),
+                    reason: Some("missing_url".to_string()),
+                    firmware_path: Some("\"/firmware/missing.fwpkg\"".to_string()),
+                    filename: None,
+                    error: None,
+                    counter_delta: 1.0,
+                },
+            },
+            Check {
+                scenario: "stale cache removal failure retains filename and error context",
+                input: Fixture::StaleCacheRemovalFailed,
+                expect: Contract {
+                    event_name: "firmware_stale_cached_artifact_removal_failed".to_string(),
+                    message: "Failed to remove stale cached firmware artifact".to_string(),
+                    metric_name: Some(ARTIFACT_UNAVAILABLE_METRIC.to_string()),
+                    reason: Some("stale_cache_removal_failed".to_string()),
+                    firmware_path: None,
+                    filename: Some("/firmware/stale.fwpkg".to_string()),
+                    error: Some("read-only filesystem".to_string()),
+                    counter_delta: 1.0,
+                },
+            },
+        ],
+        |fixture| {
+            let reason = match fixture {
+                Fixture::MissingUrl => "missing_url",
+                Fixture::StaleCacheRemovalFailed => "stale_cache_removal_failed",
+            };
+            let logs = capture_logs(|| match fixture {
+                Fixture::MissingUrl => emit(FirmwareArtifactMissingUrl {
+                    reason: ArtifactUnavailableReason::MissingUrl,
+                    firmware_path: format!("{:?}", Path::new("/firmware/missing.fwpkg")),
+                }),
+                Fixture::StaleCacheRemovalFailed => {
+                    emit(FirmwareStaleCachedArtifactRemovalFailed {
+                        reason: ArtifactUnavailableReason::StaleCacheRemovalFailed,
+                        filename: "/firmware/stale.fwpkg".to_string(),
+                        error: "read-only filesystem".to_string(),
+                    });
+                }
+            });
+
+            assert_eq!(logs.len(), 1, "one event should own the error log");
+            assert_eq!(logs[0].level, tracing::Level::ERROR);
+            Contract {
+                event_name: logs[0].metadata_name.clone(),
+                message: logs[0].message.clone(),
+                metric_name: logs[0].field("metric_name").map(str::to_string),
+                reason: logs[0].field("reason").map(str::to_string),
+                firmware_path: logs[0].field("firmware_path").map(str::to_string),
+                filename: logs[0].field("filename").map(str::to_string),
+                error: logs[0].field("error").map(str::to_string),
+                counter_delta: metrics
+                    .counter_delta(ARTIFACT_UNAVAILABLE_METRIC, &[("reason", reason)]),
+            }
+        },
+    );
+}
+
+#[test]
+fn unavailable_absent_artifact_without_url_counts_the_blocker() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let filename = temp_dir.path().join("missing.fwpkg");
+    let downloader = FirmwareDownloader::new();
+    let metrics = MetricsCapture::start();
+
+    let logs = capture_logs(|| {
+        assert!(!downloader.available(&filename, "", ""));
+    });
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].metadata_name, "firmware_artifact_missing_url");
+    assert_eq!(
+        logs[0].message,
+        "Firmware artifact is missing and has no URL"
+    );
+    assert_eq!(
+        logs[0].field("firmware_path"),
+        Some(format!("{filename:?}").as_str())
+    );
+    assert_eq!(
+        metrics.counter_delta(ARTIFACT_UNAVAILABLE_METRIC, &[("reason", "missing_url")]),
+        1.0,
+    );
+    assert!(!filename.exists());
+}
+
+#[test]
+fn unavailable_stale_artifact_removal_failure_counts_the_blocker() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let filename = temp_dir.path().join("stale.fwpkg");
+    std::fs::create_dir(&filename).unwrap();
+    let downloader = FirmwareDownloader::new();
+    let metrics = MetricsCapture::start();
+
+    let logs = capture_logs(|| {
+        assert!(!downloader.available(
+            &filename,
+            "https://firmware.example/stale.fwpkg",
+            "expected-checksum",
+        ));
+    });
+
+    assert!(logs.iter().any(|log| {
+        log.message == "Cached firmware artifact failed checksum verification"
+            && log.level == tracing::Level::WARN
+    }));
+    let unavailable = logs
+        .iter()
+        .find(|log| log.metadata_name == "firmware_stale_cached_artifact_removal_failed")
+        .expect("removal failure should emit an unavailable-artifact event");
+    assert_eq!(unavailable.level, tracing::Level::ERROR);
+    assert_eq!(
+        unavailable.message,
+        "Failed to remove stale cached firmware artifact"
+    );
+    assert_eq!(
+        unavailable.field("filename"),
+        Some(filename.to_string_lossy().as_ref())
+    );
+    assert!(
+        unavailable
+            .field("error")
+            .is_some_and(|error| !error.is_empty())
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            ARTIFACT_UNAVAILABLE_METRIC,
+            &[("reason", "stale_cache_removal_failed")],
+        ),
+        1.0,
+    );
+    assert!(filename.is_dir());
 }
 
 /// The label vocabulary is the dashboard contract: every download outcome

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -86,6 +86,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_exhausted_reprovision_retry_count</td><td>gauge</td><td>Number of host machines in the system whose host firmware upgrade retry budget is exhausted.</td></tr>
 <tr><td>carbide_extension_service_credential_cleanup_failures_total</td><td>counter</td><td>Number of extension-service credential cleanup failures, by operation.</td></tr>
 <tr><td>carbide_external_call_duration_milliseconds</td><td>histogram</td><td>Duration of outbound calls by backend, operation, and outcome; the _count series, split by outcome, gives the request and error rates.</td></tr>
+<tr><td>carbide_firmware_artifact_unavailable_total</td><td>counter</td><td>Number of firmware artifacts unavailable before download, by reason.</td></tr>
 <tr><td>carbide_firmware_download_duration_seconds</td><td>histogram</td><td>Duration of background firmware artifact downloads, by outcome; an ok attempt spans fetch, checksum verification, and publish, and the _count series, split by outcome, is the download and failure rate.</td></tr>
 <tr><td>carbide_firmware_update_failures_total</td><td>counter</td><td>Number of firmware update failures, by update target and cause</td></tr>
 <tr><td>carbide_firmware_updates_total</td><td>counter</td><td>Number of firmware updates started and completed, by update target and phase; only the host target emits both phases</td></tr>


### PR DESCRIPTION
`DownloadFinished` runs only after a firmware download starts. A missing URL and a stale cached artifact that cannot be removed both return earlier, which meant neither blocker appeared in the download metrics.

So, the two existing error branches now emit sibling Events backed by `carbide_firmware_artifact_unavailable_total`, with a bounded `reason={missing_url,stale_cache_removal_failed}` label. Separate Event types keep each branch's existing log fields intact without adding empty context, while every `false` return and the recoverable checksum warning stay the same.

The table-driven Event contract checks both reasons and exact log fields, and callsite tests exercise an empty URL and a deterministic stale-cache removal failure.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4078

Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-firmware --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo xtask check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

Closes #4078
