### PR TITLE
test(health): consolidate gNMI value and credential coverage

### DIFF
--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -420,204 +420,387 @@ pub fn typed_value_to_f64(val: &proto::TypedValue) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::{Check, check_values};
+
     use super::*;
 
-    #[test]
-    fn test_typed_value_to_string_string_val() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::StringVal("healthy".to_string())),
-        };
-        assert_eq!(typed_value_to_string(&val), Some("healthy".to_string()));
+    #[derive(Debug, PartialEq)]
+    enum AuthProjection {
+        Metadata {
+            username: Option<String>,
+            password: Option<String>,
+        },
+        InvalidUsername,
+        InvalidPassword,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ValueProjection {
+        as_string: Option<String>,
+        as_f64: Option<f64>,
+    }
+
+    struct AuthInput {
+        username: Option<String>,
+        password: Option<String>,
     }
 
     #[test]
-    fn test_typed_value_to_string_json_val() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::JsonVal(b"\"degraded\"".to_vec())),
-        };
-        assert_eq!(typed_value_to_string(&val), Some("degraded".to_string()));
+    #[allow(deprecated)]
+    fn typed_value_projection_cases() {
+        use proto::typed_value::Value;
+
+        check_values(
+            [
+                Check {
+                    scenario: "absent value",
+                    input: proto::TypedValue { value: None },
+                    expect: ValueProjection {
+                        as_string: None,
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "native non-numeric string",
+                    input: proto::TypedValue {
+                        value: Some(Value::StringVal("healthy".to_string())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("healthy".to_string()),
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "native numeric string",
+                    input: proto::TypedValue {
+                        value: Some(Value::StringVal("1.23".to_string())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("1.23".to_string()),
+                        as_f64: Some(1.23),
+                    },
+                },
+                Check {
+                    scenario: "quoted non-numeric JSON",
+                    input: proto::TypedValue {
+                        value: Some(Value::JsonVal(b"\"degraded\"".to_vec())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("degraded".to_string()),
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "quoted numeric JSON",
+                    input: proto::TypedValue {
+                        value: Some(Value::JsonVal(b"\"1.5e-3\"".to_vec())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("1.5e-3".to_string()),
+                        as_f64: Some(0.0015),
+                    },
+                },
+                Check {
+                    scenario: "unquoted numeric JSON",
+                    input: proto::TypedValue {
+                        value: Some(Value::JsonVal(b"99.9".to_vec())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("99.9".to_string()),
+                        as_f64: Some(99.9),
+                    },
+                },
+                Check {
+                    scenario: "IETF JSON",
+                    input: proto::TypedValue {
+                        value: Some(Value::JsonIetfVal(b"6.25".to_vec())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("6.25".to_string()),
+                        as_f64: Some(6.25),
+                    },
+                },
+                Check {
+                    scenario: "ASCII",
+                    input: proto::TypedValue {
+                        value: Some(Value::AsciiVal("port-up".to_string())),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("port-up".to_string()),
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "signed integer",
+                    input: proto::TypedValue {
+                        value: Some(Value::IntVal(-5)),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("-5".to_string()),
+                        as_f64: Some(-5.0),
+                    },
+                },
+                Check {
+                    scenario: "unsigned integer",
+                    input: proto::TypedValue {
+                        value: Some(Value::UintVal(100)),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("100".to_string()),
+                        as_f64: Some(100.0),
+                    },
+                },
+                Check {
+                    scenario: "Boolean",
+                    input: proto::TypedValue {
+                        value: Some(Value::BoolVal(true)),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("true".to_string()),
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "float",
+                    input: proto::TypedValue {
+                        value: Some(Value::FloatVal(1.25)),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("1.25".to_string()),
+                        as_f64: Some(1.25),
+                    },
+                },
+                Check {
+                    scenario: "double",
+                    input: proto::TypedValue {
+                        value: Some(Value::DoubleVal(42.5)),
+                    },
+                    expect: ValueProjection {
+                        as_string: Some("42.5".to_string()),
+                        as_f64: Some(42.5),
+                    },
+                },
+                Check {
+                    scenario: "unsupported bytes",
+                    input: proto::TypedValue {
+                        value: Some(Value::BytesVal(vec![0, 1])),
+                    },
+                    expect: ValueProjection {
+                        as_string: None,
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "unsupported decimal",
+                    input: proto::TypedValue {
+                        value: Some(Value::DecimalVal(proto::Decimal64 {
+                            digits: 125,
+                            precision: 2,
+                        })),
+                    },
+                    expect: ValueProjection {
+                        as_string: None,
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "unsupported leaf list",
+                    input: proto::TypedValue {
+                        value: Some(Value::LeaflistVal(proto::ScalarArray {
+                            element: Vec::new(),
+                        })),
+                    },
+                    expect: ValueProjection {
+                        as_string: None,
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "unsupported arbitrary protobuf",
+                    input: proto::TypedValue {
+                        value: Some(Value::AnyVal(prost_types::Any {
+                            type_url: "type.googleapis.com/example.Value".to_string(),
+                            value: vec![0, 1],
+                        })),
+                    },
+                    expect: ValueProjection {
+                        as_string: None,
+                        as_f64: None,
+                    },
+                },
+                Check {
+                    scenario: "unsupported protobuf bytes",
+                    input: proto::TypedValue {
+                        value: Some(Value::ProtoBytes(vec![0, 1])),
+                    },
+                    expect: ValueProjection {
+                        as_string: None,
+                        as_f64: None,
+                    },
+                },
+            ],
+            |value| ValueProjection {
+                as_string: typed_value_to_string(&value),
+                as_f64: typed_value_to_f64(&value),
+            },
+        );
     }
 
     #[test]
-    fn test_typed_value_to_string_json_unquoted() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::JsonVal(b"42".to_vec())),
-        };
-        assert_eq!(typed_value_to_string(&val), Some("42".to_string()));
+    fn auth_metadata_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "no credentials",
+                    input: AuthInput {
+                        username: None,
+                        password: None,
+                    },
+                    expect: AuthProjection::Metadata {
+                        username: None,
+                        password: None,
+                    },
+                },
+                Check {
+                    scenario: "username only",
+                    input: AuthInput {
+                        username: Some("admin".to_string()),
+                        password: None,
+                    },
+                    expect: AuthProjection::Metadata {
+                        username: Some("admin".to_string()),
+                        password: None,
+                    },
+                },
+                Check {
+                    scenario: "password only",
+                    input: AuthInput {
+                        username: None,
+                        password: Some("secret".to_string()),
+                    },
+                    expect: AuthProjection::Metadata {
+                        username: None,
+                        password: Some("secret".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "username and password",
+                    input: AuthInput {
+                        username: Some("admin".to_string()),
+                        password: Some("secret".to_string()),
+                    },
+                    expect: AuthProjection::Metadata {
+                        username: Some("admin".to_string()),
+                        password: Some("secret".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "invalid username",
+                    input: AuthInput {
+                        username: Some("bad\nusername".to_string()),
+                        password: Some("secret".to_string()),
+                    },
+                    expect: AuthProjection::InvalidUsername,
+                },
+                Check {
+                    scenario: "invalid password is redacted",
+                    input: AuthInput {
+                        username: Some("admin".to_string()),
+                        password: Some("bad\npassword".to_string()),
+                    },
+                    expect: AuthProjection::InvalidPassword,
+                },
+            ],
+            |AuthInput { username, password }| match build_auth_metadata(&username, &password) {
+                Ok(metadata) => {
+                    let get = |key| {
+                        metadata.get(key).map(|value| {
+                            value
+                                .to_str()
+                                .expect("test metadata should be visible ASCII")
+                                .to_string()
+                        })
+                    };
+                    AuthProjection::Metadata {
+                        username: get("username"),
+                        password: get("password"),
+                    }
+                }
+                Err(HealthError::GnmiError(message))
+                    if message.starts_with("invalid username for gRPC metadata:") =>
+                {
+                    AuthProjection::InvalidUsername
+                }
+                Err(HealthError::GnmiError(message))
+                    if message == "invalid password for gRPC metadata" =>
+                {
+                    AuthProjection::InvalidPassword
+                }
+                Err(error) => panic!("unexpected authentication metadata error: {error}"),
+            },
+        );
     }
 
     #[test]
-    fn test_typed_value_to_string_int() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::IntVal(-5)),
-        };
-        assert_eq!(typed_value_to_string(&val), Some("-5".to_string()));
-    }
-
-    #[test]
-    fn test_typed_value_to_string_uint() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::UintVal(100)),
-        };
-        assert_eq!(typed_value_to_string(&val), Some("100".to_string()));
-    }
-
-    #[test]
-    fn test_typed_value_to_string_bool() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::BoolVal(true)),
-        };
-        assert_eq!(typed_value_to_string(&val), Some("true".to_string()));
-    }
-
-    #[test]
-    fn test_typed_value_to_string_none() {
-        let val = proto::TypedValue { value: None };
-        assert_eq!(typed_value_to_string(&val), None);
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_double() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::DoubleVal(42.5)),
-        };
-        assert_eq!(typed_value_to_f64(&val), Some(42.5));
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_int() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::IntVal(42)),
-        };
-        assert_eq!(typed_value_to_f64(&val), Some(42.0));
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_json_string() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::JsonVal(b"\"1.5e-3\"".to_vec())),
-        };
-        assert_eq!(typed_value_to_f64(&val), Some(0.0015));
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_json_number() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::JsonVal(b"99.9".to_vec())),
-        };
-        assert_eq!(typed_value_to_f64(&val), Some(99.9));
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_string() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::StringVal("1.23".to_string())),
-        };
-        assert_eq!(typed_value_to_f64(&val), Some(1.23));
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_non_numeric_string() {
-        let val = proto::TypedValue {
-            value: Some(proto::typed_value::Value::StringVal("hello".to_string())),
-        };
-        assert_eq!(typed_value_to_f64(&val), None);
-    }
-
-    #[test]
-    fn test_typed_value_to_f64_none() {
-        let val = proto::TypedValue { value: None };
-        assert_eq!(typed_value_to_f64(&val), None);
-    }
-
-    #[test]
-    fn test_gnmi_client_stores_dangerous_tls_skip_flag() {
-        let strict = GnmiClient::new(GnmiClientConfig {
-            switch_id: "switch-1".to_string(),
-            host: "10.0.0.9".to_string(),
-            port: 9339,
-            username: None,
-            password: None,
-            request_timeout: Duration::from_secs(30),
-            dangerously_skip_tls_verification: false,
-            tls_config: None,
-        });
-
-        assert!(!strict.dangerously_skip_tls_verification);
-
-        let dangerous = GnmiClient::new(GnmiClientConfig {
-            switch_id: "switch-1".to_string(),
-            host: "10.0.0.9".to_string(),
-            port: 9339,
-            username: None,
-            password: None,
-            request_timeout: Duration::from_secs(30),
-            dangerously_skip_tls_verification: true,
-            tls_config: None,
-        });
-
-        assert!(dangerous.dangerously_skip_tls_verification);
-    }
-
-    #[test]
-    fn test_nvue_subscribe_paths_all_enabled() {
-        let paths = nvue_subscribe_paths(&NvueGnmiPaths::default());
-        assert_eq!(paths.len(), 4);
-
-        assert_eq!(paths[0].elem.len(), 2);
-        assert_eq!(paths[0].elem[0].name, "components");
-        assert_eq!(paths[0].elem[1].name, "component");
-
-        assert_eq!(paths[1].elem.len(), 2);
-        assert_eq!(paths[1].elem[0].name, "interfaces");
-        assert_eq!(paths[1].elem[1].name, "interface");
-
-        assert_eq!(paths[2].elem.len(), 2);
-        assert_eq!(paths[2].elem[0].name, "platform-general");
-        assert_eq!(paths[2].elem[1].name, "state");
-
-        assert_eq!(paths[3].elem.len(), 2);
-        assert_eq!(paths[3].elem[0].name, "platform-general");
-        assert_eq!(paths[3].elem[1].name, "versions");
-    }
-
-    #[test]
-    fn test_nvue_subscribe_paths_selective() {
-        let paths = nvue_subscribe_paths(&NvueGnmiPaths {
-            components_enabled: false,
-            interfaces_enabled: true,
-            platform_general_enabled: false,
-        });
-        assert_eq!(paths.len(), 1);
-        assert_eq!(paths[0].elem.len(), 2);
-        assert_eq!(paths[0].elem[0].name, "interfaces");
-        assert_eq!(paths[0].elem[1].name, "interface");
-    }
-
-    #[test]
-    fn test_nvue_subscribe_paths_platform_general_only() {
-        let paths = nvue_subscribe_paths(&NvueGnmiPaths {
-            components_enabled: false,
-            interfaces_enabled: false,
-            platform_general_enabled: true,
-        });
-        assert_eq!(paths.len(), 2);
-        assert_eq!(paths[0].elem.len(), 2);
-        assert_eq!(paths[0].elem[0].name, "platform-general");
-        assert_eq!(paths[0].elem[1].name, "state");
-        assert_eq!(paths[1].elem.len(), 2);
-        assert_eq!(paths[1].elem[0].name, "platform-general");
-        assert_eq!(paths[1].elem[1].name, "versions");
-    }
-
-    #[test]
-    fn test_nvue_subscribe_paths_none_enabled() {
-        let paths = nvue_subscribe_paths(&NvueGnmiPaths {
-            components_enabled: false,
-            interfaces_enabled: false,
-            platform_general_enabled: false,
-        });
-        assert!(paths.is_empty());
+    fn nvue_subscribe_path_cases() {
+        check_values(
+            [
+                Check {
+                    scenario: "all path groups",
+                    input: NvueGnmiPaths::default(),
+                    expect: "components/component,interfaces/interface,platform-general/state,platform-general/versions".to_string(),
+                },
+                Check {
+                    scenario: "components only",
+                    input: NvueGnmiPaths {
+                        components_enabled: true,
+                        interfaces_enabled: false,
+                        platform_general_enabled: false,
+                    },
+                    expect: "components/component".to_string(),
+                },
+                Check {
+                    scenario: "interfaces only",
+                    input: NvueGnmiPaths {
+                        components_enabled: false,
+                        interfaces_enabled: true,
+                        platform_general_enabled: false,
+                    },
+                    expect: "interfaces/interface".to_string(),
+                },
+                Check {
+                    scenario: "platform general only",
+                    input: NvueGnmiPaths {
+                        components_enabled: false,
+                        interfaces_enabled: false,
+                        platform_general_enabled: true,
+                    },
+                    expect: "platform-general/state,platform-general/versions".to_string(),
+                },
+                Check {
+                    scenario: "no path groups",
+                    input: NvueGnmiPaths {
+                        components_enabled: false,
+                        interfaces_enabled: false,
+                        platform_general_enabled: false,
+                    },
+                    expect: String::new(),
+                },
+            ],
+            |config| {
+                nvue_subscribe_paths(&config)
+                    .into_iter()
+                    .map(|path| {
+                        path.elem
+                            .into_iter()
+                            .map(|elem| elem.name)
+                            .collect::<Vec<_>>()
+                            .join("/")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(",")
+            },
+        );
     }
 
     #[test]
@@ -662,24 +845,6 @@ mod tests {
     }
 
     #[test]
-    fn test_system_events_prefix() {
-        let prefix = system_events_prefix();
-        assert_eq!(prefix.target, "nvos");
-        assert_eq!(prefix.elem.len(), 1);
-        assert_eq!(prefix.elem[0].name, "system-events");
-    }
-
-    #[test]
-    fn test_system_events_subscribe_path() {
-        let paths = system_events_subscribe_path();
-        assert_eq!(paths.len(), 1);
-        assert!(
-            paths[0].elem.is_empty(),
-            "empty path subscribes to all events under prefix"
-        );
-    }
-
-    #[test]
     fn test_build_on_change_subscribe_request() {
         let prefix = system_events_prefix();
         let paths = system_events_subscribe_path();
@@ -713,6 +878,13 @@ mod tests {
             sub_list.subscription[0].mode,
             i32::from(SubscriptionMode::OnChange),
             "subscription must use OnChange mode"
+        );
+        assert!(
+            sub_list.subscription[0]
+                .path
+                .as_ref()
+                .is_some_and(|path| path.elem.is_empty()),
+            "empty path subscribes to all events under prefix"
         );
     }
 }

--- a/crates/health/src/collectors/nvue/gnmi/subscriber.rs
+++ b/crates/health/src/collectors/nvue/gnmi/subscriber.rs
@@ -808,24 +808,41 @@ mod tests {
     use std::sync::Mutex as StdMutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async};
     use mac_address::MacAddress;
 
     use super::*;
     use crate::bmc::{BoxFuture, CredentialProvider};
     use crate::endpoint::{BmcAddr, BmcCredentials};
 
+    enum ProviderResponse {
+        Credentials(BmcCredentials),
+        Error(&'static str),
+        Pending,
+    }
+
+    enum RefreshInput {
+        ReconnectError(HealthError),
+        StreamStatus(tonic::Status),
+    }
+
     struct RecordingProvider {
         calls: AtomicUsize,
         observed_addrs: StdMutex<Vec<BmcAddr>>,
-        credentials: BmcCredentials,
+        response: ProviderResponse,
     }
 
     impl RecordingProvider {
         fn new(credentials: BmcCredentials) -> Arc<Self> {
+            Self::responding_with(ProviderResponse::Credentials(credentials))
+        }
+
+        fn responding_with(response: ProviderResponse) -> Arc<Self> {
             Arc::new(Self {
                 calls: AtomicUsize::new(0),
                 observed_addrs: StdMutex::new(Vec::new()),
-                credentials,
+                response,
             })
         }
     }
@@ -837,8 +854,14 @@ mod tests {
         ) -> BoxFuture<'a, Result<BmcCredentials, HealthError>> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             self.observed_addrs.lock().unwrap().push(endpoint.clone());
-            let credentials = self.credentials.clone();
-            Box::pin(async move { Ok(credentials) })
+            let response = match &self.response {
+                ProviderResponse::Credentials(credentials) => Ok(credentials.clone()),
+                ProviderResponse::Error(message) => {
+                    Err(HealthError::GenericError((*message).to_string()))
+                }
+                ProviderResponse::Pending => return Box::pin(std::future::pending()),
+            };
+            Box::pin(async move { response })
         }
     }
 
@@ -849,6 +872,46 @@ mod tests {
             mac: "55:66:77:88:99:cc"
                 .parse::<MacAddress>()
                 .expect("valid mac"),
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct CredentialFetchProjection {
+        result: Result<(Option<String>, Option<String>), String>,
+        calls: usize,
+        observed_addrs: Vec<(IpAddr, Option<u16>, String)>,
+    }
+
+    fn expected_credential_fetch(
+        result: Result<(Option<String>, Option<String>), String>,
+    ) -> CredentialFetchProjection {
+        let addr = test_addr();
+        CredentialFetchProjection {
+            result,
+            calls: 1,
+            observed_addrs: vec![(addr.ip, addr.port, addr.mac.to_string())],
+        }
+    }
+
+    fn project_credential_fetch(
+        provider: &RecordingProvider,
+        result: Result<GnmiUsernamePassword, HealthError>,
+    ) -> CredentialFetchProjection {
+        let result = result
+            .map(|credentials| (credentials.username, credentials.password))
+            .map_err(|error| error.to_string());
+        let observed_addrs = provider
+            .observed_addrs
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|addr| (addr.ip, addr.port, addr.mac.to_string()))
+            .collect();
+
+        CredentialFetchProjection {
+            result,
+            calls: provider.calls.load(Ordering::SeqCst),
+            observed_addrs,
         }
     }
 
@@ -926,56 +989,171 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gnmi_credentials_are_fetched_from_the_switch_endpoint_provider() {
+    async fn gnmi_credential_fetch_cases() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "username and password",
+                    input: ProviderResponse::Credentials(BmcCredentials::UsernamePassword {
+                        username: "nvos-admin".to_string(),
+                        password: Some("nvos-secret".to_string()),
+                    }),
+                    expect: Yields(expected_credential_fetch(Ok((
+                        Some("nvos-admin".to_string()),
+                        Some("nvos-secret".to_string()),
+                    )))),
+                },
+                Case {
+                    scenario: "username without password",
+                    input: ProviderResponse::Credentials(BmcCredentials::UsernamePassword {
+                        username: "nvos-admin".to_string(),
+                        password: None,
+                    }),
+                    expect: Yields(expected_credential_fetch(Ok((
+                        Some("nvos-admin".to_string()),
+                        None,
+                    )))),
+                },
+                Case {
+                    scenario: "session token",
+                    input: ProviderResponse::Credentials(BmcCredentials::SessionToken {
+                        token: "redfish-session-token".to_string(),
+                    }),
+                    expect: Yields(expected_credential_fetch(Err(
+                        "gNMI error: NVUE gNMI collector requires username/password credentials"
+                            .to_string(),
+                    ))),
+                },
+                Case {
+                    scenario: "credential provider error",
+                    input: ProviderResponse::Error("credential provider unavailable"),
+                    expect: Yields(expected_credential_fetch(Err(
+                        "generic error: credential provider unavailable".to_string(),
+                    ))),
+                },
+            ],
+            |response| async move {
+                let addr = test_addr();
+                let provider = RecordingProvider::responding_with(response);
+                let result = fetch_gnmi_username_password(provider.clone(), &addr).await;
+
+                Ok::<_, ()>(project_credential_fetch(&provider, result))
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gnmi_credential_fetch_times_out() {
         let addr = test_addr();
-        let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
-            username: "nvos-admin".to_string(),
-            password: Some("nvos-secret".to_string()),
-        });
+        let provider = RecordingProvider::responding_with(ProviderResponse::Pending);
+        let fetch_provider = provider.clone();
+        let fetch_addr = addr.clone();
+        let fetch =
+            tokio::spawn(
+                async move { fetch_gnmi_username_password(fetch_provider, &fetch_addr).await },
+            );
 
