### PR TITLE
feat: instrument local runtime recovery

### DIFF
--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 
 use carbide_host_support::agent_config::MachineIdentityConfig;
-use carbide_instrument::emit;
 use eyre::eyre;
 use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
 use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
@@ -29,7 +28,7 @@ use rpc::forge::ManagedHostNetworkConfigResponse;
 use tonic::transport::Channel;
 
 use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
-use crate::instrumentation::{FmdsPushFailed, FmdsPushSucceeded};
+use crate::instrumentation::FmdsPush;
 use crate::periodic_config_fetcher::InstanceMetadata;
 
 /// FmdsUpdater abstracts over embedded vs external FMDS
@@ -60,11 +59,12 @@ impl FmdsUpdater {
             FmdsUpdater::External(client) => {
                 let result = client.update_config(&instance_data, &network_config).await;
                 match &result {
-                    Ok(()) => emit(FmdsPushSucceeded::new()),
-                    Err(err) => emit(FmdsPushFailed::new(
-                        format!("{err:#}"),
-                        client.address.clone(),
-                    )),
+                    Ok(()) => FmdsPush::Succeeded.emit(),
+                    Err(err) => FmdsPush::Failed {
+                        error: format!("{err:#}"),
+                        fmds_address: client.address.clone(),
+                    }
+                    .emit(),
                 }
             }
         }

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -31,19 +31,232 @@ use carbide_instrument::Outcome;
 use carbide_uuid::machine::MachineId;
 pub use config::{get_dpu_agent_meter, get_prometheus_registry};
 
+/// LLDP and OVS expose one enum per restart flow, while the private Event
+/// structs keep each existing log level, message, and field set intact. Every
+/// variant still updates the shared counter with the same labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+enum RestartedService {
+    Lldpd,
+    OvsVswitchd,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
+enum ServiceRestartResult {
+    Succeeded,
+    Retrying,
+    Failed,
+}
+
+pub(crate) enum LldpdRestart {
+    Succeeded { attempt: u8 },
+    Retrying { error: String, attempt: u8 },
+    Failed { error: String, attempt_count: u8 },
+}
+
+pub(crate) enum OvsRestart {
+    Succeeded,
+    Retrying {
+        error: String,
+        managed_host_config_version: String,
+    },
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_lldpd_restart_succeeded",
+    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
+    component = "forge-dpu-agent",
+    log = info,
+    metric = counter,
+    message = "Restarted lldpd service",
+    describe = "Number of DPU-agent service restart attempts, by service and result."
+)]
+struct LldpdRestartSucceeded {
+    #[label]
+    service: RestartedService,
+    #[label]
+    result: ServiceRestartResult,
+    #[context(value)]
+    attempt: i64,
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_lldpd_restart_retrying",
+    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
+    component = "forge-dpu-agent",
+    log = warn,
+    metric = counter,
+    message = "Couldn't restart lldpd service, retrying",
+    describe = "Number of DPU-agent service restart attempts, by service and result."
+)]
+struct LldpdRestartRetrying {
+    #[label]
+    service: RestartedService,
+    #[label]
+    result: ServiceRestartResult,
+    #[context]
+    error: String,
+    #[context(value)]
+    attempt: i64,
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_lldpd_restart_failed",
+    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Couldn't restart lldpd service",
+    describe = "Number of DPU-agent service restart attempts, by service and result."
+)]
+struct LldpdRestartFailed {
+    #[label]
+    service: RestartedService,
+    #[label]
+    result: ServiceRestartResult,
+    #[context]
+    error: String,
+    #[context(value)]
+    attempt_count: i64,
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_ovs_restart_succeeded",
+    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
+    component = "forge-dpu-agent",
+    log = info,
+    metric = counter,
+    message = "Successfully restarted ovs-vswitchd.service",
+    describe = "Number of DPU-agent service restart attempts, by service and result."
+)]
+struct OvsRestartSucceeded {
+    #[label]
+    service: RestartedService,
+    #[label]
+    result: ServiceRestartResult,
+}
+
+#[derive(carbide_instrument::Event)]
+#[event(
+    event_name = "dpu_agent_ovs_restart_retrying",
+    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
+    component = "forge-dpu-agent",
+    log = error,
+    metric = counter,
+    message = "Restarting OVS after admin network change",
+    describe = "Number of DPU-agent service restart attempts, by service and result."
+)]
+struct OvsRestartRetrying {
+    #[label]
+    service: RestartedService,
+    #[label]
+    result: ServiceRestartResult,
+    #[context(value)]
+    error: String,
+    #[context(value)]
+    managed_host_config_version: String,
+}
+
+impl LldpdRestart {
+    pub(crate) fn emit(self) {
+        match self {
+            Self::Succeeded { attempt } => {
+                carbide_instrument::emit(LldpdRestartSucceeded {
+                    service: RestartedService::Lldpd,
+                    result: ServiceRestartResult::Succeeded,
+                    attempt: i64::from(attempt),
+                });
+            }
+            Self::Retrying { error, attempt } => {
+                carbide_instrument::emit(LldpdRestartRetrying {
+                    service: RestartedService::Lldpd,
+                    result: ServiceRestartResult::Retrying,
+                    error,
+                    attempt: i64::from(attempt),
+                });
+            }
+            Self::Failed {
+                error,
+                attempt_count,
+            } => {
+                carbide_instrument::emit(LldpdRestartFailed {
+                    service: RestartedService::Lldpd,
+                    result: ServiceRestartResult::Failed,
+                    error,
+                    attempt_count: i64::from(attempt_count),
+                });
+            }
+        }
+    }
+}
+
+impl OvsRestart {
+    pub(crate) fn emit(self) {
+        match self {
+            Self::Succeeded => {
+                carbide_instrument::emit(OvsRestartSucceeded {
+                    service: RestartedService::OvsVswitchd,
+                    result: ServiceRestartResult::Succeeded,
+                });
+            }
+            Self::Retrying {
+                error,
+                managed_host_config_version,
+            } => {
+                carbide_instrument::emit(OvsRestartRetrying {
+                    service: RestartedService::OvsVswitchd,
+                    result: ServiceRestartResult::Retrying,
+                    error,
+                    managed_host_config_version,
+                });
+            }
+        }
+    }
+}
+
 /// `ReportLoop` labels one full agent reporting iteration rather than one
 /// outbound RPC. That boundary also counts pre-RPC build and conversion
 /// failures, plus the external FMDS push that generated-client RED metrics do
 /// not see.
 ///
-/// The enum stays private so each Event constructor fixes the only valid
-/// `{report_loop, outcome}` pair.
+/// The label enum stays private so each caller-facing report variant fixes the
+/// only valid `{report_loop, outcome}` pair before emitting its Event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
 enum ReportLoop {
     Inventory,
     ConfigFetch,
     FmdsPush,
     NetworkStatus,
+}
+
+pub(crate) enum InventoryReport {
+    Succeeded,
+    Failed,
+}
+
+pub(crate) enum ConfigFetch {
+    Succeeded,
+    Failed {
+        error: String,
+        retry_interval_seconds: f64,
+    },
+    NotFound {
+        machine_id: String,
+    },
+}
+
+pub(crate) enum FmdsPush {
+    Succeeded,
+    Failed { error: String, fmds_address: String },
+}
+
+pub(crate) enum NetworkStatus {
+    Succeeded,
+    ConnectionFailed { forge_api: String, error: String },
+    RpcFailed { error: String },
 }
 
 /// `InventoryReportSucceeded` records the inventory loop's successful
