### PR TITLE
fix(health): wrap static machine id in Some after field made optional

### DIFF
--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1852,7 +1852,7 @@ mod tests {
 
     fn static_machine() -> StaticMachineEndpoint {
         StaticMachineEndpoint {
-            id: "machine-id".to_string(),
+            id: Some("machine-id".to_string()),
             serial: None,
             driver_version: None,
             slot_number: None,


### PR DESCRIPTION
PR #4003 changed \`StaticMachineEndpoint.id\` from \`String\` to \`Option<String>\` but the test fixture at \`crates/health/src/config.rs:1855\` was not updated, leaving \`id: "machine-id".to_string()\` where \`Option<String>\` is now expected. This breaks \`cargo test -p carbide-health --lib\` and the lint-police \`clippy-flow\` step.

## Related issues

Caused by #4003.

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] \`cargo test -p carbide-health --lib\` — 406 passed, 0 failed