### PR TITLE
feat(rack): coordinate power shelf,  compute , switch firmware upgrades across rack components

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -58,7 +58,7 @@ applicable.
 | `ib_partition_state_controller` | `IbPartitionStateControllerConfig` | *(see below)* | `hardware` | IB partition state controller timing. |
 | `dpa_interface_state_controller` | `DpaInterfaceStateControllerConfig` | *(see below)* | `networking` | DPA interface state controller timing. |
 | `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | `hardware` | Rack state controller timing. |
-| `power_shelf_state_controller` | `PowerShelfStateControllerConfig` | *(see below)* | `hardware` | Power shelf state controller timing. |
+| `power_shelf_state_controller` | `PowerShelfStateControllerConfig` | *(see below)* | `hardware` | Power shelf state controller timing and optional rack firmware reprovisioning. |
 | `switch_state_controller` | `SwitchStateControllerConfig` | *(see below)* | `hardware` | Switch state controller timing. |
 | `spdm_state_controller` | `SpdmStateControllerConfig` | *(see below)* | `security` | SPDM state controller timing. |
 | `host_models` | `HashMap<String, Firmware>` | `{}` | `machines` | Maps host model identifiers to firmware definitions for BMC/UEFI/NIC upgrades. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -2309,6 +2309,22 @@ pub struct PowerShelfStateControllerConfig {
     /// Common state controller configs
     #[serde(default = "StateControllerConfig::default")]
     pub controller: StateControllerConfig,
+
+    /// When `true`, the power shelf Ready handler accepts rack-level
+    /// `power_shelf_reprovisioning_requested` and enters
+    /// `ReProvisioning::WaitingForRackFirmwareUpgrade`.
+    ///
+    /// Defaults to `false` so power shelves stay out of rack firmware wait
+    /// unless explicitly enabled.
+    ///
+    /// Configured in `nico-api-config.toml`:
+    ///
+    /// ```toml
+    /// [power_shelf_state_controller]
+    /// rack_firmware_reprovisioning_enabled = true
+    /// ```
+    #[serde(default)]
+    pub rack_firmware_reprovisioning_enabled: bool,
 }
 
 /// RackStateController related config

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -653,6 +653,7 @@ struct RackFirmwareMaintenanceTarget {
     rack_id: RackId,
     machine_ids: Vec<String>,
     switch_ids: Vec<String>,
+    power_shelf_ids: Vec<String>,
 }
 
 fn push_rack_firmware_target(
@@ -660,6 +661,7 @@ fn push_rack_firmware_target(
     rack_id: RackId,
     machine_id: Option<String>,
     switch_id: Option<String>,
+    power_shelf_id: Option<String>,
 ) {
     let target = match targets.iter_mut().find(|target| target.rack_id == rack_id) {
         Some(target) => target,
@@ -668,6 +670,7 @@ fn push_rack_firmware_target(
                 rack_id,
                 machine_ids: Vec::new(),
                 switch_ids: Vec::new(),
+                power_shelf_ids: Vec::new(),
             });
             targets.last_mut().expect("target was just pushed")
         }
@@ -678,6 +681,9 @@ fn push_rack_firmware_target(
     }
     if let Some(switch_id) = switch_id {
         target.switch_ids.push(switch_id);
+    }
+    if let Some(power_shelf_id) = power_shelf_id {
+        target.power_shelf_ids.push(power_shelf_id);
     }
 }
 
@@ -707,7 +713,13 @@ async fn group_machine_ids_by_rack(
                 "machine {machine_id} is not associated with a rack"
             ))
         })?;
-        push_rack_firmware_target(&mut targets, rack_id, Some(machine_id.to_string()), None);
+        push_rack_firmware_target(
+            &mut targets,
+            rack_id,
+            Some(machine_id.to_string()),
+            None,
+            None,
+        );
     }
 
     Ok(targets)
@@ -854,7 +866,57 @@ async fn group_switch_ids_by_rack(
         let rack_id = switch.rack_id.clone().ok_or_else(|| {
             Status::failed_precondition(format!("switch {switch_id} is not associated with a rack"))
         })?;
-        push_rack_firmware_target(&mut targets, rack_id, None, Some(switch_id.to_string()));
+        push_rack_firmware_target(
+            &mut targets,
+            rack_id,
+            None,
+            Some(switch_id.to_string()),
+            None,
+        );
+    }
+
+    Ok(targets)
+}
+
+async fn group_power_shelf_ids_by_rack(
+    api: &Api,
+    power_shelf_ids: &[PowerShelfId],
+) -> Result<Vec<RackFirmwareMaintenanceTarget>, Status> {
+    let mut txn = api
+        .database_connection
+        .begin()
+        .await
+        .map_err(|e| Status::internal(format!("failed to begin transaction: {e}")))?;
+    let power_shelves = db::power_shelf::find_by(
+        &mut txn,
+        db::ObjectColumnFilter::List(db::power_shelf::IdColumn, power_shelf_ids),
+    )
+    .await
+    .map_err(|e| Status::internal(format!("failed to look up power shelves: {e}")))?;
+    drop(txn);
+
+    let power_shelves_by_id: HashMap<_, _> = power_shelves
+        .into_iter()
+        .map(|power_shelf| (power_shelf.id, power_shelf))
+        .collect();
+
+    let mut targets = Vec::new();
+    for power_shelf_id in power_shelf_ids {
+        let power_shelf = power_shelves_by_id
+            .get(power_shelf_id)
+            .ok_or_else(|| Status::not_found(format!("power shelf {power_shelf_id} not found")))?;
+        let rack_id = power_shelf.rack_id.clone().ok_or_else(|| {
+            Status::failed_precondition(format!(
+                "power shelf {power_shelf_id} is not associated with a rack"
+            ))
+        })?;
+        push_rack_firmware_target(
+            &mut targets,
+            rack_id,
+            None,
+            None,
+            Some(power_shelf_id.to_string()),
+        );
     }
 
     Ok(targets)
@@ -882,6 +944,7 @@ async fn submit_rack_firmware_maintenance_requests(
             .machine_ids
             .iter()
             .chain(target.switch_ids.iter())
+            .chain(target.power_shelf_ids.iter())
             .cloned()
             .collect();
         let maintenance_req = Request::new(rpc::RackMaintenanceOnDemandRequest {
@@ -889,7 +952,7 @@ async fn submit_rack_firmware_maintenance_requests(
             scope: Some(rpc::RackMaintenanceScope {
                 machine_ids: target.machine_ids,
                 switch_ids: target.switch_ids,
-                power_shelf_ids: vec![],
+                power_shelf_ids: target.power_shelf_ids,
                 activities: activities.clone(),
             }),
         });
@@ -2353,54 +2416,70 @@ pub(crate) async fn update_component_firmware(
             let route_through_state_controller =
                 cm.power_shelf_use_state_controller && !bypass_state_controller;
             if route_through_state_controller {
-                // TODO: implement state controller path for power shelf firmware control
-                return Err(Status::unimplemented(
-                    "power shelf firmware control through the state controller is not yet supported",
-                ));
-            }
-
-            let options = if cm.power_shelf.supports_firmware_object_json() {
-                require_firmware_object_json_for_direct_rms(
+                let token = require_firmware_object_json_for_rack_maintenance(
                     "power shelf",
                     &access_token,
                     &req.target_version,
+                )?;
+                let components = map_power_shelf_components(&t.components)?;
+                let component_names = components
+                    .iter()
+                    .map(|component| match component {
+                        PowerShelfComponent::Pmc => "pmc".to_string(),
+                        PowerShelfComponent::Psu => "psu".to_string(),
+                    })
+                    .collect();
+                maintenance_activities = vec![firmware_upgrade_activity(
+                    req.target_version.clone(),
+                    component_names,
+                    Some(token),
                     force_update,
-                )?
+                )];
+                rack_maintenance_targets = group_power_shelf_ids_by_rack(api, &list.ids).await?;
             } else {
-                reject_power_shelf_firmware_object_json(&access_token)?;
-                FirmwareUpdateOptions {
-                    force_update,
-                    ..FirmwareUpdateOptions::default()
-                }
-            };
-            let components = map_power_shelf_components(&t.components)?;
-            let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
-
-            let mut results: Vec<_> = endpoints
-                .unresolved
-                .iter()
-                .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
-                .collect();
-
-            let backend_results = cm
-                .power_shelf
-                .update_firmware(
-                    &endpoints.resolved.endpoints,
-                    &req.target_version,
-                    &components,
-                    &options,
-                )
-                .await
-                .map_err(component_manager_error_to_status)?;
-            results.extend(backend_results.into_iter().map(|r| {
-                let id = ps_mac_to_id_str(&r.pmc_mac, &endpoints.resolved.mac_to_id);
-                if r.success {
-                    success_result(&id)
+                let options = if cm.power_shelf.supports_firmware_object_json() {
+                    require_firmware_object_json_for_direct_rms(
+                        "power shelf",
+                        &access_token,
+                        &req.target_version,
+                        force_update,
+                    )?
                 } else {
-                    error_result(&id, r.error.unwrap_or_default())
-                }
-            }));
-            power_shelf_results = Some(results);
+                    reject_power_shelf_firmware_object_json(&access_token)?;
+                    FirmwareUpdateOptions {
+                        force_update,
+                        ..FirmwareUpdateOptions::default()
+                    }
+                };
+                let components = map_power_shelf_components(&t.components)?;
+                let endpoints = resolve_power_shelf_endpoints(api, &list.ids).await?;
+
+                let mut results: Vec<_> = endpoints
+                    .unresolved
+                    .iter()
+                    .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
+                    .collect();
+
+                let backend_results = cm
+                    .power_shelf
+                    .update_firmware(
+                        &endpoints.resolved.endpoints,
+                        &req.target_version,
+                        &components,
+                        &options,
+                    )
+                    .await
+                    .map_err(component_manager_error_to_status)?;
+                results.extend(backend_results.into_iter().map(|r| {
+                    let id = ps_mac_to_id_str(&r.pmc_mac, &endpoints.resolved.mac_to_id);
+                    if r.success {
+                        success_result(&id)
+                    } else {
+                        error_result(&id, r.error.unwrap_or_default())
+                    }
+                }));
+                power_shelf_results = Some(results);
+            }
         }
         rpc::update_component_firmware_request::Target::Racks(t) => {
             if bypass_state_controller {
@@ -2972,17 +3051,37 @@ mod tests {
         let rack_b = RackId::new("rack-b".to_string());
         let mut targets = Vec::new();
 
-        push_rack_firmware_target(&mut targets, rack_a.clone(), Some("machine-a".into()), None);
-        push_rack_firmware_target(&mut targets, rack_b.clone(), None, Some("switch-b".into()));
-        push_rack_firmware_target(&mut targets, rack_a.clone(), Some("machine-c".into()), None);
+        push_rack_firmware_target(
+            &mut targets,
+            rack_a.clone(),
+            Some("machine-a".into()),
+            None,
+            None,
+        );
+        push_rack_firmware_target(
+            &mut targets,
+            rack_b.clone(),
+            None,
+            Some("switch-b".into()),
+            None,
+        );
+        push_rack_firmware_target(
+            &mut targets,
+            rack_a.clone(),
+            Some("machine-c".into()),
+            None,
+            None,
+        );
 
         assert_eq!(targets.len(), 2);
         assert_eq!(targets[0].rack_id, rack_a);
         assert_eq!(targets[0].machine_ids, vec!["machine-a", "machine-c"]);
         assert!(targets[0].switch_ids.is_empty());
+        assert!(targets[0].power_shelf_ids.is_empty());
         assert_eq!(targets[1].rack_id, rack_b);
         assert_eq!(targets[1].switch_ids, vec!["switch-b"]);
         assert!(targets[1].machine_ids.is_empty());
+        assert!(targets[1].power_shelf_ids.is_empty());
     }
 
     #[test]

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1444,6 +1444,9 @@ async fn initialize_and_start_controllers<'a>(
                 component_manager: component_manager.clone().map(Arc::new),
                 credential_manager: credential_manager.clone(),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
+                rack_firmware_reprovisioning_enabled: carbide_config
+                    .power_shelf_state_controller
+                    .rack_firmware_reprovisioning_enabled,
             }
             .into(),
         )

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -186,6 +186,7 @@ pub fn get() -> CarbideConfig {
             controller: StateControllerConfig::default(),
         },
         power_shelf_state_controller: PowerShelfStateControllerConfig {
+            rack_firmware_reprovisioning_enabled: false,
             controller: StateControllerConfig::default(),
         },
         rack_state_controller: RackStateControllerConfig {

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1655,6 +1655,7 @@ pub async fn create_test_env_with_overrides(
                 component_manager: test_component_manager.clone(),
                 credential_manager: credential_manager.clone(),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
+                rack_firmware_reprovisioning_enabled: false,
             }
             .into(),
         )

--- a/crates/api-core/src/tests/power_shelf_state_controller/error_state.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/error_state.rs
@@ -66,6 +66,7 @@ async fn services(
         component_manager,
         credential_manager: Arc::new(TestCredentialManager::default()),
         per_object_metrics_registry: env.per_object_metrics_registry(),
+        rack_firmware_reprovisioning_enabled: false,
     }
 }
 

--- a/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/maintenance.rs
@@ -144,6 +144,7 @@ fn services_with_component_manager(
             password: TEST_BMC_PASSWORD.into(),
         })),
         per_object_metrics_registry: env.per_object_metrics_registry(),
+        rack_firmware_reprovisioning_enabled: false,
     }
 }
 

--- a/crates/api-core/src/tests/power_shelf_state_controller/mod.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/mod.rs
@@ -31,6 +31,7 @@ use crate::tests::common::api_fixtures::create_test_env;
 mod error_state;
 mod fixtures;
 mod maintenance;
