### PR TITLE
feat(site-explorer): correlate setup status with boot targets

### DIFF
--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -648,12 +648,13 @@ pub(crate) async fn explore(
             .map(ExpectedEntity::PowerShelf)
     };
 
-    // Look up boot_interface_mac from existing explored endpoint if available
+    // Use the same stored boot-interface target as periodic exploration.
     let mut txn = api.txn_begin().await?;
-    let boot_interface_mac = db::explored_endpoints::find_by_ips(&mut txn, vec![bmc_addr.ip()])
+    let boot_interface = db::explored_endpoints::find_by_ips(&mut txn, vec![bmc_addr.ip()])
         .await?
         .first()
-        .and_then(|ep| ep.boot_interface_mac);
+        .and_then(|ep| ep.boot_interface_target())
+        .map(Into::into);
     txn.commit().await?;
 
     let report = api
@@ -663,7 +664,7 @@ pub(crate) async fn explore(
             &machine_interface,
             expected.as_ref(),
             None,
-            boot_interface_mac,
+            boot_interface.as_ref(),
         )
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -19,6 +19,7 @@ use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_site_explorer::config::SiteExplorerConfig;
 use common::api_fixtures::TestEnv;
 use db::{self, ObjectColumnFilter};
@@ -26,7 +27,10 @@ use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
 use model::hardware_info::HardwareInfo;
 use model::machine::ManagedHostStateSnapshot;
-use model::site_explorer::{Chassis, EndpointExplorationError, EndpointExplorationReport};
+use model::machine_boot_interface::MachineBootInterfaceTarget;
+use model::site_explorer::{
+    Chassis, EndpointExplorationError, EndpointExplorationReport, MachineSetupStatus,
+};
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::forge_server::Forge;
 use rpc::{DiscoveryData, DiscoveryInfo, MachineDiscoveryInfo};
@@ -744,32 +748,215 @@ fn endpoint_explore_call_count(env: &TestEnv, bmc_ip: IpAddr) -> usize {
         .lock()
         .unwrap()
         .iter()
-        .filter(|called_ip| **called_ip == bmc_ip)
+        .filter(|call| call.ip_address == bmc_ip)
         .count()
 }
 
+fn endpoint_explore_target(env: &TestEnv, bmc_ip: IpAddr) -> Option<BootInterfaceTarget> {
+    env.endpoint_explorer
+        .explore_endpoint_calls
+        .lock()
+        .unwrap()
+        .iter()
+        .rev()
+        .find(|call| call.ip_address == bmc_ip)
+        .unwrap_or_else(|| panic!("expected endpoint {bmc_ip} to have been explored"))
+        .boot_interface
+        .clone()
+}
+
+fn boot_interface_target_cases(
+    endpoint: &model::site_explorer::ExploredEndpoint,
+) -> Vec<(&'static str, Option<BootInterfaceTarget>)> {
+    let pair = endpoint
+        .boot_interface()
+        .expect("managed-host fixture should retain a complete boot-interface pair");
+    let mac_address = pair.mac_address;
+
+    vec![
+        ("complete pair", Some(BootInterfaceTarget::Pair(pair))),
+        (
+            "legacy MAC only",
+            Some(BootInterfaceTarget::MacOnly(mac_address)),
+        ),
+        ("no target", None),
+    ]
+}
+
+async fn set_endpoint_boot_interface_target(
+    env: &TestEnv,
+    bmc_ip: IpAddr,
+    target: Option<&BootInterfaceTarget>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (mac_address, interface_id) = match target {
+        Some(BootInterfaceTarget::Pair(boot_interface)) => (
+            Some(boot_interface.mac_address),
+            Some(boot_interface.interface_id.as_str()),
+        ),
+        Some(BootInterfaceTarget::MacOnly(mac_address)) => (Some(*mac_address), None),
+        None => (None, None),
+    };
+
+    let mut txn = env.pool.begin().await?;
+    sqlx::query(
+        "UPDATE explored_endpoints
+         SET boot_interface_mac = $1, boot_interface_id = $2
+         WHERE address = $3",
+    )
+    .bind(mac_address)
+    .bind(interface_id)
+    .bind(bmc_ip)
+    .execute(&mut *txn)
+    .await?;
+    txn.commit().await?;
+
+    Ok(())
+}
+
+fn report_with_evaluated_boot_interface(
+    mut report: EndpointExplorationReport,
+    target: Option<&BootInterfaceTarget>,
+) -> EndpointExplorationReport {
+    report.machine_setup_status = Some(MachineSetupStatus {
+        is_done: true,
+        diffs: Vec::new(),
+        evaluated_boot_interface: target.map(MachineBootInterfaceTarget::from),
+    });
+    report
+}
+
+async fn prepare_endpoint_exploration_case(
+    env: &TestEnv,
+    bmc_ip: IpAddr,
+    target: Option<&BootInterfaceTarget>,
+) -> Result<model::site_explorer::ExploredEndpoint, Box<dyn std::error::Error>> {
+    set_endpoint_boot_interface_target(env, bmc_ip, target).await?;
+    let endpoint = explored_endpoint(env, bmc_ip).await?;
+    let report = report_with_evaluated_boot_interface(endpoint.report.clone(), target);
+    env.endpoint_explorer
+        .insert_endpoint_result(bmc_ip, Ok(report));
+    env.endpoint_explorer
+        .explore_endpoint_calls
+        .lock()
+        .unwrap()
+        .clear();
+
+    Ok(endpoint)
+}
+
 #[sqlx_test]
-async fn test_refresh_endpoint_report_bumps_report_version(
+async fn test_refresh_endpoint_report_correlates_each_boot_interface_target(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
     let mh = common::api_fixtures::create_managed_host(&env).await;
     let bmc_ip = host_bmc_ip(&env, &mh).await?;
-    let initial_version = explored_endpoint(&env, bmc_ip).await?.report_version;
+    let initial = explored_endpoint(&env, bmc_ip).await?;
+    for (scenario, target) in boot_interface_target_cases(&initial) {
+        let baseline = prepare_endpoint_exploration_case(&env, bmc_ip, target.as_ref()).await?;
+        let baseline_version = baseline.report_version;
+        let expected_evaluated_target = target.as_ref().map(MachineBootInterfaceTarget::from);
 
-    env.api
-        .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
-            ip_address: bmc_ip.to_string(),
-        }))
-        .await?;
+        env.api
+            .refresh_endpoint_report(Request::new(rpc::forge::RefreshEndpointReportRequest {
+                ip_address: bmc_ip.to_string(),
+            }))
+            .await?;
 
