### PR TITLE
fix(ipmi): use Redfish-discovered port for power operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "base64",
  "bmc-mock",
  "carbide-api-model",
+ "carbide-ipmi",
  "carbide-network",
  "carbide-rpc",
  "carbide-test-support",

--- a/crates/ipmi/src/bmc_mock.rs
+++ b/crates/ipmi/src/bmc_mock.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -59,7 +59,7 @@ impl IPMIToolHttpImpl {
     async fn execute_action(
         &self,
         command: IpmiCommand,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
         let action = Self::wire_action(command);
@@ -76,12 +76,12 @@ impl IPMIToolHttpImpl {
                 };
                 (
                     format!("{}/ipmi", proxy_url),
-                    Some(format!("host={}", bmc_ip)),
+                    Some(format!("host={}", bmc_address.ip())),
                 )
             }
             None => {
                 // No proxy - send directly to BMC
-                (format!("https://{}/ipmi", bmc_ip), None)
+                (format!("https://{}/ipmi", bmc_address.ip()), None)
             }
         };
 
@@ -153,30 +153,34 @@ impl IPMIToolHttpImpl {
 impl IPMITool for IPMIToolHttpImpl {
     async fn bmc_cold_reset(
         &self,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
-        self.execute_action(IpmiCommand::BmcColdReset, bmc_ip, credential_key)
+        self.execute_action(IpmiCommand::BmcColdReset, bmc_address, credential_key)
             .await
     }
 
     async fn restart(
         &self,
         _machine_id: &MachineId,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         legacy_boot: bool,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
         if legacy_boot
             && self
-                .execute_action(IpmiCommand::DpuLegacyPowerReset, bmc_ip, credential_key)
+                .execute_action(
+                    IpmiCommand::DpuLegacyPowerReset,
+                    bmc_address,
+                    credential_key,
+                )
                 .await
                 .is_ok()
         {
             return Ok(());
         }
         // Fall through to chassis_power_reset if legacy_boot fails or is false
-        self.execute_action(IpmiCommand::ChassisPowerReset, bmc_ip, credential_key)
+        self.execute_action(IpmiCommand::ChassisPowerReset, bmc_address, credential_key)
             .await
     }
 }

--- a/crates/ipmi/src/lib.rs
+++ b/crates/ipmi/src/lib.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
@@ -29,18 +29,20 @@ mod metrics;
 mod test_support;
 mod tool;
 
+pub const DEFAULT_IPMI_PORT: u16 = 623;
+
 #[async_trait]
 pub trait IPMITool: Send + Sync + 'static {
     async fn bmc_cold_reset(
         &self,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report>;
 
     async fn restart(
         &self,
         machine_id: &MachineId,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         legacy_boot: bool,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report>;

--- a/crates/ipmi/src/test_support.rs
+++ b/crates/ipmi/src/test_support.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
+use std::net::SocketAddr;
 
 use async_trait::async_trait;
 use carbide_secrets::credentials::CredentialKey;
@@ -30,7 +30,7 @@ impl IPMITool for IPMIToolTestImpl {
     async fn restart(
         &self,
         _machine_id: &MachineId,
-        _bmc_ip: IpAddr,
+        _bmc_address: SocketAddr,
         _legacy_boot: bool,
         _credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
@@ -39,7 +39,7 @@ impl IPMITool for IPMIToolTestImpl {
 
     async fn bmc_cold_reset(
         &self,
-        _bmc_ip: IpAddr,
+        _bmc_address: SocketAddr,
         _credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
         Ok(())

--- a/crates/ipmi/src/tool.rs
+++ b/crates/ipmi/src/tool.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -48,13 +48,25 @@ impl IPMIToolImpl {
             IpmiCommand::BmcColdReset => "-I lanplus -C 17 bmc reset cold",
         }
     }
+
+    fn connection_args(bmc_address: SocketAddr, username: &str) -> [String; 7] {
+        [
+            "-H".to_string(),
+            bmc_address.ip().to_string(),
+            "-p".to_string(),
+            bmc_address.port().to_string(),
+            "-U".to_string(),
+            username.to_string(),
+            "-E".to_string(),
+        ]
+    }
 }
 
 #[async_trait]
 impl IPMITool for IPMIToolImpl {
     async fn bmc_cold_reset(
         &self,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
         let credentials = self
@@ -67,7 +79,7 @@ impl IPMITool for IPMIToolImpl {
             .ok_or_else(|| eyre!("no credentials for key {credential_key:#?} found"))?;
 
         match self
-            .execute_ipmitool_command(IpmiCommand::BmcColdReset, bmc_ip, &credentials)
+            .execute_ipmitool_command(IpmiCommand::BmcColdReset, bmc_address, &credentials)
             .await
         {
             Ok(_) => Ok(()),
@@ -78,7 +90,7 @@ impl IPMITool for IPMIToolImpl {
     async fn restart(
         &self,
         machine_id: &MachineId,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         legacy_boot: bool,
         credential_key: &CredentialKey,
     ) -> Result<(), eyre::Report> {
@@ -98,7 +110,11 @@ impl IPMITool for IPMIToolImpl {
 
         if legacy_boot {
             match self
-                .execute_ipmitool_command(IpmiCommand::DpuLegacyPowerReset, bmc_ip, &credentials)
+                .execute_ipmitool_command(
+                    IpmiCommand::DpuLegacyPowerReset,
+                    bmc_address,
+                    &credentials,
+                )
                 .await
             {
                 Ok(_) => return Ok(()),   // return early if we get a successful response
@@ -106,7 +122,7 @@ impl IPMITool for IPMIToolImpl {
             }
         }
         match self
-            .execute_ipmitool_command(IpmiCommand::ChassisPowerReset, bmc_ip, &credentials)
+            .execute_ipmitool_command(IpmiCommand::ChassisPowerReset, bmc_address, &credentials)
             .await
         {
             Ok(_) => return Ok(()),   // return early if we get a successful response
@@ -131,7 +147,7 @@ impl IPMIToolImpl {
     async fn execute_ipmitool_command(
         &self,
         command: IpmiCommand,
-        bmc_ip: IpAddr,
+        bmc_address: SocketAddr,
         credentials: &Credentials,
     ) -> CmdResult<String> {
         let (username, password) = match credentials {
@@ -139,13 +155,7 @@ impl IPMIToolImpl {
         };
 
         // cmd line args that are filled in from the db
-        let prefix_args: Vec<String> =
-            vec!["-H", bmc_ip.to_string().as_str(), "-U", username, "-E"]
-                .into_iter()
-                .map(str::to_owned)
-                .collect();
-
-        let mut args = prefix_args.to_owned();
+        let mut args = Self::connection_args(bmc_address, username).to_vec();
         args.extend(Self::command_args(command).split(' ').map(str::to_owned));
         let cmd = TokioCmd::new("/usr/bin/ipmitool")
             .args(&args)
@@ -160,6 +170,7 @@ impl IPMIToolImpl {
 
 #[cfg(test)]
 mod test {
+    use std::net::SocketAddr;
     use std::sync::Arc;
 
     use carbide_secrets::credentials::Credentials;
@@ -174,5 +185,16 @@ mod test {
         let tool = super::IPMIToolImpl::new(cp, Some(1));
 
         assert_eq!(tool.attempts, 1);
+    }
+
+    #[test]
+    fn connection_args_include_non_default_port() {
+        assert_eq!(
+            super::IPMIToolImpl::connection_args(
+                "[2001:db8::1]:1623".parse::<SocketAddr>().unwrap(),
+                "admin",
+            ),
+            ["-H", "2001:db8::1", "-p", "1623", "-U", "admin", "-E"]
+        );
     }
 }

--- a/crates/machine-a-tron/Cargo.toml
+++ b/crates/machine-a-tron/Cargo.toml
@@ -67,6 +67,7 @@ russh = { workspace = true }
 
 # [local-dependencies]
 carbide-api-model = { path = "../api-model" }
+carbide-ipmi = { path = "../ipmi" }
 carbide-rpc = { path = "../rpc", features = ["model"] }
 bmc-mock = { path = "../bmc-mock" }
 carbide-tls = { path = "../tls" }

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -21,10 +21,11 @@ use std::sync::Arc;
 
 use axum::Router;
 use bmc_mock::injection::InjectionStore;
-use bmc_mock::ipmi_sim::{IpmiEndpoint, IpmiSimConfig, IpmiSimHandle, STANDARD_IPMI_PORT};
+use bmc_mock::ipmi_sim::{IpmiEndpoint, IpmiSimConfig, IpmiSimHandle};
 use bmc_mock::{
     BmcState, Callbacks, CombinedServer, HostnameQuerying, ListenerOrAddress, MachineInfo,
 };
+use carbide_ipmi::DEFAULT_IPMI_PORT;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -187,7 +188,7 @@ impl BmcMockWrapper {
         bind_ip: std::net::IpAddr,
     ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
         Ok(self
-            .start_ipmi_sim(bind_ip, Some(STANDARD_IPMI_PORT))
+            .start_ipmi_sim(bind_ip, Some(DEFAULT_IPMI_PORT))
             .await?
             .map(|ipmi_sim_handle| BmcMockWrapperHandle {
                 _bmc_mock: None,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -19,7 +19,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::mem::discriminant as enum_discr;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -3331,12 +3331,13 @@ async fn handle_dpu_reprovision(
                                 missing: "bmc_ip",
                             }
                         })?;
+                    let bmc_address = resolve_ipmi_address(bmc_ip_address, ctx).await?;
 
                     if let Err(ipmitool_error) = ctx
                         .services
                         .ipmi_tool
                         .bmc_cold_reset(
-                            bmc_ip_address,
+                            bmc_address,
                             &CredentialKey::BmcCredentials {
                                 credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
                             },
@@ -10707,13 +10708,28 @@ async fn do_ipmi_restart(
             bmc_mac_address: bmc_mac,
         },
     };
+    let bmc_address = resolve_ipmi_address(ip, ctx).await?;
     ctx.services
         .ipmi_tool
-        .restart(&machine.id, ip, false, &credential_key)
+        .restart(&machine.id, bmc_address, false, &credential_key)
         .await
         .map_err(|e| {
             StateHandlerError::GenericError(eyre!("IPMI restart failed for {}: {}", machine.id, e))
         })
+}
+
+async fn resolve_ipmi_address(
+    ip_address: IpAddr,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<SocketAddr, StateHandlerError> {
+    let metadata =
+        db::explored_endpoints::lookup_bmc_metadata_by_ip(ip_address, &mut ctx.services.db_reader)
+            .await?;
+    Ok(ipmi_socket_address(ip_address, metadata.ipmi_port))
+}
+
+fn ipmi_socket_address(ip_address: IpAddr, port: Option<u16>) -> SocketAddr {
+    SocketAddr::new(ip_address, port.unwrap_or(carbide_ipmi::DEFAULT_IPMI_PORT))
 }
 
 /// find_explored_refreshed_endpoint will locate the explored endpoint for the given state.
@@ -11943,6 +11959,20 @@ mod tests {
     use regex::Regex;
 
     use super::*;
+
+    #[test]
+    fn ipmi_socket_address_uses_reported_or_default_port() {
+        let ip_address = IpAddr::V4("192.0.2.10".parse().unwrap());
+
+        assert_eq!(
+            ipmi_socket_address(ip_address, Some(1623)),
+            "192.0.2.10:1623".parse().unwrap(),
+        );
+        assert_eq!(
+            ipmi_socket_address(ip_address, None),
+            "192.0.2.10:623".parse().unwrap(),
+        );
+    }
 
     /// One emit per actual retry: the INFO line carries the machine, the
     /// 1-based attempt, and the failure it recovers from, and the unlabeled

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -992,7 +992,10 @@ impl EndpointExplorer for BmcEndpointExplorer {
         let bmc_mac_address = interface.mac_address;
         let credential_key = get_bmc_root_credential_key(bmc_mac_address);
         self.ipmi_tool
-            .bmc_cold_reset(bmc_ip_address.ip(), &credential_key)
+            .bmc_cold_reset(
+                SocketAddr::new(bmc_ip_address.ip(), carbide_ipmi::DEFAULT_IPMI_PORT),
+                &credential_key,
+            )
             .await
             .map_err(|err| EndpointExplorationError::Other {
                 details: format!("ipmi_tool failed against {bmc_ip_address} failed: {err}"),


### PR DESCRIPTION
Redfish discovery records the BMC's advertised IPMI port, but IPMI power operations currently use only the BMC IP address. As a result, `ipmitool` implicitly connects to port 623 even when discovery reported a different port.

This PR carries the complete BMC socket address through the IPMI interface and uses the port stored in the discovered endpoint metadata.

Specifically, it:

- changes `IPMITool` operations to accept a `SocketAddr`;
- resolves the discovered IPMI port before machine restart and BMC cold-reset operations;
- falls back to the standard IPMI port, 623, when discovery did not report one;
- passes the selected port to `ipmitool` with `-p`;

## Related issues

Related: #3803

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Support for handling IPMI reboot commands in `bmc-mock` is intentionally kept in a separate change so the two updates can be reviewed and merged independently.