### PR TITLE
feat: instrument resource pool lifecycle failures

### DIFF
--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -177,15 +177,25 @@ pub async fn create_initial_vpcs(
             .organization_id
             .clone()
             .unwrap_or(uuid::Uuid::new_v4().into());
+        let owner_id = vpc_id.to_string();
 
         let vni = db::resource_pool::allocate(
             vni_pool,
             &mut txn,
             resource_pool::OwnerType::Vpc,
-            vpc_id.to_string().as_ref(),
+            &owner_id,
             def.vni,
         )
-        .await?;
+        .await
+        .inspect_err(|error| {
+            db::resource_pool::emit_allocation_failure(
+                vni_pool.value_type,
+                &owner_id,
+                def.vni.is_some(),
+                vni_pool.name(),
+                error,
+            );
+        })?;
 
         let vpc = NewVpc {
             id: vpc_id,

--- a/crates/api-core/src/handlers/ib_partition.rs
+++ b/crates/api-core/src/handlers/ib_partition.rs
@@ -309,24 +309,50 @@ async fn allocate_pkey(
     owner_id: &str,
     requested_pkey: Option<u16>,
 ) -> Result<Option<PartitionKey>, CarbideError> {
-    match db::resource_pool::allocate(api
-            .common_pools
-            .infiniband
-            .pkey_pools
-            .get(DEFAULT_IB_FABRIC_NAME)
-            .ok_or_else(|| CarbideError::internal("IB fabric is not configured".to_string()))?, txn, resource_pool::OwnerType::IBPartition, owner_id, requested_pkey)
-            .await
-        {
-            Ok(val) => Ok(Some(
-                PartitionKey::try_from(val)
-                .map_err(|_| CarbideError::internal(format!("partition key {val} return from pool is not a valid pkey. pool definition is invalid")))?)),
-            Err(ResourcePoolDatabaseError::ResourcePool(resource_pool::ResourcePoolError::Empty)) => {
-                tracing::error!(owner_id, pool = "pkey", "Pool exhausted, cannot allocate");
-                Err(CarbideError::ResourceExhausted("pool pkey".to_string()))
-            }
-            Err(err) => {
-                tracing::error!(owner_id, error = %err, pool = "pkey", "Error allocating from resource pool");
-                Err(err.into())
-            }
+    let source_pool = api
+        .common_pools
+        .infiniband
+        .pkey_pools
+        .get(DEFAULT_IB_FABRIC_NAME)
+        .ok_or_else(|| CarbideError::internal("IB fabric is not configured".to_string()))?;
+
+    match db::resource_pool::allocate(
+        source_pool,
+        txn,
+        resource_pool::OwnerType::IBPartition,
+        owner_id,
+        requested_pkey,
+    )
+    .await
+    {
+        Ok(val) => Ok(Some(PartitionKey::try_from(val).map_err(|_| {
+            CarbideError::internal(format!(
+                "partition key {val} return from pool is not a valid pkey. pool definition is invalid"
+            ))
+        })?)),
+        Err(error @ ResourcePoolDatabaseError::ResourcePool(
+            resource_pool::ResourcePoolError::Empty,
+        )) => {
+            db::resource_pool::emit_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                requested_pkey.is_some(),
+                "pkey",
+                &error,
+            );
+            Err(CarbideError::ResourceExhausted(
+                "pool pkey".to_string(),
+            ))
         }
+        Err(err) => {
+            db::resource_pool::emit_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                requested_pkey.is_some(),
+                "pkey",
+                &err,
+            );
+            Err(err.into())
+        }
+    }
 }

--- a/crates/api-core/src/handlers/network_segment.rs
+++ b/crates/api-core/src/handlers/network_segment.rs
@@ -417,14 +417,28 @@ pub async fn allocate_vni(
     .await
     {
         Ok(val) => Ok(val),
-        Err(ResourcePoolDatabaseError::ResourcePool(
-            model::resource_pool::ResourcePoolError::Empty,
-        )) => {
-            tracing::error!(owner_id, pool = "vni", "Pool exhausted, cannot allocate");
+        Err(
+            error @ ResourcePoolDatabaseError::ResourcePool(
+                model::resource_pool::ResourcePoolError::Empty,
+            ),
+        ) => {
+            db::resource_pool::emit_allocation_failure(
+                api.common_pools.ethernet.pool_vni.value_type,
+                owner_id,
+                false,
+                "vni",
+                &error,
+            );
             Err(CarbideError::ResourceExhausted("pool vni".to_string()))
         }
         Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = "vni", "Error allocating from resource pool");
+            db::resource_pool::emit_allocation_failure(
+                api.common_pools.ethernet.pool_vni.value_type,
+                owner_id,
+                false,
+                "vni",
+                &err,
+            );
             Err(err.into())
         }
     }
@@ -448,18 +462,28 @@ pub async fn allocate_vlan_id(
     .await
     {
         Ok(val) => Ok(val),
-        Err(ResourcePoolDatabaseError::ResourcePool(
-            model::resource_pool::ResourcePoolError::Empty,
-        )) => {
-            tracing::error!(
+        Err(
+            error @ ResourcePoolDatabaseError::ResourcePool(
+                model::resource_pool::ResourcePoolError::Empty,
+            ),
+        ) => {
+            db::resource_pool::emit_allocation_failure(
+                api.common_pools.ethernet.pool_vlan_id.value_type,
                 owner_id,
-                pool = "vlan_id",
-                "Pool exhausted, cannot allocate"
+                false,
+                "vlan_id",
+                &error,
             );
             Err(CarbideError::ResourceExhausted("pool vlan_id".to_string()))
         }
         Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = "vlan_id", "Error allocating from resource pool");
+            db::resource_pool::emit_allocation_failure(
+                api.common_pools.ethernet.pool_vlan_id.value_type,
+                owner_id,
+                false,
+                "vlan_id",
+                &err,
+            );
             Err(err.into())
         }
     }

--- a/crates/api-core/src/handlers/spx_partition.rs
+++ b/crates/api-core/src/handlers/spx_partition.rs
@@ -26,6 +26,63 @@ use tonic::{Request, Response, Status};
 use crate::CarbideError;
 use crate::api::{Api, log_request_data, log_tenant_organization_id};
 
+fn map_dpa_vni_allocation_failure(
+    source_pool: &resource_pool::ResourcePool<i32>,
+    owner_id: &str,
+    requested_vni: Option<i32>,
+    error: ResourcePoolDatabaseError,
+) -> CarbideError {
+    match (error, requested_vni) {
+        (
+            error
+            @ ResourcePoolDatabaseError::ResourcePool(resource_pool::ResourcePoolError::Empty),
+            requested_vni,
+        ) => {
+            db::resource_pool::emit_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                requested_vni.is_some(),
+                source_pool.name(),
+                &error,
+            );
+            CarbideError::ResourceExhausted(format!("pool {}", source_pool.name))
+        }
+        (error, Some(requested_vni))
+            if db::resource_pool::is_requested_value_unavailable(&error) =>
+        {
+            db::resource_pool::emit_requested_vni_unavailable(
+                source_pool.value_type,
+                owner_id,
+                requested_vni,
+                source_pool.name(),
+            );
+            CarbideError::FailedPrecondition(format!(
+                "VNI `{requested_vni}` cannot be requested or is already allocated"
+            ))
+        }
+        (ResourcePoolDatabaseError::Database(error), Some(_)) => {
+            db::resource_pool::emit_database_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                true,
+                source_pool.name(),
+                &error,
+            );
+            (*error).into()
+        }
+        (error, requested_vni) => {
+            db::resource_pool::emit_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                requested_vni.is_some(),
+                source_pool.name(),
+                &error,
+            );
+            error.into()
+        }
+    }
+}
+
 async fn allocate_dpa_vni(
     api: &Api,
     txn: &mut PgConnection,
@@ -34,7 +91,7 @@ async fn allocate_dpa_vni(
 ) -> Result<i32, CarbideError> {
     let source_pool = &api.common_pools.ethernet.pool_dpa_vni;
 
-    match db::resource_pool::allocate(
+    db::resource_pool::allocate(
         source_pool,
         txn,
         resource_pool::OwnerType::SpxPartition,
@@ -42,39 +99,7 @@ async fn allocate_dpa_vni(
         requested_vni,
     )
     .await
-    {
-        Ok(val) => Ok(val),
-        Err(ResourcePoolDatabaseError::ResourcePool(resource_pool::ResourcePoolError::Empty)) => {
-            tracing::error!(
-                owner_id,
-                pool = source_pool.name(),
-                "Pool exhausted, cannot allocate"
-            );
-            Err(CarbideError::ResourceExhausted(format!(
-                "pool {}",
-                source_pool.name
-            )))
-        }
-        Err(ResourcePoolDatabaseError::Database(e)) if requested_vni.is_some() => Err(match *e {
-            db::DatabaseError::FailedPrecondition(_s) => {
-                tracing::error!(
-                    owner_id,
-                    pool = source_pool.name(),
-                    requested_vni,
-                    "invalid pool value requested, cannot allocate"
-                );
-                CarbideError::FailedPrecondition(format!(
-                    "VNI `{}` cannot be requested or is already allocated",
-                    requested_vni.unwrap_or_default()
-                ))
-            }
-            e => e.into(),
-        }),
-        Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = source_pool.name, "Error allocating from resource pool");
-            Err(err.into())
-        }
-    }
+    .map_err(|error| map_dpa_vni_allocation_failure(source_pool, owner_id, requested_vni, error))
 }
 
 pub(crate) async fn create(
@@ -187,7 +212,260 @@ pub(crate) async fn find_by_ids(
 #[cfg(test)]
 mod tests {
     use ::rpc::forge as rpc;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
+    use db::resource_pool::ResourcePoolDatabaseError;
+    use model::resource_pool::common::DPA_VNI;
+    use model::resource_pool::{ResourcePool, ResourcePoolError, ValueType};
     use model::spx_partition::NewSpxPartition;
+    use tonic::Code;
+
+    use super::map_dpa_vni_allocation_failure;
+
+    const RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC: &str =
+        "carbide_resource_pool_lifecycle_failures_total";
+    const OWNER_ID: &str = "spx-1";
+    const PARSE_ERROR: &str = concat!(
+        "cannot convert 'not-an-integer' to dpa-vni's pool type for ",
+        "spx_partition spx-1: invalid integer"
+    );
+
+    #[derive(Debug, Clone, Copy)]
+    enum DpaVniFailureInput {
+        Exhausted,
+        RequestedUnavailable,
+        RequestedDatabase,
+        Generic,
+    }
+
+    impl DpaVniFailureInput {
+        fn error(self) -> ResourcePoolDatabaseError {
+            match self {
+                Self::Exhausted => ResourcePoolError::Empty.into(),
+                Self::RequestedUnavailable => db::DatabaseError::FailedPrecondition(
+                    "requested VNI is unavailable".to_string(),
+                )
+                .into(),
+                Self::RequestedDatabase => db::DatabaseError::Internal {
+                    message: "database unavailable".to_string(),
+                }
+                .into(),
+                Self::Generic => ResourcePoolError::Parse {
+                    e: "invalid integer".to_string(),
+                    v: "not-an-integer".to_string(),
+                    pool_name: DPA_VNI.to_string(),
+                    owner_type: "spx_partition".to_string(),
+                    owner_id: OWNER_ID.to_string(),
+                }
+                .into(),
+            }
+        }
+
+        fn failure_label(self) -> &'static str {
+            match self {
+                Self::Exhausted => "exhausted",
+                Self::RequestedUnavailable => "requested_value_unavailable",
+                Self::RequestedDatabase => "database",
+                Self::Generic => "parse",
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct DpaVniFailureCase {
+        failure: DpaVniFailureInput,
+        requested_vni: Option<i32>,
+    }
+
+    impl DpaVniFailureCase {
+        fn allocation_mode(self) -> &'static str {
+            if self.requested_vni.is_some() {
+                "requested"
+            } else {
+                "automatic"
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct DpaVniFailureObservation {
+        status_code: Code,
+        status_message: String,
+        metadata_name: String,
+        level: tracing::Level,
+        message: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        operation: Option<String>,
+        failure: Option<String>,
+        failure_policy: Option<String>,
+        allocation_mode: Option<String>,
+        value_type: Option<String>,
+        owner_id: Option<String>,
+        pool: Option<String>,
+        requested_vni: Option<String>,
+        error: Option<String>,
+        counter_delta: f64,
+    }
+
+    #[test]
+    fn dpa_vni_failure_mapper_preserves_status_and_event_contract() {
+        check_values(
+            [
+                Check {
+                    scenario: "pool exhaustion",
+                    input: DpaVniFailureCase {
+                        failure: DpaVniFailureInput::Exhausted,
+                        requested_vni: None,
+                    },
+                    expect: DpaVniFailureObservation {
+                        status_code: Code::ResourceExhausted,
+                        status_message: "pool dpa-vni".to_string(),
+                        metadata_name: "resource_pool_exhausted".to_string(),
+                        level: tracing::Level::ERROR,
+                        message: "Pool exhausted, cannot allocate".to_string(),
+                        event_name: Some("resource_pool_exhausted".to_string()),
+                        metric_name: Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string()),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("exhausted".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("automatic".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some(OWNER_ID.to_string()),
+                        pool: Some(DPA_VNI.to_string()),
+                        requested_vni: None,
+                        error: None,
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "requested VNI unavailable",
+                    input: DpaVniFailureCase {
+                        failure: DpaVniFailureInput::RequestedUnavailable,
+                        requested_vni: Some(42),
+                    },
+                    expect: DpaVniFailureObservation {
+                        status_code: Code::FailedPrecondition,
+                        status_message: "VNI `42` cannot be requested or is already allocated"
+                            .to_string(),
+                        metadata_name: "resource_pool_requested_vni_unavailable".to_string(),
+                        level: tracing::Level::ERROR,
+                        message: "invalid pool value requested, cannot allocate".to_string(),
+                        event_name: Some("resource_pool_requested_vni_unavailable".to_string()),
+                        metric_name: Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string()),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("requested_value_unavailable".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("requested".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some(OWNER_ID.to_string()),
+                        pool: Some(DPA_VNI.to_string()),
+                        requested_vni: Some("42".to_string()),
+                        error: None,
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "requested VNI database failure",
+                    input: DpaVniFailureCase {
+                        failure: DpaVniFailureInput::RequestedDatabase,
+                        requested_vni: Some(42),
+                    },
+                    expect: DpaVniFailureObservation {
+                        status_code: Code::Internal,
+                        status_message: "internal error: database unavailable".to_string(),
+                        metadata_name: "resource_pool_allocation_failed".to_string(),
+                        level: tracing::Level::ERROR,
+                        message: "Error allocating from resource pool".to_string(),
+                        event_name: Some("resource_pool_allocation_failed".to_string()),
+                        metric_name: Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string()),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("database".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("requested".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some(OWNER_ID.to_string()),
+                        pool: Some(DPA_VNI.to_string()),
+                        requested_vni: None,
+                        error: Some("internal error: database unavailable".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "generic allocation failure",
+                    input: DpaVniFailureCase {
+                        failure: DpaVniFailureInput::Generic,
+                        requested_vni: None,
+                    },
+                    expect: DpaVniFailureObservation {
+                        status_code: Code::Internal,
+                        status_message: format!("resource pool database error: {PARSE_ERROR}"),
+                        metadata_name: "resource_pool_allocation_failed".to_string(),
+                        level: tracing::Level::ERROR,
+                        message: "Error allocating from resource pool".to_string(),
+                        event_name: Some("resource_pool_allocation_failed".to_string()),
+                        metric_name: Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string()),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("parse".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("automatic".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some(OWNER_ID.to_string()),
+                        pool: Some(DPA_VNI.to_string()),
+                        requested_vni: None,
+                        error: Some(PARSE_ERROR.to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |input| {
+                let source_pool = ResourcePool::<i32>::new(DPA_VNI.to_string(), ValueType::Integer);
+                let metrics = MetricsCapture::start();
+                let mut mapped_error = None;
+                let logs = capture_logs(|| {
+                    mapped_error = Some(map_dpa_vni_allocation_failure(
+                        &source_pool,
+                        OWNER_ID,
+                        input.requested_vni,
+                        input.failure.error(),
+                    ));
+                });
+                let status =
+                    tonic::Status::from(mapped_error.expect("failure mapper returns an error"));
+                assert_eq!(logs.len(), 1);
+                let log = &logs[0];
+
+                DpaVniFailureObservation {
+                    status_code: status.code(),
+                    status_message: status.message().to_string(),
+                    metadata_name: log.metadata_name.clone(),
+                    level: log.level,
+                    message: log.message.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    operation: log.field("operation").map(str::to_string),
+                    failure: log.field("failure").map(str::to_string),
+                    failure_policy: log.field("failure_policy").map(str::to_string),
+                    allocation_mode: log.field("allocation_mode").map(str::to_string),
+                    value_type: log.field("value_type").map(str::to_string),
+                    owner_id: log.field("owner_id").map(str::to_string),
+                    pool: log.field("pool").map(str::to_string),
+                    requested_vni: log.field("requested_vni").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    counter_delta: metrics.counter_delta(
+                        RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC,
+                        &[
+                            ("operation", "allocate"),
+                            ("failure", input.failure.failure_label()),
+                            ("failure_policy", "required"),
+                            ("allocation_mode", input.allocation_mode()),
+                            ("value_type", "integer"),
+                        ],
+                    ),
+                }
+            },
+        );
+    }
 
     #[test]
     fn test_create_spx_partition_valid_request() {

--- a/crates/api-core/src/handlers/vpc.rs
+++ b/crates/api-core/src/handlers/vpc.rs
@@ -414,44 +414,70 @@ async fn allocate_vpc_vni(
         &api.common_pools.ethernet.pool_external_vpc_vni
     };
 
-    match db::resource_pool::allocate(
-        source_pool,
-        txn,
-        resource_pool::OwnerType::Vpc,
-        owner_id,
+    match (
+        db::resource_pool::allocate(
+            source_pool,
+            txn,
+            resource_pool::OwnerType::Vpc,
+            owner_id,
+            requested_vni,
+        )
+        .await,
         requested_vni,
-    )
-    .await
-    {
-        Ok(val) => Ok(val),
-        Err(ResourcePoolDatabaseError::ResourcePool(resource_pool::ResourcePoolError::Empty)) => {
-            tracing::error!(
+    ) {
+        (Ok(val), _) => Ok(val),
+        (
+            Err(
+                error @ ResourcePoolDatabaseError::ResourcePool(
+                    resource_pool::ResourcePoolError::Empty,
+                ),
+            ),
+            requested_vni,
+        ) => {
+            db::resource_pool::emit_allocation_failure(
+                source_pool.value_type,
                 owner_id,
-                pool = source_pool.name(),
-                "Pool exhausted, cannot allocate"
+                requested_vni.is_some(),
+                source_pool.name(),
+                &error,
             );
             Err(CarbideError::ResourceExhausted(format!(
                 "pool {}",
                 source_pool.name
             )))
         }
-        Err(ResourcePoolDatabaseError::Database(e)) if requested_vni.is_some() => Err(match *e {
-            db::DatabaseError::FailedPrecondition(_s) => {
-                tracing::error!(
-                    owner_id,
-                    pool = source_pool.name(),
-                    requested_vni,
-                    "invalid pool value requested, cannot allocate"
-                );
-                CarbideError::FailedPrecondition(format!(
-                    "VNI `{}` cannot be requested or is already allocated",
-                    requested_vni.unwrap_or_default()
-                ))
-            }
-            e => e.into(),
-        }),
-        Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = source_pool.name, "Error allocating from resource pool");
+        (Err(error), Some(requested_vni))
+            if db::resource_pool::is_requested_value_unavailable(&error) =>
+        {
+            db::resource_pool::emit_requested_vni_unavailable(
+                source_pool.value_type,
+                owner_id,
+                requested_vni,
+                source_pool.name(),
+            );
+            Err(CarbideError::FailedPrecondition(format!(
+                "VNI `{}` cannot be requested or is already allocated",
+                requested_vni
+            )))
+        }
+        (Err(ResourcePoolDatabaseError::Database(error)), Some(_)) => {
+            db::resource_pool::emit_database_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                true,
+                source_pool.name(),
+                &error,
+            );
+            Err((*error).into())
+        }
+        (Err(err), requested_vni) => {
+            db::resource_pool::emit_allocation_failure(
+                source_pool.value_type,
+                owner_id,
+                requested_vni.is_some(),
+                source_pool.name(),
+                &err,
+            );
             Err(err.into())
         }
     }

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -22,7 +22,10 @@ use std::fmt::Display;
 use std::str::FromStr;
 use std::time::Duration;
 
+use carbide_instrument::testing::{MetricsCapture, capture_logs_async};
 use carbide_network::virtualization::VpcVirtualizationType;
+use carbide_test_support::Outcome::Yields;
+use carbide_test_support::{Case, check_cases_async};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use common::network_segment::{
@@ -41,7 +44,7 @@ use model::network_segment::{
     NetworkSegmentDeletionState, NetworkSegmentType, NewNetworkSegment,
 };
 use model::resource_pool::common::VLANID;
-use model::resource_pool::{ResourcePool, ResourcePoolStats, ValueType};
+use model::resource_pool::{ResourcePool, ResourcePoolError, ResourcePoolStats, ValueType};
 use model::vpc::{NewVpc, UpdateVpcVirtualization, VpcDefinition, VpcStatus};
 use prometheus_text_parser::ParsedPrometheusMetrics;
 use rpc::Metadata;
@@ -729,6 +732,208 @@ pub async fn test_create_initial_vpc_and_attached_network(
         1,
         "second create_initial_vpcs should not create duplicate VPCs"
     );
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum InitialVpcAllocationFailure {
+    Exhausted,
+    RequestedUnavailable,
+}
+
+impl InitialVpcAllocationFailure {
+    fn pool_name(self) -> &'static str {
+        match self {
+            Self::Exhausted => "initial-vpc-empty",
+            Self::RequestedUnavailable => "initial-vpc-requested",
+        }
+    }
+
+    fn requested_vni(self) -> Option<i32> {
+        match self {
+            Self::Exhausted => None,
+            Self::RequestedUnavailable => Some(42),
+        }
+    }
+
+    fn metric_labels(self) -> [(&'static str, &'static str); 5] {
+        match self {
+            Self::Exhausted => [
+                ("operation", "allocate"),
+                ("failure", "exhausted"),
+                ("failure_policy", "required"),
+                ("allocation_mode", "automatic"),
+                ("value_type", "integer"),
+            ],
+            Self::RequestedUnavailable => [
+                ("operation", "allocate"),
+                ("failure", "requested_value_unavailable"),
+                ("failure_policy", "required"),
+                ("allocation_mode", "requested"),
+                ("value_type", "integer"),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct InitialVpcAllocationFailureRecord {
+    error_kind: &'static str,
+    error_message: String,
+    metadata_name: String,
+    event_name: Option<String>,
+    metric_name: Option<String>,
+    level: tracing::Level,
+    message: String,
+    operation: Option<String>,
+    failure: Option<String>,
+    failure_policy: Option<String>,
+    allocation_mode: Option<String>,
+    value_type: Option<String>,
+    owner_id_is_vpc: bool,
+    pool: Option<String>,
+    error: Option<String>,
+    counter_delta: f64,
+}
+
+#[crate::sqlx_test]
+async fn initial_vpc_allocation_failures_preserve_errors_and_emit(
+    db_pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    const LIFECYCLE_FAILURES_METRIC: &str = "carbide_resource_pool_lifecycle_failures_total";
+
+    check_cases_async(
+        [
+            Case {
+                scenario: "automatic pool exhaustion",
+                input: InitialVpcAllocationFailure::Exhausted,
+                expect: Yields(InitialVpcAllocationFailureRecord {
+                    error_kind: "resource_pool_empty",
+                    error_message:
+                        "resource pool database error: resource pool is empty, cannot allocate"
+                            .to_string(),
+                    metadata_name: "resource_pool_exhausted".to_string(),
+                    event_name: Some("resource_pool_exhausted".to_string()),
+                    metric_name: Some(LIFECYCLE_FAILURES_METRIC.to_string()),
+                    level: tracing::Level::ERROR,
+                    message: "Pool exhausted, cannot allocate".to_string(),
+                    operation: Some("allocate".to_string()),
+                    failure: Some("exhausted".to_string()),
+                    failure_policy: Some("required".to_string()),
+                    allocation_mode: Some("automatic".to_string()),
+                    value_type: Some("integer".to_string()),
+                    owner_id_is_vpc: true,
+                    pool: Some("initial-vpc-empty".to_string()),
+                    error: None,
+                    counter_delta: 1.0,
+                }),
+            },
+            Case {
+                scenario: "requested VNI unavailable",
+                input: InitialVpcAllocationFailure::RequestedUnavailable,
+                expect: Yields(InitialVpcAllocationFailureRecord {
+                    error_kind: "requested_value_unavailable",
+                    error_message: "resource pool database error: `42` not an available value for resource-pool `initial-vpc-requested`".to_string(),
+                    metadata_name: "resource_pool_allocation_failed".to_string(),
+                    event_name: Some("resource_pool_allocation_failed".to_string()),
+                    metric_name: Some(LIFECYCLE_FAILURES_METRIC.to_string()),
+                    level: tracing::Level::ERROR,
+                    message: "Error allocating from resource pool".to_string(),
+                    operation: Some("allocate".to_string()),
+                    failure: Some("requested_value_unavailable".to_string()),
+                    failure_policy: Some("required".to_string()),
+                    allocation_mode: Some("requested".to_string()),
+                    value_type: Some("integer".to_string()),
+                    owner_id_is_vpc: true,
+                    pool: Some("initial-vpc-requested".to_string()),
+                    error: Some(
+                        "`42` not an available value for resource-pool `initial-vpc-requested`"
+                            .to_string(),
+                    ),
+                    counter_delta: 1.0,
+                }),
+            },
+        ],
+        |failure| {
+            let db_pool = db_pool.clone();
+            async move {
+                let source_pool =
+                    ResourcePool::<i32>::new(failure.pool_name().to_string(), ValueType::Integer);
+                if matches!(failure, InitialVpcAllocationFailure::RequestedUnavailable) {
+                    let mut txn = db_pool.begin().await.expect("begin seed transaction");
+                    db::resource_pool::populate(&source_pool, &mut txn, vec![43], false)
+                        .await
+                        .expect("seed a different requestable VNI");
+                    txn.commit().await.expect("commit seed transaction");
+                }
+
+                let vpcs = HashMap::from([(
+                    format!("{}-vpc", failure.pool_name()),
+                    VpcDefinition {
+                        organization_id: Some(FIXTURE_TENANT_ORG_ID.to_string()),
+                        network_virtualization_type: VpcVirtualizationType::Flat,
+                        routing_profile_type: None,
+                        vni: failure.requested_vni(),
+                    },
+                )]);
+                let metrics = MetricsCapture::start();
+                let (result, logs) = capture_logs_async(crate::db_init::create_initial_vpcs(
+                    &db_pool,
+                    &vpcs,
+                    &source_pool,
+                ))
+                .await;
+                let returned_error = result.expect_err("initial VPC allocation must fail");
+                let error_kind = match &returned_error {
+                    crate::CarbideError::ResourcePoolDatabaseError(
+                        db::resource_pool::ResourcePoolDatabaseError::ResourcePool(
+                            ResourcePoolError::Empty,
+                        ),
+                    ) => "resource_pool_empty",
+                    crate::CarbideError::ResourcePoolDatabaseError(
+                        db::resource_pool::ResourcePoolDatabaseError::Database(error),
+                    ) if matches!(error.as_ref(), db::DatabaseError::FailedPrecondition(_)) => {
+                        "requested_value_unavailable"
+                    }
+                    error => panic!("unexpected initial VPC allocation error: {error:?}"),
+                };
+                let event_logs = logs
+                    .iter()
+                    .filter(|log| {
+                        log.field("metric_name") == Some(LIFECYCLE_FAILURES_METRIC)
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(event_logs.len(), 1);
+                let log = event_logs[0];
+
+                Ok::<_, ()>(InitialVpcAllocationFailureRecord {
+                    error_kind,
+                    error_message: returned_error.to_string(),
+                    metadata_name: log.metadata_name.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    level: log.level,
+                    message: log.message.clone(),
+                    operation: log.field("operation").map(str::to_string),
+                    failure: log.field("failure").map(str::to_string),
+                    failure_policy: log.field("failure_policy").map(str::to_string),
+                    allocation_mode: log.field("allocation_mode").map(str::to_string),
+                    value_type: log.field("value_type").map(str::to_string),
+                    owner_id_is_vpc: log
+                        .field("owner_id")
+                        .is_some_and(|owner_id| VpcId::from_str(owner_id).is_ok()),
+                    pool: log.field("pool").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    counter_delta: metrics.counter_delta(
+                        LIFECYCLE_FAILURES_METRIC,
+                        &failure.metric_labels(),
+                    ),
+                })
+            }
+        },
+    )
+    .await;
 
     Ok(())
 }

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -1577,10 +1577,10 @@ pub async fn create(
             {
                 Ok(asn) => Some(asn as i64),
                 Err(e) => {
-                    tracing::info!(
-                        stable_machine_id = %stable_machine_id,
-                        error = %e,
-                        "Failed to allocate asn for dpu",
+                    crate::resource_pool::emit_best_effort_dpu_asn_allocation_failure(
+                        common_pools.ethernet.pool_fnn_asn.value_type,
+                        &stable_machine_id_string,
+                        &e,
                     );
                     None
                 }
@@ -2294,14 +2294,28 @@ pub async fn allocate_loopback_ip(
     .await
     {
         Ok(val) => Ok(val),
-        Err(crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
-            ResourcePoolError::Empty,
-        )) => {
-            tracing::error!(owner_id, pool = "lo-ip", "Pool exhausted, cannot allocate");
+        Err(
+            error @ crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
+                ResourcePoolError::Empty,
+            ),
+        ) => {
+            crate::resource_pool::emit_allocation_failure(
+                common_pools.ethernet.pool_loopback_ip.value_type,
+                owner_id,
+                false,
+                "lo-ip",
+                &error,
+            );
             Err(DatabaseError::ResourceExhausted("pool lo-ip".to_string()))
         }
         Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = "lo-ip", "Error allocating from resource pool");
+            crate::resource_pool::emit_allocation_failure(
+                common_pools.ethernet.pool_loopback_ip.value_type,
+                owner_id,
+                false,
+                "lo-ip",
+                &err,
+            );
             Err(err.into())
         }
     }
@@ -2325,20 +2339,30 @@ pub async fn allocate_vpc_dpu_loopback(
     .await
     {
         Ok(val) => Ok(val),
-        Err(crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
-            resource_pool::ResourcePoolError::Empty,
-        )) => {
-            tracing::error!(
+        Err(
+            error @ crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
+                resource_pool::ResourcePoolError::Empty,
+            ),
+        ) => {
+            crate::resource_pool::emit_allocation_failure(
+                common_pools.ethernet.pool_vpc_dpu_loopback_ip.value_type,
                 owner_id,
-                pool = "vpc-dpu-lo-ip",
-                "Pool exhausted, cannot allocate"
+                false,
+                "vpc-dpu-lo-ip",
+                &error,
             );
             Err(DatabaseError::ResourceExhausted(
                 "pool vpc-dpu-lo-ip".to_string(),
             ))
         }
         Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = "lo-ip", "Error allocating from resource pool");
+            crate::resource_pool::emit_allocation_failure(
+                common_pools.ethernet.pool_vpc_dpu_loopback_ip.value_type,
+                owner_id,
+                false,
+                "vpc-dpu-lo-ip",
+                &err,
+            );
             Err(err.into())
         }
     }
@@ -2360,20 +2384,30 @@ pub async fn allocate_secondary_vtep_ip(
     .await
     {
         Ok(val) => Ok(val),
-        Err(crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
-            resource_pool::ResourcePoolError::Empty,
-        )) => {
-            tracing::error!(
+        Err(
+            error @ crate::resource_pool::ResourcePoolDatabaseError::ResourcePool(
+                resource_pool::ResourcePoolError::Empty,
+            ),
+        ) => {
+            crate::resource_pool::emit_allocation_failure(
+                common_pools.ethernet.pool_secondary_vtep_ip.value_type,
                 owner_id,
-                pool = "secondary-vtep-ip",
-                "Pool exhausted, cannot allocate"
+                false,
+                "secondary-vtep-ip",
+                &error,
             );
             Err(DatabaseError::ResourceExhausted(
                 "pool secondary-vtep-ip".to_string(),
             ))
         }
         Err(err) => {
-            tracing::error!(owner_id, error = %err, pool = "secondary-vtep-ip", "Error allocating from resource pool");
+            crate::resource_pool::emit_allocation_failure(
+                common_pools.ethernet.pool_secondary_vtep_ip.value_type,
+                owner_id,
+                false,
+                "secondary-vtep-ip",
+                &err,
+            );
             Err(err.into())
         }
     }
@@ -2868,9 +2902,12 @@ pub fn count_healthy_unhealthy_host_machines(
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::net::IpAddr;
     use std::str::FromStr;
+    use std::sync::{Arc, Mutex};
 
+    use carbide_instrument::testing::{MetricsCapture, capture_logs_async};
     use carbide_uuid::machine::{MachineId, MachineInterfaceId};
     use carbide_uuid::network::NetworkSegmentId;
     use model::allocation_type::AllocationType;
@@ -2879,6 +2916,104 @@ mod test {
     use model::machine::ManagedHostState;
     use model::machine::machine_search_config::MachineSearchConfig;
     use model::machine::topology::{DiscoveryData, TopologyData};
+    use model::resource_pool::common::{
+        CommonPools, DPA_VNI, EXTERNAL_VPC_VNI, EthernetPools, FNN_ASN, IbPools, LOOPBACK_IP,
+        SECONDARY_VTEP_IP, VLANID, VNI, VPC_DPU_LOOPBACK, VPC_VNI,
+    };
+    use model::resource_pool::{ResourcePool, ValueType};
+    use tokio::sync::oneshot;
+
+    fn common_pools_without_seeded_values() -> CommonPools {
+        let (stop_sender, _stop_receiver) = oneshot::channel();
+        CommonPools {
+            ethernet: EthernetPools {
+                pool_loopback_ip: Arc::new(ResourcePool::new(
+                    LOOPBACK_IP.to_string(),
+                    ValueType::Ipv4,
+                )),
+                pool_vlan_id: Arc::new(ResourcePool::new(VLANID.to_string(), ValueType::Integer)),
+                pool_vni: Arc::new(ResourcePool::new(VNI.to_string(), ValueType::Integer)),
+                pool_vpc_vni: Arc::new(ResourcePool::new(VPC_VNI.to_string(), ValueType::Integer)),
+                pool_external_vpc_vni: Arc::new(ResourcePool::new(
+                    EXTERNAL_VPC_VNI.to_string(),
+                    ValueType::Integer,
+                )),
+                pool_dpa_vni: Arc::new(ResourcePool::new(DPA_VNI.to_string(), ValueType::Integer)),
+                pool_fnn_asn: Arc::new(ResourcePool::new(FNN_ASN.to_string(), ValueType::Integer)),
+                pool_vpc_dpu_loopback_ip: Arc::new(ResourcePool::new(
+                    VPC_DPU_LOOPBACK.to_string(),
+                    ValueType::Ipv4,
+                )),
+                pool_secondary_vtep_ip: Arc::new(ResourcePool::new(
+                    SECONDARY_VTEP_IP.to_string(),
+                    ValueType::Ipv4,
+                )),
+            },
+            infiniband: IbPools::default(),
+            pool_stats: Arc::new(Mutex::new(HashMap::new())),
+            _stop_sender: stop_sender,
+        }
+    }
+
+    // `capture_logs_async` wraps only `machine::create`, whose awaits all use
+    // this connection. No unrelated work runs while the connection is held.
+    #[allow(txn_held_across_await)]
+    #[crate::sqlx_test]
+    async fn dpu_creation_keeps_exhausted_fnn_asn_nonfatal(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        const RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC: &str =
+            "carbide_resource_pool_lifecycle_failures_total";
+
+        let common_pools = common_pools_without_seeded_values();
+        let dpu_id =
+            MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")?;
+        let mut connection = pool.acquire().await?;
+        let metrics = MetricsCapture::start();
+
+        let (machine, logs) = capture_logs_async(super::create(
+            connection.as_mut(),
+            Some(&common_pools),
+            &dpu_id,
+            ManagedHostState::Ready,
+            None,
+            2,
+        ))
+        .await;
+        let machine = machine?;
+
+        assert_eq!(machine.asn, None);
+        let event_logs = logs
+            .iter()
+            .filter(|log| log.metadata_name == "dpu_asn_allocation_failed")
+            .collect::<Vec<_>>();
+        assert_eq!(event_logs.len(), 1);
+        let log = event_logs[0];
+        assert_eq!(log.level, tracing::Level::INFO);
+        assert_eq!(log.message, "Failed to allocate asn for dpu");
+        assert_eq!(
+            log.field("stable_machine_id"),
+            Some(dpu_id.to_string().as_str())
+        );
+        assert_eq!(log.field("failure"), Some("exhausted"));
+        assert_eq!(log.field("failure_policy"), Some("best_effort"));
+        assert_eq!(log.field("allocation_mode"), Some("automatic"));
+        assert_eq!(
+            metrics.counter_delta(
+                RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC,
+                &[
+                    ("operation", "allocate"),
+                    ("failure", "exhausted"),
+                    ("failure_policy", "best_effort"),
+                    ("allocation_mode", "automatic"),
+                    ("value_type", "integer"),
+                ],
+            ),
+            1.0
+        );
+
+        Ok(())
+    }
 
     /// The machine snapshot reports the BMC IP from the *live* `machine_interface_addresses`
     /// row, and reports `None` once that address is gone -- it must never fall back to the

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -19,6 +19,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
+use carbide_instrument::{Event, LabelValue, emit};
 use config_version::ConfigVersion;
 use ipnetwork::Ipv6Network;
 use model::resource_pool;
@@ -37,6 +38,196 @@ use tokio::sync::oneshot;
 use super::BIND_LIMIT;
 use crate::DatabaseError;
 use crate::db_read::DbReader;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ResourcePoolOperation {
+    Allocate,
+    Release,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ResourcePoolFailure {
+    Exhausted,
+    RequestedValueUnavailable,
+    Parse,
+    Database,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ResourcePoolFailurePolicy {
+    Required,
+    BestEffort,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ResourcePoolAllocationMode {
+    Automatic,
+    Requested,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+pub(crate) enum ResourcePoolValueType {
+    Integer,
+    Ipv4,
+    Ipv6,
+    Ipv6Prefix,
+}
+
+impl From<ValueType> for ResourcePoolValueType {
+    fn from(value: ValueType) -> Self {
+        match value {
+            ValueType::Integer => Self::Integer,
+            ValueType::Ipv4 => Self::Ipv4,
+            ValueType::Ipv6 => Self::Ipv6,
+            ValueType::Ipv6Prefix => Self::Ipv6Prefix,
+        }
+    }
+}
+
+// These Events share one counter. Keep its kind, description, and label keys
+// identical. Existing allocation diagnostics retain their messages and
+// context; `release` gains its first diagnostic at this database boundary.
+#[derive(Event)]
+#[event(
+    event_name = "resource_pool_exhausted",
+    metric_name = "carbide_resource_pool_lifecycle_failures_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "Pool exhausted, cannot allocate",
+    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+)]
+struct ResourcePoolExhausted {
+    #[label]
+    operation: ResourcePoolOperation,
+    #[label]
+    failure: ResourcePoolFailure,
+    #[label]
+    failure_policy: ResourcePoolFailurePolicy,
+    #[label]
+    allocation_mode: ResourcePoolAllocationMode,
+    #[label]
+    value_type: ResourcePoolValueType,
+    #[context]
+    owner_id: String,
+    #[context]
+    pool: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "resource_pool_requested_vni_unavailable",
+    metric_name = "carbide_resource_pool_lifecycle_failures_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "invalid pool value requested, cannot allocate",
+    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+)]
+struct ResourcePoolRequestedVniUnavailable {
+    #[label]
+    operation: ResourcePoolOperation,
+    #[label]
+    failure: ResourcePoolFailure,
+    #[label]
+    failure_policy: ResourcePoolFailurePolicy,
+    #[label]
+    allocation_mode: ResourcePoolAllocationMode,
+    #[label]
+    value_type: ResourcePoolValueType,
+    #[context]
+    owner_id: String,
+    #[context]
+    pool: String,
+    #[context(value)]
+    requested_vni: i64,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "resource_pool_allocation_failed",
+    metric_name = "carbide_resource_pool_lifecycle_failures_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "Error allocating from resource pool",
+    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+)]
+struct ResourcePoolAllocationFailed {
+    #[label]
+    operation: ResourcePoolOperation,
+    #[label]
+    failure: ResourcePoolFailure,
+    #[label]
+    failure_policy: ResourcePoolFailurePolicy,
+    #[label]
+    allocation_mode: ResourcePoolAllocationMode,
+    #[label]
+    value_type: ResourcePoolValueType,
+    #[context]
+    owner_id: String,
+    #[context]
+    error: String,
+    #[context]
+    pool: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "resource_pool_release_failed",
+    metric_name = "carbide_resource_pool_lifecycle_failures_total",
+    component = "nico-api",
+    log = error,
+    metric = counter,
+    message = "Error releasing value to resource pool",
+    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+)]
+struct ResourcePoolReleaseFailed {
+    #[label]
+    operation: ResourcePoolOperation,
+    #[label]
+    failure: ResourcePoolFailure,
+    #[label]
+    failure_policy: ResourcePoolFailurePolicy,
+    #[label]
+    allocation_mode: ResourcePoolAllocationMode,
+    #[label]
+    value_type: ResourcePoolValueType,
+    #[context]
+    error: String,
+    #[context]
+    pool: String,
+    #[context]
+    value: String,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "dpu_asn_allocation_failed",
+    metric_name = "carbide_resource_pool_lifecycle_failures_total",
+    component = "nico-api",
+    log = info,
+    metric = counter,
+    message = "Failed to allocate asn for dpu",
+    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+)]
+struct DpuAsnAllocationFailed {
+    #[label]
+    operation: ResourcePoolOperation,
+    #[label]
+    failure: ResourcePoolFailure,
+    #[label]
+    failure_policy: ResourcePoolFailurePolicy,
+    #[label]
+    allocation_mode: ResourcePoolAllocationMode,
+    #[label]
+    value_type: ResourcePoolValueType,
+    #[context]
+    stable_machine_id: String,
+    #[context]
+    error: String,
+}
 
 /// Put some resources into the pool, so they can be allocated later.
 /// This needs to be called before `allocate` can return anything.
@@ -195,19 +386,34 @@ where
 {
     // TODO: If we would get passed the current owner, we could guard on that
     // so that nothing else could release the value
+    let value = value.to_string();
     let query = "
 UPDATE resource_pool SET
   allocated = NULL,
   state = $1
 WHERE name = $2 AND value = $3
 ";
-    sqlx::query(query)
+    if let Err(source) = sqlx::query(query)
         .bind(sqlx::types::Json(ResourcePoolEntryState::Free))
         .bind(&pool.name)
-        .bind(value.to_string())
+        .bind(&value)
         .execute(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
+    {
+        let event_error = source.to_string();
+        let error = DatabaseError::query(query, source);
+        emit(ResourcePoolReleaseFailed {
+            operation: ResourcePoolOperation::Release,
+            failure: ResourcePoolFailure::Database,
+            failure_policy: ResourcePoolFailurePolicy::Required,
+            allocation_mode: ResourcePoolAllocationMode::NotApplicable,
+            value_type: pool.value_type.into(),
+            error: event_error,
+            pool: pool.name.clone(),
+            value,
+        });
+        return Err(error);
+    }
     Ok(())
 }
 
@@ -388,6 +594,164 @@ impl From<DatabaseError> for ResourcePoolDatabaseError {
     fn from(e: DatabaseError) -> Self {
         ResourcePoolDatabaseError::Database(Box::new(e))
     }
+}
+
+pub(crate) fn classify_resource_pool_failure(
+    error: &ResourcePoolDatabaseError,
+) -> ResourcePoolFailure {
+    match error {
+        ResourcePoolDatabaseError::ResourcePool(ResourcePoolError::Empty) => {
+            ResourcePoolFailure::Exhausted
+        }
+        ResourcePoolDatabaseError::ResourcePool(ResourcePoolError::Parse { .. }) => {
+            ResourcePoolFailure::Parse
+        }
+        ResourcePoolDatabaseError::Database(error) => classify_database_failure(error),
+    }
+}
+
+fn classify_database_failure(error: &DatabaseError) -> ResourcePoolFailure {
+    if matches!(error, DatabaseError::FailedPrecondition(_)) {
+        ResourcePoolFailure::RequestedValueUnavailable
+    } else {
+        ResourcePoolFailure::Database
+    }
+}
+
+/// Whether an allocation error represents an unavailable requested value.
+pub fn is_requested_value_unavailable(error: &ResourcePoolDatabaseError) -> bool {
+    classify_resource_pool_failure(error) == ResourcePoolFailure::RequestedValueUnavailable
+}
+
+/// Emit the non-fatal diagnostic used when DPU creation cannot allocate an ASN.
+pub(crate) fn emit_best_effort_dpu_asn_allocation_failure(
+    value_type: ValueType,
+    stable_machine_id: &str,
+    error: &ResourcePoolDatabaseError,
+) {
+    emit(DpuAsnAllocationFailed {
+        operation: ResourcePoolOperation::Allocate,
+        failure: classify_resource_pool_failure(error),
+        failure_policy: ResourcePoolFailurePolicy::BestEffort,
+        allocation_mode: ResourcePoolAllocationMode::Automatic,
+        value_type: value_type.into(),
+        stable_machine_id: stable_machine_id.to_string(),
+        error: error.to_string(),
+    });
+}
+
+/// Emit a generic resource-pool allocation failure at its API mapping boundary.
+///
+/// `allocate` returns a deliberately detailed error so each caller can retain
+/// its existing status mapping. Recording it here keeps that boundary as the
+/// single log and metric owner without counting the same failed query again in
+/// the database helper.
+///
+/// `diagnostic_pool` is deliberately supplied by the caller. Some existing
+/// diagnostics use a stable alias such as `lo-ip` instead of the configured
+/// pool name, and adopting an Event must preserve those structured log fields.
+pub fn emit_allocation_failure(
+    value_type: ValueType,
+    owner_id: &str,
+    requested: bool,
+    diagnostic_pool: &str,
+    error: &ResourcePoolDatabaseError,
+) {
+    let failure = classify_resource_pool_failure(error);
+    emit_classified_allocation_failure(
+        value_type,
+        owner_id,
+        requested,
+        diagnostic_pool,
+        failure,
+        error.to_string(),
+    );
+}
+
+/// Emit an allocation failure after a caller has unwrapped its database error.
+///
+/// VPC and SPX allocation preserve their existing database-error status
+/// mapping, so those callers retain ownership of the inner [`DatabaseError`].
+pub fn emit_database_allocation_failure(
+    value_type: ValueType,
+    owner_id: &str,
+    requested: bool,
+    diagnostic_pool: &str,
+    error: &DatabaseError,
+) {
+    emit_classified_allocation_failure(
+        value_type,
+        owner_id,
+        requested,
+        diagnostic_pool,
+        classify_database_failure(error),
+        error.to_string(),
+    );
+}
+
+fn emit_classified_allocation_failure(
+    value_type: ValueType,
+    owner_id: &str,
+    requested: bool,
+    diagnostic_pool: &str,
+    failure: ResourcePoolFailure,
+    error: String,
+) {
+    let allocation_mode = if requested {
+        ResourcePoolAllocationMode::Requested
+    } else {
+        ResourcePoolAllocationMode::Automatic
+    };
+    let value_type = value_type.into();
+
+    match failure {
+        ResourcePoolFailure::Exhausted => emit(ResourcePoolExhausted {
+            operation: ResourcePoolOperation::Allocate,
+            failure,
+            failure_policy: ResourcePoolFailurePolicy::Required,
+            allocation_mode,
+            value_type,
+            owner_id: owner_id.to_string(),
+            pool: diagnostic_pool.to_string(),
+        }),
+        ResourcePoolFailure::RequestedValueUnavailable
+        | ResourcePoolFailure::Parse
+        | ResourcePoolFailure::Database => {
+            emit(ResourcePoolAllocationFailed {
+                operation: ResourcePoolOperation::Allocate,
+                failure,
+                failure_policy: ResourcePoolFailurePolicy::Required,
+                allocation_mode,
+                value_type,
+                owner_id: owner_id.to_string(),
+                error,
+                pool: diagnostic_pool.to_string(),
+            });
+        }
+    }
+}
+
+/// Emit the requested-VNI diagnostic retained by VPC and SPX allocation APIs.
+///
+/// This Event shares the normalized lifecycle counter labels with generic pool
+/// failures while preserving the APIs' existing message and `requested_vni`
+/// structured field.
+pub fn emit_requested_vni_unavailable(
+    value_type: ValueType,
+    owner_id: &str,
+    requested_vni: i32,
+    diagnostic_pool: &str,
+) {
+    emit(ResourcePoolRequestedVniUnavailable {
+        operation: ResourcePoolOperation::Allocate,
+        failure: ResourcePoolFailure::RequestedValueUnavailable,
+        failure_policy: ResourcePoolFailurePolicy::Required,
+        allocation_mode: ResourcePoolAllocationMode::Requested,
+        value_type: value_type.into(),
+        owner_id: owner_id.to_string(),
+        pool: diagnostic_pool.to_string(),
+        requested_vni: i64::from(requested_vni),
+    });
 }
 
 /// A pool bigger than this is very likely a mistake
@@ -1061,11 +1425,573 @@ pub async fn create_common_pools(
 
 #[cfg(test)]
 mod tests {
+    use carbide_instrument::MetricKind;
+    use carbide_instrument::testing::{MetricsCapture, capture_logs, capture_logs_async};
     use carbide_test_support::Outcome::*;
     use carbide_test_support::query_counter::count_queries;
-    use carbide_test_support::{Case, check_cases};
+    use carbide_test_support::{Case, Check, check_cases, check_values};
 
     use super::*;
+
+    const RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC: &str =
+        "carbide_resource_pool_lifecycle_failures_total";
+    const RESOURCE_POOL_LIFECYCLE_FAILURES_DESCRIPTION: &str = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type.";
+    const RESOURCE_POOL_LIFECYCLE_FAILURE_LABELS: [&str; 5] = [
+        "operation",
+        "failure",
+        "failure_policy",
+        "allocation_mode",
+        "value_type",
+    ];
+
+    fn assert_shared_failure_metric_contract<E: Event>(event: E) {
+        assert_eq!(
+            E::METRIC_NAME,
+            Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC)
+        );
+        assert_eq!(E::METRIC, MetricKind::Counter);
+        assert_eq!(E::DESCRIBE, RESOURCE_POOL_LIFECYCLE_FAILURES_DESCRIPTION);
+        assert_eq!(E::COMPONENT, "nico-api");
+
+        let labels = event.labels();
+        let label_keys = labels
+            .as_ref()
+            .iter()
+            .map(|label| label.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(label_keys, RESOURCE_POOL_LIFECYCLE_FAILURE_LABELS);
+    }
+
+    #[test]
+    fn resource_pool_failure_events_share_one_metric_contract() {
+        assert_shared_failure_metric_contract(ResourcePoolExhausted {
+            operation: ResourcePoolOperation::Allocate,
+            failure: ResourcePoolFailure::Exhausted,
+            failure_policy: ResourcePoolFailurePolicy::Required,
+            allocation_mode: ResourcePoolAllocationMode::Automatic,
+            value_type: ResourcePoolValueType::Integer,
+            owner_id: "owner".to_string(),
+            pool: "pool".to_string(),
+        });
+        assert_shared_failure_metric_contract(ResourcePoolRequestedVniUnavailable {
+            operation: ResourcePoolOperation::Allocate,
+            failure: ResourcePoolFailure::RequestedValueUnavailable,
+            failure_policy: ResourcePoolFailurePolicy::Required,
+            allocation_mode: ResourcePoolAllocationMode::Requested,
+            value_type: ResourcePoolValueType::Integer,
+            owner_id: "owner".to_string(),
+            pool: "pool".to_string(),
+            requested_vni: 42,
+        });
+        assert_shared_failure_metric_contract(ResourcePoolAllocationFailed {
+            operation: ResourcePoolOperation::Allocate,
+            failure: ResourcePoolFailure::Database,
+            failure_policy: ResourcePoolFailurePolicy::Required,
+            allocation_mode: ResourcePoolAllocationMode::Automatic,
+            value_type: ResourcePoolValueType::Integer,
+            owner_id: "owner".to_string(),
+            error: "database unavailable".to_string(),
+            pool: "pool".to_string(),
+        });
+        assert_shared_failure_metric_contract(ResourcePoolReleaseFailed {
+            operation: ResourcePoolOperation::Release,
+            failure: ResourcePoolFailure::Database,
+            failure_policy: ResourcePoolFailurePolicy::Required,
+            allocation_mode: ResourcePoolAllocationMode::NotApplicable,
+            value_type: ResourcePoolValueType::Ipv4,
+            error: "database unavailable".to_string(),
+            pool: "pool".to_string(),
+            value: "192.0.2.1".to_string(),
+        });
+        assert_shared_failure_metric_contract(DpuAsnAllocationFailed {
+            operation: ResourcePoolOperation::Allocate,
+            failure: ResourcePoolFailure::Exhausted,
+            failure_policy: ResourcePoolFailurePolicy::BestEffort,
+            allocation_mode: ResourcePoolAllocationMode::Automatic,
+            value_type: ResourcePoolValueType::Integer,
+            stable_machine_id: "dpu-1".to_string(),
+            error: "pool exhausted".to_string(),
+        });
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum AllocationFailureInput {
+        Exhausted,
+        RequestedValueUnavailable,
+        Parse,
+        Database,
+    }
+
+    impl AllocationFailureInput {
+        fn label(self) -> &'static str {
+            match self {
+                Self::Exhausted => "exhausted",
+                Self::RequestedValueUnavailable => "requested_value_unavailable",
+                Self::Parse => "parse",
+                Self::Database => "database",
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct AllocationFailureCase {
+        failure: AllocationFailureInput,
+        allocation_mode: ResourcePoolAllocationMode,
+    }
+
+    impl AllocationFailureCase {
+        fn requested(self) -> bool {
+            self.allocation_mode == ResourcePoolAllocationMode::Requested
+        }
+
+        fn allocation_mode_label(self) -> &'static str {
+            match self.allocation_mode {
+                ResourcePoolAllocationMode::Automatic => "automatic",
+                ResourcePoolAllocationMode::Requested => "requested",
+                ResourcePoolAllocationMode::NotApplicable => "not_applicable",
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct AllocationFailureRecord {
+        metadata_name: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        message: String,
+        operation: Option<String>,
+        failure: Option<String>,
+        failure_policy: Option<String>,
+        allocation_mode: Option<String>,
+        value_type: Option<String>,
+        owner_id: Option<String>,
+        pool: Option<String>,
+        error: Option<String>,
+        counter_delta: f64,
+    }
+
+    fn allocation_error(input: AllocationFailureInput) -> ResourcePoolDatabaseError {
+        match input {
+            AllocationFailureInput::Exhausted => ResourcePoolError::Empty.into(),
+            AllocationFailureInput::RequestedValueUnavailable => {
+                DatabaseError::FailedPrecondition("value is not available".to_string()).into()
+            }
+            AllocationFailureInput::Parse => ResourcePoolError::Parse {
+                e: "invalid integer".to_string(),
+                v: "not-an-integer".to_string(),
+                pool_name: "test-pool".to_string(),
+                owner_type: "machine".to_string(),
+                owner_id: "machine-1".to_string(),
+            }
+            .into(),
+            AllocationFailureInput::Database => DatabaseError::Internal {
+                message: "database unavailable".to_string(),
+            }
+            .into(),
+        }
+    }
+
+    #[test]
+    fn allocation_failures_log_and_count_by_failure() {
+        check_values(
+            [
+                Check {
+                    scenario: "automatic pool exhaustion",
+                    input: AllocationFailureCase {
+                        failure: AllocationFailureInput::Exhausted,
+                        allocation_mode: ResourcePoolAllocationMode::Automatic,
+                    },
+                    expect: AllocationFailureRecord {
+                        metadata_name: "resource_pool_exhausted".to_string(),
+                        event_name: Some("resource_pool_exhausted".to_string()),
+                        metric_name: Some(
+                            RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string(),
+                        ),
+                        message: "Pool exhausted, cannot allocate".to_string(),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("exhausted".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("automatic".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some("machine-1".to_string()),
+                        pool: Some("legacy-pool-name".to_string()),
+                        error: None,
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "requested value unavailable",
+                    input: AllocationFailureCase {
+                        failure: AllocationFailureInput::RequestedValueUnavailable,
+                        allocation_mode: ResourcePoolAllocationMode::Requested,
+                    },
+                    expect: AllocationFailureRecord {
+                        metadata_name: "resource_pool_allocation_failed".to_string(),
+                        event_name: Some("resource_pool_allocation_failed".to_string()),
+                        metric_name: Some(
+                            RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string(),
+                        ),
+                        message: "Error allocating from resource pool".to_string(),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("requested_value_unavailable".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("requested".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some("machine-1".to_string()),
+                        pool: Some("legacy-pool-name".to_string()),
+                        error: Some("value is not available".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "allocated value parse failure",
+                    input: AllocationFailureCase {
+                        failure: AllocationFailureInput::Parse,
+                        allocation_mode: ResourcePoolAllocationMode::Automatic,
+                    },
+                    expect: AllocationFailureRecord {
+                        metadata_name: "resource_pool_allocation_failed".to_string(),
+                        event_name: Some("resource_pool_allocation_failed".to_string()),
+                        metric_name: Some(
+                            RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string(),
+                        ),
+                        message: "Error allocating from resource pool".to_string(),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("parse".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("automatic".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some("machine-1".to_string()),
+                        pool: Some("legacy-pool-name".to_string()),
+                        error: Some(
+                            "cannot convert 'not-an-integer' to test-pool's pool type for machine machine-1: invalid integer"
+                                .to_string(),
+                        ),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "database failure",
+                    input: AllocationFailureCase {
+                        failure: AllocationFailureInput::Database,
+                        allocation_mode: ResourcePoolAllocationMode::Requested,
+                    },
+                    expect: AllocationFailureRecord {
+                        metadata_name: "resource_pool_allocation_failed".to_string(),
+                        event_name: Some("resource_pool_allocation_failed".to_string()),
+                        metric_name: Some(
+                            RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string(),
+                        ),
+                        message: "Error allocating from resource pool".to_string(),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("database".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("requested".to_string()),
+                        value_type: Some("integer".to_string()),
+                        owner_id: Some("machine-1".to_string()),
+                        pool: Some("legacy-pool-name".to_string()),
+                        error: Some("internal error: database unavailable".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |input| {
+                let pool = ResourcePool::<i32>::new(
+                    "test-pool".to_string(),
+                    ValueType::Integer,
+                );
+                let error = allocation_error(input.failure);
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| {
+                    emit_allocation_failure(
+                        pool.value_type,
+                        "machine-1",
+                        input.requested(),
+                        "legacy-pool-name",
+                        &error,
+                    );
+                });
+                assert_eq!(logs.len(), 1);
+                let log = &logs[0];
+                AllocationFailureRecord {
+                    metadata_name: log.metadata_name.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    message: log.message.clone(),
+                    operation: log.field("operation").map(str::to_string),
+                    failure: log.field("failure").map(str::to_string),
+                    failure_policy: log
+                        .field("failure_policy")
+                        .map(str::to_string),
+                    allocation_mode: log
+                        .field("allocation_mode")
+                        .map(str::to_string),
+                    value_type: log.field("value_type").map(str::to_string),
+                    owner_id: log.field("owner_id").map(str::to_string),
+                    pool: log.field("pool").map(str::to_string),
+                    error: log.field("error").map(str::to_string),
+                    counter_delta: metrics.counter_delta(
+                        RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC,
+                        &[
+                            ("operation", "allocate"),
+                            ("failure", input.failure.label()),
+                            ("failure_policy", "required"),
+                            ("allocation_mode", input.allocation_mode_label()),
+                            ("value_type", "integer"),
+                        ],
+                    ),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn requested_vni_unavailable_preserves_diagnostic_and_counter_schema() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| {
+            emit_requested_vni_unavailable(ValueType::Integer, "vpc-1", 42, "vpc-vni");
+        });
+
+        assert_eq!(logs.len(), 1);
+        let log = &logs[0];
+        assert_eq!(log.metadata_name, "resource_pool_requested_vni_unavailable");
+        assert_eq!(log.message, "invalid pool value requested, cannot allocate");
+        assert_eq!(
+            log.field("event_name"),
+            Some("resource_pool_requested_vni_unavailable")
+        );
+        assert_eq!(
+            log.field("metric_name"),
+            Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC)
+        );
+        assert_eq!(log.field("owner_id"), Some("vpc-1"));
+        assert_eq!(log.field("pool"), Some("vpc-vni"));
+        assert_eq!(log.field("requested_vni"), Some("42"));
+        assert_eq!(log.field("failure_policy"), Some("required"));
+        assert_eq!(
+            metrics.counter_delta(
+                RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC,
+                &[
+                    ("operation", "allocate"),
+                    ("failure", "requested_value_unavailable"),
+                    ("failure_policy", "required"),
+                    ("allocation_mode", "requested"),
+                    ("value_type", "integer"),
+                ],
+            ),
+            1.0
+        );
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum PolicySpecificFailureInput {
+        Release,
+        BestEffortDpuAsn,
+    }
+
+    impl PolicySpecificFailureInput {
+        fn metric_labels(self) -> [(&'static str, &'static str); 5] {
+            match self {
+                Self::Release => [
+                    ("operation", "release"),
+                    ("failure", "database"),
+                    ("failure_policy", "required"),
+                    ("allocation_mode", "not_applicable"),
+                    ("value_type", "ipv4"),
+                ],
+                Self::BestEffortDpuAsn => [
+                    ("operation", "allocate"),
+                    ("failure", "exhausted"),
+                    ("failure_policy", "best_effort"),
+                    ("allocation_mode", "automatic"),
+                    ("value_type", "integer"),
+                ],
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    struct PolicySpecificFailureRecord {
+        metadata_name: String,
+        event_name: Option<String>,
+        metric_name: Option<String>,
+        level: tracing::Level,
+        message: String,
+        operation: Option<String>,
+        failure: Option<String>,
+        failure_policy: Option<String>,
+        allocation_mode: Option<String>,
+        value_type: Option<String>,
+        counter_delta: f64,
+    }
+
+    #[test]
+    fn policy_specific_resource_pool_failures_preserve_their_log_contracts() {
+        check_values(
+            [
+                Check {
+                    scenario: "release failure",
+                    input: PolicySpecificFailureInput::Release,
+                    expect: PolicySpecificFailureRecord {
+                        metadata_name: "resource_pool_release_failed".to_string(),
+                        event_name: Some("resource_pool_release_failed".to_string()),
+                        metric_name: Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string()),
+                        level: tracing::Level::ERROR,
+                        message: "Error releasing value to resource pool".to_string(),
+                        operation: Some("release".to_string()),
+                        failure: Some("database".to_string()),
+                        failure_policy: Some("required".to_string()),
+                        allocation_mode: Some("not_applicable".to_string()),
+                        value_type: Some("ipv4".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "best-effort DPU ASN allocation",
+                    input: PolicySpecificFailureInput::BestEffortDpuAsn,
+                    expect: PolicySpecificFailureRecord {
+                        metadata_name: "dpu_asn_allocation_failed".to_string(),
+                        event_name: Some("dpu_asn_allocation_failed".to_string()),
+                        metric_name: Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC.to_string()),
+                        level: tracing::Level::INFO,
+                        message: "Failed to allocate asn for dpu".to_string(),
+                        operation: Some("allocate".to_string()),
+                        failure: Some("exhausted".to_string()),
+                        failure_policy: Some("best_effort".to_string()),
+                        allocation_mode: Some("automatic".to_string()),
+                        value_type: Some("integer".to_string()),
+                        counter_delta: 1.0,
+                    },
+                },
+            ],
+            |input| {
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| match input {
+                    PolicySpecificFailureInput::Release => {
+                        emit(ResourcePoolReleaseFailed {
+                            operation: ResourcePoolOperation::Release,
+                            failure: ResourcePoolFailure::Database,
+                            failure_policy: ResourcePoolFailurePolicy::Required,
+                            allocation_mode: ResourcePoolAllocationMode::NotApplicable,
+                            value_type: ResourcePoolValueType::Ipv4,
+                            error: "database unavailable".to_string(),
+                            pool: "lo-ip".to_string(),
+                            value: "192.0.2.10".to_string(),
+                        });
+                    }
+                    PolicySpecificFailureInput::BestEffortDpuAsn => {
+                        let error: ResourcePoolDatabaseError = ResourcePoolError::Empty.into();
+                        emit_best_effort_dpu_asn_allocation_failure(
+                            ValueType::Integer,
+                            "dpu-1",
+                            &error,
+                        );
+                    }
+                });
+                assert_eq!(logs.len(), 1);
+                let log = &logs[0];
+                let operation = log.field("operation").map(str::to_string);
+                let failure = log.field("failure").map(str::to_string);
+                let failure_policy = log.field("failure_policy").map(str::to_string);
+                let allocation_mode = log.field("allocation_mode").map(str::to_string);
+                let value_type = log.field("value_type").map(str::to_string);
+                PolicySpecificFailureRecord {
+                    metadata_name: log.metadata_name.clone(),
+                    event_name: log.field("event_name").map(str::to_string),
+                    metric_name: log.field("metric_name").map(str::to_string),
+                    level: log.level,
+                    message: log.message.clone(),
+                    operation,
+                    failure,
+                    failure_policy,
+                    allocation_mode,
+                    value_type,
+                    counter_delta: metrics.counter_delta(
+                        RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC,
+                        &input.metric_labels(),
+                    ),
+                }
+            },
+        );
+    }
+
+    // `capture_logs_async` wraps only `release`, whose await uses this
+    // connection. No unrelated work runs while the connection is held.
+    #[allow(txn_held_across_await)]
+    #[crate::sqlx_test]
+    async fn release_database_failure_emits_at_database_boundary(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut connection = pool.acquire().await?;
+        // `sqlx_test` gives this case its own database. Hiding the table forces
+        // `release` through its production error boundary without affecting
+        // another test.
+        sqlx::query("ALTER TABLE resource_pool RENAME TO unavailable_resource_pool")
+            .execute(connection.as_mut())
+            .await?;
+
+        let resource_pool =
+            ResourcePool::<IpAddr>::new("release-test".to_string(), ValueType::Ipv4);
+        let value: IpAddr = "192.0.2.10".parse()?;
+        let metrics = MetricsCapture::start();
+        let (result, logs) =
+            capture_logs_async(release(&resource_pool, connection.as_mut(), value)).await;
+
+        let returned_error = result.expect_err("the renamed table must make release fail");
+        assert!(
+            returned_error
+                .to_string()
+                .contains("UPDATE resource_pool SET"),
+            "the returned error retains its query context"
+        );
+        let event_logs = logs
+            .iter()
+            .filter(|log| log.metadata_name == "resource_pool_release_failed")
+            .collect::<Vec<_>>();
+        assert_eq!(event_logs.len(), 1);
+        let log = event_logs[0];
+        assert_eq!(log.level, tracing::Level::ERROR);
+        assert_eq!(log.message, "Error releasing value to resource pool");
+        assert_eq!(
+            log.field("event_name"),
+            Some("resource_pool_release_failed")
+        );
+        assert_eq!(
+            log.field("metric_name"),
+            Some(RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC)
+        );
+        assert_eq!(log.field("failure_policy"), Some("required"));
+        assert_eq!(log.field("pool"), Some("release-test"));
+        assert_eq!(log.field("value"), Some("192.0.2.10"));
+        let logged_error = log.field("error").expect("release error context");
+        assert!(
+            logged_error.contains("relation \"resource_pool\" does not exist"),
+            "the Event retains the database cause"
+        );
+        assert!(
+            !logged_error.contains("UPDATE"),
+            "the Event omits the failed query"
+        );
+        assert!(
+            !logged_error.contains('\n'),
+            "the Event error remains single-line"
+        );
+        assert_eq!(
+            metrics.counter_delta(
+                RESOURCE_POOL_LIFECYCLE_FAILURES_METRIC,
+                &[
+                    ("operation", "release"),
+                    ("failure", "database"),
+                    ("failure_policy", "required"),
+                    ("allocation_mode", "not_applicable"),
+                    ("value_type", "ipv4"),
+                ],
+            ),
+            1.0
+        );
+
+        Ok(())
+    }
 
     /// A single successful auto-assign `allocate` must cost exactly one database
     /// round-trip. It previously cost two: a full-pool `stats()` pre-scan ran

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -39,8 +39,10 @@
 //! ```
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
+use tracing::instrument::WithSubscriber;
 use tracing_subscriber::layer::{Context, SubscriberExt};
 
 /// `CapturedFieldKind` identifies which `tracing::field::Visit` method
@@ -86,8 +88,9 @@ impl CapturedLog {
     }
 }
 
-/// Runs `f` under a capturing subscriber (this thread only) and returns every
-/// log event it emitted, at any level.
+/// Runs `f` under a capturing subscriber (this thread only) and returns its log
+/// events at every level. Internal diagnostics whose target starts with
+/// `opentelemetry` are excluded.
 pub fn capture_logs(f: impl FnOnce()) -> Vec<CapturedLog> {
     let captured = Arc::new(Mutex::new(Vec::new()));
     let layer = CaptureLayer {
@@ -97,6 +100,28 @@ pub fn capture_logs(f: impl FnOnce()) -> Vec<CapturedLog> {
     tracing::subscriber::with_default(subscriber, f);
     let logs = captured.lock().unwrap_or_else(|p| p.into_inner());
     logs.clone()
+}
+
+/// Polls `future` under a capturing subscriber and returns its output together
+/// with its log events at every level. Internal diagnostics whose target starts
+/// with `opentelemetry` are excluded.
+///
+/// Only events emitted while `future` itself is polled are captured. Before
+/// spawning work whose events matter, attach the current subscriber with
+/// [`WithSubscriber::with_current_subscriber`], then join that work before
+/// `future` resolves.
+pub async fn capture_logs_async<F>(future: F) -> (F::Output, Vec<CapturedLog>)
+where
+    F: Future,
+{
+    let captured = Arc::new(Mutex::new(Vec::new()));
+    let layer = CaptureLayer {
+        captured: captured.clone(),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let output = future.with_subscriber(subscriber).await;
+    let logs = captured.lock().unwrap_or_else(|p| p.into_inner());
+    (output, logs.clone())
 }
 
 struct CaptureLayer {

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -217,6 +217,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_reboot_attempts_in_booting_with_discovery_image</td><td>histogram</td><td>Reboot attempts per machine in BootingWithDiscoveryImage, recorded when a machine is rebooted again after no response from the host.</td></tr>
 <tr><td>carbide_redfish_action_result_persistence_failures_total</td><td>counter</td><td>Number of detached Redfish action results that failed to persist</td></tr>
 <tr><td>carbide_reserved_ips_count</td><td>gauge</td><td>Number of reserved IPs per network segment</td></tr>
+<tr><td>carbide_resource_pool_lifecycle_failures_total</td><td>counter</td><td>Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type.</td></tr>
 <tr><td>carbide_resourcepool_free_count</td><td>gauge</td><td>Number of values in the resource pool currently available for allocation</td></tr>
 <tr><td>carbide_resourcepool_used_count</td><td>gauge</td><td>Number of currently allocated values in the resource pool</td></tr>
 <tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>Number of machines in the system that are currently running a DPU/NIC firmware update</td></tr>


### PR DESCRIPTION
Resource-pool failures were spread across database allocation and release, API status mapping, startup VPC creation, and one best-effort DPU ASN path. Some of those failures stop the request, while the DPU enrichment deliberately continues. They all describe the same pool lifecycle, but operators didn't have one bounded rate that kept that policy difference visible.

So, this puts allocation exhaustion, requested-value rejection, parse and database failures, release failures, initial-VPC startup allocation, and optional DPU ASN allocation under `carbide_resource_pool_lifecycle_failures_total`. The `failure_policy` label separates required work from best-effort enrichment. Pool names, owners, values, and errors stay in log-only context.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4156

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-instrument`
- `cargo test -p carbide-api-db`
- `cargo test -p carbide-api-core --lib`
- `cargo test -p carbide-api-core --test integration`
- `cargo clippy -p carbide-api-core -p carbide-api-db -p carbide-instrument --all-targets -- -D warnings`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make check-format-nightly`

## Additional Notes

IB, network-segment, SPX, and VPC handlers plus initial-VPC startup retain their existing error and status mappings. Optional DPU ASN exhaustion remains nonfatal, and release failures preserve the returned `DatabaseError` while logging only the database cause rather than multiline SQL. The SQLx capture tests have narrow `txn_held_across_await` annotations because every await inside the captured `machine::create` and `release` futures uses the held connection; there is no unrelated work under either annotation. The generated core metric catalogue stays with this code change.

Closes #4156