### PR TITLE
fix(admin-cli): emit valid expected device JSON

### DIFF
--- a/crates/admin-cli/src/async_write.rs
+++ b/crates/admin-cli/src/async_write.rs
@@ -80,3 +80,41 @@ macro_rules! async_write_table_as_csv {
         result
     }};
 }
+
+#[cfg(test)]
+pub(crate) struct CapturedOutput {
+    writer: Box<dyn tokio::io::AsyncWrite + Unpin>,
+    collect: tokio::task::JoinHandle<Vec<u8>>,
+}
+
+#[cfg(test)]
+impl CapturedOutput {
+    pub(crate) fn new() -> Self {
+        let (writer, mut reader) = tokio::io::duplex(64 * 1024);
+        let collect = tokio::spawn(async move {
+            use tokio::io::AsyncReadExt;
+
+            let mut output = Vec::new();
+            reader
+                .read_to_end(&mut output)
+                .await
+                .expect("captured output should be readable");
+            output
+        });
+
+        Self {
+            writer: Box::new(writer),
+            collect,
+        }
+    }
+
+    pub(crate) fn writer(&mut self) -> &mut Box<dyn tokio::io::AsyncWrite + Unpin> {
+        &mut self.writer
+    }
+
+    pub(crate) async fn into_bytes(self) -> Vec<u8> {
+        let Self { writer, collect } = self;
+        drop(writer);
+        collect.await.expect("output collector should complete")
+    }
+}

--- a/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
@@ -20,34 +20,73 @@ use std::collections::HashMap;
 use mac_address::MacAddress;
 use prettytable::{Table, row};
 use rpc::admin_cli::OutputFormat;
-use rpc::forge::ExpectedPowerShelfRequest;
+use rpc::forge::{ExpectedPowerShelf, ExpectedPowerShelfList, ExpectedPowerShelfRequest};
 
 use super::args::Args;
 use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
+use crate::{async_write, async_writeln};
+
+enum ShowResult {
+    Single(ExpectedPowerShelf),
+    List(ExpectedPowerShelfList),
+}
+
+enum RenderOutcome {
+    Complete,
+    TableRequired(ExpectedPowerShelfList),
+}
+
+async fn render_show_result(
+    result: ShowResult,
+    output_format: OutputFormat,
+    output: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+) -> CarbideCliResult<RenderOutcome> {
+    match result {
+        ShowResult::Single(expected_power_shelf) => {
+            if output_format == OutputFormat::Json {
+                async_writeln!(
+                    output,
+                    "{}",
+                    serde_json::to_string_pretty(&expected_power_shelf)?
+                )?;
+            } else {
+                async_writeln!(output, "{:#?}", expected_power_shelf)?;
+            }
+            Ok(RenderOutcome::Complete)
+        }
+        ShowResult::List(expected_power_shelves) if output_format == OutputFormat::Json => {
+            async_writeln!(
+                output,
+                "{}",
+                serde_json::to_string_pretty(&expected_power_shelves)?
+            )?;
+            Ok(RenderOutcome::Complete)
+        }
+        ShowResult::List(expected_power_shelves) => {
+            Ok(RenderOutcome::TableRequired(expected_power_shelves))
+        }
+    }
+}
 
 pub async fn show(
     query: Args,
     api_client: &ApiClient,
     output_format: OutputFormat,
+    output: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
 ) -> CarbideCliResult<()> {
     let req: Option<ExpectedPowerShelfRequest> = query.try_into()?;
 
-    if let Some(req) = req {
-        let expected_power_shelf = api_client.0.get_expected_power_shelf(req).await?;
-        if output_format == OutputFormat::Json {
-            println!("{}", serde_json::to_string_pretty(&expected_power_shelf)?);
-        } else {
-            println!("{:#?}", expected_power_shelf);
-        }
-        return Ok(());
-    }
+    let result = if let Some(req) = req {
+        ShowResult::Single(api_client.0.get_expected_power_shelf(req).await?)
+    } else {
+        ShowResult::List(api_client.0.get_all_expected_power_shelves().await?)
+    };
 
-    let expected_power_shelves = api_client.0.get_all_expected_power_shelves().await?;
-    if output_format == OutputFormat::Json {
-        println!("{}", serde_json::to_string_pretty(&expected_power_shelves)?);
-        return Ok(());
-    }
+    let expected_power_shelves = match render_show_result(result, output_format, output).await? {
+        RenderOutcome::Complete => return Ok(()),
+        RenderOutcome::TableRequired(expected_power_shelves) => expected_power_shelves,
+    };
 
     // TODO: This should be optimised. `find_interfaces` should accept a list of macs also and
     // return related interfaces details.
@@ -92,15 +131,18 @@ pub async fn show(
     );
 
     convert_and_print_into_nice_table(
+        output,
         &expected_power_shelves,
         &expected_bmc_ip_vs_ids,
         &expected_mi,
-    )?;
+    )
+    .await?;
 
     Ok(())
 }
 
