### PR TITLE
fix(route-server): return not_found when remove matches no rows

### DIFF
--- a/crates/api-core/src/handlers/route_server.rs
+++ b/crates/api-core/src/handlers/route_server.rs
@@ -79,7 +79,13 @@ pub(crate) async fn remove(
         .map_err(|_| CarbideError::InvalidArgument("source_type".to_string()))?;
 
     let mut txn = api.txn_begin().await?;
-    db::route_servers::remove(&mut txn, &route_servers, source_type.into()).await?;
+    let deleted = db::route_servers::remove(&mut txn, &route_servers, source_type.into()).await?;
+    if !route_servers.is_empty() && deleted == 0 {
+        return Err(Status::not_found(
+            "no route servers found matching the given addresses and source_type; \
+             if these are config-file sourced, retry with --source-type config_file",
+        ));
+    }
     txn.commit().await?;
 
     Ok(tonic::Response::new(()))

--- a/crates/api-core/src/handlers/route_server.rs
+++ b/crates/api-core/src/handlers/route_server.rs
@@ -62,9 +62,8 @@ pub(crate) async fn add(
     Ok(tonic::Response::new(()))
 }
 
-// remove will remove RouteServer entries. Since this comes in
-// via the API, this will be restricted to entries which have
-// the admin_api source type.
+// remove will remove RouteServer entries matching the given
+// addresses and source_type supplied in the request.
 pub(crate) async fn remove(
     api: &Api,
     request: tonic::Request<rpc::RouteServers>,
@@ -82,8 +81,9 @@ pub(crate) async fn remove(
     let deleted = db::route_servers::remove(&mut txn, &route_servers, source_type.into()).await?;
     if !route_servers.is_empty() && deleted == 0 {
         return Err(Status::not_found(
-            "no route servers found matching the given addresses and source_type; \
-             if these are config-file sourced, retry with --source-type config_file",
+            "no route servers found matching the given addresses for the requested \
+             source_type; config-file-sourced entries must be targeted with \
+             source_type config_file",
         ));
     }
     txn.commit().await?;

--- a/crates/api-core/tests/integration/route_servers.rs
+++ b/crates/api-core/tests/integration/route_servers.rs
@@ -126,7 +126,7 @@ async fn test_remove_route_servers_wrong_source_type(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
-    let servers = vec![IpAddr::from_str("1.2.3.4")?];
+    let servers = [IpAddr::from_str("1.2.3.4")?];
 
     // Add a server with ConfigFile source type
     let request = tonic::Request::new(RouteServers {

--- a/crates/api-core/tests/integration/route_servers.rs
+++ b/crates/api-core/tests/integration/route_servers.rs
@@ -122,6 +122,46 @@ async fn test_remove_route_servers(pool: PgPool) -> Result<(), Box<dyn std::erro
 }
 
 #[sqlx_test]
+async fn test_remove_route_servers_wrong_source_type(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool).build().await;
+    let servers = vec![IpAddr::from_str("1.2.3.4")?];
+
+    // Add a server with ConfigFile source type
+    let request = tonic::Request::new(RouteServers {
+        route_servers: servers.iter().map(ToString::to_string).collect(),
+        source_type: RouteServerSourceTypePb::ConfigFile as i32,
+    });
+    env.api().add_route_servers(request).await?;
+
+    // Try to remove it with AdminApi source type — should return not_found
+    let request = tonic::Request::new(RouteServers {
+        route_servers: servers.iter().map(ToString::to_string).collect(),
+        source_type: RouteServerSourceTypePb::AdminApi as i32,
+    });
+    let result = env.api().remove_route_servers(request).await;
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().code(), tonic::Code::NotFound);
+
+    // The row must still be present after the failed removal
+    let response = env.api().get_route_servers(tonic::Request::new(())).await?;
+    assert_eq!(response.into_inner().route_servers.len(), 1);
+
+    // Removing with the correct source type must succeed and leave the table empty
+    let request = tonic::Request::new(RouteServers {
+        route_servers: servers.iter().map(ToString::to_string).collect(),
+        source_type: RouteServerSourceTypePb::ConfigFile as i32,
+    });
+    env.api().remove_route_servers(request).await?;
+
+    let response = env.api().get_route_servers(tonic::Request::new(())).await?;
+    assert!(response.into_inner().route_servers.is_empty());
+
+    Ok(())
+}
+
+#[sqlx_test]
 async fn test_initial_set(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let env = TestHarness::builder(pool).build().await;
     let expected_servers = [

--- a/crates/api-db/src/route_servers.rs
+++ b/crates/api-db/src/route_servers.rs
@@ -122,11 +122,12 @@ pub async fn add(
 
 // remove deletes route server addresses matching the input
 // list of IP addresses for the given input source_type.
+// Returns the number of rows deleted.
 pub async fn remove(
     txn: &mut PgConnection,
-    addresses: &Vec<IpAddr>,
+    addresses: &[IpAddr],
     source_type: RouteServerSourceType,
-) -> DatabaseResult<()> {
+) -> DatabaseResult<u64> {
     // len + 1 since we're going to be binding all addresses
     // plus the source_type when we do the delete below.
     if addresses.len() + 1 > BIND_LIMIT {
@@ -137,14 +138,15 @@ pub async fn remove(
         )));
     } else if !addresses.is_empty() {
         let query = r#"DELETE FROM route_servers WHERE address = ANY($1) AND source_type = $2;"#;
-        sqlx::query(query)
+        let result = sqlx::query(query)
             .bind(addresses)
             .bind(source_type)
             .execute(txn)
             .await
             .map_err(|e| DatabaseError::new("super::remove", e))?;
+        return Ok(result.rows_affected());
     }
-    Ok(())
+    Ok(0)
 }
 
 #[cfg(test)]
@@ -534,13 +536,16 @@ mod tests {
 
         // Try to remove an AdminApi address using ConfigFile source type - should not remove anything
         let to_remove = vec![admin_addresses[0]];
-        super::remove(&mut txn, &to_remove, RouteServerSourceType::ConfigFile).await?;
+        let deleted =
+            super::remove(&mut txn, &to_remove, RouteServerSourceType::ConfigFile).await?;
+        assert_eq!(deleted, 0);
 
         let remaining = super::get(txn.as_mut()).await?;
         assert_eq!(remaining.len(), 5); // All entries should remain
 
         // Now remove with correct source type
-        super::remove(&mut txn, &to_remove, RouteServerSourceType::AdminApi).await?;
+        let deleted = super::remove(&mut txn, &to_remove, RouteServerSourceType::AdminApi).await?;
+        assert_eq!(deleted, 1);
 
         let remaining = super::get(txn.as_mut()).await?;
         assert_eq!(remaining.len(), 4); // One entry should be removed


### PR DESCRIPTION
## Summary

- `route-server remove` was silently returning success even when no rows were deleted, because the default `source_type` in the CLI is `admin_api` but entries loaded from a config file have `source_type = config_file`. The `DELETE` matched zero rows and returned `Ok(())` with no feedback.
- The DB `remove` function now returns the deleted row count (`u64`) via `rows_affected()`.
- The handler returns `Status::not_found` when the input is non-empty but nothing was deleted, with a message that tells the operator to retry with `source_type config_file` if the entries are config-file sourced.
- The stale handler comment (which claimed removal was restricted to `admin_api`) is corrected.

Fixes #4110

## Test plan

- [ ] All 13 `carbide-api-db` route_servers unit tests pass (verified on Linux with `DATABASE_URL` set)
- [ ] New integration test `test_remove_route_servers_wrong_source_type` passes: adds a `ConfigFile` entry, removes with `AdminApi` → `NotFound`, verifies row survives, removes with `ConfigFile` → success, verifies table empty
- [ ] `cargo make --no-workspace clippy-flow` passes on Linux
- [ ] Existing `test_remove_route_servers` integration test still passes (happy path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)