-    let refreshed = explored_endpoint(&env, bmc_ip).await?;
-    assert!(
-        refreshed.report_version.version_nr() > initial_version.version_nr(),
-        "refresh should bump report version from {} to a newer version, got {}",
-        initial_version.version_nr(),
-        refreshed.report_version.version_nr()
-    );
+        let refreshed = explored_endpoint(&env, bmc_ip).await?;
+        assert!(
+            refreshed.report_version.version_nr() > baseline_version.version_nr(),
+            "{scenario}: refresh should bump report version from {} to a newer version, got {}",
+            baseline_version.version_nr(),
+            refreshed.report_version.version_nr()
+        );
+        assert_eq!(
+            endpoint_explore_target(&env, bmc_ip),
+            target,
+            "{scenario}: explicit refresh should evaluate the target stored with the endpoint"
+        );
+        let status = refreshed
+            .report
+            .machine_setup_status
+            .expect("mock report should include machine setup status");
+        assert_eq!(
+            status.evaluated_boot_interface, expected_evaluated_target,
+            "{scenario}: the persisted status and evaluated target should come from the same report update"
+        );
+    }
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_ad_hoc_explore_uses_stored_boot_interface_target(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let initial = explored_endpoint(&env, bmc_ip).await?;
+    for (scenario, target) in boot_interface_target_cases(&initial) {
+        prepare_endpoint_exploration_case(&env, bmc_ip, target.as_ref()).await?;
+
+        let response = env
+            .api
+            .explore(Request::new(rpc::forge::BmcEndpointRequest {
+                ip_address: bmc_ip.to_string(),
+                mac_address: None,
+            }))
+            .await?
+            .into_inner();
+
+        assert_eq!(
+            endpoint_explore_target(&env, bmc_ip),
+            target,
+            "{scenario}: ad-hoc exploration should evaluate the target stored with the endpoint"
+        );
+        assert!(
+            response.machine_setup_status.is_some(),
+            "{scenario}: ad-hoc exploration should return the machine setup observation"
+        );
+    }
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn test_periodic_exploration_uses_stored_boot_interface_target(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = common::api_fixtures::create_test_env(pool.clone()).await;
+    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let initial = explored_endpoint(&env, bmc_ip).await?;
+    for (scenario, target) in boot_interface_target_cases(&initial) {
+        let expected_evaluated_target = target.as_ref().map(MachineBootInterfaceTarget::from);
+        prepare_endpoint_exploration_case(&env, bmc_ip, target.as_ref()).await?;
+
+        env.api
+            .re_explore_endpoint(Request::new(rpc::forge::ReExploreEndpointRequest {
+                ip_address: bmc_ip.to_string(),
+                if_version_match: None,
+            }))
+            .await?;
+        env.run_site_explorer_iteration().await;
+
+        assert_eq!(
+            endpoint_explore_target(&env, bmc_ip),
+            target,
+            "{scenario}: periodic exploration should evaluate the target stored with the endpoint"
+        );
+        let status = explored_endpoint(&env, bmc_ip)
+            .await?
+            .report
+            .machine_setup_status
+            .expect("mock report should include machine setup status");
+        assert_eq!(
+            status.evaluated_boot_interface, expected_evaluated_target,
+            "{scenario}: periodic exploration should persist the correlated observation"
+        );
+    }
 
     Ok(())
 }
@@ -891,6 +1078,12 @@ async fn test_refresh_endpoint_report_rejects_concurrent_report_update(
 
     let mut concurrent_report = baseline.report.clone();
     concurrent_report.model = Some("concurrent update".to_string());
+    let concurrent_target = MachineBootInterfaceTarget::MacOnly("02:00:00:00:00:77".parse()?);
+    concurrent_report.machine_setup_status = Some(MachineSetupStatus {
+        is_done: false,
+        diffs: Vec::new(),
+        evaluated_boot_interface: Some(concurrent_target.clone()),
+    });
     let mut txn = env.pool.begin().await?;
     assert!(
         db::explored_endpoints::try_update(
@@ -919,6 +1112,14 @@ async fn test_refresh_endpoint_report_rejects_concurrent_report_update(
         final_endpoint.report.model.as_deref(),
         Some("concurrent update")
     );
+    assert_eq!(
+        final_endpoint
+            .report
+            .machine_setup_status
+            .and_then(|status| status.evaluated_boot_interface),
+        Some(concurrent_target),
+        "stale refresh must not replace the target correlated with the concurrent report"
+    );
 
     Ok(())
 }
@@ -930,6 +1131,27 @@ async fn test_refresh_endpoint_report_failure_persists_error_and_bumps_version(
     let env = common::api_fixtures::create_test_env(pool.clone()).await;
     let mh = common::api_fixtures::create_managed_host(&env).await;
     let bmc_ip = host_bmc_ip(&env, &mh).await?;
+    let mut initial = explored_endpoint(&env, bmc_ip).await?;
+    let preserved_target = initial
+        .boot_interface_target()
+        .expect("managed-host fixture should retain a boot-interface target");
+    initial.report.machine_setup_status = Some(MachineSetupStatus {
+        is_done: true,
+        diffs: Vec::new(),
+        evaluated_boot_interface: Some(preserved_target.clone()),
+    });
+    let mut txn = env.pool.begin().await?;
+    assert!(
+        db::explored_endpoints::try_update(
+            bmc_ip,
+            initial.report_version,
+            &initial.report,
+            initial.waiting_for_explorer_refresh,
+            &mut txn,
+        )
+        .await?
+    );
+    txn.commit().await?;
     let initial_version = explored_endpoint(&env, bmc_ip).await?.report_version;
     env.endpoint_explorer.insert_endpoint_result(
         bmc_ip,
@@ -952,6 +1174,14 @@ async fn test_refresh_endpoint_report_failure_persists_error_and_bumps_version(
     assert!(
         refreshed.report.last_exploration_error.is_some(),
         "failed refresh should persist the exploration error"
+    );
+    assert_eq!(
+        refreshed
+            .report
+            .machine_setup_status
+            .and_then(|status| status.evaluated_boot_interface),
+        Some(preserved_target),
+        "failed refresh should preserve the last successful target-correlated observation"
     );
 
     Ok(())

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use carbide_uuid::network::NetworkSegmentId;
 use model::machine_interface::InterfaceType;
 use model::network_prefix::NewNetworkPrefix;
 use model::network_segment::{
@@ -52,6 +53,91 @@ async fn create_static_assignments_segment(
     )
     .await?;
     txn.commit().await?;
+
+    Ok(())
+}
+
+async fn create_test_segment(
+    pool: &sqlx::PgPool,
+    name: &str,
+) -> Result<NetworkSegmentId, Box<dyn std::error::Error>> {
+    let segment_id = NetworkSegmentId::new();
+    let mut txn = db::Transaction::begin(pool).await?;
+    db::network_segment::persist(
+        NewNetworkSegment {
+            id: segment_id,
+            name: name.to_string(),
+            subdomain_id: None,
+            vpc_id: None,
+            mtu: 1500,
+            prefixes: Vec::new(),
+            vlan_id: None,
+            vni: None,
+            segment_type: NetworkSegmentType::HostInband,
+            can_stretch: Some(false),
+            allocation_strategy: AllocationStrategy::Reserved,
+        },
+        txn.as_pgconn(),
+        NetworkSegmentControllerState::Ready,
+    )
+    .await?;
+    txn.commit().await?;
+
+    Ok(segment_id)
+}
+
+/// A MAC identifies one physical interface even when stale or transitional
+/// rows represent it on more than one segment. Site Explorer learns one
+/// vendor-native Redfish id for that interface, so `set_boot_interface_id`
+/// updates every row for the MAC rather than whichever segment happened to
+/// report first.
+#[crate::sqlx_test]
+async fn set_boot_interface_id_updates_every_segment_row_for_mac(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_a = create_test_segment(&pool, "boot-id-segment-a").await?;
+    let segment_b = create_test_segment(&pool, "boot-id-segment-b").await?;
+    let boot_mac: MacAddress = "7A:7B:7C:7D:7E:41".parse()?;
+    let other_mac: MacAddress = "7A:7B:7C:7D:7E:42".parse()?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    let query = "
+INSERT INTO machine_interfaces
+    (segment_id, mac_address, primary_interface, hostname)
+VALUES
+    ($1, $2, false, 'boot-a'),
+    ($3, $2, false, 'boot-b'),
+    ($1, $4, false, 'other')";
+    sqlx::query(query)
+        .bind(segment_a)
+        .bind(boot_mac)
+        .bind(segment_b)
+        .bind(other_mac)
+        .execute(txn.as_pgconn())
+        .await?;
+
+    set_boot_interface_id(boot_mac, "NIC.Slot.7-1-1", txn.as_pgconn()).await?;
+
+    let boot_ids: Vec<Option<String>> = sqlx::query_scalar(
+        "SELECT boot_interface_id FROM machine_interfaces WHERE mac_address=$1 ORDER BY hostname",
+    )
+    .bind(boot_mac)
+    .fetch_all(txn.as_pgconn())
+    .await?;
+    let other_id: Option<String> =
+        sqlx::query_scalar("SELECT boot_interface_id FROM machine_interfaces WHERE mac_address=$1")
+            .bind(other_mac)
+            .fetch_one(txn.as_pgconn())
+            .await?;
+
+    assert_eq!(
+        boot_ids,
+        vec![
+            Some("NIC.Slot.7-1-1".to_string()),
+            Some("NIC.Slot.7-1-1".to_string())
+        ]
+    );
+    assert_eq!(other_id, None, "a different MAC must remain unchanged");
 
     Ok(())
 }

--- a/crates/api-model/src/machine_boot_interface.rs
+++ b/crates/api-model/src/machine_boot_interface.rs
@@ -66,8 +66,50 @@ impl MachineBootInterface {
     }
 }
 
+/// The logical boot-interface target NICo asked a Redfish backend to assess for
+/// a machine-setup observation.
+///
+/// Newer endpoint records retain the complete [`MachineBootInterface`] pair.
+/// Older records may only have the MAC, which remains a valid selector but
+/// must stay distinguishable from a pair. A backend may match with only the
+/// identifiers its read path supports -- NvRedfish currently uses the MAC --
+/// while this value keeps the `Pair` identity NICo requested. The state
+/// controller can therefore compare the logical target with its current target
+/// before trusting the associated setup status.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum MachineBootInterfaceTarget {
+    /// Both the MAC and vendor-native Redfish interface id are known.
+    Pair(MachineBootInterface),
+    /// Only the MAC is known.
+    MacOnly(MacAddress),
+}
+
+impl MachineBootInterfaceTarget {
+    /// Builds the strongest usable target from an endpoint record.
+    ///
+    /// A MAC plus a non-empty interface id becomes [`Self::Pair`]. A MAC
+    /// without an id remains [`Self::MacOnly`], while an id without a MAC
+    /// cannot identify an interface and yields `None`.
+    pub fn from_parts(
+        mac_address: Option<MacAddress>,
+        interface_id: Option<String>,
+    ) -> Option<Self> {
+        let mac_address = mac_address?;
+        Some(match interface_id.none_if_empty() {
+            Some(interface_id) => Self::Pair(MachineBootInterface {
+                mac_address,
+                interface_id,
+            }),
+            None => Self::MacOnly(mac_address),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use carbide_test_support::value_scenarios;
+
     use super::*;
 
     #[test]
@@ -97,5 +139,39 @@ mod tests {
             "an interface id with no MAC is not fully populated"
         );
         assert_eq!(MachineBootInterface::from_parts(None, None), None);
+    }
+
+    #[test]
+    fn target_from_parts_preserves_the_available_selector() {
+        let mac = MacAddress::new([1, 2, 3, 4, 5, 6]);
+
+        value_scenarios!(run = |(mac_address, interface_id)| {
+            MachineBootInterfaceTarget::from_parts(mac_address, interface_id)
+        };
+            "complete pair" {
+                (Some(mac), Some("NIC.Slot.7-1-1".to_string())) =>
+                    Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address: mac,
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    })),
+            }
+
+            "legacy MAC only" {
+                (Some(mac), None) => Some(MachineBootInterfaceTarget::MacOnly(mac)),
+            }
+
+            "empty interface id is MAC only" {
+                (Some(mac), Some(String::new())) =>
+                    Some(MachineBootInterfaceTarget::MacOnly(mac)),
+            }
+
+            "interface id without MAC" {
+                (None, Some("NIC.Slot.7-1-1".to_string())) => None,
+            }
+
+            "no target parts" {
+                (None, None) => None,
+            }
+        );
     }
 }

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -41,7 +41,7 @@ use crate::errors::{ErrorCode, ErrorSubsystem, ModelError, ModelResult, Operator
 use crate::firmware::{Firmware, FirmwareComponentType};
 use crate::hardware_info::{DmiData, HardwareInfo, HardwareInfoError};
 use crate::machine::machine_id::{MissingHardwareInfo, from_hardware_info_with_type};
-use crate::machine_boot_interface::MachineBootInterface;
+use crate::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 use crate::power_shelf::power_shelf_id;
 use crate::switch::switch_id;
 
@@ -219,8 +219,9 @@ pub struct ExploredEndpoint {
     /// The MAC address of the boot interface (primary interface) for this host endpoint
     pub boot_interface_mac: Option<MacAddress>,
     /// The vendor-native Redfish interface id of the boot interface, captured
-    /// alongside `boot_interface_mac`. Combined with the MAC via
-    /// [`ExploredEndpoint::boot_interface`] to form a [`MachineBootInterface`].
+    /// alongside `boot_interface_mac`. [`ExploredEndpoint::boot_interface`]
+    /// returns the complete pair, while
+    /// [`ExploredEndpoint::boot_interface_target`] preserves a MAC-only target.
     pub boot_interface_id: Option<String>,
 }
 
@@ -239,6 +240,19 @@ impl ExploredEndpoint {
     /// interface id.
     pub fn boot_interface(&self) -> Option<MachineBootInterface> {
         MachineBootInterface::from_parts(self.boot_interface_mac, self.boot_interface_id.clone())
+    }
+
+    /// Returns the boot interface selector Site Explorer should evaluate.
+    ///
+    /// A complete endpoint record yields [`MachineBootInterfaceTarget::Pair`].
+    /// Older records with only `boot_interface_mac` remain usable as
+    /// [`MachineBootInterfaceTarget::MacOnly`]. An interface id by itself
+    /// cannot identify the target and yields `None`.
+    pub fn boot_interface_target(&self) -> Option<MachineBootInterfaceTarget> {
+        MachineBootInterfaceTarget::from_parts(
+            self.boot_interface_mac,
+            self.boot_interface_id.clone(),
+        )
     }
 
     /// find_version will locate a version number within an ExploredEndpoint
@@ -1659,12 +1673,28 @@ pub struct Inventory {
     pub release_date: Option<String>,
 }
 
-/// `MachineSetupStatus` definition. Matches redfish definition
+/// The result of one Redfish machine-setup check.
+///
+/// `is_done` and `diffs` mirror the vendor result. The evaluated boot interface
+/// records the logical target NICo asked the backend to assess, so a later
+/// controller never has to infer it from endpoint columns that may have changed
+/// after the report was written.
 #[derive(Debug, Default, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct MachineSetupStatus {
     pub is_done: bool,
     pub diffs: Vec<MachineSetupDiff>,
+    /// The logical boot-interface target NICo asked the backend to assess.
+    ///
+    /// This does not claim that the backend used every identifier in the
+    /// target: a backend may match with a subset (NvRedfish currently uses the
+    /// MAC) while retaining the requested `Pair` identity. This lives inside
+    /// `MachineSetupStatus` so the report's versioned JSON stores the
+    /// observation and its target together. Reports written before target
+    /// capture leave it as `None`, which tells a later controller not to treat
+    /// the status as evidence for a newly selected interface.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evaluated_boot_interface: Option<MachineBootInterfaceTarget>,
 }
 
 /// `BootOrder` definition.
@@ -2603,6 +2633,127 @@ mod tests {
             boot_interface_id: None,
             pause_ingestion_and_poweron: false,
         }
+    }
+
+    #[test]
+    fn endpoint_boot_interface_target_preserves_legacy_mac_only_records() {
+        let mac = MacAddress::new([0x02, 0, 0, 0, 0, 1]);
+
+        value_scenarios!(run = |(boot_interface_mac, boot_interface_id)| {
+            let mut endpoint = create_test_endpoint(Vec::new());
+            endpoint.boot_interface_mac = boot_interface_mac;
+            endpoint.boot_interface_id = boot_interface_id;
+            endpoint.boot_interface_target()
+        };
+            "complete pair" {
+                (Some(mac), Some("NIC.Slot.7-1-1".to_string())) =>
+                    Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address: mac,
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    })),
+            }
+
+            "legacy MAC only" {
+                (Some(mac), None) => Some(MachineBootInterfaceTarget::MacOnly(mac)),
+            }
+
+            "interface id without MAC" {
+                (None, Some("NIC.Slot.7-1-1".to_string())) => None,
+            }
+
+            "no stored target" {
+                (None, None) => None,
+            }
+        );
+    }
+
+    #[test]
+    fn machine_setup_status_json_correlates_the_evaluated_target() {
+        let mac = MacAddress::new([0x02, 0, 0, 0, 0, 1]);
+
+        value_scenarios!(run = |status: MachineSetupStatus| {
+            let json = serde_json::to_value(&status).expect("status serializes");
+            let round_trip =
+                serde_json::from_value(json.clone()).expect("serialized status deserializes");
+            (json, round_trip)
+        };
+            "status without a target remains backward compatible" {
+                MachineSetupStatus {
+                    is_done: true,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: None,
+                } => (
+                    serde_json::json!({
+                        "IsDone": true,
+                        "Diffs": [],
+                    }),
+                    MachineSetupStatus {
+                        is_done: true,
+                        diffs: Vec::new(),
+                        evaluated_boot_interface: None,
+                    },
+                ),
+            }
+
+            "paired target" {
+                MachineSetupStatus {
+                    is_done: false,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: Some(MachineBootInterfaceTarget::Pair(
+                        MachineBootInterface {
+                            mac_address: mac,
+                            interface_id: "NIC.Slot.7-1-1".to_string(),
+                        },
+                    )),
+                } => (
+                    serde_json::json!({
+                        "IsDone": false,
+                        "Diffs": [],
+                        "EvaluatedBootInterface": {
+                            "Pair": {
+                                "MacAddress": "02:00:00:00:00:01",
+                                "InterfaceId": "NIC.Slot.7-1-1",
+                            },
+                        },
+                    }),
+                    MachineSetupStatus {
+                        is_done: false,
+                        diffs: Vec::new(),
+                        evaluated_boot_interface: Some(MachineBootInterfaceTarget::Pair(
+                            MachineBootInterface {
+                                mac_address: mac,
+                                interface_id: "NIC.Slot.7-1-1".to_string(),
+                            },
+                        )),
+                    },
+                ),
+            }
+
+            "legacy MAC-only target" {
+                MachineSetupStatus {
+                    is_done: true,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: Some(MachineBootInterfaceTarget::MacOnly(mac)),
+                } => (
+                    serde_json::json!({
+                        "IsDone": true,
+                        "Diffs": [],
+                        "EvaluatedBootInterface": {
+                            "MacOnly": "02:00:00:00:00:01",
+                        },
+                    }),
+                    MachineSetupStatus {
+                        is_done: true,
+                        diffs: Vec::new(),
+                        evaluated_boot_interface: Some(MachineBootInterfaceTarget::MacOnly(mac)),
+                    },
+                ),
+            }
+        );
+
+        let legacy: MachineSetupStatus = serde_json::from_str(r#"{"IsDone":true,"Diffs":[]}"#)
+            .expect("reports written before target capture still deserialize");
+        assert_eq!(legacy.evaluated_boot_interface, None);
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
+use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use carbide_secrets::credentials::Credentials;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
@@ -62,7 +63,7 @@ struct Cli {
     #[arg(long, default_value_t = 443)]
     bmc_port: u16,
 
-    /// Boot MAC Address (e.g. 02:03:04:05:06:07)
+    /// Boot interface MAC address (e.g. 02:03:04:05:06:07)
     #[arg(long)]
     boot_mac: Option<MacAddress>,
 }
@@ -117,6 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ip = args.bmc_ip.parse()?;
     let port = args.bmc_port;
     let bmc_ip_address = SocketAddr::new(ip, port);
+    let boot_interface = args.boot_mac.map(BootInterfaceTarget::MacOnly);
 
     if let Some(iterations) = args.benchmark {
         let start = Instant::now();
@@ -125,7 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .generate_exploration_report(
                     bmc_ip_address,
                     fallback_credentials.clone(),
-                    args.boot_mac,
+                    boot_interface.as_ref(),
                     None,
                 )
                 .await?;
@@ -140,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .generate_exploration_report(
                         bmc_ip_address,
                         fallback_credentials.clone(),
-                        args.boot_mac,
+                        boot_interface.as_ref(),
                         None,
                     )
                     .await?,

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -275,6 +275,7 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
                 expected: "can detect".into(),
                 actual: "cannot detect".into(),
             }],
+            evaluated_boot_interface: None,
         });
 
     let system = explored_system.to_model(hw_type, &explored_chassis, &pcie_devices)?;
