### PR TITLE
test(health): own sensor metric projection

### DIFF
--- a/crates/health/src/collectors/sensors.rs
+++ b/crates/health/src/collectors/sensors.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::{StreamExt, stream};
 use nv_redfish::core::{Bmc, EntityTypeRef, ToSnakeCase};
+use nv_redfish::schema::sensor::Sensor;
 use nv_redfish::sensor::SensorLink;
 
 use crate::HealthError;
@@ -51,6 +52,42 @@ impl SensorRangeKind {
             Self::Min => "reading_range_min",
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SensorSweepPlan {
+    Skip,
+    Collect {
+        include_derived_metrics: bool,
+        sensor_limit: Option<usize>,
+    },
+}
+
+impl From<CollectorSweep> for SensorSweepPlan {
+    fn from(sweep: CollectorSweep) -> Self {
+        match sweep {
+            CollectorSweep::Full => Self::Collect {
+                include_derived_metrics: true,
+                sensor_limit: None,
+            },
+            CollectorSweep::Probe => Self::Collect {
+                include_derived_metrics: false,
+                sensor_limit: Some(1),
+            },
+            CollectorSweep::Skip => Self::Skip,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SensorProjectionError {
+    NoHealth,
+    IncompleteReading,
+}
+
+struct SensorProjection {
+    primary: MetricSample,
+    ranges: Vec<MetricSample>,
 }
 
 /// Configuration for the sensor collector.
@@ -110,8 +147,12 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         // instead of the full fan-out — a still-dead BMC then costs one request,
         // not hundreds, and one fetch is enough to let the breaker self-heal.
         // See NVBug 6036327.
-        let sweep = self.endpoint.bmc.collector_sweep();
-        if sweep == CollectorSweep::Skip {
+        let sweep_plan = SensorSweepPlan::from(self.endpoint.bmc.collector_sweep());
+        let SensorSweepPlan::Collect {
+            include_derived_metrics,
+            sensor_limit,
+        } = sweep_plan
+        else {
             tracing::debug!(
                 bmc_address = ?self.endpoint.addr,
                 "BMC connection circuit is open; skipping sensor iteration"
@@ -121,8 +162,8 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
                 entity_count: None,
                 fetch_failures: 0,
             });
-        }
-        let probe_only = sweep == CollectorSweep::Probe;
+        };
+        let probe_only = sensor_limit == Some(1);
 
         tracing::debug!(
             bmc_address = ?self.endpoint.addr,
@@ -139,7 +180,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
         // Entity-level derived metrics (drive media life, PSU capacity), once
         // per entity. Skipped while probing — they would emit metrics from stale
         // inventory for a BMC we already believe is down.
-        if !probe_only {
+        if include_derived_metrics {
             for entity in &inventory.entities {
                 self.emit_derived_metrics(entity);
             }
@@ -158,11 +199,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for SensorCollector<B> {
                 .iter()
                 .map(move |sensor| this.update_sensor(entity, sensor, failures))
         });
-        let futures: Vec<_> = if probe_only {
-            fetches.take(1).collect()
-        } else {
-            fetches.collect()
-        };
+        let futures: Vec<_> = fetches.take(sensor_limit.unwrap_or(usize::MAX)).collect();
 
         let processed: usize = stream::iter(futures)
             .buffer_unordered(self.sensor_fetch_concurrency)
@@ -239,85 +276,109 @@ impl<B: Bmc + 'static> SensorCollector<B> {
             }
         };
 
-        let Some(bmc_health) = sensor
-            .status
-            .as_ref()
-            .and_then(|s| s.health.and_then(std::convert::identity))
-        else {
-            tracing::debug!(
-                sensor_id = %sensor.base.id,
-                entity_type = entity.entity_type(),
-                "Sensor does not have health status field, skipping"
-            );
-            return 0;
+        let projection = match project_sensor(
+            &sensor,
+            entity.entity_type(),
+            entity.physical_context_fallback(),
+            entity.base_attributes(),
+            entity.entity_specific_attributes(),
+            self.include_sensor_thresholds,
+        ) {
+            Ok(projection) => projection,
+            Err(SensorProjectionError::NoHealth) => {
+                tracing::debug!(
+                    sensor_id = %sensor.base.id,
+                    entity_type = entity.entity_type(),
+                    "Sensor does not have health status field, skipping"
+                );
+                return 0;
+            }
+            Err(SensorProjectionError::IncompleteReading) => {
+                tracing::warn!(
+                    sensor_id = %sensor.base.id,
+                    entity_type = entity.entity_type(),
+                    "Sensor missing required fields (reading, reading_type, or units)"
+                );
+                return 0;
+            }
         };
 
-        let Some((reading, reading_type, unit)) = sensor
-            .reading
-            .flatten()
-            .zip(sensor.reading_type.flatten())
-            .zip(sensor.reading_units.clone().flatten())
-            .filter(|(_, reading)| !reading.is_empty())
-            .map(|((r, rt), u)| (r, rt, u))
-        else {
-            tracing::warn!(
-                sensor_id = %sensor.base.id,
-                entity_type = entity.entity_type(),
-                "Sensor missing required fields (reading, reading_type, or units)"
-            );
-            return 0;
-        };
-
-        let mut attributes = entity.base_attributes();
-        attributes.reserve(6);
-        attributes.push((Cow::Borrowed("sensor_name"), sensor.base.id.clone()));
-
-        if let Some(thresholds) = sensor
-            .thresholds
-            .as_ref()
-            .filter(|_| self.include_sensor_thresholds)
-        {
-            attributes.push((
-                Cow::Borrowed("upper_critical_threshold"),
-                thresholds
-                    .upper_critical
-                    .as_ref()
-                    .and_then(|th| th.reading.flatten())
-                    .unwrap_or_default()
-                    .to_string(),
-            ));
-            attributes.push((
-                Cow::Borrowed("lower_critical_threshold"),
-                thresholds
-                    .lower_critical
-                    .as_ref()
-                    .and_then(|th| th.reading.flatten())
-                    .unwrap_or_default()
-                    .to_string(),
-            ));
+        self.emit_event(CollectorEvent::Metric(projection.primary.into()));
+        for metric in projection.ranges {
+            self.emit_event(CollectorEvent::Metric(metric.into()));
         }
 
-        let physical_context = sensor
-            .physical_context
-            .flatten()
-            .map(|phc| phc.to_snake_case().to_string())
-            .unwrap_or_else(|| entity.physical_context_fallback().to_string());
-        attributes.push((Cow::Borrowed("physical_context"), physical_context));
-        attributes.extend(entity.entity_specific_attributes());
+        1
+    }
+}
 
-        let metric_type = reading_type.to_snake_case().to_string();
-        let unit = sanitize_unit(&unit);
-        let range_max = sensor.reading_range_max.flatten();
-        let range_min = sensor.reading_range_min.flatten();
+fn project_sensor(
+    sensor: &Sensor,
+    entity_type: &str,
+    physical_context_fallback: &str,
+    base_attributes: Vec<MetricLabel>,
+    entity_attributes: Vec<MetricLabel>,
+    include_sensor_thresholds: bool,
+) -> Result<SensorProjection, SensorProjectionError> {
+    let Some(bmc_health) = sensor.status.as_ref().and_then(|s| s.health.flatten()) else {
+        return Err(SensorProjectionError::NoHealth);
+    };
 
-        let (
-            upper_fatal,
-            lower_fatal,
-            upper_critical,
-            lower_critical,
-            upper_caution,
-            lower_caution,
-        ) = if let Some(thresholds) = &sensor.thresholds {
+    let Some((reading, reading_type, unit)) = sensor
+        .reading
+        .flatten()
+        .zip(sensor.reading_type.flatten())
+        .zip(sensor.reading_units.clone().flatten())
+        .filter(|(_, unit)| !unit.is_empty())
+        .map(|((r, rt), u)| (r, rt, u))
+    else {
+        return Err(SensorProjectionError::IncompleteReading);
+    };
+
+    let mut attributes = base_attributes;
+    attributes.reserve(6);
+    attributes.push((Cow::Borrowed("sensor_name"), sensor.base.id.clone()));
+
+    if let Some(thresholds) = sensor
+        .thresholds
+        .as_ref()
+        .filter(|_| include_sensor_thresholds)
+    {
+        attributes.push((
+            Cow::Borrowed("upper_critical_threshold"),
+            thresholds
+                .upper_critical
+                .as_ref()
+                .and_then(|th| th.reading.flatten())
+                .unwrap_or_default()
+                .to_string(),
+        ));
+        attributes.push((
+            Cow::Borrowed("lower_critical_threshold"),
+            thresholds
+                .lower_critical
+                .as_ref()
+                .and_then(|th| th.reading.flatten())
+                .unwrap_or_default()
+                .to_string(),
+        ));
+    }
+
+    let physical_context = sensor
+        .physical_context
+        .flatten()
+        .map(|phc| phc.to_snake_case().to_string())
+        .unwrap_or_else(|| physical_context_fallback.to_string());
+    attributes.push((Cow::Borrowed("physical_context"), physical_context));
+    attributes.extend(entity_attributes);
+
+    let metric_type = reading_type.to_snake_case().to_string();
+    let unit = sanitize_unit(&unit);
+    let range_max = sensor.reading_range_max.flatten();
+    let range_min = sensor.reading_range_min.flatten();
+
+    let (upper_fatal, lower_fatal, upper_critical, lower_critical, upper_caution, lower_caution) =
+        if let Some(thresholds) = &sensor.thresholds {
             (
                 thresholds
                     .upper_fatal
@@ -348,105 +409,967 @@ impl<B: Bmc + 'static> SensorCollector<B> {
             (None, None, None, None, None, None)
         };
 
-        self.emit_event(CollectorEvent::Metric(
-            MetricSample {
-                key: sensor.odata_id().to_string(),
-                name: "hw_sensor".to_string(),
-                metric_type: metric_type.clone(),
-                unit: unit.clone(),
-                value: reading,
-                labels: attributes.clone(),
-                context: Some(SensorThresholdContext {
-                    entity_type: entity.entity_type().to_string(),
-                    sensor_id: sensor.base.id.clone(),
-                    upper_fatal,
-                    lower_fatal,
-                    upper_critical,
-                    lower_critical,
-                    upper_caution,
-                    lower_caution,
-                    range_max,
-                    range_min,
-                    bmc_health,
-                }),
-            }
-            .into(),
-        ));
+    let primary = MetricSample {
+        key: sensor.odata_id().to_string(),
+        name: "hw_sensor".to_string(),
+        metric_type: metric_type.clone(),
+        unit: unit.clone(),
+        value: reading,
+        labels: attributes.clone(),
+        context: Some(SensorThresholdContext {
+            entity_type: entity_type.to_string(),
+            sensor_id: sensor.base.id.clone(),
+            upper_fatal,
+            lower_fatal,
+            upper_critical,
+            lower_critical,
+            upper_caution,
+            lower_caution,
+            range_max,
+            range_min,
+            bmc_health,
+        }),
+    };
 
-        if self.include_sensor_thresholds {
-            self.emit_sensor_range_metric(
+    let ranges = if include_sensor_thresholds {
+        [
+            (SensorRangeKind::Max, range_max),
+            (SensorRangeKind::Min, range_min),
+        ]
+        .into_iter()
+        .filter_map(|(range_kind, value)| {
+            sensor_range_metric(
                 sensor.odata_id().to_string(),
                 &metric_type,
                 &unit,
                 &attributes,
-                SensorRangeKind::Max,
-                range_max,
-            );
-            self.emit_sensor_range_metric(
-                sensor.odata_id().to_string(),
-                &metric_type,
-                &unit,
-                &attributes,
-                SensorRangeKind::Min,
-                range_min,
-            );
-        }
-
-        1
-    }
-
-    fn emit_sensor_range_metric(
-        &self,
-        sensor_key: String,
-        reading_type: &str,
-        unit: &str,
-        attributes: &[MetricLabel],
-        range_kind: SensorRangeKind,
-        value: Option<f64>,
-    ) {
-        let Some(value) = value else { return };
-        let metric_suffix = range_kind.metric_suffix();
-        let mut labels = attributes.to_vec();
-        labels.push((
-            Cow::Borrowed("sensor_range"),
-            range_kind.label_value().to_string(),
-        ));
-        self.emit_event(CollectorEvent::Metric(
-            MetricSample {
-                key: format!("{sensor_key}/{metric_suffix}"),
-                name: "hw_sensor".to_string(),
-                metric_type: format!("{reading_type}_{metric_suffix}"),
-                unit: unit.to_string(),
+                range_kind,
                 value,
-                labels,
-                context: None,
-            }
-            .into(),
-        ));
-    }
+            )
+        })
+        .collect()
+    } else {
+        Vec::new()
+    };
+
+    Ok(SensorProjection { primary, ranges })
+}
+
+fn sensor_range_metric(
+    sensor_key: String,
+    reading_type: &str,
+    unit: &str,
+    attributes: &[MetricLabel],
+    range_kind: SensorRangeKind,
+    value: Option<f64>,
+) -> Option<MetricSample> {
+    let value = value?;
+    let metric_suffix = range_kind.metric_suffix();
+    let mut labels = attributes.to_vec();
+    labels.push((
+        Cow::Borrowed("sensor_range"),
+        range_kind.label_value().to_string(),
+    ));
+    Some(MetricSample {
+        key: format!("{sensor_key}/{metric_suffix}"),
+        name: "hw_sensor".to_string(),
+        metric_type: format!("{reading_type}_{metric_suffix}"),
+        unit: unit.to_string(),
+        value,
+        labels,
+        context: None,
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::convert::Infallible;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Instant;
 
-    #[test]
-    fn sensor_range_kind_uses_documented_metric_suffixes_and_label_values() {
-        assert_eq!(SensorRangeKind::Max.metric_suffix(), "range_max");
-        assert_eq!(SensorRangeKind::Max.label_value(), "reading_range_max");
-        assert_eq!(SensorRangeKind::Min.metric_suffix(), "range_min");
-        assert_eq!(SensorRangeKind::Min.label_value(), "reading_range_min");
+    use arc_swap::ArcSwapOption;
+    use bmc_mock::injection::{Action, Rule, RuleId, Selector};
+    use bmc_mock::test_support::{TestBmc, TestBmcHandle, liteon_powershelf_bmc};
+    use carbide_test_support::Outcome::Yields;
+    use carbide_test_support::{Case, Check, check_cases, check_cases_async, check_values};
+    use serde_json::{Value, json};
+
+    use super::*;
+    use crate::bmc::BmcClient;
+    use crate::collectors::inventory::EntityInventory;
+    use crate::endpoint::test_support::{mac, test_endpoint};
+
+    const SENSOR_PATH: &str = "/redfish/v1/Chassis/powershelf/Sensors/Temp_1";
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ObservedContext {
+        entity_type: String,
+        sensor_id: String,
+        upper_fatal: Option<f64>,
+        lower_fatal: Option<f64>,
+        upper_critical: Option<f64>,
+        lower_critical: Option<f64>,
+        upper_caution: Option<f64>,
+        lower_caution: Option<f64>,
+        range_max: Option<f64>,
+        range_min: Option<f64>,
+        bmc_health: String,
+    }
+
+    impl From<&SensorThresholdContext> for ObservedContext {
+        fn from(context: &SensorThresholdContext) -> Self {
+            Self {
+                entity_type: context.entity_type.clone(),
+                sensor_id: context.sensor_id.clone(),
+                upper_fatal: context.upper_fatal,
+                lower_fatal: context.lower_fatal,
+                upper_critical: context.upper_critical,
+                lower_critical: context.lower_critical,
+                upper_caution: context.upper_caution,
+                lower_caution: context.lower_caution,
+                range_max: context.range_max,
+                range_min: context.range_min,
+                bmc_health: context.bmc_health.to_snake_case().to_string(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ObservedMetric {
+        key: String,
+        name: String,
+        metric_type: String,
+        unit: String,
+        value: f64,
+        labels: Vec<(String, String)>,
+        context: Option<ObservedContext>,
+    }
+
+    impl From<&MetricSample> for ObservedMetric {
+        fn from(sample: &MetricSample) -> Self {
+            Self {
+                key: sample.key.clone(),
+                name: sample.name.clone(),
+                metric_type: sample.metric_type.clone(),
+                unit: sample.unit.clone(),
+                value: sample.value,
+                labels: sample
+                    .labels
+                    .iter()
+                    .map(|(key, value)| (key.to_string(), value.clone()))
+                    .collect(),
+                context: sample.context.as_ref().map(ObservedContext::from),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ObservedProjection {
+        primary: ObservedMetric,
+        ranges: Vec<ObservedMetric>,
+    }
+
+    fn observe_projection(projection: SensorProjection) -> ObservedProjection {
+        ObservedProjection {
+            primary: ObservedMetric::from(&projection.primary),
+            ranges: projection.ranges.iter().map(ObservedMetric::from).collect(),
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum ObservedEvent {
+        Start,
+        Metric(Box<ObservedMetric>),
+        End,
+        Removed,
+    }
+
+    #[derive(Default)]
+    struct CapturingSink {
+        events: StdMutex<Vec<ObservedEvent>>,
+    }
+
+    impl CapturingSink {
+        fn events(&self) -> Vec<ObservedEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl DataSink for CapturingSink {
+        fn sink_type(&self) -> &'static str {
+            "capturing_sink"
+        }
+
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
+            let observed = match event {
+                CollectorEvent::MetricCollectionStart => Some(ObservedEvent::Start),
+                CollectorEvent::Metric(sample) => Some(ObservedEvent::Metric(Box::new(
+                    ObservedMetric::from(sample.as_ref()),
+                ))),
+                CollectorEvent::MetricCollectionEnd => Some(ObservedEvent::End),
+                CollectorEvent::CollectorRemoved => Some(ObservedEvent::Removed),
+                CollectorEvent::Log(_)
+                | CollectorEvent::Firmware(_)
+                | CollectorEvent::HealthReport(_) => None,
+            };
+
+            if let Some(observed) = observed {
+                self.events.lock().unwrap().push(observed);
+            }
+            Ok(())
+        }
+    }
+
+    struct ProjectionInput {
+        sensor: Value,
+        entity_type: &'static str,
+        physical_context_fallback: &'static str,
+        base_attributes: Vec<(&'static str, &'static str)>,
+        entity_attributes: Vec<(&'static str, &'static str)>,
+        include_sensor_thresholds: bool,
+    }
+
+    fn metric_labels(labels: Vec<(&'static str, &'static str)>) -> Vec<MetricLabel> {
+        labels
+            .into_iter()
+            .map(|(key, value)| (Cow::Borrowed(key), value.to_string()))
+            .collect()
+    }
+
+    fn observed_labels(labels: &[(&str, &str)]) -> Vec<(String, String)> {
+        labels
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    fn sensor_json() -> Value {
+        json!({
+            "@odata.id": SENSOR_PATH,
+            "@odata.type": "#Sensor.v1_6_0.Sensor",
+            "Id": "Sensor0",
+            "Name": "Sensor 0",
+            "Reading": 42.5,
+            "ReadingType": "Temperature",
+            "ReadingUnits": "Cel",
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            }
+        })
+    }
+
+    fn sensor_json_with(overrides: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
+        let mut sensor = sensor_json();
+        let fields = sensor.as_object_mut().expect("sensor fixture is an object");
+        for (name, value) in overrides {
+            fields.insert(name.to_string(), value);
+        }
+        sensor
+    }
+
+    fn sensor_json_without(fields: &[&str]) -> Value {
+        let mut sensor = sensor_json();
+        let object = sensor.as_object_mut().expect("sensor fixture is an object");
+        for field in fields {
+            object.remove(*field);
+        }
+        sensor
+    }
+
+    fn threshold_sensor_json() -> Value {
+        sensor_json_with([
+            ("PhysicalContext", json!("CPU")),
+            ("ReadingRangeMax", json!(2.0)),
+            ("ReadingRangeMin", json!(1.0)),
+            (
+                "Status",
+                json!({
+                    "Health": "Warning",
+                    "State": "Enabled"
+                }),
+            ),
+            (
+                "Thresholds",
+                json!({
+                    "UpperFatal": { "Reading": 1.9 },
+                    "LowerFatal": { "Reading": 1.1 },
+                    "UpperCritical": { "Reading": 1.8 },
+                    "LowerCritical": { "Reading": 1.2 },
+                    "UpperCaution": { "Reading": 1.7 },
+                    "LowerCaution": { "Reading": 1.3 }
+                }),
+            ),
+        ])
+    }
+
+    fn empty_context(entity_type: &str, sensor_id: &str, bmc_health: &str) -> ObservedContext {
+        ObservedContext {
+            entity_type: entity_type.to_string(),
+            sensor_id: sensor_id.to_string(),
+            upper_fatal: None,
+            lower_fatal: None,
+            upper_critical: None,
+            lower_critical: None,
+            upper_caution: None,
+            lower_caution: None,
+            range_max: None,
+            range_min: None,
+            bmc_health: bmc_health.to_string(),
+        }
+    }
+
+    fn threshold_context() -> ObservedContext {
+        ObservedContext {
+            entity_type: "processor".to_string(),
+            sensor_id: "Sensor0".to_string(),
+            upper_fatal: Some(1.9),
+            lower_fatal: Some(1.1),
+            upper_critical: Some(1.8),
+            lower_critical: Some(1.2),
+            upper_caution: Some(1.7),
+            lower_caution: Some(1.3),
+            range_max: Some(2.0),
+            range_min: Some(1.0),
+            bmc_health: "warning".to_string(),
+        }
+    }
+
+    fn observed_metric(
+        key: &str,
+        name: &str,
+        metric_type: &str,
+        unit: &str,
+        value: f64,
+        labels: &[(&str, &str)],
+        context: Option<ObservedContext>,
+    ) -> ObservedMetric {
+        ObservedMetric {
+            key: key.to_string(),
+            name: name.to_string(),
+            metric_type: metric_type.to_string(),
+            unit: unit.to_string(),
+            value,
+            labels: observed_labels(labels),
+            context,
+        }
+    }
+
+    fn project(input: ProjectionInput) -> Result<ObservedProjection, SensorProjectionError> {
+        let sensor = serde_json::from_value(input.sensor).expect("valid sensor fixture");
+        project_sensor(
+            &sensor,
+            input.entity_type,
+            input.physical_context_fallback,
+            metric_labels(input.base_attributes),
+            metric_labels(input.entity_attributes),
+            input.include_sensor_thresholds,
+        )
+        .map(observe_projection)
     }
 
     #[test]
-    fn sensor_range_metric_contract_matches_matrix_surface() {
-        let reading_type = "fan_speed";
-        let range_kind = SensorRangeKind::Max;
-
-        assert_eq!(
-            format!("{reading_type}_{}", range_kind.metric_suffix()),
-            "fan_speed_range_max"
+    fn incomplete_sensor_cases() {
+        check_cases(
+            [
+                Case {
+                    scenario: "missing status",
+                    input: sensor_json_without(&["Status"]),
+                    expect: Yields(SensorProjectionError::NoHealth),
+                },
+                Case {
+                    scenario: "status missing health",
+                    input: sensor_json_with([("Status", json!({ "State": "Enabled" }))]),
+                    expect: Yields(SensorProjectionError::NoHealth),
+                },
+                Case {
+                    scenario: "null health",
+                    input: sensor_json_with([(
+                        "Status",
+                        json!({ "Health": null, "State": "Enabled" }),
+                    )]),
+                    expect: Yields(SensorProjectionError::NoHealth),
+                },
+                Case {
+                    scenario: "missing reading",
+                    input: sensor_json_without(&["Reading"]),
+                    expect: Yields(SensorProjectionError::IncompleteReading),
+                },
+                Case {
+                    scenario: "null reading",
+                    input: sensor_json_with([("Reading", Value::Null)]),
+                    expect: Yields(SensorProjectionError::IncompleteReading),
+                },
+                Case {
+                    scenario: "missing reading type",
+                    input: sensor_json_without(&["ReadingType"]),
+                    expect: Yields(SensorProjectionError::IncompleteReading),
+                },
+                Case {
+                    scenario: "empty reading units",
+                    input: sensor_json_with([("ReadingUnits", json!(""))]),
+                    expect: Yields(SensorProjectionError::IncompleteReading),
+                },
+                Case {
+                    scenario: "missing reading units",
+                    input: sensor_json_without(&["ReadingUnits"]),
+                    expect: Yields(SensorProjectionError::IncompleteReading),
+                },
+            ],
+            |sensor| {
+                let sensor = serde_json::from_value(sensor).expect("valid sensor fixture");
+                let error = match project_sensor(
+                    &sensor,
+                    "chassis",
+                    "chassis",
+                    Vec::new(),
+                    Vec::new(),
+                    false,
+                ) {
+                    Ok(_) => panic!("incomplete sensor must be rejected"),
+                    Err(error) => error,
+                };
+                Ok::<_, Infallible>(error)
+            },
         );
-        assert_eq!(range_kind.label_value(), "reading_range_max");
+    }
+
+    #[test]
+    fn accepted_projection_cases() {
+        let threshold_labels = [
+            ("processor_id", "CPU0"),
+            ("system_id", "SYS0"),
+            ("sensor_name", "Sensor0"),
+            ("upper_critical_threshold", "1.8"),
+            ("lower_critical_threshold", "1.2"),
+            ("physical_context", "cpu"),
+            ("processor_type", "cpu"),
+        ];
+        let threshold_labels_without_exposition = [
+            ("processor_id", "CPU0"),
+            ("system_id", "SYS0"),
+            ("sensor_name", "Sensor0"),
+            ("physical_context", "cpu"),
+            ("processor_type", "cpu"),
+        ];
+
+        check_cases(
+            [
+                Case {
+                    scenario: "entity physical-context fallback",
+                    input: ProjectionInput {
+                        sensor: sensor_json(),
+                        entity_type: "chassis",
+                        physical_context_fallback: "chassis",
+                        base_attributes: vec![("chassis_id", "CH0")],
+                        entity_attributes: vec![("model", "Baseboard")],
+                        include_sensor_thresholds: false,
+                    },
+                    expect: Yields(ObservedProjection {
+                        primary: observed_metric(
+                            SENSOR_PATH,
+                            "hw_sensor",
+                            "temperature",
+                            "celsius",
+                            42.5,
+                            &[
+                                ("chassis_id", "CH0"),
+                                ("sensor_name", "Sensor0"),
+                                ("physical_context", "chassis"),
+                                ("model", "Baseboard"),
+                            ],
+                            Some(empty_context("chassis", "Sensor0", "ok")),
+                        ),
+                        ranges: Vec::new(),
+                    }),
+                },
+                Case {
+                    scenario: "threshold labels and range metrics",
+                    input: ProjectionInput {
+                        sensor: threshold_sensor_json(),
+                        entity_type: "processor",
+                        physical_context_fallback: "socket",
+                        base_attributes: vec![("processor_id", "CPU0"), ("system_id", "SYS0")],
+                        entity_attributes: vec![("processor_type", "cpu")],
+                        include_sensor_thresholds: true,
+                    },
+                    expect: Yields(ObservedProjection {
+                        primary: observed_metric(
+                            SENSOR_PATH,
+                            "hw_sensor",
+                            "temperature",
+                            "celsius",
+                            42.5,
+                            &threshold_labels,
+                            Some(threshold_context()),
+                        ),
+                        ranges: vec![
+                            observed_metric(
+                                &format!("{SENSOR_PATH}/range_max"),
+                                "hw_sensor",
+                                "temperature_range_max",
+                                "celsius",
+                                2.0,
+                                &[
+                                    ("processor_id", "CPU0"),
+                                    ("system_id", "SYS0"),
+                                    ("sensor_name", "Sensor0"),
+                                    ("upper_critical_threshold", "1.8"),
+                                    ("lower_critical_threshold", "1.2"),
+                                    ("physical_context", "cpu"),
+                                    ("processor_type", "cpu"),
+                                    ("sensor_range", "reading_range_max"),
+                                ],
+                                None,
+                            ),
+                            observed_metric(
+                                &format!("{SENSOR_PATH}/range_min"),
+                                "hw_sensor",
+                                "temperature_range_min",
+                                "celsius",
+                                1.0,
+                                &[
+                                    ("processor_id", "CPU0"),
+                                    ("system_id", "SYS0"),
+                                    ("sensor_name", "Sensor0"),
+                                    ("upper_critical_threshold", "1.8"),
+                                    ("lower_critical_threshold", "1.2"),
+                                    ("physical_context", "cpu"),
+                                    ("processor_type", "cpu"),
+                                    ("sensor_range", "reading_range_min"),
+                                ],
+                                None,
+                            ),
+                        ],
+                    }),
+                },
+                Case {
+                    scenario: "threshold context without threshold exposition",
+                    input: ProjectionInput {
+                        sensor: threshold_sensor_json(),
+                        entity_type: "processor",
+                        physical_context_fallback: "socket",
+                        base_attributes: vec![("processor_id", "CPU0"), ("system_id", "SYS0")],
+                        entity_attributes: vec![("processor_type", "cpu")],
+                        include_sensor_thresholds: false,
+                    },
+                    expect: Yields(ObservedProjection {
+                        primary: observed_metric(
+                            SENSOR_PATH,
+                            "hw_sensor",
+                            "temperature",
+                            "celsius",
+                            42.5,
+                            &threshold_labels_without_exposition,
+                            Some(threshold_context()),
+                        ),
+                        ranges: Vec::new(),
+                    }),
+                },
+                Case {
+                    scenario: "threshold exposition without sensor thresholds",
+                    input: ProjectionInput {
+                        sensor: sensor_json(),
+                        entity_type: "chassis",
+                        physical_context_fallback: "chassis",
+                        base_attributes: vec![("chassis_id", "CH0")],
+                        entity_attributes: vec![("model", "Baseboard")],
+                        include_sensor_thresholds: true,
+                    },
+                    expect: Yields(ObservedProjection {
+                        primary: observed_metric(
+                            SENSOR_PATH,
+                            "hw_sensor",
+                            "temperature",
+                            "celsius",
+                            42.5,
+                            &[
+                                ("chassis_id", "CH0"),
+                                ("sensor_name", "Sensor0"),
+                                ("physical_context", "chassis"),
+                                ("model", "Baseboard"),
+                            ],
+                            Some(empty_context("chassis", "Sensor0", "ok")),
+                        ),
+                        ranges: Vec::new(),
+                    }),
+                },
+                Case {
+                    scenario: "critical percentage power-supply reading",
+                    input: ProjectionInput {
+                        sensor: sensor_json_with([
+                            ("Reading", json!(90.0)),
+                            ("ReadingType", json!("Percent")),
+                            ("ReadingUnits", json!("%")),
+                            (
+                                "Status",
+                                json!({ "Health": "Critical", "State": "Enabled" }),
+                            ),
+                        ]),
+                        entity_type: "powersupply",
+                        physical_context_fallback: "power_supply",
+                        base_attributes: vec![("powersupply_id", "PSU0"), ("chassis_id", "CH0")],
+                        entity_attributes: vec![("model", "PSU-3KW")],
+                        include_sensor_thresholds: false,
+                    },
+                    expect: Yields(ObservedProjection {
+                        primary: observed_metric(
+                            SENSOR_PATH,
+                            "hw_sensor",
+                            "percent",
+                            "percent",
+                            90.0,
+                            &[
+                                ("powersupply_id", "PSU0"),
+                                ("chassis_id", "CH0"),
+                                ("sensor_name", "Sensor0"),
+                                ("physical_context", "power_supply"),
+                                ("model", "PSU-3KW"),
+                            ],
+                            Some(empty_context("powersupply", "Sensor0", "critical")),
+                        ),
+                        ranges: Vec::new(),
+                    }),
+                },
+            ],
+            project,
+        );
+    }
+
+    #[test]
+    fn sweep_plan_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "full sweep",
+                    input: CollectorSweep::Full,
+                    expect: SensorSweepPlan::Collect {
+                        include_derived_metrics: true,
+                        sensor_limit: None,
+                    },
+                },
+                Check {
+                    scenario: "probe sweep",
+                    input: CollectorSweep::Probe,
+                    expect: SensorSweepPlan::Collect {
+                        include_derived_metrics: false,
+                        sensor_limit: Some(1),
+                    },
+                },
+                Check {
+                    scenario: "skipped sweep",
+                    input: CollectorSweep::Skip,
+                    expect: SensorSweepPlan::Skip,
+                },
+            ],
+            SensorSweepPlan::from,
+        );
+    }
+
+    #[test]
+    fn fetch_concurrency_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "zero concurrency is normalized",
+                    input: 0,
+                    expect: 1,
+                },
+                Check {
+                    scenario: "configured concurrency is retained",
+                    input: 8,
+                    expect: 8,
+                },
+            ],
+            |sensor_fetch_concurrency| {
+                let endpoint = Arc::new(test_endpoint(mac("00:11:22:33:44:55")));
+                let collector = SensorCollector::<BmcClient>::new_runner(
+                    endpoint.bmc().clone(),
+                    endpoint,
+                    SensorCollectorConfig {
+                        data_sink: None,
+                        shared: Arc::new(ArcSwapOption::empty()),
+                        sensor_fetch_concurrency,
+                        include_sensor_thresholds: false,
+                    },
+                )
+                .expect("sensor collector");
+                collector.sensor_fetch_concurrency
+            },
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    enum CollectionCase {
+        MissingInventory,
+        EmptyInventory,
+        Sensor,
+        SensorFetchFailure,
+        DerivedMetric,
+        Stop,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ObservedIteration {
+        refresh_triggered: bool,
+        entity_count: Option<usize>,
+        fetch_failures: usize,
+    }
+
+    impl From<IterationResult> for ObservedIteration {
+        fn from(result: IterationResult) -> Self {
+            Self {
+                refresh_triggered: result.refresh_triggered,
+                entity_count: result.entity_count,
+                fetch_failures: result.fetch_failures,
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct CollectionObservation {
+        iteration: Option<ObservedIteration>,
+        events: Vec<ObservedEvent>,
+    }
+
+    async fn first_chassis(handle: &TestBmcHandle) -> Arc<nv_redfish::chassis::Chassis<TestBmc>> {
+        let collection = handle
+            .service_root
+            .chassis()
+            .await
+            .expect("chassis collection")
+            .expect("fixture has chassis");
+        Arc::new(
+            collection
+                .members()
+                .await
+                .expect("chassis members")
+                .into_iter()
+                .next()
+                .expect("fixture has one chassis"),
+        )
+    }
+
+    fn store_inventory(
+        shared: &SharedInventory<TestBmc>,
+        entities: Vec<DiscoveredEntity<TestBmc>>,
+    ) {
+        shared.store(Some(Arc::new(EntityInventory {
+            entities,
+            discovered_at: Instant::now(),
+            generation: 1,
+        })));
+    }
+
+    async fn observe_collection(case: CollectionCase) -> Result<CollectionObservation, Infallible> {
+        let handle = liteon_powershelf_bmc().await;
+        let endpoint = Arc::new(test_endpoint(mac("00:11:22:33:44:55")));
+        let shared = Arc::new(ArcSwapOption::empty());
+        let sink = Arc::new(CapturingSink::default());
+        let mut collector = SensorCollector::<TestBmc> {
+            endpoint: endpoint.clone(),
+            event_context: EventContext::from_endpoint(endpoint.as_ref(), "sensor_collector"),
+            shared: shared.clone(),
+            data_sink: Some(sink.clone()),
+            sensor_fetch_concurrency: 2,
+            include_sensor_thresholds: true,
+        };
+
+        match case {
+            CollectionCase::MissingInventory => {}
+            CollectionCase::EmptyInventory => store_inventory(&shared, Vec::new()),
+            CollectionCase::Sensor | CollectionCase::SensorFetchFailure => {
+                let chassis = first_chassis(&handle).await;
+                let sensor = chassis
+                    .sensor_links()
+                    .await
+                    .expect("sensor links")
+                    .expect("fixture has sensors")
+                    .into_iter()
+                    .next()
+                    .expect("fixture has a sensor");
+                assert_eq!(sensor.odata_id().to_string(), SENSOR_PATH);
+
+                handle.state.injection.upsert(Rule {
+                    id: RuleId::from("sensor-collection"),
+                    selector: Selector::OdataId(SENSOR_PATH.to_string()),
+                    action: match case {
+                        CollectionCase::Sensor => Action::Replace(sensor_json()),
+                        CollectionCase::SensorFetchFailure => Action::Status(500),
+                        _ => unreachable!(),
+                    },
+                    remaining: None,
+                });
+                store_inventory(
+                    &shared,
+                    vec![DiscoveredEntity::Chassis {
+                        entity: chassis,
+                        sensors: vec![sensor],
+                    }],
+                );
+            }
+            CollectionCase::DerivedMetric => {
+                handle.state.injection.upsert(Rule {
+                    id: RuleId::from("power-supply-capacity"),
+                    selector: Selector::OdataId(
+                        "/redfish/v1/Chassis/*/PowerSubsystem/PowerSupplies/*".to_string(),
+                    ),
+                    action: Action::JsonMerge(json!({
+                        "Model": "PSU-3KW",
+                        "PowerCapacityWatts": 3000.0
+                    })),
+                    remaining: None,
+                });
+                let chassis = first_chassis(&handle).await;
+                let power_supply = Arc::new(
+                    chassis
+                        .power_supplies()
+                        .await
+                        .expect("power supplies")
+                        .into_iter()
+                        .next()
+                        .expect("fixture has a power supply"),
+                );
+                store_inventory(
+                    &shared,
+                    vec![DiscoveredEntity::PowerSupply {
+                        entity: power_supply,
+                        chassis,
+                        sensors: Vec::new(),
+                    }],
+                );
+            }
+            CollectionCase::Stop => {
+                collector.stop().await;
+                return Ok(CollectionObservation {
+                    iteration: None,
+                    events: sink.events(),
+                });
+            }
+        }
+
+        let iteration = collector
+            .run_iteration()
+            .await
+            .expect("sensor collection succeeds");
+        Ok(CollectionObservation {
+            iteration: Some(iteration.into()),
+            events: sink.events(),
+        })
+    }
+
+    #[tokio::test]
+    async fn collection_cases() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "missing inventory",
+                    input: CollectionCase::MissingInventory,
+                    expect: Yields(CollectionObservation {
+                        iteration: Some(ObservedIteration {
+                            refresh_triggered: false,
+                            entity_count: None,
+                            fetch_failures: 0,
+                        }),
+                        events: Vec::new(),
+                    }),
+                },
+                Case {
+                    scenario: "empty inventory",
+                    input: CollectionCase::EmptyInventory,
+                    expect: Yields(CollectionObservation {
+                        iteration: Some(ObservedIteration {
+                            refresh_triggered: false,
+                            entity_count: Some(0),
+                            fetch_failures: 0,
+                        }),
+                        events: vec![ObservedEvent::Start, ObservedEvent::End],
+                    }),
+                },
+                Case {
+                    scenario: "sensor metric",
+                    input: CollectionCase::Sensor,
+                    expect: Yields(CollectionObservation {
+                        iteration: Some(ObservedIteration {
+                            refresh_triggered: false,
+                            entity_count: Some(1),
+                            fetch_failures: 0,
+                        }),
+                        events: vec![
+                            ObservedEvent::Start,
+                            ObservedEvent::Metric(Box::new(observed_metric(
+                                SENSOR_PATH,
+                                "hw_sensor",
+                                "temperature",
+                                "celsius",
+                                42.5,
+                                &[
+                                    ("chassis_id", "powershelf"),
+                                    ("sensor_name", "Sensor0"),
+                                    ("physical_context", "chassis"),
+                                    ("model", "PF-1333-7R"),
+                                ],
+                                Some(empty_context("chassis", "Sensor0", "ok")),
+                            ))),
+                            ObservedEvent::End,
+                        ],
+                    }),
+                },
+                Case {
+                    scenario: "sensor fetch failure",
+                    input: CollectionCase::SensorFetchFailure,
+                    expect: Yields(CollectionObservation {
+                        iteration: Some(ObservedIteration {
+                            refresh_triggered: false,
+                            entity_count: Some(0),
+                            fetch_failures: 1,
+                        }),
+                        events: vec![ObservedEvent::Start, ObservedEvent::End],
+                    }),
+                },
+                Case {
+                    scenario: "derived metric",
+                    input: CollectionCase::DerivedMetric,
+                    expect: Yields(CollectionObservation {
+                        iteration: Some(ObservedIteration {
+                            refresh_triggered: false,
+                            entity_count: Some(0),
+                            fetch_failures: 0,
+                        }),
+                        events: vec![
+                            ObservedEvent::Start,
+                            ObservedEvent::Metric(Box::new(observed_metric(
+                                "/redfish/v1/Chassis/powershelf/PowerSubsystem/PowerSupplies/0/powersupply_capacity",
+                                "hw",
+                                "powersupply_capacity",
+                                "watts",
+                                3000.0,
+                                &[
+                                    ("powersupply_id", "0"),
+                                    ("chassis_id", "powershelf"),
+                                    ("model", "PSU-3KW"),
+                                ],
+                                None,
+                            ))),
+                            ObservedEvent::End,
+                        ],
+                    }),
+                },
+                Case {
+                    scenario: "collector stop",
+                    input: CollectionCase::Stop,
+                    expect: Yields(CollectionObservation {
+                        iteration: None,
+                        events: vec![ObservedEvent::Removed],
+                    }),
+                },
+            ],
+            observe_collection,
+        )
+        .await;
     }
 }

--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -562,6 +562,8 @@ pub fn sanitize_unit(unit: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
     #[test]
@@ -586,5 +588,79 @@ mod tests {
             assert_eq!(registry.registry.desc.fq_name, expected_fq_name);
             assert_eq!(registry.registry.desc.help, id);
         }
+    }
+
+    #[test]
+    fn sanitize_unit_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "percent symbol",
+                    input: "%",
+                    expect: "percent".to_string(),
+                },
+                Check {
+                    scenario: "degree Celsius",
+                    input: "°C",
+                    expect: "celsius".to_string(),
+                },
+                Check {
+                    scenario: "Celsius abbreviation",
+                    input: "c",
+                    expect: "celsius".to_string(),
+                },
+                Check {
+                    scenario: "Redfish Celsius unit",
+                    input: "CEL",
+                    expect: "celsius".to_string(),
+                },
+                Check {
+                    scenario: "degree Fahrenheit",
+                    input: "°F",
+                    expect: "fahrenheit".to_string(),
+                },
+                Check {
+                    scenario: "Fahrenheit abbreviation",
+                    input: "f",
+                    expect: "fahrenheit".to_string(),
+                },
+                Check {
+                    scenario: "volts",
+                    input: "V",
+                    expect: "volts".to_string(),
+                },
+                Check {
+                    scenario: "amperes",
+                    input: "A",
+                    expect: "amperes".to_string(),
+                },
+                Check {
+                    scenario: "amps alias",
+                    input: "Amps",
+                    expect: "amperes".to_string(),
+                },
+                Check {
+                    scenario: "watts",
+                    input: "W",
+                    expect: "watts".to_string(),
+                },
+                Check {
+                    scenario: "hertz",
+                    input: "Hz",
+                    expect: "hertz".to_string(),
+                },
+                Check {
+                    scenario: "revolutions per minute",
+                    input: "RPM",
+                    expect: "rpm".to_string(),
+                },
+                Check {
+                    scenario: "punctuation is normalized",
+                    input: "J/s",
+                    expect: "j_s".to_string(),
+                },
+            ],
+            sanitize_unit,
+        );
     }
 }


### PR DESCRIPTION
The sensor collector had two direct tests that checked only range suffix and
label strings. Redfish-to-metric projection, unit normalization, sweep
planning, and the collector boundary still had little or no owner coverage.

This extracts private projection and sweep-plan helpers, then replaces the
narrow checks with six table-driven entries and 37 rows:

- eight incomplete samples;
- five accepted projections;
- thirteen unit aliases;
- three sweep plans;
- six collection and lifecycle cases;
- two concurrency-normalization cases.

The collection table exercises representative fetch, failure, derived-metric,
and stop paths. Drive and power-supply mapping stays with the entity projection
tests instead of being repeated here. The health suite moves from 405 Original
entries to 404 Converted entries and 409 Expanded entries.

Selected production coverage for `sensors.rs` plus `sanitize_unit`, excluding
test-module bodies:

- Original: 4/30 functions, 28/324 LLVM line-instances, 24/413 regions
- Converted: 4/33 functions, 28/344 LLVM line-instances, 24/439 regions
- Expanded: 33/43 functions, 319/470 LLVM line-instances, 409/611 regions
- Converted to Expanded: +29 covered functions, +291 covered line-instances, +385 covered regions

Expanded adds ten `TestBmc` monomorphs when the collector table instantiates
its generic production methods. Those records add ten functions, 126
line-instances, and 172 regions to the denominator; all 33 common production
records retain identical non-count layouts, and test-body records are excluded.

## Related issues

- Closes #4081
- Part of #3914

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-health --lib` — 409 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Local CodeRabbit review — no findings
- Local Claude review — no correctness findings

## Additional Notes

The collector keeps its existing event placement, failure accounting, and
unordered sensor fetch scheduling.
