### PR TITLE
fix(build): NVMe inventory fields in conversions

### DIFF
--- a/crates/rpc/src/model/hardware_info.rs
+++ b/crates/rpc/src/model/hardware_info.rs
@@ -707,6 +707,8 @@ mod tests {
         model: String,
         firmware_rev: String,
         serial: String,
+        size_mb: Option<u32>,
+        pci_path: Option<String>,
     }
 
     #[derive(Debug, PartialEq)]
@@ -876,6 +878,8 @@ mod tests {
                 model: value.model,
                 firmware_rev: value.firmware_rev,
                 serial: value.serial,
+                size_mb: value.size_mb,
+                pci_path: value.pci_path,
             }
         }
     }
@@ -886,6 +890,8 @@ mod tests {
                 model: value.model,
                 firmware_rev: value.firmware_rev,
                 serial: value.serial,
+                size_mb: value.size_mb,
+                pci_path: value.pci_path,
             }
         }
     }
@@ -1316,6 +1322,8 @@ mod tests {
                 model: "NVMe Model".to_string(),
                 firmware_rev: "nvme-fw".to_string(),
                 serial: "nvme-serial".to_string(),
+                size_mb: Some(3_840_000),
+                pci_path: Some("/devices/pci0000:00/0000:00:01.0/nvme/nvme0".to_string()),
             }],
             dmi_data: Some(rpc::machine_discovery::DmiData {
                 board_name: "Board".to_string(),
@@ -1422,6 +1430,8 @@ mod tests {
                 model: "NVMe Model".to_string(),
                 firmware_rev: "nvme-fw".to_string(),
                 serial: "nvme-serial".to_string(),
+                size_mb: Some(3_840_000),
+                pci_path: Some("/devices/pci0000:00/0000:00:01.0/nvme/nvme0".to_string()),
             }],
             dmi_data: Some(DmiData {
                 board_name: "Board".to_string(),
@@ -1523,6 +1533,8 @@ mod tests {
             model: "NVMe Model".to_string(),
             firmware_rev: "nvme-fw".to_string(),
             serial: "nvme-serial".to_string(),
+            size_mb: Some(3_840_000),
+            pci_path: Some("/devices/pci0000:00/0000:00:01.0/nvme/nvme0".to_string()),
         }]
     }
 


### PR DESCRIPTION
#4060  added comprehensive RPC hardware-discovery conversion tests using the original three-field `NvmeDevice`.

#3717 independently added the optional `size_mb` and `pci_path` fields. Its tested branch did not contain #4060. 

When  #3717 was subsequently squash-merged after #4060, Git combined the changes without a textual conflict, but the resulting test struct initializers were incomplete. This caused `make verify` to fail while compiling the `carbide-rpc` library tests.

Update the RPC and model fixtures with representative NVMe capacity and PCI-path values. Include both fields in the test projections so the existing tests verify that they survive RPC-to-model and model-to-RPC conversion.

## Related issues

#4060
#3717

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