-        let credentials = fetch_gnmi_username_password(provider.clone(), &addr)
-            .await
-            .expect("username/password credentials are accepted");
+        tokio::time::advance(CREDENTIAL_REFRESH_TIMEOUT + Duration::from_secs(1)).await;
+        let result = fetch.await.expect("credential fetch task should join");
 
-        assert_eq!(credentials.username.as_deref(), Some("nvos-admin"));
-        assert_eq!(credentials.password.as_deref(), Some("nvos-secret"));
-        assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
-        let observed_addrs = provider.observed_addrs.lock().unwrap();
-        assert_eq!(observed_addrs.len(), 1);
-        assert_eq!(observed_addrs[0].ip, addr.ip);
-        assert_eq!(observed_addrs[0].port, addr.port);
         assert_eq!(
-            observed_addrs[0].mac, addr.mac,
-            "gNMI must ask the switch host endpoint provider using the switch host address"
+            project_credential_fetch(&provider, result),
+            expected_credential_fetch(Err(format!(
+                "gNMI error: Timed out after {}s fetching NVUE gNMI credentials",
+                CREDENTIAL_REFRESH_TIMEOUT.as_secs()
+            )))
         );
     }
 
     #[tokio::test]
-    async fn gnmi_client_provider_reuses_cached_credentials() {
-        let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
-            username: "nvos-admin".to_string(),
-            password: Some("nvos-secret".to_string()),
-        });
-        let client_provider = test_client_provider(provider.clone());
+    async fn gnmi_auth_refresh_cases() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "reconnect unauthenticated",
+                    input: RefreshInput::ReconnectError(HealthError::GnmiStatus(
+                        tonic::Status::unauthenticated("expired gNMI credentials"),
+                    )),
+                    expect: Yields(2),
+                },
+                Case {
+                    scenario: "reconnect permission denied",
+                    input: RefreshInput::ReconnectError(HealthError::GnmiStatus(
+                        tonic::Status::permission_denied("rejected gNMI credentials"),
+                    )),
+                    expect: Yields(2),
+                },
+                Case {
+                    scenario: "reconnect unavailable",
+                    input: RefreshInput::ReconnectError(HealthError::GnmiStatus(
+                        tonic::Status::unavailable("connection timed out"),
+                    )),
+                    expect: Yields(1),
+                },
+                Case {
+                    scenario: "non-gNMI error",
+                    input: RefreshInput::ReconnectError(HealthError::GenericError(
+                        "connection setup failed".to_string(),
+                    )),
+                    expect: Yields(1),
+                },
+                Case {
+                    scenario: "stream unauthenticated",
+                    input: RefreshInput::StreamStatus(tonic::Status::unauthenticated(
+                        "expired gNMI credentials",
+                    )),
+                    expect: Yields(2),
+                },
+                Case {
+                    scenario: "stream permission denied",
+                    input: RefreshInput::StreamStatus(tonic::Status::permission_denied(
+                        "rejected gNMI credentials",
+                    )),
+                    expect: Yields(2),
+                },
+                Case {
+                    scenario: "stream unavailable",
+                    input: RefreshInput::StreamStatus(tonic::Status::unavailable(
+                        "connection timed out",
+                    )),
+                    expect: Yields(1),
+                },
+            ],
+            |input| async move {
+                let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
+                    username: "nvos-admin".to_string(),
+                    password: Some("nvos-secret".to_string()),
+                });
+                let client_provider = test_client_provider(provider.clone());
+                let (_client, generation) =
+                    client_provider.new_client().await.expect("client builds");
 
