### PR TITLE
fix(rest-api): Expose Scout version for Machines

### DIFF
--- a/rest-api/api/pkg/api/model/machine.go
+++ b/rest-api/api/pkg/api/model/machine.go
@@ -342,8 +342,8 @@ type APIMachine struct {
 	PlacementInRack *APIPlacementInRack `json:"placementInRack"`
 	// MaintenanceMessage is the message to display during maintenance mode
 	MaintenanceMessage *string `json:"maintenanceMessage"`
-	// LastScoutObservedVersion is the last Scout version reported by the Machine
-	LastScoutObservedVersion *string `json:"lastScoutObservedVersion"`
+	// ScoutVersion is the Scout version reported by the Machine
+	ScoutVersion *string `json:"scoutVersion"`
 	// Metadata contains additional metadata about the machine
 	Metadata *APIMachineMetadata `json:"metadata,omitempty"`
 	// Health contains health information about the machine
@@ -612,9 +612,9 @@ func NewAPIMachine(dbm *cdbm.Machine, dbmcs []cdbm.MachineCapability, dbmis []cd
 	if dbm.Metadata != nil {
 		if machine := dbm.Metadata.Machine; machine != nil {
 			if status := machine.GetStatus(); status != nil && status.LastScoutObservedVersion != nil {
-				apim.LastScoutObservedVersion = status.LastScoutObservedVersion
+				apim.ScoutVersion = status.LastScoutObservedVersion
 			} else {
-				apim.LastScoutObservedVersion = machine.LastScoutObservedVersion
+				apim.ScoutVersion = machine.LastScoutObservedVersion
 			}
 		}
 		for _, dpuID := range dbm.Metadata.GetAssociatedDpuMachineIds() {

--- a/rest-api/api/pkg/api/model/machine.go
+++ b/rest-api/api/pkg/api/model/machine.go
@@ -342,6 +342,8 @@ type APIMachine struct {
 	PlacementInRack *APIPlacementInRack `json:"placementInRack"`
 	// MaintenanceMessage is the message to display during maintenance mode
 	MaintenanceMessage *string `json:"maintenanceMessage"`
+	// LastScoutObservedVersion is the last Scout version reported by the Machine
+	LastScoutObservedVersion *string `json:"lastScoutObservedVersion"`
 	// Metadata contains additional metadata about the machine
 	Metadata *APIMachineMetadata `json:"metadata,omitempty"`
 	// Health contains health information about the machine
@@ -608,6 +610,13 @@ func NewAPIMachine(dbm *cdbm.Machine, dbmcs []cdbm.MachineCapability, dbmis []cd
 	// surfaced regardless of the includeMetadata / provider gate below.
 	apim.AssociatedDpuMachineIds = []string{}
 	if dbm.Metadata != nil {
+		if machine := dbm.Metadata.Machine; machine != nil {
+			if status := machine.GetStatus(); status != nil && status.LastScoutObservedVersion != nil {
+				apim.LastScoutObservedVersion = status.LastScoutObservedVersion
+			} else {
+				apim.LastScoutObservedVersion = machine.LastScoutObservedVersion
+			}
+		}
 		for _, dpuID := range dbm.Metadata.GetAssociatedDpuMachineIds() {
 			if id := dpuID.GetId(); id != "" {
 				apim.AssociatedDpuMachineIds = append(apim.AssociatedDpuMachineIds, id)

--- a/rest-api/api/pkg/api/model/machine_test.go
+++ b/rest-api/api/pkg/api/model/machine_test.go
@@ -465,6 +465,74 @@ func TestMachine_NewAPIMachine(t *testing.T) {
 	assert.Equal(t, dbm.IsUsableByTenant, apimi.IsUsableByTenant)
 }
 
+func TestMachine_NewAPIMachineLastScoutObservedVersion(t *testing.T) {
+	statusVersion := "2.6.1"
+	legacyVersion := "2.5.0"
+
+	tests := []struct {
+		name     string
+		metadata *cdbm.SiteControllerMachine
+		want     *string
+	}{
+		{
+			name: "uses Machine status value",
+			metadata: &cdbm.SiteControllerMachine{Machine: &corev1.Machine{
+				Status: &corev1.MachineStatus{LastScoutObservedVersion: &statusVersion},
+			}},
+			want: &statusVersion,
+		},
+		{
+			name: "falls back to deprecated Machine value",
+			metadata: &cdbm.SiteControllerMachine{Machine: &corev1.Machine{
+				LastScoutObservedVersion: &legacyVersion,
+			}},
+			want: &legacyVersion,
+		},
+		{
+			name: "prefers Machine status value",
+			metadata: &cdbm.SiteControllerMachine{Machine: &corev1.Machine{
+				Status:                   &corev1.MachineStatus{LastScoutObservedVersion: &statusVersion},
+				LastScoutObservedVersion: &legacyVersion,
+			}},
+			want: &statusVersion,
+		},
+		{
+			name:     "returns null when version is unknown",
+			metadata: &cdbm.SiteControllerMachine{Machine: &corev1.Machine{}},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiMachine := NewAPIMachine(
+				&cdbm.Machine{Metadata: tt.metadata},
+				nil,
+				nil,
+				nil,
+				nil,
+				false,
+				false,
+			)
+
+			assert.Equal(t, tt.want, apiMachine.LastScoutObservedVersion)
+
+			response, err := json.Marshal(apiMachine)
+			require.NoError(t, err)
+
+			var fields map[string]interface{}
+			require.NoError(t, json.Unmarshal(response, &fields))
+			value, found := fields["lastScoutObservedVersion"]
+			require.True(t, found)
+			if tt.want == nil {
+				assert.Nil(t, value)
+			} else {
+				assert.Equal(t, *tt.want, value)
+			}
+		})
+	}
+}
+
 func TestMachine_NewAPIMachineSummary(t *testing.T) {
 	mID := uuid.NewString()
 	dbm := &cdbm.Machine{

--- a/rest-api/api/pkg/api/model/machine_test.go
+++ b/rest-api/api/pkg/api/model/machine_test.go
@@ -489,6 +489,14 @@ func TestMachine_NewAPIMachineLastScoutObservedVersion(t *testing.T) {
 			want: &legacyVersion,
 		},
 		{
+			name: "falls back when Machine status version is unset",
+			metadata: &cdbm.SiteControllerMachine{Machine: &corev1.Machine{
+				Status:                   &corev1.MachineStatus{},
+				LastScoutObservedVersion: &legacyVersion,
+			}},
+			want: &legacyVersion,
+		},
+		{
 			name: "prefers Machine status value",
 			metadata: &cdbm.SiteControllerMachine{Machine: &corev1.Machine{
 				Status:                   &corev1.MachineStatus{LastScoutObservedVersion: &statusVersion},

--- a/rest-api/api/pkg/api/model/machine_test.go
+++ b/rest-api/api/pkg/api/model/machine_test.go
@@ -465,7 +465,7 @@ func TestMachine_NewAPIMachine(t *testing.T) {
 	assert.Equal(t, dbm.IsUsableByTenant, apimi.IsUsableByTenant)
 }
 
-func TestMachine_NewAPIMachineLastScoutObservedVersion(t *testing.T) {
+func TestMachine_NewAPIMachineScoutVersion(t *testing.T) {
 	statusVersion := "2.6.1"
 	legacyVersion := "2.5.0"
 
@@ -523,14 +523,15 @@ func TestMachine_NewAPIMachineLastScoutObservedVersion(t *testing.T) {
 				false,
 			)
 
-			assert.Equal(t, tt.want, apiMachine.LastScoutObservedVersion)
+			assert.Equal(t, tt.want, apiMachine.ScoutVersion)
 
 			response, err := json.Marshal(apiMachine)
 			require.NoError(t, err)
 
 			var fields map[string]interface{}
 			require.NoError(t, json.Unmarshal(response, &fields))
-			value, found := fields["lastScoutObservedVersion"]
+			assert.NotContains(t, fields, "lastScoutObservedVersion")
+			value, found := fields["scoutVersion"]
 			require.True(t, found)
 			if tt.want == nil {
 				assert.Nil(t, value)

--- a/rest-api/openapi/spec.yaml
+++ b/rest-api/openapi/spec.yaml
@@ -20607,7 +20607,7 @@ components:
               created: '2019-08-24T14:15:22Z'
               updated: '2019-08-24T14:15:22Z'
           maintenanceMessage: null
-          lastScoutObservedVersion: 2.6.1
+          scoutVersion: 2.6.1
           health:
             source: aggregate-host-health
             observedAt: null
@@ -20738,11 +20738,11 @@ components:
             - string
             - 'null'
           description: 'If the Machine is in maintenance mode, this message will typically describe the reason and how long it is expected to be in maintenance'
-        lastScoutObservedVersion:
+        scoutVersion:
           type:
             - string
             - 'null'
-          description: 'Last Scout version reported by the Machine, if known'
+          description: 'Scout version reported by the Machine, if known'
           readOnly: true
         health:
           $ref: '#/components/schemas/MachineHealth'

--- a/rest-api/openapi/spec.yaml
+++ b/rest-api/openapi/spec.yaml
@@ -20607,6 +20607,7 @@ components:
               created: '2019-08-24T14:15:22Z'
               updated: '2019-08-24T14:15:22Z'
           maintenanceMessage: null
+          lastScoutObservedVersion: 2.6.1
           health:
             source: aggregate-host-health
             observedAt: null
@@ -20737,6 +20738,12 @@ components:
             - string
             - 'null'
           description: 'If the Machine is in maintenance mode, this message will typically describe the reason and how long it is expected to be in maintenance'
+        lastScoutObservedVersion:
+          type:
+            - string
+            - 'null'
+          description: 'Last Scout version reported by the Machine, if known'
+          readOnly: true
         health:
           $ref: '#/components/schemas/MachineHealth'
           description: 'Health information about the machine'

--- a/rest-api/sdk/simple/machine.go
+++ b/rest-api/sdk/simple/machine.go
@@ -13,20 +13,21 @@ import (
 
 // Machine represents a simplified Machine
 type Machine struct {
-	ID                  string                  `json:"id"`
-	InstanceTypeID      *string                 `json:"instanceTypeId"`
-	InstanceID          *string                 `json:"instanceId"`
-	Vendor              *string                 `json:"vendor"`
-	ProductName         *string                 `json:"productName"`
-	SerialNumber        *string                 `json:"serialNumber"`
-	Hostname            *string                 `json:"hostname"`
-	MachineCapabilities []MachineCapability     `json:"machineCapabilities"`
-	AdminInterfaces     []MachineAdminInterface `json:"adminInterfaces"`
-	MaintenanceMessage  *string                 `json:"maintenanceMessage"`
-	Labels              map[string]string       `json:"labels"`
-	Status              string                  `json:"status"`
-	Created             time.Time               `json:"created"`
-	Updated             time.Time               `json:"updated"`
+	ID                       string                  `json:"id"`
+	InstanceTypeID           *string                 `json:"instanceTypeId"`
+	InstanceID               *string                 `json:"instanceId"`
+	Vendor                   *string                 `json:"vendor"`
+	ProductName              *string                 `json:"productName"`
+	SerialNumber             *string                 `json:"serialNumber"`
+	Hostname                 *string                 `json:"hostname"`
+	MachineCapabilities      []MachineCapability     `json:"machineCapabilities"`
+	AdminInterfaces          []MachineAdminInterface `json:"adminInterfaces"`
+	MaintenanceMessage       *string                 `json:"maintenanceMessage"`
+	LastScoutObservedVersion *string                 `json:"lastScoutObservedVersion"`
+	Labels                   map[string]string       `json:"labels"`
+	Status                   string                  `json:"status"`
+	Created                  time.Time               `json:"created"`
+	Updated                  time.Time               `json:"updated"`
 }
 
 // MachineCapability represents a machine capability
@@ -81,6 +82,9 @@ func machineFromStandard(api standard.Machine) Machine {
 	}
 	if api.MaintenanceMessage.IsSet() {
 		m.MaintenanceMessage = api.MaintenanceMessage.Get()
+	}
+	if api.LastScoutObservedVersion.IsSet() {
+		m.LastScoutObservedVersion = api.LastScoutObservedVersion.Get()
 	}
 	if api.Status != nil {
 		m.Status = string(*api.Status)

--- a/rest-api/sdk/simple/machine.go
+++ b/rest-api/sdk/simple/machine.go
@@ -13,21 +13,21 @@ import (
 
 // Machine represents a simplified Machine
 type Machine struct {
-	ID                       string                  `json:"id"`
-	InstanceTypeID           *string                 `json:"instanceTypeId"`
-	InstanceID               *string                 `json:"instanceId"`
-	Vendor                   *string                 `json:"vendor"`
-	ProductName              *string                 `json:"productName"`
-	SerialNumber             *string                 `json:"serialNumber"`
-	Hostname                 *string                 `json:"hostname"`
-	MachineCapabilities      []MachineCapability     `json:"machineCapabilities"`
-	AdminInterfaces          []MachineAdminInterface `json:"adminInterfaces"`
-	MaintenanceMessage       *string                 `json:"maintenanceMessage"`
-	LastScoutObservedVersion *string                 `json:"lastScoutObservedVersion"`
-	Labels                   map[string]string       `json:"labels"`
-	Status                   string                  `json:"status"`
-	Created                  time.Time               `json:"created"`
-	Updated                  time.Time               `json:"updated"`
+	ID                  string                  `json:"id"`
+	InstanceTypeID      *string                 `json:"instanceTypeId"`
+	InstanceID          *string                 `json:"instanceId"`
+	Vendor              *string                 `json:"vendor"`
+	ProductName         *string                 `json:"productName"`
+	SerialNumber        *string                 `json:"serialNumber"`
+	Hostname            *string                 `json:"hostname"`
+	MachineCapabilities []MachineCapability     `json:"machineCapabilities"`
+	AdminInterfaces     []MachineAdminInterface `json:"adminInterfaces"`
+	MaintenanceMessage  *string                 `json:"maintenanceMessage"`
+	ScoutVersion        *string                 `json:"scoutVersion"`
+	Labels              map[string]string       `json:"labels"`
+	Status              string                  `json:"status"`
+	Created             time.Time               `json:"created"`
+	Updated             time.Time               `json:"updated"`
 }
 
 // MachineCapability represents a machine capability
@@ -83,8 +83,8 @@ func machineFromStandard(api standard.Machine) Machine {
 	if api.MaintenanceMessage.IsSet() {
 		m.MaintenanceMessage = api.MaintenanceMessage.Get()
 	}
-	if api.LastScoutObservedVersion.IsSet() {
-		m.LastScoutObservedVersion = api.LastScoutObservedVersion.Get()
+	if api.ScoutVersion.IsSet() {
+		m.ScoutVersion = api.ScoutVersion.Get()
 	}
 	if api.Status != nil {
 		m.Status = string(*api.Status)

--- a/rest-api/sdk/simple/machine_test.go
+++ b/rest-api/sdk/simple/machine_test.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package simple
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/sdk/standard"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMachineFromStandardIncludesLastScoutObservedVersion(t *testing.T) {
+	version := "2.6.1"
+	apiMachine := standard.NewMachine()
+	apiMachine.SetLastScoutObservedVersion(version)
+
+	machine := machineFromStandard(*apiMachine)
+
+	assert.Equal(t, &version, machine.LastScoutObservedVersion)
+}

--- a/rest-api/sdk/simple/machine_test.go
+++ b/rest-api/sdk/simple/machine_test.go
@@ -4,16 +4,18 @@
 package simple
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/NVIDIA/infra-controller/rest-api/sdk/standard"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestMachineFromStandardIncludesLastScoutObservedVersion(t *testing.T) {
+func TestMachineFromStandardIncludesScoutVersion(t *testing.T) {
 	version := "2.6.1"
 	apiMachine := standard.NewMachine()
-	apiMachine.SetLastScoutObservedVersion(version)
+	apiMachine.SetScoutVersion(version)
 
 	tests := []struct {
 		name       string
@@ -36,7 +38,16 @@ func TestMachineFromStandardIncludesLastScoutObservedVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			machine := machineFromStandard(tt.apiMachine)
 
-			assert.Equal(t, tt.want, machine.LastScoutObservedVersion)
+			assert.Equal(t, tt.want, machine.ScoutVersion)
+
+			response, err := json.Marshal(machine)
+			require.NoError(t, err)
+
+			var fields map[string]interface{}
+			require.NoError(t, json.Unmarshal(response, &fields))
+			assert.NotContains(t, fields, "lastScoutObservedVersion")
+			_, found := fields["scoutVersion"]
+			assert.True(t, found)
 		})
 	}
 }

--- a/rest-api/sdk/simple/machine_test.go
+++ b/rest-api/sdk/simple/machine_test.go
@@ -15,7 +15,28 @@ func TestMachineFromStandardIncludesLastScoutObservedVersion(t *testing.T) {
 	apiMachine := standard.NewMachine()
 	apiMachine.SetLastScoutObservedVersion(version)
 
-	machine := machineFromStandard(*apiMachine)
+	tests := []struct {
+		name       string
+		apiMachine standard.Machine
+		want       *string
+	}{
+		{
+			name:       "returns reported version",
+			apiMachine: *apiMachine,
+			want:       &version,
+		},
+		{
+			name:       "returns nil when version is unknown",
+			apiMachine: *standard.NewMachine(),
+			want:       nil,
+		},
+	}
 
-	assert.Equal(t, &version, machine.LastScoutObservedVersion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			machine := machineFromStandard(tt.apiMachine)
+
+			assert.Equal(t, tt.want, machine.LastScoutObservedVersion)
+		})
+	}
 }

--- a/rest-api/sdk/standard/model_machine.go
+++ b/rest-api/sdk/standard/model_machine.go
@@ -57,8 +57,8 @@ type Machine struct {
 	PlacementInRack *PlacementInRack `json:"placementInRack,omitempty"`
 	// If the Machine is in maintenance mode, this message will typically describe the reason and how long it is expected to be in maintenance
 	MaintenanceMessage NullableString `json:"maintenanceMessage,omitempty"`
-	// Last Scout version reported by the Machine, if known
-	LastScoutObservedVersion NullableString `json:"lastScoutObservedVersion,omitempty"`
+	// Scout version reported by the Machine, if known
+	ScoutVersion NullableString `json:"scoutVersion,omitempty"`
 	// Health information about the machine
 	Health *MachineHealth `json:"health,omitempty"`
 	// Only available to Providers. Returned if the `includeMetadata` query parameter is specified. Otherwise attribute is omitted from response.
@@ -737,47 +737,47 @@ func (o *Machine) UnsetMaintenanceMessage() {
 	o.MaintenanceMessage.Unset()
 }
 
-// GetLastScoutObservedVersion returns the LastScoutObservedVersion field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *Machine) GetLastScoutObservedVersion() string {
-	if o == nil || IsNil(o.LastScoutObservedVersion.Get()) {
+// GetScoutVersion returns the ScoutVersion field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *Machine) GetScoutVersion() string {
+	if o == nil || IsNil(o.ScoutVersion.Get()) {
 		var ret string
 		return ret
 	}
-	return *o.LastScoutObservedVersion.Get()
+	return *o.ScoutVersion.Get()
 }
 
-// GetLastScoutObservedVersionOk returns a tuple with the LastScoutObservedVersion field value if set, nil otherwise
+// GetScoutVersionOk returns a tuple with the ScoutVersion field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
-func (o *Machine) GetLastScoutObservedVersionOk() (*string, bool) {
+func (o *Machine) GetScoutVersionOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return o.LastScoutObservedVersion.Get(), o.LastScoutObservedVersion.IsSet()
+	return o.ScoutVersion.Get(), o.ScoutVersion.IsSet()
 }
 
-// HasLastScoutObservedVersion returns a boolean if a field has been set.
-func (o *Machine) HasLastScoutObservedVersion() bool {
-	if o != nil && o.LastScoutObservedVersion.IsSet() {
+// HasScoutVersion returns a boolean if a field has been set.
+func (o *Machine) HasScoutVersion() bool {
+	if o != nil && o.ScoutVersion.IsSet() {
 		return true
 	}
 
 	return false
 }
 
-// SetLastScoutObservedVersion gets a reference to the given NullableString and assigns it to the LastScoutObservedVersion field.
-func (o *Machine) SetLastScoutObservedVersion(v string) {
-	o.LastScoutObservedVersion.Set(&v)
+// SetScoutVersion gets a reference to the given NullableString and assigns it to the ScoutVersion field.
+func (o *Machine) SetScoutVersion(v string) {
+	o.ScoutVersion.Set(&v)
 }
 
-// SetLastScoutObservedVersionNil sets the value for LastScoutObservedVersion to be an explicit nil
-func (o *Machine) SetLastScoutObservedVersionNil() {
-	o.LastScoutObservedVersion.Set(nil)
+// SetScoutVersionNil sets the value for ScoutVersion to be an explicit nil
+func (o *Machine) SetScoutVersionNil() {
+	o.ScoutVersion.Set(nil)
 }
 
-// UnsetLastScoutObservedVersion ensures that no value is present for LastScoutObservedVersion, not even an explicit nil
-func (o *Machine) UnsetLastScoutObservedVersion() {
-	o.LastScoutObservedVersion.Unset()
+// UnsetScoutVersion ensures that no value is present for ScoutVersion, not even an explicit nil
+func (o *Machine) UnsetScoutVersion() {
+	o.ScoutVersion.Unset()
 }
 
 // GetHealth returns the Health field value if set, zero value otherwise.
@@ -1097,8 +1097,8 @@ func (o Machine) ToMap() (map[string]interface{}, error) {
 	if o.MaintenanceMessage.IsSet() {
 		toSerialize["maintenanceMessage"] = o.MaintenanceMessage.Get()
 	}
-	if o.LastScoutObservedVersion.IsSet() {
-		toSerialize["lastScoutObservedVersion"] = o.LastScoutObservedVersion.Get()
+	if o.ScoutVersion.IsSet() {
+		toSerialize["scoutVersion"] = o.ScoutVersion.Get()
 	}
 	if !IsNil(o.Health) {
 		toSerialize["health"] = o.Health

--- a/rest-api/sdk/standard/model_machine.go
+++ b/rest-api/sdk/standard/model_machine.go
@@ -57,6 +57,8 @@ type Machine struct {
 	PlacementInRack *PlacementInRack `json:"placementInRack,omitempty"`
 	// If the Machine is in maintenance mode, this message will typically describe the reason and how long it is expected to be in maintenance
 	MaintenanceMessage NullableString `json:"maintenanceMessage,omitempty"`
+	// Last Scout version reported by the Machine, if known
+	LastScoutObservedVersion NullableString `json:"lastScoutObservedVersion,omitempty"`
 	// Health information about the machine
 	Health *MachineHealth `json:"health,omitempty"`
 	// Only available to Providers. Returned if the `includeMetadata` query parameter is specified. Otherwise attribute is omitted from response.
@@ -735,6 +737,49 @@ func (o *Machine) UnsetMaintenanceMessage() {
 	o.MaintenanceMessage.Unset()
 }
 
+// GetLastScoutObservedVersion returns the LastScoutObservedVersion field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *Machine) GetLastScoutObservedVersion() string {
+	if o == nil || IsNil(o.LastScoutObservedVersion.Get()) {
+		var ret string
+		return ret
+	}
+	return *o.LastScoutObservedVersion.Get()
+}
+
+// GetLastScoutObservedVersionOk returns a tuple with the LastScoutObservedVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *Machine) GetLastScoutObservedVersionOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.LastScoutObservedVersion.Get(), o.LastScoutObservedVersion.IsSet()
+}
+
+// HasLastScoutObservedVersion returns a boolean if a field has been set.
+func (o *Machine) HasLastScoutObservedVersion() bool {
+	if o != nil && o.LastScoutObservedVersion.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetLastScoutObservedVersion gets a reference to the given NullableString and assigns it to the LastScoutObservedVersion field.
+func (o *Machine) SetLastScoutObservedVersion(v string) {
+	o.LastScoutObservedVersion.Set(&v)
+}
+
+// SetLastScoutObservedVersionNil sets the value for LastScoutObservedVersion to be an explicit nil
+func (o *Machine) SetLastScoutObservedVersionNil() {
+	o.LastScoutObservedVersion.Set(nil)
+}
+
+// UnsetLastScoutObservedVersion ensures that no value is present for LastScoutObservedVersion, not even an explicit nil
+func (o *Machine) UnsetLastScoutObservedVersion() {
+	o.LastScoutObservedVersion.Unset()
+}
+
 // GetHealth returns the Health field value if set, zero value otherwise.
 func (o *Machine) GetHealth() MachineHealth {
 	if o == nil || IsNil(o.Health) {
@@ -1051,6 +1096,9 @@ func (o Machine) ToMap() (map[string]interface{}, error) {
 	}
 	if o.MaintenanceMessage.IsSet() {
 		toSerialize["maintenanceMessage"] = o.MaintenanceMessage.Get()
+	}
+	if o.LastScoutObservedVersion.IsSet() {
+		toSerialize["lastScoutObservedVersion"] = o.LastScoutObservedVersion.Get()
 	}
 	if !IsNil(o.Health) {
 		toSerialize["health"] = o.Health


### PR DESCRIPTION
Machine responses omit the last Scout version already stored in Core metadata, so the REST API and nicocli cannot show it. This exposes `scoutVersion` from the current status field with the deprecated top-level value as a compatibility fallback.

## Related issues

- #1614
- [NVBug 6504114](https://nvbugspro.nvidia.com/bug/6504114)

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed targeted REST model, nicocli spec/output, simple and generated SDK, OpenAPI lint, and Go vet checks.

## Additional Notes
