### PR TITLE
docs: add GPU support to HCL

### DIFF
--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -68,7 +68,7 @@ NICo supports all current NVIDIA data center GPUs.
 
 Unlike host platforms, GPU compatibility is not validated on a per-platform basis in this Hardware Compatibility List. GPU support is provided through the supported host platforms and NVIDIA software stack. For platform-specific GPU qualification, certification, thermal, power, or configuration guidance, refer to your server manufacturer.
 
-GPU Family | Support
---- | ---
-Current NVIDIA Data Center GPUs | Supported
+| GPU Family | Support |
+| ---------- | ------- |
+| Current NVIDIA Data Center GPUs | Supported |
 

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -64,7 +64,7 @@ This list outlines platforms that are under development and have not undergone f
 
 ## GPUs
 
-All current NVIDIA data center GPUs are supported by NICo.
+NICo supports all current NVIDIA data center GPUs.
 
 Unlike host platforms, GPU compatibility is not validated on a per-platform basis in this Hardware Compatibility List. GPU support is provided through the supported host platforms and NVIDIA software stack. For platform-specific GPU qualification, certification, thermal, power, or configuration guidance, refer to your server manufacturer.
 

--- a/docs/hcl.md
+++ b/docs/hcl.md
@@ -62,3 +62,13 @@ This list outlines platforms that are under development and have not undergone f
 | BlueField 2  | DOCA 3.2.0                                        |
 | BlueField 3  | DOCA 3.2.0                                        |
 
+## GPUs
+
+All current NVIDIA data center GPUs are supported by NICo.
+
+Unlike host platforms, GPU compatibility is not validated on a per-platform basis in this Hardware Compatibility List. GPU support is provided through the supported host platforms and NVIDIA software stack. For platform-specific GPU qualification, certification, thermal, power, or configuration guidance, refer to your server manufacturer.
+
+GPU Family | Support
+--- | ---
+Current NVIDIA Data Center GPUs | Supported
+


### PR DESCRIPTION
## Summary

- add a GPUs section immediately after the existing DPUs section
- document support for all current NVIDIA data center GPUs
- clarify that platform-specific GPU qualification, certification, thermal, power, and configuration guidance remains with the server manufacturer
- keep the existing host/platform compatibility information at the top of the HCL

## Impact

Readers can now confirm NICo's general GPU support policy directly in the Hardware Compatibility List while retaining the existing platform-first organization.

## Validation

- `git diff --check`
- reviewed the rendered Markdown structure and exact approved copy