### PR TITLE
fix(rest-api): Preserve addressless Interfaces when processing Machine inventory

### DIFF
--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -404,7 +404,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 						Hostname:              &controllerMachineInterface.Hostname,
 						IsPrimary:             controllerMachineInterface.PrimaryInterface,
 						MacAddress:            &controllerMachineInterface.MacAddress,
-						IpAddresses:           machineInterfaceIPAddresses(controllerMachineInterface.Address),
+						IpAddresses:           normalizeMachineInterfaceIPAddresses(controllerMachineInterface.Address),
 					},
 				)
 				if serr != nil {
@@ -623,7 +623,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 							Hostname:              &controllerMachineInterface.Hostname,
 							IsPrimary:             controllerMachineInterface.PrimaryInterface,
 							MacAddress:            &controllerMachineInterface.MacAddress,
-							IpAddresses:           machineInterfaceIPAddresses(controllerMachineInterface.Address),
+							IpAddresses:           normalizeMachineInterfaceIPAddresses(controllerMachineInterface.Address),
 						},
 					)
 					if serr != nil {
@@ -642,7 +642,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 							Hostname:             &controllerMachineInterface.Hostname,
 							IsPrimary:            &controllerMachineInterface.PrimaryInterface,
 							MacAddress:           &controllerMachineInterface.MacAddress,
-							IpAddresses:          machineInterfaceIPAddresses(controllerMachineInterface.Address),
+							IpAddresses:          normalizeMachineInterfaceIPAddresses(controllerMachineInterface.Address),
 						},
 					)
 					if serr != nil {
@@ -735,9 +735,9 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 	return nil
 }
 
-// machineInterfaceIPAddresses maps Core's optional repeated addresses to the
+// normalizeMachineInterfaceIPAddresses maps Core's optional repeated addresses to the
 // non-null array required by the REST database model.
-func machineInterfaceIPAddresses(addresses []string) []string {
+func normalizeMachineInterfaceIPAddresses(addresses []string) []string {
 	if addresses == nil {
 		return []string{}
 	}

--- a/rest-api/workflow/pkg/activity/machine/machine.go
+++ b/rest-api/workflow/pkg/activity/machine/machine.go
@@ -404,7 +404,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 						Hostname:              &controllerMachineInterface.Hostname,
 						IsPrimary:             controllerMachineInterface.PrimaryInterface,
 						MacAddress:            &controllerMachineInterface.MacAddress,
-						IpAddresses:           controllerMachineInterface.Address,
+						IpAddresses:           machineInterfaceIPAddresses(controllerMachineInterface.Address),
 					},
 				)
 				if serr != nil {
@@ -623,7 +623,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 							Hostname:              &controllerMachineInterface.Hostname,
 							IsPrimary:             controllerMachineInterface.PrimaryInterface,
 							MacAddress:            &controllerMachineInterface.MacAddress,
-							IpAddresses:           controllerMachineInterface.Address,
+							IpAddresses:           machineInterfaceIPAddresses(controllerMachineInterface.Address),
 						},
 					)
 					if serr != nil {
@@ -642,7 +642,7 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 							Hostname:             &controllerMachineInterface.Hostname,
 							IsPrimary:            &controllerMachineInterface.PrimaryInterface,
 							MacAddress:           &controllerMachineInterface.MacAddress,
-							IpAddresses:          controllerMachineInterface.Address,
+							IpAddresses:          machineInterfaceIPAddresses(controllerMachineInterface.Address),
 						},
 					)
 					if serr != nil {
@@ -733,6 +733,15 @@ func (mm *ManageMachine) UpdateMachinesInDB(ctx context.Context, siteIDStr strin
 	logger.Info().Msg("completed activity")
 
 	return nil
+}
+
+// machineInterfaceIPAddresses maps Core's optional repeated addresses to the
+// non-null array required by the REST database model.
+func machineInterfaceIPAddresses(addresses []string) []string {
+	if addresses == nil {
+		return []string{}
+	}
+	return addresses
 }
 
 // Utility function to parse discovery data and create/update Machine Capability records

--- a/rest-api/workflow/pkg/activity/machine/machine_test.go
+++ b/rest-api/workflow/pkg/activity/machine/machine_test.go
@@ -1363,6 +1363,57 @@ func TestManageMachine_UpdateMachinesInDB(t *testing.T) {
 	}
 }
 
+func TestManageMachine_UpdateMachinesInDB_AddresslessInterface(t *testing.T) {
+	dbSession := testMachineInitDB(t)
+	defer dbSession.Close()
+	testMachineSetupSchema(t, dbSession)
+
+	ip := testMachineBuildInfrastructureProvider(t, dbSession, "test-ip-org", "test-ip")
+	site := testMachineBuildSite(t, dbSession, ip, "test-site", cdbm.SiteStatusRegistered)
+	machineID := uuid.NewString()
+	interfaceID := uuid.New()
+
+	machineInventory := &corev1.MachineInventory{
+		Machines: []*corev1.MachineInfo{
+			{
+				Machine: &corev1.Machine{
+					Id:    &corev1.MachineId{Id: machineID},
+					State: controllerMachineStatePrefixReady,
+					Interfaces: []*corev1.MachineInterface{
+						{
+							Id:               &corev1.MachineInterfaceId{Value: interfaceID.String()},
+							MachineId:        &corev1.MachineId{Id: machineID},
+							SegmentId:        &corev1.NetworkSegmentId{Value: uuid.NewString()},
+							Address:          nil,
+							Hostname:         "addressless.example.com",
+							MacAddress:       "00:00:00:00:00:00",
+							PrimaryInterface: true,
+						},
+					},
+				},
+			},
+		},
+		Timestamp: timestamppb.Now(),
+	}
+
+	mm := NewManageMachine(dbSession, nil)
+	require.NoError(t, mm.UpdateMachinesInDB(context.Background(), site.ID.String(), machineInventory))
+
+	miDAO := cdbm.NewMachineInterfaceDAO(dbSession)
+	machineInterfaces, _, err := miDAO.GetAll(
+		context.Background(),
+		nil,
+		cdbm.MachineInterfaceFilterInput{MachineIDs: []string{machineID}},
+		cdbp.PageInput{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, machineInterfaces, 1)
+	assert.Equal(t, interfaceID, *machineInterfaces[0].ControllerInterfaceID)
+	assert.NotNil(t, machineInterfaces[0].IPAddresses)
+	assert.Empty(t, machineInterfaces[0].IPAddresses)
+}
+
 func TestNewManageMachine(t *testing.T) {
 	type args struct {
 		dbSession     *cdb.Session


### PR DESCRIPTION
REST machine inventory currently passes Core's empty interface address list through as nil, causing the non-null database write to fail and the interface to be omitted while inventory processing continues. This change maps empty address lists to an empty database array and adds regression coverage showing an addressless interface remains in inventory.

## Related issues
- [NVBug 6503989](https://nvbugspro.nvidia.com/bug/6503989)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