@@ -59,20 +272,11 @@ enum ReportLoop {
     message = "Successfully updated machine inventory",
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct InventoryReportSucceeded {
+struct InventoryReportSucceeded {
     #[label]
     report_loop: ReportLoop,
     #[label]
     outcome: Outcome,
-}
-
-impl InventoryReportSucceeded {
-    pub(crate) fn new() -> Self {
-        Self {
-            report_loop: ReportLoop::Inventory,
-            outcome: Outcome::Ok,
-        }
-    }
 }
 
 /// `InventoryReportFailed` counts an inventory error without logging it.
@@ -87,20 +291,11 @@ impl InventoryReportSucceeded {
     metric = counter,
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct InventoryReportFailed {
+struct InventoryReportFailed {
     #[label]
     report_loop: ReportLoop,
     #[label]
     outcome: Outcome,
-}
-
-impl InventoryReportFailed {
-    pub(crate) fn new() -> Self {
-        Self {
-            report_loop: ReportLoop::Inventory,
-            outcome: Outcome::Error,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -112,20 +307,11 @@ impl InventoryReportFailed {
     metric = counter,
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct ConfigFetchSucceeded {
+struct ConfigFetchSucceeded {
     #[label]
     report_loop: ReportLoop,
     #[label]
     outcome: Outcome,
-}
-
-impl ConfigFetchSucceeded {
-    pub(crate) fn new() -> Self {
-        Self {
-            report_loop: ReportLoop::ConfigFetch,
-            outcome: Outcome::Ok,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -138,7 +324,7 @@ impl ConfigFetchSucceeded {
     message = "Failed to fetch the latest configuration. Will retry",
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct ConfigFetchFailed {
+struct ConfigFetchFailed {
     #[label]
     report_loop: ReportLoop,
     #[label]
@@ -147,17 +333,6 @@ pub(crate) struct ConfigFetchFailed {
     error: String,
     #[context(value)]
     retry_interval_seconds: f64,
-}
-
-impl ConfigFetchFailed {
-    pub(crate) fn new(error: String, retry_interval_seconds: f64) -> Self {
-        Self {
-            report_loop: ReportLoop::ConfigFetch,
-            outcome: Outcome::Error,
-            error,
-            retry_interval_seconds,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -170,23 +345,13 @@ impl ConfigFetchFailed {
     message = "DPU not found",
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct ConfigNotFound {
+struct ConfigNotFound {
     #[label]
     report_loop: ReportLoop,
     #[label]
     outcome: Outcome,
     #[context]
     machine_id: String,
-}
-
-impl ConfigNotFound {
-    pub(crate) fn new(machine_id: String) -> Self {
-        Self {
-            report_loop: ReportLoop::ConfigFetch,
-            outcome: Outcome::Error,
-            machine_id,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -198,20 +363,11 @@ impl ConfigNotFound {
     metric = counter,
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct FmdsPushSucceeded {
+struct FmdsPushSucceeded {
     #[label]
     report_loop: ReportLoop,
     #[label]
     outcome: Outcome,
-}
-
-impl FmdsPushSucceeded {
-    pub(crate) fn new() -> Self {
-        Self {
-            report_loop: ReportLoop::FmdsPush,
-            outcome: Outcome::Ok,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -224,7 +380,7 @@ impl FmdsPushSucceeded {
     message = "Failed to send config update to external FMDS",
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct FmdsPushFailed {
+struct FmdsPushFailed {
     #[label]
     report_loop: ReportLoop,
     #[label]
@@ -233,17 +389,6 @@ pub(crate) struct FmdsPushFailed {
     error: String,
     #[context]
     fmds_address: String,
-}
-
-impl FmdsPushFailed {
-    pub(crate) fn new(error: String, fmds_address: String) -> Self {
-        Self {
-            report_loop: ReportLoop::FmdsPush,
-            outcome: Outcome::Error,
-            error,
-            fmds_address,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -255,20 +400,11 @@ impl FmdsPushFailed {
     metric = counter,
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct NetworkStatusSucceeded {
+struct NetworkStatusSucceeded {
     #[label]
     report_loop: ReportLoop,
     #[label]
     outcome: Outcome,
-}
-
-impl NetworkStatusSucceeded {
-    pub(crate) fn new() -> Self {
-        Self {
-            report_loop: ReportLoop::NetworkStatus,
-            outcome: Outcome::Ok,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -281,7 +417,7 @@ impl NetworkStatusSucceeded {
     message = "record_network_status: Could not connect to Forge API server. Will retry.",
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct NetworkStatusConnectionFailed {
+struct NetworkStatusConnectionFailed {
     #[label]
     report_loop: ReportLoop,
     #[label]
@@ -290,17 +426,6 @@ pub(crate) struct NetworkStatusConnectionFailed {
     forge_api: String,
     #[context]
     error: String,
-}
-
-impl NetworkStatusConnectionFailed {
-    pub(crate) fn new(forge_api: String, error: String) -> Self {
-        Self {
-            report_loop: ReportLoop::NetworkStatus,
-            outcome: Outcome::Error,
-            forge_api,
-            error,
-        }
-    }
 }
 
 #[derive(carbide_instrument::Event)]
@@ -313,7 +438,7 @@ impl NetworkStatusConnectionFailed {
     message = "Error while executing the record_network_status gRPC call",
     describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
 )]
-pub(crate) struct NetworkStatusRpcFailed {
+struct NetworkStatusRpcFailed {
     #[label]
     report_loop: ReportLoop,
     #[label]
@@ -322,12 +447,86 @@ pub(crate) struct NetworkStatusRpcFailed {
     error: String,
 }
 
-impl NetworkStatusRpcFailed {
-    pub(crate) fn new(error: String) -> Self {
-        Self {
-            report_loop: ReportLoop::NetworkStatus,
-            outcome: Outcome::Error,
-            error,
+impl InventoryReport {
+    pub(crate) fn emit(self) {
+        match self {
+            Self::Succeeded => carbide_instrument::emit(InventoryReportSucceeded {
+                report_loop: ReportLoop::Inventory,
+                outcome: Outcome::Ok,
+            }),
+            Self::Failed => carbide_instrument::emit(InventoryReportFailed {
+                report_loop: ReportLoop::Inventory,
+                outcome: Outcome::Error,
+            }),
+        }
+    }
+}
+
+impl ConfigFetch {
+    pub(crate) fn emit(self) {
+        match self {
+            Self::Succeeded => carbide_instrument::emit(ConfigFetchSucceeded {
+                report_loop: ReportLoop::ConfigFetch,
+                outcome: Outcome::Ok,
+            }),
+            Self::Failed {
+                error,
+                retry_interval_seconds,
+            } => carbide_instrument::emit(ConfigFetchFailed {
+                report_loop: ReportLoop::ConfigFetch,
+                outcome: Outcome::Error,
+                error,
+                retry_interval_seconds,
+            }),
+            Self::NotFound { machine_id } => carbide_instrument::emit(ConfigNotFound {
+                report_loop: ReportLoop::ConfigFetch,
+                outcome: Outcome::Error,
+                machine_id,
+            }),
+        }
+    }
+}
+
+impl FmdsPush {
+    pub(crate) fn emit(self) {
+        match self {
+            Self::Succeeded => carbide_instrument::emit(FmdsPushSucceeded {
+                report_loop: ReportLoop::FmdsPush,
+                outcome: Outcome::Ok,
+            }),
+            Self::Failed {
+                error,
+                fmds_address,
+            } => carbide_instrument::emit(FmdsPushFailed {
+                report_loop: ReportLoop::FmdsPush,
+                outcome: Outcome::Error,
+                error,
+                fmds_address,
+            }),
+        }
+    }
+}
+
+impl NetworkStatus {
+    pub(crate) fn emit(self) {
+        match self {
+            Self::Succeeded => carbide_instrument::emit(NetworkStatusSucceeded {
+                report_loop: ReportLoop::NetworkStatus,
+                outcome: Outcome::Ok,
+            }),
+            Self::ConnectionFailed { forge_api, error } => {
+                carbide_instrument::emit(NetworkStatusConnectionFailed {
+                    report_loop: ReportLoop::NetworkStatus,
+                    outcome: Outcome::Error,
+                    forge_api,
+                    error,
+                });
+            }
+            Self::RpcFailed { error } => carbide_instrument::emit(NetworkStatusRpcFailed {
+                report_loop: ReportLoop::NetworkStatus,
+                outcome: Outcome::Error,
+                error,
+            }),
         }
     }
 }
@@ -619,7 +818,6 @@ impl WithTracingLayer for Router {
 
 #[cfg(test)]
 mod report_loop_tests {
-    use carbide_instrument::emit;
     use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
@@ -717,7 +915,7 @@ mod report_loop_tests {
                 Check {
                     scenario: "inventory success logs at debug",
                     input: EventCase {
-                        emit: || emit(InventoryReportSucceeded::new()),
+                        emit: || InventoryReport::Succeeded.emit(),
                         report_loop: "inventory",
                         outcome: "ok",
                     },
@@ -737,7 +935,7 @@ mod report_loop_tests {
                 Check {
                     scenario: "inventory failure remains metric-only",
                     input: EventCase {
-                        emit: || emit(InventoryReportFailed::new()),
+                        emit: || InventoryReport::Failed.emit(),
                         report_loop: "inventory",
                         outcome: "error",
                     },
@@ -749,7 +947,7 @@ mod report_loop_tests {
                 Check {
                     scenario: "config fetch success remains metric-only",
                     input: EventCase {
-                        emit: || emit(ConfigFetchSucceeded::new()),
+                        emit: || ConfigFetch::Succeeded.emit(),
                         report_loop: "config_fetch",
                         outcome: "ok",
                     },
@@ -761,7 +959,13 @@ mod report_loop_tests {
                 Check {
                     scenario: "config fetch failure retains retry context",
                     input: EventCase {
-                        emit: || emit(ConfigFetchFailed::new("config failed".to_string(), 30.5)),
+                        emit: || {
+                            ConfigFetch::Failed {
+                                error: "config failed".to_string(),
+                                retry_interval_seconds: 30.5,
+                            }
+                            .emit()
+                        },
                         report_loop: "config_fetch",
                         outcome: "error",
                     },
@@ -784,7 +988,7 @@ mod report_loop_tests {
                 Check {
                     scenario: "FMDS success remains metric-only",
                     input: EventCase {
-                        emit: || emit(FmdsPushSucceeded::new()),
+                        emit: || FmdsPush::Succeeded.emit(),
                         report_loop: "fmds_push",
                         outcome: "ok",
                     },
@@ -797,10 +1001,11 @@ mod report_loop_tests {
                     scenario: "FMDS failure retains address context",
                     input: EventCase {
                         emit: || {
-                            emit(FmdsPushFailed::new(
-                                "FMDS failed".to_string(),
-                                "http://fmds:50051".to_string(),
-                            ))
+                            FmdsPush::Failed {
+                                error: "FMDS failed".to_string(),
+                                fmds_address: "http://fmds:50051".to_string(),
+                            }
+                            .emit()
                         },
                         report_loop: "fmds_push",
                         outcome: "error",
@@ -824,7 +1029,7 @@ mod report_loop_tests {
                 Check {
                     scenario: "network status success remains metric-only",
                     input: EventCase {
-                        emit: || emit(NetworkStatusSucceeded::new()),
+                        emit: || NetworkStatus::Succeeded.emit(),
                         report_loop: "network_status",
                         outcome: "ok",
                     },
@@ -836,7 +1041,12 @@ mod report_loop_tests {
                 Check {
                     scenario: "network status RPC failure retains error context",
                     input: EventCase {
-                        emit: || emit(NetworkStatusRpcFailed::new("RPC failed".to_string())),
+                        emit: || {
+                            NetworkStatus::RpcFailed {
+                                error: "RPC failed".to_string(),
+                            }
+                            .emit()
+                        },
                         report_loop: "network_status",
                         outcome: "error",
                     },
@@ -856,7 +1066,12 @@ mod report_loop_tests {
                 Check {
                     scenario: "missing config retains machine context",
                     input: EventCase {
-                        emit: || emit(ConfigNotFound::new(MACHINE_ID.to_string())),
+                        emit: || {
+                            ConfigFetch::NotFound {
+                                machine_id: MACHINE_ID.to_string(),
+                            }
+                            .emit()
+                        },
                         report_loop: "config_fetch",
                         outcome: "error",
                     },
@@ -877,10 +1092,11 @@ mod report_loop_tests {
                     scenario: "network connection failure retains endpoint context",
                     input: EventCase {
                         emit: || {
-                            emit(NetworkStatusConnectionFailed::new(
-                                "https://forge:50051".to_string(),
-                                "connection refused".to_string(),
-                            ))
+                            NetworkStatus::ConnectionFailed {
+                                forge_api: "https://forge:50051".to_string(),
+                                error: "connection refused".to_string(),
+                            }
+                            .emit()
                         },
                         report_loop: "network_status",
                         outcome: "error",
@@ -903,6 +1119,232 @@ mod report_loop_tests {
                 },
             ],
             observe_event,
+        );
+    }
+}
+
+#[cfg(test)]
+mod service_restart_tests {
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    const RESTART_METRIC: &str = "carbide_dpu_agent_service_restart_attempts_total";
+
+    struct RestartCase {
+        emit: fn(),
+        service: &'static str,
+        result: &'static str,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct RestartObservation {
+        counter_delta: f64,
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        service: Option<String>,
+        result: Option<String>,
+        error: Option<String>,
+        error_kind: Option<CapturedFieldKind>,
+        attempt: Option<String>,
+        attempt_kind: Option<CapturedFieldKind>,
+        attempt_count: Option<String>,
+        attempt_count_kind: Option<CapturedFieldKind>,
+        managed_host_config_version: Option<String>,
+        managed_host_config_version_kind: Option<CapturedFieldKind>,
+    }
+
+    fn observe_restart(case: RestartCase) -> RestartObservation {
+        let metrics = MetricsCapture::start();
+        let mut logs = capture_logs(case.emit);
+        assert_eq!(logs.len(), 1, "one restart attempt writes one result");
+        let log = logs.pop().expect("the service restart log");
+        let field = |name: &str| log.field(name).map(str::to_owned);
+
+        RestartObservation {
+            counter_delta: metrics.counter_delta(
+                RESTART_METRIC,
+                &[("service", case.service), ("result", case.result)],
+            ),
+            level: log.level,
+            metadata_name: log.metadata_name.clone(),
+            message: log.message.clone(),
+            service: field("service"),
+            result: field("result"),
+            error: field("error"),
+            error_kind: log.field_kind("error"),
+            attempt: field("attempt"),
+            attempt_kind: log.field_kind("attempt"),
+            attempt_count: field("attempt_count"),
+            attempt_count_kind: log.field_kind("attempt_count"),
+            managed_host_config_version: field("managed_host_config_version"),
+            managed_host_config_version_kind: log.field_kind("managed_host_config_version"),
+        }
+    }
+
+    fn expected_restart(
+        diagnostic: (tracing::Level, &str, &str),
+        service: &str,
+        result: &str,
+        error: Option<(&str, CapturedFieldKind)>,
+        attempt: Option<u8>,
+        attempt_count: Option<u8>,
+        managed_host_config_version: Option<&str>,
+    ) -> RestartObservation {
+        let (level, metadata_name, message) = diagnostic;
+        let (error, error_kind) = error
+            .map(|(value, kind)| (Some(value.to_string()), Some(kind)))
+            .unwrap_or_default();
+        RestartObservation {
+            counter_delta: 1.0,
+            level,
+            metadata_name: metadata_name.to_string(),
+            message: message.to_string(),
+            service: Some(service.to_string()),
+            result: Some(result.to_string()),
+            error,
+            error_kind,
+            attempt: attempt.map(|value| value.to_string()),
+            attempt_kind: attempt.map(|_| CapturedFieldKind::I64),
+            attempt_count: attempt_count.map(|value| value.to_string()),
+            attempt_count_kind: attempt_count.map(|_| CapturedFieldKind::I64),
+            managed_host_config_version: managed_host_config_version.map(str::to_string),
+            managed_host_config_version_kind: managed_host_config_version
+                .map(|_| CapturedFieldKind::String),
+        }
+    }
+
+    #[test]
+    fn service_restart_attempts_keep_the_existing_diagnostics() {
+        check_values(
+            [
+                Check {
+                    scenario: "lldpd restart succeeds",
+                    input: RestartCase {
+                        emit: || LldpdRestart::Succeeded { attempt: 2 }.emit(),
+                        service: "lldpd",
+                        result: "succeeded",
+                    },
+                    expect: expected_restart(
+                        (
+                            tracing::Level::INFO,
+                            "dpu_agent_lldpd_restart_succeeded",
+                            "Restarted lldpd service",
+                        ),
+                        "lldpd",
+                        "succeeded",
+                        None,
+                        Some(2),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "lldpd restart will retry",
+                    input: RestartCase {
+                        emit: || {
+                            LldpdRestart::Retrying {
+                                error: "service busy".to_string(),
+                                attempt: 1,
+                            }
+                            .emit()
+                        },
+                        service: "lldpd",
+                        result: "retrying",
+                    },
+                    expect: expected_restart(
+                        (
+                            tracing::Level::WARN,
+                            "dpu_agent_lldpd_restart_retrying",
+                            "Couldn't restart lldpd service, retrying",
+                        ),
+                        "lldpd",
+                        "retrying",
+                        Some(("service busy", CapturedFieldKind::Debug)),
+                        Some(1),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "lldpd restart exhausts its retries",
+                    input: RestartCase {
+                        emit: || {
+                            LldpdRestart::Failed {
+                                error: "service busy".to_string(),
+                                attempt_count: 3,
+                            }
+                            .emit()
+                        },
+                        service: "lldpd",
+                        result: "failed",
+                    },
+                    expect: expected_restart(
+                        (
+                            tracing::Level::ERROR,
+                            "dpu_agent_lldpd_restart_failed",
+                            "Couldn't restart lldpd service",
+                        ),
+                        "lldpd",
+                        "failed",
+                        Some(("service busy", CapturedFieldKind::Debug)),
+                        None,
+                        Some(3),
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "OVS restart succeeds",
+                    input: RestartCase {
+                        emit: || OvsRestart::Succeeded.emit(),
+                        service: "ovs_vswitchd",
+                        result: "succeeded",
+                    },
+                    expect: expected_restart(
+                        (
+                            tracing::Level::INFO,
+                            "dpu_agent_ovs_restart_succeeded",
+                            "Successfully restarted ovs-vswitchd.service",
+                        ),
+                        "ovs_vswitchd",
+                        "succeeded",
+                        None,
+                        None,
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "OVS restart enters backoff",
+                    input: RestartCase {
+                        emit: || {
+                            OvsRestart::Retrying {
+                                error: "restarting OVS: timed out".to_string(),
+                                managed_host_config_version: "version-42".to_string(),
+                            }
+                            .emit()
+                        },
+                        service: "ovs_vswitchd",
+                        result: "retrying",
+                    },
+                    expect: expected_restart(
+                        (
+                            tracing::Level::ERROR,
+                            "dpu_agent_ovs_restart_retrying",
+                            "Restarting OVS after admin network change",
+                        ),
+                        "ovs_vswitchd",
+                        "retrying",
+                        Some(("restarting OVS: timed out", CapturedFieldKind::String)),
+                        None,
+                        None,
+                        Some("version-42"),
+                    ),
+                },
+            ],
+            observe_restart,
         );
     }
 }

--- a/crates/agent/src/lldp.rs
+++ b/crates/agent/src/lldp.rs
@@ -25,6 +25,8 @@ use carbide_uuid::machine::MachineId;
 use eyre::WrapErr;
 use tokio::process::Command;
 
+use crate::instrumentation::LldpdRestart;
+
 // FIXME: This should probably be configurable and come from the API's config
 // file.
 const SITE_OPERATOR: &str = "Forge-SRE (ngc-forge-sre@exchange.nvidia.com)";
@@ -37,6 +39,20 @@ const LLDPD_RESTART_ATTEMPTS: u8 = 3;
 const LLDP_MED_CONFIGURATION_CHECK_ATTEMPTS: u8 = 3;
 const LLDPCLI_TIMEOUT: Duration = Duration::from_secs(10);
 const LLDPD_RESTART_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LldpdRestartFailureAction {
+    Retry,
+    ReturnError,
+}
+
+fn lldpd_restart_failure_action(attempt: u8) -> LldpdRestartFailureAction {
+    if attempt == LLDPD_RESTART_ATTEMPTS {
+        LldpdRestartFailureAction::ReturnError
+    } else {
+        LldpdRestartFailureAction::Retry
+    }
+}
 
 pub(crate) async fn prepare_lldp() -> eyre::Result<()> {
     let interfaces_config_disabled = disable_interfaces_config()?;
@@ -249,22 +265,28 @@ async fn restart_lldpd() -> eyre::Result<()> {
 
         match restart_result {
             Ok(()) => {
-                tracing::info!(attempt, "Restarted lldpd service");
+                LldpdRestart::Succeeded { attempt }.emit();
                 return Ok(());
             }
-            Err(error) if attempt == LLDPD_RESTART_ATTEMPTS => {
-                tracing::error!(
-                    error = %error,
-                    attempt_count = attempt,
-                    "Couldn't restart lldpd service"
-                );
-                return Err(error);
-            }
-            Err(error) => {
-                tracing::warn!(error = %error, attempt, "Couldn't restart lldpd service, retrying");
-                tokio::time::sleep(Duration::from_secs(u64::from(attempt))).await;
-                attempt += 1;
-            }
+            Err(error) => match lldpd_restart_failure_action(attempt) {
+                LldpdRestartFailureAction::Retry => {
+                    LldpdRestart::Retrying {
+                        error: error.to_string(),
+                        attempt,
+                    }
+                    .emit();
+                    tokio::time::sleep(Duration::from_secs(u64::from(attempt))).await;
+                    attempt += 1;
+                }
+                LldpdRestartFailureAction::ReturnError => {
+                    LldpdRestart::Failed {
+                        error: error.to_string(),
+                        attempt_count: attempt,
+                    }
+                    .emit();
+                    return Err(error);
+                }
+            },
         }
     }
 }
@@ -396,6 +418,20 @@ mod tests {
                 r#"{"configuration":[{"config":[{}]}]}"# => Fails,
                 r#"{"configuration":[{"config":[{"lldpmed-no-inventory":[{"value":"maybe"}]}]}]}"# =>
                     Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn lldpd_restart_failures_retry_until_the_final_attempt() {
+        value_scenarios!(lldpd_restart_failure_action:
+            "retry budget remains" {
+                1 => LldpdRestartFailureAction::Retry,
+                2 => LldpdRestartFailureAction::Retry,
+            }
+
+            "retry budget is exhausted" {
+                3 => LldpdRestartFailureAction::ReturnError,
             }
         );
     }

--- a/crates/agent/src/machine_inventory_updater.rs
+++ b/crates/agent/src/machine_inventory_updater.rs
@@ -19,13 +19,12 @@ use std::time::Duration;
 
 use ::rpc::forge as rpc;
 use ::rpc::forge_tls_client::{self, ApiConfig, ForgeClientConfig};
-use carbide_instrument::emit;
 use carbide_uuid::machine::MachineId;
 
 use crate::command_line::AgentPlatformType;
 use crate::containerd::container;
 use crate::containerd::container::ContainerSummary;
-use crate::instrumentation::{InventoryReportFailed, InventoryReportSucceeded};
+use crate::instrumentation::InventoryReport;
 
 #[derive(Debug, Clone)]
 pub struct MachineInventoryUpdaterConfig {
@@ -111,12 +110,12 @@ pub async fn single_run(config: &MachineInventoryUpdaterConfig) -> eyre::Result<
     .await;
 
     // `single_run` returns failures to the scheduler, which logs the error.
-    // Keep `InventoryReportFailed` metric-only to avoid a duplicate diagnostic;
-    // `InventoryReportSucceeded` owns the DEBUG record.
+    // Keep `InventoryReport::Failed` metric-only to avoid a duplicate
+    // diagnostic; `InventoryReport::Succeeded` owns the DEBUG record.
     if result.is_ok() {
-        emit(InventoryReportSucceeded::new());
+        InventoryReport::Succeeded.emit();
     } else {
-        emit(InventoryReportFailed::new());
+        InventoryReport::Failed.emit();
     }
 
     result

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -29,7 +29,6 @@ use ::rpc::forge::ManagedHostNetworkConfigResponse;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::{forge as rpc, forge_tls_client};
 use carbide_host_support::agent_config::AgentConfig;
-use carbide_instrument::emit;
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_rpc_utils::dhcp::{DhcpTimestamps, DhcpTimestampsFilePath};
 use carbide_systemd::systemd;
@@ -57,8 +56,7 @@ use crate::fmds_client::FmdsUpdater;
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
 use crate::instrumentation::{
-    NetworkStatusConnectionFailed, NetworkStatusRpcFailed, NetworkStatusSucceeded, create_metrics,
-    get_dpu_agent_meter, get_prometheus_registry,
+    NetworkStatus, OvsRestart, create_metrics, get_dpu_agent_meter, get_prometheus_registry,
 };
 use crate::machine_inventory_updater::MachineInventoryUpdaterConfig;
 use crate::network_monitor::{self, NetworkPingerType};
@@ -735,10 +733,11 @@ impl MainLoop {
                 .await
                 .wrap_err("restarting OVS after admin network change")
             {
-                tracing::error!(
-                    error = format!("{err:#}"),
-                    "Restarting OVS after admin network change"
-                );
+                OvsRestart::Retrying {
+                    error: format!("{err:#}"),
+                    managed_host_config_version: conf.managed_host_config_version.clone(),
+                }
+                .emit();
                 status_out.network_config_error = Some(err.to_string());
                 self.ovs_restart_retry_backoff = Some(OvsRestartRetryBackoff {
                     managed_host_config_version: conf.managed_host_config_version.clone(),
@@ -1440,18 +1439,22 @@ pub async fn record_network_status(
     {
         Ok(client) => client,
         Err(err) => {
-            emit(NetworkStatusConnectionFailed::new(
-                forge_api.to_string(),
-                format!("{err:#}"),
-            ));
+            NetworkStatus::ConnectionFailed {
+                forge_api: forge_api.to_string(),
+                error: format!("{err:#}"),
+            }
+            .emit();
             return;
         }
     };
     let request = tonic::Request::new(status);
     let result = client.record_dpu_network_status(request).await;
     match &result {
-        Ok(_) => emit(NetworkStatusSucceeded::new()),
-        Err(err) => emit(NetworkStatusRpcFailed::new(format!("{err:#}"))),
+        Ok(_) => NetworkStatus::Succeeded.emit(),
+        Err(err) => NetworkStatus::RpcFailed {
+            error: format!("{err:#}"),
+        }
+        .emit(),
     }
 }
 

--- a/crates/agent/src/ovs.rs
+++ b/crates/agent/src/ovs.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 
 use eyre::WrapErr;
 
+use crate::instrumentation::OvsRestart;
+
 /// ovs-vswitchd is part of HBN. It handles network packets in user-space using DPDK
 /// (https://www.dpdk.org/). By default it uses 100% of a CPU core to poll for new packets, never
 /// yielding. Here we set it to yield the CPU for up to 100us if it's been idle recently.
@@ -79,6 +81,6 @@ pub async fn restart_ovs() -> eyre::Result<()> {
         );
     }
 
-    tracing::info!("Successfully restarted ovs-vswitchd.service");
+    OvsRestart::Succeeded.emit();
     Ok(())
 }

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -22,7 +22,6 @@ use std::time::Duration;
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use ::rpc::{Instance, forge as rpc};
 use arc_swap::ArcSwapOption;
-use carbide_instrument::emit;
 use carbide_uuid::infiniband::IBPartitionId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
@@ -31,7 +30,7 @@ use eyre::Context;
 use forge_dpu_agent_utils::utils::create_forge_client;
 use tracing::{trace, warn};
 
-use crate::instrumentation::{ConfigFetchFailed, ConfigFetchSucceeded, ConfigNotFound};
+use crate::instrumentation::ConfigFetch;
 use crate::util::{get_periodic_dpu_config, get_sitename};
 
 pub struct PeriodicFetcherState {
@@ -211,28 +210,33 @@ async fn single_fetch(
             match instance_metadata_from_instance(resp.instance, state.sitename.clone()) {
                 Ok(Some(config)) => {
                     state.instmeta.store(Some(Arc::new(config)));
-                    emit(ConfigFetchSucceeded::new());
+                    ConfigFetch::Succeeded.emit();
                 }
                 Ok(None) => {
                     state.instmeta.store(None);
-                    emit(ConfigFetchSucceeded::new());
+                    ConfigFetch::Succeeded.emit();
                 }
-                Err(err) => emit(ConfigFetchFailed::new(
-                    err.to_string(),
-                    state.config.config_fetch_interval.as_secs_f64(),
-                )),
+                Err(err) => ConfigFetch::Failed {
+                    error: err.to_string(),
+                    retry_interval_seconds: state.config.config_fetch_interval.as_secs_f64(),
+                }
+                .emit(),
             }
         }
         Err(err) => match err.downcast_ref::<tonic::Status>() {
             Some(grpc_status) if grpc_status.code() == tonic::Code::NotFound => {
                 state.netconf.store(None);
                 state.instmeta.store(None);
-                emit(ConfigNotFound::new(state.config.machine_id.to_string()));
+                ConfigFetch::NotFound {
+                    machine_id: state.config.machine_id.to_string(),
+                }
+                .emit();
             }
-            _ => emit(ConfigFetchFailed::new(
-                format!("{err:?}"),
-                state.config.config_fetch_interval.as_secs_f64(),
-            )),
+            _ => ConfigFetch::Failed {
+                error: format!("{err:?}"),
+                retry_interval_seconds: state.config.config_fetch_interval.as_secs_f64(),
+            }
+            .emit(),
         },
     }
 

--- a/crates/api-core/src/handlers/machine_identity.rs
+++ b/crates/api-core/src/handlers/machine_identity.rs
@@ -35,10 +35,10 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::auth::AuthContext;
 use crate::machine_identity::{
-    Es256Signer, SignOptions, Signer, decrypt_machine_identity_ciphertext,
-    decrypt_token_delegation_encrypted_blob, emit_signing_key_decryption_failed,
-    emit_token_delegation_auth_decryption_failed, token_delegation_credentials,
-    token_exchange_http_client, token_exchange_request,
+    Es256Signer, MachineIdentitySigningKeyDecryptionFailed,
+    MachineIdentityTokenDelegationAuthDecryptionFailed, SignOptions, Signer,
+    decrypt_machine_identity_ciphertext, decrypt_token_delegation_encrypted_blob,
+    token_delegation_credentials, token_exchange_http_client, token_exchange_request,
 };
 
 /// Shared gate for APIs that require site `[machine_identity].enabled` (identity admin + discovery).
@@ -194,7 +194,10 @@ pub(crate) async fn sign_machine_identity(
         decrypt_machine_identity_ciphertext(api.credential_manager.as_ref(), enc_key.as_str())
             .await
             .inspect_err(|e| {
-                emit_signing_key_decryption_failed(identity_row.organization_id.as_str(), e);
+                carbide_instrument::emit(MachineIdentitySigningKeyDecryptionFailed::from_status(
+                    identity_row.organization_id.as_str(),
+                    e,
+                ));
             })
             .map_err(|_| {
                 CarbideError::internal("stored signing key could not be decrypted".to_string())
@@ -240,7 +243,12 @@ pub(crate) async fn sign_machine_identity(
         )
         .await
         .inspect_err(|e| {
-            emit_token_delegation_auth_decryption_failed(identity_row.organization_id.as_str(), e);
+            carbide_instrument::emit(
+                MachineIdentityTokenDelegationAuthDecryptionFailed::from_status(
+                    identity_row.organization_id.as_str(),
+                    e,
+                ),
+            );
         })?;
         let delegation_creds =
             token_delegation_credentials(auth_method, delegation_plain.as_deref())?;

--- a/crates/api-core/src/handlers/spx_partition.rs
+++ b/crates/api-core/src/handlers/spx_partition.rs
@@ -26,7 +26,7 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::{Api, log_request_data, log_tenant_organization_id};
 
-fn map_dpa_vni_allocation_failure(
+fn emit_and_map_dpa_vni_allocation_failure(
     source_pool: &resource_pool::ResourcePool<i32>,
     owner_id: &str,
     requested_vni: Option<i32>,
@@ -99,7 +99,9 @@ async fn allocate_dpa_vni(
         requested_vni,
     )
     .await
-    .map_err(|error| map_dpa_vni_allocation_failure(source_pool, owner_id, requested_vni, error))
+    .map_err(|error| {
+        emit_and_map_dpa_vni_allocation_failure(source_pool, owner_id, requested_vni, error)
+    })
 }
 
 pub(crate) async fn create(
@@ -220,7 +222,7 @@ mod tests {
     use model::spx_partition::NewSpxPartition;
     use tonic::Code;
 
-    use super::map_dpa_vni_allocation_failure;
+    use super::emit_and_map_dpa_vni_allocation_failure;
 
     const RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC: &str =
         "carbide_resource_pool_lifecycle_failures_total";
@@ -423,7 +425,7 @@ mod tests {
                 let metrics = MetricsCapture::start();
                 let mut mapped_error = None;
                 let logs = capture_logs(|| {
-                    mapped_error = Some(map_dpa_vni_allocation_failure(
+                    mapped_error = Some(emit_and_map_dpa_vni_allocation_failure(
                         &source_pool,
                         OWNER_ID,
                         input.requested_vni,

--- a/crates/api-core/src/handlers/tenant_identity_config.rs
+++ b/crates/api-core/src/handlers/tenant_identity_config.rs
@@ -49,9 +49,9 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data, log_request_data_redacted};
 use crate::handlers::machine_identity::require_machine_identity_site_enabled;
 use crate::machine_identity::{
-    ReencryptBlobOutcome, StoredMachineIdentitySecretKind, decrypt_token_delegation_encrypted_blob,
-    emit_token_delegation_auth_decryption_failed, machine_identity_encryption_secret,
-    reencrypt_ciphertext_if_needed,
+    MachineIdentityTokenDelegationAuthDecryptionFailed, ReencryptBlobOutcome,
+    StoredMachineIdentitySecretKind, decrypt_token_delegation_encrypted_blob,
+    machine_identity_encryption_secret, reencrypt_ciphertext_if_needed,
 };
 
 /// Decrypts DB ciphertext into [`TenantIdentityConfigDecrypted`]: `row` keeps envelope in
@@ -66,7 +66,12 @@ async fn tenant_identity_with_decrypted_token_delegation(
     )
     .await
     .inspect_err(|e| {
-        emit_token_delegation_auth_decryption_failed(cfg.organization_id.as_str(), e);
+        carbide_instrument::emit(
+            MachineIdentityTokenDelegationAuthDecryptionFailed::from_status(
+                cfg.organization_id.as_str(),
+                e,
+            ),
+        );
     })?;
     Ok(TenantIdentityConfigDecrypted {
         row: cfg,

--- a/crates/api-core/src/machine_identity/crypto.rs
+++ b/crates/api-core/src/machine_identity/crypto.rs
@@ -50,13 +50,23 @@ pub(crate) enum StoredMachineIdentitySecretKind {
     message = "tenant signing key decrypt failed",
     describe = "Number of stored machine identity secret decryption failures, by secret kind."
 )]
-struct MachineIdentitySigningKeyDecryptionFailed {
+pub(crate) struct MachineIdentitySigningKeyDecryptionFailed {
     #[label]
     secret_kind: StoredMachineIdentitySecretKind,
     #[context]
     organization_id: String,
     #[context]
     error: String,
+}
+
+impl MachineIdentitySigningKeyDecryptionFailed {
+    pub(crate) fn from_status(organization_id: &str, error: &Status) -> Self {
+        Self {
+            secret_kind: StoredMachineIdentitySecretKind::SigningKey,
+            organization_id: organization_id.to_string(),
+            error: error.message().to_string(),
+        }
+    }
 }
 
 /// A tenant's stored token-delegation authentication could not be decrypted.
@@ -70,7 +80,7 @@ struct MachineIdentitySigningKeyDecryptionFailed {
     message = "token delegation auth config decrypt failed",
     describe = "Number of stored machine identity secret decryption failures, by secret kind."
 )]
-struct MachineIdentityTokenDelegationAuthDecryptionFailed {
+pub(crate) struct MachineIdentityTokenDelegationAuthDecryptionFailed {
     #[label]
     secret_kind: StoredMachineIdentitySecretKind,
     #[context]
@@ -79,20 +89,14 @@ struct MachineIdentityTokenDelegationAuthDecryptionFailed {
     error: String,
 }
 
-pub(crate) fn emit_signing_key_decryption_failed(organization_id: &str, error: &Status) {
-    emit_stored_secret_decryption_failed(
-        StoredMachineIdentitySecretKind::SigningKey,
-        organization_id,
-        error,
-    );
-}
-
-pub(crate) fn emit_token_delegation_auth_decryption_failed(organization_id: &str, error: &Status) {
-    emit_stored_secret_decryption_failed(
-        StoredMachineIdentitySecretKind::TokenDelegationAuth,
-        organization_id,
-        error,
-    );
+impl MachineIdentityTokenDelegationAuthDecryptionFailed {
+    pub(crate) fn from_status(organization_id: &str, error: &Status) -> Self {
+        Self {
+            secret_kind: StoredMachineIdentitySecretKind::TokenDelegationAuth,
+            organization_id: organization_id.to_string(),
+            error: error.message().to_string(),
+        }
+    }
 }
 
 fn emit_stored_secret_decryption_failed(
@@ -101,20 +105,12 @@ fn emit_stored_secret_decryption_failed(
     error: &Status,
 ) {
     match secret_kind {
-        StoredMachineIdentitySecretKind::SigningKey => {
-            emit(MachineIdentitySigningKeyDecryptionFailed {
-                secret_kind,
-                organization_id: organization_id.to_string(),
-                error: error.message().to_string(),
-            });
-        }
-        StoredMachineIdentitySecretKind::TokenDelegationAuth => {
-            emit(MachineIdentityTokenDelegationAuthDecryptionFailed {
-                secret_kind,
-                organization_id: organization_id.to_string(),
-                error: error.message().to_string(),
-            });
-        }
+        StoredMachineIdentitySecretKind::SigningKey => emit(
+            MachineIdentitySigningKeyDecryptionFailed::from_status(organization_id, error),
+        ),
+        StoredMachineIdentitySecretKind::TokenDelegationAuth => emit(
+            MachineIdentityTokenDelegationAuthDecryptionFailed::from_status(organization_id, error),
+        ),
     }
 }
 

--- a/crates/api-core/src/machine_identity/mod.rs
+++ b/crates/api-core/src/machine_identity/mod.rs
@@ -30,9 +30,9 @@ use std::fmt;
 
 use base64::Engine;
 pub(crate) use crypto::{
+    MachineIdentitySigningKeyDecryptionFailed, MachineIdentityTokenDelegationAuthDecryptionFailed,
     ReencryptBlobOutcome, StoredMachineIdentitySecretKind, decrypt_machine_identity_ciphertext,
-    decrypt_token_delegation_encrypted_blob, emit_signing_key_decryption_failed,
-    emit_token_delegation_auth_decryption_failed, machine_identity_encryption_secret,
+    decrypt_token_delegation_encrypted_blob, machine_identity_encryption_secret,
     reencrypt_ciphertext_if_needed, token_delegation_credentials,
 };
 use jsonwebtoken::{EncodingKey, Header, encode};

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -2215,16 +2215,15 @@ async fn rms_get_switch_password_rotation_job_status(
 )]
 struct RmsSwitchCertificateJobStateUnrecognized;
 
-fn map_rms_configure_switch_certificate_job_state(state: &str) -> ConfigureSwitchCertificateState {
+fn map_rms_configure_switch_certificate_job_state(
+    state: &str,
+) -> Option<ConfigureSwitchCertificateState> {
     match state.to_ascii_lowercase().as_str() {
-        "queued" | "pending" => ConfigureSwitchCertificateState::Started,
-        "running" | "in_progress" | "active" => ConfigureSwitchCertificateState::InProgress,
-        "completed" | "success" | "done" => ConfigureSwitchCertificateState::Completed,
-        "failed" | "error" => ConfigureSwitchCertificateState::Failed,
-        _ => {
-            emit(RmsSwitchCertificateJobStateUnrecognized);
-            ConfigureSwitchCertificateState::InProgress
-        }
+        "queued" | "pending" => Some(ConfigureSwitchCertificateState::Started),
+        "running" | "in_progress" | "active" => Some(ConfigureSwitchCertificateState::InProgress),
+        "completed" | "success" | "done" => Some(ConfigureSwitchCertificateState::Completed),
+        "failed" | "error" => Some(ConfigureSwitchCertificateState::Failed),
+        _ => None,
     }
 }
 
@@ -2326,7 +2325,11 @@ async fn rms_get_configure_switch_certificate_job_status(
         });
     }
 
-    let state = map_rms_configure_switch_certificate_job_state(&response.state);
+    let state =
+        map_rms_configure_switch_certificate_job_state(&response.state).unwrap_or_else(|| {
+            emit(RmsSwitchCertificateJobStateUnrecognized);
+            ConfigureSwitchCertificateState::InProgress
+        });
     let error = if matches!(state, ConfigureSwitchCertificateState::Failed) {
         Some(
             (!response.error_message.is_empty())
@@ -2634,7 +2637,7 @@ impl ComputeTrayManager for RmsBackend {
 #[cfg(test)]
 mod tests {
     use api_test_helper::mock_rms::MockRmsApi;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{MetricsCapture, capture_logs_async};
     use carbide_test_support::{Check, check_values, value_scenarios};
     use carbide_uuid::machine::MachineId;
     use carbide_uuid::power_shelf::PowerShelfId;
@@ -2807,88 +2810,70 @@ mod tests {
         value_scenarios!(
             run = map_rms_configure_switch_certificate_job_state;
             "started" {
-                "queued" => ConfigureSwitchCertificateState::Started,
-                "pending" => ConfigureSwitchCertificateState::Started,
+                "queued" => Some(ConfigureSwitchCertificateState::Started),
+                "pending" => Some(ConfigureSwitchCertificateState::Started),
             }
 
             "in progress" {
-                "running" => ConfigureSwitchCertificateState::InProgress,
-                "in_progress" => ConfigureSwitchCertificateState::InProgress,
-                "active" => ConfigureSwitchCertificateState::InProgress,
+                "running" => Some(ConfigureSwitchCertificateState::InProgress),
+                "in_progress" => Some(ConfigureSwitchCertificateState::InProgress),
+                "active" => Some(ConfigureSwitchCertificateState::InProgress),
             }
 
             "completed" {
-                "completed" => ConfigureSwitchCertificateState::Completed,
-                "success" => ConfigureSwitchCertificateState::Completed,
-                "done" => ConfigureSwitchCertificateState::Completed,
+                "completed" => Some(ConfigureSwitchCertificateState::Completed),
+                "success" => Some(ConfigureSwitchCertificateState::Completed),
+                "done" => Some(ConfigureSwitchCertificateState::Completed),
             }
 
             "failed" {
-                "failed" => ConfigureSwitchCertificateState::Failed,
-                "error" => ConfigureSwitchCertificateState::Failed,
+                "failed" => Some(ConfigureSwitchCertificateState::Failed),
+                "error" => Some(ConfigureSwitchCertificateState::Failed),
             }
 
             "case insensitive" {
-                "RUNNING" => ConfigureSwitchCertificateState::InProgress,
+                "RUNNING" => Some(ConfigureSwitchCertificateState::InProgress),
+            }
+
+            "unrecognized" {
+                "waiting_for_reboot" => None,
+                "" => None,
             }
         );
     }
 
-    #[test]
-    fn unrecognized_switch_certificate_job_state_keeps_polling_and_counts_silently() {
+    #[tokio::test]
+    async fn unrecognized_switch_certificate_job_state_keeps_polling_and_counts_silently() {
         const METRIC: &str = "carbide_rms_switch_certificate_unrecognized_job_states_total";
 
-        #[derive(Debug, PartialEq)]
-        struct Observation {
-            mapped_state: ConfigureSwitchCertificateState,
-            log_count: usize,
-            counter_delta: f64,
-        }
+        let mock = MockRmsApi::new();
+        mock.enqueue_get_configure_switch_certificate_job_status(Ok(
+            MockRmsApi::configure_switch_certificate_job_status_ok("waiting_for_reboot"),
+        ))
+        .await;
 
-        check_values(
-            [
-                Check {
-                    scenario: "recognized state stays quiet",
-                    input: "running",
-                    expect: Observation {
-                        mapped_state: ConfigureSwitchCertificateState::InProgress,
-                        log_count: 0,
-                        counter_delta: 0.0,
-                    },
-                },
-                Check {
-                    scenario: "unknown state remains in progress",
-                    input: "waiting_for_reboot",
-                    expect: Observation {
-                        mapped_state: ConfigureSwitchCertificateState::InProgress,
-                        log_count: 0,
-                        counter_delta: 1.0,
-                    },
-                },
-                Check {
-                    scenario: "empty state remains in progress",
-                    input: "",
-                    expect: Observation {
-                        mapped_state: ConfigureSwitchCertificateState::InProgress,
-                        log_count: 0,
-                        counter_delta: 1.0,
-                    },
-                },
-            ],
-            |state| {
-                let metrics = MetricsCapture::start();
-                let mut mapped_state = None;
-                let logs = capture_logs(|| {
-                    mapped_state = Some(map_rms_configure_switch_certificate_job_state(state));
-                });
+        let metrics = MetricsCapture::start();
+        let (status, logs) = capture_logs_async(rms_get_configure_switch_certificate_job_status(
+            &mock,
+            "cert-job-1",
+        ))
+        .await;
+        let status = status.expect("unknown RMS state keeps certificate polling active");
 
-                Observation {
-                    mapped_state: mapped_state.expect("state was mapped"),
-                    log_count: logs.len(),
-                    counter_delta: metrics.counter_delta(METRIC, &[]),
-                }
-            },
+        assert_eq!(status.state, ConfigureSwitchCertificateState::InProgress);
+        assert!(status.error.is_none());
+        assert!(
+            logs.iter().all(|log| log.field("event_name")
+                != Some("rms_switch_certificate_job_state_unrecognized")),
+            "the polling fallback remains metric-only"
         );
+        assert_eq!(metrics.counter_delta(METRIC, &[]), 1.0);
+
+        let calls = mock
+            .get_configure_switch_certificate_job_status_calls()
+            .await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].job_id, "cert-job-1");
     }
 
     #[test]

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -23,7 +23,7 @@
 //! Timestamp-file failures share a counter by operation while their paths,
 //! host interface, and errors remain log-only diagnostics.
 
-use carbide_instrument::{Event, LabelValue};
+use carbide_instrument::{DynamicMessage, Event, LabelValue};
 use dhcproto::v4::MessageType;
 
 use crate::errors::DhcpError;
@@ -125,6 +125,114 @@ enum TimestampFileOperation {
     Initialize,
     Write,
     Read,
+}
+
+/// `SocketSetupOperation` identifies the bounded syscall or socket option that
+/// failed. Interface names, addresses, and error text stay on the log line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum SocketSetupOperation {
+    Create,
+    ReuseAddress,
+    SetNonblocking,
+    BindAddress,
+    SetBroadcast,
+    BindDevice,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum SocketSetupNextAction {
+    Retry,
+    Panic,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_socket_setup_failed",
+    metric_name = "carbide_dhcp_socket_setup_failures_total",
+    component = "nico-dhcp",
+    log = info,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of DHCP socket setup failures, by operation and next action."
+)]
+pub(crate) struct DhcpSocketSetupFailed {
+    #[label]
+    operation: SocketSetupOperation,
+    #[label]
+    next_action: SocketSetupNextAction,
+    #[context(value)]
+    retry: i64,
+    #[context]
+    error: String,
+}
+
+impl DhcpSocketSetupFailed {
+    pub(crate) fn new(
+        operation: SocketSetupOperation,
+        next_action: SocketSetupNextAction,
+        retry: i32,
+        error: String,
+    ) -> Self {
+        Self {
+            operation,
+            next_action,
+            retry: i64::from(retry),
+            error,
+        }
+    }
+}
+
+impl DynamicMessage for DhcpSocketSetupFailed {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            SocketSetupOperation::Create => "Socket creation failed",
+            SocketSetupOperation::ReuseAddress
+            | SocketSetupOperation::SetNonblocking
+            | SocketSetupOperation::BindAddress
+            | SocketSetupOperation::SetBroadcast
+            | SocketSetupOperation::BindDevice => "Socket set option failed",
+        }
+    }
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dhcp_server_interface_bind_failed",
+    metric_name = "carbide_dhcp_socket_setup_failures_total",
+    component = "nico-dhcp",
+    log = info,
+    metric = counter,
+    message = "Interface not ready, retrying",
+    describe = "Number of DHCP socket setup failures, by operation and next action."
+)]
+pub(crate) struct DhcpInterfaceBindFailed {
+    #[label]
+    operation: SocketSetupOperation,
+    #[label]
+    next_action: SocketSetupNextAction,
+    #[context(value)]
+    interface_name: String,
+    #[context(value)]
+    retries_left: i64,
+    #[context]
+    error: String,
+}
+
+impl DhcpInterfaceBindFailed {
+    pub(crate) fn new(
+        next_action: SocketSetupNextAction,
+        interface_name: String,
+        retries_left: i32,
+        error: String,
+    ) -> Self {
+        Self {
+            operation: SocketSetupOperation::BindDevice,
+            next_action,
+            interface_name,
+            retries_left: i64::from(retries_left),
+            error,
+        }
+    }
 }
 
 /// A DHCP packet was decoded from the wire, whatever becomes of it next.
@@ -285,14 +393,41 @@ mod tests {
     use std::net::Ipv4Addr;
 
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
     use dhcproto::v4::OptionCode;
     use dhcproto::v4::relay::RelayCode;
 
     use super::*;
 
+    const SOCKET_SETUP_FAILURE_METRIC: &str = "carbide_dhcp_socket_setup_failures_total";
     const TIMESTAMP_FILE_FAILURE_METRIC: &str = "carbide_dhcp_timestamp_file_failures_total";
+
+    struct SocketSetupFailureCase {
+        emit: fn(),
+        operation: &'static str,
+        next_action: &'static str,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct SocketSetupFailureObservation {
+        counter_delta: f64,
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        operation: Option<String>,
+        next_action: Option<String>,
+        retry: Option<String>,
+        retry_kind: Option<CapturedFieldKind>,
+        error: Option<String>,
+        error_kind: Option<CapturedFieldKind>,
+        interface_name: Option<String>,
+        interface_name_kind: Option<CapturedFieldKind>,
+        retries_left: Option<String>,
+        retries_left_kind: Option<CapturedFieldKind>,
+    }
 
     struct TimestampFileFailureInput {
         emit: fn(),
@@ -398,6 +533,268 @@ mod tests {
                 error: Some(error.to_string()),
             },
         }
+    }
+
+    fn observe_socket_setup_failure(
+        metrics: &MetricsCapture,
+        case: SocketSetupFailureCase,
+    ) -> SocketSetupFailureObservation {
+        let mut logs = capture_logs(case.emit);
+        assert_eq!(logs.len(), 1, "one socket failure logs once");
+        let log = logs.pop().expect("the socket setup failure log");
+        let field = |name: &str| log.field(name).map(str::to_owned);
+
+        SocketSetupFailureObservation {
+            counter_delta: metrics.counter_delta(
+                SOCKET_SETUP_FAILURE_METRIC,
+                &[
+                    ("operation", case.operation),
+                    ("next_action", case.next_action),
+                ],
+            ),
+            level: log.level,
+            metadata_name: log.metadata_name.clone(),
+            message: log.message.clone(),
+            event_name: field("event_name"),
+            metric_name: field("metric_name"),
+            operation: field("operation"),
+            next_action: field("next_action"),
+            retry: field("retry"),
+            retry_kind: log.field_kind("retry"),
+            error: field("error"),
+            error_kind: log.field_kind("error"),
+            interface_name: field("interface_name"),
+            interface_name_kind: log.field_kind("interface_name"),
+            retries_left: field("retries_left"),
+            retries_left_kind: log.field_kind("retries_left"),
+        }
+    }
+
+    fn expected_socket_setup_failure(
+        diagnostic: (&str, &str),
+        operation: &str,
+        next_action: &str,
+        retry: Option<i32>,
+        error: Option<&str>,
+        interface_name: Option<&str>,
+        retries_left: Option<i32>,
+    ) -> SocketSetupFailureObservation {
+        let (metadata_name, message) = diagnostic;
+        SocketSetupFailureObservation {
+            counter_delta: 1.0,
+            level: tracing::Level::INFO,
+            metadata_name: metadata_name.to_string(),
+            message: message.to_string(),
+            event_name: Some(metadata_name.to_string()),
+            metric_name: Some(SOCKET_SETUP_FAILURE_METRIC.to_string()),
+            operation: Some(operation.to_string()),
+            next_action: Some(next_action.to_string()),
+            retry: retry.map(|value| value.to_string()),
+            retry_kind: retry.map(|_| CapturedFieldKind::I64),
+            error: error.map(str::to_owned),
+            error_kind: error.map(|_| CapturedFieldKind::Debug),
+            interface_name: interface_name.map(str::to_owned),
+            interface_name_kind: interface_name.map(|_| CapturedFieldKind::String),
+            retries_left: retries_left.map(|value| value.to_string()),
+            retries_left_kind: retries_left.map(|_| CapturedFieldKind::I64),
+        }
+    }
+
+    #[test]
+    fn socket_setup_failures_keep_the_existing_diagnostics() {
+        let metrics = MetricsCapture::start();
+
+        check_values(
+            [
+                Check {
+                    scenario: "socket creation will retry",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpSocketSetupFailed::new(
+                                SocketSetupOperation::Create,
+                                SocketSetupNextAction::Retry,
+                                0,
+                                "too many open files".to_string(),
+                            ))
+                        },
+                        operation: "create",
+                        next_action: "retry",
+                    },
+                    expect: expected_socket_setup_failure(
+                        ("dhcp_server_socket_setup_failed", "Socket creation failed"),
+                        "create",
+                        "retry",
+                        Some(0),
+                        Some("too many open files"),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "reuse-address setup will retry",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpSocketSetupFailed::new(
+                                SocketSetupOperation::ReuseAddress,
+                                SocketSetupNextAction::Retry,
+                                1,
+                                "operation not supported".to_string(),
+                            ))
+                        },
+                        operation: "reuse_address",
+                        next_action: "retry",
+                    },
+                    expect: expected_socket_setup_failure(
+                        (
+                            "dhcp_server_socket_setup_failed",
+                            "Socket set option failed",
+                        ),
+                        "reuse_address",
+                        "retry",
+                        Some(1),
+                        Some("operation not supported"),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "nonblocking setup will retry",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpSocketSetupFailed::new(
+                                SocketSetupOperation::SetNonblocking,
+                                SocketSetupNextAction::Retry,
+                                2,
+                                "bad file descriptor".to_string(),
+                            ))
+                        },
+                        operation: "set_nonblocking",
+                        next_action: "retry",
+                    },
+                    expect: expected_socket_setup_failure(
+                        (
+                            "dhcp_server_socket_setup_failed",
+                            "Socket set option failed",
+                        ),
+                        "set_nonblocking",
+                        "retry",
+                        Some(2),
+                        Some("bad file descriptor"),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "address bind will retry",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpSocketSetupFailed::new(
+                                SocketSetupOperation::BindAddress,
+                                SocketSetupNextAction::Retry,
+                                3,
+                                "address in use".to_string(),
+                            ))
+                        },
+                        operation: "bind_address",
+                        next_action: "retry",
+                    },
+                    expect: expected_socket_setup_failure(
+                        (
+                            "dhcp_server_socket_setup_failed",
+                            "Socket set option failed",
+                        ),
+                        "bind_address",
+                        "retry",
+                        Some(3),
+                        Some("address in use"),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "broadcast setup exhausts the outer loop",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpSocketSetupFailed::new(
+                                SocketSetupOperation::SetBroadcast,
+                                SocketSetupNextAction::Panic,
+                                9,
+                                "permission denied".to_string(),
+                            ))
+                        },
+                        operation: "set_broadcast",
+                        next_action: "panic",
+                    },
+                    expect: expected_socket_setup_failure(
+                        (
+                            "dhcp_server_socket_setup_failed",
+                            "Socket set option failed",
+                        ),
+                        "set_broadcast",
+                        "panic",
+                        Some(9),
+                        Some("permission denied"),
+                        None,
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "device bind will retry",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpInterfaceBindFailed::new(
+                                SocketSetupNextAction::Retry,
+                                "pf0hpf".to_string(),
+                                1,
+                                "device not found".to_string(),
+                            ))
+                        },
+                        operation: "bind_device",
+                        next_action: "retry",
+                    },
+                    expect: expected_socket_setup_failure(
+                        (
+                            "dhcp_server_interface_bind_failed",
+                            "Interface not ready, retrying",
+                        ),
+                        "bind_device",
+                        "retry",
+                        None,
+                        Some("device not found"),
+                        Some("pf0hpf"),
+                        Some(1),
+                    ),
+                },
+                Check {
+                    scenario: "device bind exhausts its retry loop",
+                    input: SocketSetupFailureCase {
+                        emit: || {
+                            emit(DhcpInterfaceBindFailed::new(
+                                SocketSetupNextAction::Panic,
+                                "pf0hpf".to_string(),
+                                0,
+                                "permission denied".to_string(),
+                            ))
+                        },
+                        operation: "bind_device",
+                        next_action: "panic",
+                    },
+                    expect: expected_socket_setup_failure(
+                        (
+                            "dhcp_server_interface_bind_failed",
+                            "Interface not ready, retrying",
+                        ),
+                        "bind_device",
+                        "panic",
+                        None,
+                        Some("permission denied"),
+                        Some("pf0hpf"),
+                        Some(0),
+                    ),
+                },
+            ],
+            |case| observe_socket_setup_failure(&metrics, case),
+        );
     }
 
     /// Every timestamp-file failure keeps its historical diagnostic while the

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -15,25 +15,60 @@
  * limitations under the License.
  */
 use carbide_dhcp_common::{MachineArchitecture, VendorClass};
+use carbide_instrument::emit;
 use rpc::forge::DhcpRecord;
 use tokio::net::UdpSocket;
 
 use crate::Config;
 use crate::errors::DhcpError;
+use crate::metrics::{
+    DhcpInterfaceBindFailed, DhcpSocketSetupFailed, SocketSetupNextAction, SocketSetupOperation,
+};
 
-macro_rules! socket_opr {
-    ($socket:expr, $statement:expr, $retry:expr) => {
-        if let Err(e) = $statement {
-            drop($socket);
-            tracing::info!(
-                retry = $retry,
-                error = %e,
-                "Socket set option failed"
-            );
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            continue;
-        }
-    };
+const SOCKET_SETUP_ATTEMPTS: i32 = 10;
+const INTERFACE_BIND_ATTEMPTS: i32 = 10;
+
+fn open_configured_socket(
+    listen_address: core::net::SocketAddrV4,
+) -> Result<socket2::Socket, (SocketSetupOperation, std::io::Error)> {
+    let socket = socket2::Socket::new(
+        socket2::Domain::IPV4,
+        socket2::Type::DGRAM,
+        Some(socket2::Protocol::UDP),
+    )
+    .map_err(|error| (SocketSetupOperation::Create, error))?;
+
+    socket
+        .set_reuse_address(true)
+        .map_err(|error| (SocketSetupOperation::ReuseAddress, error))?;
+    socket
+        .set_nonblocking(true)
+        .map_err(|error| (SocketSetupOperation::SetNonblocking, error))?;
+    socket
+        .bind(&listen_address.into())
+        .map_err(|error| (SocketSetupOperation::BindAddress, error))?;
+    // SO_BROADCAST permits sends to broadcast addresses; receiving does not require it.
+    socket
+        .set_broadcast(true)
+        .map_err(|error| (SocketSetupOperation::SetBroadcast, error))?;
+
+    Ok(socket)
+}
+
+fn socket_setup_next_action(retry: i32) -> SocketSetupNextAction {
+    if retry + 1 == SOCKET_SETUP_ATTEMPTS {
+        SocketSetupNextAction::Panic
+    } else {
+        SocketSetupNextAction::Retry
+    }
+}
+
+fn interface_bind_next_action(retries_left: i32) -> SocketSetupNextAction {
+    if retries_left == 0 {
+        SocketSetupNextAction::Panic
+    } else {
+        SocketSetupNextAction::Retry
+    }
 }
 
 pub fn u8_to_mac(data: &[u8]) -> String {
@@ -88,36 +123,35 @@ pub fn machine_get_filename(
 
 /// Create a UDP socket and set non_blocking, broadcast and other options flag on it.
 pub async fn get_socket(listen_address: core::net::SocketAddrV4, interface: String) -> UdpSocket {
-    for retry in 0..10 {
-        // Create a socket2.socket. std and tokio sockets do not support advance options like
-        // reuseaddr to be set.
-        let socket = match socket2::Socket::new(
-            socket2::Domain::IPV4,
-            socket2::Type::DGRAM,
-            Some(socket2::Protocol::UDP),
-        ) {
+    for retry in 0..SOCKET_SETUP_ATTEMPTS {
+        // Create a socket2 socket because std and Tokio sockets do not expose
+        // the options that must be set before binding.
+        let socket = match open_configured_socket(listen_address) {
             Ok(socket) => socket,
-            Err(e) => {
-                tracing::info!(retry, error = %e, "Socket creation failed");
+            Err((operation, error)) => {
+                emit(DhcpSocketSetupFailed::new(
+                    operation,
+                    socket_setup_next_action(retry),
+                    retry,
+                    error.to_string(),
+                ));
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 continue;
             }
         };
 
-        socket_opr!(socket, socket.set_reuse_address(true), retry);
-        socket_opr!(socket, socket.set_nonblocking(true), retry);
-        socket_opr!(socket, socket.bind(&listen_address.into()), retry);
-        // Not for listening, but allowed for sending.
-        socket_opr!(socket, socket.set_broadcast(true), retry);
-
-        let mut retries_left = 10;
-        while retries_left > 0 && socket.bind_device(Some(interface.as_bytes())).is_err() {
+        let mut retries_left = INTERFACE_BIND_ATTEMPTS;
+        while retries_left > 0 {
+            let Err(error) = socket.bind_device(Some(interface.as_bytes())) else {
+                break;
+            };
             retries_left -= 1;
-            tracing::info!(
-                interface_name = interface.as_str(),
+            emit(DhcpInterfaceBindFailed::new(
+                interface_bind_next_action(retries_left),
+                interface.clone(),
                 retries_left,
-                "Interface not ready, retrying"
-            );
+                error.to_string(),
+            ));
             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
         if retries_left == 0 {
@@ -132,13 +166,40 @@ pub async fn get_socket(listen_address: core::net::SocketAddrV4, interface: Stri
 
 #[cfg(test)]
 mod tests {
-    use super::u8_to_mac;
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
 
     #[test]
     fn u8_to_mac_zero_pads_octets() {
         assert_eq!(
             u8_to_mac(&[0x00, 0x00, 0x5e, 0x00, 0x53, 0x01]),
             "00:00:5e:00:53:01"
+        );
+    }
+
+    #[test]
+    fn socket_setup_failures_report_whether_the_next_step_retries_or_panics() {
+        value_scenarios!(socket_setup_next_action:
+            "another socket attempt follows" {
+                0 => SocketSetupNextAction::Retry,
+                8 => SocketSetupNextAction::Retry,
+            }
+
+            "the outer retry budget is exhausted" {
+                9 => SocketSetupNextAction::Panic,
+            }
+        );
+
+        value_scenarios!(interface_bind_next_action:
+            "another interface bind follows" {
+                9 => SocketSetupNextAction::Retry,
+                1 => SocketSetupNextAction::Retry,
+            }
+
+            "the interface bind budget is exhausted" {
+                0 => SocketSetupNextAction::Panic,
+            }
         );
     }
 }

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -396,25 +396,23 @@ async fn load_single_fabric_data(
     let conn = match fabric_manager.new_client(fabric).await {
         Ok(conn) => conn,
         Err(e) => {
-            note_fabric_error(
-                fabric_metrics,
+            emit(IbFabricDataLoadFailed::build_client(
                 fabric,
                 &fabric_definition.endpoints,
                 &e,
-                FabricDataLoadFailureStage::BuildClient,
-            );
+            ));
+            fabric_metrics.fabric_error = e.to_string();
             return None;
         }
     };
 
     if let Err(e) = check_ib_fabric(conn.as_ref(), fabric_metrics).await {
-        note_fabric_error(
-            fabric_metrics,
+        emit(IbFabricDataLoadFailed::health_check(
             fabric,
             &fabric_definition.endpoints,
             &e,
-            FabricDataLoadFailureStage::HealthCheck,
-        );
+        ));
+        fabric_metrics.fabric_error = e.to_string();
         // There's no point in loading other information case the fabric is down
         return Some(conn);
     }
@@ -424,13 +422,12 @@ async fn load_single_fabric_data(
             fabric_data.ports_by_guid = Some(ports);
         }
         Err(e) => {
-            note_fabric_error(
-                fabric_metrics,
+            emit(IbFabricDataLoadFailed::load_ports(
                 fabric,
                 &fabric_definition.endpoints,
                 &e,
-                FabricDataLoadFailureStage::LoadPorts,
-            );
+            ));
+            fabric_metrics.fabric_error = e.to_string();
             // There's no point in loading other information case the fabric is down
             return Some(conn);
         }
@@ -441,13 +438,12 @@ async fn load_single_fabric_data(
             fabric_data.partitions = Some(partitions);
         }
         Err(e) => {
-            note_fabric_error(
-                fabric_metrics,
+            emit(IbFabricDataLoadFailed::load_partitions(
                 fabric,
                 &fabric_definition.endpoints,
                 &e,
-                FabricDataLoadFailureStage::LoadPartitions,
-            );
+            ));
+            fabric_metrics.fabric_error = e.to_string();
             // There's no point in loading other information case the fabric is down
             return Some(conn);
         }
@@ -457,48 +453,6 @@ async fn load_single_fabric_data(
     fabric_data.derive_partitions_by_guid();
 
     Some(conn)
-}
-
-#[derive(Clone, Copy)]
-enum FabricDataLoadFailureStage {
-    BuildClient,
-    HealthCheck,
-    LoadPorts,
-    LoadPartitions,
-}
-
-/// Records a failed stage of a fabric's data load and stores the error as the
-/// fabric's error metric.
-///
-/// TODO: Storing the raw error string isn't efficient because we will get a
-/// lot of different dimensions. We need to have better defined errors from the
-/// UFM APIs, so we can convert those into a smaller set of labels.
-fn note_fabric_error(
-    fabric_metrics: &mut FabricMetrics,
-    fabric: &str,
-    endpoints: &[String],
-    error: &IbError,
-    failure_stage: FabricDataLoadFailureStage,
-) {
-    let fabric = fabric.to_string();
-    let endpoints = endpoints.join(",");
-    let error_message = error.to_string();
-    let event = match failure_stage {
-        FabricDataLoadFailureStage::BuildClient => {
-            IbFabricDataLoadFailed::build_client(fabric, endpoints, error_message)
-        }
-        FabricDataLoadFailureStage::HealthCheck => {
-            IbFabricDataLoadFailed::health_check(fabric, endpoints, error_message)
-        }
-        FabricDataLoadFailureStage::LoadPorts => {
-            IbFabricDataLoadFailed::load_ports(fabric, endpoints, error_message)
-        }
-        FabricDataLoadFailureStage::LoadPartitions => {
-            IbFabricDataLoadFailed::load_partitions(fabric, endpoints, error_message)
-        }
-    };
-    emit(event);
-    fabric_metrics.fabric_error = error.to_string();
 }
 
 /// Checks the status of a single IB fabric over an established client connection
@@ -1383,91 +1337,9 @@ fn is_pkey_in_managed_range(pkey: PartitionKey, fabric_definition: &IbFabricDefi
 
 #[cfg(test)]
 mod tests {
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
-    use carbide_test_support::{Check, check_values, value_scenarios};
+    use carbide_test_support::value_scenarios;
 
     use super::*;
-
-    #[test]
-    fn fabric_partial_failures_still_set_the_existing_gauge_state() {
-        const METRIC: &str = "carbide_ib_monitor_partial_failures_total";
-
-        #[derive(Debug, PartialEq)]
-        struct Observation {
-            fabric_error: String,
-            log_count: usize,
-            counter_delta: f64,
-        }
-
-        check_values(
-            [
-                Check {
-                    scenario: "client build",
-                    input: (FabricDataLoadFailureStage::BuildClient, "build_client"),
-                    expect: Observation {
-                        fabric_error: "failed to call IBFabricManager: simulated failure"
-                            .to_string(),
-                        log_count: 1,
-                        counter_delta: 1.0,
-                    },
-                },
-                Check {
-                    scenario: "health check",
-                    input: (FabricDataLoadFailureStage::HealthCheck, "health_check"),
-                    expect: Observation {
-                        fabric_error: "failed to call IBFabricManager: simulated failure"
-                            .to_string(),
-                        log_count: 1,
-                        counter_delta: 1.0,
-                    },
-                },
-                Check {
-                    scenario: "port load",
-                    input: (FabricDataLoadFailureStage::LoadPorts, "load_ports"),
-                    expect: Observation {
-                        fabric_error: "failed to call IBFabricManager: simulated failure"
-                            .to_string(),
-                        log_count: 1,
-                        counter_delta: 1.0,
-                    },
-                },
-                Check {
-                    scenario: "partition load",
-                    input: (
-                        FabricDataLoadFailureStage::LoadPartitions,
-                        "load_partitions",
-                    ),
-                    expect: Observation {
-                        fabric_error: "failed to call IBFabricManager: simulated failure"
-                            .to_string(),
-                        log_count: 1,
-                        counter_delta: 1.0,
-                    },
-                },
-            ],
-            |(failure_stage, failure_stage_label)| {
-                let mut fabric_metrics = FabricMetrics::default();
-                let error = IbError::IBFabricError("simulated failure".to_string());
-                let metrics = MetricsCapture::start();
-                let logs = capture_logs(|| {
-                    note_fabric_error(
-                        &mut fabric_metrics,
-                        "fabric-1",
-                        &["https://ufm-1".to_string()],
-                        &error,
-                        failure_stage,
-                    );
-                });
-
-                Observation {
-                    fabric_error: fabric_metrics.fabric_error,
-                    log_count: logs.len(),
-                    counter_delta: metrics
-                        .counter_delta(METRIC, &[("failure_stage", failure_stage_label)]),
-                }
-            },
-        );
-    }
 
     #[test]
     fn parses_numbers() {
@@ -1811,6 +1683,235 @@ mod tests {
                 } => false,
             }
         );
+    }
+
+    mod fabric_load_failures {
+        use std::convert::Infallible;
+
+        use async_trait::async_trait;
+        use carbide_instrument::testing::{MetricsCapture, capture_logs_async};
+        use carbide_test_support::Outcome::Yields;
+        use carbide_test_support::{Case, check_cases_async};
+        use model::ib::IBQosConf;
+
+        use super::*;
+        use crate::ib::{
+            Filter, IBFabricConfig, IBFabricManagerConfig, IBFabricRawResponse, IBFabricVersions,
+        };
+
+        const ERROR: &str = "failed to call IBFabricManager: simulated failure";
+        const FABRIC: &str = "fabric-1";
+        const METRIC: &str = "carbide_ib_monitor_partial_failures_total";
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        enum FabricLoadFailure {
+            BuildClient,
+            HealthCheck,
+            LoadPorts,
+            LoadPartitions,
+        }
+
+        fn simulated_failure() -> IbError {
+            IbError::IBFabricError("simulated failure".to_string())
+        }
+
+        struct FailingFabricManager {
+            failure: FabricLoadFailure,
+        }
+
+        #[async_trait]
+        impl IBFabricManager for FailingFabricManager {
+            async fn new_client(&self, _fabric_name: &str) -> Result<Arc<dyn IBFabric>, IbError> {
+                if self.failure == FabricLoadFailure::BuildClient {
+                    return Err(simulated_failure());
+                }
+                Ok(Arc::new(FailingFabric {
+                    failure: self.failure,
+                }))
+            }
+
+            fn get_config(&self) -> IBFabricManagerConfig {
+                IBFabricManagerConfig::default()
+            }
+        }
+
+        struct FailingFabric {
+            failure: FabricLoadFailure,
+        }
+
+        #[async_trait]
+        impl IBFabric for FailingFabric {
+            async fn get_fabric_config(&self) -> Result<IBFabricConfig, IbError> {
+                Ok(IBFabricConfig::default())
+            }
+
+            async fn update_partition_qos_conf(
+                &self,
+                _pkey: u16,
+                _qos_conf: &IBQosConf,
+            ) -> Result<(), IbError> {
+                unreachable!("fabric data loading does not update partition QoS")
+            }
+
+            async fn get_ib_networks(
+                &self,
+                _options: GetPartitionOptions,
+            ) -> Result<HashMap<u16, IBNetwork>, IbError> {
+                if self.failure == FabricLoadFailure::LoadPartitions {
+                    return Err(simulated_failure());
+                }
+                Ok(HashMap::new())
+            }
+
+            async fn get_ib_network(
+                &self,
+                pkey: u16,
+                _options: GetPartitionOptions,
+            ) -> Result<IBNetwork, IbError> {
+                Ok(IBNetwork {
+                    name: "default".to_string(),
+                    pkey,
+                    ipoib: false,
+                    qos_conf: None,
+                    associated_guids: Some(HashSet::new()),
+                    membership: None,
+                })
+            }
+
+            async fn bind_ib_ports(
+                &self,
+                _ibnetwork: IBNetwork,
+                _ports: Vec<String>,
+            ) -> Result<(), IbError> {
+                unreachable!("fabric data loading does not bind ports")
+            }
+
+            async fn unbind_ib_ports(&self, _pkey: u16, _id: Vec<String>) -> Result<(), IbError> {
+                unreachable!("fabric data loading does not unbind ports")
+            }
+
+            async fn find_ib_port(&self, _filter: Option<Filter>) -> Result<Vec<IBPort>, IbError> {
+                if self.failure == FabricLoadFailure::LoadPorts {
+                    return Err(simulated_failure());
+                }
+                Ok(Vec::new())
+            }
+
+            async fn versions(&self) -> Result<IBFabricVersions, IbError> {
+                if self.failure == FabricLoadFailure::HealthCheck {
+                    return Err(simulated_failure());
+                }
+                Ok(IBFabricVersions {
+                    ufm_version: "test".to_string(),
+                })
+            }
+
+            async fn raw_get(&self, _path: &str) -> Result<IBFabricRawResponse, IbError> {
+                unreachable!("fabric data loading does not make raw requests")
+            }
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            client_returned: bool,
+            fabric_error: String,
+            log_count: usize,
+            event_name: Option<String>,
+            failure_stage: Option<String>,
+            counter_delta: f64,
+        }
+
+        #[tokio::test]
+        async fn fabric_load_failures_update_gauge_state_and_emit_the_stage_event() {
+            check_cases_async(
+                [
+                    Case {
+                        scenario: "client build",
+                        input: FabricLoadFailure::BuildClient,
+                        expect: Yields(Observation {
+                            client_returned: false,
+                            fabric_error: ERROR.to_string(),
+                            log_count: 1,
+                            event_name: Some("ib_fabric_data_load_failed".to_string()),
+                            failure_stage: Some("build_client".to_string()),
+                            counter_delta: 1.0,
+                        }),
+                    },
+                    Case {
+                        scenario: "health check",
+                        input: FabricLoadFailure::HealthCheck,
+                        expect: Yields(Observation {
+                            client_returned: true,
+                            fabric_error: ERROR.to_string(),
+                            log_count: 1,
+                            event_name: Some("ib_fabric_data_load_failed".to_string()),
+                            failure_stage: Some("health_check".to_string()),
+                            counter_delta: 1.0,
+                        }),
+                    },
+                    Case {
+                        scenario: "port load",
+                        input: FabricLoadFailure::LoadPorts,
+                        expect: Yields(Observation {
+                            client_returned: true,
+                            fabric_error: ERROR.to_string(),
+                            log_count: 1,
+                            event_name: Some("ib_fabric_data_load_failed".to_string()),
+                            failure_stage: Some("load_ports".to_string()),
+                            counter_delta: 1.0,
+                        }),
+                    },
+                    Case {
+                        scenario: "partition load",
+                        input: FabricLoadFailure::LoadPartitions,
+                        expect: Yields(Observation {
+                            client_returned: true,
+                            fabric_error: ERROR.to_string(),
+                            log_count: 1,
+                            event_name: Some("ib_fabric_data_load_failed".to_string()),
+                            failure_stage: Some("load_partitions".to_string()),
+                            counter_delta: 1.0,
+                        }),
+                    },
+                ],
+                |failure| async move {
+                    let manager = FailingFabricManager { failure };
+                    let definition = IbFabricDefinition {
+                        endpoints: vec!["https://ufm-1".to_string()],
+                        pkeys: Vec::new(),
+                    };
+                    let mut fabric_data = FabricData::default();
+                    let mut fabric_metrics = FabricMetrics::default();
+                    let metrics = MetricsCapture::start();
+                    let (client, logs) = capture_logs_async(load_single_fabric_data(
+                        &manager,
+                        FABRIC,
+                        &definition,
+                        &mut fabric_data,
+                        &mut fabric_metrics,
+                    ))
+                    .await;
+                    let log = logs.first().expect("fabric failure Event logged");
+                    let failure_stage = log.field("failure_stage").map(str::to_string);
+
+                    Ok::<_, Infallible>(Observation {
+                        client_returned: client.is_some(),
+                        fabric_error: fabric_metrics.fabric_error,
+                        log_count: logs.len(),
+                        event_name: log.field("event_name").map(str::to_string),
+                        counter_delta: metrics.counter_delta(
+                            METRIC,
+                            &[(
+                                "failure_stage",
+                                failure_stage.as_deref().expect("failure stage label"),
+                            )],
+                        ),
+                        failure_stage,
+                    })
+                },
+            )
+            .await;
+        }
     }
 
     // ============================================================

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::time::Duration;
 
 use ::carbide_utils::metrics::SharedMetricsHolder;
@@ -65,6 +66,9 @@ pub struct FabricMetrics {
     /// The endpoint that we use to interact with the fabric
     pub endpoints: Vec<String>,
     /// Error when trying to connect to the fabric
+    ///
+    /// TODO: Replace raw UFM errors with a bounded classification so distinct
+    /// error strings do not create separate dimensions.
     pub fabric_error: String,
     /// UFM version
     pub ufm_version: String,
@@ -182,7 +186,7 @@ pub(crate) struct IbFabricDataLoadFailed {
 }
 
 impl IbFabricDataLoadFailed {
-    pub(crate) fn build_client(fabric: String, endpoints: String, error: String) -> Self {
+    pub(crate) fn build_client(fabric: &str, endpoints: &[String], error: &dyn Display) -> Self {
         Self::new(
             IbMonitorPartialFailureStage::BuildClient,
             fabric,
@@ -191,7 +195,7 @@ impl IbFabricDataLoadFailed {
         )
     }
 
-    pub(crate) fn health_check(fabric: String, endpoints: String, error: String) -> Self {
+    pub(crate) fn health_check(fabric: &str, endpoints: &[String], error: &dyn Display) -> Self {
         Self::new(
             IbMonitorPartialFailureStage::HealthCheck,
             fabric,
@@ -200,7 +204,7 @@ impl IbFabricDataLoadFailed {
         )
     }
 
-    pub(crate) fn load_ports(fabric: String, endpoints: String, error: String) -> Self {
+    pub(crate) fn load_ports(fabric: &str, endpoints: &[String], error: &dyn Display) -> Self {
         Self::new(
             IbMonitorPartialFailureStage::LoadPorts,
             fabric,
@@ -209,7 +213,7 @@ impl IbFabricDataLoadFailed {
         )
     }
 
-    pub(crate) fn load_partitions(fabric: String, endpoints: String, error: String) -> Self {
+    pub(crate) fn load_partitions(fabric: &str, endpoints: &[String], error: &dyn Display) -> Self {
         Self::new(
             IbMonitorPartialFailureStage::LoadPartitions,
             fabric,
@@ -220,15 +224,15 @@ impl IbFabricDataLoadFailed {
 
     fn new(
         failure_stage: IbMonitorPartialFailureStage,
-        fabric: String,
-        endpoints: String,
-        error: String,
+        fabric: &str,
+        endpoints: &[String],
+        error: &dyn Display,
     ) -> Self {
         Self {
             failure_stage,
-            fabric,
-            endpoints,
-            error,
+            fabric: fabric.to_string(),
+            endpoints: endpoints.join(","),
+            error: error.to_string(),
         }
     }
 }
@@ -1131,33 +1135,30 @@ mod tests {
                     PartialFailureCase::ResolvePartition => "resolve_partition",
                 };
                 let metrics = MetricsCapture::start();
+                let endpoints = vec![
+                    "https://ufm-1".to_string(),
+                    "https://ufm-2".to_string(),
+                ];
+                let error = ERROR.to_string();
                 let logs = capture_logs(|| match case {
                     PartialFailureCase::BuildClient => {
                         emit(IbFabricDataLoadFailed::build_client(
-                            FABRIC.to_string(),
-                            ENDPOINTS.to_string(),
-                            ERROR.to_string(),
+                            FABRIC, &endpoints, &error,
                         ));
                     }
                     PartialFailureCase::HealthCheck => {
                         emit(IbFabricDataLoadFailed::health_check(
-                            FABRIC.to_string(),
-                            ENDPOINTS.to_string(),
-                            ERROR.to_string(),
+                            FABRIC, &endpoints, &error,
                         ));
                     }
                     PartialFailureCase::LoadPorts => {
                         emit(IbFabricDataLoadFailed::load_ports(
-                            FABRIC.to_string(),
-                            ENDPOINTS.to_string(),
-                            ERROR.to_string(),
+                            FABRIC, &endpoints, &error,
                         ));
                     }
                     PartialFailureCase::LoadPartitions => {
                         emit(IbFabricDataLoadFailed::load_partitions(
-                            FABRIC.to_string(),
-                            ENDPOINTS.to_string(),
-                            ERROR.to_string(),
+                            FABRIC, &endpoints, &error,
                         ));
                     }
                     PartialFailureCase::PreloadSkuInactiveDevices => {

--- a/crates/secrets/src/local_credentials/file.rs
+++ b/crates/secrets/src/local_credentials/file.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use carbide_instrument::{DynamicMessage, Event, LabelValue, emit};
 use notify::{PollWatcher, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -30,6 +31,74 @@ use crate::credentials::{CredentialKey, CredentialReader, Credentials};
 
 const DEFAULT_FILE_POLL_INTERVAL: Duration = Duration::from_secs(60);
 const DEFAULT_CREDENTIALS_FILE_PATH: &str = "secrets.yaml";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+enum StaticCredentialWatcherOperation {
+    PrimaryWatch,
+    PollWatch,
+    Reload,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "static_credential_watcher_failed",
+    metric_name = "carbide_static_credential_watcher_failures_total",
+    component = "nico-api",
+    log = warn,
+    metric = counter,
+    message = dynamic,
+    describe = "Number of static credential watcher failures, by operation."
+)]
+struct StaticCredentialWatcherFailed {
+    #[label]
+    operation: StaticCredentialWatcherOperation,
+    #[context]
+    error: String,
+}
+
+impl DynamicMessage for StaticCredentialWatcherFailed {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            StaticCredentialWatcherOperation::PrimaryWatch => {
+                "primary static credential watcher error"
+            }
+            StaticCredentialWatcherOperation::PollWatch => "credentials file watcher event error",
+            StaticCredentialWatcherOperation::Reload => "failed to reload credentials file",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WatchEventDelivery {
+    Primary,
+    Poll,
+}
+
+fn forward_watch_event(
+    delivery: WatchEventDelivery,
+    tx: &mpsc::Sender<notify::Result<notify::Event>>,
+    result: notify::Result<notify::Event>,
+) {
+    if let Err(err) = tx.blocking_send(result) {
+        // A closed receiver means this watcher is tearing down, not that file
+        // observation or credential reload failed. Keep this as a plain WARN
+        // so shutdown cannot increment the live-failure counter.
+        match delivery {
+            WatchEventDelivery::Primary => {
+                tracing::warn!(
+                    error = %err,
+                    "failed to send static credential watch event",
+                );
+            }
+            WatchEventDelivery::Poll => {
+                tracing::warn!(
+                    error = %err,
+                    "failed to send static credential poll event",
+                );
+            }
+        }
+    }
+}
 
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct FileCredentialsConfig {
@@ -82,16 +151,14 @@ impl FileCredentialsWatcher {
         let mut primary = RecommendedWatcher::new(
             move |res: notify::Result<notify::Event>| match res {
                 Ok(ref event) if event.kind.is_create() || event.kind.is_modify() => {
-                    if let Err(err) = tx_clone.blocking_send(res) {
-                        tracing::warn!(
-                            error = %err,
-                            "failed to send static credential watch event",
-                        );
-                    }
+                    forward_watch_event(WatchEventDelivery::Primary, &tx_clone, res);
                 }
                 Ok(_) => {}
                 Err(err) => {
-                    tracing::warn!(error = %err, "primary static credential watcher error");
+                    emit(StaticCredentialWatcherFailed {
+                        operation: StaticCredentialWatcherOperation::PrimaryWatch,
+                        error: err.to_string(),
+                    });
                 }
             },
             notify::Config::default(),
@@ -104,12 +171,7 @@ impl FileCredentialsWatcher {
 
         let mut secondary = PollWatcher::new(
             move |res| {
-                if let Err(err) = tx.blocking_send(res) {
-                    tracing::warn!(
-                        error = %err,
-                        "failed to send static credential poll event",
-                    );
-                }
+                forward_watch_event(WatchEventDelivery::Poll, &tx, res);
             },
             notify::Config::default()
                 .with_poll_interval(poll_interval)
@@ -140,18 +202,18 @@ impl FileCredentialsWatcher {
                                 credentials_clone.store(Arc::new(updated));
                             }
                             Err(err) => {
-                                tracing::warn!(
-                                    error = %err,
-                                    "failed to reload credentials file",
-                                );
+                                emit(StaticCredentialWatcherFailed {
+                                    operation: StaticCredentialWatcherOperation::Reload,
+                                    error: err.to_string(),
+                                });
                             }
                         }
                     }
                     Err(err) => {
-                        tracing::warn!(
-                            error = %err,
-                            "credentials file watcher event error",
-                        );
+                        emit(StaticCredentialWatcherFailed {
+                            operation: StaticCredentialWatcherOperation::PollWatch,
+                            error: err.to_string(),
+                        });
                     }
                 }
             }
@@ -194,6 +256,8 @@ impl CredentialReader for FileCredentialsWatcher {
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use tempfile::tempdir;
 
     use super::*;
@@ -362,6 +426,217 @@ mod tests {
                 username: "v2".to_string(),
                 password: "secret-2".to_string(),
             })
+        );
+    }
+
+    const WATCHER_FAILURE_METRIC: &str = "carbide_static_credential_watcher_failures_total";
+
+    #[derive(Clone, Copy)]
+    struct WatcherFailureCase {
+        operation: StaticCredentialWatcherOperation,
+        operation_label: &'static str,
+        error: &'static str,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct WatcherFailureObservation {
+        counter_delta: f64,
+        level: tracing::Level,
+        metadata_name: String,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        operation: Option<String>,
+        error: Option<String>,
+    }
+
+    fn watcher_failure_delta(metrics: &MetricsCapture) -> f64 {
+        ["primary_watch", "poll_watch", "reload"]
+            .iter()
+            .map(|operation| {
+                metrics.counter_delta(WATCHER_FAILURE_METRIC, &[("operation", operation)])
+            })
+            .sum()
+    }
+
+    #[test]
+    fn live_watcher_failures_keep_the_existing_diagnostics() {
+        let metrics = MetricsCapture::start();
+
+        check_values(
+            [
+                Check {
+                    scenario: "primary watcher reports an error",
+                    input: WatcherFailureCase {
+                        operation: StaticCredentialWatcherOperation::PrimaryWatch,
+                        operation_label: "primary_watch",
+                        error: "inotify queue overflow",
+                    },
+                    expect: WatcherFailureObservation {
+                        counter_delta: 1.0,
+                        level: tracing::Level::WARN,
+                        metadata_name: "static_credential_watcher_failed".to_string(),
+                        message: "primary static credential watcher error".to_string(),
+                        event_name: Some("static_credential_watcher_failed".to_string()),
+                        metric_name: Some(WATCHER_FAILURE_METRIC.to_string()),
+                        operation: Some("primary_watch".to_string()),
+                        error: Some("inotify queue overflow".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "poll watcher reports an error",
+                    input: WatcherFailureCase {
+                        operation: StaticCredentialWatcherOperation::PollWatch,
+                        operation_label: "poll_watch",
+                        error: "stat failed",
+                    },
+                    expect: WatcherFailureObservation {
+                        counter_delta: 1.0,
+                        level: tracing::Level::WARN,
+                        metadata_name: "static_credential_watcher_failed".to_string(),
+                        message: "credentials file watcher event error".to_string(),
+                        event_name: Some("static_credential_watcher_failed".to_string()),
+                        metric_name: Some(WATCHER_FAILURE_METRIC.to_string()),
+                        operation: Some("poll_watch".to_string()),
+                        error: Some("stat failed".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "credential reload fails",
+                    input: WatcherFailureCase {
+                        operation: StaticCredentialWatcherOperation::Reload,
+                        operation_label: "reload",
+                        error: "invalid yaml",
+                    },
+                    expect: WatcherFailureObservation {
+                        counter_delta: 1.0,
+                        level: tracing::Level::WARN,
+                        metadata_name: "static_credential_watcher_failed".to_string(),
+                        message: "failed to reload credentials file".to_string(),
+                        event_name: Some("static_credential_watcher_failed".to_string()),
+                        metric_name: Some(WATCHER_FAILURE_METRIC.to_string()),
+                        operation: Some("reload".to_string()),
+                        error: Some("invalid yaml".to_string()),
+                    },
+                },
+            ],
+            |case| {
+                let mut logs = capture_logs(|| {
+                    emit(StaticCredentialWatcherFailed {
+                        operation: case.operation,
+                        error: case.error.to_string(),
+                    });
+                });
+                assert_eq!(logs.len(), 1, "one watcher failure logs once");
+                let log = logs.pop().expect("the watcher failure log");
+                let field = |name: &str| log.field(name).map(str::to_owned);
+
+                WatcherFailureObservation {
+                    counter_delta: metrics.counter_delta(
+                        WATCHER_FAILURE_METRIC,
+                        &[("operation", case.operation_label)],
+                    ),
+                    level: log.level,
+                    metadata_name: log.metadata_name.clone(),
+                    message: log.message.clone(),
+                    event_name: field("event_name"),
+                    metric_name: field("metric_name"),
+                    operation: field("operation"),
+                    error: field("error"),
+                }
+            },
+        );
+    }
+
+    #[derive(Clone, Copy)]
+    struct ClosedReceiverCase {
+        delivery: WatchEventDelivery,
+        message: &'static str,
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct ClosedReceiverObservation {
+        counter_delta: f64,
+        level: tracing::Level,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        error: Option<String>,
+    }
+
+    #[test]
+    fn closed_receiver_warnings_do_not_count_as_live_watcher_failures() {
+        let metrics = MetricsCapture::start();
+
+        check_values(
+            [
+                Check {
+                    scenario: "primary receiver is closed",
+                    input: ClosedReceiverCase {
+                        delivery: WatchEventDelivery::Primary,
+                        message: "failed to send static credential watch event",
+                    },
+                    expect: ClosedReceiverObservation {
+                        counter_delta: 0.0,
+                        level: tracing::Level::WARN,
+                        message: "failed to send static credential watch event".to_string(),
+                        event_name: None,
+                        metric_name: None,
+                        error: Some("channel closed".to_string()),
+                    },
+                },
+                Check {
+                    scenario: "poll receiver is closed",
+                    input: ClosedReceiverCase {
+                        delivery: WatchEventDelivery::Poll,
+                        message: "failed to send static credential poll event",
+                    },
+                    expect: ClosedReceiverObservation {
+                        counter_delta: 0.0,
+                        level: tracing::Level::WARN,
+                        message: "failed to send static credential poll event".to_string(),
+                        event_name: None,
+                        metric_name: None,
+                        error: Some("channel closed".to_string()),
+                    },
+                },
+            ],
+            |case| {
+                let (tx, rx) = mpsc::channel(1);
+                drop(rx);
+                let logs = capture_logs(|| {
+                    forward_watch_event(
+                        case.delivery,
+                        &tx,
+                        Err(notify::Error::generic("watch failed")),
+                    );
+                });
+                let matching_logs = logs
+                    .into_iter()
+                    .filter(|log| log.message == case.message)
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    matching_logs.len(),
+                    1,
+                    "one failed delivery writes its historical WARN"
+                );
+                let log = matching_logs
+                    .into_iter()
+                    .next()
+                    .expect("the failed delivery log");
+                let event_name = log.field("event_name").map(str::to_owned);
+                let metric_name = log.field("metric_name").map(str::to_owned);
+                let error = log.field("error").map(str::to_owned);
+
+                ClosedReceiverObservation {
+                    counter_delta: watcher_failure_delta(&metrics),
+                    level: log.level,
+                    message: log.message,
+                    event_name,
+                    metric_name,
+                    error,
+                }
+            },
         );
     }
 }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -211,29 +211,10 @@ pub(crate) async fn ensure_rack_exists(
     }
 }
 
-#[derive(Clone, Copy)]
-enum RmsLocationField {
-    SlotNumber,
-    TrayIndex,
-}
-
-fn rms_location_value(value: Option<u32>, field: RmsLocationField) -> Option<i32> {
-    let value = value?;
-    match i32::try_from(value) {
-        Ok(value) => Some(value),
-        Err(_) => {
-            let event = match field {
-                RmsLocationField::SlotNumber => {
-                    SiteExplorerMachineSlotTrayValueInvalid::slot_number(value)
-                }
-                RmsLocationField::TrayIndex => {
-                    SiteExplorerMachineSlotTrayValueInvalid::tray_index(value)
-                }
-            };
-            carbide_instrument::emit(event);
-            None
-        }
-    }
+fn rms_location_value(value: Option<u32>) -> Result<Option<i32>, u32> {
+    value
+        .map(|value| i32::try_from(value).map_err(|_| value))
+        .transpose()
 }
 
 /// Fetches `slot_number` and `tray_index` from RMS for one rack/node pair.
@@ -249,12 +230,20 @@ pub async fn fetch_slot_and_tray(
                 return (None, None);
             };
 
-            let slot_number = rms_location_value(
-                node_device_details.slot_number,
-                RmsLocationField::SlotNumber,
-            );
+            let slot_number =
+                rms_location_value(node_device_details.slot_number).unwrap_or_else(|value| {
+                    carbide_instrument::emit(SiteExplorerMachineSlotTrayValueInvalid::slot_number(
+                        value,
+                    ));
+                    None
+                });
             let tray_index =
-                rms_location_value(node_device_details.tray_index, RmsLocationField::TrayIndex);
+                rms_location_value(node_device_details.tray_index).unwrap_or_else(|value| {
+                    carbide_instrument::emit(SiteExplorerMachineSlotTrayValueInvalid::tray_index(
+                        value,
+                    ));
+                    None
+                });
 
             (slot_number, tray_index)
         }
@@ -4170,7 +4159,6 @@ fn health_reports_equal_ignoring_observed_at(
 
 #[cfg(test)]
 mod tests {
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, Check, check_cases, check_values, value_scenarios};
     use config_version::ConfigVersion;
@@ -4179,91 +4167,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rms_location_values_keep_valid_and_absent_fields_without_failure_events() {
-        const METRIC: &str = "carbide_site_explorer_machine_slot_tray_enrichment_failures_total";
-
-        #[derive(Clone, Copy)]
-        struct ConversionCase {
-            value: Option<u32>,
-            field: RmsLocationField,
-        }
-
-        #[derive(Debug, PartialEq)]
-        struct Observation {
-            converted: Option<i32>,
-            log_count: usize,
-            counter_delta: f64,
-        }
-
+    fn rms_location_value_preserves_valid_and_absent_values_and_returns_out_of_range_input() {
         check_values(
             [
                 Check {
-                    scenario: "valid slot number",
-                    input: ConversionCase {
-                        value: Some(42),
-                        field: RmsLocationField::SlotNumber,
-                    },
-                    expect: Observation {
-                        converted: Some(42),
-                        log_count: 0,
-                        counter_delta: 0.0,
-                    },
+                    scenario: "valid value",
+                    input: Some(42),
+                    expect: Ok(Some(42)),
                 },
                 Check {
-                    scenario: "absent tray index",
-                    input: ConversionCase {
-                        value: None,
-                        field: RmsLocationField::TrayIndex,
-                    },
-                    expect: Observation {
-                        converted: None,
-                        log_count: 0,
-                        counter_delta: 0.0,
-                    },
+                    scenario: "absent value",
+                    input: None,
+                    expect: Ok(None),
                 },
                 Check {
-                    scenario: "slot number outside i32",
-                    input: ConversionCase {
-                        value: Some(i32::MAX as u32 + 1),
-                        field: RmsLocationField::SlotNumber,
-                    },
-                    expect: Observation {
-                        converted: None,
-                        log_count: 1,
-                        counter_delta: 1.0,
-                    },
+                    scenario: "first value outside i32",
+                    input: Some(i32::MAX as u32 + 1),
+                    expect: Err(i32::MAX as u32 + 1),
                 },
                 Check {
-                    scenario: "tray index outside i32",
-                    input: ConversionCase {
-                        value: Some(u32::MAX),
-                        field: RmsLocationField::TrayIndex,
-                    },
-                    expect: Observation {
-                        converted: None,
-                        log_count: 1,
-                        counter_delta: 1.0,
-                    },
+                    scenario: "largest value outside i32",
+                    input: Some(u32::MAX),
+                    expect: Err(u32::MAX),
                 },
             ],
-            |ConversionCase { value, field }| {
-                let failure_stage_label = match field {
-                    RmsLocationField::SlotNumber => "slot_number_out_of_range",
-                    RmsLocationField::TrayIndex => "tray_index_out_of_range",
-                };
-                let metrics = MetricsCapture::start();
-                let mut converted = None;
-                let logs = capture_logs(|| {
-                    converted = rms_location_value(value, field);
-                });
-
-                Observation {
-                    converted,
-                    log_count: logs.len(),
-                    counter_delta: metrics
-                        .counter_delta(METRIC, &[("failure_stage", failure_stage_label)]),
-                }
-            },
+            rms_location_value,
         );
     }
 

--- a/crates/switch-controller/src/fetch_info.rs
+++ b/crates/switch-controller/src/fetch_info.rs
@@ -157,21 +157,6 @@ impl SwitchSlotTrayPersistenceFailed {
     }
 }
 
-fn emit_switch_slot_tray_backend_response_failure(
-    error: Option<&str>,
-    switch_id: &SwitchId,
-    backend: &str,
-) {
-    let Some(error) = error else {
-        return;
-    };
-    emit(SwitchSlotTrayBackendLookupFailed::response(
-        error.to_string(),
-        switch_id,
-        backend,
-    ));
-}
-
 /// Handles the FetchInfo state for a switch.
 pub async fn handle_fetch_info(
     switch_id: &SwitchId,
@@ -195,11 +180,13 @@ pub async fn handle_fetch_info(
             {
                 Ok(results) => {
                     if let Some(result) = results.into_iter().next() {
-                        emit_switch_slot_tray_backend_response_failure(
-                            result.error.as_deref(),
-                            switch_id,
-                            component_manager.nv_switch.name(),
-                        );
+                        if let Some(error) = result.error.as_deref() {
+                            emit(SwitchSlotTrayBackendLookupFailed::response(
+                                error.to_string(),
+                                switch_id,
+                                component_manager.nv_switch.name(),
+                            ));
+                        }
                         let mut update_txn = ctx.services.db_pool.begin().await?;
                         if let Err(e) = db::switch::update_slot_and_tray(
                             &mut update_txn,
@@ -379,11 +366,11 @@ mod tests {
                         ));
                     }
                     FailureCase::BackendResponse => {
-                        emit_switch_slot_tray_backend_response_failure(
-                            Some(ERROR),
+                        emit(SwitchSlotTrayBackendLookupFailed::response(
+                            ERROR.to_string(),
                             &switch_id,
                             "rms",
-                        );
+                        ));
                     }
                     FailureCase::DatabaseUpdate => {
                         emit(SwitchSlotTrayPersistenceFailed::new(

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -52,6 +52,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dhcp_dropped_requests_total</td><td>counter</td><td>Number of DHCP packets dropped without a reply, by drop reason.</td></tr>
 <tr><td>carbide_dhcp_replies_sent_total</td><td>counter</td><td>Number of DHCP replies sent, by reply message type.</td></tr>
 <tr><td>carbide_dhcp_requests_total</td><td>counter</td><td>Number of DHCP packets received and decoded, by DHCP message type.</td></tr>
+<tr><td>carbide_dhcp_socket_setup_failures_total</td><td>counter</td><td>Number of DHCP socket setup failures, by operation and next action.</td></tr>
 <tr><td>carbide_dhcp_timestamp_file_failures_total</td><td>counter</td><td>Number of DHCP timestamp file failures, by operation</td></tr>
 <tr><td>carbide_dhcp_v6_replies_sent_total</td><td>counter</td><td>Number of DHCPv6 replies sent, by response message type.</td></tr>
 <tr><td>carbide_dns_negative_cache_hit_count_total</td><td>counter</td><td>Number of negative DNS cache hits, by response code</td></tr>
@@ -62,6 +63,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_dpa_monitor_iteration_latency_milliseconds</td><td>histogram</td><td>Time consumed for one monitor iteration</td></tr>
 <tr><td>carbide_dpa_monitor_operations_latency_milliseconds</td><td>histogram</td><td>Time consumed for one operation</td></tr>
 <tr><td>carbide_dpu_agent_report_total</td><td>counter</td><td>Number of DPU-agent report-loop iterations, by loop and outcome</td></tr>
+<tr><td>carbide_dpu_agent_service_restart_attempts_total</td><td>counter</td><td>Number of DPU-agent service restart attempts, by service and result.</td></tr>
 <tr><td>carbide_dpu_agent_version_count</td><td>gauge</td><td>Number of DPU agents which have reported a certain version.</td></tr>
 <tr><td>carbide_dpu_firmware_version_count</td><td>gauge</td><td>Number of DPUs which have reported a certain firmware version.</td></tr>
 <tr><td>carbide_dpu_remediation_executor_failures_total</td><td>counter</td><td>Number of DPU remediation executor failures, by failure stage.</td></tr>
@@ -251,6 +253,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_site_explorer_update_explored_endpoints_count</td><td>gauge</td><td>Counts from the last update_explored_endpoints phase by kind</td></tr>
 <tr><td>carbide_spdm_evidence_collection_unexpected_task_states_total</td><td>counter</td><td>Number of unexpected SPDM evidence collection task states, by task state and next action.</td></tr>
 <tr><td>carbide_state_handler_wakeup_failures_total</td><td>counter</td><td>Number of times a machine&#39;s state handler could not be woken after an agent-reported event</td></tr>
+<tr><td>carbide_static_credential_watcher_failures_total</td><td>counter</td><td>Number of static credential watcher failures, by operation.</td></tr>
 <tr><td>carbide_switch_slot_tray_enrichment_failures_total</td><td>counter</td><td>Number of switch slot and tray enrichment failures, by failure stage.</td></tr>
 <tr><td>carbide_switches_enqueuer_iteration_latency_milliseconds</td><td>histogram</td><td>The overall time it took to enqueue state handling tasks for all carbide_switches in the system</td></tr>
 <tr><td>carbide_switches_health_overrides_count</td><td>gauge</td><td>Number of health overrides configured in the site</td></tr>


### PR DESCRIPTION
The LLDP and OVS loops already log every restart, and the DHCP and credential-watcher paths already explain why they retry or stop. What they were missing was a stable rate for repeated local recovery work, so operators could see a restart or setup failure building up without reconstructing it from individual logs.

While reviewing the final instrumentation wave, `emit(OvsRestartSucceeded::new())` also made a separate call-site problem pretty visible: the Event was doing the right work, but related states did not read like one family. A few conversion and mapping helpers had the opposite problem and hid `emit()` inside an otherwise ordinary-looking function.

So, this moves the local recovery paths onto Events and makes the final-wave emission sites explicit. LLDP and OVS share one bounded restart-attempt counter; DHCP socket setup and live credential-watcher failures get their own bounded labels. The agent's related restart and report cases use semantic variants, pure helpers return data, and the RMS, Site Explorer, switch, IB fabric, and machine-identity branches emit where the diagnostic decision is made. The call-site cleanup leaves existing Event names, metric names, log levels, messages, field kinds, retry decisions, and return behavior unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4154

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

A closed credential-watch receiver remains the existing plain warning because it represents shutdown, not a recoverable live failure. `new()` remains appropriate when the Event type already says exactly what happened; semantic variants are reserved for related cases that share hidden labels. The generated core metric catalogue stays with this code change.

Closes #4154