-        client_provider
-            .new_client()
-            .await
-            .expect("first client builds");
-        client_provider
-            .new_client()
-            .await
-            .expect("second client builds");
+                match input {
+                    RefreshInput::ReconnectError(error) => {
+                        client_provider
+                            .refresh_auth_if_needed(&error, generation)
+                            .await;
+                    }
+                    RefreshInput::StreamStatus(status) => {
+                        client_provider
+                            .refresh_status_auth_if_needed(&status, generation)
+                            .await;
+                    }
+                }
+                client_provider
+                    .new_client()
+                    .await
+                    .expect("cached credentials are reused");
 
-        assert_eq!(
-            provider.calls.load(Ordering::SeqCst),
-            1,
-            "gNMI reconnects should reuse cached credentials until an auth failure is observed"
-        );
+                Ok::<_, ()>(provider.calls.load(Ordering::SeqCst))
+            },
+        )
+        .await;
     }
 
     #[tokio::test]
-    async fn gnmi_client_provider_refreshes_cached_credentials_after_auth_failure() {
+    async fn gnmi_client_provider_ignores_stale_refresh_generation() {
         let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
             username: "nvos-admin".to_string(),
             password: Some("nvos-secret".to_string()),
@@ -1020,74 +1198,5 @@ mod tests {
             2,
             "reconnect after refresh should reuse refreshed credentials"
         );
-    }
-
-    #[tokio::test]
-    async fn gnmi_client_provider_refreshes_cached_credentials_after_auth_stream_status() {
-        let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
-            username: "nvos-admin".to_string(),
-            password: Some("nvos-secret".to_string()),
-        });
-        let client_provider = test_client_provider(provider.clone());
-        let (_client, generation) = client_provider.new_client().await.expect("client builds");
-
-        client_provider
-            .refresh_status_auth_if_needed(
-                &tonic::Status::unauthenticated("expired gNMI credentials"),
-                generation,
-            )
-            .await;
-
-        assert_eq!(
-            provider.calls.load(Ordering::SeqCst),
-            2,
-            "in-stream unauthenticated statuses should refresh cached credentials"
-        );
-    }
-
-    #[tokio::test]
-    async fn gnmi_client_provider_does_not_refresh_cached_credentials_after_non_auth_failure() {
-        let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
-            username: "nvos-admin".to_string(),
-            password: Some("nvos-secret".to_string()),
-        });
-        let client_provider = test_client_provider(provider.clone());
-        let (_client, generation) = client_provider.new_client().await.expect("client builds");
-
-        client_provider
-            .refresh_auth_if_needed(
-                &HealthError::GnmiStatus(tonic::Status::unavailable("connection timed out")),
-                generation,
-            )
-            .await;
-        client_provider
-            .new_client()
-            .await
-            .expect("cached credentials are reused");
-
-        assert_eq!(
-            provider.calls.load(Ordering::SeqCst),
-            1,
-            "non-auth reconnect failures should not fetch credentials again"
-        );
-    }
-
-    #[tokio::test]
-    async fn gnmi_credentials_reject_session_tokens() {
-        let provider = RecordingProvider::new(BmcCredentials::SessionToken {
-            token: "redfish-session-token".to_string(),
-        });
-
-        let error = fetch_gnmi_username_password(provider, &test_addr())
-            .await
-            .expect_err("gNMI metadata auth requires username/password credentials");
-
-        match error {
-            HealthError::GnmiError(message) => assert!(
-                message.contains("requires username/password"),
-                "expected explicit credential-kind message, got: {message}"
-            ),
-            other => panic!("unexpected error variant: {other:?}"),
-        }
     }
 }

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1826,7 +1826,7 @@ where
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{scenarios, value_scenarios};
+    use carbide_test_support::{Check, check_values, scenarios, value_scenarios};
 
     use super::*;
 
