### PR TITLE
perf(build): reduce debug info for CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -874,7 +874,6 @@ jobs:
             -e DATABASE_URL='postgresql://root@%2Fvar%2Frun%2Fpostgresql/root' \
             -e SCCACHE_DIR=/sccache \
             -e RUSTC_WRAPPER=sccache \
-            -e CARGO_PROFILE_RELEASE_DEBUG=true \
             -e CI_COMMIT_SHORT_SHA="${CI_COMMIT_SHORT_SHA}" \
             -e VERSION="${VERSION}" \
             -e CONTAINER_REPO_ROOT=/carbide \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,10 @@ zeroize = { version = "1", features = ["derive"] }
 zip = { version = "8.6", default-features = false }
 jsonpath-rust = "1.0.4"
 
+[profile.ci-tests]
+inherits = "dev"
+debug = "line-tables-only"
+
 [profile.release]
 debug = "line-tables-only"
 debug-assertions = true    # Add some extra assurance during development

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -711,8 +711,10 @@ dependencies = [
 
 [tasks.test-release-container-services]
 workspace = false
-dependencies = [
-  "test-flow",
+command = "cargo"
+args = [
+  "test",
+  "--profile=ci-tests",
 ]
 
 [tasks.build-and-test-release-container-services]


### PR DESCRIPTION
The `test-release-container-services` job builds the workspace test targets using Cargo’s development profile. Development builds generate full debug information by default, adding unnecessary work to the job’s lengthy compilation phase.

Add a dedicated `ci-tests` profile that inherits development behavior but generates line tables instead of complete debug metadata. The workflow passes this profile through cargo-make when compiling and running the tests.

Line tables preserve function names and source locations in panic backtraces, while avoiding the cost of generating debug information intended for interactive debugging. Local development and release profiles remain unchanged.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

It reduces tests compilation time from ~8m to ~5m 30s. 

