### PR TITLE
feat: minimal SMC GB300 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.2#5bf822b5e7814df67e2b9a8f98f41fb96dea0a3b"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.3#b199e7bebeb8238fe1440f110d06affba5b6b799"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.2" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.3" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 

--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -27,6 +27,7 @@ pub mod lenovo;
 pub mod lenovo_ami;
 pub mod lenovo_gb300;
 pub mod supermicro;
+pub mod supermicro_gb300;
 pub mod vera_rubin;
 pub mod viking;
 

--- a/crates/bmc-explorer/src/hw/supermicro_gb300.rs
+++ b/crates/bmc-explorer/src/hw/supermicro_gb300.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::hw::BiosAttr;
+
+/// Setup attributes exposed by the Supermicro OpenBMC firmware on GB300.
+///
+/// Unlike GB200, this platform does not expose `TPM`, `EmbeddedUefiShell`, or
+/// `SecureBootEnable`. `SecurityDeviceSupport` is its TPM control, while the
+/// PCIe option ROMs must be enabled for the host to expose the DPU boot target.
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 3] = [
+    BiosAttr::new_str("SecurityDeviceSupport", "Enabled"),
+    BiosAttr::new_bool("Socket0Pcie6DisableOptionROM", false),
+    BiosAttr::new_bool("Socket1Pcie6DisableOptionROM", false),
+];

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -389,9 +389,7 @@ pub(crate) fn hw_type<B: Bmc>(
         {
             return Some(hw::HwType::DgxGb300);
         }
-        // SMC GB300: Supermicro host BMC. The tray scrape shows ServiceRoot vendor "Supermicro"
-        // (Product "GB NVL", no OEM key), so the vendor string carries it -- no chassis helper
-        // needed. See gb300-firmus-ingestion/triangulation-matrix.md.
+        // SMC GB300: Supermicro OpenBMC host.
         if root.vendor() == Some(Vendor::new("Supermicro")) {
             return Some(hw::HwType::SupermicroGb300);
         }
@@ -1058,11 +1056,10 @@ fn machine_setup_status<B: Bmc>(
             }
         }
 
-        hw::HwType::DgxGb300 | hw::HwType::SupermicroGb300 => {
-            // GB300 platforms (DGX on the NVIDIA "GB BMC", SMC on a Supermicro OpenBMC) share
-            // the platform-level setup expectations: secure boot off and boot order by MAC.
-            // TODO(gb300): add per-ODM EXPECTED_BIOS_ATTRS tables once each GB300 tray's
-            // BIOS is characterized; until then no BIOS-attr verification is applied.
+        hw::HwType::DgxGb300 => {
+            // DGX GB300 on the NVIDIA "GB BMC" uses the platform-level setup expectations:
+            // secure boot off and boot order by MAC.
+            // TODO(dgx-gb300): add EXPECTED_BIOS_ATTRS once the tray BIOS is characterized.
             if explored_system
                 .secure_boot_status()
                 .is_ok_and(|s| s.is_enabled)
@@ -1073,6 +1070,31 @@ fn machine_setup_status<B: Bmc>(
                     actual: "true".to_string(),
                 })
             }
+            if let Some(mac) = boot_interface_mac {
+                let actual = explored_system.boot_order_first_option();
+                let mac_str = format!("/MAC({},", mac.to_string().replace(":", ""));
+                let expected = explored_system.boot_options.iter().find(|option| {
+                    option.uefi_device_path().is_some_and(|path| {
+                        path.inner().contains(&mac_str)
+                            && path.inner().contains("/IPv4(")
+                            && path.inner().ends_with("/Uri()")
+                    })
+                });
+                if let Some(diff) = compare_boot_options(expected, actual) {
+                    diffs.push(diff)
+                }
+            }
+        }
+
+        hw::HwType::SupermicroGb300 => {
+            // Supermicro GB300 uses the GBx00 OpenBMC flow, but its firmware does not expose
+            // SecureBootEnable or EmbeddedUefiShell. Verify only the controls present in the
+            // real tray: TPM support and the DPU-facing PCIe option ROMs.
+            diffs.extend(
+                hw::supermicro_gb300::EXPECTED_BIOS_ATTRS
+                    .iter()
+                    .flat_map(|expected| explored_system.verify_bios_attr(expected)),
+            );
             if let Some(mac) = boot_interface_mac {
                 let actual = explored_system.boot_order_first_option();
                 let mac_str = format!("/MAC({},", mac.to_string().replace(":", ""));

--- a/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
+++ b/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
@@ -63,11 +63,17 @@ async fn explore_supermicro_gb300() {
         setup
             .diffs
             .iter()
-            .map(|diff| diff.key.as_str())
+            .map(|diff| {
+                (
+                    diff.key.as_str(),
+                    diff.expected.as_str(),
+                    diff.actual.as_str(),
+                )
+            })
             .collect::<Vec<_>>(),
         [
-            "Socket0Pcie6DisableOptionROM",
-            "Socket1Pcie6DisableOptionROM",
+            ("Socket0Pcie6DisableOptionROM", "false", "true"),
+            ("Socket1Pcie6DisableOptionROM", "false", "true"),
         ]
     );
 }

--- a/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
+++ b/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
@@ -54,4 +54,20 @@ async fn explore_supermicro_gb300() {
     );
     assert!(!report.systems.is_empty(), "systems must be present");
     assert!(!report.chassis.is_empty(), "chassis must be present");
+
+    let setup = report
+        .machine_setup_status
+        .expect("SMC GB300 must report machine setup status");
+    assert!(!setup.is_done);
+    assert_eq!(
+        setup
+            .diffs
+            .iter()
+            .map(|diff| diff.key.as_str())
+            .collect::<Vec<_>>(),
+        [
+            "Socket0Pcie6DisableOptionROM",
+            "Socket1Pcie6DisableOptionROM",
+        ]
+    );
 }

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -182,7 +182,7 @@ impl SupermicroGB300Nvl<'_> {
                     base_bios: Some(base_bios(system_id)),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
                     boot_options: Some(boot_options),