+mod reprovisioning;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use fixtures::power_shelf::mark_power_shelf_as_deleted;
 
@@ -71,6 +72,7 @@ async fn test_power_shelf_deletion_with_state_controller(
                 component_manager: None,
                 credential_manager: credential_manager.clone(),
                 per_object_metrics_registry: env.per_object_metrics_registry(),
+                rack_firmware_reprovisioning_enabled: false,
             }
             .into(),
         )

--- a/crates/api-core/src/tests/power_shelf_state_controller/reprovisioning.rs
+++ b/crates/api-core/src/tests/power_shelf_state_controller/reprovisioning.rs
@@ -1,0 +1,226 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Tests for power-shelf rack firmware reprovisioning.
+
+use std::sync::Arc;
+
+use carbide_power_shelf_controller::context::{
+    PowerShelfStateHandlerContextObjects, PowerShelfStateHandlerServices,
+};
+use carbide_power_shelf_controller::handler::PowerShelfStateHandler;
+use carbide_power_shelf_controller::metrics::PowerShelfMetrics;
+use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_uuid::power_shelf::PowerShelfId;
+use db::power_shelf as db_power_shelf;
+use model::power_shelf::{PowerShelf, PowerShelfControllerState, ReProvisioningState};
+use model::rack::MaintenanceActivity;
+use sqlx::PgConnection;
+use state_controller::db_write_batch::DbWriteBatch;
+use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
+
+use crate::tests::common::api_fixtures::create_test_env;
+use crate::tests::common::api_fixtures::site_explorer::new_power_shelf;
+use crate::tests::power_shelf_state_controller::fixtures::power_shelf::set_power_shelf_controller_state;
+
+fn firmware_only_activities() -> Vec<MaintenanceActivity> {
+    vec![MaintenanceActivity::FirmwareUpgrade {
+        firmware_version: None,
+        components: vec![],
+        force_update: false,
+    }]
+}
+
+fn services(
+    env: &crate::tests::common::api_fixtures::TestEnv,
+    rack_firmware_reprovisioning_enabled: bool,
+) -> PowerShelfStateHandlerServices {
+    PowerShelfStateHandlerServices {
+        db_pool: env.pool.clone(),
+        component_manager: None,
+        credential_manager: Arc::new(TestCredentialManager::default()),
+        per_object_metrics_registry: env.per_object_metrics_registry(),
+        rack_firmware_reprovisioning_enabled,
+    }
+}
+
+async fn load_power_shelf(pool: &sqlx::PgPool, id: &PowerShelfId) -> PowerShelf {
+    let mut conn = pool.acquire().await.unwrap();
+    db_power_shelf::find_by_id(conn.as_mut(), id)
+        .await
+        .unwrap()
+        .expect("power shelf should exist")
+}
+
+async fn run_handler(
+    services: &mut PowerShelfStateHandlerServices,
+    state: &mut PowerShelf,
+) -> StateHandlerOutcome<PowerShelfControllerState> {
+    let handler = PowerShelfStateHandler::default();
+    let mut metrics = PowerShelfMetrics::default();
+    let mut writes = DbWriteBatch::default();
+    let mut ctx = StateHandlerContext::<PowerShelfStateHandlerContextObjects> {
+        services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut writes,
+    };
+    let controller_state = state.controller_state.value.clone();
+    let power_shelf_id = state.id;
+    handler
+        .handle_object_state(&power_shelf_id, state, &controller_state, &mut ctx)
+        .await
+        .expect("state handler should not return an error result")
+}
+
+async fn commit_outcome(mut outcome: StateHandlerOutcome<PowerShelfControllerState>) {
+    if let Some(txn) = outcome.take_transaction() {
+        txn.commit().await.unwrap();
+    }
+}
+
+async fn park_ready(txn: &mut PgConnection, power_shelf_id: &PowerShelfId) {
+    set_power_shelf_controller_state(txn, power_shelf_id, PowerShelfControllerState::Ready)
+        .await
+        .expect("set Ready");
+}
+
+#[crate::sqlx_test]
+async fn test_ready_clears_reprovision_request_when_flag_disabled(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    park_ready(txn.as_mut(), &power_shelf_id).await;
+    db_power_shelf::set_power_shelf_reprovisioning_requested(
+        txn.as_mut(),
+        power_shelf_id,
+        "rack-test",
+        firmware_only_activities(),
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut state = load_power_shelf(&pool, &power_shelf_id).await;
+    let mut services = services(&env, false);
+    let outcome = run_handler(&mut services, &mut state).await;
+    assert!(matches!(outcome, StateHandlerOutcome::DoNothing { .. }));
+    commit_outcome(outcome).await;
+
+    let state = load_power_shelf(&pool, &power_shelf_id).await;
+    assert!(state.power_shelf_reprovisioning_requested.is_none());
+    assert!(matches!(
+        state.controller_state.value,
+        PowerShelfControllerState::Ready
+    ));
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_ready_enters_waiting_for_rack_firmware_when_flag_enabled(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    park_ready(txn.as_mut(), &power_shelf_id).await;
+    db_power_shelf::set_power_shelf_reprovisioning_requested(
+        txn.as_mut(),
+        power_shelf_id,
+        "rack-test",
+        firmware_only_activities(),
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut state = load_power_shelf(&pool, &power_shelf_id).await;
+    let mut services = services(&env, true);
+    let outcome = run_handler(&mut services, &mut state).await;
+    assert!(matches!(
+        outcome,
+        StateHandlerOutcome::Transition {
+            next_state: PowerShelfControllerState::ReProvisioning {
+                reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
+            },
+            ..
+        }
+    ));
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_waiting_for_rack_firmware_completes_to_ready(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let power_shelf_id = new_power_shelf(&env, None, None, None, None).await?;
+
+    let mut txn = pool.begin().await?;
+    db_power_shelf::set_power_shelf_reprovisioning_requested(
+        txn.as_mut(),
+        power_shelf_id,
+        "rack-test",
+        firmware_only_activities(),
+    )
+    .await?;
+    let power_shelf = db_power_shelf::find_by_id(txn.as_mut(), &power_shelf_id)
+        .await?
+        .expect("power shelf should exist");
+    let requested_at = power_shelf
+        .power_shelf_reprovisioning_requested
+        .as_ref()
+        .expect("request should exist")
+        .requested_at;
+    set_power_shelf_controller_state(
+        txn.as_mut(),
+        &power_shelf_id,
+        PowerShelfControllerState::ReProvisioning {
+            reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
+        },
+    )
+    .await?;
+    db_power_shelf::update_firmware_upgrade_status(
+        txn.as_mut(),
+        power_shelf_id,
+        Some(&model::rack::RackFirmwareUpgradeStatus {
+            task_id: "rack-job".to_string(),
+            status: model::rack::RackFirmwareUpgradeState::Completed,
+            started_at: Some(requested_at),
+            ended_at: Some(requested_at + chrono::Duration::seconds(1)),
+        }),
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut state = load_power_shelf(&pool, &power_shelf_id).await;
+    let mut services = services(&env, true);
+    let outcome = run_handler(&mut services, &mut state).await;
+    assert!(matches!(
+        outcome,
+        StateHandlerOutcome::Transition {
+            next_state: PowerShelfControllerState::Ready,
+            ..
+        }
+    ));
+    commit_outcome(outcome).await;
+
+    let state = load_power_shelf(&pool, &power_shelf_id).await;
+    assert!(state.power_shelf_reprovisioning_requested.is_none());
+    Ok(())
+}

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -207,6 +207,52 @@ async fn create_single_compute_rack(
     Ok((rack_id, host))
 }
 
+async fn set_machine_host_reprovision_state(
+    pool: &sqlx::PgPool,
+    machine_id: &MachineId,
+    reprovision_state: model::machine::HostReprovisionState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+    let machine = db::machine::find_one(
+        txn.as_mut(),
+        machine_id,
+        model::machine::machine_search_config::MachineSearchConfig::default(),
+    )
+    .await?
+    .expect("machine should exist");
+    db::machine::advance(
+        &machine,
+        txn.as_mut(),
+        &model::machine::ManagedHostState::HostReprovision {
+            reprovision_state,
+            retry_count: 0,
+        },
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+    Ok(())
+}
+
+fn waiting_for_rack_firmware_upgrade_state() -> model::machine::HostReprovisionState {
+    model::machine::HostReprovisionState::WaitingForRackFirmwareUpgrade
+}
+
+fn failed_rack_firmware_upgrade_state() -> model::machine::HostReprovisionState {
+    model::machine::HostReprovisionState::FailedFirmwareUpgrade {
+        firmware_type: model::firmware::FirmwareComponentType::Bmc,
+        report_time: Some(chrono::Utc::now()),
+        reason: Some("upgrade failed".to_string()),
+    }
+}
+
+fn completed_rack_firmware_upgrade_state() -> model::machine::HostReprovisionState {
+    model::machine::HostReprovisionState::CheckingFirmwareRepeatV2 {
+        firmware_type: None,
+        firmware_number: None,
+    }
+}
+
 async fn create_two_compute_rack(
     env: &TestEnv,
     pool: &sqlx::PgPool,
@@ -1532,8 +1578,9 @@ async fn test_firmware_upgrade_start_missing_profile_deletes_access_token(
 }
 
 /// test_firmware_upgrade_wait_for_complete_waits_while_jobs_running verifies
-/// that WaitForComplete remains in a wait state while RMS child jobs are still
-/// running and writes in-progress rack firmware status back to the machine.
+/// that WaitForComplete remains in a wait state while machines are still in
+/// WaitingForRackFirmwareUpgrade and writes in-progress rack firmware status
+/// back to the machine from RMS.
 #[crate::sqlx_test]
 async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
     pool: sqlx::PgPool,
@@ -1547,6 +1594,12 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
     )
     .await;
     let (rack_id, host) = create_single_compute_rack(&env, &pool).await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host.host_snapshot.id,
+        waiting_for_rack_firmware_upgrade_state(),
+    )
+    .await?;
     env.rms_sim
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
@@ -1600,7 +1653,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
 
     assert!(
         matches!(outcome, StateHandlerOutcome::Wait { .. }),
-        "Expected Wait while RMS job is running"
+        "Expected Wait while machine controller is still WaitingForRackFirmwareUpgrade"
     );
 
     let machine = db::machine::find_one(
@@ -1620,8 +1673,8 @@ async fn test_firmware_upgrade_wait_for_complete_waits_while_jobs_running(
 }
 
 /// test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_failure
-/// verifies that a failed RMS child job writes failed machine status and moves
-/// the rack into Error.
+/// verifies that a machine left WaitingForRackFirmwareUpgrade in
+/// FailedFirmwareUpgrade moves the rack into Error.
 #[crate::sqlx_test]
 async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_failure(
     pool: sqlx::PgPool,
@@ -1635,6 +1688,12 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
     )
     .await;
     let (rack_id, host) = create_single_compute_rack(&env, &pool).await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host.host_snapshot.id,
+        failed_rack_firmware_upgrade_state(),
+    )
+    .await?;
     env.rms_sim
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
@@ -1721,9 +1780,9 @@ async fn test_firmware_upgrade_wait_for_complete_transitions_to_error_on_job_fai
 }
 
 /// test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_terminal_before_error
-/// verifies that the rack keeps polling when a mixed result contains both
-/// failed and in-progress devices, then errors only after all tracked devices
-/// reach a terminal state.
+/// verifies that the rack keeps waiting while any tracked machine is still in
+/// WaitingForRackFirmwareUpgrade, then errors only after every machine has left
+/// that wait state and at least one failed.
 #[crate::sqlx_test]
 async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_terminal_before_error(
     pool: sqlx::PgPool,
@@ -1737,6 +1796,18 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
     )
     .await;
     let (rack_id, host_a, host_b) = create_two_compute_rack(&env, &pool).await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host_a.host_snapshot.id,
+        waiting_for_rack_firmware_upgrade_state(),
+    )
+    .await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host_b.host_snapshot.id,
+        waiting_for_rack_firmware_upgrade_state(),
+    )
+    .await?;
 
     env.rms_sim
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
@@ -1813,7 +1884,7 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
 
     assert!(
         matches!(outcome, StateHandlerOutcome::Wait { .. }),
-        "Expected Wait while some tracked devices are still non-terminal"
+        "Expected Wait while some tracked machines are still WaitingForRackFirmwareUpgrade"
     );
 
     let machine_a = db::machine::find_one(
@@ -1847,6 +1918,19 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         RackFirmwareUpgradeState::InProgress
     );
 
+    set_machine_host_reprovision_state(
+        &pool,
+        &host_a.host_snapshot.id,
+        failed_rack_firmware_upgrade_state(),
+    )
+    .await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host_b.host_snapshot.id,
+        waiting_for_rack_firmware_upgrade_state(),
+    )
+    .await?;
+
     env.rms_sim
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Success as i32,
@@ -1866,11 +1950,31 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
         txn.commit().await?;
     }
 
