### PR TITLE
chore(site-explorer): suppress per-bmc info log one each iteration

### DIFF
--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -733,7 +733,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
             }
         };
 
-        tracing::info!(
+        tracing::debug!(
             target: "carbide_diagnostics::bmc_redfish_supported",
             %bmc_ip_address,
             %vendor,


### PR DESCRIPTION
Reduce level of one info log message that appears on each iteration per each BMC. 

On bigger scale it can become an issue without any significant value.

## Related issues

#1864 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

