### PR TITLE
patch(2.0): Make ovs port moves tolerant to OVS failures (#4029)

### DIFF
--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -494,6 +494,13 @@ mod tests {
             .unwrap();
 
         // The loop should emit one assignment and invocation per bridge entry.
+        // Verify unavailable representors do not abort the remaining cloud-init work.
+        assert!(rendered.contains(
+            r#"set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}' || true"#
+        ));
+        assert!(rendered.contains(
+            r#"ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport) || true"#
+        ));
         assert!(rendered.contains("ovs-vsctl get bridge br-sfc external_ids"));
         assert!(rendered.contains("ovs-vsctl --may-exist add-port br-sfc"));
         assert!(rendered.contains(

--- a/pxe/templates/user-data
+++ b/pxe/templates/user-data
@@ -341,11 +341,12 @@ write_files:
           # Adjust the sfc.conf to insert our patch port where the host representor used to be
           sed -i "s#{{ forge_hbn_bridge }}~${host_representor}~${host_representor}_if_r~${host_representor}_if~${host_representor}_if_r#{{ forge_hbn_bridge }}~${host_intercept_hbn_port}~${host_representor}_if_r~${host_representor}_if~${host_representor}_if_r#" /etc/mellanox/sfc.conf
 
+          # Keep the OVSDB move when its backing host PF/VF is not available yet.
           # Now pop the host representor off of br-hbn and attach it to the host intercept bridge
           ovs-vsctl --if-exists del-port "${host_representor}" -- \
             --may-exist add-port "${host_intercept_bridge_name}" "${host_representor}" -- \
-            set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}'
-          ovs-vsctl set interface "${host_representor}" ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport)
+            set interface "${host_representor}" type=dpdk mtu_request=9216 external_ids='{}' || true
+          ovs-vsctl set interface "${host_representor}" ofport_request=$(ovs-vsctl get interface "${host_representor}" ofport) || true
 
           # Add the detail about the "uplink" for this bridge to external ids for the bridge
           ovs-vsctl br-set-external-id "${host_intercept_bridge_name}" bridge-uplink "${host_intercept_bridge_port}"


### PR DESCRIPTION
Backports #4029 to `release/v2.0`.

DPU provisioning can encounter a transient OVS failure when a host PF/VF representor has not materialized yet. That failure currently terminates cloud-init before service restart and Scout execution.

This change keeps the existing OVS configuration and `ofport_request` synchronization attempts, but makes those operations tolerant of the expected transient failure. The working PF path remains unchanged.

  ## Related issues

  - Original fix: #4029
  - Related issue: #4028

  ## Type of Change

  - [ ] **Add** - New feature or capability
  - [ ] **Change** - Changes in existing functionality
  - [x] **Fix** - Bug fixes
  - [ ] **Remove** - Removed features or deprecated functionality
  - [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

  ## Breaking Changes

  - [ ] **This PR contains breaking changes**

  No breaking changes are expected.

  ## Testing

  - [x] Unit tests added/updated
  - [ ] Integration tests added/updated
  - [ ] Manual testing performed
  - [ ] No testing required (docs, internal refactor, etc.)

  ## Additional Notes

Cherry-picked from 58959fcf5eab90c93faa4df3d94da3620884ae0a.

The production template change is unchanged from the original fix. The associated test was adapted to preserve the existing release/v2.0 assertions.
