### PR TITLE
feat(rack): add custom attributes to rack profiles

### DIFF
--- a/crates/api-core/src/bootstrap.rs
+++ b/crates/api-core/src/bootstrap.rs
@@ -23,6 +23,7 @@
 
 use std::sync::Arc;
 
+use carbide_rack::rms_node_type::warn_rms_node_descriptor_attribute_overrides;
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::CredentialManager;
 use sqlx::PgPool;
@@ -45,7 +46,11 @@ pub struct RuntimePrelude {
     dynamic_settings: DynamicSettings,
 }
 
-/// Start the core runtime work that must precede external resource initialization.
+/// Starts the core runtime work that follows logging initialization and precedes
+/// external resource initialization.
+///
+/// Rack-profile attribute override collisions are logged once here so the
+/// configured tracing subscriber receives the diagnostics.
 #[doc(hidden)]
 pub fn start_runtime_prelude(
     carbide_config: &CarbideConfig,
@@ -53,6 +58,9 @@ pub fn start_runtime_prelude(
     join_set: &mut JoinSet<()>,
     cancel_token: &CancellationToken,
 ) -> RuntimePrelude {
+    // These diagnostics require the tracing subscriber installed by the caller.
+    warn_rms_node_descriptor_attribute_overrides(&carbide_config.rack_profiles);
+
     // Redact credentials before printing the config
     let print_config = carbide_config.redacted();
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -2073,6 +2073,70 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::result_large_err)] // Figment controls the error representation.
+    fn rack_profile_attributes_merge_per_key_with_provider_precedence() {
+        figment::Jail::expect_with(|jail| {
+            jail.clear_env();
+
+            // Environment input replaces only its duplicate key; unrelated
+            // keys from lower-priority providers remain in the effective map.
+            jail.set_env(
+                "CARBIDE_API_RACK_PROFILES",
+                "{NVL72={attributes={attribute1=environment,additional_attribute4=environment}}}",
+            );
+
+            let global_config = format!(
+                r#"{}
+
+[rack_profiles.NVL72]
+product_family = "gb200"
+attributes = {{ attribute1 = "global", additional_attribute2 = "global" }}
+
+[rack_profiles.NVL72.rack_capabilities.compute]
+count = 18
+
+[rack_profiles.NVL72.rack_capabilities.switch]
+count = 9
+
+[rack_profiles.NVL72.rack_capabilities.power_shelf]
+count = 8
+"#,
+                include_str!("cfg/test_data/min_config.toml"),
+            );
+
+            let site_config = r#"
+[rack_profiles.NVL72]
+attributes = { attribute1 = "site", additional_attribute3 = "site" }
+"#;
+            jail.create_file("global.toml", &global_config)?;
+            jail.create_file("site.toml", site_config)?;
+
+            let config = merged_carbide_config_figment(
+                Path::new("global.toml"),
+                Some(Path::new("site.toml")),
+            )
+            .extract::<CarbideConfig>()?;
+
+            let attributes = &config.rack_profiles.get("NVL72").unwrap().attributes;
+
+            assert_eq!(
+                attributes,
+                &HashMap::from([
+                    ("attribute1".to_string(), "environment".to_string()),
+                    ("additional_attribute2".to_string(), "global".to_string()),
+                    ("additional_attribute3".to_string(), "site".to_string()),
+                    (
+                        "additional_attribute4".to_string(),
+                        "environment".to_string(),
+                    ),
+                ])
+            );
+
+            Ok(())
+        });
+    }
+
+    #[test]
     fn parse_rejects_rms_component_manager_missing_vendor() -> eyre::Result<()> {
         let mut config = tempfile::NamedTempFile::new()?;
         std::io::Write::write_all(

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -62,18 +62,21 @@ fn test_capabilities() -> RackCapabilitiesSet {
             count: 2,
             vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
         switch: RackCapabilitySwitch {
             name: None,
             count: 1,
             vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
         power_shelf: RackCapabilityPowerShelf {
             name: None,
             count: 1,
             vendor: Some("LiteOn".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
     }
 }
@@ -85,18 +88,21 @@ fn simple_capabilities() -> RackCapabilitiesSet {
             count: 2,
             vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
         switch: RackCapabilitySwitch {
             name: None,
             count: 0,
             vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
         power_shelf: RackCapabilityPowerShelf {
             name: None,
             count: 0,
             vendor: Some("LiteOn".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
     }
 }
@@ -108,18 +114,21 @@ fn single_capabilities() -> RackCapabilitiesSet {
             count: 1,
             vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
         switch: RackCapabilitySwitch {
             name: None,
             count: 0,
             vendor: Some("NVIDIA".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
         power_shelf: RackCapabilityPowerShelf {
             name: None,
             count: 0,
             vendor: Some("LiteOn".to_string()),
             slot_ids: None,
+            attributes: Default::default(),
         },
     }
 }
@@ -144,6 +153,7 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
                     rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_hardware_type: Some(RackHardwareType::any()),
                     rack_hardware_class: Some(RackHardwareClass::Prod),
+                    attributes: Default::default(),
                     rack_capabilities: simple_capabilities(),
                 },
             ),
@@ -154,6 +164,7 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
                     rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_hardware_type: Some(RackHardwareType::any()),
                     rack_hardware_class: Some(RackHardwareClass::Prod),
+                    attributes: Default::default(),
                     rack_capabilities: single_capabilities(),
                 },
             ),

--- a/crates/api-core/tests/integration/expected_rack.rs
+++ b/crates/api-core/tests/integration/expected_rack.rs
@@ -39,18 +39,21 @@ fn config_with_rack_profiles() -> CarbideConfig {
                             count: 18,
                             vendor: Some("NVIDIA".to_string()),
                             slot_ids: None,
+                            attributes: Default::default(),
                         },
                         switch: RackCapabilitySwitch {
                             name: None,
                             count: 9,
                             vendor: None,
                             slot_ids: None,
+                            attributes: Default::default(),
                         },
                         power_shelf: RackCapabilityPowerShelf {
                             name: None,
                             count: 4,
                             vendor: None,
                             slot_ids: None,
+                            attributes: Default::default(),
                         },
                     },
                     ..Default::default()
@@ -66,18 +69,21 @@ fn config_with_rack_profiles() -> CarbideConfig {
                             count: 9,
                             vendor: None,
                             slot_ids: None,
+                            attributes: Default::default(),
                         },
                         switch: RackCapabilitySwitch {
                             name: None,
                             count: 4,
                             vendor: None,
                             slot_ids: None,
+                            attributes: Default::default(),
                         },
                         power_shelf: RackCapabilityPowerShelf {
                             name: None,
                             count: 2,
                             vendor: None,
                             slot_ids: None,
+                            attributes: Default::default(),
                         },
                     },
                     ..Default::default()

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -279,6 +279,14 @@ pub struct RackCapabilityCompute {
     /// Slot IDs that compute trays are expected to occupy.
     #[serde(default)]
     pub slot_ids: Option<Vec<u32>>,
+
+    /// Optional custom attributes for compute trays.
+    ///
+    /// Missing maps default to empty. Keys and values are preserved exactly,
+    /// with case-sensitive key matching. These attributes override rack-level
+    /// attributes with identical keys when a consumer combines both maps.
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
 }
 
 /* ********************************** */
@@ -303,6 +311,14 @@ pub struct RackCapabilitySwitch {
     /// Slot IDs that switches are expected to occupy.
     #[serde(default)]
     pub slot_ids: Option<Vec<u32>>,
+
+    /// Optional custom attributes for switches.
+    ///
+    /// Missing maps default to empty. Keys and values are preserved exactly,
+    /// with case-sensitive key matching. These attributes override rack-level
+    /// attributes with identical keys when a consumer combines both maps.
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
 }
 
 /* ********************************** */
@@ -327,6 +343,14 @@ pub struct RackCapabilityPowerShelf {
     /// Slot IDs that power shelves are expected to occupy.
     #[serde(default)]
     pub slot_ids: Option<Vec<u32>>,
+
+    /// Optional custom attributes for power shelves.
+    ///
+    /// Missing maps default to empty. Keys and values are preserved exactly,
+    /// with case-sensitive key matching. These attributes override rack-level
+    /// attributes with identical keys when a consumer combines both maps.
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
 }
 
 /* ********************************** */
@@ -364,6 +388,14 @@ pub struct RackProfile {
 
     #[serde(default)]
     pub rack_hardware_class: Option<RackHardwareClass>,
+
+    /// Optional custom attributes inherited by each component role.
+    ///
+    /// Missing maps default to empty. Keys and values are preserved exactly,
+    /// with case-sensitive key matching. Role-level attributes override
+    /// rack-level attributes with identical keys.
+    #[serde(default)]
+    pub attributes: HashMap<String, String>,
 
     pub rack_capabilities: RackCapabilitiesSet,
 }
@@ -414,18 +446,21 @@ mod tests {
                         count: 18,
                         vendor: Some("NVIDIA".to_string()),
                         slot_ids: None,
+                        attributes: HashMap::new(),
                     },
                     switch: RackCapabilitySwitch {
                         name: None,
                         count: 9,
                         vendor: None,
                         slot_ids: None,
+                        attributes: HashMap::new(),
                     },
                     power_shelf: RackCapabilityPowerShelf {
                         name: None,
                         count: 8,
                         vendor: None,
                         slot_ids: None,
+                        attributes: HashMap::new(),
                     },
                 },
                 ..Default::default()
