### PR TITLE
feat(redfish): count skipped DPU UEFI password setup

### DIFF
--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -31,12 +31,73 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 pub use auth::RedfishAuth;
+use carbide_instrument::{DynamicMessage, Event, LabelValue, emit};
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
 use carbide_utils::HostPortPair;
 use carbide_utils::redfish::BmcAccessInfo;
 pub use error::RedfishClientCreationError;
 use libredfish::Redfish;
 use libredfish::model::service_root::RedfishVendor;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum DpuUefiPasswordSetupSkipReason {
+    BiosAttributesMissing,
+    BiosAttributesNotObject,
+    CurrentUefiPasswordMissing,
+}
+
+/// The DPU BIOS response cannot support replacing its factory UEFI password.
+///
+/// The response and all credentials stay out of both telemetry surfaces; the
+/// bounded reason is enough to identify the incompatible response form.
+#[derive(Event)]
+#[event(
+    event_name = "dpu_uefi_password_setup_skipped",
+    metric_name = "carbide_dpu_uefi_password_setup_skips_total",
+    component = "carbide-redfish",
+    log = warn,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of DPU UEFI password setup operations skipped, by reason."
+)]
+struct DpuUefiPasswordSetupSkipped {
+    #[label]
+    reason: DpuUefiPasswordSetupSkipReason,
+}
+
+impl DynamicMessage for DpuUefiPasswordSetupSkipped {
+    fn message(&self) -> &'static str {
+        match self.reason {
+            DpuUefiPasswordSetupSkipReason::BiosAttributesMissing => {
+                "BIOS Attributes are missing in the Redfish System BIOS endpoint, skipping UEFI password setting"
+            }
+            DpuUefiPasswordSetupSkipReason::BiosAttributesNotObject => {
+                "BIOS attributes are not an object in the Redfish System BIOS endpoint, skipping UEFI password setting"
+            }
+            DpuUefiPasswordSetupSkipReason::CurrentUefiPasswordMissing => {
+                "BIOS Attributes exist, but is missing CurrentUefiPassword key, skipping UEFI password setting"
+            }
+        }
+    }
+}
+
+fn emit_dpu_uefi_password_setup_skipped_if_needed(
+    bios_attrs: &std::collections::HashMap<String, serde_json::Value>,
+) -> bool {
+    let reason = match bios_attrs.get("Attributes") {
+        None => DpuUefiPasswordSetupSkipReason::BiosAttributesMissing,
+        Some(attrs) => match attrs.as_object() {
+            None => DpuUefiPasswordSetupSkipReason::BiosAttributesNotObject,
+            Some(attrs) if !attrs.contains_key("CurrentUefiPassword") => {
+                DpuUefiPasswordSetupSkipReason::CurrentUefiPasswordMissing
+            }
+            Some(_) => return false,
+        },
+    };
+
+    emit(DpuUefiPasswordSetupSkipped { reason });
+    true
+}
 
 pub fn new_pool(
     credential_reader: Arc<dyn CredentialReader>,
@@ -155,39 +216,14 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 .await
                 .map_err(RedfishClientCreationError::RedfishError)?;
 
-            //
-            // This should be changed to be an actual failure once we make it this far since we don't
-            // want to leave machines lying around in the datacenter without UEFI credentials.
-            //
-            // But adding logs here so that we know when it happens
-            //
-            match bios_attrs.get("Attributes") {
-                None => {
-                    tracing::warn!(
-                        "BIOS Attributes are missing in the Redfish System BIOS endpoint, skipping UEFI password setting"
-                    );
-                    return Ok(None);
-                }
-                Some(attrs) => match attrs.as_object() {
-                    None => {
-                        tracing::warn!(
-                            "BIOS attributes are not an object in the Redfish System BIOS endpoint, skipping UEFI password setting"
-                        );
-                        return Ok(None);
-                    }
-                    Some(attrs) if !attrs.contains_key("CurrentUefiPassword") => {
-                        tracing::warn!(
-                            "BIOS Attributes exist, but is missing CurrentUefiPassword key, skipping UEFI password setting"
-                        );
-                        return Ok(None);
-                    }
-                    _ => {
-                        tracing::info!(
-                            "BIOS Attributes found, and contains CurrentUefiPassword, continuing with UEFI password setting"
-                        );
-                    }
-                },
+            // Preserve the non-fatal return for now, but this should become a hard
+            // failure once callers can reject DPUs that retain factory credentials.
+            if emit_dpu_uefi_password_setup_skipped_if_needed(&bios_attrs) {
+                return Ok(None);
             }
+            tracing::info!(
+                "BIOS Attributes found, and contains CurrentUefiPassword, continuing with UEFI password setting"
+            );
 
             // Replace the DPU UEFI default password with the site default.
             // The current (factory) password is taken from the DpuUefi factory
@@ -647,10 +683,133 @@ pub fn redact_passwords(
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use libredfish::PowerState;
 
     use super::*;
     use crate::libredfish::test_support::*;
+
+    #[derive(Debug, PartialEq)]
+    struct DpuUefiPasswordSetupObservation {
+        skipped: bool,
+        counter_deltas: [f64; 3],
+        log_count: usize,
+        level: Option<tracing::Level>,
+        metadata_name: Option<String>,
+        message: Option<String>,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        reason: Option<String>,
+    }
+
+    #[test]
+    fn dpu_uefi_password_setup_skips_only_incompatible_bios_attributes() {
+        const EVENT_NAME: &str = "dpu_uefi_password_setup_skipped";
+        const METRIC_NAME: &str = "carbide_dpu_uefi_password_setup_skips_total";
+
+        carbide_test_support::value_scenarios!(
+            run = |bios_attrs: serde_json::Value| {
+                let bios_attrs: std::collections::HashMap<String, serde_json::Value> =
+                    serde_json::from_value(bios_attrs).expect("valid test BIOS response");
+                let metrics = MetricsCapture::start();
+                let mut skipped = false;
+                let logs = capture_logs(|| {
+                    skipped = emit_dpu_uefi_password_setup_skipped_if_needed(&bios_attrs);
+                });
+                let logs = logs
+                    .into_iter()
+                    .filter(|log| log.field("event_name") == Some(EVENT_NAME))
+                    .collect::<Vec<_>>();
+                let log = logs.first();
+
+                DpuUefiPasswordSetupObservation {
+                    skipped,
+                    counter_deltas: [
+                        metrics.counter_delta(
+                            METRIC_NAME,
+                            &[("reason", "bios_attributes_missing")],
+                        ),
+                        metrics.counter_delta(
+                            METRIC_NAME,
+                            &[("reason", "bios_attributes_not_object")],
+                        ),
+                        metrics.counter_delta(
+                            METRIC_NAME,
+                            &[("reason", "current_uefi_password_missing")],
+                        ),
+                    ],
+                    log_count: logs.len(),
+                    level: log.map(|log| log.level),
+                    metadata_name: log.map(|log| log.metadata_name.clone()),
+                    message: log.map(|log| log.message.clone()),
+                    event_name: log
+                        .and_then(|log| log.field("event_name"))
+                        .map(str::to_string),
+                    metric_name: log
+                        .and_then(|log| log.field("metric_name"))
+                        .map(str::to_string),
+                    reason: log
+                        .and_then(|log| log.field("reason"))
+                        .map(str::to_string),
+                }
+            };
+            "incompatible BIOS attributes skip password setup" {
+                serde_json::json!({}) => DpuUefiPasswordSetupObservation {
+                    skipped: true,
+                    counter_deltas: [1.0, 0.0, 0.0],
+                    log_count: 1,
+                    level: Some(tracing::Level::WARN),
+                    metadata_name: Some(EVENT_NAME.to_string()),
+                    message: Some(
+                        "BIOS Attributes are missing in the Redfish System BIOS endpoint, skipping UEFI password setting".to_string(),
+                    ),
+                    event_name: Some(EVENT_NAME.to_string()),
+                    metric_name: Some(METRIC_NAME.to_string()),
+                    reason: Some("bios_attributes_missing".to_string()),
+                },
+                serde_json::json!({"Attributes": []}) => DpuUefiPasswordSetupObservation {
+                    skipped: true,
+                    counter_deltas: [0.0, 1.0, 0.0],
+                    log_count: 1,
+                    level: Some(tracing::Level::WARN),
+                    metadata_name: Some(EVENT_NAME.to_string()),
+                    message: Some(
+                        "BIOS attributes are not an object in the Redfish System BIOS endpoint, skipping UEFI password setting".to_string(),
+                    ),
+                    event_name: Some(EVENT_NAME.to_string()),
+                    metric_name: Some(METRIC_NAME.to_string()),
+                    reason: Some("bios_attributes_not_object".to_string()),
+                },
+                serde_json::json!({"Attributes": {"BootMode": "Uefi"}}) => DpuUefiPasswordSetupObservation {
+                    skipped: true,
+                    counter_deltas: [0.0, 0.0, 1.0],
+                    log_count: 1,
+                    level: Some(tracing::Level::WARN),
+                    metadata_name: Some(EVENT_NAME.to_string()),
+                    message: Some(
+                        "BIOS Attributes exist, but is missing CurrentUefiPassword key, skipping UEFI password setting".to_string(),
+                    ),
+                    event_name: Some(EVENT_NAME.to_string()),
+                    metric_name: Some(METRIC_NAME.to_string()),
+                    reason: Some("current_uefi_password_missing".to_string()),
+                },
+            }
+
+            "compatible BIOS attributes continue password setup" {
+                serde_json::json!({"Attributes": {"CurrentUefiPassword": ""}}) => DpuUefiPasswordSetupObservation {
+                    skipped: false,
+                    counter_deltas: [0.0, 0.0, 0.0],
+                    log_count: 0,
+                    level: None,
+                    metadata_name: None,
+                    message: None,
+                    event_name: None,
+                    metric_name: None,
+                    reason: None,
+                },
+            }
+        );
+    }
 
     /// The mask covers the union of ALL matches, including a needle's
     /// self-overlapping matches (`aa` occurs at both offsets in `xaaay`) and

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -64,6 +64,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>Number of DPU agents which have reported a certain version.</td></tr>
 <tr><td>carbide_dpu_firmware_version_count</td><td>gauge</td><td>Number of DPUs which have reported a certain firmware version.</td></tr>
 <tr><td>carbide_dpu_remediation_executor_failures_total</td><td>counter</td><td>Number of DPU remediation executor failures, by failure stage.</td></tr>
+<tr><td>carbide_dpu_uefi_password_setup_skips_total</td><td>counter</td><td>Number of DPU UEFI password setup operations skipped, by reason.</td></tr>
 <tr><td>carbide_dpus_healthy_count</td><td>gauge</td><td>Number of DPUs in the system that have reported healthy in the last report. Healthy does not imply up - the report from the DPU might be outdated.</td></tr>
 <tr><td>carbide_dpus_up_count</td><td>gauge</td><td>Number of DPUs in the system that are up. Up means we have received a health report less than 5 minutes ago.</td></tr>
 <tr><td>carbide_dropped_v6_requests_total</td><td>counter</td><td>Number of dropped DHCPv6 requests, by reason.</td></tr>


### PR DESCRIPTION
DPU UEFI setup already returns `Ok(None)` when a Redfish BIOS response cannot support replacing the factory password, and each of those branches logs a different warning. Since those skips can leave a DPU on factory credentials, they are operational failures worth counting even though the existing non-fatal behavior remains for now.

So, the three warning branches now emit `DpuUefiPasswordSetupSkipped` through one classifier. A bounded `reason` distinguishes missing attributes, non-object attributes, and a missing `CurrentUefiPassword` field; the exact existing warning text stays unchanged, and no BIOS response or credential material enters telemetry.

The table-driven test covers all three skip cases plus the compatible response and verifies that the Event writes exactly one warning and counter increment only when setup is skipped.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4107

Part of https://github.com/NVIDIA/infra-controller/issues/3169

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-redfish --features test-support --lib` (35 passed)
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo xtask check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

The legacy warning strings, including their existing grammar, are preserved byte-for-byte. The current `Ok(None)` behavior is also unchanged; the nearby comment still records the intent to make retained factory credentials a hard failure once callers can reject that DPU safely.