+    assert!(
+        matches!(outcome, StateHandlerOutcome::Wait { .. }),
+        "Expected Wait while machine B is still WaitingForRackFirmwareUpgrade"
+    );
+
+    set_machine_host_reprovision_state(
+        &pool,
+        &host_b.host_snapshot.id,
+        completed_rack_firmware_upgrade_state(),
+    )
+    .await?;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let mut outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &fw_state, &mut ctx)
+        .await?;
+    if let Some(txn) = outcome.take_transaction() {
+        txn.commit().await?;
+    }
+
     match outcome {
         StateHandlerOutcome::Transition { next_state, .. } => {
             assert!(
                 matches!(next_state, RackState::Error { .. }),
-                "Expected rack to transition to Error after all tracked devices are terminal, got {:?}",
+                "Expected rack to transition to Error after all tracked machines left firmware wait with a failure, got {:?}",
                 next_state
             );
         }
@@ -1901,7 +2005,8 @@ async fn test_firmware_upgrade_wait_for_complete_waits_for_all_nodes_to_be_termi
 
 /// test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails
 /// verifies that a response-level lookup failure from GetFirmwareJobStatus does
-/// not mark the device failed and instead keeps the rack waiting.
+/// not mark the device failed and instead keeps the rack waiting while the
+/// machine remains in WaitingForRackFirmwareUpgrade.
 #[crate::sqlx_test]
 async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
     pool: sqlx::PgPool,
@@ -1915,6 +2020,12 @@ async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
     )
     .await;
     let (rack_id, host) = create_single_compute_rack(&env, &pool).await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host.host_snapshot.id,
+        waiting_for_rack_firmware_upgrade_state(),
+    )
+    .await?;
     env.rms_sim
         .set_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusResponse {
             status: librms::protos::rack_manager::ReturnCode::Failure as i32,
@@ -1986,7 +2097,7 @@ async fn test_firmware_upgrade_wait_for_complete_retries_when_job_lookup_fails(
 
 /// test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
 /// verifies that transport-level polling failures do not immediately fail the
-/// rack upgrade.
+/// rack upgrade while machines remain in WaitingForRackFirmwareUpgrade.
 #[crate::sqlx_test]
 async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error(
     pool: sqlx::PgPool,
@@ -2000,6 +2111,12 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
     )
     .await;
     let (rack_id, host) = create_single_compute_rack(&env, &pool).await?;
+    set_machine_host_reprovision_state(
+        &pool,
+        &host.host_snapshot.id,
+        waiting_for_rack_firmware_upgrade_state(),
+    )
+    .await?;
     env.rms_sim
         .set_firmware_job_error("child-job-1", "mock transport failure")
         .await;

--- a/crates/api-core/src/tests/switch_state_controller/mod.rs
+++ b/crates/api-core/src/tests/switch_state_controller/mod.rs
@@ -56,6 +56,33 @@ fn default_switch_mtls_services() -> Vec<i32> {
     )
 }
 
+fn firmware_only_activities() -> Vec<model::rack::MaintenanceActivity> {
+    vec![model::rack::MaintenanceActivity::FirmwareUpgrade {
+        firmware_version: None,
+        components: vec![],
+        force_update: false,
+    }]
+}
+
+fn nvos_and_nmxc_activities() -> Vec<model::rack::MaintenanceActivity> {
+    vec![
+        model::rack::MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+            force_update: false,
+        },
+        model::rack::MaintenanceActivity::NvosUpdate {
+            config_json: String::new(),
+        },
+        model::rack::MaintenanceActivity::ConfigureNmxCluster,
+    ]
+}
+
+/// Empty activities means all phases, matching rack `MaintenanceScope::should_run`.
+fn all_phases_activities() -> Vec<model::rack::MaintenanceActivity> {
+    vec![]
+}
+
 async fn build_test_component_manager(
     env: &common::api_fixtures::TestEnv,
     rms_client: Option<Arc<dyn librms::RmsApi>>,
@@ -772,7 +799,13 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_waits_for_terminal_status
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-test").await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -829,7 +862,13 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_transitions_to_waiting_fo
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-test").await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -878,6 +917,135 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_transitions_to_waiting_fo
     Ok(())
 }
 
+/// Empty activities must keep the same all-phases meaning as `should_run`, so
+/// firmware completion advances to WaitingForNVOSUpgrade rather than skipping
+/// NVOS for ConfigureNmxCluster.
+#[crate::sqlx_test]
+async fn test_switch_waiting_for_rack_firmware_upgrade_next_state_by_activities(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use carbide_test_support::Check;
+    use model::switch::ReProvisioningState;
+
+    #[derive(Clone)]
+    struct CaseInput {
+        activities: Vec<model::rack::MaintenanceActivity>,
+        /// Distinct expected-switch fixture name so each case gets a unique PK.
+        switch_name: &'static str,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum Expect {
+        ReProvisioning(ReProvisioningState),
+        Ready,
+    }
+
+    let env = create_test_env(pool.clone()).await;
+    let cases = [
+        Check {
+            scenario: "empty activities advance to WaitingForNVOSUpgrade",
+            input: CaseInput {
+                activities: all_phases_activities(),
+                switch_name: "Switch1",
+            },
+            expect: Expect::ReProvisioning(ReProvisioningState::WaitingForNVOSUpgrade),
+        },
+        Check {
+            scenario: "explicit NVOS+NMXC advance to WaitingForNVOSUpgrade",
+            input: CaseInput {
+                activities: nvos_and_nmxc_activities(),
+                switch_name: "Switch2",
+            },
+            expect: Expect::ReProvisioning(ReProvisioningState::WaitingForNVOSUpgrade),
+        },
+        Check {
+            scenario: "firmware-only returns Ready",
+            input: CaseInput {
+                activities: firmware_only_activities(),
+                switch_name: "Switch3",
+            },
+            expect: Expect::Ready,
+        },
+    ];
+
+    for case in cases {
+        let switch_id = common::api_fixtures::site_explorer::new_switch(
+            &env,
+            Some(case.input.switch_name.to_string()),
+            None,
+        )
+        .await?;
+
+        let mut txn = pool.begin().await?;
+        db_switch::set_switch_reprovisioning_requested(
+            txn.as_mut(),
+            switch_id,
+            "rack-test",
+            case.input.activities.clone(),
+        )
+        .await?;
+        let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
+            .await?
+            .expect("switch should exist");
+        let requested_at = switch
+            .switch_reprovisioning_requested
+            .as_ref()
+            .expect("switch reprovision request should exist")
+            .requested_at;
+        db_switch::try_update_controller_state(
+            txn.as_mut(),
+            switch_id,
+            switch.controller_state.version,
+            switch.controller_state.version.increment(),
+            &SwitchControllerState::ReProvisioning {
+                reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
+            },
+        )
+        .await?;
+        db_switch::update_firmware_upgrade_status(
+            txn.as_mut(),
+            switch_id,
+            Some(&model::rack::RackFirmwareUpgradeStatus {
+                task_id: "rack-job".to_string(),
+                status: model::rack::RackFirmwareUpgradeState::Completed,
+                started_at: Some(requested_at),
+                ended_at: Some(chrono::Utc::now()),
+            }),
+        )
+        .await?;
+        txn.commit().await?;
+
+        env.run_switch_controller_iteration().await;
+
+        let mut txn = pool.acquire().await?;
+        let switch = db_switch::find_by_id(&mut txn, &switch_id)
+            .await?
+            .expect("switch should exist");
+        let got = match &switch.controller_state.value {
+            SwitchControllerState::Ready => Expect::Ready,
+            SwitchControllerState::ReProvisioning {
+                reprovisioning_state,
+            } => Expect::ReProvisioning(reprovisioning_state.clone()),
+            other => panic!("{}: unexpected controller state {:?}", case.scenario, other),
+        };
+        assert_eq!(got, case.expect, "{}", case.scenario);
+        match case.expect {
+            Expect::Ready => assert!(
+                switch.switch_reprovisioning_requested.is_none(),
+                "{}: request should be cleared",
+                case.scenario
+            ),
+            Expect::ReProvisioning(_) => assert!(
+                switch.switch_reprovisioning_requested.is_some(),
+                "{}: request should remain",
+                case.scenario
+            ),
+        }
+    }
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 async fn test_switch_waiting_for_rack_firmware_upgrade_returns_ready_for_firmware_only_request(
     pool: sqlx::PgPool,
@@ -886,11 +1054,11 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_returns_ready_for_firmwar
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested_with_firmware_continuation(
+    db_switch::set_switch_reprovisioning_requested(
         txn.as_mut(),
         switch_id,
         "rack-test",
-        false,
+        firmware_only_activities(),
     )
     .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
@@ -947,7 +1115,13 @@ async fn test_switch_waiting_for_rack_firmware_upgrade_accepts_completion_when_o
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-test").await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -1004,7 +1178,13 @@ async fn test_switch_ready_routes_rack_requests_to_waiting_for_rack_firmware_upg
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-test").await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -1042,8 +1222,13 @@ async fn test_switch_waiting_for_nvos_upgrade_transitions_to_waiting_for_nmxc_on
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-nvos-test")
-        .await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-nvos-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -1102,8 +1287,13 @@ async fn test_switch_waiting_for_nvos_upgrade_waits_for_current_cycle_status(
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-nvos-test")
-        .await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-nvos-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -1162,8 +1352,13 @@ async fn test_switch_waiting_for_nvos_upgrade_transitions_to_error_on_failure(
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-nvos-test")
-        .await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-nvos-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");
@@ -1222,8 +1417,13 @@ async fn test_switch_waiting_for_nmxc_configure_returns_ready_when_fm_is_running
     let switch_id = common::api_fixtures::site_explorer::new_switch(&env, None, None).await?;
 
     let mut txn = pool.begin().await?;
-    db_switch::set_switch_reprovisioning_requested(txn.as_mut(), switch_id, "rack-nmxc-test")
-        .await?;
+    db_switch::set_switch_reprovisioning_requested(
+        txn.as_mut(),
+        switch_id,
+        "rack-nmxc-test",
+        nvos_and_nmxc_activities(),
+    )
+    .await?;
     let switch = db_switch::find_by_id(txn.as_mut(), &switch_id)
         .await?
         .expect("switch should exist");

--- a/crates/api-db/migrations/20260724120000_power_shelf_reprovisioning_requested.sql
+++ b/crates/api-db/migrations/20260724120000_power_shelf_reprovisioning_requested.sql
@@ -1,0 +1,7 @@
+-- Add power_shelf_reprovisioning_requested and firmware_upgrade_status columns
+-- to power_shelves. Mirrors switches.switch_reprovisioning_requested /
+-- firmware_upgrade_status for rack-level firmware upgrade wait phases.
+
+ALTER TABLE power_shelves
+    ADD COLUMN power_shelf_reprovisioning_requested JSONB,
+    ADD COLUMN firmware_upgrade_status JSONB;

--- a/crates/api-db/src/power_shelf.rs
+++ b/crates/api-db/src/power_shelf.rs
@@ -24,8 +24,9 @@ use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::metadata::Metadata;
 use model::power_shelf::{
     NewPowerShelf, PowerShelf, PowerShelfControllerState, PowerShelfMaintenanceOperation,
-    PowerShelfMaintenanceRequest,
+    PowerShelfMaintenanceRequest, PowerShelfReprovisionRequest,
 };
+use model::rack::{MaintenanceActivity, RackFirmwareUpgradeStatus};
 use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
@@ -133,6 +134,8 @@ pub async fn create(
         version,
         rack_id: new_power_shelf.rack_id.clone(),
         power_shelf_maintenance_requested: None,
+        power_shelf_reprovisioning_requested: None,
+        firmware_upgrade_status: None,
         health_reports: Default::default(),
     })
 }
@@ -345,6 +348,65 @@ pub async fn clear_power_shelf_maintenance_requested(
         .fetch_optional(txn)
         .await
         .map_err(|e| DatabaseError::new("clear_power_shelf_maintenance_requested", e))?;
+    Ok(())
+}
+
+/// Sets `power_shelf_reprovisioning_requested` so the Ready handler can enter
+/// `ReProvisioning` when rack-firmware reprovisioning is enabled.
+///
+/// `activities` selects which rack maintenance phases the power shelf should wait
+/// for. Empty means all activities.
+pub async fn set_power_shelf_reprovisioning_requested(
+    txn: &mut PgConnection,
+    power_shelf_id: PowerShelfId,
+    initiator: &str,
+    activities: Vec<MaintenanceActivity>,
+) -> DatabaseResult<()> {
+    let req = PowerShelfReprovisionRequest {
+        requested_at: Utc::now(),
+        initiator: initiator.to_string(),
+        activities,
+    };
+    let query = "UPDATE power_shelves SET power_shelf_reprovisioning_requested = $1 WHERE id = $2 RETURNING id";
+    sqlx::query_as::<_, PowerShelfId>(query)
+        .bind(sqlx::types::Json(req))
+        .bind(power_shelf_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::new("set_power_shelf_reprovisioning_requested", e))?;
+    Ok(())
+}
+
+/// Clears `power_shelf_reprovisioning_requested`. Typically called when
+/// reprovisioning completes or is cancelled.
+pub async fn clear_power_shelf_reprovisioning_requested(
+    txn: &mut PgConnection,
+    power_shelf_id: PowerShelfId,
+) -> DatabaseResult<()> {
+    let query = "UPDATE power_shelves SET power_shelf_reprovisioning_requested = NULL WHERE id = $1 RETURNING id";
+    sqlx::query_as::<_, PowerShelfId>(query)
+        .bind(power_shelf_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::new("clear_power_shelf_reprovisioning_requested", e))?;
+    Ok(())
+}
+
+/// Sets `firmware_upgrade_status` on the power shelf. Call from rack maintenance
+/// to report upgrade progress. `WaitingForRackFirmwareUpgrade` reads this:
+/// Completed → Ready, Failed → Error.
+pub async fn update_firmware_upgrade_status(
+    txn: &mut PgConnection,
+    power_shelf_id: PowerShelfId,
+    status: Option<&RackFirmwareUpgradeStatus>,
+) -> DatabaseResult<()> {
+    let query = "UPDATE power_shelves SET firmware_upgrade_status = $1 WHERE id = $2 RETURNING id";
+    sqlx::query_as::<_, PowerShelfId>(query)
+        .bind(status.map(|s| sqlx::types::Json(s.clone())))
+        .bind(power_shelf_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::new("update_firmware_upgrade_status", e))?;
     Ok(())
 }
 

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -368,25 +368,19 @@ pub async fn update_controller_state_outcome(
 /// Sets switch_reprovisioning_requested on the switch. Can be called from any state machine or
 /// service. When the switch is in Ready state, the switch state controller will observe the flag
 /// and transition to ReProvisioning::Start.
+///
+/// `activities` selects which rack maintenance phases the switch should wait for.
+/// Empty means all activities.
 pub async fn set_switch_reprovisioning_requested(
     txn: &mut PgConnection,
     switch_id: SwitchId,
     initiator: &str,
-) -> DatabaseResult<()> {
-    set_switch_reprovisioning_requested_with_firmware_continuation(txn, switch_id, initiator, true)
-        .await
-}
-
-pub async fn set_switch_reprovisioning_requested_with_firmware_continuation(
-    txn: &mut PgConnection,
-    switch_id: SwitchId,
-    initiator: &str,
-    continue_after_firmware_upgrade: bool,
+    activities: Vec<model::rack::MaintenanceActivity>,
 ) -> DatabaseResult<()> {
     let req = SwitchReprovisionRequest {
         requested_at: Utc::now(),
         initiator: initiator.to_string(),
-        continue_after_firmware_upgrade,
+        activities,
     };
     let query =
         "UPDATE switches SET switch_reprovisioning_requested = $1 WHERE id = $2 RETURNING id";

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -86,6 +86,17 @@ pub struct PowerShelf {
 
     pub power_shelf_maintenance_requested: Option<PowerShelfMaintenanceRequest>,
 
+    /// Set by rack maintenance to request power-shelf participation in a
+    /// rack-level firmware upgrade. When the power shelf is Ready and
+    /// rack-firmware reprovisioning is enabled on the controller, it
+    /// transitions to `ReProvisioning`.
+    pub power_shelf_reprovisioning_requested: Option<PowerShelfReprovisionRequest>,
+
+    /// Per-device firmware upgrade status written by the rack state machine
+    /// during rack-level firmware upgrades. Read by
+    /// `ReProvisioning::WaitingForRackFirmwareUpgrade`.
+    pub firmware_upgrade_status: Option<crate::rack::RackFirmwareUpgradeStatus>,
+
     // Columns for these exist, but are unused in rust code
     // pub created: DateTime<Utc>,
     // pub updated: DateTime<Utc>,
@@ -105,6 +116,12 @@ impl<'r> FromRow<'r, PgRow> for PowerShelf {
         let power_shelf_maintenance_requested: Option<
             sqlx::types::Json<PowerShelfMaintenanceRequest>,
         > = row.try_get("power_shelf_maintenance_requested").ok();
+        let power_shelf_reprovisioning_requested: Option<
+            sqlx::types::Json<PowerShelfReprovisionRequest>,
+        > = row.try_get("power_shelf_reprovisioning_requested").ok();
+        let firmware_upgrade_status: Option<
+            sqlx::types::Json<crate::rack::RackFirmwareUpgradeStatus>,
+        > = row.try_get("firmware_upgrade_status").ok();
 
         let health_reports: HealthReportSources = row
             .try_get::<sqlx::types::Json<HealthReportSources>, _>("health_reports")
@@ -137,6 +154,8 @@ impl<'r> FromRow<'r, PgRow> for PowerShelf {
             version: row.try_get("version")?,
             rack_id: row.try_get("rack_id").ok().flatten(),
             power_shelf_maintenance_requested: power_shelf_maintenance_requested.map(|r| r.0),
+            power_shelf_reprovisioning_requested: power_shelf_reprovisioning_requested.map(|r| r.0),
+            firmware_upgrade_status: firmware_upgrade_status.map(|j| j.0),
             health_reports,
         })
     }
@@ -179,6 +198,30 @@ pub struct PowerShelfMaintenanceRequest {
     pub operation: PowerShelfMaintenanceOperation,
 }
 
+/// Set by an external entity (typically rack maintenance) to request power-shelf
+/// participation in rack-level reprovisioning. When the power shelf is Ready and
+/// rack-firmware reprovisioning is enabled, the controller transitions to
+/// `ReProvisioning`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PowerShelfReprovisionRequest {
+    pub requested_at: DateTime<Utc>,
+    pub initiator: String,
+    /// Rack maintenance activities that initiated this request. The power shelf
+    /// controller uses these to decide whether to wait for firmware. Empty means
+    /// all activities.
+    #[serde(default)]
+    pub activities: Vec<crate::rack::MaintenanceActivity>,
+}
+
+/// Sub-state for PowerShelfControllerState::ReProvisioning
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::enum_variant_names)]
+pub enum ReProvisioningState {
+    /// Rack-level firmware upgrade in progress; the rack state machine manages the
+    /// upgrade and clears `power_shelf_reprovisioning_requested` when done.
+    WaitingForRackFirmwareUpgrade,
+}
+
 /// State of a PowerShelf as tracked by the controller
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "lowercase")]
@@ -194,6 +237,11 @@ pub enum PowerShelfControllerState {
 
     Maintenance {
         operation: PowerShelfMaintenanceOperation,
+    },
+
+    /// Rack-driven firmware wait in progress.
+    ReProvisioning {
+        reprovisioning_state: ReProvisioningState,
     },
     /// There is error in PowerShelf; PowerShelf can not be used if it's in error.
     Error { cause: String },
@@ -224,6 +272,10 @@ pub fn state_sla(state: &PowerShelfControllerState, state_version: &ConfigVersio
         PowerShelfControllerState::Ready => StateSla::no_sla(),
         PowerShelfControllerState::Maintenance { .. } => StateSla::with_sla(
             std::time::Duration::from_secs(slas::MAINTENANCE),
+            time_in_state,
+        ),
+        PowerShelfControllerState::ReProvisioning { .. } => StateSla::with_sla(
+            std::time::Duration::from_secs(slas::REPROVISIONING),
             time_in_state,
         ),
         PowerShelfControllerState::Error { .. } => StateSla::no_sla(),
@@ -328,6 +380,18 @@ mod tests {
                         .to_string(),
                     PowerShelfControllerState::Maintenance {
                         operation: PowerShelfMaintenanceOperation::PowerOff,
+                    },
+                )),
+            }
+
+            "reprovisioning waiting for rack firmware" {
+                PowerShelfControllerState::ReProvisioning {
+                    reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
+                } => Yields((
+                    r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForRackFirmwareUpgrade"}"#
+                        .to_string(),
+                    PowerShelfControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
                     },
                 )),
             }