-                    boot_order_mode: redfish::computer_system::BootOrderMode::OrderedCollection,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                     chassis: vec!["Chassis_0".into()],
                     eth_interfaces: None,
                     id: system_id.into(),

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -193,7 +193,9 @@ impl SupermicroGB300Nvl<'_> {
                     model: Some("GB NVL".into()),
                     oem: redfish::computer_system::Oem::Generic,
                     callbacks: Some(callbacks),
-                    secure_boot_available: true,
+                    // This firmware exposes the SecureBoot resource but omits
+                    // SecureBootEnable, so there is no usable status to report.
+                    secure_boot_available: false,
                     serial_console: Some(
                         redfish::serial_console::builder()
                             .max_concurrent_sessions(1)
@@ -299,12 +301,13 @@ impl SupermicroGB300Nvl<'_> {
 }
 
 fn base_bios(system_id: &str) -> serde_json::Value {
-    // libredfish uses this attribute to detect whether this BMC spells the
-    // enabled TPM state as "Enable" or "Enabled" before building its setup
-    // request. The suffixed key and value mirror a real Supermicro fixture.
+    // Security device support is already enabled; the DPU-facing option ROMs
+    // still need to be enabled by clearing their DisableOptionROM controls.
     redfish::bios::builder(&redfish::bios::resource(system_id))
         .attributes(json!({
-            "SecurityDeviceSupport_005A": "Enable",
+            "SecurityDeviceSupport": "Enabled",
+            "Socket0Pcie6DisableOptionROM": true,
+            "Socket1Pcie6DisableOptionROM": true,
         }))
         .build()
 }

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -124,7 +124,7 @@ impl SupermicroGB300Nvl<'_> {
         let system_id = "System_0";
         let boot_options = std::iter::once(
             redfish::boot_option::builder(
-                &redfish::boot_option::resource(system_id, "0002"),
+                &redfish::boot_option::resource(system_id, "Boot0002"),
                 BootOptionKind::Disk,
             )
             .boot_option_reference("Boot0002")
@@ -136,21 +136,20 @@ impl SupermicroGB300Nvl<'_> {
                 .into_iter()
                 .enumerate()
                 .map(|(n, nic)| {
-                    let id = format!("{:04X}", n + 3); // Starting with 0003
+                    let id = format!("Boot{:04X}", n + 3); // Starting with Boot0003
                     let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
                     redfish::boot_option::builder(
                         &redfish::boot_option::resource(system_id, &id),
                         BootOptionKind::Network,
                     )
-                    .boot_option_reference(&format!("Boot{id}"))
+                    .boot_option_reference(&id)
                     .display_name(&format!(
-                        "UEFI HTTP IPv4 Nvidia Network Adapter - {} - {}",
-                        nic.mac_address,
+                        "UEFI HTTPv4 (MAC:{})",
                         nic.mac_address.to_string().replace(":", "")
                     ))
                     .uefi_device_path(&format!(
                         "{pci_path}/MAC({},0x1)\
-                             /IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                         /IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
                         nic.mac_address.to_string().replace(":", "")
                     ))
                     .build()


### PR DESCRIPTION
This PR adds minimal support for OpenBMC-based Supermicro GB300 systems and bumps libredfish to `v0.46.3` for the required platform support which brings in the following changes:

- feat: minimal SMC GB300 support by @krish-nvidia in https://github.com/NVIDIA/libredfish/pull/111
- fix: pick the correct manager/system on multi-system, multi-chassis hosts by @shevchenko-evgeny in https://github.com/NVIDIA/libredfish/pull/108

Validated on a real SMC GB300.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/1909

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes