### PR TITLE
feat: instrument scout firmware and mlx observations

### DIFF
--- a/crates/scout/src/firmware_upgrade.rs
+++ b/crates/scout/src/firmware_upgrade.rs
@@ -18,14 +18,108 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use carbide_instrument::emit;
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use futures_util::TryStreamExt;
 use rpc::scout_firmware_upgrade::ScoutFirmwareUpgradeTask as FirmwareUpgradeTask;
 use sha2::{Digest, Sha256};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use crate::metrics::{
+    FirmwareDownloadKind, FirmwareDownloadNextAction, ScoutFirmwareDownloadAttemptFailed,
+};
+
 const SCRIPT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
 const DOWNLOAD_MAX_RETRIES: u32 = 3;
+
+struct LoggableFirmwareUrl {
+    value: String,
+    task_forms: Vec<String>,
+}
+
+fn is_downloadable_firmware_url(url: &reqwest::Url) -> bool {
+    matches!(url.scheme(), "http" | "https") && url.host_str().is_some()
+}
+
+fn remove_url_credentials(url: &mut reqwest::Url) {
+    // `http` and `https` URLs are always base URLs. `Url` only rejects
+    // username and password changes for cannot-be-a-base schemes;
+    // `LoggableFirmwareUrl::new` rejects those before calling us, so these
+    // results are safe to ignore.
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+}
+
+impl LoggableFirmwareUrl {
+    fn invalid() -> Self {
+        Self {
+            value: "<invalid firmware URL>".to_string(),
+            task_forms: Vec::new(),
+        }
+    }
+
+    fn new(raw: &str) -> Self {
+        let Ok(parsed) = reqwest::Url::parse(raw) else {
+            return Self::invalid();
+        };
+        if !is_downloadable_firmware_url(&parsed) {
+            return Self::invalid();
+        }
+
+        let mut task_forms = vec![raw.to_string(), parsed.to_string()];
+        for remove_fragment in [false, true] {
+            for remove_query in [false, true] {
+                let mut form = parsed.clone();
+                if remove_fragment {
+                    form.set_fragment(None);
+                }
+                if remove_query {
+                    form.set_query(None);
+                }
+                task_forms.push(form.to_string());
+
+                remove_url_credentials(&mut form);
+                task_forms.push(form.to_string());
+            }
+        }
+
+        let mut loggable = parsed;
+        remove_url_credentials(&mut loggable);
+        loggable.set_query(None);
+        loggable.set_fragment(None);
+        let value = loggable.to_string();
+
+        task_forms.retain(|form| !form.is_empty() && form != &value);
+        task_forms
+            .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        task_forms.dedup();
+
+        Self { value, task_forms }
+    }
+
+    fn redact_from(&self, text: &str) -> String {
+        let mut redacted = text.to_string();
+        for form in &self.task_forms {
+            redacted = redacted.replace(form, &self.value);
+        }
+        redacted
+    }
+
+    fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+fn firmware_task_text_context(value: &str, task: &FirmwareUpgradeTask) -> String {
+    let urls = task.script.iter().map(|script| script.url.as_str()).chain(
+        task.file_artifacts
+            .iter()
+            .map(|artifact| artifact.url.as_str()),
+    );
+    urls.fold(value.to_string(), |text, url| {
+        LoggableFirmwareUrl::new(url).redact_from(&text)
+    })
+}
 
 // FirmwareUpgradeResult captures the outcome of a firmware upgrade execution.
 // Fields will be used when ReportScoutFirmwareUpgradeStatus RPC is implemented.
@@ -39,13 +133,22 @@ pub struct FirmwareUpgradeResult {
     pub error: String,
 }
 
+impl FirmwareUpgradeResult {
+    fn with_url_context(mut self, task: &FirmwareUpgradeTask) -> Self {
+        self.stdout = firmware_task_text_context(&self.stdout, task);
+        self.stderr = firmware_task_text_context(&self.stderr, task);
+        self.error = firmware_task_text_context(&self.error, task);
+        self
+    }
+}
+
 // handle_firmware_upgrade downloads file artifacts and a script from carbide-api,
 // then executes the script on the host.
 pub async fn handle_firmware_upgrade(
     client: &reqwest::Client,
     task: &FirmwareUpgradeTask,
 ) -> FirmwareUpgradeResult {
-    match run_firmware_upgrade(client, task).await {
+    let result = match run_firmware_upgrade(client, task).await {
         Ok(result) => result,
         Err(e) => FirmwareUpgradeResult {
             success: false,
@@ -54,7 +157,8 @@ pub async fn handle_firmware_upgrade(
             stderr: String::new(),
             error: format!("firmware upgrade failed: {e}"),
         },
-    }
+    };
+    result.with_url_context(task)
 }
 
 async fn run_firmware_upgrade(
@@ -78,7 +182,12 @@ async fn run_firmware_upgrade(
     // Download the script and verify its checksum.
     let script_path = tokio::time::timeout(
         SCRIPT_DOWNLOAD_TIMEOUT,
-        download_file_with_retries(client, &script.url, work_dir.path()),
+        download_file_with_retries(
+            client,
+            &script.url,
+            work_dir.path(),
+            FirmwareDownloadKind::Script,
+        ),
     )
     .await
     .map_err(|_| {
@@ -89,9 +198,11 @@ async fn run_firmware_upgrade(
     })??;
     let actual = sha256_file(&script_path).await?;
     if actual != script.sha256 {
+        let script_url = LoggableFirmwareUrl::new(&script.url);
         return Err(format!(
             "checksum mismatch for script {}: expected {}, got {actual}",
-            script.url, script.sha256
+            script_url.as_str(),
+            script.sha256
         )
         .into());
     }
@@ -105,27 +216,35 @@ async fn run_firmware_upgrade(
     tokio::fs::create_dir_all(&download_dir).await?;
     let mut downloaded_artifacts = Vec::with_capacity(task.file_artifacts.len());
     for artifact in &task.file_artifacts {
+        let artifact_url = LoggableFirmwareUrl::new(&artifact.url);
         let dest = tokio::time::timeout(
             download_timeout,
-            download_file_with_retries(client, &artifact.url, &download_dir),
+            download_file_with_retries(
+                client,
+                &artifact.url,
+                &download_dir,
+                FirmwareDownloadKind::Artifact,
+            ),
         )
         .await
         .map_err(|_| {
             format!(
                 "download timed out for {} after {} seconds",
-                artifact.url, task.artifact_download_timeout_seconds
+                artifact_url.as_str(),
+                task.artifact_download_timeout_seconds
             )
         })??;
         let actual = sha256_file(&dest).await?;
         if actual != artifact.sha256 {
             return Err(format!(
                 "checksum mismatch for {}: expected {}, got {actual}",
-                artifact.url, artifact.sha256
+                artifact_url.as_str(),
+                artifact.sha256
             )
             .into());
         }
         tracing::info!(
-            artifact_url = %artifact.url,
+            artifact_url = %artifact_url.as_str(),
             "[firmware_upgrade] checksum verified",
         );
         downloaded_artifacts.push(dest);
@@ -163,6 +282,8 @@ async fn run_firmware_upgrade(
                 .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into_owned());
             let stderr = String::from_utf8(output.stderr)
                 .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_bytes()).into_owned());
+            let stdout = firmware_task_text_context(&stdout, task);
+            let stderr = firmware_task_text_context(&stderr, task);
             let exit_code = output.status.code().unwrap_or(-1);
             let success = output.status.success();
 
@@ -199,20 +320,29 @@ async fn download_file_with_retries(
     client: &reqwest::Client,
     url: &str,
     target_dir: &Path,
+    kind: FirmwareDownloadKind,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let url_owned = url.to_string();
+    let url_context = LoggableFirmwareUrl::new(url);
     let result = tryhard::retry_fn(|| download_file(client, &url_owned, target_dir))
         .retries(DOWNLOAD_MAX_RETRIES)
         .exponential_backoff(Duration::from_secs(1))
         .on_retry(|attempt, next_delay, error| {
+            let next_action = if next_delay.is_some() {
+                FirmwareDownloadNextAction::Retry
+            } else {
+                FirmwareDownloadNextAction::GiveUp
+            };
             let delay = next_delay.unwrap_or_default();
-            tracing::warn!(
-                attempt,
-                url = %url_owned,
-                error = %error,
-                retry_delay_seconds = delay.as_secs_f64(),
-                "[firmware_upgrade] download attempt failed; retrying",
-            );
+            let error = url_context.redact_from(&error.to_string());
+            emit(ScoutFirmwareDownloadAttemptFailed {
+                kind,
+                next_action,
+                attempt: i64::from(attempt),
+                url: url_context.as_str().to_string(),
+                error,
+                retry_delay_seconds: delay.as_secs_f64(),
+            });
             std::future::ready(())
         })
         .await?;
@@ -227,20 +357,24 @@ async fn download_file(
     target_dir: &Path,
 ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
     let parsed = reqwest::Url::parse(url)?;
+    if !is_downloadable_firmware_url(&parsed) {
+        return Err("firmware URL must use HTTP or HTTPS and include a host".into());
+    }
+    let url_context = LoggableFirmwareUrl::new(url);
     let segment = parsed
         .path_segments()
         .and_then(|mut s| s.next_back())
         .none_if_empty()
-        .ok_or_else(|| format!("cannot extract filename from URL: {url}"))?;
+        .ok_or_else(|| format!("cannot extract filename from URL: {}", url_context.as_str()))?;
 
     let filename = Path::new(segment)
         .file_name()
-        .ok_or_else(|| format!("invalid filename in URL: {url}"))?;
+        .ok_or_else(|| format!("invalid filename in URL: {}", url_context.as_str()))?;
 
     let dest = target_dir.join(filename);
 
     tracing::info!(
-        url,
+        url = %url_context.as_str(),
         destination = ?dest,
         "[firmware_upgrade] downloading",
     );
@@ -275,6 +409,8 @@ async fn sha256_file(path: &Path) -> Result<String, Box<dyn std::error::Error>> 
 mod tests {
     use axum::Router;
     use axum::routing::get;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use rpc::scout_firmware_upgrade::FileArtifact;
     use tokio::net::TcpListener;
 
@@ -306,6 +442,177 @@ mod tests {
             url: format!("{base}{path}"),
             sha256: sha256_hex(content),
         }
+    }
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should build")
+    }
+
+    #[test]
+    fn loggable_firmware_url_excludes_credentials() {
+        check_values(
+            [
+                Check {
+                    scenario: "path remains available for diagnostics",
+                    input: "https://firmware.example/images/fw.bin",
+                    expect: "https://firmware.example/images/fw.bin".to_string(),
+                },
+                Check {
+                    scenario: "userinfo query and fragment are removed",
+                    input: "https://user:password@firmware.example/images/fw.bin?token=secret#download",
+                    expect: "https://firmware.example/images/fw.bin".to_string(),
+                },
+                Check {
+                    scenario: "invalid locations do not echo caller input",
+                    input: "not a URL?token=secret",
+                    expect: "<invalid firmware URL>".to_string(),
+                },
+            ],
+            |url| LoggableFirmwareUrl::new(url).as_str().to_string(),
+        );
+    }
+
+    #[test]
+    fn task_url_redaction_excludes_only_task_credentials() {
+        struct ErrorCase {
+            error: &'static str,
+            url: &'static str,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "raw URL is redacted",
+                    input: ErrorCase {
+                        error: "request failed for https://user:password@firmware.example/fw.bin?token=secret#download",
+                        url: "https://user:password@firmware.example/fw.bin?token=secret#download",
+                    },
+                    expect: "request failed for https://firmware.example/fw.bin".to_string(),
+                },
+                Check {
+                    scenario: "canonicalized URL is redacted independently",
+                    input: ErrorCase {
+                        error: "request failed for https://user:password@firmware.example/fw.bin?token=secret",
+                        url: "HTTPS://user:password@FIRMWARE.EXAMPLE:443/fw.bin?token=secret",
+                    },
+                    expect: "request failed for https://firmware.example/fw.bin".to_string(),
+                },
+                Check {
+                    scenario: "short invalid URL does not rewrite parse errors",
+                    input: ErrorCase {
+                        error: "relative URL without a base",
+                        url: "a",
+                    },
+                    expect: "relative URL without a base".to_string(),
+                },
+                Check {
+                    scenario: "empty URL does not rewrite unrelated errors",
+                    input: ErrorCase {
+                        error: "connection reset",
+                        url: "",
+                    },
+                    expect: "connection reset".to_string(),
+                },
+                Check {
+                    scenario: "unrelated URLs remain untouched",
+                    input: ErrorCase {
+                        error: "upstream=https://user:password@other.example/fw.bin?token=secret",
+                        url: "https://firmware.example/task.bin?token=task-secret",
+                    },
+                    expect: "upstream=https://user:password@other.example/fw.bin?token=secret"
+                        .to_string(),
+                },
+            ],
+            |case| LoggableFirmwareUrl::new(case.url).redact_from(case.error),
+        );
+    }
+
+    #[test]
+    fn malformed_firmware_url_parse_errors_do_not_echo_the_input() {
+        const RAW_URL: &str = "MALFORMED_FIRMWARE_TASK_URL";
+
+        let parse_error = reqwest::Url::parse(RAW_URL).unwrap_err().to_string();
+        let url_context = LoggableFirmwareUrl::new(RAW_URL);
+        let loggable_error = url_context.redact_from(&parse_error);
+
+        assert_eq!(url_context.as_str(), "<invalid firmware URL>");
+        assert_eq!(loggable_error, parse_error);
+        assert!(!loggable_error.contains(RAW_URL));
+    }
+
+    #[test]
+    fn firmware_upgrade_redacts_only_task_urls_from_status_context() {
+        const TASK_SECRET: &str = "TASK_URL_SECRET_MARKER";
+        const UNRELATED_SECRET: &str = "UNRELATED_URL_SECRET_MARKER";
+        const ARTIFACT: &str = "firmware";
+
+        let runtime = test_runtime();
+        let mut output = None;
+        let logs = capture_logs(|| {
+            output = Some(runtime.block_on(async {
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let addr = listener.local_addr().unwrap();
+                let script_url =
+                    format!("HTTP://{addr}/scripts/upgrade.sh?token={TASK_SECRET}#{TASK_SECRET}");
+                let canonical_script_url = reqwest::Url::parse(&script_url).unwrap().to_string();
+                let unrelated_url = format!(
+                    "https://user:password@other.example/output.bin?token={UNRELATED_SECRET}"
+                );
+                let script = format!(
+                    "#!/bin/sh\n\
+                     echo \"raw={script_url}\"\n\
+                     echo \"canonical={canonical_script_url}\"\n\
+                     echo \"unrelated={unrelated_url}\" >&2\n"
+                );
+                let script_body = script.clone();
+                let app = Router::new()
+                    .route(
+                        "/scripts/upgrade.sh",
+                        get(move || {
+                            let body = script_body.clone();
+                            async move { body }
+                        }),
+                    )
+                    .route("/firmware/blob.bin", get(|| async { ARTIFACT }));
+                tokio::spawn(async move {
+                    axum::serve(listener, app).await.unwrap();
+                });
+                let task = FirmwareUpgradeTask {
+                    upgrade_task_id: "test-upgrade-task-id".into(),
+                    component_type: "cpld".into(),
+                    target_version: "1.2.3".into(),
+                    script: Some(FileArtifact {
+                        url: script_url.clone(),
+                        sha256: sha256_hex(&script),
+                    }),
+                    execution_timeout_seconds: 30,
+                    artifact_download_timeout_seconds: 30,
+                    file_artifacts: vec![FileArtifact {
+                        url: format!(
+                            "http://{addr}/firmware/blob.bin?token={TASK_SECRET}#{TASK_SECRET}"
+                        ),
+                        sha256: sha256_hex(ARTIFACT),
+                    }],
+                };
+
+                let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+                let loggable_script_url =
+                    LoggableFirmwareUrl::new(&script_url).as_str().to_string();
+                (result, loggable_script_url, unrelated_url)
+            }));
+        });
+        let (result, loggable_script_url, unrelated_url) =
+            output.expect("upgrade should produce a result");
+
+        assert!(result.success, "upgrade failed: {}", result.error);
+        assert_eq!(result.stdout.matches(&loggable_script_url).count(), 2);
+        assert!(result.stderr.contains(&unrelated_url));
+        let observed = format!("{result:?}\n{logs:?}");
+        assert!(!observed.contains(TASK_SECRET));
+        assert!(observed.contains(UNRELATED_SECRET));
     }
 
     #[tokio::test]
@@ -387,6 +694,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_artifact_download_timeout_redacts_url_secret() {
+        const SECRET: &str = "ARTIFACT_TIMEOUT_SECRET_MARKER";
+        let script = "#!/bin/sh\necho ok";
+        let app = Router::new()
+            .route("/scripts/upgrade.sh", get(move || async move { script }))
+            .route(
+                "/firmware/slow.bin",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    "firmware"
+                }),
+            );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let base = format!("http://{addr}");
+        let task = FirmwareUpgradeTask {
+            upgrade_task_id: "test-upgrade-task-id".into(),
+            component_type: "cpld".into(),
+            target_version: "1.0.0".into(),
+            script: Some(script_artifact(&base, "/scripts/upgrade.sh", script)),
+            execution_timeout_seconds: 30,
+            artifact_download_timeout_seconds: 0,
+            file_artifacts: vec![FileArtifact {
+                url: format!("{base}/firmware/slow.bin?token={SECRET}#{SECRET}"),
+                sha256: sha256_hex("firmware"),
+            }],
+        };
+
+        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+
+        assert!(!result.success);
+        assert!(result.error.contains("download timed out"));
+        assert!(result.error.contains(&format!("{base}/firmware/slow.bin")));
+        assert!(!result.error.contains(SECRET));
+    }
+
+    #[tokio::test]
     async fn test_script_receives_env_vars() {
         let script =
             "#!/bin/sh\necho \"comp=$COMPONENT_TYPE ver=$TARGET_VERSION dir=$DOWNLOAD_DIR\"";
@@ -458,31 +805,85 @@ test "$(basename "$2")" = "second.bin"
         assert!(result.stdout.contains("arg2=second.bin"));
     }
 
-    #[tokio::test]
-    async fn test_download_failure() {
-        let base = start_file_server(vec![]).await;
+    #[test]
+    fn test_download_failure() {
+        const SECRET: &str = "DOWNLOAD_FAILURE_SECRET_MARKER";
 
-        let task = FirmwareUpgradeTask {
-            upgrade_task_id: "test-upgrade-task-id".into(),
-            component_type: "cpld".into(),
-            target_version: "1.0.0".into(),
-            script: Some(FileArtifact {
-                url: format!("{base}/scripts/nonexistent.sh"),
-                sha256: "doesntmatter".into(),
-            }),
-            execution_timeout_seconds: 30,
-            artifact_download_timeout_seconds: 30,
-            file_artifacts: vec![],
-        };
+        let metrics = MetricsCapture::start();
+        let runtime = test_runtime();
+        let mut output = None;
+        let logs = capture_logs(|| {
+            output = Some(runtime.block_on(async {
+                let base = start_file_server(vec![]).await;
+                let task = FirmwareUpgradeTask {
+                    upgrade_task_id: "test-upgrade-task-id".into(),
+                    component_type: "cpld".into(),
+                    target_version: "1.0.0".into(),
+                    script: Some(FileArtifact {
+                        url: format!("{base}/scripts/nonexistent.sh?token={SECRET}#{SECRET}"),
+                        sha256: "doesntmatter".into(),
+                    }),
+                    execution_timeout_seconds: 30,
+                    artifact_download_timeout_seconds: 30,
+                    file_artifacts: vec![],
+                };
+                let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
+                (base, result)
+            }));
+        });
+        let (base, result) = output.expect("download should produce a result");
 
-        let result = handle_firmware_upgrade(&reqwest::Client::new(), &task).await;
-
+        let attempt_logs = logs
+            .iter()
+            .filter(|log| log.field("event_name") == Some("scout_firmware_download_attempt_failed"))
+            .collect::<Vec<_>>();
+        let expected_url = format!("{base}/scripts/nonexistent.sh");
+        let expected_attempts = DOWNLOAD_MAX_RETRIES + 1;
+        assert_eq!(attempt_logs.len(), expected_attempts as usize);
+        assert!(attempt_logs.iter().all(|log| {
+            log.field("kind") == Some("script")
+                && log.field("url") == Some(expected_url.as_str())
+                && log.message == "[firmware_upgrade] download attempt failed; retrying"
+                && log
+                    .field("error")
+                    .is_some_and(|error| !error.contains(SECRET))
+        }));
+        assert_eq!(
+            attempt_logs
+                .iter()
+                .filter(|log| log.field("next_action") == Some("retry"))
+                .count(),
+            DOWNLOAD_MAX_RETRIES as usize
+        );
+        assert_eq!(
+            attempt_logs
+                .iter()
+                .filter(|log| log.field("next_action") == Some("give_up"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_scout_firmware_download_attempt_failures_total",
+                &[("kind", "script"), ("next_action", "retry")],
+            ),
+            f64::from(DOWNLOAD_MAX_RETRIES)
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                "carbide_scout_firmware_download_attempt_failures_total",
+                &[("kind", "script"), ("next_action", "give_up")],
+            ),
+            1.0
+        );
         assert!(!result.success);
         assert!(!result.error.is_empty());
+        assert!(!format!("{result:?}\n{logs:?}").contains(SECRET));
     }
 
     #[tokio::test]
     async fn test_checksum_mismatch() {
+        const SECRET: &str = "ARTIFACT_CHECKSUM_SECRET_MARKER";
         let script = "#!/bin/sh\necho ok";
         let base = start_file_server(vec![
             ("/scripts/upgrade.sh", script),
@@ -498,7 +899,7 @@ test "$(basename "$2")" = "second.bin"
             execution_timeout_seconds: 30,
             artifact_download_timeout_seconds: 30,
             file_artifacts: vec![FileArtifact {
-                url: format!("{base}/firmware/fw.bin"),
+                url: format!("{base}/firmware/fw.bin?token={SECRET}#{SECRET}"),
                 sha256: "bad_checksum".to_string(),
             }],
         };
@@ -507,10 +908,13 @@ test "$(basename "$2")" = "second.bin"
 
         assert!(!result.success);
         assert!(result.error.contains("checksum mismatch"));
+        assert!(result.error.contains(&format!("{base}/firmware/fw.bin")));
+        assert!(!result.error.contains(SECRET));
     }
 
     #[tokio::test]
     async fn test_script_checksum_mismatch() {
+        const SECRET: &str = "SCRIPT_CHECKSUM_SECRET_MARKER";
         let script = "#!/bin/sh\necho ok";
         let base = start_file_server(vec![("/scripts/upgrade.sh", script)]).await;
 
@@ -519,7 +923,7 @@ test "$(basename "$2")" = "second.bin"
             component_type: "cpld".into(),
             target_version: "1.0.0".into(),
             script: Some(FileArtifact {
-                url: format!("{base}/scripts/upgrade.sh"),
+                url: format!("{base}/scripts/upgrade.sh?token={SECRET}#{SECRET}"),
                 sha256: "bad_checksum".into(),
             }),
             execution_timeout_seconds: 30,
@@ -531,6 +935,8 @@ test "$(basename "$2")" = "second.bin"
 
         assert!(!result.success);
         assert!(result.error.contains("checksum mismatch for script"));
+        assert!(result.error.contains(&format!("{base}/scripts/upgrade.sh")));
+        assert!(!result.error.contains(SECRET));
     }
 
     #[tokio::test]

--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -232,15 +232,13 @@ async fn run_as_service(config: &Options) -> Result<(), eyre::Report> {
     match mlx_device::create_device_report_request(machine_id) {
         Ok(request) => match mlx_device::publish_mlx_device_report(config, request).await {
             Ok(response) => tracing::info!(?response, "received PublishMlxDeviceReportResponse",),
-            Err(e) => tracing::warn!(
-                error = ?e,
-                "failed to publish PublishMlxDeviceReportRequest",
-            ),
+            Err(e) => emit(metrics::ScoutMlxOperationFailed::device_report_publish(
+                format!("{e:?}"),
+            )),
         },
-        Err(e) => tracing::warn!(
-            error = ?e,
-            "failed to create PublishMlxDeviceReportRequest",
-        ),
+        Err(e) => emit(metrics::ScoutMlxOperationFailed::device_report_create(
+            format!("{e:?}"),
+        )),
     };
 
     let mut scout_stream_started = false;
@@ -578,11 +576,10 @@ async fn handle_mlxreport_action(
         .filter_map(|device_action| match DpaCommand::try_from(device_action) {
             Ok(command) => Some((device_action.pci_name.clone(), command)),
             Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    pci_name = %device_action.pci_name,
-                    "handle_mlxreport_action error decoding command",
-                );
+                emit(metrics::ScoutMlxReconciliationFailed::decode(
+                    device_action.pci_name.clone(),
+                    e,
+                ));
                 None
             }
         })
@@ -604,18 +601,17 @@ async fn handle_mlxreport_commands(
 
     for (dev_pci_name, dpa_cmd) in commands {
         if dev_pci_name.is_empty() {
-            tracing::error!("handle_mlxreport_action dev_pci_name empty");
+            emit(metrics::ScoutMlxRequestRejected::reconciliation());
             continue;
         }
 
         let dev = match discover_device(&dev_pci_name) {
             Ok(d) => d,
             Err(s) => {
-                tracing::error!(
-                    error = %s,
-                    pci_name = %dev_pci_name,
-                    "handle_mlxreport_action error from discover_device::from_str",
-                );
+                emit(metrics::ScoutMlxReconciliationFailed::discover(
+                    dev_pci_name,
+                    s,
+                ));
                 continue;
             }
         };
@@ -729,10 +725,7 @@ async fn handle_mlxreport_commands(
     match mlx_device::publish_mlx_observation_report(config, req).await {
         Ok(_resp) => (),
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "Error from publish_mlx_observation_report",
-            );
+            emit(metrics::ScoutMlxOperationFailed::observation_report_publish(e.to_string()));
         }
     }
 }

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -159,6 +159,700 @@ pub(crate) struct ScoutStreamResponseDropped {
     pub error: String,
 }
 
+/// Which firmware-upgrade input is being downloaded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum FirmwareDownloadKind {
+    Script,
+    Artifact,
+}
+
+/// What Scout will do after a failed firmware download attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum FirmwareDownloadNextAction {
+    Retry,
+    GiveUp,
+}
+
+/// A firmware download attempt failed.
+#[derive(Event)]
+#[event(
+    event_name = "scout_firmware_download_attempt_failed",
+    metric_name = "carbide_scout_firmware_download_attempt_failures_total",
+    component = "nico-scout",
+    log = warn,
+    metric = counter,
+    message = "[firmware_upgrade] download attempt failed; retrying",
+    describe = "Number of failed Scout firmware download attempts, by download kind and next action."
+)]
+pub(crate) struct ScoutFirmwareDownloadAttemptFailed {
+    #[label]
+    pub kind: FirmwareDownloadKind,
+    #[label]
+    pub next_action: FirmwareDownloadNextAction,
+    #[context(value)]
+    pub attempt: i64,
+    #[context]
+    pub url: String,
+    #[context]
+    pub error: String,
+    #[context(value)]
+    pub retry_delay_seconds: f64,
+}
+
+/// The bounded operation vocabulary for Scout's MLX failure counter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ScoutMlxOperation {
+    DeviceReportPublish,
+    InfoReport,
+    ObservationReport,
+    Reconciliation,
+    ProfileCompare,
+    LockdownStatus,
+    DeviceInfo,
+    RegistryShow,
+    ConfigQuery,
+    ConfigCompare,
+}
+
+/// Where an MLX operation failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ScoutMlxFailureStage {
+    Create,
+    Publish,
+    Decode,
+    Validate,
+    Discover,
+    Initialize,
+    Lookup,
+    Execute,
+    Serialize,
+}
+
+/// The bounded class of an MLX failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ScoutMlxFailureKind {
+    InvalidRequest,
+    NotFound,
+    Backend,
+    Serialization,
+    Rpc,
+}
+
+impl ScoutMlxFailureStage {
+    fn failure_kind(self) -> ScoutMlxFailureKind {
+        match self {
+            Self::Create | Self::Discover | Self::Initialize | Self::Execute => {
+                ScoutMlxFailureKind::Backend
+            }
+            Self::Publish => ScoutMlxFailureKind::Rpc,
+            Self::Decode | Self::Validate => ScoutMlxFailureKind::InvalidRequest,
+            Self::Lookup => ScoutMlxFailureKind::NotFound,
+            Self::Serialize => ScoutMlxFailureKind::Serialization,
+        }
+    }
+}
+
+// The operation, request, device, profile, registry, config, and
+// reconciliation families all feed `carbide_scout_mlx_failures_total`, but
+// their existing diagnostics need different context. Keep separate `Event`
+// structs so each log retains its fields without filling unrelated fields
+// with empty values.
+//
+// Named constructors own each valid (`operation`, `failure_stage`) pair and
+// derive `failure_kind` from the stage. That makes contradictory metric
+// series unrepresentable at call sites. The dynamic log and message matches
+// still have generic fallbacks: `emit()` is diagnostic plumbing and must not
+// panic if a future constructor reaches a pair its matching table does not
+// know yet.
+
+/// An MLX failure whose existing diagnostic only carries an error.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_operation_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = dynamic,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxOperationFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxOperationFailed {
+    fn new(
+        operation: ScoutMlxOperation,
+        failure_stage: ScoutMlxFailureStage,
+        error: String,
+    ) -> Self {
+        Self {
+            operation,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            error,
+        }
+    }
+
+    pub(crate) fn device_report_create(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::DeviceReportPublish,
+            ScoutMlxFailureStage::Create,
+            error,
+        )
+    }
+
+    pub(crate) fn device_report_publish(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::DeviceReportPublish,
+            ScoutMlxFailureStage::Publish,
+            error,
+        )
+    }
+
+    pub(crate) fn observation_report_publish(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ObservationReport,
+            ScoutMlxFailureStage::Publish,
+            error,
+        )
+    }
+
+    pub(crate) fn profile_compare_decode(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ProfileCompare,
+            ScoutMlxFailureStage::Decode,
+            error,
+        )
+    }
+
+    pub(crate) fn profile_compare_serialize(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ProfileCompare,
+            ScoutMlxFailureStage::Serialize,
+            error,
+        )
+    }
+
+    pub(crate) fn lockdown_status_initialize(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::LockdownStatus,
+            ScoutMlxFailureStage::Initialize,
+            error,
+        )
+    }
+
+    pub(crate) fn info_report_decode(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::InfoReport,
+            ScoutMlxFailureStage::Decode,
+            error,
+        )
+    }
+
+    pub(crate) fn info_report_execute(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::InfoReport,
+            ScoutMlxFailureStage::Execute,
+            error,
+        )
+    }
+}
+
+impl DynamicLog for ScoutMlxOperationFailed {
+    fn log_at(&self) -> LogAt {
+        match (self.operation, self.failure_stage) {
+            (
+                ScoutMlxOperation::DeviceReportPublish,
+                ScoutMlxFailureStage::Create | ScoutMlxFailureStage::Publish,
+            ) => LogAt::Level(tracing::Level::WARN),
+            (ScoutMlxOperation::ObservationReport, ScoutMlxFailureStage::Publish)
+            | (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Decode)
+            | (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Serialize)
+            | (ScoutMlxOperation::LockdownStatus, ScoutMlxFailureStage::Initialize)
+            | (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Decode)
+            | (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Execute) => {
+                LogAt::Level(tracing::Level::ERROR)
+            }
+            _ => LogAt::Level(tracing::Level::ERROR),
+        }
+    }
+}
+
+impl DynamicMessage for ScoutMlxOperationFailed {
+    fn message(&self) -> &'static str {
+        match (self.operation, self.failure_stage) {
+            (ScoutMlxOperation::DeviceReportPublish, ScoutMlxFailureStage::Create) => {
+                "failed to create PublishMlxDeviceReportRequest"
+            }
+            (ScoutMlxOperation::DeviceReportPublish, ScoutMlxFailureStage::Publish) => {
+                "failed to publish PublishMlxDeviceReportRequest"
+            }
+            (ScoutMlxOperation::ObservationReport, ScoutMlxFailureStage::Publish) => {
+                "Error from publish_mlx_observation_report"
+            }
+            (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Decode) => {
+                "[scout_stream::mlx_device] failed to parse profile"
+            }
+            (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Serialize) => {
+                "[scout_stream::mlx_device] profile compare result failed to serialize"
+            }
+            (ScoutMlxOperation::LockdownStatus, ScoutMlxFailureStage::Initialize) => {
+                "[scout_stream::mlx_device] lockdown manager initialization failed"
+            }
+            (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Decode) => {
+                "[scout_stream::mlx_device] device report request failed to parse filters"
+            }
+            (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] device report generation failed"
+            }
+            _ => "Scout MLX operation failed",
+        }
+    }
+}
+
+/// An MLX request failed validation before it had additional context.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_request_rejected",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = dynamic,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxRequestRejected {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+}
+
+impl ScoutMlxRequestRejected {
+    fn new(operation: ScoutMlxOperation) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Validate;
+        Self {
+            operation,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+        }
+    }
+
+    pub(crate) fn profile_compare() -> Self {
+        Self::new(ScoutMlxOperation::ProfileCompare)
+    }
+
+    pub(crate) fn reconciliation() -> Self {
+        Self::new(ScoutMlxOperation::Reconciliation)
+    }
+}
+
+impl DynamicLog for ScoutMlxRequestRejected {
+    fn log_at(&self) -> LogAt {
+        match self.operation {
+            ScoutMlxOperation::ProfileCompare => LogAt::Off,
+            ScoutMlxOperation::Reconciliation => LogAt::Level(tracing::Level::ERROR),
+            _ => LogAt::Level(tracing::Level::WARN),
+        }
+    }
+}
+
+impl DynamicMessage for ScoutMlxRequestRejected {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            ScoutMlxOperation::ProfileCompare => "no serializable profile data in message",
+            ScoutMlxOperation::Reconciliation => "handle_mlxreport_action dev_pci_name empty",
+            _ => "Scout MLX request rejected",
+        }
+    }
+}
+
+/// An MLX device read failed.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_device_operation_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxDeviceOperationFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device_id: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxDeviceOperationFailed {
+    fn new(
+        operation: ScoutMlxOperation,
+        failure_stage: ScoutMlxFailureStage,
+        device_id: String,
+        error: String,
+    ) -> Self {
+        Self {
+            operation,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device_id,
+            error,
+        }
+    }
+
+    pub(crate) fn lockdown_status_execute(device_id: String, error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::LockdownStatus,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            error,
+        )
+    }
+
+    pub(crate) fn device_info_discover(device_id: String, error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::DeviceInfo,
+            ScoutMlxFailureStage::Discover,
+            device_id,
+            error,
+        )
+    }
+}
+
+impl DynamicMessage for ScoutMlxDeviceOperationFailed {
+    fn message(&self) -> &'static str {
+        match (self.operation, self.failure_stage) {
+            (ScoutMlxOperation::LockdownStatus, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] lockdown status check failed"
+            }
+            (ScoutMlxOperation::DeviceInfo, ScoutMlxFailureStage::Discover) => {
+                "[scout_stream::mlx_device] device info request failed"
+            }
+            _ => "[scout_stream::mlx_device] device operation failed",
+        }
+    }
+}
+
+/// A profile comparison failed against one device.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_profile_operation_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "[scout_stream::mlx_device] profile compare against device failed",
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxProfileOperationFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device_id: String,
+    #[context]
+    profile_name: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxProfileOperationFailed {
+    pub(crate) fn profile_compare_execute(
+        device_id: String,
+        profile_name: String,
+        error: String,
+    ) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Execute;
+        Self {
+            operation: ScoutMlxOperation::ProfileCompare,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device_id,
+            profile_name,
+            error,
+        }
+    }
+}
+
+/// A registry-show request named a registry Scout does not know.
+///
+/// Registry show preserves its existing error severity. Config query and
+/// comparison use the warning-level `Event` below for the same lookup failure.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_registry_lookup_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "[scout_stream::mlx_device] variable registry not found",
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxRegistryLookupFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    registry_name: String,
+}
+
+impl ScoutMlxRegistryLookupFailed {
+    pub(crate) fn registry_show_lookup(registry_name: String) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Lookup;
+        Self {
+            operation: ScoutMlxOperation::RegistryShow,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            registry_name,
+        }
+    }
+}
+
+/// A config read named a registry Scout does not know.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_config_registry_lookup_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = warn,
+    metric = counter,
+    message = "[scout_stream::mlx_device] config registry not found",
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxConfigRegistryLookupFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device_id: String,
+    #[context]
+    registry_name: String,
+}
+
+impl ScoutMlxConfigRegistryLookupFailed {
+    fn new(operation: ScoutMlxOperation, device_id: String, registry_name: String) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Lookup;
+        Self {
+            operation,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device_id,
+            registry_name,
+        }
+    }
+
+    pub(crate) fn config_query_lookup(device_id: String, registry_name: String) -> Self {
+        Self::new(ScoutMlxOperation::ConfigQuery, device_id, registry_name)
+    }
+
+    pub(crate) fn config_compare_lookup(device_id: String, registry_name: String) -> Self {
+        Self::new(ScoutMlxOperation::ConfigCompare, device_id, registry_name)
+    }
+}
+
+/// An MLX config read failed after registry lookup.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_config_operation_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxConfigOperationFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device_id: String,
+    #[context]
+    registry_name: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxConfigOperationFailed {
+    fn new(
+        operation: ScoutMlxOperation,
+        failure_stage: ScoutMlxFailureStage,
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self {
+            operation,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device_id,
+            registry_name,
+            error,
+        }
+    }
+
+    pub(crate) fn config_query_serialize(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigQuery,
+            ScoutMlxFailureStage::Serialize,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
+
+    pub(crate) fn config_query_execute(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigQuery,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
+
+    pub(crate) fn config_compare_serialize(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigCompare,
+            ScoutMlxFailureStage::Serialize,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
+
+    pub(crate) fn config_compare_execute(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigCompare,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
+}
+
+impl DynamicMessage for ScoutMlxConfigOperationFailed {
+    fn message(&self) -> &'static str {
+        match (self.operation, self.failure_stage) {
+            (ScoutMlxOperation::ConfigQuery, ScoutMlxFailureStage::Serialize) => {
+                "[scout_stream::mlx_device] config query result failed to serialize"
+            }
+            (ScoutMlxOperation::ConfigQuery, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] config query against device failed"
+            }
+            (ScoutMlxOperation::ConfigCompare, ScoutMlxFailureStage::Serialize) => {
+                "[scout_stream::mlx_device] config compare result failed to serialize"
+            }
+            (ScoutMlxOperation::ConfigCompare, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] config compare against device failed"
+            }
+            _ => "[scout_stream::mlx_device] config operation failed",
+        }
+    }
+}
+
+/// Scout could not reconcile one MLX command with its target device.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_reconciliation_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxReconciliationFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    pci_name: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxReconciliationFailed {
+    fn new(failure_stage: ScoutMlxFailureStage, pci_name: String, error: String) -> Self {
+        Self {
+            operation: ScoutMlxOperation::Reconciliation,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            pci_name,
+            error,
+        }
+    }
+
+    pub(crate) fn decode(pci_name: String, error: String) -> Self {
+        Self::new(ScoutMlxFailureStage::Decode, pci_name, error)
+    }
+
+    pub(crate) fn discover(pci_name: String, error: String) -> Self {
+        Self::new(ScoutMlxFailureStage::Discover, pci_name, error)
+    }
+}
+
+impl DynamicMessage for ScoutMlxReconciliationFailed {
+    fn message(&self) -> &'static str {
+        match self.failure_stage {
+            ScoutMlxFailureStage::Decode => "handle_mlxreport_action error decoding command",
+            ScoutMlxFailureStage::Discover => {
+                "handle_mlxreport_action error from discover_device::from_str"
+            }
+            _ => "handle_mlxreport_action failed",
+        }
+    }
+}
+
 /// Which storage cleanup path scout ran for a device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
 pub(crate) enum StorageDeviceType {
@@ -246,6 +940,536 @@ mod tests {
     use carbide_test_support::{Check, check_values};
 
     use super::*;
+
+    #[test]
+    fn firmware_download_attempt_failures_share_one_bounded_metric() {
+        struct AttemptCase {
+            kind: FirmwareDownloadKind,
+            kind_label: &'static str,
+            next_action: FirmwareDownloadNextAction,
+            next_action_label: &'static str,
+            retry_delay_seconds: f64,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            counter_delta: f64,
+            level: tracing::Level,
+            message: String,
+            kind: Option<String>,
+            next_action: Option<String>,
+            attempt: Option<String>,
+            url: Option<String>,
+            error: Option<String>,
+            retry_delay_seconds: Option<String>,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "script attempt will retry",
+                    input: AttemptCase {
+                        kind: FirmwareDownloadKind::Script,
+                        kind_label: "script",
+                        next_action: FirmwareDownloadNextAction::Retry,
+                        next_action_label: "retry",
+                        retry_delay_seconds: 4.0,
+                    },
+                    expect: Observation {
+                        counter_delta: 1.0,
+                        level: tracing::Level::WARN,
+                        message: "[firmware_upgrade] download attempt failed; retrying".to_string(),
+                        kind: Some("script".to_string()),
+                        next_action: Some("retry".to_string()),
+                        attempt: Some("2".to_string()),
+                        url: Some("https://firmware.example/script.sh".to_string()),
+                        error: Some("HTTP 503".to_string()),
+                        retry_delay_seconds: Some("4".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "artifact attempt will give up",
+                    input: AttemptCase {
+                        kind: FirmwareDownloadKind::Artifact,
+                        kind_label: "artifact",
+                        next_action: FirmwareDownloadNextAction::GiveUp,
+                        next_action_label: "give_up",
+                        retry_delay_seconds: 0.0,
+                    },
+                    expect: Observation {
+                        counter_delta: 1.0,
+                        level: tracing::Level::WARN,
+                        message: "[firmware_upgrade] download attempt failed; retrying".to_string(),
+                        kind: Some("artifact".to_string()),
+                        next_action: Some("give_up".to_string()),
+                        attempt: Some("2".to_string()),
+                        url: Some("https://firmware.example/image.bin".to_string()),
+                        error: Some("HTTP 503".to_string()),
+                        retry_delay_seconds: Some("0".to_string()),
+                    },
+                },
+            ],
+            |case| {
+                let metrics = MetricsCapture::start();
+                let url = match case.kind {
+                    FirmwareDownloadKind::Script => "https://firmware.example/script.sh",
+                    FirmwareDownloadKind::Artifact => "https://firmware.example/image.bin",
+                };
+                let logs = capture_logs(|| {
+                    emit(ScoutFirmwareDownloadAttemptFailed {
+                        kind: case.kind,
+                        next_action: case.next_action,
+                        attempt: 2,
+                        url: url.to_string(),
+                        error: "HTTP 503".to_string(),
+                        retry_delay_seconds: case.retry_delay_seconds,
+                    });
+                });
+                let log = &logs[0];
+
+                Observation {
+                    counter_delta: metrics.counter_delta(
+                        "carbide_scout_firmware_download_attempt_failures_total",
+                        &[
+                            ("kind", case.kind_label),
+                            ("next_action", case.next_action_label),
+                        ],
+                    ),
+                    level: log.level,
+                    message: log.message.clone(),
+                    kind: log.field("kind").map(str::to_string),
+                    next_action: log.field("next_action").map(str::to_string),
+                    attempt: log.field("attempt").map(str::to_string),
+                    url: log.field("url").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    retry_delay_seconds: log.field("retry_delay_seconds").map(str::to_string),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn mlx_failure_stages_derive_one_failure_kind() {
+        check_values(
+            [
+                Check {
+                    scenario: "create failures come from the backend",
+                    input: ScoutMlxFailureStage::Create,
+                    expect: ScoutMlxFailureKind::Backend,
+                },
+                Check {
+                    scenario: "publish failures come from the RPC",
+                    input: ScoutMlxFailureStage::Publish,
+                    expect: ScoutMlxFailureKind::Rpc,
+                },
+                Check {
+                    scenario: "decode failures reject the request",
+                    input: ScoutMlxFailureStage::Decode,
+                    expect: ScoutMlxFailureKind::InvalidRequest,
+                },
+                Check {
+                    scenario: "validation failures reject the request",
+                    input: ScoutMlxFailureStage::Validate,
+                    expect: ScoutMlxFailureKind::InvalidRequest,
+                },
+                Check {
+                    scenario: "discovery failures come from the backend",
+                    input: ScoutMlxFailureStage::Discover,
+                    expect: ScoutMlxFailureKind::Backend,
+                },
+                Check {
+                    scenario: "initialization failures come from the backend",
+                    input: ScoutMlxFailureStage::Initialize,
+                    expect: ScoutMlxFailureKind::Backend,
+                },
+                Check {
+                    scenario: "lookup failures are not found",
+                    input: ScoutMlxFailureStage::Lookup,
+                    expect: ScoutMlxFailureKind::NotFound,
+                },
+                Check {
+                    scenario: "execution failures come from the backend",
+                    input: ScoutMlxFailureStage::Execute,
+                    expect: ScoutMlxFailureKind::Backend,
+                },
+                Check {
+                    scenario: "serialization failures keep their own class",
+                    input: ScoutMlxFailureStage::Serialize,
+                    expect: ScoutMlxFailureKind::Serialization,
+                },
+            ],
+            ScoutMlxFailureStage::failure_kind,
+        );
+    }
+
+    #[test]
+    fn mlx_dynamic_contracts_preserve_existing_severity_and_messages() {
+        #[derive(Clone, Copy)]
+        enum ContractCase {
+            DeviceReportCreate,
+            DeviceReportPublish,
+            ObservationReportPublish,
+            ProfileCompareDecode,
+            ProfileCompareSerialize,
+            LockdownStatusInitialize,
+            InfoReportDecode,
+            InfoReportExecute,
+            ProfileCompareRequest,
+            ReconciliationRequest,
+            LockdownStatusExecute,
+            DeviceInfoDiscover,
+            ConfigQuerySerialize,
+            ConfigQueryExecute,
+            ConfigCompareSerialize,
+            ConfigCompareExecute,
+            ReconciliationDecode,
+            ReconciliationDiscover,
+            OperationFallback,
+            RequestFallback,
+            DeviceFallback,
+            ConfigFallback,
+            ReconciliationFallback,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Contract {
+            log_at: LogAt,
+            message: &'static str,
+        }
+
+        fn contract<E>(event: &E) -> Contract
+        where
+            E: Event,
+        {
+            Contract {
+                log_at: event.log_at(),
+                message: event.message(),
+            }
+        }
+
+        let warn = |message| Contract {
+            log_at: LogAt::Level(tracing::Level::WARN),
+            message,
+        };
+        let error = |message| Contract {
+            log_at: LogAt::Level(tracing::Level::ERROR),
+            message,
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "device report creation",
+                    input: ContractCase::DeviceReportCreate,
+                    expect: warn("failed to create PublishMlxDeviceReportRequest"),
+                },
+                Check {
+                    scenario: "device report publication",
+                    input: ContractCase::DeviceReportPublish,
+                    expect: warn("failed to publish PublishMlxDeviceReportRequest"),
+                },
+                Check {
+                    scenario: "observation report publication",
+                    input: ContractCase::ObservationReportPublish,
+                    expect: error("Error from publish_mlx_observation_report"),
+                },
+                Check {
+                    scenario: "profile decode",
+                    input: ContractCase::ProfileCompareDecode,
+                    expect: error("[scout_stream::mlx_device] failed to parse profile"),
+                },
+                Check {
+                    scenario: "profile result serialization",
+                    input: ContractCase::ProfileCompareSerialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] profile compare result failed to serialize",
+                    ),
+                },
+                Check {
+                    scenario: "lockdown manager initialization",
+                    input: ContractCase::LockdownStatusInitialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] lockdown manager initialization failed",
+                    ),
+                },
+                Check {
+                    scenario: "info report filter decode",
+                    input: ContractCase::InfoReportDecode,
+                    expect: error(
+                        "[scout_stream::mlx_device] device report request failed to parse filters",
+                    ),
+                },
+                Check {
+                    scenario: "info report execution",
+                    input: ContractCase::InfoReportExecute,
+                    expect: error("[scout_stream::mlx_device] device report generation failed"),
+                },
+                Check {
+                    scenario: "missing profile request",
+                    input: ContractCase::ProfileCompareRequest,
+                    expect: Contract {
+                        log_at: LogAt::Off,
+                        message: "no serializable profile data in message",
+                    },
+                },
+                Check {
+                    scenario: "empty reconciliation PCI request",
+                    input: ContractCase::ReconciliationRequest,
+                    expect: error("handle_mlxreport_action dev_pci_name empty"),
+                },
+                Check {
+                    scenario: "lockdown status execution",
+                    input: ContractCase::LockdownStatusExecute,
+                    expect: error("[scout_stream::mlx_device] lockdown status check failed"),
+                },
+                Check {
+                    scenario: "device information discovery",
+                    input: ContractCase::DeviceInfoDiscover,
+                    expect: error("[scout_stream::mlx_device] device info request failed"),
+                },
+                Check {
+                    scenario: "config query result serialization",
+                    input: ContractCase::ConfigQuerySerialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] config query result failed to serialize",
+                    ),
+                },
+                Check {
+                    scenario: "config query execution",
+                    input: ContractCase::ConfigQueryExecute,
+                    expect: error("[scout_stream::mlx_device] config query against device failed"),
+                },
+                Check {
+                    scenario: "config comparison result serialization",
+                    input: ContractCase::ConfigCompareSerialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] config compare result failed to serialize",
+                    ),
+                },
+                Check {
+                    scenario: "config comparison execution",
+                    input: ContractCase::ConfigCompareExecute,
+                    expect: error(
+                        "[scout_stream::mlx_device] config compare against device failed",
+                    ),
+                },
+                Check {
+                    scenario: "reconciliation command decode",
+                    input: ContractCase::ReconciliationDecode,
+                    expect: error("handle_mlxreport_action error decoding command"),
+                },
+                Check {
+                    scenario: "reconciliation device discovery",
+                    input: ContractCase::ReconciliationDiscover,
+                    expect: error("handle_mlxreport_action error from discover_device::from_str"),
+                },
+                Check {
+                    scenario: "unknown operation pair remains diagnostic",
+                    input: ContractCase::OperationFallback,
+                    expect: error("Scout MLX operation failed"),
+                },
+                Check {
+                    scenario: "unknown request operation remains diagnostic",
+                    input: ContractCase::RequestFallback,
+                    expect: warn("Scout MLX request rejected"),
+                },
+                Check {
+                    scenario: "unknown device pair remains diagnostic",
+                    input: ContractCase::DeviceFallback,
+                    expect: error("[scout_stream::mlx_device] device operation failed"),
+                },
+                Check {
+                    scenario: "unknown config pair remains diagnostic",
+                    input: ContractCase::ConfigFallback,
+                    expect: error("[scout_stream::mlx_device] config operation failed"),
+                },
+                Check {
+                    scenario: "unknown reconciliation stage remains diagnostic",
+                    input: ContractCase::ReconciliationFallback,
+                    expect: error("handle_mlxreport_action failed"),
+                },
+            ],
+            |case| match case {
+                ContractCase::DeviceReportCreate => contract(
+                    &ScoutMlxOperationFailed::device_report_create("failure".to_string()),
+                ),
+                ContractCase::DeviceReportPublish => contract(
+                    &ScoutMlxOperationFailed::device_report_publish("failure".to_string()),
+                ),
+                ContractCase::ObservationReportPublish => contract(
+                    &ScoutMlxOperationFailed::observation_report_publish("failure".to_string()),
+                ),
+                ContractCase::ProfileCompareDecode => contract(
+                    &ScoutMlxOperationFailed::profile_compare_decode("failure".to_string()),
+                ),
+                ContractCase::ProfileCompareSerialize => contract(
+                    &ScoutMlxOperationFailed::profile_compare_serialize("failure".to_string()),
+                ),
+                ContractCase::LockdownStatusInitialize => contract(
+                    &ScoutMlxOperationFailed::lockdown_status_initialize("failure".to_string()),
+                ),
+                ContractCase::InfoReportDecode => contract(
+                    &ScoutMlxOperationFailed::info_report_decode("failure".to_string()),
+                ),
+                ContractCase::InfoReportExecute => contract(
+                    &ScoutMlxOperationFailed::info_report_execute("failure".to_string()),
+                ),
+                ContractCase::ProfileCompareRequest => {
+                    contract(&ScoutMlxRequestRejected::profile_compare())
+                }
+                ContractCase::ReconciliationRequest => {
+                    contract(&ScoutMlxRequestRejected::reconciliation())
+                }
+                ContractCase::LockdownStatusExecute => {
+                    contract(&ScoutMlxDeviceOperationFailed::lockdown_status_execute(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::DeviceInfoDiscover => {
+                    contract(&ScoutMlxDeviceOperationFailed::device_info_discover(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ConfigQuerySerialize => {
+                    contract(&ScoutMlxConfigOperationFailed::config_query_serialize(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ConfigQueryExecute => {
+                    contract(&ScoutMlxConfigOperationFailed::config_query_execute(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ConfigCompareSerialize => {
+                    contract(&ScoutMlxConfigOperationFailed::config_compare_serialize(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ConfigCompareExecute => {
+                    contract(&ScoutMlxConfigOperationFailed::config_compare_execute(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ReconciliationDecode => {
+                    contract(&ScoutMlxReconciliationFailed::decode(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ReconciliationDiscover => {
+                    contract(&ScoutMlxReconciliationFailed::discover(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::OperationFallback => contract(&ScoutMlxOperationFailed::new(
+                    ScoutMlxOperation::ConfigQuery,
+                    ScoutMlxFailureStage::Create,
+                    "failure".to_string(),
+                )),
+                ContractCase::RequestFallback => contract(&ScoutMlxRequestRejected::new(
+                    ScoutMlxOperation::ConfigQuery,
+                )),
+                ContractCase::DeviceFallback => contract(&ScoutMlxDeviceOperationFailed::new(
+                    ScoutMlxOperation::ConfigQuery,
+                    ScoutMlxFailureStage::Create,
+                    "device".to_string(),
+                    "failure".to_string(),
+                )),
+                ContractCase::ConfigFallback => contract(&ScoutMlxConfigOperationFailed::new(
+                    ScoutMlxOperation::DeviceInfo,
+                    ScoutMlxFailureStage::Publish,
+                    "device".to_string(),
+                    "registry".to_string(),
+                    "failure".to_string(),
+                )),
+                ContractCase::ReconciliationFallback => {
+                    contract(&ScoutMlxReconciliationFailed::new(
+                        ScoutMlxFailureStage::Serialize,
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn mlx_request_rejections_count_with_existing_diagnostics() {
+        #[derive(Clone, Copy)]
+        enum RequestCase {
+            ProfileCompare,
+            Reconciliation,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            counter_delta: f64,
+            logs: Vec<(tracing::Level, String)>,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "missing profile data remains metric-only",
+                    input: RequestCase::ProfileCompare,
+                    expect: Observation {
+                        counter_delta: 1.0,
+                        logs: Vec::new(),
+                    },
+                },
+                Check {
+                    scenario: "empty reconciliation PCI retains its error",
+                    input: RequestCase::Reconciliation,
+                    expect: Observation {
+                        counter_delta: 1.0,
+                        logs: vec![(
+                            tracing::Level::ERROR,
+                            "handle_mlxreport_action dev_pci_name empty".to_string(),
+                        )],
+                    },
+                },
+            ],
+            |case| {
+                let (event, operation) = match case {
+                    RequestCase::ProfileCompare => (
+                        ScoutMlxRequestRejected::profile_compare(),
+                        "profile_compare",
+                    ),
+                    RequestCase::Reconciliation => {
+                        (ScoutMlxRequestRejected::reconciliation(), "reconciliation")
+                    }
+                };
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| emit(event));
+
+                Observation {
+                    counter_delta: metrics.counter_delta(
+                        "carbide_scout_mlx_failures_total",
+                        &[
+                            ("operation", operation),
+                            ("failure_stage", "validate"),
+                            ("failure_kind", "invalid_request"),
+                        ],
+                    ),
+                    logs: logs
+                        .into_iter()
+                        .map(|log| (log.level, log.message))
+                        .collect(),
+                }
+            },
+        );
+    }
 
     #[test]
     fn scout_action_maps_every_dispatchable_action() {

--- a/crates/scout/src/mlx_device.rs
+++ b/crates/scout/src/mlx_device.rs
@@ -20,6 +20,7 @@ use ::rpc::protos::mlx_device::{
     PublishMlxDeviceReportRequest, PublishMlxDeviceReportResponse,
     PublishMlxObservationReportRequest, PublishMlxObservationReportResponse,
 };
+use carbide_instrument::emit;
 use carbide_uuid::machine::MachineId;
 use libmlx::device::discovery;
 use libmlx::device::report::MlxDeviceReport;
@@ -38,6 +39,11 @@ use scout::CarbideClientResult;
 
 use crate::cfg::Options;
 use crate::client;
+use crate::metrics::{
+    ScoutMlxConfigOperationFailed, ScoutMlxConfigRegistryLookupFailed,
+    ScoutMlxDeviceOperationFailed, ScoutMlxOperationFailed, ScoutMlxProfileOperationFailed,
+    ScoutMlxRegistryLookupFailed, ScoutMlxRequestRejected,
+};
 
 // create_device_report_request is a one stop shop to collect
 // Mellanox device data from the machine, create a report, convert
@@ -222,6 +228,7 @@ pub fn handle_profile_compare(
     );
 
     let Some(serializable_profile_pb) = request.serializable_profile else {
+        emit(ScoutMlxRequestRejected::profile_compare());
         return mlx_device_pb::MlxDeviceProfileCompareResponse {
             reply: Some(
                 mlx_device_pb::mlx_device_profile_compare_response::Reply::Error(
@@ -237,10 +244,9 @@ pub fn handle_profile_compare(
     let serializable_profile: SerializableProfile = match serializable_profile_pb.try_into() {
         Ok(profile) => profile,
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "[scout_stream::mlx_device] failed to parse profile",
-            );
+            emit(ScoutMlxOperationFailed::profile_compare_decode(
+                e.to_string(),
+            ));
             return mlx_device_pb::MlxDeviceProfileCompareResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_profile_compare_response::Reply::Error(
@@ -271,10 +277,9 @@ pub fn handle_profile_compare(
                     ),
                 },
                 Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        "[scout_stream::mlx_device] profile compare result failed to serialize",
-                    );
+                    emit(ScoutMlxOperationFailed::profile_compare_serialize(
+                        e.to_string(),
+                    ));
                     mlx_device_pb::MlxDeviceProfileCompareResponse {
                         reply: Some(
                             mlx_device_pb::mlx_device_profile_compare_response::Reply::Error(
@@ -290,12 +295,11 @@ pub fn handle_profile_compare(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                profile_name = %request.profile_name,
-                error = %e,
-                "[scout_stream::mlx_device] profile compare against device failed",
-            );
+            emit(ScoutMlxProfileOperationFailed::profile_compare_execute(
+                request.device_id.clone(),
+                request.profile_name.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceProfileCompareResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_profile_compare_response::Reply::Error(
@@ -440,10 +444,9 @@ pub fn handle_lockdown_status(
     let manager = match LockdownManager::new() {
         Ok(m) => m,
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "[scout_stream::mlx_device] lockdown manager initialization failed",
-            );
+            emit(ScoutMlxOperationFailed::lockdown_status_initialize(
+                e.to_string(),
+            ));
             return mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -470,11 +473,10 @@ pub fn handle_lockdown_status(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                error = %e,
-                "[scout_stream::mlx_device] lockdown status check failed",
-            );
+            emit(ScoutMlxDeviceOperationFailed::lockdown_status_execute(
+                request.device_id.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -510,11 +512,10 @@ pub fn handle_info_device(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                error = %e,
-                "[scout_stream::mlx_device] device info request failed",
-            );
+            emit(ScoutMlxDeviceOperationFailed::device_info_discover(
+                request.device_id.clone(),
+                e.clone(),
+            ));
             mlx_device_pb::MlxDeviceInfoDeviceResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_info_device_response::Reply::Error(
@@ -538,10 +539,7 @@ pub fn handle_info_report(
         match libmlx::device::filters::DeviceFilterSet::try_from(filter_set_pb) {
             Ok(filters) => MlxDeviceReport::new().with_filter_set(filters),
             Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    "[scout_stream::mlx_device] device report request failed to parse filters",
-                );
+                emit(ScoutMlxOperationFailed::info_report_decode(e.to_string()));
                 return mlx_device_pb::MlxDeviceInfoReportResponse {
                     reply: Some(
                         mlx_device_pb::mlx_device_info_report_response::Reply::Error(
@@ -573,10 +571,7 @@ pub fn handle_info_report(
             }
         }
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "[scout_stream::mlx_device] device report generation failed",
-            );
+            emit(ScoutMlxOperationFailed::info_report_execute(e.clone()));
             mlx_device_pb::MlxDeviceInfoReportResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_info_report_response::Reply::Error(
@@ -632,10 +627,9 @@ pub fn handle_registry_show(
             }
         }
         None => {
-            tracing::error!(
-                registry_name = %request.registry_name,
-                "[scout_stream::mlx_device] variable registry not found",
-            );
+            emit(ScoutMlxRegistryLookupFailed::registry_show_lookup(
+                request.registry_name.clone(),
+            ));
             mlx_device_pb::MlxDeviceRegistryShowResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_registry_show_response::Reply::Error(
@@ -665,11 +659,10 @@ pub fn handle_config_query(
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
-            tracing::warn!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                "[scout_stream::mlx_device] config registry not found",
-            );
+            emit(ScoutMlxConfigRegistryLookupFailed::config_query_lookup(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+            ));
             return mlx_device_pb::MlxDeviceConfigQueryResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_config_query_response::Reply::Error(
@@ -713,12 +706,11 @@ pub fn handle_config_query(
                     ),
                 },
                 Err(e) => {
-                    tracing::error!(
-                        device_id = %request.device_id,
-                        registry_name = %request.registry_name,
-                        error = %e,
-                        "[scout_stream::mlx_device] config query result failed to serialize",
-                    );
+                    emit(ScoutMlxConfigOperationFailed::config_query_serialize(
+                        request.device_id.clone(),
+                        request.registry_name.clone(),
+                        e.to_string(),
+                    ));
                     mlx_device_pb::MlxDeviceConfigQueryResponse {
                         reply: Some(
                             mlx_device_pb::mlx_device_config_query_response::Reply::Error(
@@ -737,12 +729,11 @@ pub fn handle_config_query(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                error = %e,
-                "[scout_stream::mlx_device] config query against device failed",
-            );
+            emit(ScoutMlxConfigOperationFailed::config_query_execute(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceConfigQueryResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_config_query_response::Reply::Error(
@@ -969,11 +960,10 @@ pub fn handle_config_compare(
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
-            tracing::warn!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                "[scout_stream::mlx_device] config registry not found",
-            );
+            emit(ScoutMlxConfigRegistryLookupFailed::config_compare_lookup(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+            ));
             return mlx_device_pb::MlxDeviceConfigCompareResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_config_compare_response::Reply::Error(
@@ -1018,12 +1008,11 @@ pub fn handle_config_compare(
                     ),
                 },
                 Err(e) => {
-                    tracing::error!(
-                        device_id = %request.device_id,
-                        registry_name = %request.registry_name,
-                        error = %e,
-                        "[scout_stream::mlx_device] config compare result failed to serialize",
-                    );
+                    emit(ScoutMlxConfigOperationFailed::config_compare_serialize(
+                        request.device_id.clone(),
+                        request.registry_name.clone(),
+                        e.to_string(),
+                    ));
                     mlx_device_pb::MlxDeviceConfigCompareResponse {
                         reply: Some(
                             mlx_device_pb::mlx_device_config_compare_response::Reply::Error(
@@ -1042,12 +1031,11 @@ pub fn handle_config_compare(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                error = %e,
-                "[scout_stream::mlx_device] config compare against device failed",
-            );
+            emit(ScoutMlxConfigOperationFailed::config_compare_execute(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceConfigCompareResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_config_compare_response::Reply::Error(
@@ -1216,4 +1204,242 @@ fn load_and_compare_profile(
     let profile = serializable_profile.into_profile()?;
     let comparison_result = profile.compare(device_id, None)?;
     Ok(comparison_result)
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const MLX_FAILURE_METRIC: &str = "carbide_scout_mlx_failures_total";
+    const DEVICE_ID: &str = "0000:01:00.0";
+    const REGISTRY: &str = "missing-registry";
+
+    #[derive(Clone, Copy)]
+    enum ReadFailure {
+        MissingProfile,
+        MissingRegistry,
+        QueryMissingRegistry,
+        CompareMissingRegistry,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct EventObservation {
+        level: tracing::Level,
+        message: String,
+        event_name: String,
+        operation: Option<String>,
+        failure_stage: Option<String>,
+        failure_kind: Option<String>,
+        device_id: Option<String>,
+        registry_name: Option<String>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct HandlerObservation {
+        response_status: i32,
+        response_message: String,
+        events: Vec<EventObservation>,
+        counter_delta: f64,
+    }
+
+    impl ReadFailure {
+        fn metric_labels(self) -> [(&'static str, &'static str); 3] {
+            let operation = match self {
+                Self::MissingProfile => "profile_compare",
+                Self::MissingRegistry => "registry_show",
+                Self::QueryMissingRegistry => "config_query",
+                Self::CompareMissingRegistry => "config_compare",
+            };
+            let failure_stage = match self {
+                Self::MissingProfile => "validate",
+                _ => "lookup",
+            };
+            let failure_kind = match self {
+                Self::MissingProfile => "invalid_request",
+                _ => "not_found",
+            };
+            [
+                ("operation", operation),
+                ("failure_stage", failure_stage),
+                ("failure_kind", failure_kind),
+            ]
+        }
+
+        fn invoke(self) -> mlx_device_pb::MlxDeviceStreamError {
+            match self {
+                Self::MissingProfile => {
+                    let response =
+                        handle_profile_compare(mlx_device_pb::MlxDeviceProfileCompareRequest {
+                            device_id: DEVICE_ID.to_string(),
+                            profile_name: "default".to_string(),
+                            serializable_profile: None,
+                        });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_profile_compare_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing profile should return an error"),
+                    }
+                }
+                Self::MissingRegistry => {
+                    let response =
+                        handle_registry_show(mlx_device_pb::MlxDeviceRegistryShowRequest {
+                            registry_name: REGISTRY.to_string(),
+                        });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_registry_show_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing registry should return an error"),
+                    }
+                }
+                Self::QueryMissingRegistry => {
+                    let response =
+                        handle_config_query(mlx_device_pb::MlxDeviceConfigQueryRequest {
+                            device_id: DEVICE_ID.to_string(),
+                            registry_name: REGISTRY.to_string(),
+                            variables: Vec::new(),
+                        });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_config_query_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing query registry should return an error"),
+                    }
+                }
+                Self::CompareMissingRegistry => {
+                    let response =
+                        handle_config_compare(mlx_device_pb::MlxDeviceConfigCompareRequest {
+                            device_id: DEVICE_ID.to_string(),
+                            registry_name: REGISTRY.to_string(),
+                            assignments: Vec::new(),
+                        });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_config_compare_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing compare registry should return an error"),
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn read_handlers_preserve_responses_and_classify_failures() {
+        let internal = mlx_device_pb::MlxDeviceStreamErrorStatus::Internal as i32;
+        let missing_config = || {
+            format!("config registry not found (device_id:{DEVICE_ID}, registry_name:{REGISTRY})")
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "profile comparison requires profile data",
+                    input: ReadFailure::MissingProfile,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: "no serializable profile data in message".to_string(),
+                        events: Vec::new(),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "registry show rejects an unknown registry",
+                    input: ReadFailure::MissingRegistry,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: format!("registry not found: {REGISTRY}"),
+                        events: vec![EventObservation {
+                            level: tracing::Level::ERROR,
+                            message: "[scout_stream::mlx_device] variable registry not found"
+                                .to_string(),
+                            event_name: "scout_mlx_registry_lookup_failed".to_string(),
+                            operation: Some("registry_show".to_string()),
+                            failure_stage: Some("lookup".to_string()),
+                            failure_kind: Some("not_found".to_string()),
+                            device_id: None,
+                            registry_name: Some(REGISTRY.to_string()),
+                        }],
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "config query rejects an unknown registry",
+                    input: ReadFailure::QueryMissingRegistry,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: missing_config(),
+                        events: vec![EventObservation {
+                            level: tracing::Level::WARN,
+                            message: "[scout_stream::mlx_device] config registry not found"
+                                .to_string(),
+                            event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
+                            operation: Some("config_query".to_string()),
+                            failure_stage: Some("lookup".to_string()),
+                            failure_kind: Some("not_found".to_string()),
+                            device_id: Some(DEVICE_ID.to_string()),
+                            registry_name: Some(REGISTRY.to_string()),
+                        }],
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "config comparison rejects an unknown registry",
+                    input: ReadFailure::CompareMissingRegistry,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: missing_config(),
+                        events: vec![EventObservation {
+                            level: tracing::Level::WARN,
+                            message: "[scout_stream::mlx_device] config registry not found"
+                                .to_string(),
+                            event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
+                            operation: Some("config_compare".to_string()),
+                            failure_stage: Some("lookup".to_string()),
+                            failure_kind: Some("not_found".to_string()),
+                            device_id: Some(DEVICE_ID.to_string()),
+                            registry_name: Some(REGISTRY.to_string()),
+                        }],
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |fixture| {
+                let metrics = MetricsCapture::start();
+                let mut response = mlx_device_pb::MlxDeviceStreamError {
+                    status: 0,
+                    message: String::new(),
+                };
+                let logs = capture_logs(|| response = fixture.invoke());
+                let events = logs
+                    .iter()
+                    .filter_map(|log| {
+                        let event_name = log.field("event_name")?;
+                        Some(EventObservation {
+                            level: log.level,
+                            message: log.message.clone(),
+                            event_name: event_name.to_string(),
+                            operation: log.field("operation").map(str::to_string),
+                            failure_stage: log.field("failure_stage").map(str::to_string),
+                            failure_kind: log.field("failure_kind").map(str::to_string),
+                            device_id: log.field("device_id").map(str::to_string),
+                            registry_name: log.field("registry_name").map(str::to_string),
+                        })
+                    })
+                    .collect();
+
+                HandlerObservation {
+                    response_status: response.status,
+                    response_message: response.message,
+                    events,
+                    counter_delta: metrics
+                        .counter_delta(MLX_FAILURE_METRIC, &fixture.metric_labels()),
+                }
+            },
+        );
+    }
 }

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -221,6 +221,8 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_resourcepool_used_count</td><td>gauge</td><td>Number of currently allocated values in the resource pool</td></tr>
 <tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>Number of machines in the system that are currently running a DPU/NIC firmware update</td></tr>
 <tr><td>carbide_scout_actions_total</td><td>counter</td><td>Number of scout control-loop actions handled, by action and outcome.</td></tr>
+<tr><td>carbide_scout_firmware_download_attempt_failures_total</td><td>counter</td><td>Number of failed Scout firmware download attempts, by download kind and next action.</td></tr>
+<tr><td>carbide_scout_mlx_failures_total</td><td>counter</td><td>Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind.</td></tr>
 <tr><td>carbide_scout_storage_device_cleanup_duration_seconds</td><td>histogram</td><td>Duration of per-device scout storage cleanup operations, by device type and outcome.</td></tr>
 <tr><td>carbide_scout_stream_connections_total</td><td>counter</td><td>Number of scout stream connection attempts, by outcome.</td></tr>
 <tr><td>carbide_scout_stream_reconnects_total</td><td>counter</td><td>Number of scout stream reconnect cycles after a stream closed or errored.</td></tr>


### PR DESCRIPTION
Scout already retries firmware downloads and keeps MLX observation failures visible in logs, but there wasn't a bounded rate for either side. That makes it hard to tell whether a retry is an occasional blip or something a site is doing over and over, and the MLX read paths had the same gap across reconciliation, profile comparison, lockdown status, and device or registry reads.

So, this adds one firmware counter for script and artifact attempts plus retry and give-up decisions, and one MLX counter with a bounded operation, stage, and failure vocabulary. The existing responses, retries, and log messages stay as they were. Task credentials are redacted from every local diagnostic, and shared label combinations remain constructor-owned.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4157

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-scout`
- `cargo clippy -p carbide-scout --all-targets -- -D warnings`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make check-format-nightly`

## Additional Notes

Task-derived credentials are redacted from firmware URLs, output, status, and result diagnostics, including malformed URLs, without rewriting unrelated URLs emitted by scripts. Existing response statuses, retries, and log messages remain unchanged. #4160 handles the remaining MLX mutation and recovery paths as the only safety split from the consolidated Scout work; the generated core metric catalogue stays with this code change.

Closes #4157