@@ -449,6 +513,14 @@ mod tests {
                 r#"{"state":"maintenance","operation":{"operation":"poweroff"}}"# => Yields(PowerShelfControllerState::Maintenance {
                     operation: PowerShelfMaintenanceOperation::PowerOff,
                 }),
+            }
+
+            "reprovisioning waiting for rack firmware" {
+                r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForRackFirmwareUpgrade"}"# => Yields(
+                    PowerShelfControllerState::ReProvisioning {
+                        reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
+                    },
+                ),
             }
 
             "unknown tag is rejected" {
@@ -667,6 +739,12 @@ mod tests {
                 PowerShelfControllerState::Maintenance {
                     operation: PowerShelfMaintenanceOperation::PowerOff,
                 } => (secs(slas::MAINTENANCE), true),
+            }
+
+            "reprovisioning has the reprovisioning SLA" {
+                PowerShelfControllerState::ReProvisioning {
+                    reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
+                } => (secs(slas::REPROVISIONING), true),
             }
 
             "ready carries no SLA" {

--- a/crates/api-model/src/power_shelf/slas.rs
+++ b/crates/api-model/src/power_shelf/slas.rs
@@ -35,3 +35,6 @@ pub const DELETING: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf maintenance (PowerOn / PowerOff) in seconds
 pub const MAINTENANCE: u64 = 300; // 5 minutes
+
+/// SLA for PowerShelf rack-level reprovisioning (firmware wait) in seconds
+pub const REPROVISIONING: u64 = 3600; // 1 hour

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -65,10 +65,6 @@ pub struct SwitchStatus {
     pub health_status: String, // "ok", "warning", "critical"
 }
 
-fn default_continue_after_firmware_upgrade() -> bool {
-    true
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "operation", rename_all = "lowercase")]
 #[allow(clippy::enum_variant_names)]
@@ -96,9 +92,11 @@ pub struct SwitchMaintenanceRequest {
 pub struct SwitchReprovisionRequest {
     pub requested_at: DateTime<Utc>,
     pub initiator: String,
-    /// Continue through rack-managed post-firmware phases such as NVOS/NMXC.
-    #[serde(default = "default_continue_after_firmware_upgrade")]
-    pub continue_after_firmware_upgrade: bool,
+    /// Rack maintenance activities that initiated this request. The switch
+    /// controller uses these to decide which ReProvisioning phases to wait for
+    /// (firmware / NVOS / NMXC). Empty means all activities.
+    #[serde(default)]
+    pub activities: Vec<crate::rack::MaintenanceActivity>,
 }
 
 pub use crate::rack::{
@@ -863,24 +861,19 @@ mod tests {
     }
 
     #[test]
-    fn reprovision_request_defaults_continue_after_firmware_upgrade_to_true() {
-        scenarios!(
-            run = |json| {
-                serde_json::from_str::<SwitchReprovisionRequest>(json)
-                    .map(|r| r.continue_after_firmware_upgrade)
-                    .map_err(drop)
-            };
-            "omitted flag defaults to true" {
-                r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op"}"# => Yields(true),
-            }
+    fn reprovision_request_defaults_activities_to_empty() {
+        let request: SwitchReprovisionRequest =
+            serde_json::from_str(r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op"}"#)
+                .expect("SwitchReprovisionRequest should deserialize");
+        assert!(request.activities.is_empty());
+    }
 
-            "explicit false is honored" {
-                r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":false}"# => Yields(false),
-            }
-
-            "explicit true is honored" {
-                r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":true}"# => Yields(true),
-            }
-        );
+    #[test]
+    fn reprovision_request_ignores_legacy_fields() {
+        let request: SwitchReprovisionRequest = serde_json::from_str(
+            r#"{"requested_at":"2026-01-01T00:00:00Z","initiator":"op","continue_after_firmware_upgrade":true,"scope":{"activities":[]}}"#,
+        )
+        .expect("legacy continue_after_firmware_upgrade and scope fields should be ignored");
+        assert!(request.activities.is_empty());
     }
 }

--- a/crates/power-shelf-controller/src/context.rs
+++ b/crates/power-shelf-controller/src/context.rs
@@ -34,6 +34,11 @@ pub struct PowerShelfStateHandlerServices {
     pub credential_manager: Arc<dyn CredentialManager>,
     /// Shared registry backing the generic per-object health metrics.
     pub per_object_metrics_registry: Arc<PerObjectMetricsRegistry>,
+    /// When `true`, Ready accepts rack-level `power_shelf_reprovisioning_requested`
+    /// and enters `ReProvisioning::WaitingForRackFirmwareUpgrade`. Defaults to
+    /// `false` so power shelves stay out of rack firmware wait unless explicitly
+    /// enabled.
+    pub rack_firmware_reprovisioning_enabled: bool,
 }
 
 impl StateHandlerContextObjects for PowerShelfStateHandlerContextObjects {

--- a/crates/power-shelf-controller/src/handler.rs
+++ b/crates/power-shelf-controller/src/handler.rs
@@ -34,6 +34,7 @@ use crate::fetching_data::handle_fetching_data;
 use crate::initializing::handle_initializing;
 use crate::maintenance::handle_maintenance;
 use crate::ready::handle_ready;
+use crate::reprovisioning::handle_reprovisioning;
 
 /// The actual PowerShelf State handler (structure mirrors SwitchStateHandler).
 #[derive(Debug, Default, Clone)]
@@ -81,6 +82,9 @@ impl PowerShelfStateHandler {
             PowerShelfControllerState::Ready => handle_ready(power_shelf_id, state, ctx).await,
             PowerShelfControllerState::Maintenance { .. } => {
                 handle_maintenance(power_shelf_id, state, ctx).await
+            }
+            PowerShelfControllerState::ReProvisioning { .. } => {
+                handle_reprovisioning(power_shelf_id, state, ctx).await
             }
             PowerShelfControllerState::Deleting => {
                 handle_deleting(power_shelf_id, state, ctx).await

--- a/crates/power-shelf-controller/src/io.rs
+++ b/crates/power-shelf-controller/src/io.rs
@@ -160,6 +160,16 @@ impl StateControllerIO for PowerShelfStateControllerIO {
                 };
                 ("maintenance", op)
             }
+            PowerShelfControllerState::ReProvisioning {
+                reprovisioning_state,
+            } => {
+                let sub = match reprovisioning_state {
+                    model::power_shelf::ReProvisioningState::WaitingForRackFirmwareUpgrade => {
+                        "waiting_for_rack_firmware_upgrade"
+                    }
+                };
+                ("reprovisioning", sub)
+            }
             PowerShelfControllerState::Error { .. } => ("error", ""),
             PowerShelfControllerState::Deleting => ("deleting", ""),
         }

--- a/crates/power-shelf-controller/src/lib.rs
+++ b/crates/power-shelf-controller/src/lib.rs
@@ -28,3 +28,4 @@ pub mod io;
 pub mod maintenance;
 pub mod metrics;
 pub mod ready;
+pub mod reprovisioning;

--- a/crates/power-shelf-controller/src/ready.rs
+++ b/crates/power-shelf-controller/src/ready.rs
@@ -28,15 +28,17 @@ use state_controller::state_handler::{
 
 use crate::context::PowerShelfStateHandlerContextObjects;
 use crate::maintenance::build_power_shelf_endpoint;
+use crate::reprovisioning::first_reprovisioning_state;
 
 /// Handles the Ready state for a power shelf.
 ///
 /// If the power shelf is marked for deletion, transitions to `Deleting`.
 /// If a maintenance request has been posted via
 /// `power_shelf_maintenance_requested`, transitions to `Maintenance` with the
-/// requested operation (PowerOn / PowerOff). Otherwise polls the configured
-/// component manager backend for the current power state (best-effort
-/// observation) and idles.
+/// requested operation (PowerOn / PowerOff). If rack-level reprovisioning has
+/// been requested and `rack_firmware_reprovisioning_enabled` is set, transitions
+/// to `ReProvisioning`. Otherwise polls the configured component manager backend
+/// for the current power state (best-effort observation) and idles.
 ///
 /// TODO: Implement PowerShelf monitoring (health checks, status updates,
 /// power consumption / efficiency tracking).
@@ -64,10 +66,74 @@ pub async fn handle_ready(
         ));
     }
 
+    if let Some(req) = &state.power_shelf_reprovisioning_requested {
+        if !ctx.services.rack_firmware_reprovisioning_enabled {
+            tracing::info!(
+                power_shelf_id = %power_shelf_id,
+                initiator = %req.initiator,
+                "Rack reprovision request ignored; rack_firmware_reprovisioning_enabled is false"
+            );
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_power_shelf::clear_power_shelf_reprovisioning_requested(
+                txn.as_mut(),
+                *power_shelf_id,
+            )
+            .await?;
+            return Ok(StateHandlerOutcome::do_nothing().with_txn(txn));
+        }
+
+        if !req.initiator.starts_with("rack-") {
+            tracing::warn!(
+                initiator = %req.initiator,
+                "Unknown initiator for power shelf reprovisioning request",
+            );
+            let cause = format!(
+                "unknown initiator for power shelf reprovisioning request: {}",
+                req.initiator
+            );
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_power_shelf::clear_power_shelf_reprovisioning_requested(
+                txn.as_mut(),
+                *power_shelf_id,
+            )
+            .await?;
+            return Ok(
+                StateHandlerOutcome::transition(PowerShelfControllerState::Error { cause })
+                    .with_txn(txn),
+            );
+        }
+
+        let Some(reprovisioning_state) = first_reprovisioning_state(req) else {
+            tracing::warn!(
+                power_shelf_id = %power_shelf_id,
+                initiator = %req.initiator,
+                "Rack reprovision request has no power-shelf-relevant activities; clearing request"
+            );
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_power_shelf::clear_power_shelf_reprovisioning_requested(
+                txn.as_mut(),
+                *power_shelf_id,
+            )
+            .await?;
+            return Ok(StateHandlerOutcome::do_nothing().with_txn(txn));
+        };
+
+        tracing::info!(
+            ?reprovisioning_state,
+            "Rack-level reprovisioning requested — entering ReProvisioning"
+        );
+        return Ok(StateHandlerOutcome::transition(
+            PowerShelfControllerState::ReProvisioning {
+                reprovisioning_state,
+            },
+        ));
+    }
+
     let txn = poll_power_state(power_shelf_id, state, ctx).await;
 
     Ok(StateHandlerOutcome::do_nothing().with_txn_opt(txn))
 }
+
 ///
 /// On a successful response, the observed power state for this power shelf is
 /// persisted to the `power_shelves.status` column and the in-memory `state`

--- a/crates/power-shelf-controller/src/reprovisioning.rs
+++ b/crates/power-shelf-controller/src/reprovisioning.rs
@@ -1,0 +1,183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for PowerShelfControllerState::ReProvisioning.
+
+use carbide_uuid::power_shelf::PowerShelfId;
+use db::db_read::PgPoolReader;
+use db::{ObjectColumnFilter, power_shelf as db_power_shelf, rack as db_rack};
+use model::power_shelf::{
+    PowerShelf, PowerShelfControllerState, PowerShelfReprovisionRequest, ReProvisioningState,
+};
+use model::rack::{MaintenanceActivity, RackState};
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+use crate::context::PowerShelfStateHandlerContextObjects;
+
+fn is_rack_level_reprovisioning(state: &PowerShelf) -> bool {
+    state
+        .power_shelf_reprovisioning_requested
+        .as_ref()
+        .is_some_and(|req| req.initiator.starts_with("rack-"))
+}
+
+fn should_run(activities: &[MaintenanceActivity], activity: &MaintenanceActivity) -> bool {
+    activities.is_empty() || activities.iter().any(|a| a.same_kind(activity))
+}
+
+fn firmware_upgrade_requested(activities: &[MaintenanceActivity]) -> bool {
+    should_run(
+        activities,
+        &MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+            force_update: false,
+        },
+    )
+}
+
+/// First ReProvisioning sub-state to enter from Ready, based on the request
+/// activities. Empty activities means all phases. Returns `None` when the
+/// activities list has no power-shelf-relevant wait phases.
+pub(crate) fn first_reprovisioning_state(
+    request: &PowerShelfReprovisionRequest,
+) -> Option<ReProvisioningState> {
+    if firmware_upgrade_requested(&request.activities) {
+        return Some(ReProvisioningState::WaitingForRackFirmwareUpgrade);
+    }
+    None
+}
+
+/// If the parent rack is in `RackState::Error`, clear
+/// `power_shelf_reprovisioning_requested` and short-circuit to `Ready`.
+async fn rack_failed_abort_outcome(
+    power_shelf_id: &PowerShelfId,
+    state: &PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<Option<StateHandlerOutcome<PowerShelfControllerState>>, StateHandlerError> {
+    if !is_rack_level_reprovisioning(state) {
+        return Ok(None);
+    }
+
+    let Some(rack_id) = state.rack_id.as_ref() else {
+        return Ok(None);
+    };
+
+    let mut reader: PgPoolReader = ctx.services.db_pool.clone().into();
+    let racks = db_rack::find_by(
+        reader.as_mut(),
+        ObjectColumnFilter::One(db_rack::IdColumn, rack_id),
+    )
+    .await?;
+    let Some(rack) = racks.into_iter().next() else {
+        return Ok(None);
+    };
+    if !matches!(rack.controller_state.value, RackState::Error { .. }) {
+        return Ok(None);
+    }
+
+    tracing::info!(
+        power_shelf_id = %power_shelf_id,
+        rack_id = %rack_id,
+        "Rack is in Error; aborting power shelf ReProvisioning and returning to Ready",
+    );
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db_power_shelf::clear_power_shelf_reprovisioning_requested(txn.as_mut(), *power_shelf_id)
+        .await?;
+    Ok(Some(
+        StateHandlerOutcome::transition(PowerShelfControllerState::Ready).with_txn(txn),
+    ))
+}
+
+/// Handles the ReProvisioning state for a power shelf.
+pub async fn handle_reprovisioning(
+    power_shelf_id: &PowerShelfId,
+    state: &mut PowerShelf,
+    ctx: &mut StateHandlerContext<'_, PowerShelfStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<PowerShelfControllerState>, StateHandlerError> {
+    let reprovisioning_state = match &state.controller_state.value {
+        PowerShelfControllerState::ReProvisioning {
+            reprovisioning_state,
+        } => reprovisioning_state,
+        _ => unreachable!("handle_reprovisioning called with non-ReProvisioning state"),
+    };
+
+    if let Some(outcome) = rack_failed_abort_outcome(power_shelf_id, state, ctx).await? {
+        return Ok(outcome);
+    }
+
+    match reprovisioning_state {
+        ReProvisioningState::WaitingForRackFirmwareUpgrade => {
+            let request = state
+                .power_shelf_reprovisioning_requested
+                .as_ref()
+                .expect("WaitingForRackFirmwareUpgrade requires a rack reprovision request");
+            let requested_at = request.requested_at;
+            let Some(firmware_upgrade_status) = state.firmware_upgrade_status.as_ref() else {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for power shelf firmware upgrade status".into(),
+                ));
+            };
+            if !firmware_upgrade_status.is_current_for(requested_at) {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for current rack firmware cycle".into(),
+                ));
+            }
+            if !firmware_upgrade_status.is_terminal() {
+                return Ok(StateHandlerOutcome::wait(
+                    "waiting for power shelf firmware completion".into(),
+                ));
+            }
+
+            match &firmware_upgrade_status.status {
+                model::rack::RackFirmwareUpgradeState::Completed => {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db_power_shelf::clear_power_shelf_reprovisioning_requested(
+                        txn.as_mut(),
+                        *power_shelf_id,
+                    )
+                    .await?;
+                    Ok(
+                        StateHandlerOutcome::transition(PowerShelfControllerState::Ready)
+                            .with_txn(txn),
+                    )
+                }
+                model::rack::RackFirmwareUpgradeState::Failed { cause } => {
+                    let mut txn = ctx.services.db_pool.begin().await?;
+                    db_power_shelf::clear_power_shelf_reprovisioning_requested(
+                        txn.as_mut(),
+                        *power_shelf_id,
+                    )
+                    .await?;
+                    Ok(
+                        StateHandlerOutcome::transition(PowerShelfControllerState::Error {
+                            cause: cause.clone(),
+                        })
+                        .with_txn(txn),
+                    )
+                }
+                model::rack::RackFirmwareUpgradeState::Started
+                | model::rack::RackFirmwareUpgradeState::InProgress => Ok(
+                    StateHandlerOutcome::wait("waiting for power shelf firmware completion".into()),
+                ),
+            }
+        }
+    }
+}

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -44,7 +44,8 @@ use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::{
     host_machine_update as db_host_machine_update, machine as db_machine,
-    machine_topology as db_machine_topology, rack as db_rack, switch as db_switch,
+    machine_topology as db_machine_topology, power_shelf as db_power_shelf, rack as db_rack,
+    switch as db_switch,
 };
 use librms::protos::rack_manager as rms;
 use model::rack::{
@@ -97,7 +98,8 @@ async fn trigger_rack_firmware_reprovisioning_requests(
     rack_id: &RackId,
     machine_ids: &[carbide_uuid::machine::MachineId],
     switch_ids: &[carbide_uuid::switch::SwitchId],
-    continue_after_firmware_upgrade: bool,
+    power_shelf_ids: &[carbide_uuid::power_shelf::PowerShelfId],
+    activities: &[MaintenanceActivity],
 ) -> Result<(), StateHandlerError> {
     for machine_id in machine_ids {
         db_host_machine_update::trigger_host_reprovisioning_request(
@@ -108,11 +110,20 @@ async fn trigger_rack_firmware_reprovisioning_requests(
         .await?;
     }
     for switch_id in switch_ids {
-        db_switch::set_switch_reprovisioning_requested_with_firmware_continuation(
+        db_switch::set_switch_reprovisioning_requested(
             txn,
             *switch_id,
             &format!("rack-{}", rack_id),
-            continue_after_firmware_upgrade,
+            activities.to_vec(),
+        )
+        .await?;
+    }
+    for power_shelf_id in power_shelf_ids {
+        db_power_shelf::set_power_shelf_reprovisioning_requested(
+            txn,
+            *power_shelf_id,
+            &format!("rack-{}", rack_id),
+            activities.to_vec(),
         )
         .await?;
     }
@@ -123,12 +134,16 @@ async fn clear_rack_firmware_device_statuses(
     txn: &mut sqlx::PgConnection,
     machine_ids: &[carbide_uuid::machine::MachineId],
     switch_ids: &[carbide_uuid::switch::SwitchId],
+    power_shelf_ids: &[carbide_uuid::power_shelf::PowerShelfId],
 ) -> Result<(), StateHandlerError> {
     for machine_id in machine_ids {
         db_machine::update_rack_fw_details(txn, machine_id, None).await?;
     }
     for switch_id in switch_ids {
         db_switch::update_firmware_upgrade_status(txn, *switch_id, None).await?;
+    }
+    for power_shelf_id in power_shelf_ids {
+        db_power_shelf::update_firmware_upgrade_status(txn, *power_shelf_id, None).await?;
     }
     Ok(())
 }
@@ -141,6 +156,336 @@ async fn clear_nvos_update_statuses(
         db_switch::update_nvos_update_status(txn, *switch_id, None).await?;
     }
     Ok(())
+}
+
+/// Aggregated firmware progress for machines/switches participating in a rack
+/// firmware job. Advancement out of `WaitForComplete` is based on machine and
+/// switch controller states, not RMS job strings or `rack_fw_details`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeviceFirmwareProgress {
+    Waiting {
+        pending: usize,
+        total: usize,
+        completed: usize,
+        failed: usize,
+    },
+    Failed {
+        failed: usize,
+        total: usize,
+    },
+    Completed {
+        completed: usize,
+        total: usize,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeviceFirmwareOutcome {
+    Waiting,
+    Failed,
+    Completed,
+}
+
+async fn resolve_machine_id_for_firmware_device(
+    txn: &mut sqlx::PgConnection,
+    device: &FirmwareUpgradeDeviceStatus,
+) -> Result<Option<carbide_uuid::machine::MachineId>, StateHandlerError> {
+    if !device.node_id.is_empty() {
+        return Ok(device
+            .node_id
+            .parse::<carbide_uuid::machine::MachineId>()
+            .ok());
+    }
+    let mac: mac_address::MacAddress = match device.mac.parse() {
+        Ok(mac) => mac,
+        Err(_) => return Ok(None),
+    };
+    Ok(db_machine_topology::find_machine_id_by_bmc_mac(txn, mac).await?)
+}
+
+async fn resolve_switch_id_for_firmware_device(
+    txn: &mut sqlx::PgConnection,
+    rack_id: &RackId,
+    device: &FirmwareUpgradeDeviceStatus,
+) -> Result<Option<carbide_uuid::switch::SwitchId>, StateHandlerError> {
+    if !device.node_id.is_empty() {
+        return Ok(device
+            .node_id
+            .parse::<carbide_uuid::switch::SwitchId>()
+            .ok());
+    }
+    let mac: mac_address::MacAddress = match device.mac.parse() {
+        Ok(mac) => mac,
+        Err(_) => return Ok(None),
+    };
+    Ok(db_switch::find_ids(
+        txn,
+        model::switch::SwitchSearchFilter {
+            bmc_mac: Some(mac),
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?
+    .first()
+    .copied())
+}
+
+async fn resolve_power_shelf_id_for_firmware_device(
+    txn: &mut sqlx::PgConnection,
+    rack_id: &RackId,
+    device: &FirmwareUpgradeDeviceStatus,
+) -> Result<Option<carbide_uuid::power_shelf::PowerShelfId>, StateHandlerError> {
+    if !device.node_id.is_empty() {
+        return Ok(device
+            .node_id
+            .parse::<carbide_uuid::power_shelf::PowerShelfId>()
+            .ok());
+    }
+    let mac: mac_address::MacAddress = match device.mac.parse() {
+        Ok(mac) => mac,
+        Err(_) => return Ok(None),
+    };
+    Ok(db_power_shelf::find_ids(
+        txn,
+        model::power_shelf::PowerShelfSearchFilter {
+            bmc_mac: Some(mac),
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?
+    .first()
+    .copied())
+}
+
+fn machine_firmware_outcome(machine: &model::machine::Machine) -> DeviceFirmwareOutcome {
+    match &machine.state.value {
+        model::machine::ManagedHostState::HostReprovision {
+            reprovision_state: model::machine::HostReprovisionState::WaitingForRackFirmwareUpgrade,
+            ..
+        } => DeviceFirmwareOutcome::Waiting,
+        model::machine::ManagedHostState::HostReprovision {
+            reprovision_state: model::machine::HostReprovisionState::FailedFirmwareUpgrade { .. },
+            ..
+        }
+        | model::machine::ManagedHostState::Failed { .. } => DeviceFirmwareOutcome::Failed,
+        // Machine has left WaitingForRackFirmwareUpgrade for a later
+        // HostReprovision sub-state (success path).
+        model::machine::ManagedHostState::HostReprovision { .. } => {
+            DeviceFirmwareOutcome::Completed
+        }
+        // Request posted but controller has not entered the wait state yet.
+        _ if machine.host_reprovision_requested.is_some() => DeviceFirmwareOutcome::Waiting,
+        _ => DeviceFirmwareOutcome::Completed,
+    }
+}
+
+fn switch_firmware_outcome(switch: &model::switch::Switch) -> DeviceFirmwareOutcome {
+    match &switch.controller_state.value {
+        model::switch::SwitchControllerState::ReProvisioning {
+            reprovisioning_state: model::switch::ReProvisioningState::WaitingForRackFirmwareUpgrade,
+        } => DeviceFirmwareOutcome::Waiting,
+        model::switch::SwitchControllerState::ReProvisioning {
+            reprovisioning_state:
+                model::switch::ReProvisioningState::WaitingForNVOSUpgrade
+                | model::switch::ReProvisioningState::WaitingForNMXCConfigure,
+        } => DeviceFirmwareOutcome::Completed,
+        model::switch::SwitchControllerState::Error { .. } => DeviceFirmwareOutcome::Failed,
+        // Request posted but controller has not entered the wait state yet.
+        model::switch::SwitchControllerState::Ready
+            if switch.switch_reprovisioning_requested.is_some() =>
+        {
+            DeviceFirmwareOutcome::Waiting
+        }
+        _ => DeviceFirmwareOutcome::Completed,
+    }
+}
+
+fn power_shelf_firmware_outcome(
+    power_shelf: &model::power_shelf::PowerShelf,
+) -> DeviceFirmwareOutcome {
+    match &power_shelf.controller_state.value {
+        model::power_shelf::PowerShelfControllerState::ReProvisioning {
+            reprovisioning_state:
+                model::power_shelf::ReProvisioningState::WaitingForRackFirmwareUpgrade,
+        } => DeviceFirmwareOutcome::Waiting,
+        model::power_shelf::PowerShelfControllerState::Error { .. } => {
+            DeviceFirmwareOutcome::Failed
+        }
+        // Request posted but controller has not entered the wait state yet
+        // (or is about to clear it when rack_firmware_reprovisioning_enabled
+        // is false).
+        model::power_shelf::PowerShelfControllerState::Ready
+            if power_shelf.power_shelf_reprovisioning_requested.is_some() =>
+        {
+            DeviceFirmwareOutcome::Waiting
+        }
+        _ => DeviceFirmwareOutcome::Completed,
+    }
+}
+
+fn summarize_firmware_outcomes(outcomes: &[DeviceFirmwareOutcome]) -> DeviceFirmwareProgress {
+    let total = outcomes.len();
+    let completed = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, DeviceFirmwareOutcome::Completed))
+        .count();
+    let failed = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, DeviceFirmwareOutcome::Failed))
+        .count();
+    let pending = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, DeviceFirmwareOutcome::Waiting))
+        .count();
+    if pending > 0 {
+        return DeviceFirmwareProgress::Waiting {
+            pending,
+            total,
+            completed,
+            failed,
+        };
+    }
+    if failed > 0 {
+        return DeviceFirmwareProgress::Failed { failed, total };
+    }
+    DeviceFirmwareProgress::Completed { completed, total }
+}
+
+/// Reads machine and switch controller states for devices in `rack_id`,
+/// filtered by `scope`, and decides whether firmware WaitForComplete can
+/// advance. Device membership comes from the DB + scope, not the firmware job.
+async fn evaluate_firmware_progress_from_devices(
+    txn: &mut sqlx::PgConnection,
+    rack_id: &RackId,
+    scope: &MaintenanceScope,
+) -> Result<DeviceFirmwareProgress, StateHandlerError> {
+    let machine_ids = db_machine::find_machine_ids(
+        &mut *txn,
+        model::machine::machine_search_config::MachineSearchConfig {
+            rack_id: Some(rack_id.clone()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let machines = if machine_ids.is_empty() {
+        Vec::new()
+    } else {
+        db_machine::find(
+            &mut *txn,
+            db::ObjectFilter::List(&machine_ids),
+            model::machine::machine_search_config::MachineSearchConfig::default(),
+        )
+        .await?
+    };
+    let machines = filter_machines_by_scope(machines, scope);
+
+    let switch_ids = db_switch::find_ids(
+        &mut *txn,
+        model::switch::SwitchSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: model::DeletedFilter::Exclude,
+            ..Default::default()
+        },
+    )
+    .await?;
+    let switches = if switch_ids.is_empty() {
+        Vec::new()
+    } else {
+        db_switch::find_by(
+            txn,
+            db::ObjectColumnFilter::List(db_switch::IdColumn, &switch_ids),
+        )
+        .await?
+    };
+    let switches = filter_switches_by_scope(switches, scope);
+
+    let power_shelf_ids = db_power_shelf::find_ids(
+        &mut *txn,
+        model::power_shelf::PowerShelfSearchFilter {
+            rack_id: Some(rack_id.clone()),
+            deleted: model::DeletedFilter::Exclude,
+            ..Default::default()
+        },
+    )
+    .await?;
+    let power_shelves = if power_shelf_ids.is_empty() {
+        Vec::new()
+    } else {
+        db_power_shelf::find_by(
+            txn,
+            db::ObjectColumnFilter::List(db_power_shelf::IdColumn, &power_shelf_ids),
+        )
+        .await?
+    };
+    let power_shelves = filter_power_shelves_by_scope(power_shelves, scope);
+
+    let mut outcomes = Vec::with_capacity(machines.len() + switches.len() + power_shelves.len());
+    outcomes.extend(machines.iter().map(machine_firmware_outcome));
+    outcomes.extend(switches.iter().map(switch_firmware_outcome));
+    outcomes.extend(power_shelves.iter().map(power_shelf_firmware_outcome));
+    Ok(summarize_firmware_outcomes(&outcomes))
+}
+
+fn filter_machines_by_scope(
+    mut machines: Vec<model::machine::Machine>,
+    scope: &MaintenanceScope,
+) -> Vec<model::machine::Machine> {
+    if scope.is_full_rack() {
+        return machines;
+    }
+    if scope.machine_ids.is_empty() {
+        return Vec::new();
+    }
+    let allowed: std::collections::HashSet<_> = scope.machine_ids.iter().collect();
+    machines.retain(|machine| allowed.contains(&machine.id));
+    machines
+}
+
+fn filter_switches_by_scope(
+    mut switches: Vec<model::switch::Switch>,
+    scope: &MaintenanceScope,
+) -> Vec<model::switch::Switch> {
+    if scope.is_full_rack() {
+        return switches;
+    }
+    if scope.switch_ids.is_empty() {
+        return Vec::new();
+    }
+    let allowed: std::collections::HashSet<_> = scope.switch_ids.iter().collect();
+    switches.retain(|switch| allowed.contains(&switch.id));
+    switches
+}
+
+fn filter_power_shelves_by_scope(
+    mut power_shelves: Vec<model::power_shelf::PowerShelf>,
+    scope: &MaintenanceScope,
+) -> Vec<model::power_shelf::PowerShelf> {
+    if scope.is_full_rack() {
+        return power_shelves;
+    }
+    if scope.power_shelf_ids.is_empty() {
+        return Vec::new();
+    }
+    let allowed: std::collections::HashSet<_> = scope.power_shelf_ids.iter().collect();
+    power_shelves.retain(|power_shelf| allowed.contains(&power_shelf.id));
+    power_shelves
+}
+
+fn filter_power_shelf_ids_by_scope(
+    mut power_shelf_ids: Vec<carbide_uuid::power_shelf::PowerShelfId>,
+    scope: &MaintenanceScope,
+) -> Vec<carbide_uuid::power_shelf::PowerShelfId> {
+    if scope.is_full_rack() {
+        return power_shelf_ids;
+    }
+    if scope.power_shelf_ids.is_empty() {
+        return Vec::new();
+    }
+    let allowed: std::collections::HashSet<_> = scope.power_shelf_ids.iter().collect();
+    power_shelf_ids.retain(|id| allowed.contains(id));
+    power_shelf_ids
 }
 
 fn skip_firmware_upgrade_outcome(
@@ -375,6 +720,36 @@ pub(crate) fn first_maintenance_state(scope: &MaintenanceScope) -> RackMaintenan
         }
     } else {
         next_state_after_firmware(scope)
+    }
+}
+
+/// Returns the state to advance to when the current maintenance state's
+/// activity is not requested. Every [`RackMaintenanceState`] variant is
+/// checked here so a persisted or stale state cannot execute outside the
+/// current scope.
+fn next_state_if_activity_not_requested(
+    maintenance_state: &RackMaintenanceState,
+    scope: &MaintenanceScope,
+) -> Option<RackMaintenanceState> {
+    match maintenance_state {
+        RackMaintenanceState::FirmwareUpgrade { .. } => {
+            (!scope.should_run(&MaintenanceActivity::FirmwareUpgrade {
+                firmware_version: None,
+                components: vec![],
+                force_update: false,
+            }))
+            .then(|| next_state_after_firmware(scope))
+        }
+        RackMaintenanceState::NVOSUpdate { .. } => {
+            (!nvos_update_requested(scope)).then(|| next_state_after_nvos(scope))
+        }
+        RackMaintenanceState::ConfigureNmxCluster { .. } => (!scope
+            .should_run(&MaintenanceActivity::ConfigureNmxCluster))
+        .then(|| next_state_after_configure(scope)),
+        RackMaintenanceState::PowerSequence { .. } => (!scope
+            .should_run(&MaintenanceActivity::PowerSequence))
+        .then_some(RackMaintenanceState::Completed),
+        RackMaintenanceState::Completed => None,
     }
 }
 
@@ -1321,6 +1696,18 @@ pub async fn handle_maintenance(
         .unwrap_or_default();
     let scope = &scope;
 
+    if let Some(next) = next_state_if_activity_not_requested(maintenance_state, scope) {
+        tracing::info!(
+            rack_id = %id,
+            current_state = %maintenance_state,
+            next_state = %next,
+            "Skipping rack maintenance state not requested by scope activities"
+        );
+        return Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+            maintenance_state: next,
+        }));
+    }
+
     match maintenance_state {
         RackMaintenanceState::FirmwareUpgrade {
             rack_firmware_upgrade,
@@ -1479,19 +1866,30 @@ pub async fn handle_maintenance(
                 };
 
                 let mut txn = ctx.services.db_pool.begin().await?;
-                let continue_after_firmware_upgrade = nvos_update_requested(scope);
+                let power_shelf_ids = db_power_shelf::find_ids(
+                    txn.as_mut(),
+                    model::power_shelf::PowerShelfSearchFilter {
+                        rack_id: Some(id.clone()),
+                        deleted: model::DeletedFilter::Exclude,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+                let power_shelf_ids = filter_power_shelf_ids_by_scope(power_shelf_ids, scope);
                 trigger_rack_firmware_reprovisioning_requests(
                     txn.as_mut(),
                     id,
                     &inventory.machine_ids,
                     &inventory.switch_ids,
-                    continue_after_firmware_upgrade,
+                    &power_shelf_ids,
+                    &scope.activities,
                 )
                 .await?;
                 clear_rack_firmware_device_statuses(
                     txn.as_mut(),
                     &inventory.machine_ids,
                     &inventory.switch_ids,
+                    &power_shelf_ids,
                 )
                 .await?;
                 job.started_at = Some(chrono::Utc::now());
@@ -1526,18 +1924,6 @@ pub async fn handle_maintenance(
                 let mut job =
                     rms_get_firmware_upgrade_status(rms_client.as_ref(), current_job).await?;
 
-                let all: Vec<_> = job.all_devices().collect();
-                let total = all.len();
-                let completed = all.iter().filter(|d| d.status == "completed").count();
-                let failed = all.iter().filter(|d| d.status == "failed").count();
-                let terminal = completed + failed;
-                if failed > 0 && requested_nvos_config_json(scope).is_some() {
-                    delete_rack_maintenance_access_token(
-                        ctx.services.credential_manager.as_ref(),
-                        id,
-                    )
-                    .await;
-                }
                 let mut txn = ctx.services.db_pool.begin().await?;
 
                 let build_status =
@@ -1568,19 +1954,9 @@ pub async fn handle_maintenance(
                     };
 
                 for device in job.machines.iter() {
-                    let machine_id = if !device.node_id.is_empty() {
-                        device
-                            .node_id
-                            .parse::<carbide_uuid::machine::MachineId>()
-                            .ok()
-                    } else {
-                        let mac: mac_address::MacAddress = match device.mac.parse() {
-                            Ok(mac) => mac,
-                            Err(_) => continue,
-                        };
-                        db_machine_topology::find_machine_id_by_bmc_mac(txn.as_mut(), mac).await?
-                    };
-                    if let Some(machine_id) = machine_id {
+                    if let Some(machine_id) =
+                        resolve_machine_id_for_firmware_device(txn.as_mut(), device).await?
+                    {
                         let fw_status = build_status(device);
                         db_machine::update_rack_fw_details(
                             txn.as_mut(),
@@ -1592,29 +1968,9 @@ pub async fn handle_maintenance(
                 }
 
                 for device in job.switches.iter() {
-                    let switch_id = if !device.node_id.is_empty() {
-                        device
-                            .node_id
-                            .parse::<carbide_uuid::switch::SwitchId>()
-                            .ok()
-                    } else {
-                        let mac: mac_address::MacAddress = match device.mac.parse() {
-                            Ok(mac) => mac,
-                            Err(_) => continue,
-                        };
-                        db_switch::find_ids(
-                            txn.as_mut(),
-                            model::switch::SwitchSearchFilter {
-                                bmc_mac: Some(mac),
-                                rack_id: Some(id.clone()),
-                                ..Default::default()
-                            },
-                        )
-                        .await?
-                        .first()
-                        .copied()
-                    };
-                    if let Some(switch_id) = switch_id {
+                    if let Some(switch_id) =
+                        resolve_switch_id_for_firmware_device(txn.as_mut(), id, device).await?
+                    {
                         let fw_status = build_status(device);
                         db_switch::update_firmware_upgrade_status(
                             txn.as_mut(),
@@ -1625,71 +1981,142 @@ pub async fn handle_maintenance(
                     }
                 }
 
-                if terminal < total {
-                    db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
-                    state.firmware_upgrade_job = Some(job);
-                    return Ok(StateHandlerOutcome::wait(format!(
-                        "firmware upgrade: {}/{} devices terminal (completed={}, failed={})",
-                        terminal, total, completed, failed
-                    ))
-                    .with_txn(txn));
+                for device in job.power_shelves.iter() {
+                    if let Some(power_shelf_id) =
+                        resolve_power_shelf_id_for_firmware_device(txn.as_mut(), id, device).await?
+                    {
+                        let fw_status = build_status(device);
+                        db_power_shelf::update_firmware_upgrade_status(
+                            txn.as_mut(),
+                            power_shelf_id,
+                            Some(&fw_status),
+                        )
+                        .await?;
+                    }
                 }
 
-                if failed > 0 {
-                    let now = chrono::Utc::now();
-                    job.status = Some("failed".into());
-                    if job.completed_at.is_none() {
-                        job.completed_at = Some(now);
+                // When RMS does not yet report power-shelf devices, stamp
+                // Completed for scoped shelves so enabled controllers can leave
+                // WaitingForRackFirmwareUpgrade without hanging.
+                if job.power_shelves.is_empty() {
+                    let power_shelf_ids = db_power_shelf::find_ids(
+                        txn.as_mut(),
+                        model::power_shelf::PowerShelfSearchFilter {
+                            rack_id: Some(id.clone()),
+                            deleted: model::DeletedFilter::Exclude,
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                    let power_shelf_ids = filter_power_shelf_ids_by_scope(power_shelf_ids, scope);
+                    if !power_shelf_ids.is_empty() {
+                        let fw_status = RackFirmwareUpgradeStatus {
+                            task_id: job.job_id.clone().unwrap_or_else(|| "unknown".to_string()),
+                            status: RackFirmwareUpgradeState::Completed,
+                            started_at: job.started_at,
+                            ended_at: Some(chrono::Utc::now()),
+                        };
+                        for power_shelf_id in power_shelf_ids {
+                            db_power_shelf::update_firmware_upgrade_status(
+                                txn.as_mut(),
+                                power_shelf_id,
+                                Some(&fw_status),
+                            )
+                            .await?;
+                        }
                     }
-                    db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
-                    state.firmware_upgrade_job = Some(job);
-                    if state.config.maintenance_requested.is_some() {
-                        state.config.maintenance_requested = None;
-                        db_rack::update(txn.as_mut(), id, &state.config).await?;
+                }
+
+                // Advancement is driven by machine/switch/power-shelf controller
+                // states for devices in this rack that are selected by the
+                // maintenance scope.
+                let progress =
+                    evaluate_firmware_progress_from_devices(txn.as_mut(), id, scope).await?;
+
+                match progress {
+                    DeviceFirmwareProgress::Waiting {
+                        pending: _,
+                        total,
+                        completed,
+                        failed,
+                    } => {
+                        db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
+                        state.firmware_upgrade_job = Some(job);
+                        Ok(StateHandlerOutcome::wait(format!(
+                            "firmware upgrade: waiting on machine/switch/power-shelf controller state ({}/{} past firmware wait, completed={}, failed={})",
+                            completed + failed,
+                            total,
+                            completed,
+                            failed
+                        ))
+                        .with_txn(txn))
                     }
-                    return Ok(StateHandlerOutcome::transition(RackState::Error {
-                        cause: format!(
+                    DeviceFirmwareProgress::Failed { failed, total } => {
+                        let should_cleanup_token = requested_nvos_config_json(scope).is_some();
+                        let now = chrono::Utc::now();
+                        job.status = Some("failed".into());
+                        if job.completed_at.is_none() {
+                            job.completed_at = Some(now);
+                        }
+                        db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
+                        state.firmware_upgrade_job = Some(job);
+                        if state.config.maintenance_requested.is_some() {
+                            state.config.maintenance_requested = None;
+                            db_rack::update(txn.as_mut(), id, &state.config).await?;
+                        }
+                        let cause = format!(
                             "firmware upgrade failed: {}/{} devices failed",
                             failed, total
-                        ),
-                    })
-                    .with_txn(txn));
+                        );
+                        // Commit before credentials cleanup so the transaction is
+                        // not held across that await.
+                        txn.commit().await?;
+                        if should_cleanup_token {
+                            delete_rack_maintenance_access_token(
+                                ctx.services.credential_manager.as_ref(),
+                                id,
+                            )
+                            .await;
+                        }
+                        Ok(StateHandlerOutcome::transition(RackState::Error { cause }))
+                    }
+                    DeviceFirmwareProgress::Completed { completed, total } => {
+                        let now = chrono::Utc::now();
+                        job.status = Some("completed".into());
+                        if job.completed_at.is_none() {
+                            job.completed_at = Some(now);
+                        }
+                        db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
+                        state.firmware_upgrade_job = Some(job);
+
+                        let next_maintenance_state = if nvos_update_requested(scope) {
+                            let next = next_state_after_firmware(scope);
+                            tracing::info!(
+                                rack_id = %id,
+                                completed_device_count = completed,
+                                total_device_count = total,
+                                next_state = %next,
+                                "Rack firmware upgrade complete on machine/switch controllers; advancing to explicitly requested next activity"
+                            );
+                            next
+                        } else {
+                            let next = next_state_after_nvos(scope);
+                            tracing::info!(
+                                rack_id = %id,
+                                completed_device_count = completed,
+                                total_device_count = total,
+                                next_state = %next,
+                                "Rack firmware upgrade complete on machine/switch controllers; no explicit NVOS update requested, advancing"
+                            );
+                            next
+                        };
+
+                        Ok(StateHandlerOutcome::transition(RackState::Maintenance {
+                            maintenance_state: next_maintenance_state,
+                        })
+                        .with_txn(txn))
+                    }
                 }
-
-                let now = chrono::Utc::now();
-                job.status = Some("completed".into());
-                if job.completed_at.is_none() {
-                    job.completed_at = Some(now);
-                }
-                db_rack::update_firmware_upgrade_job(txn.as_mut(), id, Some(&job)).await?;
-                state.firmware_upgrade_job = Some(job);
-
-                let next_maintenance_state = if nvos_update_requested(scope) {
-                    let next = next_state_after_firmware(scope);
-                    tracing::info!(
-                        rack_id = %id,
-                        completed_device_count = completed,
-                        total_device_count = total,
-                        next_state = %next,
-                        "Rack firmware upgrade complete; advancing to explicitly requested next activity"
-                    );
-                    next
-                } else {
-                    let next = next_state_after_nvos(scope);
-                    tracing::info!(
-                        rack_id = %id,
-                        completed_device_count = completed,
-                        total_device_count = total,
-                        next_state = %next,
-                        "Rack firmware upgrade complete; no explicit NVOS update requested, advancing"
-                    );
-                    next
-                };
-
-                Ok(StateHandlerOutcome::transition(RackState::Maintenance {
-                    maintenance_state: next_maintenance_state,
-                })
-                .with_txn(txn))
             }
         },
         RackMaintenanceState::NVOSUpdate { nvos_update } => match nvos_update {
@@ -2499,10 +2926,11 @@ mod tests {
     use model::rack_type::{RackHardwareType, RackProductFamily, RackProfile};
 
     use super::{
-        build_switch_device_info_request, delete_rack_maintenance_access_token,
-        filter_inventory_by_scope, firmware_device_status, first_maintenance_state,
-        next_state_after_configure, next_state_after_firmware, next_state_after_nvos,
-        profile_hardware_type_or_any,
+        DeviceFirmwareOutcome, DeviceFirmwareProgress, build_switch_device_info_request,
+        delete_rack_maintenance_access_token, filter_inventory_by_scope, firmware_device_status,
+        first_maintenance_state, next_state_after_configure, next_state_after_firmware,
+        next_state_after_nvos, next_state_if_activity_not_requested, profile_hardware_type_or_any,
+        summarize_firmware_outcomes,
     };
 
     fn test_machine_id(seed: u8) -> MachineId {
@@ -2793,6 +3221,51 @@ mod tests {
         assert_eq!(status.error_message.as_deref(), Some("invalid SOT JSON"));
     }
 
+    #[test]
+    fn test_summarize_firmware_outcomes_from_controller_states() {
+        check_values(
+            [
+                Check {
+                    scenario: "any waiting keeps rack waiting",
+                    input: vec![
+                        DeviceFirmwareOutcome::Completed,
+                        DeviceFirmwareOutcome::Waiting,
+                        DeviceFirmwareOutcome::Failed,
+                    ],
+                    expect: DeviceFirmwareProgress::Waiting {
+                        pending: 1,
+                        total: 3,
+                        completed: 1,
+                        failed: 1,
+                    },
+                },
+                Check {
+                    scenario: "all completed advances",
+                    input: vec![
+                        DeviceFirmwareOutcome::Completed,
+                        DeviceFirmwareOutcome::Completed,
+                    ],
+                    expect: DeviceFirmwareProgress::Completed {
+                        completed: 2,
+                        total: 2,
+                    },
+                },
+                Check {
+                    scenario: "any failed without waiting errors",
+                    input: vec![
+                        DeviceFirmwareOutcome::Completed,
+                        DeviceFirmwareOutcome::Failed,
+                    ],
+                    expect: DeviceFirmwareProgress::Failed {
+                        failed: 1,
+                        total: 2,
+                    },
+                },
+            ],
+            |outcomes| summarize_firmware_outcomes(&outcomes),
+        );
+    }
+
     /// A firmware-upgrade activity with no version/components/force, the form
     /// used by the maintenance-state transition tables.
     fn firmware_upgrade() -> MaintenanceActivity {
@@ -2838,6 +3311,82 @@ mod tests {
         RackMaintenanceState::PowerSequence {
             rack_power: RackPowerState::PoweringOn,
         }
+    }
+
+    // ── current-state scope enforcement ─────────────────────────────────
+
+    #[test]
+    fn test_next_state_if_activity_not_requested() {
+        check_values(
+            [
+                Check {
+                    scenario: "requested firmware continues",
+                    input: (firmware_start(), scope_of(vec![firmware_upgrade()])),
+                    expect: None,
+                },
+                Check {
+                    scenario: "unrequested firmware skips to configure",
+                    input: (
+                        firmware_start(),
+                        scope_of(vec![MaintenanceActivity::ConfigureNmxCluster]),
+                    ),
+                    expect: Some(configure_start()),
+                },
+                Check {
+                    scenario: "requested nvos continues",
+                    input: (nvos_start(), scope_of(vec![nvos_update()])),
+                    expect: None,
+                },
+                Check {
+                    scenario: "unrequested nvos skips to configure",
+                    input: (
+                        nvos_start(),
+                        scope_of(vec![MaintenanceActivity::ConfigureNmxCluster]),
+                    ),
+                    expect: Some(configure_start()),
+                },
+                Check {
+                    scenario: "requested configure continues",
+                    input: (
+                        configure_start(),
+                        scope_of(vec![MaintenanceActivity::ConfigureNmxCluster]),
+                    ),
+                    expect: None,
+                },
+                Check {
+                    scenario: "unrequested configure skips to power",
+                    input: (
+                        configure_start(),
+                        scope_of(vec![MaintenanceActivity::PowerSequence]),
+                    ),
+                    expect: Some(powering_on()),
+                },
+                Check {
+                    scenario: "requested power continues",
+                    input: (
+                        powering_on(),
+                        scope_of(vec![MaintenanceActivity::PowerSequence]),
+                    ),
+                    expect: None,
+                },
+                Check {
+                    scenario: "unrequested power skips to completed",
+                    input: (powering_on(), scope_of(vec![firmware_upgrade()])),
+                    expect: Some(RackMaintenanceState::Completed),
+                },
+                Check {
+                    scenario: "completed always continues",
+                    input: (
+                        RackMaintenanceState::Completed,
+                        scope_of(vec![firmware_upgrade()]),
+                    ),
+                    expect: None,
+                },
+            ],
+            |(maintenance_state, scope)| {
+                next_state_if_activity_not_requested(&maintenance_state, &scope)
+            },
+        );
     }
 
     // ── first_maintenance_state ─────────────────────────────────────────

--- a/crates/rpc/src/model/power_shelf.rs
+++ b/crates/rpc/src/model/power_shelf.rs
@@ -186,6 +186,8 @@ mod tests {
             bmc_info: None,
             rack_id: None,
             power_shelf_maintenance_requested: None,
+            power_shelf_reprovisioning_requested: None,
+            firmware_upgrade_status: None,
             metadata: Metadata::default(),
             version: ConfigVersion::initial(),
             health_reports: Default::default(),

--- a/crates/switch-controller/src/ready.rs
+++ b/crates/switch-controller/src/ready.rs
@@ -18,13 +18,15 @@
 //! Handler for SwitchControllerState::Ready.
 
 use carbide_uuid::switch::SwitchId;
-use model::switch::{ConfiguringState, ReProvisioningState, Switch, SwitchControllerState};
+use db::switch as db_switch;
+use model::switch::{ConfiguringState, Switch, SwitchControllerState};
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
 
 use crate::context::SwitchStateHandlerContextObjects;
 use crate::nvos_password_rotation::needs_nvos_password_reconciliation;
+use crate::reprovisioning::first_reprovisioning_state;
 
 /// Handles the Ready state for a switch.
 ///
@@ -56,27 +58,41 @@ pub async fn handle_ready(
     }
 
     if let Some(req) = &state.switch_reprovisioning_requested {
-        if req.initiator.starts_with("rack-") {
-            tracing::info!(
-                "Rack-level firmware upgrade requested — transitioning to WaitingForRackFirmwareUpgrade"
+        if !req.initiator.starts_with("rack-") {
+            tracing::warn!(
+                initiator = %req.initiator,
+                "Unknown initiator for switch reprovisioning request",
             );
-            return Ok(StateHandlerOutcome::transition(
-                SwitchControllerState::ReProvisioning {
-                    reprovisioning_state: ReProvisioningState::WaitingForRackFirmwareUpgrade,
-                },
-            ));
+            let cause = format!(
+                "unknown initiator for switch reprovisioning request: {}",
+                req.initiator
+            );
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
+            return Ok(
+                StateHandlerOutcome::transition(SwitchControllerState::Error { cause })
+                    .with_txn(txn),
+            );
         }
 
-        tracing::warn!(
-            initiator = %req.initiator,
-            "Unknown initiator for switch reprovisioning request",
+        let Some(reprovisioning_state) = first_reprovisioning_state(req) else {
+            tracing::warn!(
+                switch_id = %switch_id,
+                initiator = %req.initiator,
+                "Rack reprovision request has no switch-relevant activities; clearing request"
+            );
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
+            return Ok(StateHandlerOutcome::do_nothing().with_txn(txn));
+        };
+
+        tracing::info!(
+            ?reprovisioning_state,
+            "Rack-level reprovisioning requested — entering ReProvisioning"
         );
         return Ok(StateHandlerOutcome::transition(
-            SwitchControllerState::Error {
-                cause: format!(
-                    "unknown initiator for switch reprovisioning request: {}",
-                    req.initiator
-                ),
+            SwitchControllerState::ReProvisioning {
+                reprovisioning_state,
             },
         ));
     }

--- a/crates/switch-controller/src/reprovisioning.rs
+++ b/crates/switch-controller/src/reprovisioning.rs
@@ -20,8 +20,8 @@
 use carbide_uuid::switch::SwitchId;
 use db::db_read::PgPoolReader;
 use db::{ObjectColumnFilter, rack as db_rack, switch as db_switch};
-use model::rack::RackState;
-use model::switch::{ReProvisioningState, Switch, SwitchControllerState};
+use model::rack::{MaintenanceActivity, RackState};
+use model::switch::{ReProvisioningState, Switch, SwitchControllerState, SwitchReprovisionRequest};
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -35,6 +35,71 @@ fn is_rack_level_reprovisioning(state: &Switch) -> bool {
         .switch_reprovisioning_requested
         .as_ref()
         .is_some_and(|req| req.initiator.starts_with("rack-"))
+}
+
+fn should_run(activities: &[MaintenanceActivity], activity: &MaintenanceActivity) -> bool {
+    activities.is_empty() || activities.iter().any(|a| a.same_kind(activity))
+}
+
+fn nvos_update_requested(activities: &[MaintenanceActivity]) -> bool {
+    should_run(
+        activities,
+        &MaintenanceActivity::NvosUpdate {
+            config_json: String::new(),
+        },
+    )
+}
+
+fn configure_nmx_cluster_requested(activities: &[MaintenanceActivity]) -> bool {
+    should_run(activities, &MaintenanceActivity::ConfigureNmxCluster)
+}
+
+fn firmware_upgrade_requested(activities: &[MaintenanceActivity]) -> bool {
+    should_run(
+        activities,
+        &MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+            force_update: false,
+        },
+    )
+}
+
+/// First ReProvisioning sub-state to enter from Ready, based on the request
+/// activities. Empty activities means all phases. Returns `None` when the
+/// activities list has no switch-relevant wait phases.
+pub(crate) fn first_reprovisioning_state(
+    request: &SwitchReprovisionRequest,
+) -> Option<ReProvisioningState> {
+    let activities = &request.activities;
+    if firmware_upgrade_requested(activities) {
+        return Some(ReProvisioningState::WaitingForRackFirmwareUpgrade);
+    }
+    if nvos_update_requested(activities) {
+        return Some(ReProvisioningState::WaitingForNVOSUpgrade);
+    }
+    if configure_nmx_cluster_requested(activities) {
+        return Some(ReProvisioningState::WaitingForNMXCConfigure);
+    }
+    None
+}
+
+/// Next ReProvisioning sub-state after firmware completes.
+fn next_state_after_firmware(request: &SwitchReprovisionRequest) -> Option<ReProvisioningState> {
+    let activities = &request.activities;
+    if nvos_update_requested(activities) {
+        return Some(ReProvisioningState::WaitingForNVOSUpgrade);
+    }
+    if configure_nmx_cluster_requested(activities) {
+        return Some(ReProvisioningState::WaitingForNMXCConfigure);
+    }
+    None
+}
+
+/// Next ReProvisioning sub-state after NVOS completes.
+fn next_state_after_nvos(request: &SwitchReprovisionRequest) -> Option<ReProvisioningState> {
+    configure_nmx_cluster_requested(&request.activities)
+        .then_some(ReProvisioningState::WaitingForNMXCConfigure)
 }
 
 /// If the parent rack is in `RackState::Error`, clear
@@ -107,7 +172,7 @@ pub async fn handle_reprovisioning(
                 .as_ref()
                 .expect("WaitingForRackFirmwareUpgrade requires a rack reprovision request");
             let requested_at = request.requested_at;
-            let continue_after_firmware_upgrade = request.continue_after_firmware_upgrade;
+            let next_after_firmware = next_state_after_firmware(request);
             let Some(firmware_upgrade_status) = state.firmware_upgrade_status.as_ref() else {
                 return Ok(StateHandlerOutcome::wait(
                     "waiting for switch firmware upgrade status".into(),
@@ -126,10 +191,10 @@ pub async fn handle_reprovisioning(
 
             match &firmware_upgrade_status.status {
                 model::rack::RackFirmwareUpgradeState::Completed => {
-                    if continue_after_firmware_upgrade {
+                    if let Some(reprovisioning_state) = next_after_firmware {
                         return Ok(StateHandlerOutcome::transition(
                             SwitchControllerState::ReProvisioning {
-                                reprovisioning_state: ReProvisioningState::WaitingForNVOSUpgrade,
+                                reprovisioning_state,
                             },
                         ));
                     }
@@ -157,11 +222,12 @@ pub async fn handle_reprovisioning(
             }
         }
         ReProvisioningState::WaitingForNVOSUpgrade => {
-            let requested_at = state
+            let request = state
                 .switch_reprovisioning_requested
                 .as_ref()
-                .map(|request| request.requested_at)
                 .expect("WaitingForNVOSUpgrade requires a rack reprovision request");
+            let requested_at = request.requested_at;
+            let next_after_nvos = next_state_after_nvos(request);
             let Some(nvos_update_status) = state.nvos_update_status.as_ref() else {
                 return Ok(StateHandlerOutcome::wait(
                     "waiting for switch NVOS update status".into(),
@@ -179,11 +245,23 @@ pub async fn handle_reprovisioning(
             }
 
             match &nvos_update_status.status {
-                model::rack::SwitchNvosUpdateState::Completed => Ok(
-                    StateHandlerOutcome::transition(SwitchControllerState::ReProvisioning {
-                        reprovisioning_state: ReProvisioningState::WaitingForNMXCConfigure,
-                    }),
-                ),
+                model::rack::SwitchNvosUpdateState::Completed => {
+                    if let Some(reprovisioning_state) = next_after_nvos {
+                        Ok(StateHandlerOutcome::transition(
+                            SwitchControllerState::ReProvisioning {
+                                reprovisioning_state,
+                            },
+                        ))
+                    } else {
+                        let mut txn = ctx.services.db_pool.begin().await?;
+                        db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
+                            .await?;
+                        Ok(
+                            StateHandlerOutcome::transition(SwitchControllerState::Ready)
+                                .with_txn(txn),
+                        )
+                    }
+                }
                 model::rack::SwitchNvosUpdateState::Failed { cause } => {
                     let mut txn = ctx.services.db_pool.begin().await?;
                     db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id)
@@ -236,5 +314,78 @@ pub async fn handle_reprovisioning(
             db_switch::clear_switch_reprovisioning_requested(txn.as_mut(), *switch_id).await?;
             Ok(StateHandlerOutcome::transition(SwitchControllerState::Ready).with_txn(txn))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use model::rack::MaintenanceActivity;
+    use model::switch::{ReProvisioningState, SwitchReprovisionRequest};
+
+    use super::{first_reprovisioning_state, next_state_after_firmware};
+
+    fn request(activities: Vec<MaintenanceActivity>) -> SwitchReprovisionRequest {
+        SwitchReprovisionRequest {
+            // Timestamp is unused by activity selection helpers under test.
+            requested_at: Default::default(),
+            initiator: "rack-test".to_string(),
+            activities,
+        }
+    }
+
+    fn firmware() -> MaintenanceActivity {
+        MaintenanceActivity::FirmwareUpgrade {
+            firmware_version: None,
+            components: vec![],
+            force_update: false,
+        }
+    }
+
+    fn nvos() -> MaintenanceActivity {
+        MaintenanceActivity::NvosUpdate {
+            config_json: String::new(),
+        }
+    }
+
+    #[test]
+    fn next_state_after_firmware_treats_empty_activities_as_all_phases() {
+        value_scenarios!(
+            run = |req| next_state_after_firmware(&req);
+            "empty means all remaining phases" {
+                request(vec![]) => Some(ReProvisioningState::WaitingForNVOSUpgrade),
+            }
+
+            "explicit NVOS still advances to NVOS" {
+                request(vec![firmware(), nvos()]) => Some(ReProvisioningState::WaitingForNVOSUpgrade),
+            }
+
+            "firmware-only skips NVOS and later phases" {
+                request(vec![firmware()]) => None,
+            }
+
+            "NMXC-only after firmware skips NVOS" {
+                request(vec![MaintenanceActivity::ConfigureNmxCluster])
+                    => Some(ReProvisioningState::WaitingForNMXCConfigure),
+            }
+        );
+    }
+
+    #[test]
+    fn first_reprovisioning_state_treats_empty_activities_as_all_phases() {
+        value_scenarios!(
+            run = |req| first_reprovisioning_state(&req);
+            "empty starts at firmware wait" {
+                request(vec![]) => Some(ReProvisioningState::WaitingForRackFirmwareUpgrade),
+            }
+
+            "NVOS-only starts at NVOS wait" {
+                request(vec![nvos()]) => Some(ReProvisioningState::WaitingForNVOSUpgrade),
+            }
+
+            "firmware-only starts at firmware wait" {
+                request(vec![firmware()]) => Some(ReProvisioningState::WaitingForRackFirmwareUpgrade),
+            }
+        );
     }
 }


### PR DESCRIPTION
Route state-controller firmware requests for power shelves through rack maintenance, alongside machines and switches. Persist per-device reprovisioning requests and firmware status so rack orchestration can synchronize component progress and terminal outcomes.

Add the power-shelf reprovisioning state machine behind an opt-in configuration flag, including completion, failure, stale-cycle, and rack-error handling. Tighten switch reprovisioning behavior and expand rack maintenance coordination to handle mixed component scopes, retries, and status propagation.

Add the database migration, model and RPC wiring, controller configuration, and integration coverage for rack, switch, and power-shelf firmware workflows.


## Related issues
https://github.com/NVIDIA/infra-controller/issues/4088

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
NONE 