-fn convert_and_print_into_nice_table(
+async fn convert_and_print_into_nice_table(
+    output: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
     expected_power_shelves: &::rpc::forge::ExpectedPowerShelfList,
     expected_discovered_machine_ids: &HashMap<String, String>,
     expected_discovered_machine_interfaces: &HashMap<MacAddress, ::rpc::forge::MachineInterface>,
@@ -155,7 +197,56 @@ fn convert_and_print_into_nice_table(
         ]);
     }
 
-    table.printstd();
+    async_write!(output, "{}", table)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+    use crate::async_write::CapturedOutput;
+
+    fn expected_power_shelf() -> ExpectedPowerShelf {
+        ExpectedPowerShelf {
+            bmc_mac_address: "00:11:22:33:44:55".to_string(),
+            shelf_serial_number: "shelf-1".to_string(),
+            ..Default::default()
+        }
+    }
+
+    async fn render_json(result: ShowResult) -> (RenderOutcome, Value) {
+        let mut captured = CapturedOutput::new();
+        let outcome = render_show_result(result, OutputFormat::Json, captured.writer())
+            .await
+            .expect("JSON output should render");
+        let output = captured.into_bytes().await;
+        let json = serde_json::from_slice(&output)
+            .expect("the complete captured output should be one JSON document");
+        (outcome, json)
+    }
+
+    #[tokio::test]
+    async fn single_json_output_is_complete_document() {
+        let (outcome, json) = render_json(ShowResult::Single(expected_power_shelf())).await;
+
+        assert!(matches!(outcome, RenderOutcome::Complete));
+        assert_eq!(json["shelf_serial_number"], "shelf-1");
+    }
+
+    #[tokio::test]
+    async fn list_json_output_is_complete_document() {
+        let list = ExpectedPowerShelfList {
+            expected_power_shelves: vec![expected_power_shelf()],
+        };
+        let (outcome, json) = render_json(ShowResult::List(list)).await;
+
+        assert!(matches!(outcome, RenderOutcome::Complete));
+        assert_eq!(
+            json["expected_power_shelves"][0]["shelf_serial_number"],
+            "shelf-1"
+        );
+    }
 }

--- a/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/cmd.rs
@@ -35,13 +35,18 @@ pub async fn show(
 
     if let Some(req) = req {
         let expected_power_shelf = api_client.0.get_expected_power_shelf(req).await?;
-        println!("{:#?}", expected_power_shelf);
+        if output_format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&expected_power_shelf)?);
+        } else {
+            println!("{:#?}", expected_power_shelf);
+        }
         return Ok(());
     }
 
     let expected_power_shelves = api_client.0.get_all_expected_power_shelves().await?;
     if output_format == OutputFormat::Json {
         println!("{}", serde_json::to_string_pretty(&expected_power_shelves)?);
+        return Ok(());
     }
 
     // TODO: This should be optimised. `find_interfaces` should accept a list of macs also and

--- a/crates/admin-cli/src/expected_power_shelf/show/mod.rs
+++ b/crates/admin-cli/src/expected_power_shelf/show/mod.rs
@@ -26,7 +26,13 @@ use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::show(self, &ctx.api_client, ctx.config.format).await?;
+        cmd::show(
+            self,
+            &ctx.api_client,
+            ctx.config.format,
+            &mut ctx.output_file,
+        )
+        .await?;
         Ok(())
     }
 }

