### PR TITLE
fix(ssh-console): avoid test port allocation race

### DIFF
--- a/crates/ssh-console/src/lib.rs
+++ b/crates/ssh-console/src/lib.rs
@@ -67,6 +67,8 @@ pub async fn spawn(config: Config) -> Result<SpawnHandle, SpawnError> {
 
     // 3) Start metrics server
     let metrics_handle = metrics::spawn(config.clone(), metrics).await?;
+    let listen_address = server.listen_address();
+    let metrics_address = metrics_handle.metrics_address();
 
     // 4) Wait for a shutdown signal, then shut down the above
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -78,6 +80,8 @@ pub async fn spawn(config: Config) -> Result<SpawnHandle, SpawnError> {
     });
 
     Ok(SpawnHandle {
+        listen_address,
+        metrics_address,
         shutdown_tx,
         join_handle,
     })
@@ -94,8 +98,20 @@ pub enum SpawnError {
 }
 
 pub struct SpawnHandle {
+    listen_address: std::net::SocketAddr,
+    metrics_address: std::net::SocketAddr,
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
+}
+
+impl SpawnHandle {
+    pub fn listen_address(&self) -> std::net::SocketAddr {
+        self.listen_address
+    }
+
+    pub fn metrics_address(&self) -> std::net::SocketAddr {
+        self.metrics_address
+    }
 }
 
 impl ShutdownHandle<()> for SpawnHandle {

--- a/crates/ssh-console/src/metrics.rs
+++ b/crates/ssh-console/src/metrics.rs
@@ -42,9 +42,10 @@ pub async fn spawn(
     let listener = TcpListener::bind(config.metrics_address)
         .await
         .map_err(SpawnError::Listen)?;
+    let metrics_address = listener.local_addr().map_err(SpawnError::Listen)?;
 
     tracing::info!(
-        metrics_address = %config.metrics_address,
+        %metrics_address,
         "metrics service listening"
     );
 
@@ -86,6 +87,7 @@ pub async fn spawn(
     });
 
     Ok(MetricsHandle {
+        metrics_address,
         shutdown_tx,
         join_handle,
     })
@@ -125,8 +127,15 @@ fn serve_metrics(
 }
 
 pub struct MetricsHandle {
+    metrics_address: std::net::SocketAddr,
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
+}
+
+impl MetricsHandle {
+    pub fn metrics_address(&self) -> std::net::SocketAddr {
+        self.metrics_address
+    }
 }
 
 impl ShutdownHandle<()> for MetricsHandle {

--- a/crates/ssh-console/src/ssh_server.rs
+++ b/crates/ssh-console/src/ssh_server.rs
@@ -75,12 +75,17 @@ pub async fn spawn(
             addr: listen_address,
             error,
         })?;
+    let listen_address = listener.local_addr().map_err(|error| Listening {
+        addr: listen_address,
+        error,
+    })?;
     tracing::info!(%listen_address, "SSH server listening");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join_handle = tokio::spawn(server.run(listener, shutdown_rx));
 
     Ok(Handle {
+        listen_address,
         shutdown_tx,
         join_handle,
     })
@@ -101,8 +106,15 @@ pub enum SpawnError {
 }
 
 pub struct Handle {
+    listen_address: SocketAddr,
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
+}
+
+impl Handle {
+    pub fn listen_address(&self) -> SocketAddr {
+        self.listen_address
+    }
 }
 
 impl ShutdownHandle<()> for Handle {

--- a/crates/ssh-console/tests/util/ssh_console_test_helper.rs
+++ b/crates/ssh-console/tests/util/ssh_console_test_helper.rs
@@ -24,6 +24,7 @@ use hyper_util::rt::TokioExecutor;
 use size::Size;
 use ssh_console::config::Defaults;
 use temp_dir::TempDir;
+use tokio::net::TcpStream;
 
 use crate::util::fixtures::{
     API_CA_CERT, API_CLIENT_CERT, API_CLIENT_KEY, AUTHORIZED_KEYS_PATH, SSH_HOST_KEY,
@@ -96,6 +97,14 @@ pub async fn spawn(
     let spawn_handle = ssh_console::spawn(config).await?;
     let listen_address = spawn_handle.listen_address();
     let metrics_address = spawn_handle.metrics_address();
+    assert_ne!(listen_address.port(), 0);
+    assert_ne!(metrics_address.port(), 0);
+    TcpStream::connect(listen_address)
+        .await
+        .context("error connecting to runtime-assigned SSH address")?;
+    TcpStream::connect(metrics_address)
+        .await
+        .context("error connecting to runtime-assigned metrics address")?;
 
     Ok(NewSshConsoleHandle {
         addr: listen_address,

--- a/crates/ssh-console/tests/util/ssh_console_test_helper.rs
+++ b/crates/ssh-console/tests/util/ssh_console_test_helper.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use eyre::Context;
@@ -41,22 +41,8 @@ pub async fn spawn(
     carbide_port: u16,
     config_overrides: Option<ConfigOverrides>,
 ) -> eyre::Result<NewSshConsoleHandle> {
-    let listen_address = {
-        // Pick an open port
-        let l = TcpListener::bind("127.0.0.1:0")?;
-        l.local_addr()?
-            .to_socket_addrs()?
-            .next()
-            .expect("No socket available")
-    };
-    let metrics_address = {
-        // Pick an open port
-        let l = TcpListener::bind("127.0.0.1:0")?;
-        l.local_addr()?
-            .to_socket_addrs()?
-            .next()
-            .expect("No socket available")
-    };
+    let listen_address = "127.0.0.1:0".parse().expect("Invalid listen address");
+    let metrics_address = "127.0.0.1:0".parse().expect("Invalid metrics address");
 
     let logs_dir = TempDir::new().context("error creating temp dir for console logs")?;
 
@@ -108,6 +94,8 @@ pub async fn spawn(
     };
 
     let spawn_handle = ssh_console::spawn(config).await?;
+    let listen_address = spawn_handle.listen_address();
+    let metrics_address = spawn_handle.metrics_address();
 
     Ok(NewSshConsoleHandle {
         addr: listen_address,


### PR DESCRIPTION
## Summary

- let the SSH and metrics listeners atomically select ephemeral ports during their real bind
- expose the effective listener addresses through `SpawnHandle`
- update the SSH-console integration-test helper to use those effective addresses

## Root cause

The test helper previously bound `127.0.0.1:0`, recorded the selected port, dropped the listener, and later asked `ssh_console::spawn` to bind that port again. Parallel tests or another process could claim the released port in between, intermittently causing `Address already in use` failures such as the metrics-listener failure in [this CI run](https://github.com/NVIDIA/infra-controller/actions/runs/30125241660).

Binding port `0` in the actual SSH and metrics servers removes that time-of-check/time-of-use window. Configured nonzero production addresses retain their existing behavior.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p carbide-ssh-console --no-default-features` reached the crate but is blocked on macOS by existing Linux-specific `termios`/`ioctl` assumptions in `io_util.rs`
- Linux cross-checking was attempted but is blocked locally by the unavailable `x86_64-linux-gnu-gcc` toolchain required by crypto dependencies

The Linux CI integration suite will provide the full runtime validation.