@@ -442,26 +477,38 @@ mod tests {
 
     #[test]
     fn test_rack_profile_config_toml_deserialization() {
+        // Inline and expanded TOML tables produce the same attribute maps, and
+        // deserialization does not normalize custom keys or values.
         let toml_str = r#"
 [NVL72]
 product_family = "gb200"
+attributes = { attribute1 = "value1", additional_attribute2 = "value2" }
 
 [NVL72.rack_capabilities.compute]
 name = "GB200"
 count = 18
 vendor = "NVIDIA"
+attributes = { attribute1 = "compute-value", additional_attribute2 = "  MiXeD-Value  " }
 
 [NVL72.rack_capabilities.switch]
 count = 9
+attributes = { attribute1 = "switch-value" }
 
 [NVL72.rack_capabilities.power_shelf]
 count = 8
+attributes = { additional_attribute2 = "power-shelf-value" }
 
 [NVL36]
 product_family = "test-product-family"
 
+[NVL36.attributes]
+attribute1 = "value1"
+
 [NVL36.rack_capabilities.compute]
 count = 9
+
+[NVL36.rack_capabilities.compute.attributes]
+additional_attribute2 = "compute-value"
 
 [NVL36.rack_capabilities.switch]
 count = 9
@@ -480,11 +527,56 @@ count = 2
             Some("GB200")
         );
 
+        assert_eq!(
+            nvl72.attributes,
+            HashMap::from([
+                ("attribute1".to_string(), "value1".to_string()),
+                ("additional_attribute2".to_string(), "value2".to_string()),
+            ])
+        );
+
+        assert_eq!(
+            nvl72.rack_capabilities.compute.attributes,
+            HashMap::from([
+                ("attribute1".to_string(), "compute-value".to_string()),
+                (
+                    "additional_attribute2".to_string(),
+                    "  MiXeD-Value  ".to_string(),
+                ),
+            ])
+        );
+
+        assert_eq!(
+            nvl72.rack_capabilities.switch.attributes,
+            HashMap::from([("attribute1".to_string(), "switch-value".to_string())])
+        );
+
+        assert_eq!(
+            nvl72.rack_capabilities.power_shelf.attributes,
+            HashMap::from([(
+                "additional_attribute2".to_string(),
+                "power-shelf-value".to_string(),
+            )])
+        );
+
         let nvl36 = config.get("NVL36").unwrap();
 
         assert_eq!(
             nvl36.product_family,
             Some(RackProductFamily::Other("test-product-family".to_string()))
+        );
+
+        assert_eq!(
+            nvl36.attributes,
+            HashMap::from([("attribute1".to_string(), "value1".to_string())])
+        );
+
+        assert_eq!(
+            nvl36.rack_capabilities.compute.attributes,
+            HashMap::from([(
+                "additional_attribute2".to_string(),
+                "compute-value".to_string(),
+            )])
         );
 
         assert_eq!(nvl36.rack_capabilities.compute.count, 9);
@@ -548,6 +640,28 @@ count = 2
         assert_eq!(nvl36.rack_hardware_type, None);
         assert_eq!(nvl36.rack_hardware_topology, None);
         assert_eq!(nvl36.rack_hardware_class, None);
+        assert!(nvl36.attributes.is_empty());
+        assert!(nvl36.rack_capabilities.compute.attributes.is_empty());
+        assert!(nvl36.rack_capabilities.switch.attributes.is_empty());
+        assert!(nvl36.rack_capabilities.power_shelf.attributes.is_empty());
+    }
+
+    #[test]
+    fn test_rack_profile_config_rejects_duplicate_attribute_keys() {
+        // TOML rejects repeated literal keys before Serde constructs the map.
+        let toml_str = r#"
+[NVL36]
+attributes = { attribute1 = "value1", attribute1 = "value2" }
+
+[NVL36.rack_capabilities.compute]
+count = 9
+[NVL36.rack_capabilities.switch]
+count = 9
+[NVL36.rack_capabilities.power_shelf]
+count = 2
+"#;
+
+        assert!(toml::from_str::<RackProfileConfig>(toml_str).is_err());
     }
 
     #[test]