--- a/crates/admin-cli/src/expected_switch/show/cmd.rs
+++ b/crates/admin-cli/src/expected_switch/show/cmd.rs
@@ -35,13 +35,18 @@ pub async fn show(
 
     if let Some(req) = req {
         let expected_switch = api_client.0.get_expected_switch(req).await?;
-        println!("{:#?}", expected_switch);
+        if output_format == OutputFormat::Json {
+            println!("{}", serde_json::to_string_pretty(&expected_switch)?);
+        } else {
+            println!("{:#?}", expected_switch);
+        }
         return Ok(());
     }
 
     let expected_switches = api_client.0.get_all_expected_switches().await?;
     if output_format == OutputFormat::Json {
         println!("{}", serde_json::to_string_pretty(&expected_switches)?);
+        return Ok(());
     }
 
     let linked_switches = api_client.0.get_all_expected_switches_linked().await?;

--- a/crates/admin-cli/src/expected_switch/show/cmd.rs
+++ b/crates/admin-cli/src/expected_switch/show/cmd.rs
@@ -20,34 +20,71 @@ use std::collections::HashMap;
 use mac_address::MacAddress;
 use prettytable::{Table, row};
 use rpc::admin_cli::OutputFormat;
-use rpc::forge::{ExpectedSwitchRequest, LinkedExpectedSwitch};
+use rpc::forge::{ExpectedSwitch, ExpectedSwitchList, ExpectedSwitchRequest, LinkedExpectedSwitch};
 
 use super::args::Args;
 use crate::errors::CarbideCliResult;
 use crate::rpc::ApiClient;
+use crate::{async_write, async_writeln};
+
+enum ShowResult {
+    Single(ExpectedSwitch),
+    List(ExpectedSwitchList),
+}
+
+enum RenderOutcome {
+    Complete,
+    TableRequired(ExpectedSwitchList),
+}
+
+async fn render_show_result(
+    result: ShowResult,
+    output_format: OutputFormat,
+    output: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+) -> CarbideCliResult<RenderOutcome> {
+    match result {
+        ShowResult::Single(expected_switch) => {
+            if output_format == OutputFormat::Json {
+                async_writeln!(
+                    output,
+                    "{}",
+                    serde_json::to_string_pretty(&expected_switch)?
+                )?;
+            } else {
+                async_writeln!(output, "{:#?}", expected_switch)?;
+            }
+            Ok(RenderOutcome::Complete)
+        }
+        ShowResult::List(expected_switches) if output_format == OutputFormat::Json => {
+            async_writeln!(
+                output,
+                "{}",
+                serde_json::to_string_pretty(&expected_switches)?
+            )?;
+            Ok(RenderOutcome::Complete)
+        }
+        ShowResult::List(expected_switches) => Ok(RenderOutcome::TableRequired(expected_switches)),
+    }
+}
 
 pub async fn show(
     query: &Args,
     api_client: &ApiClient,
     output_format: OutputFormat,
+    output: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
 ) -> CarbideCliResult<()> {
     let req: Option<ExpectedSwitchRequest> = query.try_into()?;
 
-    if let Some(req) = req {
-        let expected_switch = api_client.0.get_expected_switch(req).await?;
-        if output_format == OutputFormat::Json {
-            println!("{}", serde_json::to_string_pretty(&expected_switch)?);
-        } else {
-            println!("{:#?}", expected_switch);
-        }
-        return Ok(());
-    }
+    let result = if let Some(req) = req {
+        ShowResult::Single(api_client.0.get_expected_switch(req).await?)
+    } else {
+        ShowResult::List(api_client.0.get_all_expected_switches().await?)
+    };
 
-    let expected_switches = api_client.0.get_all_expected_switches().await?;
-    if output_format == OutputFormat::Json {
-        println!("{}", serde_json::to_string_pretty(&expected_switches)?);
-        return Ok(());
-    }
+    let expected_switches = match render_show_result(result, output_format, output).await? {
+        RenderOutcome::Complete => return Ok(()),
+        RenderOutcome::TableRequired(expected_switches) => expected_switches,
+    };
 
     let linked_switches = api_client.0.get_all_expected_switches_linked().await?;
     let linked_by_bmc_mac: HashMap<String, LinkedExpectedSwitch> = linked_switches
@@ -73,7 +110,8 @@ pub async fn show(
             }
         }));
 