@@ -351,6 +352,7 @@ async fn build_delta_powershelf_report<B: Bmc>(
         machine_setup_status: Some(MachineSetupStatus {
             is_done: true,
             diffs: vec![],
+            evaluated_boot_interface: None,
         }),
         secure_boot_status: None,
         lockdown_status: None,
@@ -1091,6 +1093,7 @@ fn machine_setup_status<B: Bmc>(
     MachineSetupStatus {
         is_done: diffs.is_empty(),
         diffs,
+        evaluated_boot_interface: None,
     }
 }
 

--- a/crates/redfish/src/boot_interface.rs
+++ b/crates/redfish/src/boot_interface.rs
@@ -20,7 +20,7 @@ use std::future::Future;
 
 use ::libredfish::{BootInterfaceRef, RedfishError};
 use mac_address::MacAddress;
-use model::machine_boot_interface::MachineBootInterface;
+use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 
 /// How to target a host's boot interface for a Redfish setup operation.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -71,9 +71,35 @@ impl BootInterfaceTarget {
     }
 }
 
+impl From<MachineBootInterfaceTarget> for BootInterfaceTarget {
+    fn from(target: MachineBootInterfaceTarget) -> Self {
+        match target {
+            MachineBootInterfaceTarget::Pair(boot_interface) => Self::Pair(boot_interface),
+            MachineBootInterfaceTarget::MacOnly(mac_address) => Self::MacOnly(mac_address),
+        }
+    }
+}
+
+impl From<BootInterfaceTarget> for MachineBootInterfaceTarget {
+    fn from(target: BootInterfaceTarget) -> Self {
+        match target {
+            BootInterfaceTarget::Pair(boot_interface) => Self::Pair(boot_interface),
+            BootInterfaceTarget::MacOnly(mac_address) => Self::MacOnly(mac_address),
+        }
+    }
+}
+
+impl From<&BootInterfaceTarget> for MachineBootInterfaceTarget {
+    fn from(target: &BootInterfaceTarget) -> Self {
+        target.clone().into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use carbide_test_support::value_scenarios;
 
     use super::*;
 
@@ -121,5 +147,37 @@ mod tests {
             })
             .await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn model_and_redfish_targets_preserve_both_selector_forms() {
+        value_scenarios!(run = |target: MachineBootInterfaceTarget| {
+            let redfish = BootInterfaceTarget::from(target);
+            let round_trip = MachineBootInterfaceTarget::from(redfish.clone());
+            (redfish, round_trip)
+        };
+            "complete pair" {
+                MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                    mac_address: mac(),
+                    interface_id: "NIC.Slot.7-1-1".to_string(),
+                }) => (
+                    BootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address: mac(),
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    }),
+                    MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address: mac(),
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    }),
+                ),
+            }
+
+            "legacy MAC only" {
+                MachineBootInterfaceTarget::MacOnly(mac()) => (
+                    BootInterfaceTarget::MacOnly(mac()),
+                    MachineBootInterfaceTarget::MacOnly(mac()),
+                ),
+            }
+        );
     }
 }

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -40,6 +40,7 @@ use libredfish::{
     Assembly, Chassis, Collection, EnabledDisabled, JobState, NetworkAdapter, PowerState, Redfish,
     RedfishError, Resource, SystemPowerControl,
 };
+use mac_address::MacAddress;
 
 use crate::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
 