--- a/crates/rack/src/rms_node_type.rs
+++ b/crates/rack/src/rms_node_type.rs
@@ -21,11 +21,17 @@
 //! product family. RMS remains responsible for deciding whether a descriptor is
 //! supported. A legacy [`rms::NodeType`] is included only for combinations known
 //! to this NICo version and never limits descriptor construction.
+//!
+//! Custom attribute keys and values are copied without normalization, and key
+//! matching is case-sensitive. Rack attributes are inherited by every role,
+//! role attributes override identical rack keys, and generated `role`, `vendor`,
+//! and `product_family` attributes have highest priority. Custom attributes
+//! cannot supply missing required named fields.
 
 use std::collections::HashMap;
 
 use librms::protos::rack_manager as rms;
-use model::rack_type::RackProfile;
+use model::rack_type::{RackProfile, RackProfileConfig};
 
 const KEY_ROLE: &str = "role";
 const KEY_VENDOR: &str = "vendor";
@@ -33,6 +39,11 @@ const KEY_PRODUCT_FAMILY: &str = "product_family";
 const ROLE_COMPUTE: &str = "compute";
 const ROLE_SWITCH: &str = "switch";
 const ROLE_POWER_SHELF: &str = "power_shelf";
+const RMS_NODE_ROLES: [RmsNodeRole; 3] = [
+    RmsNodeRole::Compute,
+    RmsNodeRole::Switch,
+    RmsNodeRole::PowerShelf,
+];
 
 /// Error returned when a rack profile lacks data required for an RMS descriptor.
 ///