-    convert_and_print_into_nice_table(&expected_switches, &linked_by_bmc_mac, &expected_mi)?;
+    convert_and_print_into_nice_table(output, &expected_switches, &linked_by_bmc_mac, &expected_mi)
+        .await?;
 
     Ok(())
 }
@@ -97,7 +135,8 @@ fn format_interface_ip(
     "Undiscovered".to_string()
 }
 
-fn convert_and_print_into_nice_table(
+async fn convert_and_print_into_nice_table(
+    output: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
     expected_switches: &::rpc::forge::ExpectedSwitchList,
     linked_by_bmc_mac: &HashMap<String, LinkedExpectedSwitch>,
     expected_discovered_machine_interfaces: &HashMap<MacAddress, ::rpc::forge::MachineInterface>,
@@ -157,7 +196,56 @@ fn convert_and_print_into_nice_table(
         ]);
     }
 
-    table.printstd();
+    async_write!(output, "{}", table)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::*;
+    use crate::async_write::CapturedOutput;
+
+    fn expected_switch() -> ExpectedSwitch {
+        ExpectedSwitch {
+            bmc_mac_address: "00:11:22:33:44:55".to_string(),
+            switch_serial_number: "switch-1".to_string(),
+            ..Default::default()
+        }
+    }
+
+    async fn render_json(result: ShowResult) -> (RenderOutcome, Value) {
+        let mut captured = CapturedOutput::new();
+        let outcome = render_show_result(result, OutputFormat::Json, captured.writer())
+            .await
+            .expect("JSON output should render");
+        let output = captured.into_bytes().await;
+        let json = serde_json::from_slice(&output)
+            .expect("the complete captured output should be one JSON document");
+        (outcome, json)
+    }
+
+    #[tokio::test]
+    async fn single_json_output_is_complete_document() {
+        let (outcome, json) = render_json(ShowResult::Single(expected_switch())).await;
+
+        assert!(matches!(outcome, RenderOutcome::Complete));
+        assert_eq!(json["switch_serial_number"], "switch-1");
+    }
+
+    #[tokio::test]
+    async fn list_json_output_is_complete_document() {
+        let list = ExpectedSwitchList {
+            expected_switches: vec![expected_switch()],
+        };
+        let (outcome, json) = render_json(ShowResult::List(list)).await;
+
+        assert!(matches!(outcome, RenderOutcome::Complete));
+        assert_eq!(
+            json["expected_switches"][0]["switch_serial_number"],
+            "switch-1"
+        );
+    }
 }

--- a/crates/admin-cli/src/expected_switch/show/mod.rs
+++ b/crates/admin-cli/src/expected_switch/show/mod.rs
@@ -26,7 +26,13 @@ use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
-        cmd::show(&self, &ctx.api_client, ctx.config.format).await?;
+        cmd::show(
+            &self,
+            &ctx.api_client,
+            ctx.config.format,
+            &mut ctx.output_file,
+        )
+        .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
The expected power shelf and expected switch `show` commands produced invalid
output when JSON format was selected. A single-resource query printed Rust
debug output instead of JSON, while a list query printed JSON and then
continued into table rendering, appending non-JSON text.

This change routes these commands through the runtime output writer and makes
the rendering decision explicit. JSON output completes immediately, while
non-JSON list output carries the already-fetched data into table rendering
without cloning or issuing another API request.

Four regression cases capture the complete output for single and list results
for both resource types and parse it with `serde_json::from_slice`. Appended
debug or table output therefore causes the tests to fail.

## Related issues

Fixes #4101

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation completed:

- `cargo test -p nico-admin-cli` — 397 passed, 0 failed
- `cargo test -p nico-admin-cli json_output_is_complete_document` — 4 passed, 0 failed
- `cargo clippy -p nico-admin-cli --all-targets --all-features -- -D warnings` — passed
- `cargo build -p nico-admin-cli` — passed
- `cargo fmt --package nico-admin-cli -- --check` — passed with the installed stable toolchain

## Additional Notes

- `cargo make check-format-nightly` could not be run because `cargo-make` and
  the repository's pinned nightly toolchain are not installed locally.
- Live CLI validation against a NICo API was not performed because this host
  has no NICo API configuration. The new unit tests exercise and validate the
  complete emitted JSON buffer without requiring an API server.