@@ -80,6 +81,9 @@ struct RedfishSimState {
     /// tests can drive `probe_bmc_vendor`'s Lite-On/Delta chassis fallback.
     chassis_manufacturer: Option<String>,
     platform_actions: Vec<RedfishSimPlatformAction>,
+    /// Lossless `machine_setup_status` target observations. These reads stay
+    /// separate from mutating platform actions and preserve both `Pair` fields.
+    machine_setup_status_targets: HashMap<String, Vec<Option<RedfishSimBootInterfaceRef>>>,
     /// Opt-in authentication enforcement. Off by default so existing tests
     /// (which pass arbitrary or anonymous credentials) are undisturbed. When on,
     /// `get_accounts` returns `401` unless the client was created with a
@@ -211,6 +215,21 @@ impl RedfishSim {
     /// Return calls related to platform configuration and UEFI credentials.
     pub fn platform_actions(&self) -> Vec<RedfishSimPlatformAction> {
         self.state.lock().unwrap().platform_actions.clone()
+    }
+
+    /// Returns each boot-interface selector supplied to
+    /// `Redfish::machine_setup_status` for one simulated endpoint.
+    pub fn machine_setup_status_targets(
+        &self,
+        host: &str,
+    ) -> Vec<Option<RedfishSimBootInterfaceRef>> {
+        self.state
+            .lock()
+            .unwrap()
+            .machine_setup_status_targets
+            .get(host)
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Build a simulator with optional SPDM / firmware-integration test flags.
@@ -387,6 +406,36 @@ pub enum RedfishSimPlatformAction {
     SetHostPrivilegeLevel { host: String },
     IsBiosSetup { host: String },
     UefiSetup { dpu: bool },
+}
+
+/// Owned form of the boot-interface reference observed by the Redfish
+/// simulator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedfishSimBootInterfaceRef {
+    Mac(MacAddress),
+    InterfaceId(String),
+    Pair {
+        mac_address: MacAddress,
+        interface_id: String,
+    },
+}
+
+impl From<libredfish::BootInterfaceRef<'_>> for RedfishSimBootInterfaceRef {
+    fn from(value: libredfish::BootInterfaceRef<'_>) -> Self {
+        match value {
+            libredfish::BootInterfaceRef::Mac(mac_address) => Self::Mac(mac_address),
+            libredfish::BootInterfaceRef::InterfaceId(interface_id) => {
+                Self::InterfaceId(interface_id.to_string())
+            }
+            libredfish::BootInterfaceRef::Pair {
+                mac_address,
+                interface_id,
+            } => Self::Pair {
+                mac_address,
+                interface_id: interface_id.to_string(),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -579,9 +628,16 @@ impl Redfish for RedfishSimClient {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
+        boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
     ) -> libredfish::RedfishFuture<'a, Result<libredfish::MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
+            self.state
+                .lock()
+                .unwrap()
+                .machine_setup_status_targets
+                .entry(self._host.clone())
+                .or_default()
+                .push(boot_interface.map(RedfishSimBootInterfaceRef::from));
             Ok(libredfish::MachineSetupStatus {
                 is_done: true,
                 diffs: vec![],

--- a/crates/rpc/proto/site_explorer.proto
+++ b/crates/rpc/proto/site_explorer.proto
@@ -314,10 +314,32 @@ message Inventory {
   optional string release_date = 4;
 }
 
-// `MachineSetupStatus` definition. Matches redfish definition
+// The result of one Redfish machine-setup check, including the logical boot
+// interface target NICo asked the backend to assess.
 message MachineSetupStatus {
   bool is_done = 1;
   repeated MachineSetupDiff diffs = 2;
+  // The logical boot-interface target NICo asked the backend to assess. A
+  // backend may match with a subset (NvRedfish currently uses the MAC) while
+  // retaining Pair identity. Reports written before target capture leave this
+  // unset.
+  MachineBootInterfaceTarget evaluated_boot_interface = 3;
+}
+
+// The logical boot-interface target NICo asked a Redfish backend to assess. It
+// retains the complete pair when Site Explorer has it while keeping older
+// MAC-only endpoint records explicit.
+message MachineBootInterfaceTarget {
+  oneof target {
+    MachineBootInterfacePair pair = 1;
+    string mac_only = 2;
+  }
+}
+
+// MAC and vendor-native Redfish EthernetInterface.Id for one interface.
+message MachineBootInterfacePair {
+  string mac_address = 1;
+  string interface_id = 2;
 }
 
 // `MachineSetupDiff` definition. Matches redfish definition

--- a/crates/rpc/src/model/site_explorer.rs
+++ b/crates/rpc/src/model/site_explorer.rs
@@ -16,6 +16,7 @@
  */
 
 use model::errors::{OperatorError, OperatorErrorSchema};
+use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::site_explorer::{
     BlueFieldOperatingMode, BootOption, BootOrder, Chassis, ComputerSystem,
     ComputerSystemAttributes, EndpointExplorationReport, EthernetInterface, ExploredDpu,
@@ -342,6 +343,27 @@ impl From<Inventory> for rpc::site_explorer::Inventory {
     }
 }
 
+impl From<MachineBootInterfaceTarget> for rpc::site_explorer::MachineBootInterfaceTarget {
+    fn from(target: MachineBootInterfaceTarget) -> Self {
+        use rpc::site_explorer::machine_boot_interface_target::Target;
+
+        let target = match target {
+            MachineBootInterfaceTarget::Pair(boot_interface) => {
+                Target::Pair(rpc::site_explorer::MachineBootInterfacePair {
+                    mac_address: boot_interface.mac_address.to_string(),
+                    interface_id: boot_interface.interface_id,
+                })
+            }
+            MachineBootInterfaceTarget::MacOnly(mac_address) => {
+                Target::MacOnly(mac_address.to_string())
+            }
+        };
+        Self {
+            target: Some(target),
+        }
+    }
+}
+
 impl From<MachineSetupStatus> for rpc::site_explorer::MachineSetupStatus {
     fn from(machine_setup_status: MachineSetupStatus) -> Self {
         rpc::site_explorer::MachineSetupStatus {
@@ -351,6 +373,9 @@ impl From<MachineSetupStatus> for rpc::site_explorer::MachineSetupStatus {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            evaluated_boot_interface: machine_setup_status
+                .evaluated_boot_interface
+                .map(Into::into),
         }
     }
 }
@@ -435,6 +460,7 @@ mod tests {
     use carbide_uuid::machine::MachineId;
     use chrono::{DateTime, TimeZone as _, Utc};
     use model::firmware::FirmwareComponentType;
+    use model::machine_boot_interface::MachineBootInterface;
     use model::site_explorer::{EndpointExplorationError, EndpointType, PreingestionState};
     use prost::Message;
 
@@ -1185,6 +1211,65 @@ mod tests {
     }
 
     #[test]
+    fn machine_setup_statuses_include_the_evaluated_boot_interface() {
+        let mac_address = "02:00:00:00:10:03".parse().expect("valid test MAC");
+
+        value_scenarios!(run = rpc::site_explorer::MachineSetupStatus::from;
+            "report written before target capture" {
+                MachineSetupStatus::default() => rpc::site_explorer::MachineSetupStatus::default(),
+            }
+
+            "complete pair" {
+                MachineSetupStatus {
+                    is_done: true,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: Some(MachineBootInterfaceTarget::Pair(
+                        MachineBootInterface {
+                            mac_address,
+                            interface_id: "NIC.Slot.7-1-1".to_string(),
+                        },
+                    )),
+                } => rpc::site_explorer::MachineSetupStatus {
+                    is_done: true,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: Some(
+                        rpc::site_explorer::MachineBootInterfaceTarget {
+                            target: Some(
+                                rpc::site_explorer::machine_boot_interface_target::Target::Pair(
+                                    rpc::site_explorer::MachineBootInterfacePair {
+                                        mac_address: "02:00:00:00:10:03".to_string(),
+                                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            }
+
+            "legacy MAC only" {
+                MachineSetupStatus {
+                    is_done: false,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: Some(MachineBootInterfaceTarget::MacOnly(mac_address)),
+                } => rpc::site_explorer::MachineSetupStatus {
+                    is_done: false,
+                    diffs: Vec::new(),
+                    evaluated_boot_interface: Some(
+                        rpc::site_explorer::MachineBootInterfaceTarget {
+                            target: Some(
+                                rpc::site_explorer::machine_boot_interface_target::Target::MacOnly(
+                                    "02:00:00:00:10:03".to_string(),
+                                ),
+                            ),
+                        },
+                    ),
+                },
+            }
+        );
+    }
+
+    #[test]
     fn endpoint_reports_convert_to_rpc() {
         let error = EndpointExplorationError::MissingVendor { observed: None };
         let expected_schema = error.operator_error_schema();
@@ -1285,6 +1370,7 @@ mod tests {
                     expected: "PXE".to_string(),
                     actual: "Disk".to_string(),
                 }],
+                evaluated_boot_interface: None,
             }),
             secure_boot_status: Some(SecureBootStatus { is_enabled: true }),
             lockdown_status: Some(LockdownStatus {

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -289,7 +289,7 @@ impl BmcEndpointExplorer {
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
-        boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<&BootInterfaceTarget>,
         vendor: Option<RedfishVendor>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         match self.mode {
@@ -298,14 +298,14 @@ impl BmcEndpointExplorer {
                     .generate_exploration_report(
                         bmc_ip_address,
                         credentials.clone(),
-                        boot_interface_mac,
+                        boot_interface,
                         vendor,
                     )
                     .await
             }
             SiteExplorerExploreMode::NvRedfish => {
                 self.redfish_client
-                    .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface_mac)
+                    .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface)
                     .await
             }
             SiteExplorerExploreMode::CompareResult => {
@@ -314,13 +314,13 @@ impl BmcEndpointExplorer {
                     .generate_exploration_report(
                         bmc_ip_address,
                         credentials.clone(),
-                        boot_interface_mac,
+                        boot_interface,
                         vendor,
                     )
                     .await;
                 let nvredfish = self
                     .redfish_client
-                    .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface_mac)
+                    .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface)
                     .await;
                 match (&libredfish, &nvredfish) {
                     (Ok(report), Ok(nv_report)) => warn_report_diff(report, nv_report),
@@ -666,7 +666,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
         interface: &MachineInterfaceSnapshot,
         expected: Option<&ExpectedEntity>,
         last_exploration_error: Option<&EndpointExplorationError>,
-        boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<&BootInterfaceTarget>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         // If the site explorer was previously unable to login to the root BMC account using
         // the expected credentials, wait for an operator to manually intervene.
@@ -751,7 +751,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     .generate_exploration_report(
                         bmc_ip_address,
                         credentials,
-                        boot_interface_mac,
+                        boot_interface,
                         Some(vendor),
                     )
                     .await
@@ -916,7 +916,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 self.generate_exploration_report(
                     bmc_ip_address,
                     bmc_credentials,
-                    None,
+                    boot_interface,
                     Some(vendor),
                 )
                 .await?
@@ -1655,7 +1655,9 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
     } else if let Some(r1) = &report1.machine_setup_status
         && let Some(r2) = &report2.machine_setup_status
     {
-        if r1.is_done != r2.is_done {
+        // Both backends should retain the same logical target. Keep the target
+        // in this comparison so future backend changes cannot hide a mismatch.
+        if r1.is_done != r2.is_done || r1.evaluated_boot_interface != r2.evaluated_boot_interface {
             tracing::warn!(
                 libredfish_machine_setup_status = ?r1,
                 nvredfish_machine_setup_status = ?r2,
@@ -1755,10 +1757,150 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
 
 #[cfg(test)]
 mod tests {
+    use arc_swap::ArcSwap;
     use carbide_instrument::Outcome;
     use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+    use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
+    use carbide_redfish::nv_redfish::NvRedfishClientPool;
+    use carbide_secrets::test_support::credentials::TestCredentialManager;
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::{Case, check_cases_async, value_scenarios};
+    use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
+    use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
+    use model::site_explorer::MachineSetupStatus;
 
     use super::*;
+
+    fn report_with_evaluated_target(
+        evaluated_boot_interface: Option<MachineBootInterfaceTarget>,
+    ) -> EndpointExplorationReport {
+        EndpointExplorationReport {
+            machine_setup_status: Some(MachineSetupStatus {
+                is_done: true,
+                diffs: Vec::new(),
+                evaluated_boot_interface,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn report_comparison_includes_the_evaluated_boot_interface() {
+        let mac_address = MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]);
+        let pair = MachineBootInterfaceTarget::Pair(MachineBootInterface {
+            mac_address,
+            interface_id: "NIC.Slot.7-1-1".to_string(),
+        });
+        let mac_only = MachineBootInterfaceTarget::MacOnly(mac_address);
+
+        value_scenarios!(run = |(libredfish_target, nvredfish_target)| {
+            let libredfish_report = report_with_evaluated_target(libredfish_target);
+            let nvredfish_report = report_with_evaluated_target(nvredfish_target);
+            capture_logs(|| warn_report_diff(&libredfish_report, &nvredfish_report))
+                .into_iter()
+                .map(|log| log.message)
+                .collect::<Vec<_>>()
+        };
+            "same evaluated pair does not warn" {
+                (Some(pair.clone()), Some(pair)) => Vec::<String>::new(),
+            }
+
+            "pair and MAC-only targets warn" {
+                (Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                    mac_address,
+                    interface_id: "NIC.Slot.7-1-1".to_string(),
+                })), Some(mac_only)) => vec!["machine setup statuses are not equal".to_string()],
+            }
+
+            "two targetless statuses do not warn" {
+                (None, None) => Vec::<String>::new(),
+            }
+
+            "pair and targetless statuses warn" {
+                (Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                    mac_address,
+                    interface_id: "NIC.Slot.7-1-1".to_string(),
+                })), None) => vec!["machine setup statuses are not equal".to_string()],
+            }
+        );
+    }
+
+    async fn explore_after_credential_bootstrap(
+        boot_interface: Option<BootInterfaceTarget>,
+    ) -> Result<Vec<Option<RedfishSimBootInterfaceRef>>, String> {
+        let sim = Arc::new(RedfishSim::default());
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let explorer = BmcEndpointExplorer::new(
+            sim.clone(),
+            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            carbide_ipmi::test_support(),
+            Arc::new(TestCredentialManager::default()),
+            Arc::new(AtomicBool::new(false)),
+            SiteExplorerExploreMode::LibRedfish,
+            None,
+        );
+        let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
+        let bmc_mac_address: MacAddress = "02:00:00:00:00:01".parse().expect("valid test BMC MAC");
+        let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
+        let expected = ExpectedEntity::Machine(ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                bmc_username: "root".to_string(),
+                bmc_password: "factory-password".to_string(),
+                serial_number: "credential-bootstrap-host".to_string(),
+                bmc_retain_credentials: Some(true),
+                ..Default::default()
+            },
+        });
+
+        explorer
+            .explore_endpoint(
+                bmc_ip_address,
+                &interface,
+                Some(&expected),
+                None,
+                boot_interface.as_ref(),
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+
+        Ok(sim.machine_setup_status_targets(&bmc_ip_address.ip().to_string()))
+    }
+
+    #[tokio::test]
+    async fn credential_bootstrap_preserves_the_evaluated_boot_interface() {
+        let mac_address = MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]);
+        let boot_interface = MachineBootInterface {
+            mac_address,
+            interface_id: "NIC.Slot.7-1-1".to_string(),
+        };
+
+        check_cases_async(
+            [
+                Case {
+                    scenario: "complete pair",
+                    input: Some(BootInterfaceTarget::Pair(boot_interface.clone())),
+                    expect: Yields(vec![Some(RedfishSimBootInterfaceRef::Pair {
+                        mac_address,
+                        interface_id: boot_interface.interface_id,
+                    })]),
+                },
+                Case {
+                    scenario: "legacy MAC only",
+                    input: Some(BootInterfaceTarget::MacOnly(mac_address)),
+                    expect: Yields(vec![Some(RedfishSimBootInterfaceRef::Mac(mac_address))]),
+                },
+                Case {
+                    scenario: "no boot interface",
+                    input: None,
+                    expect: Yields(vec![None]),
+                },
+            ],
+            explore_after_credential_bootstrap,
+        )
+        .await;
+    }
 
     /// One emit per rotation attempt writes the INFO log line and moves
     /// carbide_site_explorer_bmc_password_rotations_total, split by outcome.

--- a/crates/site-explorer/src/endpoint_exploration_service.rs
+++ b/crates/site-explorer/src/endpoint_exploration_service.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use carbide_firmware::{FirmwareConfig, FirmwareConfigSnapshot};
-use mac_address::MacAddress;
+use carbide_redfish::boot_interface::BootInterfaceTarget;
 use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, ExploredEndpoint};
@@ -104,7 +104,7 @@ impl EndpointExplorationService {
         interface: &MachineInterfaceSnapshot,
         expected: Option<&ExpectedEntity>,
         last_exploration_error: Option<&EndpointExplorationError>,
-        boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<BootInterfaceTarget>,
     ) -> Option<EndpointProbeResult> {
         let guard = self.locks.try_claim(address.ip())?;
 
@@ -116,7 +116,7 @@ impl EndpointExplorationService {
                 interface,
                 expected,
                 last_exploration_error,
-                boot_interface_mac,
+                boot_interface.as_ref(),
             )
             .await;
         let redfish_explore_duration = redfish_explore_started_at.elapsed();
@@ -176,8 +176,8 @@ impl EndpointExplorationService {
         // The generated report is based on this row. Use its version for the eventual CAS so a
         // concurrent report update during the probe cannot be overwritten.
         let baseline_version = existing_endpoint.report_version;
+        let boot_interface = existing_endpoint.boot_interface_target().map(Into::into);
         let existing_report = existing_endpoint.report;
-        let boot_interface_mac = existing_endpoint.boot_interface_mac;
 
         let join_handle = tokio::spawn(async move {
             let probe = service
@@ -186,7 +186,7 @@ impl EndpointExplorationService {
                     &bmc_interface,
                     expected.as_ref(),
                     existing_report.last_exploration_error.as_ref(),
-                    boot_interface_mac,
+                    boot_interface,
                 )
                 .await
                 .ok_or(EndpointExplorationServiceError::AlreadyInProgress(bmc_ip))?;

--- a/crates/site-explorer/src/endpoint_explorer.rs
+++ b/crates/site-explorer/src/endpoint_explorer.rs
@@ -20,7 +20,6 @@ use std::net::SocketAddr;
 use carbide_redfish::boot_interface::BootInterfaceTarget;
 use libredfish::RoleId;
 use libredfish::model::service_root::RedfishVendor;
-use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{
@@ -43,7 +42,7 @@ pub trait EndpointExplorer: Send + Sync + 'static {
         interface: &MachineInterfaceSnapshot,
         expected: Option<&ExpectedEntity>,
         last_exploration_error: Option<&EndpointExplorationError>,
-        boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<&BootInterfaceTarget>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError>;
 
     async fn check_preconditions(

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -2335,7 +2335,10 @@ impl SiteExplorer {
                             endpoint
                                 .last_explored
                                 .and_then(|e| e.report.last_exploration_error.as_ref()),
-                            endpoint.last_explored.and_then(|e| e.boot_interface_mac),
+                            endpoint
+                                .last_explored
+                                .and_then(ExploredEndpoint::boot_interface_target)
+                                .map(Into::into),
                         )
                         .await
                     else {

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -31,9 +31,10 @@ use carbide_secrets::credentials::Credentials;
 use libredfish::model::ODataId;
 use libredfish::model::oem::nvidia_dpu::NicMode;
 use libredfish::model::service_root::RedfishVendor;
-use libredfish::{BootInterfaceRef, Redfish, RedfishError};
+use libredfish::{Redfish, RedfishError};
 use mac_address::MacAddress;
 use model::errors::{ErrorCode, ErrorSubsystem, OperatorError, OperatorErrorSchema};
+use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::site_explorer::{
     BootOption, BootOrder, Chassis, ComputerSystem, ComputerSystemAttributes,
     EndpointExplorationError, EndpointExplorationReport, EndpointType, EthernetInterface,
@@ -272,7 +273,7 @@ impl RedfishClient {
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
-        boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<&BootInterfaceTarget>,
         vendor: Option<RedfishVendor>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let client = self
@@ -300,7 +301,7 @@ impl RedfishClient {
         let is_dpu = system.id.to_lowercase().contains("bluefield");
         let (machine_setup_status, remediation_error) = match fetch_machine_setup_status(
             client.as_ref(),
-            boot_interface_mac,
+            boot_interface,
         )
         .await
         {
@@ -386,7 +387,7 @@ impl RedfishClient {
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
-        boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<&BootInterfaceTarget>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let service_root = self
             .nv_redfish_client_pool
@@ -407,12 +408,16 @@ impl RedfishClient {
                 details: format!("Cannot Redfish service root: {err}"),
             })?;
 
-        bmc_explorer::nv_generate_exploration_report(
+        let mut report = bmc_explorer::nv_generate_exploration_report(
             service_root,
-            &nv_bmc_explore_config(boot_interface_mac),
+            &nv_bmc_explore_config(boot_interface),
         )
         .await
-        .map_err(map_nv_redfish_explore_error)
+        .map_err(map_nv_redfish_explore_error)?;
+
+        record_evaluated_boot_interface(report.machine_setup_status.as_mut(), boot_interface);
+
+        Ok(report)
     }
 
     pub async fn reset_bmc(
@@ -1276,11 +1281,16 @@ async fn fetch_service(client: &dyn Redfish) -> Result<Vec<Service>, RedfishErro
 
 async fn fetch_machine_setup_status(
     client: &dyn Redfish,
-    boot_interface_mac: Option<MacAddress>,
+    boot_interface: Option<&BootInterfaceTarget>,
 ) -> Result<MachineSetupStatus, RedfishError> {
-    let status = client
-        .machine_setup_status(boot_interface_mac.map(BootInterfaceRef::Mac))
-        .await?;
+    let status = match boot_interface {
+        Some(target) => {
+            target
+                .run(|boot_interface| client.machine_setup_status(Some(boot_interface)))
+                .await?
+        }
+        None => client.machine_setup_status(None).await?,
+    };
     let mut diffs: Vec<MachineSetupDiff> = Vec::new();
 
     for diff in status.diffs {
@@ -1294,6 +1304,7 @@ async fn fetch_machine_setup_status(
     Ok(MachineSetupStatus {
         is_done: status.is_done,
         diffs,
+        evaluated_boot_interface: boot_interface.map(MachineBootInterfaceTarget::from),
     })
 }
 
@@ -1443,15 +1454,26 @@ fn nv_error_classifier(
 }
 
 fn nv_bmc_explore_config(
-    boot_interface_mac: Option<MacAddress>,
+    boot_interface: Option<&BootInterfaceTarget>,
 ) -> bmc_explorer::Config<'static, carbide_redfish::nv_redfish::RedfishBmc> {
     bmc_explorer::Config {
-        boot_interface_mac,
+        boot_interface_mac: boot_interface.map(BootInterfaceTarget::mac_address),
         error_classifier: &nv_error_classifier,
         // Chosen arbitrarily: we want to wait a bit between tries,
         // but not for too long relative to the total exploration
         // time.
         retry_timeout: Duration::from_millis(1000),
+    }
+}
+
+fn record_evaluated_boot_interface(
+    machine_setup_status: Option<&mut MachineSetupStatus>,
+    boot_interface: Option<&BootInterfaceTarget>,
+) {
+    if let Some(status) = machine_setup_status {
+        // NvRedfish currently matches by MAC, but the observation remains
+        // correlated with the complete logical target requested by NICo.
+        status.evaluated_boot_interface = boot_interface.map(MachineBootInterfaceTarget::from);
     }
 }
 
@@ -1543,14 +1565,20 @@ mod tests {
     use std::sync::Arc;
 
     use arc_swap::ArcSwap;
-    use carbide_redfish::libredfish::test_support::RedfishSim;
+    use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
+    use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
     use carbide_secrets::credentials::Credentials;
     use carbide_test_support::Outcome::*;
-    use carbide_test_support::{Case, check_cases_async};
+    use carbide_test_support::{Case, check_cases_async, value_scenarios};
     use libredfish::model::service_root::RedfishVendor;
+    use mac_address::MacAddress;
+    use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 
-    use super::{EndpointExplorationError, RedfishClient};
+    use super::{
+        BootInterfaceTarget, EndpointExplorationError, MachineSetupStatus, RedfishClient,
+        fetch_machine_setup_status, nv_bmc_explore_config, record_evaluated_boot_interface,
+    };
 
     fn test_addr() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 443)
@@ -1560,6 +1588,107 @@ mod tests {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let nv_pool = Arc::new(NvRedfishClientPool::new(proxy_address));
         RedfishClient::new(sim, nv_pool)
+    }
+
+    async fn machine_setup_status_target(
+        target: Option<BootInterfaceTarget>,
+    ) -> Result<
+        (
+            Option<MachineBootInterfaceTarget>,
+            Vec<Option<RedfishSimBootInterfaceRef>>,
+        ),
+        String,
+    > {
+        let sim = RedfishSim::default();
+        let client = sim
+            .create_client("test-host", None, RedfishAuth::Anonymous, None)
+            .await
+            .map_err(|error| error.to_string())?;
+        let status = fetch_machine_setup_status(client.as_ref(), target.as_ref())
+            .await
+            .map_err(|error| error.to_string())?;
+
+        Ok((
+            status.evaluated_boot_interface,
+            sim.machine_setup_status_targets("test-host"),
+        ))
+    }
+
+    #[tokio::test]
+    async fn machine_setup_status_records_the_exact_evaluated_target() {
+        let mac_address = MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]);
+        let boot_interface = MachineBootInterface {
+            mac_address,
+            interface_id: "NIC.Slot.7-1-1".to_string(),
+        };
+
+        check_cases_async(
+            [
+                Case {
+                    scenario: "complete pair",
+                    input: Some(BootInterfaceTarget::Pair(boot_interface.clone())),
+                    expect: Yields((
+                        Some(MachineBootInterfaceTarget::Pair(boot_interface.clone())),
+                        vec![Some(RedfishSimBootInterfaceRef::Pair {
+                            mac_address,
+                            interface_id: boot_interface.interface_id.clone(),
+                        })],
+                    )),
+                },
+                Case {
+                    scenario: "legacy MAC only",
+                    input: Some(BootInterfaceTarget::MacOnly(mac_address)),
+                    expect: Yields((
+                        Some(MachineBootInterfaceTarget::MacOnly(mac_address)),
+                        vec![Some(RedfishSimBootInterfaceRef::Mac(mac_address))],
+                    )),
+                },
+                Case {
+                    scenario: "no boot interface",
+                    input: None,
+                    expect: Yields((None, vec![None])),
+                },
+            ],
+            machine_setup_status_target,
+        )
+        .await;
+    }
+
+    #[test]
+    fn nvredfish_projects_the_mac_and_records_the_logical_target() {
+        let mac_address = MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]);
+        let boot_interface = MachineBootInterface {
+            mac_address,
+            interface_id: "NIC.Slot.7-1-1".to_string(),
+        };
+
+        value_scenarios!(run = |target: Option<BootInterfaceTarget>| {
+            let config = nv_bmc_explore_config(target.as_ref());
+            let mut status = MachineSetupStatus::default();
+            record_evaluated_boot_interface(Some(&mut status), target.as_ref());
+            (
+                config.boot_interface_mac,
+                status.evaluated_boot_interface,
+            )
+        };
+            "complete pair" {
+                Some(BootInterfaceTarget::Pair(boot_interface.clone())) => (
+                    Some(mac_address),
+                    Some(MachineBootInterfaceTarget::Pair(boot_interface)),
+                ),
+            }
+
+            "legacy MAC only" {
+                Some(BootInterfaceTarget::MacOnly(mac_address)) => (
+                    Some(mac_address),
+                    Some(MachineBootInterfaceTarget::MacOnly(mac_address)),
+                ),
+            }
+
+            "no boot interface" {
+                None => (None, None),
+            }
+        );
     }
 
     /// Rotate a BMC's root password against the sim and report the vendor

--- a/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
+++ b/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
@@ -20,9 +20,9 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use carbide_redfish::boot_interface::BootInterfaceTarget;
 use libredfish::model::service_root::RedfishVendor;
 use libredfish::{PowerState, RoleId, SystemPowerControl};
-use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{
@@ -32,6 +32,13 @@ use model::site_explorer::{
 use tokio::sync::Notify;
 
 use crate::{EndpointExplorer, SiteExplorationMetrics};
+
+/// One recorded endpoint exploration and its boot-interface target.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EndpointExplorationCall {
+    pub ip_address: IpAddr,
+    pub boot_interface: Option<BootInterfaceTarget>,
+}
 
 #[derive(Clone)]
 pub struct MockEndpointExplorationBlocker {
@@ -76,8 +83,8 @@ pub struct MockEndpointExplorer {
     /// mode) so tests can assert the auto-correct path fired with the
     /// right arguments.
     pub set_nic_mode_calls: Arc<Mutex<Vec<(SocketAddr, BlueFieldOperatingMode)>>>,
-    /// Records IPs that `explore_endpoint` was called for.
-    pub explore_endpoint_calls: Arc<Mutex<Vec<IpAddr>>>,
+    /// Records each call to `explore_endpoint`.
+    pub explore_endpoint_calls: Arc<Mutex<Vec<EndpointExplorationCall>>>,
     next_exploration_blocker: Arc<Mutex<Option<MockEndpointExplorationBlocker>>>,
     /// Real explorer that `machine_setup`/`set_boot_order_dpu_first` forward to
     /// (see [`Self::with_redfish_backend`]); `None` for the pure in-memory mock
@@ -178,13 +185,16 @@ impl EndpointExplorer for MockEndpointExplorer {
         _interface: &MachineInterfaceSnapshot,
         _expected: Option<&ExpectedEntity>,
         _last_error: Option<&EndpointExplorationError>,
-        _boot_interface_mac: Option<MacAddress>,
+        boot_interface: Option<&BootInterfaceTarget>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         tracing::info!(%bmc_ip_address, "Endpoint is getting explored");
         self.explore_endpoint_calls
             .lock()
             .unwrap()
-            .push(bmc_ip_address.ip());
+            .push(EndpointExplorationCall {
+                ip_address: bmc_ip_address.ip(),
+                boot_interface: boot_interface.cloned(),
+            });
         let blocker = self.next_exploration_blocker.lock().unwrap().take();
         if let Some(blocker) = blocker {
             blocker.started.notify_one();

--- a/rest-api/proto/core/gen/v1/site_explorer_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/site_explorer_nico.pb.go
@@ -2173,13 +2173,19 @@ func (x *Inventory) GetReleaseDate() string {
 	return ""
 }
 
-// `MachineSetupStatus` definition. Matches redfish definition
+// The result of one Redfish machine-setup check, including the logical boot
+// interface target NICo asked the backend to assess.
 type MachineSetupStatus struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	IsDone        bool                   `protobuf:"varint,1,opt,name=is_done,json=isDone,proto3" json:"is_done,omitempty"`
-	Diffs         []*MachineSetupDiff    `protobuf:"bytes,2,rep,name=diffs,proto3" json:"diffs,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	IsDone bool                   `protobuf:"varint,1,opt,name=is_done,json=isDone,proto3" json:"is_done,omitempty"`
+	Diffs  []*MachineSetupDiff    `protobuf:"bytes,2,rep,name=diffs,proto3" json:"diffs,omitempty"`
+	// The logical boot-interface target NICo asked the backend to assess. A
+	// backend may match with a subset (NvRedfish currently uses the MAC) while
+	// retaining Pair identity. Reports written before target capture leave this
+	// unset.
+	EvaluatedBootInterface *MachineBootInterfaceTarget `protobuf:"bytes,3,opt,name=evaluated_boot_interface,json=evaluatedBootInterface,proto3" json:"evaluated_boot_interface,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *MachineSetupStatus) Reset() {
@@ -2226,6 +2232,151 @@ func (x *MachineSetupStatus) GetDiffs() []*MachineSetupDiff {
 	return nil
 }
 
+func (x *MachineSetupStatus) GetEvaluatedBootInterface() *MachineBootInterfaceTarget {
+	if x != nil {
+		return x.EvaluatedBootInterface
+	}
+	return nil
+}
+
+// The logical boot-interface target NICo asked a Redfish backend to assess. It
+// retains the complete pair when Site Explorer has it while keeping older
+// MAC-only endpoint records explicit.
+type MachineBootInterfaceTarget struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Target:
+	//
+	//	*MachineBootInterfaceTarget_Pair
+	//	*MachineBootInterfaceTarget_MacOnly
+	Target        isMachineBootInterfaceTarget_Target `protobuf_oneof:"target"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachineBootInterfaceTarget) Reset() {
+	*x = MachineBootInterfaceTarget{}
+	mi := &file_site_explorer_nico_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachineBootInterfaceTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachineBootInterfaceTarget) ProtoMessage() {}
+
+func (x *MachineBootInterfaceTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_site_explorer_nico_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachineBootInterfaceTarget.ProtoReflect.Descriptor instead.
+func (*MachineBootInterfaceTarget) Descriptor() ([]byte, []int) {
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *MachineBootInterfaceTarget) GetTarget() isMachineBootInterfaceTarget_Target {
+	if x != nil {
+		return x.Target
+	}
+	return nil
+}
+
+func (x *MachineBootInterfaceTarget) GetPair() *MachineBootInterfacePair {
+	if x != nil {
+		if x, ok := x.Target.(*MachineBootInterfaceTarget_Pair); ok {
+			return x.Pair
+		}
+	}
+	return nil
+}
+
+func (x *MachineBootInterfaceTarget) GetMacOnly() string {
+	if x != nil {
+		if x, ok := x.Target.(*MachineBootInterfaceTarget_MacOnly); ok {
+			return x.MacOnly
+		}
+	}
+	return ""
+}
+
+type isMachineBootInterfaceTarget_Target interface {
+	isMachineBootInterfaceTarget_Target()
+}
+
+type MachineBootInterfaceTarget_Pair struct {
+	Pair *MachineBootInterfacePair `protobuf:"bytes,1,opt,name=pair,proto3,oneof"`
+}
+
+type MachineBootInterfaceTarget_MacOnly struct {
+	MacOnly string `protobuf:"bytes,2,opt,name=mac_only,json=macOnly,proto3,oneof"`
+}
+
+func (*MachineBootInterfaceTarget_Pair) isMachineBootInterfaceTarget_Target() {}
+
+func (*MachineBootInterfaceTarget_MacOnly) isMachineBootInterfaceTarget_Target() {}
+
+// MAC and vendor-native Redfish EthernetInterface.Id for one interface.
+type MachineBootInterfacePair struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	MacAddress    string                 `protobuf:"bytes,1,opt,name=mac_address,json=macAddress,proto3" json:"mac_address,omitempty"`
+	InterfaceId   string                 `protobuf:"bytes,2,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MachineBootInterfacePair) Reset() {
+	*x = MachineBootInterfacePair{}
+	mi := &file_site_explorer_nico_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MachineBootInterfacePair) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MachineBootInterfacePair) ProtoMessage() {}
+
+func (x *MachineBootInterfacePair) ProtoReflect() protoreflect.Message {
+	mi := &file_site_explorer_nico_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MachineBootInterfacePair.ProtoReflect.Descriptor instead.
+func (*MachineBootInterfacePair) Descriptor() ([]byte, []int) {
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *MachineBootInterfacePair) GetMacAddress() string {
+	if x != nil {
+		return x.MacAddress
+	}
+	return ""
+}
+
+func (x *MachineBootInterfacePair) GetInterfaceId() string {
+	if x != nil {
+		return x.InterfaceId
+	}
+	return ""
+}
+
 // `MachineSetupDiff` definition. Matches redfish definition
 type MachineSetupDiff struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2238,7 +2389,7 @@ type MachineSetupDiff struct {
 
 func (x *MachineSetupDiff) Reset() {
 	*x = MachineSetupDiff{}
-	mi := &file_site_explorer_nico_proto_msgTypes[30]
+	mi := &file_site_explorer_nico_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2250,7 +2401,7 @@ func (x *MachineSetupDiff) String() string {
 func (*MachineSetupDiff) ProtoMessage() {}
 
 func (x *MachineSetupDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[30]
+	mi := &file_site_explorer_nico_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2263,7 +2414,7 @@ func (x *MachineSetupDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MachineSetupDiff.ProtoReflect.Descriptor instead.
 func (*MachineSetupDiff) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{30}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *MachineSetupDiff) GetKey() string {
@@ -2304,7 +2455,7 @@ type PCIeDevice struct {
 
 func (x *PCIeDevice) Reset() {
 	*x = PCIeDevice{}
-	mi := &file_site_explorer_nico_proto_msgTypes[31]
+	mi := &file_site_explorer_nico_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2316,7 +2467,7 @@ func (x *PCIeDevice) String() string {
 func (*PCIeDevice) ProtoMessage() {}
 
 func (x *PCIeDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[31]
+	mi := &file_site_explorer_nico_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2329,7 +2480,7 @@ func (x *PCIeDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PCIeDevice.ProtoReflect.Descriptor instead.
 func (*PCIeDevice) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{31}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *PCIeDevice) GetDescription() string {
@@ -2406,7 +2557,7 @@ type SystemStatus struct {
 
 func (x *SystemStatus) Reset() {
 	*x = SystemStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[32]
+	mi := &file_site_explorer_nico_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2418,7 +2569,7 @@ func (x *SystemStatus) String() string {
 func (*SystemStatus) ProtoMessage() {}
 
 func (x *SystemStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[32]
+	mi := &file_site_explorer_nico_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2431,7 +2582,7 @@ func (x *SystemStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SystemStatus.ProtoReflect.Descriptor instead.
 func (*SystemStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{32}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *SystemStatus) GetHealth() string {
@@ -2464,7 +2615,7 @@ type BootOrder struct {
 
 func (x *BootOrder) Reset() {
 	*x = BootOrder{}
-	mi := &file_site_explorer_nico_proto_msgTypes[33]
+	mi := &file_site_explorer_nico_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2476,7 +2627,7 @@ func (x *BootOrder) String() string {
 func (*BootOrder) ProtoMessage() {}
 
 func (x *BootOrder) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[33]
+	mi := &file_site_explorer_nico_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2489,7 +2640,7 @@ func (x *BootOrder) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootOrder.ProtoReflect.Descriptor instead.
 func (*BootOrder) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{33}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *BootOrder) GetBootOrder() []*BootOption {
@@ -2511,7 +2662,7 @@ type BootOption struct {
 
 func (x *BootOption) Reset() {
 	*x = BootOption{}
-	mi := &file_site_explorer_nico_proto_msgTypes[34]
+	mi := &file_site_explorer_nico_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2523,7 +2674,7 @@ func (x *BootOption) String() string {
 func (*BootOption) ProtoMessage() {}
 
 func (x *BootOption) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[34]
+	mi := &file_site_explorer_nico_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2536,7 +2687,7 @@ func (x *BootOption) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BootOption.ProtoReflect.Descriptor instead.
 func (*BootOption) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{34}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *BootOption) GetDisplayName() string {
@@ -2576,7 +2727,7 @@ type SecureBootStatus struct {
 
 func (x *SecureBootStatus) Reset() {
 	*x = SecureBootStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[35]
+	mi := &file_site_explorer_nico_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2588,7 +2739,7 @@ func (x *SecureBootStatus) String() string {
 func (*SecureBootStatus) ProtoMessage() {}
 
 func (x *SecureBootStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[35]
+	mi := &file_site_explorer_nico_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2601,7 +2752,7 @@ func (x *SecureBootStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SecureBootStatus.ProtoReflect.Descriptor instead.
 func (*SecureBootStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{35}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *SecureBootStatus) GetIsEnabled() bool {
@@ -2622,7 +2773,7 @@ type LockdownStatus struct {
 
 func (x *LockdownStatus) Reset() {
 	*x = LockdownStatus{}
-	mi := &file_site_explorer_nico_proto_msgTypes[36]
+	mi := &file_site_explorer_nico_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2634,7 +2785,7 @@ func (x *LockdownStatus) String() string {
 func (*LockdownStatus) ProtoMessage() {}
 
 func (x *LockdownStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_site_explorer_nico_proto_msgTypes[36]
+	mi := &file_site_explorer_nico_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2647,7 +2798,7 @@ func (x *LockdownStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockdownStatus.ProtoReflect.Descriptor instead.
 func (*LockdownStatus) Descriptor() ([]byte, []int) {
-	return file_site_explorer_nico_proto_rawDescGZIP(), []int{36}
+	return file_site_explorer_nico_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *LockdownStatus) GetStatus() InternalLockdownStatus {
@@ -2867,10 +3018,19 @@ const file_site_explorer_nico_proto_rawDesc = "" +
 	"\f_descriptionB\n" +
 	"\n" +
 	"\b_versionB\x0f\n" +
-	"\r_release_date\"d\n" +
+	"\r_release_date\"\xc9\x01\n" +
 	"\x12MachineSetupStatus\x12\x17\n" +
 	"\ais_done\x18\x01 \x01(\bR\x06isDone\x125\n" +
-	"\x05diffs\x18\x02 \x03(\v2\x1f.site_explorer.MachineSetupDiffR\x05diffs\"X\n" +
+	"\x05diffs\x18\x02 \x03(\v2\x1f.site_explorer.MachineSetupDiffR\x05diffs\x12c\n" +
+	"\x18evaluated_boot_interface\x18\x03 \x01(\v2).site_explorer.MachineBootInterfaceTargetR\x16evaluatedBootInterface\"\x82\x01\n" +
+	"\x1aMachineBootInterfaceTarget\x12=\n" +
+	"\x04pair\x18\x01 \x01(\v2'.site_explorer.MachineBootInterfacePairH\x00R\x04pair\x12\x1b\n" +
+	"\bmac_only\x18\x02 \x01(\tH\x00R\amacOnlyB\b\n" +
+	"\x06target\"^\n" +
+	"\x18MachineBootInterfacePair\x12\x1f\n" +
+	"\vmac_address\x18\x01 \x01(\tR\n" +
+	"macAddress\x12!\n" +
+	"\finterface_id\x18\x02 \x01(\tR\vinterfaceId\"X\n" +
 	"\x10MachineSetupDiff\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x1a\n" +
 	"\bexpected\x18\x02 \x01(\tR\bexpected\x12\x16\n" +
@@ -2956,7 +3116,7 @@ func file_site_explorer_nico_proto_rawDescGZIP() []byte {
 }
 
 var file_site_explorer_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_site_explorer_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
+var file_site_explorer_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_site_explorer_nico_proto_goTypes = []any{
 	(MlxDeviceKind)(0),                        // 0: site_explorer.MlxDeviceKind
 	(NicMode)(0),                              // 1: site_explorer.NicMode
@@ -2992,26 +3152,28 @@ var file_site_explorer_nico_proto_goTypes = []any{
 	(*Service)(nil),                           // 31: site_explorer.Service
 	(*Inventory)(nil),                         // 32: site_explorer.Inventory
 	(*MachineSetupStatus)(nil),                // 33: site_explorer.MachineSetupStatus
-	(*MachineSetupDiff)(nil),                  // 34: site_explorer.MachineSetupDiff
-	(*PCIeDevice)(nil),                        // 35: site_explorer.PCIeDevice
-	(*SystemStatus)(nil),                      // 36: site_explorer.SystemStatus
-	(*BootOrder)(nil),                         // 37: site_explorer.BootOrder
-	(*BootOption)(nil),                        // 38: site_explorer.BootOption
-	(*SecureBootStatus)(nil),                  // 39: site_explorer.SecureBootStatus
-	(*LockdownStatus)(nil),                    // 40: site_explorer.LockdownStatus
-	nil,                                       // 41: site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
-	(*durationpb.Duration)(nil),               // 42: google.protobuf.Duration
+	(*MachineBootInterfaceTarget)(nil),        // 34: site_explorer.MachineBootInterfaceTarget
+	(*MachineBootInterfacePair)(nil),          // 35: site_explorer.MachineBootInterfacePair
+	(*MachineSetupDiff)(nil),                  // 36: site_explorer.MachineSetupDiff
+	(*PCIeDevice)(nil),                        // 37: site_explorer.PCIeDevice
+	(*SystemStatus)(nil),                      // 38: site_explorer.SystemStatus
+	(*BootOrder)(nil),                         // 39: site_explorer.BootOrder
+	(*BootOption)(nil),                        // 40: site_explorer.BootOption
+	(*SecureBootStatus)(nil),                  // 41: site_explorer.SecureBootStatus
+	(*LockdownStatus)(nil),                    // 42: site_explorer.LockdownStatus
+	nil,                                       // 43: site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
+	(*durationpb.Duration)(nil),               // 44: google.protobuf.Duration
 }
 var file_site_explorer_nico_proto_depIdxs = []int32{
-	42, // 0: site_explorer.EndpointExplorationReport.last_exploration_latency:type_name -> google.protobuf.Duration
+	44, // 0: site_explorer.EndpointExplorationReport.last_exploration_latency:type_name -> google.protobuf.Duration
 	27, // 1: site_explorer.EndpointExplorationReport.managers:type_name -> site_explorer.Manager
 	26, // 2: site_explorer.EndpointExplorationReport.systems:type_name -> site_explorer.ComputerSystem
 	29, // 3: site_explorer.EndpointExplorationReport.chassis:type_name -> site_explorer.Chassis
 	31, // 4: site_explorer.EndpointExplorationReport.service:type_name -> site_explorer.Service
 	33, // 5: site_explorer.EndpointExplorationReport.machine_setup_status:type_name -> site_explorer.MachineSetupStatus
-	39, // 6: site_explorer.EndpointExplorationReport.secure_boot_status:type_name -> site_explorer.SecureBootStatus
-	40, // 7: site_explorer.EndpointExplorationReport.lockdown_status:type_name -> site_explorer.LockdownStatus
-	41, // 8: site_explorer.EndpointExplorationReport.firmware_versions:type_name -> site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
+	41, // 6: site_explorer.EndpointExplorationReport.secure_boot_status:type_name -> site_explorer.SecureBootStatus
+	42, // 7: site_explorer.EndpointExplorationReport.lockdown_status:type_name -> site_explorer.LockdownStatus
+	43, // 8: site_explorer.EndpointExplorationReport.firmware_versions:type_name -> site_explorer.EndpointExplorationReport.FirmwareVersionsEntry
 	4,  // 9: site_explorer.EndpointExplorationReport.last_exploration_error_schema:type_name -> site_explorer.OperatorErrorSchema
 	5,  // 10: site_explorer.ExploredEndpoint.report:type_name -> site_explorer.EndpointExplorationReport
 	7,  // 11: site_explorer.ExploredManagedHost.dpus:type_name -> site_explorer.ExploredDpu
@@ -3027,21 +3189,23 @@ var file_site_explorer_nico_proto_depIdxs = []int32{
 	1,  // 21: site_explorer.ComputerSystemAttributes.nic_mode:type_name -> site_explorer.NicMode
 	25, // 22: site_explorer.ComputerSystem.attributes:type_name -> site_explorer.ComputerSystemAttributes
 	28, // 23: site_explorer.ComputerSystem.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
-	35, // 24: site_explorer.ComputerSystem.pcie_devices:type_name -> site_explorer.PCIeDevice
+	37, // 24: site_explorer.ComputerSystem.pcie_devices:type_name -> site_explorer.PCIeDevice
 	2,  // 25: site_explorer.ComputerSystem.power_state:type_name -> site_explorer.ComputerSystemPowerState
-	37, // 26: site_explorer.ComputerSystem.boot_order:type_name -> site_explorer.BootOrder
+	39, // 26: site_explorer.ComputerSystem.boot_order:type_name -> site_explorer.BootOrder
 	28, // 27: site_explorer.Manager.ethernet_interfaces:type_name -> site_explorer.EthernetInterface
 	30, // 28: site_explorer.Chassis.network_adapters:type_name -> site_explorer.NetworkAdapter
 	32, // 29: site_explorer.Service.inventories:type_name -> site_explorer.Inventory
-	34, // 30: site_explorer.MachineSetupStatus.diffs:type_name -> site_explorer.MachineSetupDiff
-	36, // 31: site_explorer.PCIeDevice.status:type_name -> site_explorer.SystemStatus
-	38, // 32: site_explorer.BootOrder.boot_order:type_name -> site_explorer.BootOption
-	3,  // 33: site_explorer.LockdownStatus.status:type_name -> site_explorer.InternalLockdownStatus
-	34, // [34:34] is the sub-list for method output_type
-	34, // [34:34] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	36, // 30: site_explorer.MachineSetupStatus.diffs:type_name -> site_explorer.MachineSetupDiff
+	34, // 31: site_explorer.MachineSetupStatus.evaluated_boot_interface:type_name -> site_explorer.MachineBootInterfaceTarget
+	35, // 32: site_explorer.MachineBootInterfaceTarget.pair:type_name -> site_explorer.MachineBootInterfacePair
+	38, // 33: site_explorer.PCIeDevice.status:type_name -> site_explorer.SystemStatus
+	40, // 34: site_explorer.BootOrder.boot_order:type_name -> site_explorer.BootOption
+	3,  // 35: site_explorer.LockdownStatus.status:type_name -> site_explorer.InternalLockdownStatus
+	36, // [36:36] is the sub-list for method output_type
+	36, // [36:36] is the sub-list for method input_type
+	36, // [36:36] is the sub-list for extension type_name
+	36, // [36:36] is the sub-list for extension extendee
+	0,  // [0:36] is the sub-list for field type_name
 }
 
 func init() { file_site_explorer_nico_proto_init() }
@@ -3063,16 +3227,20 @@ func file_site_explorer_nico_proto_init() {
 	file_site_explorer_nico_proto_msgTypes[25].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[26].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[28].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[31].OneofWrappers = []any{}
-	file_site_explorer_nico_proto_msgTypes[32].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[30].OneofWrappers = []any{
+		(*MachineBootInterfaceTarget_Pair)(nil),
+		(*MachineBootInterfaceTarget_MacOnly)(nil),
+	}
+	file_site_explorer_nico_proto_msgTypes[33].OneofWrappers = []any{}
 	file_site_explorer_nico_proto_msgTypes[34].OneofWrappers = []any{}
+	file_site_explorer_nico_proto_msgTypes[36].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_site_explorer_nico_proto_rawDesc), len(file_site_explorer_nico_proto_rawDesc)),
 			NumEnums:      4,
-			NumMessages:   38,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/rest-api/proto/core/src/v1/site_explorer_nico.proto
+++ b/rest-api/proto/core/src/v1/site_explorer_nico.proto
@@ -320,10 +320,32 @@ message Inventory {
   optional string release_date = 4;
 }
 
-// `MachineSetupStatus` definition. Matches redfish definition
+// The result of one Redfish machine-setup check, including the logical boot
+// interface target NICo asked the backend to assess.
 message MachineSetupStatus {
   bool is_done = 1;
   repeated MachineSetupDiff diffs = 2;
+  // The logical boot-interface target NICo asked the backend to assess. A
+  // backend may match with a subset (NvRedfish currently uses the MAC) while
+  // retaining Pair identity. Reports written before target capture leave this
+  // unset.
+  MachineBootInterfaceTarget evaluated_boot_interface = 3;
+}
+
+// The logical boot-interface target NICo asked a Redfish backend to assess. It
+// retains the complete pair when Site Explorer has it while keeping older
+// MAC-only endpoint records explicit.
+message MachineBootInterfaceTarget {
+  oneof target {
+    MachineBootInterfacePair pair = 1;
+    string mac_only = 2;
+  }
+}
+
+// MAC and vendor-native Redfish EthernetInterface.Id for one interface.
+message MachineBootInterfacePair {
+  string mac_address = 1;
+  string interface_id = 2;
 }
 
 // `MachineSetupDiff` definition. Matches redfish definition


### PR DESCRIPTION
Site Explorer already records `machine_setup_status`, but the report could not say which boot interface it checked. A target change could therefore leave a status that looked current even though it belonged to another interface.

This adds an explicit `Pair(MachineBootInterface)` / `MacOnly(MacAddress)` target to `MachineSetupStatus` and passes it through periodic exploration, explicit refresh, ad-hoc exploration, credential bootstrap, and each Redfish backend. LibRedfish evaluates a complete pair in one call. NvRedfish keeps its existing MAC matcher while recording the same logical target.

The status and target stay together in the existing versioned report JSON, so the current CAS prevents stale refreshes from replacing a newer observation. Reports written before target capture continue to decode with no target. The tracked REST proto copy and Go binding are regenerated with the new field.

This is the observation contract only. Machine-controller reconciliation, `SetPrimaryInterface`, reboot policy, normalized observation storage, and Site Explorer actuation ownership remain follow-up work.

## Testing

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- affected Rust unit suites (`carbide-api-model`, `carbide-rpc`, `carbide-redfish`, `bmc-explorer`, and `carbide-site-explorer`)
- Pair / MAC-only / targetless periodic, explicit-refresh, ad-hoc, compare, and credential-bootstrap tests
- stale-CAS and failed-refresh preservation tests
- MAC-wide interface-ID propagation test
- `go test ./proto/core/...`

Part of #4105.

Closes #4105