@@ -3004,6 +3004,7 @@ skip_empty_reports = false
     fn test_nvue_config_defaults() {
         let defaults = NvueCollectorConfig::default();
         assert!(defaults.rest.is_enabled());
+        assert!(!defaults.gnmi.is_enabled());
 
         if let Configurable::Enabled(ref rest) = defaults.rest {
             assert_eq!(rest.poll_interval, Duration::from_secs(300));
@@ -3278,34 +3279,135 @@ platform_environment_leakage_enabled = false
     }
 
     #[test]
-    fn test_nvue_gnmi_events_disabled() {
-        let toml_content = r#"
-[endpoint_sources.carbide_api]
-enabled = false
-
-[sinks.health_report]
-enabled = false
-
-[collectors.nvue.gnmi]
-gnmi_port = 9339
-system_events_enabled = false
-"#;
-
-        let config: Config = Figment::new()
-            .merge(Serialized::defaults(Config::default()))
-            .merge(Toml::string(toml_content))
-            .extract()
-            .expect("failed to parse");
-
-        if let Configurable::Enabled(ref nvue) = config.collectors.nvue {
-            if let Configurable::Enabled(ref gnmi) = nvue.gnmi {
-                assert!(!gnmi.system_events_enabled);
-            } else {
-                panic!("gnmi config should be enabled");
-            }
-        } else {
-            panic!("nvue config should be enabled");
+    fn nvue_gnmi_config_parsing() {
+        #[derive(Debug, PartialEq)]
+        enum Projection {
+            NvueDisabled,
+            GnmiDisabled,
+            Enabled {
+                port: u16,
+                sample_interval: Duration,
+                request_timeout: Duration,
+                dangerously_skip_tls_verification: bool,
+                system_events_enabled: bool,
+                components_enabled: bool,
+                interfaces_enabled: bool,
+                platform_general_enabled: bool,
+            },
         }
+
+        check_values(
+            [
+                Check {
+                    scenario: "NVUE disabled",
+                    input: "",
+                    expect: Projection::NvueDisabled,
+                },
+                Check {
+                    scenario: "gNMI disabled",
+                    input: "[collectors.nvue]",
+                    expect: Projection::GnmiDisabled,
+                },
+                Check {
+                    scenario: "gNMI defaults",
+                    input: "[collectors.nvue.gnmi]",
+                    expect: Projection::Enabled {
+                        port: 9339,
+                        sample_interval: Duration::from_secs(300),
+                        request_timeout: Duration::from_secs(30),
+                        dangerously_skip_tls_verification: false,
+                        system_events_enabled: true,
+                        components_enabled: true,
+                        interfaces_enabled: true,
+                        platform_general_enabled: true,
+                    },
+                },
+                Check {
+                    scenario: "custom gNMI settings and paths",
+                    input: r#"
+[collectors.nvue.gnmi]
+gnmi_port = 19339
+sample_interval = "45s"
+request_timeout = "7s"
+dangerously_skip_tls_verification = true
+system_events_enabled = false
+
+[collectors.nvue.gnmi.paths]
+components_enabled = false
+interfaces_enabled = true
+platform_general_enabled = false
+"#,
+                    expect: Projection::Enabled {
+                        port: 19339,
+                        sample_interval: Duration::from_secs(45),
+                        request_timeout: Duration::from_secs(7),
+                        dangerously_skip_tls_verification: true,
+                        system_events_enabled: false,
+                        components_enabled: false,
+                        interfaces_enabled: true,
+                        platform_general_enabled: false,
+                    },
+                },
+                Check {
+                    scenario: "system events subscription alias",
+                    input: r#"
+[collectors.nvue.gnmi]
+system_events_subscription_enabled = false
+"#,
+                    expect: Projection::Enabled {
+                        port: 9339,
+                        sample_interval: Duration::from_secs(300),
+                        request_timeout: Duration::from_secs(30),
+                        dangerously_skip_tls_verification: false,
+                        system_events_enabled: false,
+                        components_enabled: true,
+                        interfaces_enabled: true,
+                        platform_general_enabled: true,
+                    },
+                },
+                Check {
+                    scenario: "events enabled alias",
+                    input: r#"
+[collectors.nvue.gnmi]
+events_enabled = false
+"#,
+                    expect: Projection::Enabled {
+                        port: 9339,
+                        sample_interval: Duration::from_secs(300),
+                        request_timeout: Duration::from_secs(30),
+                        dangerously_skip_tls_verification: false,
+                        system_events_enabled: false,
+                        components_enabled: true,
+                        interfaces_enabled: true,
+                        platform_general_enabled: true,
+                    },
+                },
+            ],
+            |toml| {
+                let config: Config = Figment::new()
+                    .merge(Serialized::defaults(Config::default()))
+                    .merge(Toml::string(toml))
+                    .extract()
+                    .expect("failed to parse NVUE gNMI config");
+                let Configurable::Enabled(nvue) = config.collectors.nvue else {
+                    return Projection::NvueDisabled;
+                };
+                let Configurable::Enabled(gnmi) = nvue.gnmi else {
+                    return Projection::GnmiDisabled;
+                };
+
+                Projection::Enabled {
+                    port: gnmi.gnmi_port,
+                    sample_interval: gnmi.sample_interval,
+                    request_timeout: gnmi.request_timeout,
+                    dangerously_skip_tls_verification: gnmi.dangerously_skip_tls_verification,
+                    system_events_enabled: gnmi.system_events_enabled,
+                    components_enabled: gnmi.paths.components_enabled,
+                    interfaces_enabled: gnmi.paths.interfaces_enabled,
+                    platform_general_enabled: gnmi.paths.platform_general_enabled,
+                }
+            },
+        );
     }
 
     #[test]
@@ -3515,60 +3617,6 @@ root_ca = "/var/run/secrets/spiffe.io/ca.crt"
                 .lines()
                 .any(|line| line == "platform_environment_fan_enabled = true")
         );
-    }
-
-    #[test]
-    fn test_nvue_gnmi_dangerous_tls_skip_defaults_false_and_parses_true() {
-        let omitted = r#"
-[endpoint_sources.carbide_api]
-enabled = false
-
-[sinks.health_report]
-enabled = false
-
-[collectors.nvue.gnmi]
-gnmi_port = 9339
-"#;
-
-        let config: Config = Figment::new()
-            .merge(Serialized::defaults(Config::default()))
-            .merge(Toml::string(omitted))
-            .extract()
-            .expect("failed to parse omitted tls flag");
-
-        let Configurable::Enabled(nvue) = config.collectors.nvue else {
-            panic!("nvue config should be enabled");
-        };
-        let Configurable::Enabled(gnmi) = nvue.gnmi else {
-            panic!("gnmi config should be enabled");
-        };
-        assert!(!gnmi.dangerously_skip_tls_verification);
-
-        let enabled = r#"
-[endpoint_sources.carbide_api]
-enabled = false
-
-[sinks.health_report]
-enabled = false
-
-[collectors.nvue.gnmi]
-gnmi_port = 9339
-dangerously_skip_tls_verification = true
-"#;
-
-        let config: Config = Figment::new()
-            .merge(Serialized::defaults(Config::default()))
-            .merge(Toml::string(enabled))
-            .extract()
-            .expect("failed to parse enabled tls flag");
-
-        let Configurable::Enabled(nvue) = config.collectors.nvue else {
-            panic!("nvue config should be enabled");
-        };
-        let Configurable::Enabled(gnmi) = nvue.gnmi else {
-            panic!("gnmi config should be enabled");
-        };
-        assert!(gnmi.dangerously_skip_tls_verification);
     }
 
     #[test]


### PR DESCRIPTION
The gNMI client spread one conversion contract across fourteen direct tests, repeated path/configuration decisions in separate entries, and had no direct coverage for authentication metadata or the credential timeout. The subscriber refresh checks also left `PermissionDenied` and non-gNMI failures implicit.

So, this gives each decision one table at its production owner:

- nineteen `TypedValue` rows enumerate every oneof variant and check named string plus `f64` projections;
- six authentication-metadata rows cover absent, partial, valid, and invalid credentials, including password-error redaction;
- five path rows cover all groups, each individual group, and none;
- four credential-fetch rows check credential kinds, provider errors, the exact `BmcAddr`, and one provider call, with the timeout kept as a separate paused-time test;
- seven refresh rows cover both authentication codes and negative reconnect/stream cases, while the stale-generation sequence remains standalone;
- six configuration rows cover nested enablement, defaults, custom values/paths, and both event-setting aliases.

The negative refresh rows also own cached-credential reuse, so the older standalone cache test can go away. The health suite moves from 405 Original entries to 384 Converted entries and stays at 384 after expansion.

Production code is byte-identical across all three checkpoints. Coverage excluding test-module bodies is:

| Scope | Original | Converted | Expanded |
| --- | ---: | ---: | ---: |
| Selected owners -- functions | 7/11 | 7/11 | 11/11 |
| Selected owners -- line instances | 114/147 | 114/147 | 147/147 |
| Selected owners -- regions | 104/150 | 104/150 | 150/150 |
| Three production files -- functions | 145/186 | 145/186 | 150/187 |
| Three production files -- line instances | 1,429/1,917 | 1,429/1,917 | 1,465/1,920 |
| Three production files -- regions | 1,495/2,174 | 1,495/2,174 | 1,545/2,179 |

The extra production record is the test-invoked `Configurable<NvueGnmiConfig>::is_enabled` monomorph. No production location loses coverage.

## Related issues

- Closes #4087
- Part of #3914

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-health --lib` -- 384 passed
- `cargo llvm-cov` checkpoint -- 384 passed
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- Local CodeRabbit review -- no findings
- Independent Claude review -- no correctness findings; named expected fields adopted

## Additional Notes

The removed dangerous-TLS test inspected `GnmiClient` private storage. Configuration parsing and its TLS-policy validation remain covered; this PR does not pin private field assignment as a separate contract.

Downstream notification routing, row assembly, discovery spawning, shared TLS behavior, and Redfish credential tests remain unchanged because they own separate behavior.