@@ -76,9 +87,11 @@ impl RmsNodeRole {
 
 /// RMS node identity derived from a rack profile and component role.
 ///
-/// Every identity contains a descriptor with `role`, `vendor`, and
-/// `product_family`. Known hardware may also carry a legacy enum override for
-/// compatibility with RMS versions that predate descriptor dispatch.
+/// Every identity contains rack-level custom attributes, role-level custom
+/// attributes, and the generated `role`, `vendor`, and `product_family`
+/// attributes, in increasing precedence order. Known hardware may also carry a
+/// legacy enum override for compatibility with RMS versions that predate
+/// descriptor dispatch.
 #[derive(Clone, Debug, PartialEq)]
 pub struct RmsNodeIdentity {
     role: RmsNodeRole,
@@ -139,6 +152,80 @@ pub fn power_shelf_node_identity_for_profile(
     node_identity_for_profile(profile, RmsNodeRole::PowerShelf)
 }
 
+/// Warns about custom RMS descriptor attributes overridden during inheritance.
+///
+/// Callers should invoke this once after configuration-provider merging so the
+/// warnings describe the effective profiles. Role attributes override rack
+/// attributes, then the generated `role` and present, non-blank `vendor` and
+/// `product_family` fields override custom attributes. Each call emits all
+/// collisions without deduplication, and collisions are intentionally non-fatal.
+pub fn warn_rms_node_descriptor_attribute_overrides(config: &RackProfileConfig) {
+    for (rack_profile_id, profile) in &config.rack_profiles {
+        for role in RMS_NODE_ROLES {
+            let (vendor, role_attributes) = vendor_and_attributes_for_role(profile, role);
+
+            // Role-level values replace rack-level values with the same exact key.
+            for key in role_attributes
+                .keys()
+                .filter(|key| profile.attributes.contains_key(*key))
+            {
+                tracing::warn!(
+                    rack_profile_id,
+                    role = role.descriptor_value(),
+                    attribute_key = key,
+                    overridden_source = "rack",
+                    winning_source = "role",
+                    "RMS node descriptor attribute is overridden"
+                );
+            }
+
+            // Only present named fields override custom values. Custom
+            // attributes cannot satisfy missing required named fields.
+            let named_attribute_keys = [
+                (KEY_ROLE, true),
+                (
+                    KEY_VENDOR,
+                    vendor
+                        .map(str::trim)
+                        .is_some_and(|vendor| !vendor.is_empty()),
+                ),
+                (
+                    KEY_PRODUCT_FAMILY,
+                    profile
+                        .product_family
+                        .as_ref()
+                        .is_some_and(|family| !family.as_str().is_empty()),
+                ),
+            ];
+
+            for (key, is_present) in named_attribute_keys {
+                if !is_present {
+                    continue;
+                }
+
+                let winning_custom_source = if role_attributes.contains_key(key) {
+                    Some("role")
+                } else if profile.attributes.contains_key(key) {
+                    Some("rack")
+                } else {
+                    None
+                };
+
+                if let Some(winning_custom_source) = winning_custom_source {
+                    tracing::warn!(
+                        rack_profile_id,
+                        role = role.descriptor_value(),
+                        attribute_key = key,
+                        overridden_source = winning_custom_source,
+                        winning_source = "named_field",
+                        "RMS node descriptor attribute is overridden"
+                    );
+                }
+            }
+        }
+    }
+}
+
 /// Builds firmware-object component filters for RMS node identities.
 ///
 /// The first tuple element contains compatibility filters keyed by legacy
@@ -191,16 +278,27 @@ fn node_identity_for_profile(
         return Err(NodeDescriptorError::MissingProductFamily);
     };
 
-    let Some(vendor) = vendor_for_role(profile, role) else {
+    let (vendor, role_attributes) = vendor_and_attributes_for_role(profile, role);
+
+    let Some(vendor) = vendor.map(str::trim).filter(|vendor| !vendor.is_empty()) else {
         return Err(NodeDescriptorError::VendorMissing { role: role.label() });
     };
 
+    // HashMap collection keeps the last value for duplicate keys. Iterator
+    // order therefore implements rack, role, then generated-field precedence
+    // while leaving custom keys and values unchanged.
     let node_descriptor = rms::NodeDescriptor {
-        attributes: HashMap::from([
-            (KEY_ROLE.to_string(), role.descriptor_value().to_string()),
-            (KEY_VENDOR.to_string(), vendor.to_string()),
-            (KEY_PRODUCT_FAMILY.to_string(), product_family.to_string()),
-        ]),
+        attributes: profile
+            .attributes
+            .iter()
+            .chain(role_attributes)
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .chain([
+                (KEY_ROLE.to_string(), role.descriptor_value().to_string()),
+                (KEY_VENDOR.to_string(), vendor.to_string()),
+                (KEY_PRODUCT_FAMILY.to_string(), product_family.to_string()),
+            ])
+            .collect(),
     };
 
     let legacy_node_type = legacy_node_type(role, product_family, vendor);
@@ -248,14 +346,26 @@ fn legacy_node_type(
     }
 }
 
-fn vendor_for_role(profile: &RackProfile, role: RmsNodeRole) -> Option<&str> {
+// Keep the named vendor and custom attributes paired so validation, warning,
+// and descriptor construction all resolve the same capability block.
+fn vendor_and_attributes_for_role(
+    profile: &RackProfile,
+    role: RmsNodeRole,
+) -> (Option<&str>, &HashMap<String, String>) {
     match role {
-        RmsNodeRole::Compute => profile.rack_capabilities.compute.vendor.as_deref(),
-        RmsNodeRole::Switch => profile.rack_capabilities.switch.vendor.as_deref(),
-        RmsNodeRole::PowerShelf => profile.rack_capabilities.power_shelf.vendor.as_deref(),
+        RmsNodeRole::Compute => (
+            profile.rack_capabilities.compute.vendor.as_deref(),
+            &profile.rack_capabilities.compute.attributes,
+        ),
+        RmsNodeRole::Switch => (
+            profile.rack_capabilities.switch.vendor.as_deref(),
+            &profile.rack_capabilities.switch.attributes,
+        ),
+        RmsNodeRole::PowerShelf => (
+            profile.rack_capabilities.power_shelf.vendor.as_deref(),
+            &profile.rack_capabilities.power_shelf.attributes,
+        ),
     }
-    .map(str::trim)
-    .filter(|vendor| !vendor.is_empty())
 }
 
 fn normalize_descriptor_value(value: &str) -> String {
@@ -267,6 +377,7 @@ fn normalize_descriptor_value(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::capture_logs;
     use model::rack_type::{RackHardwareType, RackProductFamily};
 
     use super::*;
@@ -374,6 +485,186 @@ mod tests {
             identity.node_descriptor.attributes.get(KEY_PRODUCT_FAMILY),
             Some(&"gb300".to_string())
         );
+    }
+
+    #[test]
+    fn descriptor_attributes_follow_inheritance_precedence() {
+        type IdentityBuilder = fn(&RackProfile) -> Result<RmsNodeIdentity, NodeDescriptorError>;
+
+        let mut profile = profile_with_product_family(RackProductFamily::Gb300);
+
+        profile.attributes = HashMap::from([
+            (
+                "additional_attribute2".to_string(),
+                "  MiXeD-Value  ".to_string(),
+            ),
+            ("attribute1".to_string(), "rack-value".to_string()),
+            ("role".to_string(), "custom-role".to_string()),
+            ("vendor".to_string(), "custom-vendor".to_string()),
+            (
+                "product_family".to_string(),
+                "custom-product-family".to_string(),
+            ),
+        ]);
+
+        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
+
+        profile.rack_capabilities.compute.attributes = HashMap::from([
+            ("attribute1".to_string(), "compute-value".to_string()),
+            ("role".to_string(), "custom-compute-role".to_string()),
+            ("vendor".to_string(), "custom-compute-vendor".to_string()),
+            (
+                "product_family".to_string(),
+                "custom-compute-family".to_string(),
+            ),
+        ]);
+
+        profile.rack_capabilities.switch.vendor = Some("NVIDIA".to_string());
+
+        profile.rack_capabilities.switch.attributes = HashMap::from([
+            ("attribute1".to_string(), "switch-value".to_string()),
+            ("role".to_string(), "custom-switch-role".to_string()),
+            ("vendor".to_string(), "custom-switch-vendor".to_string()),
+            (
+                "product_family".to_string(),
+                "custom-switch-family".to_string(),
+            ),
+        ]);
+
+        profile.rack_capabilities.power_shelf.vendor = Some("Delta".to_string());
+
+        profile.rack_capabilities.power_shelf.attributes = HashMap::from([
+            ("attribute1".to_string(), "power-shelf-value".to_string()),
+            ("role".to_string(), "custom-power-shelf-role".to_string()),
+            (
+                "vendor".to_string(),
+                "custom-power-shelf-vendor".to_string(),
+            ),
+            (
+                "product_family".to_string(),
+                "custom-power-shelf-family".to_string(),
+            ),
+        ]);
+
+        let cases: [(&str, &str, &str, IdentityBuilder); 3] = [
+            (
+                ROLE_COMPUTE,
+                "NVIDIA",
+                "compute-value",
+                compute_node_identity_for_profile,
+            ),
+            (
+                ROLE_SWITCH,
+                "NVIDIA",
+                "switch-value",
+                switch_node_identity_for_profile,
+            ),
+            (
+                ROLE_POWER_SHELF,
+                "Delta",
+                "power-shelf-value",
+                power_shelf_node_identity_for_profile,
+            ),
+        ];
+
+        for (expected_role, expected_vendor, expected_attribute1, build_identity) in cases {
+            let attributes = build_identity(&profile).unwrap().node_descriptor.attributes;
+
+            assert_eq!(
+                attributes.get("additional_attribute2").map(String::as_str),
+                Some("  MiXeD-Value  ")
+            );
+
+            assert_eq!(
+                attributes.get("attribute1").map(String::as_str),
+                Some(expected_attribute1)
+            );
+
+            assert_eq!(
+                attributes.get(KEY_ROLE).map(String::as_str),
+                Some(expected_role)
+            );
+
+            assert_eq!(
+                attributes.get(KEY_VENDOR).map(String::as_str),
+                Some(expected_vendor)
+            );
+
+            assert_eq!(
+                attributes.get(KEY_PRODUCT_FAMILY).map(String::as_str),
+                Some("gb300")
+            );
+        }
+    }
+
+    #[test]
+    fn attribute_collisions_emit_non_fatal_structured_warnings() {
+        let mut profile = RackProfile::default();
+        profile
+            .attributes
+            .insert("attribute1".to_string(), "rack-value".to_string());
+
+        profile
+            .rack_capabilities
+            .compute
+            .attributes
+            .extend(HashMap::from([
+                ("attribute1".to_string(), "compute-value".to_string()),
+                ("vendor".to_string(), "custom-vendor".to_string()),
+            ]));
+
+        profile.rack_capabilities.compute.vendor = Some("NVIDIA".to_string());
+
+        let config = RackProfileConfig {
+            rack_profiles: HashMap::from([("NVL72".to_string(), profile)]),
+        };
+
+        let logs = capture_logs(|| warn_rms_node_descriptor_attribute_overrides(&config));
+
+        assert_eq!(logs.len(), 2);
+
+        assert!(logs.iter().all(|log| {
+            log.level == tracing::Level::WARN
+                && log.message == "RMS node descriptor attribute is overridden"
+                && log.field("rack_profile_id") == Some("NVL72")
+                && log.field("role") == Some(ROLE_COMPUTE)
+        }));
+
+        assert!(logs.iter().any(|log| {
+            log.field("attribute_key") == Some("attribute1")
+                && log.field("overridden_source") == Some("rack")
+                && log.field("winning_source") == Some("role")
+        }));
+
+        assert!(logs.iter().any(|log| {
+            log.field("attribute_key") == Some(KEY_VENDOR)
+                && log.field("overridden_source") == Some("role")
+                && log.field("winning_source") == Some("named_field")
+        }));
+    }
+
+    #[test]
+    fn missing_named_fields_do_not_emit_override_warnings() {
+        let mut profile = RackProfile::default();
+
+        profile.attributes.insert(
+            KEY_PRODUCT_FAMILY.to_string(),
+            "custom-product-family".to_string(),
+        );
+
+        profile
+            .rack_capabilities
+            .compute
+            .attributes
+            .insert(KEY_VENDOR.to_string(), "custom-vendor".to_string());
+
+        let config = RackProfileConfig {
+            rack_profiles: HashMap::from([("NVL72".to_string(), profile)]),
+        };
+
+        let logs = capture_logs(|| warn_rms_node_descriptor_attribute_overrides(&config));
+
+        assert!(logs.is_empty(), "{logs:?}");
     }
 
     #[test]
@@ -551,6 +842,11 @@ mod tests {
 
         profile.rack_capabilities.compute.vendor = Some("test-compute-vendor".to_string());
 
+        profile.attributes.insert(
+            KEY_PRODUCT_FAMILY.to_string(),
+            "custom-product-family".to_string(),
+        );
+
         let err = compute_node_identity_for_profile(&profile);
 
         assert_eq!(err, Err(NodeDescriptorError::MissingProductFamily));
@@ -568,7 +864,12 @@ mod tests {
 
     #[test]
     fn identity_requires_role_vendor() {
-        let profile = profile_with_product_family(RackProductFamily::Gb200);
+        let mut profile = profile_with_product_family(RackProductFamily::Gb200);
+        profile
+            .rack_capabilities
+            .power_shelf
+            .attributes
+            .insert(KEY_VENDOR.to_string(), "custom-vendor".to_string());
 
         let err = power_shelf_node_identity_for_profile(&profile);
 

--- a/crates/rpc/src/model/rack_type.rs
+++ b/crates/rpc/src/model/rack_type.rs
@@ -143,6 +143,8 @@ impl TryFrom<rpc::forge::RackHardwareClass> for RackHardwareClass {
     }
 }
 
+// Custom attributes are descriptor inputs and intentionally remain outside
+// rack-profile protobuf responses.
 impl From<&RackCapabilityCompute> for rpc::forge::RackCapabilityCompute {
     fn from(value: &RackCapabilityCompute) -> Self {
         rpc::forge::RackCapabilityCompute {
@@ -402,20 +404,24 @@ mod tests {
                     count: 18,
                     vendor: Some("NVIDIA".to_string()),
                     slot_ids: Some(vec![1, 2, 3]),
+                    attributes: Default::default(),
                 },
                 switch: RackCapabilitySwitch {
                     name: None,
                     count: 9,
                     vendor: None,
                     slot_ids: None,
+                    attributes: Default::default(),
                 },
                 power_shelf: RackCapabilityPowerShelf {
                     name: Some("PSU".to_string()),
                     count: 8,
                     vendor: Some("Delta".to_string()),
                     slot_ids: None,
+                    attributes: Default::default(),
                 },
             },
+            attributes: Default::default(),
         };
 
         let proto: rpc::forge::RackProfile = (&profile).into();

--- a/crates/site-explorer/tests/integration/machine_creator.rs
+++ b/crates/site-explorer/tests/integration/machine_creator.rs
@@ -117,15 +117,28 @@ fn machine_creator(env: &Env, config: SiteExplorerConfig) -> MachineCreator {
 }
 
 fn machine_creator_with_rms(env: &Env, rms_sim: &RmsSim) -> MachineCreator {
+    // Rack attributes are inherited by the compute descriptor, while its
+    // role-level attribute replaces the identical rack-level key.
     let rack_profiles = RackProfileConfig {
         rack_profiles: [(
             TEST_RMS_RACK_PROFILE_ID.to_string(),
             RackProfile {
                 product_family: Some(RackProductFamily::Gb200),
                 rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
+                attributes: HashMap::from([
+                    ("attribute1".to_string(), "rack-value".to_string()),
+                    (
+                        "additional_attribute2".to_string(),
+                        "additional-value".to_string(),
+                    ),
+                ]),
                 rack_capabilities: RackCapabilitiesSet {
                     compute: RackCapabilityCompute {
                         vendor: Some("NVIDIA".to_string()),
+                        attributes: HashMap::from([(
+                            "attribute1".to_string(),
+                            "compute-value".to_string(),
+                        )]),
                         ..Default::default()
                     },
                     switch: RackCapabilitySwitch {
@@ -263,6 +276,19 @@ async fn test_machine_creator_compute_rms_request_uses_rack_profile(
             .get(KEY_PRODUCT_FAMILY)
             .map(String::as_str),
         Some("gb200")
+    );
+
+    assert_eq!(
+        descriptor
+            .attributes
+            .get("additional_attribute2")
+            .map(String::as_str),
+        Some("additional-value")
+    );
+
+    assert_eq!(
+        descriptor.attributes.get("attribute1").map(String::as_str),
+        Some("compute-value")
     );
 
     Ok(())


### PR DESCRIPTION
Rack profiles currently provide predefined fields. They cannot carry optional key-value attributes/metadata that may be used to identify specific hardware variants or select workflows.

This PR adds attributes that can be configured at rack and component-role levels:

```toml
[rack_profiles.NVL72]
attributes = { attribute1 = "value1", additional_attribute2 = "value2" }

[rack_profiles.NVL72.rack_capabilities.compute]
attributes = { attribute1 = "compute-value" }
```

Attributes use the following precedence, from lowest to highest priority:

1. Rack-level attributes
2. Compute, switch, or power-shelf attributes
3. Predefined role, vendor, and product_family fields, overriding all custom values when names are identical

The value must be `string` typed. The `vendor` and `product_family` attributes do not populate the corresponding named rack-profile fields.

## Related issues

Resolves #4146

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)