### PR TITLE
feat: instrument scout firmware and mlx mutations

### DIFF
--- a/crates/scout/src/main.rs
+++ b/crates/scout/src/main.rs
@@ -630,11 +630,10 @@ async fn handle_mlxreport_commands(
                     report.observations.push(obs);
                 }
                 Err(e) => {
-                    tracing::info!(
-                        error = %e,
-                        pci_name = %dev_pci_name,
-                        "handle_mlxreport_action error from lock_device",
-                    );
+                    emit(metrics::ScoutMlxReconciliationFailed::lock(
+                        dev_pci_name,
+                        mlx_device::lockdown_error_context(&e, &key),
+                    ));
                 }
             },
             // ApplyFirmware attempts to apply the provided FirmwareFlasherProfile
@@ -707,11 +706,10 @@ async fn handle_mlxreport_commands(
                     report.observations.push(obs);
                 }
                 Err(e) => {
-                    tracing::info!(
-                        error = %e,
-                        pci_name = %dev_pci_name,
-                        "handle_mlxreport_action error from unlock_device",
-                    );
+                    emit(metrics::ScoutMlxReconciliationFailed::unlock(
+                        dev_pci_name,
+                        mlx_device::lockdown_error_context(&e, &key),
+                    ));
                 }
             },
         };

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -206,12 +206,22 @@ pub(crate) enum ScoutMlxOperation {
     InfoReport,
     ObservationReport,
     Reconciliation,
+    ReconciliationLock,
+    ReconciliationUnlock,
+    ProfileSync,
     ProfileCompare,
+    ProfileApply,
+    ProfileReset,
+    LockdownLock,
+    LockdownUnlock,
     LockdownStatus,
     DeviceInfo,
     RegistryShow,
     ConfigQuery,
     ConfigCompare,
+    ConfigSet,
+    ConfigSync,
+    FirmwareFlash,
 }
 
 /// Where an MLX operation failed.
@@ -252,7 +262,7 @@ impl ScoutMlxFailureStage {
     }
 }
 
-// The operation, request, device, profile, registry, config, and
+// The operation, request, device, profile, registry, config, firmware, and
 // reconciliation families all feed `carbide_scout_mlx_failures_total`, but
 // their existing diagnostics need different context. Keep separate `Event`
 // structs so each log retains its fields without filling unrelated fields
@@ -274,7 +284,7 @@ impl ScoutMlxFailureStage {
     log = dynamic,
     metric = counter,
     message = dynamic,
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxOperationFailed {
     #[label]
@@ -333,10 +343,42 @@ impl ScoutMlxOperationFailed {
         )
     }
 
+    pub(crate) fn profile_sync_decode(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ProfileSync,
+            ScoutMlxFailureStage::Decode,
+            error,
+        )
+    }
+
     pub(crate) fn profile_compare_serialize(error: String) -> Self {
         Self::new(
             ScoutMlxOperation::ProfileCompare,
             ScoutMlxFailureStage::Serialize,
+            error,
+        )
+    }
+
+    pub(crate) fn profile_sync_serialize(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ProfileSync,
+            ScoutMlxFailureStage::Serialize,
+            error,
+        )
+    }
+
+    pub(crate) fn lockdown_lock_initialize(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::LockdownLock,
+            ScoutMlxFailureStage::Initialize,
+            error,
+        )
+    }
+
+    pub(crate) fn lockdown_unlock_initialize(error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::LockdownUnlock,
+            ScoutMlxFailureStage::Initialize,
             error,
         )
     }
@@ -373,14 +415,6 @@ impl DynamicLog for ScoutMlxOperationFailed {
                 ScoutMlxOperation::DeviceReportPublish,
                 ScoutMlxFailureStage::Create | ScoutMlxFailureStage::Publish,
             ) => LogAt::Level(tracing::Level::WARN),
-            (ScoutMlxOperation::ObservationReport, ScoutMlxFailureStage::Publish)
-            | (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Decode)
-            | (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Serialize)
-            | (ScoutMlxOperation::LockdownStatus, ScoutMlxFailureStage::Initialize)
-            | (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Decode)
-            | (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Execute) => {
-                LogAt::Level(tracing::Level::ERROR)
-            }
             _ => LogAt::Level(tracing::Level::ERROR),
         }
     }
@@ -398,15 +432,22 @@ impl DynamicMessage for ScoutMlxOperationFailed {
             (ScoutMlxOperation::ObservationReport, ScoutMlxFailureStage::Publish) => {
                 "Error from publish_mlx_observation_report"
             }
-            (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Decode) => {
-                "[scout_stream::mlx_device] failed to parse profile"
-            }
+            (
+                ScoutMlxOperation::ProfileCompare | ScoutMlxOperation::ProfileSync,
+                ScoutMlxFailureStage::Decode,
+            ) => "[scout_stream::mlx_device] failed to parse profile",
             (ScoutMlxOperation::ProfileCompare, ScoutMlxFailureStage::Serialize) => {
                 "[scout_stream::mlx_device] profile compare result failed to serialize"
             }
-            (ScoutMlxOperation::LockdownStatus, ScoutMlxFailureStage::Initialize) => {
-                "[scout_stream::mlx_device] lockdown manager initialization failed"
+            (ScoutMlxOperation::ProfileSync, ScoutMlxFailureStage::Serialize) => {
+                "[scout_stream::mlx_device] profile sync result failed to serialize"
             }
+            (
+                ScoutMlxOperation::LockdownLock
+                | ScoutMlxOperation::LockdownUnlock
+                | ScoutMlxOperation::LockdownStatus,
+                ScoutMlxFailureStage::Initialize,
+            ) => "[scout_stream::mlx_device] lockdown manager initialization failed",
             (ScoutMlxOperation::InfoReport, ScoutMlxFailureStage::Decode) => {
                 "[scout_stream::mlx_device] device report request failed to parse filters"
             }
@@ -427,7 +468,7 @@ impl DynamicMessage for ScoutMlxOperationFailed {
     log = dynamic,
     metric = counter,
     message = dynamic,
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxRequestRejected {
     #[label]
@@ -452,6 +493,10 @@ impl ScoutMlxRequestRejected {
         Self::new(ScoutMlxOperation::ProfileCompare)
     }
 
+    pub(crate) fn profile_sync() -> Self {
+        Self::new(ScoutMlxOperation::ProfileSync)
+    }
+
     pub(crate) fn reconciliation() -> Self {
         Self::new(ScoutMlxOperation::Reconciliation)
     }
@@ -460,7 +505,7 @@ impl ScoutMlxRequestRejected {
 impl DynamicLog for ScoutMlxRequestRejected {
     fn log_at(&self) -> LogAt {
         match self.operation {
-            ScoutMlxOperation::ProfileCompare => LogAt::Off,
+            ScoutMlxOperation::ProfileCompare | ScoutMlxOperation::ProfileSync => LogAt::Off,
             ScoutMlxOperation::Reconciliation => LogAt::Level(tracing::Level::ERROR),
             _ => LogAt::Level(tracing::Level::WARN),
         }
@@ -471,6 +516,7 @@ impl DynamicMessage for ScoutMlxRequestRejected {
     fn message(&self) -> &'static str {
         match self.operation {
             ScoutMlxOperation::ProfileCompare => "no serializable profile data in message",
+            ScoutMlxOperation::ProfileSync => "no serializable profile data in message",
             ScoutMlxOperation::Reconciliation => "handle_mlxreport_action dev_pci_name empty",
             _ => "Scout MLX request rejected",
         }
@@ -486,7 +532,7 @@ impl DynamicMessage for ScoutMlxRequestRejected {
     log = error,
     metric = counter,
     message = dynamic,
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxDeviceOperationFailed {
     #[label]
@@ -526,6 +572,24 @@ impl ScoutMlxDeviceOperationFailed {
         )
     }
 
+    pub(crate) fn lockdown_lock_execute(device_id: String, error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::LockdownLock,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            error,
+        )
+    }
+
+    pub(crate) fn lockdown_unlock_execute(device_id: String, error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::LockdownUnlock,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            error,
+        )
+    }
+
     pub(crate) fn device_info_discover(device_id: String, error: String) -> Self {
         Self::new(
             ScoutMlxOperation::DeviceInfo,
@@ -541,6 +605,12 @@ impl DynamicMessage for ScoutMlxDeviceOperationFailed {
         match (self.operation, self.failure_stage) {
             (ScoutMlxOperation::LockdownStatus, ScoutMlxFailureStage::Execute) => {
                 "[scout_stream::mlx_device] lockdown status check failed"
+            }
+            (ScoutMlxOperation::LockdownLock, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] lockdown lock failed"
+            }
+            (ScoutMlxOperation::LockdownUnlock, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] lockdown unlock failed"
             }
             (ScoutMlxOperation::DeviceInfo, ScoutMlxFailureStage::Discover) => {
                 "[scout_stream::mlx_device] device info request failed"
@@ -558,8 +628,8 @@ impl DynamicMessage for ScoutMlxDeviceOperationFailed {
     component = "nico-scout",
     log = error,
     metric = counter,
-    message = "[scout_stream::mlx_device] profile compare against device failed",
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    message = dynamic,
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxProfileOperationFailed {
     #[label]
@@ -592,6 +662,36 @@ impl ScoutMlxProfileOperationFailed {
             error,
         }
     }
+
+    pub(crate) fn profile_sync_execute(
+        device_id: String,
+        profile_name: String,
+        error: String,
+    ) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Execute;
+        Self {
+            operation: ScoutMlxOperation::ProfileSync,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device_id,
+            profile_name,
+            error,
+        }
+    }
+}
+
+impl DynamicMessage for ScoutMlxProfileOperationFailed {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            ScoutMlxOperation::ProfileCompare => {
+                "[scout_stream::mlx_device] profile compare against device failed"
+            }
+            ScoutMlxOperation::ProfileSync => {
+                "[scout_stream::mlx_device] profile sync to device failed"
+            }
+            _ => "[scout_stream::mlx_device] profile operation failed",
+        }
+    }
 }
 
 /// A registry-show request named a registry Scout does not know.
@@ -606,7 +706,7 @@ impl ScoutMlxProfileOperationFailed {
     log = error,
     metric = counter,
     message = "[scout_stream::mlx_device] variable registry not found",
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxRegistryLookupFailed {
     #[label]
@@ -640,7 +740,7 @@ impl ScoutMlxRegistryLookupFailed {
     log = warn,
     metric = counter,
     message = "[scout_stream::mlx_device] config registry not found",
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxConfigRegistryLookupFailed {
     #[label]
@@ -674,9 +774,17 @@ impl ScoutMlxConfigRegistryLookupFailed {
     pub(crate) fn config_compare_lookup(device_id: String, registry_name: String) -> Self {
         Self::new(ScoutMlxOperation::ConfigCompare, device_id, registry_name)
     }
+
+    pub(crate) fn config_set_lookup(device_id: String, registry_name: String) -> Self {
+        Self::new(ScoutMlxOperation::ConfigSet, device_id, registry_name)
+    }
+
+    pub(crate) fn config_sync_lookup(device_id: String, registry_name: String) -> Self {
+        Self::new(ScoutMlxOperation::ConfigSync, device_id, registry_name)
+    }
 }
 
-/// An MLX config read failed after registry lookup.
+/// An MLX configuration operation failed after registry lookup.
 #[derive(Event)]
 #[event(
     event_name = "scout_mlx_config_operation_failed",
@@ -685,7 +793,7 @@ impl ScoutMlxConfigRegistryLookupFailed {
     log = error,
     metric = counter,
     message = dynamic,
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxConfigOperationFailed {
     #[label]
@@ -775,6 +883,48 @@ impl ScoutMlxConfigOperationFailed {
             error,
         )
     }
+
+    pub(crate) fn config_set_execute(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigSet,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
+
+    pub(crate) fn config_sync_serialize(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigSync,
+            ScoutMlxFailureStage::Serialize,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
+
+    pub(crate) fn config_sync_execute(
+        device_id: String,
+        registry_name: String,
+        error: String,
+    ) -> Self {
+        Self::new(
+            ScoutMlxOperation::ConfigSync,
+            ScoutMlxFailureStage::Execute,
+            device_id,
+            registry_name,
+            error,
+        )
+    }
 }
 
 impl DynamicMessage for ScoutMlxConfigOperationFailed {
@@ -792,7 +942,192 @@ impl DynamicMessage for ScoutMlxConfigOperationFailed {
             (ScoutMlxOperation::ConfigCompare, ScoutMlxFailureStage::Execute) => {
                 "[scout_stream::mlx_device] config compare against device failed"
             }
+            (ScoutMlxOperation::ConfigSet, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] config set to device failed"
+            }
+            (ScoutMlxOperation::ConfigSync, ScoutMlxFailureStage::Serialize) => {
+                "[scout_stream::mlx_device] config sync result failed to serialize"
+            }
+            (ScoutMlxOperation::ConfigSync, ScoutMlxFailureStage::Execute) => {
+                "[scout_stream::mlx_device] config sync to device failed"
+            }
             _ => "[scout_stream::mlx_device] config operation failed",
+        }
+    }
+}
+
+/// Resetting one device's MLX configuration to its factory defaults failed.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_profile_reset_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "mlxconfig reset failed",
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxProfileResetFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxProfileResetFailed {
+    pub(crate) fn execute(device: String, error: String) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Execute;
+        Self {
+            operation: ScoutMlxOperation::ProfileReset,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device,
+            error,
+        }
+    }
+}
+
+/// Applying one tenant profile after its device reset failed.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_profile_apply_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "mlxconfig profile sync failed",
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxProfileApplyFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device: String,
+    #[context]
+    profile: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxProfileApplyFailed {
+    pub(crate) fn execute(device: String, profile: String, error: String) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Execute;
+        Self {
+            operation: ScoutMlxOperation::ProfileApply,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device,
+            profile,
+            error,
+        }
+    }
+}
+
+/// Scout could not initialize a firmware flasher for one MLX device.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_firmware_flasher_initialization_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "failed to create FirmwareFlasher",
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxFirmwareFlasherInitializationFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device: String,
+    #[context]
+    part_number: String,
+    #[context]
+    psid: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxFirmwareFlasherInitializationFailed {
+    pub(crate) fn new(device: String, part_number: String, psid: String, error: String) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Initialize;
+        Self {
+            operation: ScoutMlxOperation::FirmwareFlash,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device,
+            part_number,
+            psid,
+            error,
+        }
+    }
+}
+
+/// Scout initialized a firmware flasher, but applying its profile failed.
+#[derive(Event)]
+#[event(
+    event_name = "scout_mlx_firmware_flash_failed",
+    metric_name = "carbide_scout_mlx_failures_total",
+    component = "nico-scout",
+    log = error,
+    metric = counter,
+    message = "firmware flash failed",
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
+)]
+pub(crate) struct ScoutMlxFirmwareFlashFailed {
+    #[label]
+    operation: ScoutMlxOperation,
+    #[label]
+    failure_stage: ScoutMlxFailureStage,
+    #[label]
+    failure_kind: ScoutMlxFailureKind,
+    #[context]
+    device: String,
+    #[context]
+    part_number: String,
+    #[context]
+    psid: String,
+    #[context]
+    firmware_url: String,
+    #[context]
+    target_version: String,
+    #[context]
+    error: String,
+}
+
+impl ScoutMlxFirmwareFlashFailed {
+    pub(crate) fn execute(
+        device: String,
+        part_number: String,
+        psid: String,
+        firmware_url: String,
+        target_version: String,
+        error: String,
+    ) -> Self {
+        let failure_stage = ScoutMlxFailureStage::Execute;
+        Self {
+            operation: ScoutMlxOperation::FirmwareFlash,
+            failure_stage,
+            failure_kind: failure_stage.failure_kind(),
+            device,
+            part_number,
+            psid,
+            firmware_url,
+            target_version,
+            error,
         }
     }
 }
@@ -803,10 +1138,10 @@ impl DynamicMessage for ScoutMlxConfigOperationFailed {
     event_name = "scout_mlx_reconciliation_failed",
     metric_name = "carbide_scout_mlx_failures_total",
     component = "nico-scout",
-    log = error,
+    log = dynamic,
     metric = counter,
     message = dynamic,
-    describe = "Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind."
+    describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
 pub(crate) struct ScoutMlxReconciliationFailed {
     #[label]
@@ -822,9 +1157,14 @@ pub(crate) struct ScoutMlxReconciliationFailed {
 }
 
 impl ScoutMlxReconciliationFailed {
-    fn new(failure_stage: ScoutMlxFailureStage, pci_name: String, error: String) -> Self {
+    fn new(
+        operation: ScoutMlxOperation,
+        failure_stage: ScoutMlxFailureStage,
+        pci_name: String,
+        error: String,
+    ) -> Self {
         Self {
-            operation: ScoutMlxOperation::Reconciliation,
+            operation,
             failure_stage,
             failure_kind: failure_stage.failure_kind(),
             pci_name,
@@ -833,20 +1173,68 @@ impl ScoutMlxReconciliationFailed {
     }
 
     pub(crate) fn decode(pci_name: String, error: String) -> Self {
-        Self::new(ScoutMlxFailureStage::Decode, pci_name, error)
+        Self::new(
+            ScoutMlxOperation::Reconciliation,
+            ScoutMlxFailureStage::Decode,
+            pci_name,
+            error,
+        )
     }
 
     pub(crate) fn discover(pci_name: String, error: String) -> Self {
-        Self::new(ScoutMlxFailureStage::Discover, pci_name, error)
+        Self::new(
+            ScoutMlxOperation::Reconciliation,
+            ScoutMlxFailureStage::Discover,
+            pci_name,
+            error,
+        )
+    }
+
+    pub(crate) fn lock(pci_name: String, error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ReconciliationLock,
+            ScoutMlxFailureStage::Execute,
+            pci_name,
+            error,
+        )
+    }
+
+    pub(crate) fn unlock(pci_name: String, error: String) -> Self {
+        Self::new(
+            ScoutMlxOperation::ReconciliationUnlock,
+            ScoutMlxFailureStage::Execute,
+            pci_name,
+            error,
+        )
+    }
+}
+
+impl DynamicLog for ScoutMlxReconciliationFailed {
+    fn log_at(&self) -> LogAt {
+        match (self.operation, self.failure_stage) {
+            (
+                ScoutMlxOperation::ReconciliationLock | ScoutMlxOperation::ReconciliationUnlock,
+                ScoutMlxFailureStage::Execute,
+            ) => LogAt::Level(tracing::Level::INFO),
+            _ => LogAt::Level(tracing::Level::ERROR),
+        }
     }
 }
 
 impl DynamicMessage for ScoutMlxReconciliationFailed {
     fn message(&self) -> &'static str {
-        match self.failure_stage {
-            ScoutMlxFailureStage::Decode => "handle_mlxreport_action error decoding command",
-            ScoutMlxFailureStage::Discover => {
+        match (self.operation, self.failure_stage) {
+            (ScoutMlxOperation::Reconciliation, ScoutMlxFailureStage::Decode) => {
+                "handle_mlxreport_action error decoding command"
+            }
+            (ScoutMlxOperation::Reconciliation, ScoutMlxFailureStage::Discover) => {
                 "handle_mlxreport_action error from discover_device::from_str"
+            }
+            (ScoutMlxOperation::ReconciliationLock, ScoutMlxFailureStage::Execute) => {
+                "handle_mlxreport_action error from lock_device"
+            }
+            (ScoutMlxOperation::ReconciliationUnlock, ScoutMlxFailureStage::Execute) => {
+                "handle_mlxreport_action error from unlock_device"
             }
             _ => "handle_mlxreport_action failed",
         }
@@ -1111,19 +1499,33 @@ mod tests {
             ObservationReportPublish,
             ProfileCompareDecode,
             ProfileCompareSerialize,
+            ProfileSyncDecode,
+            ProfileSyncSerialize,
             LockdownStatusInitialize,
+            LockdownLockInitialize,
+            LockdownUnlockInitialize,
             InfoReportDecode,
             InfoReportExecute,
             ProfileCompareRequest,
+            ProfileSyncRequest,
             ReconciliationRequest,
             LockdownStatusExecute,
+            LockdownLockExecute,
+            LockdownUnlockExecute,
             DeviceInfoDiscover,
+            ProfileCompareExecute,
+            ProfileSyncExecute,
             ConfigQuerySerialize,
             ConfigQueryExecute,
             ConfigCompareSerialize,
             ConfigCompareExecute,
+            ConfigSetExecute,
+            ConfigSyncSerialize,
+            ConfigSyncExecute,
             ReconciliationDecode,
             ReconciliationDiscover,
+            ReconciliationLock,
+            ReconciliationUnlock,
             OperationFallback,
             RequestFallback,
             DeviceFallback,
@@ -1153,6 +1555,10 @@ mod tests {
         };
         let error = |message| Contract {
             log_at: LogAt::Level(tracing::Level::ERROR),
+            message,
+        };
+        let info = |message| Contract {
+            log_at: LogAt::Level(tracing::Level::INFO),
             message,
         };
 
@@ -1186,8 +1592,34 @@ mod tests {
                     ),
                 },
                 Check {
+                    scenario: "profile sync decode",
+                    input: ContractCase::ProfileSyncDecode,
+                    expect: error("[scout_stream::mlx_device] failed to parse profile"),
+                },
+                Check {
+                    scenario: "profile sync result serialization",
+                    input: ContractCase::ProfileSyncSerialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] profile sync result failed to serialize",
+                    ),
+                },
+                Check {
                     scenario: "lockdown manager initialization",
                     input: ContractCase::LockdownStatusInitialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] lockdown manager initialization failed",
+                    ),
+                },
+                Check {
+                    scenario: "lockdown lock manager initialization",
+                    input: ContractCase::LockdownLockInitialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] lockdown manager initialization failed",
+                    ),
+                },
+                Check {
+                    scenario: "lockdown unlock manager initialization",
+                    input: ContractCase::LockdownUnlockInitialize,
                     expect: error(
                         "[scout_stream::mlx_device] lockdown manager initialization failed",
                     ),
@@ -1213,6 +1645,14 @@ mod tests {
                     },
                 },
                 Check {
+                    scenario: "missing profile sync request",
+                    input: ContractCase::ProfileSyncRequest,
+                    expect: Contract {
+                        log_at: LogAt::Off,
+                        message: "no serializable profile data in message",
+                    },
+                },
+                Check {
                     scenario: "empty reconciliation PCI request",
                     input: ContractCase::ReconciliationRequest,
                     expect: error("handle_mlxreport_action dev_pci_name empty"),
@@ -1223,9 +1663,31 @@ mod tests {
                     expect: error("[scout_stream::mlx_device] lockdown status check failed"),
                 },
                 Check {
+                    scenario: "lockdown lock execution",
+                    input: ContractCase::LockdownLockExecute,
+                    expect: error("[scout_stream::mlx_device] lockdown lock failed"),
+                },
+                Check {
+                    scenario: "lockdown unlock execution",
+                    input: ContractCase::LockdownUnlockExecute,
+                    expect: error("[scout_stream::mlx_device] lockdown unlock failed"),
+                },
+                Check {
                     scenario: "device information discovery",
                     input: ContractCase::DeviceInfoDiscover,
                     expect: error("[scout_stream::mlx_device] device info request failed"),
+                },
+                Check {
+                    scenario: "profile sync execution",
+                    input: ContractCase::ProfileSyncExecute,
+                    expect: error("[scout_stream::mlx_device] profile sync to device failed"),
+                },
+                Check {
+                    scenario: "profile comparison execution",
+                    input: ContractCase::ProfileCompareExecute,
+                    expect: error(
+                        "[scout_stream::mlx_device] profile compare against device failed",
+                    ),
                 },
                 Check {
                     scenario: "config query result serialization",
@@ -1254,6 +1716,23 @@ mod tests {
                     ),
                 },
                 Check {
+                    scenario: "config set execution",
+                    input: ContractCase::ConfigSetExecute,
+                    expect: error("[scout_stream::mlx_device] config set to device failed"),
+                },
+                Check {
+                    scenario: "config sync result serialization",
+                    input: ContractCase::ConfigSyncSerialize,
+                    expect: error(
+                        "[scout_stream::mlx_device] config sync result failed to serialize",
+                    ),
+                },
+                Check {
+                    scenario: "config sync execution",
+                    input: ContractCase::ConfigSyncExecute,
+                    expect: error("[scout_stream::mlx_device] config sync to device failed"),
+                },
+                Check {
                     scenario: "reconciliation command decode",
                     input: ContractCase::ReconciliationDecode,
                     expect: error("handle_mlxreport_action error decoding command"),
@@ -1262,6 +1741,16 @@ mod tests {
                     scenario: "reconciliation device discovery",
                     input: ContractCase::ReconciliationDiscover,
                     expect: error("handle_mlxreport_action error from discover_device::from_str"),
+                },
+                Check {
+                    scenario: "reconciliation lock execution",
+                    input: ContractCase::ReconciliationLock,
+                    expect: info("handle_mlxreport_action error from lock_device"),
+                },
+                Check {
+                    scenario: "reconciliation unlock execution",
+                    input: ContractCase::ReconciliationUnlock,
+                    expect: info("handle_mlxreport_action error from unlock_device"),
                 },
                 Check {
                     scenario: "unknown operation pair remains diagnostic",
@@ -1305,8 +1794,20 @@ mod tests {
                 ContractCase::ProfileCompareSerialize => contract(
                     &ScoutMlxOperationFailed::profile_compare_serialize("failure".to_string()),
                 ),
+                ContractCase::ProfileSyncDecode => contract(
+                    &ScoutMlxOperationFailed::profile_sync_decode("failure".to_string()),
+                ),
+                ContractCase::ProfileSyncSerialize => contract(
+                    &ScoutMlxOperationFailed::profile_sync_serialize("failure".to_string()),
+                ),
                 ContractCase::LockdownStatusInitialize => contract(
                     &ScoutMlxOperationFailed::lockdown_status_initialize("failure".to_string()),
+                ),
+                ContractCase::LockdownLockInitialize => contract(
+                    &ScoutMlxOperationFailed::lockdown_lock_initialize("failure".to_string()),
+                ),
+                ContractCase::LockdownUnlockInitialize => contract(
+                    &ScoutMlxOperationFailed::lockdown_unlock_initialize("failure".to_string()),
                 ),
                 ContractCase::InfoReportDecode => contract(
                     &ScoutMlxOperationFailed::info_report_decode("failure".to_string()),
@@ -1317,6 +1818,9 @@ mod tests {
                 ContractCase::ProfileCompareRequest => {
                     contract(&ScoutMlxRequestRejected::profile_compare())
                 }
+                ContractCase::ProfileSyncRequest => {
+                    contract(&ScoutMlxRequestRejected::profile_sync())
+                }
                 ContractCase::ReconciliationRequest => {
                     contract(&ScoutMlxRequestRejected::reconciliation())
                 }
@@ -1326,9 +1830,35 @@ mod tests {
                         "failure".to_string(),
                     ))
                 }
+                ContractCase::LockdownLockExecute => {
+                    contract(&ScoutMlxDeviceOperationFailed::lockdown_lock_execute(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::LockdownUnlockExecute => {
+                    contract(&ScoutMlxDeviceOperationFailed::lockdown_unlock_execute(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
                 ContractCase::DeviceInfoDiscover => {
                     contract(&ScoutMlxDeviceOperationFailed::device_info_discover(
                         "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ProfileSyncExecute => {
+                    contract(&ScoutMlxProfileOperationFailed::profile_sync_execute(
+                        "device".to_string(),
+                        "profile".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ProfileCompareExecute => {
+                    contract(&ScoutMlxProfileOperationFailed::profile_compare_execute(
+                        "device".to_string(),
+                        "profile".to_string(),
                         "failure".to_string(),
                     ))
                 }
@@ -1360,6 +1890,27 @@ mod tests {
                         "failure".to_string(),
                     ))
                 }
+                ContractCase::ConfigSetExecute => {
+                    contract(&ScoutMlxConfigOperationFailed::config_set_execute(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ConfigSyncSerialize => {
+                    contract(&ScoutMlxConfigOperationFailed::config_sync_serialize(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ConfigSyncExecute => {
+                    contract(&ScoutMlxConfigOperationFailed::config_sync_execute(
+                        "device".to_string(),
+                        "registry".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
                 ContractCase::ReconciliationDecode => {
                     contract(&ScoutMlxReconciliationFailed::decode(
                         "device".to_string(),
@@ -1368,6 +1919,16 @@ mod tests {
                 }
                 ContractCase::ReconciliationDiscover => {
                     contract(&ScoutMlxReconciliationFailed::discover(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    ))
+                }
+                ContractCase::ReconciliationLock => contract(&ScoutMlxReconciliationFailed::lock(
+                    "device".to_string(),
+                    "failure".to_string(),
+                )),
+                ContractCase::ReconciliationUnlock => {
+                    contract(&ScoutMlxReconciliationFailed::unlock(
                         "device".to_string(),
                         "failure".to_string(),
                     ))
@@ -1395,6 +1956,7 @@ mod tests {
                 )),
                 ContractCase::ReconciliationFallback => {
                     contract(&ScoutMlxReconciliationFailed::new(
+                        ScoutMlxOperation::Reconciliation,
                         ScoutMlxFailureStage::Serialize,
                         "device".to_string(),
                         "failure".to_string(),
@@ -1409,6 +1971,7 @@ mod tests {
         #[derive(Clone, Copy)]
         enum RequestCase {
             ProfileCompare,
+            ProfileSync,
             Reconciliation,
         }
 
@@ -1423,6 +1986,14 @@ mod tests {
                 Check {
                     scenario: "missing profile data remains metric-only",
                     input: RequestCase::ProfileCompare,
+                    expect: Observation {
+                        counter_delta: 1.0,
+                        logs: Vec::new(),
+                    },
+                },
+                Check {
+                    scenario: "missing profile sync data remains metric-only",
+                    input: RequestCase::ProfileSync,
                     expect: Observation {
                         counter_delta: 1.0,
                         logs: Vec::new(),
@@ -1446,6 +2017,9 @@ mod tests {
                         ScoutMlxRequestRejected::profile_compare(),
                         "profile_compare",
                     ),
+                    RequestCase::ProfileSync => {
+                        (ScoutMlxRequestRejected::profile_sync(), "profile_sync")
+                    }
                     RequestCase::Reconciliation => {
                         (ScoutMlxRequestRejected::reconciliation(), "reconciliation")
                     }
@@ -1465,6 +2039,183 @@ mod tests {
                     logs: logs
                         .into_iter()
                         .map(|log| (log.level, log.message))
+                        .collect(),
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn mlx_mutation_events_keep_context_out_of_metric_labels() {
+        #[derive(Clone, Copy)]
+        enum MutationCase {
+            ProfileReset,
+            ProfileApply,
+            FirmwareInitialize,
+            FirmwareExecute,
+        }
+
+        struct Expected {
+            operation: &'static str,
+            failure_stage: &'static str,
+            event_name: &'static str,
+            message: &'static str,
+            context: Vec<(&'static str, &'static str)>,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct Observation {
+            counter_delta: f64,
+            level: tracing::Level,
+            event_name: Option<String>,
+            message: String,
+            context: Vec<(String, String, Option<CapturedFieldKind>)>,
+        }
+
+        let expected = |case| match case {
+            MutationCase::ProfileReset => Expected {
+                operation: "profile_reset",
+                failure_stage: "execute",
+                event_name: "scout_mlx_profile_reset_failed",
+                message: "mlxconfig reset failed",
+                context: vec![("device", "device"), ("error", "failure")],
+            },
+            MutationCase::ProfileApply => Expected {
+                operation: "profile_apply",
+                failure_stage: "execute",
+                event_name: "scout_mlx_profile_apply_failed",
+                message: "mlxconfig profile sync failed",
+                context: vec![
+                    ("device", "device"),
+                    ("profile", "profile"),
+                    ("error", "failure"),
+                ],
+            },
+            MutationCase::FirmwareInitialize => Expected {
+                operation: "firmware_flash",
+                failure_stage: "initialize",
+                event_name: "scout_mlx_firmware_flasher_initialization_failed",
+                message: "failed to create FirmwareFlasher",
+                context: vec![
+                    ("device", "device"),
+                    ("part_number", "part-number"),
+                    ("psid", "psid"),
+                    ("error", "failure"),
+                ],
+            },
+            MutationCase::FirmwareExecute => Expected {
+                operation: "firmware_flash",
+                failure_stage: "execute",
+                event_name: "scout_mlx_firmware_flash_failed",
+                message: "firmware flash failed",
+                context: vec![
+                    ("device", "device"),
+                    ("part_number", "part-number"),
+                    ("psid", "psid"),
+                    ("firmware_url", "https://firmware.example/fw.bin"),
+                    ("target_version", "1.2.3"),
+                    ("error", "failure"),
+                ],
+            },
+        };
+        let expected_observation = |case| {
+            let expected = expected(case);
+            Observation {
+                counter_delta: 1.0,
+                level: tracing::Level::ERROR,
+                event_name: Some(expected.event_name.to_string()),
+                message: expected.message.to_string(),
+                context: expected
+                    .context
+                    .into_iter()
+                    .map(|(name, value)| {
+                        (
+                            name.to_string(),
+                            value.to_string(),
+                            Some(CapturedFieldKind::Debug),
+                        )
+                    })
+                    .collect(),
+            }
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "profile reset failure",
+                    input: MutationCase::ProfileReset,
+                    expect: expected_observation(MutationCase::ProfileReset),
+                },
+                Check {
+                    scenario: "profile apply failure",
+                    input: MutationCase::ProfileApply,
+                    expect: expected_observation(MutationCase::ProfileApply),
+                },
+                Check {
+                    scenario: "firmware flasher initialization failure",
+                    input: MutationCase::FirmwareInitialize,
+                    expect: expected_observation(MutationCase::FirmwareInitialize),
+                },
+                Check {
+                    scenario: "firmware flash execution failure",
+                    input: MutationCase::FirmwareExecute,
+                    expect: expected_observation(MutationCase::FirmwareExecute),
+                },
+            ],
+            |case| {
+                let expected = expected(case);
+                let metrics = MetricsCapture::start();
+                let logs = capture_logs(|| match case {
+                    MutationCase::ProfileReset => emit(ScoutMlxProfileResetFailed::execute(
+                        "device".to_string(),
+                        "failure".to_string(),
+                    )),
+                    MutationCase::ProfileApply => emit(ScoutMlxProfileApplyFailed::execute(
+                        "device".to_string(),
+                        "profile".to_string(),
+                        "failure".to_string(),
+                    )),
+                    MutationCase::FirmwareInitialize => {
+                        emit(ScoutMlxFirmwareFlasherInitializationFailed::new(
+                            "device".to_string(),
+                            "part-number".to_string(),
+                            "psid".to_string(),
+                            "failure".to_string(),
+                        ))
+                    }
+                    MutationCase::FirmwareExecute => emit(ScoutMlxFirmwareFlashFailed::execute(
+                        "device".to_string(),
+                        "part-number".to_string(),
+                        "psid".to_string(),
+                        "https://firmware.example/fw.bin".to_string(),
+                        "1.2.3".to_string(),
+                        "failure".to_string(),
+                    )),
+                });
+                let log = &logs[0];
+
+                Observation {
+                    counter_delta: metrics.counter_delta(
+                        "carbide_scout_mlx_failures_total",
+                        &[
+                            ("operation", expected.operation),
+                            ("failure_stage", expected.failure_stage),
+                            ("failure_kind", "backend"),
+                        ],
+                    ),
+                    level: log.level,
+                    event_name: log.field("event_name").map(str::to_string),
+                    message: log.message.clone(),
+                    context: expected
+                        .context
+                        .iter()
+                        .map(|(name, _)| {
+                            (
+                                (*name).to_string(),
+                                log.field(name).unwrap().to_string(),
+                                log.field_kind(name),
+                            )
+                        })
                         .collect(),
                 }
             },

--- a/crates/scout/src/mlx_device.rs
+++ b/crates/scout/src/mlx_device.rs
@@ -25,8 +25,9 @@ use carbide_uuid::machine::MachineId;
 use libmlx::device::discovery;
 use libmlx::device::report::MlxDeviceReport;
 use libmlx::firmware::config::FirmwareFlasherProfile;
+use libmlx::firmware::credentials::Credentials;
 use libmlx::firmware::flasher::FirmwareFlasher;
-use libmlx::lockdown::error::MlxResult;
+use libmlx::lockdown::error::{MlxError, MlxResult};
 use libmlx::lockdown::lockdown::{LockdownManager, StatusReport};
 use libmlx::profile::error::MlxProfileError;
 use libmlx::profile::serialization::SerializableProfile;
@@ -41,7 +42,9 @@ use crate::cfg::Options;
 use crate::client;
 use crate::metrics::{
     ScoutMlxConfigOperationFailed, ScoutMlxConfigRegistryLookupFailed,
-    ScoutMlxDeviceOperationFailed, ScoutMlxOperationFailed, ScoutMlxProfileOperationFailed,
+    ScoutMlxDeviceOperationFailed, ScoutMlxFirmwareFlashFailed,
+    ScoutMlxFirmwareFlasherInitializationFailed, ScoutMlxOperationFailed,
+    ScoutMlxProfileApplyFailed, ScoutMlxProfileOperationFailed, ScoutMlxProfileResetFailed,
     ScoutMlxRegistryLookupFailed, ScoutMlxRequestRejected,
 };
 
@@ -120,6 +123,166 @@ pub fn unlock_device(device_address: &str, key: &str) -> MlxResult<()> {
     Ok(())
 }
 
+pub(crate) fn lockdown_error_context(error: &MlxError, key: &str) -> String {
+    // Flint dry-run and command errors can echo the full invocation. Keep the
+    // diagnostic while removing any non-empty key that reached the tool.
+    let context = error.to_string();
+    match error {
+        MlxError::InvalidKey => context,
+        _ if key.is_empty() => context,
+        _ => context.replace(key, "REDACTED"),
+    }
+}
+
+struct LoggableFirmwareSource {
+    value: String,
+    source_forms: Vec<String>,
+}
+
+impl LoggableFirmwareSource {
+    fn new(raw: &str) -> Self {
+        let Ok(parsed) = reqwest::Url::parse(raw) else {
+            let scheme_length = ["http://", "https://", "ssh://"].iter().find_map(|scheme| {
+                raw.get(..scheme.len())
+                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case(scheme))
+                    .then_some(scheme.len())
+            });
+            return Self {
+                value: if scheme_length.is_some() {
+                    "<invalid firmware source>".to_string()
+                } else {
+                    raw.to_string()
+                },
+                source_forms: scheme_length
+                    .is_some_and(|length| raw.len() > length)
+                    .then(|| raw.to_string())
+                    .into_iter()
+                    .collect(),
+            };
+        };
+
+        if parsed.host_str().is_none() {
+            return Self {
+                value: raw.to_string(),
+                source_forms: Vec::new(),
+            };
+        }
+
+        let mut source_forms = vec![raw.to_string(), parsed.to_string()];
+        for remove_fragment in [false, true] {
+            for remove_query in [false, true] {
+                let mut form = parsed.clone();
+                if remove_fragment {
+                    form.set_fragment(None);
+                }
+                if remove_query {
+                    form.set_query(None);
+                }
+                source_forms.push(form.to_string());
+
+                remove_url_credentials(&mut form);
+                source_forms.push(form.to_string());
+            }
+        }
+
+        let mut loggable = parsed;
+        remove_url_credentials(&mut loggable);
+        loggable.set_query(None);
+        loggable.set_fragment(None);
+        let value = loggable.to_string();
+
+        source_forms.retain(|form| !form.is_empty() && form != &value);
+        source_forms
+            .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+        source_forms.dedup();
+
+        Self {
+            value,
+            source_forms,
+        }
+    }
+
+    fn redact_from(&self, text: &str) -> String {
+        self.source_forms
+            .iter()
+            .fold(text.to_string(), |redacted, form| {
+                redacted.replace(form, &self.value)
+            })
+    }
+
+    fn as_str(&self) -> &str {
+        &self.value
+    }
+}
+
+fn remove_url_credentials(url: &mut reqwest::Url) {
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+}
+
+fn firmware_error_context(error: &str, profile: &FirmwareFlasherProfile) -> String {
+    let sources = std::iter::once(profile.flash_spec.firmware_url.as_str())
+        .chain(profile.flash_spec.device_conf_url.as_deref());
+    let redacted = sources.fold(error.to_string(), |text, source| {
+        LoggableFirmwareSource::new(source).redact_from(&text)
+    });
+
+    mask_secret_values(&redacted, firmware_credentials(profile))
+}
+
+fn firmware_credentials(profile: &FirmwareFlasherProfile) -> impl Iterator<Item = &str> {
+    profile
+        .flash_spec
+        .firmware_credentials
+        .iter()
+        .chain(profile.flash_spec.device_conf_credentials.iter())
+        .filter_map(|credentials| match credentials {
+            Credentials::BearerToken { token } => Some(token.as_str()),
+            Credentials::BasicAuth {
+                username: _,
+                password,
+            } => Some(password.as_str()),
+            Credentials::Header { name: _, value } => Some(value.as_str()),
+            Credentials::SshKey {
+                path: _,
+                passphrase,
+            } => passphrase.as_deref(),
+            Credentials::SshAgent => None,
+        })
+}
+
+fn mask_secret_values<'a>(text: &str, secrets: impl Iterator<Item = &'a str>) -> String {
+    // Merge touching matches before rendering them. Sequential replacement can
+    // leave part of either secret behind when two credential values overlap.
+    let mut ranges: Vec<(usize, usize)> = secrets
+        .filter(|secret| !secret.is_empty())
+        .flat_map(|secret| {
+            let secret = secret.as_bytes();
+            (0..=text.len().saturating_sub(secret.len()))
+                .filter(move |&start| text.as_bytes()[start..].starts_with(secret))
+                .map(move |start| (start, start + secret.len()))
+        })
+        .collect();
+    ranges.sort_unstable();
+
+    let mut redacted = String::with_capacity(text.len());
+    let mut cursor = 0;
+    let mut range_index = 0;
+    while range_index < ranges.len() {
+        let (start, mut end) = ranges[range_index];
+        range_index += 1;
+        while range_index < ranges.len() && ranges[range_index].0 <= end {
+            end = end.max(ranges[range_index].1);
+            range_index += 1;
+        }
+        redacted.push_str(&text[cursor..start]);
+        redacted.push_str("REDACTED");
+        cursor = end;
+    }
+    redacted.push_str(&text[cursor..]);
+    redacted
+}
+
 pub fn handle_profile_sync(
     request: mlx_device_pb::MlxDeviceProfileSyncRequest,
 ) -> mlx_device_pb::MlxDeviceProfileSyncResponse {
@@ -130,6 +293,7 @@ pub fn handle_profile_sync(
     );
 
     let Some(serializable_profile_pb) = request.serializable_profile else {
+        emit(ScoutMlxRequestRejected::profile_sync());
         return mlx_device_pb::MlxDeviceProfileSyncResponse {
             reply: Some(
                 mlx_device_pb::mlx_device_profile_sync_response::Reply::Error(
@@ -145,10 +309,7 @@ pub fn handle_profile_sync(
     let serializable_profile: SerializableProfile = match serializable_profile_pb.try_into() {
         Ok(profile) => profile,
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "[scout_stream::mlx_device] failed to parse profile",
-            );
+            emit(ScoutMlxOperationFailed::profile_sync_decode(e.to_string()));
             return mlx_device_pb::MlxDeviceProfileSyncResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_profile_sync_response::Reply::Error(
@@ -179,10 +340,9 @@ pub fn handle_profile_sync(
                     ),
                 },
                 Err(e) => {
-                    tracing::error!(
-                        error = %e,
-                        "[scout_stream::mlx_device] profile sync result failed to serialize",
-                    );
+                    emit(ScoutMlxOperationFailed::profile_sync_serialize(
+                        e.to_string(),
+                    ));
                     mlx_device_pb::MlxDeviceProfileSyncResponse {
                         reply: Some(
                             mlx_device_pb::mlx_device_profile_sync_response::Reply::Error(
@@ -198,12 +358,11 @@ pub fn handle_profile_sync(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                profile_name = %request.profile_name,
-                error = %e,
-                "[scout_stream::mlx_device] profile sync to device failed",
-            );
+            emit(ScoutMlxProfileOperationFailed::profile_sync_execute(
+                request.device_id.clone(),
+                request.profile_name.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceProfileSyncResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_profile_sync_response::Reply::Error(
@@ -326,10 +485,9 @@ pub fn handle_lockdown_lock(
     let manager = match LockdownManager::new() {
         Ok(m) => m,
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "[scout_stream::mlx_device] lockdown manager initialization failed",
-            );
+            emit(ScoutMlxOperationFailed::lockdown_lock_initialize(
+                e.to_string(),
+            ));
             return mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -356,11 +514,10 @@ pub fn handle_lockdown_lock(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                error = %e,
-                "[scout_stream::mlx_device] lockdown lock failed",
-            );
+            emit(ScoutMlxDeviceOperationFailed::lockdown_lock_execute(
+                request.device_id.clone(),
+                lockdown_error_context(&e, &request.key),
+            ));
             mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -385,10 +542,9 @@ pub fn handle_lockdown_unlock(
     let manager = match LockdownManager::new() {
         Ok(m) => m,
         Err(e) => {
-            tracing::error!(
-                error = %e,
-                "[scout_stream::mlx_device] lockdown manager initialization failed",
-            );
+            emit(ScoutMlxOperationFailed::lockdown_unlock_initialize(
+                e.to_string(),
+            ));
             return mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -415,11 +571,10 @@ pub fn handle_lockdown_unlock(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                error = %e,
-                "[scout_stream::mlx_device] lockdown unlock failed",
-            );
+            emit(ScoutMlxDeviceOperationFailed::lockdown_unlock_execute(
+                request.device_id.clone(),
+                lockdown_error_context(&e, &request.key),
+            ));
             mlx_device_pb::MlxDeviceLockdownResponse {
                 reply: Some(mlx_device_pb::mlx_device_lockdown_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -765,11 +920,10 @@ pub fn handle_config_set(
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
-            tracing::warn!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                "[scout_stream::mlx_device] config registry not found",
-            );
+            emit(ScoutMlxConfigRegistryLookupFailed::config_set_lookup(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+            ));
             return mlx_device_pb::MlxDeviceConfigSetResponse {
                 reply: Some(mlx_device_pb::mlx_device_config_set_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -813,12 +967,11 @@ pub fn handle_config_set(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                error = %e,
-                "[scout_stream::mlx_device] config set to device failed",
-            );
+            emit(ScoutMlxConfigOperationFailed::config_set_execute(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceConfigSetResponse {
                 reply: Some(mlx_device_pb::mlx_device_config_set_response::Reply::Error(
                     mlx_device_pb::MlxDeviceStreamError {
@@ -849,11 +1002,10 @@ pub fn handle_config_sync(
     let registry = match registries::get(&request.registry_name) {
         Some(r) => r.clone(),
         None => {
-            tracing::warn!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                "[scout_stream::mlx_device] config registry not found",
-            );
+            emit(ScoutMlxConfigRegistryLookupFailed::config_sync_lookup(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+            ));
             return mlx_device_pb::MlxDeviceConfigSyncResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_config_sync_response::Reply::Error(
@@ -898,12 +1050,11 @@ pub fn handle_config_sync(
                     ),
                 },
                 Err(e) => {
-                    tracing::error!(
-                        device_id = %request.device_id,
-                        registry_name = %request.registry_name,
-                        error = %e,
-                        "[scout_stream::mlx_device] config sync result failed to serialize",
-                    );
+                    emit(ScoutMlxConfigOperationFailed::config_sync_serialize(
+                        request.device_id.clone(),
+                        request.registry_name.clone(),
+                        e.to_string(),
+                    ));
                     mlx_device_pb::MlxDeviceConfigSyncResponse {
                         reply: Some(
                             mlx_device_pb::mlx_device_config_sync_response::Reply::Error(
@@ -922,12 +1073,11 @@ pub fn handle_config_sync(
             }
         }
         Err(e) => {
-            tracing::error!(
-                device_id = %request.device_id,
-                registry_name = %request.registry_name,
-                error = %e,
-                "[scout_stream::mlx_device] config sync to device failed",
-            );
+            emit(ScoutMlxConfigOperationFailed::config_sync_execute(
+                request.device_id.clone(),
+                request.registry_name.clone(),
+                e.to_string(),
+            ));
             mlx_device_pb::MlxDeviceConfigSyncResponse {
                 reply: Some(
                     mlx_device_pb::mlx_device_config_sync_response::Reply::Error(
@@ -1062,6 +1212,12 @@ pub async fn apply_firmware(
     device: &str,
     profile: &FirmwareFlasherProfile,
 ) -> Option<FirmwareFlashReportPb> {
+    let firmware_url = LoggableFirmwareSource::new(&profile.flash_spec.firmware_url);
+    let device_conf_url = profile
+        .flash_spec
+        .device_conf_url
+        .as_deref()
+        .map(LoggableFirmwareSource::new);
     let firmware_credential_type = profile
         .flash_spec
         .firmware_credentials
@@ -1080,9 +1236,12 @@ pub async fn apply_firmware(
         device = %device,
         part_number = %profile.firmware_spec.part_number,
         psid = %profile.firmware_spec.psid,
-        firmware_url = %profile.flash_spec.firmware_url,
+        firmware_url = %firmware_url.as_str(),
         firmware_credential_type,
-        device_configuration_url = profile.flash_spec.device_conf_url.as_deref().unwrap_or("none"),
+        device_configuration_url = device_conf_url
+            .as_ref()
+            .map(LoggableFirmwareSource::as_str)
+            .unwrap_or("none"),
         device_configuration_credential_type = device_conf_credential_type,
         target_version = %profile.firmware_spec.version,
         "applying firmware"
@@ -1093,13 +1252,12 @@ pub async fn apply_firmware(
     let flasher = match FirmwareFlasher::new(device, &profile.firmware_spec) {
         Ok(f) => f,
         Err(e) => {
-            tracing::error!(
-                device = %device,
-                part_number = %profile.firmware_spec.part_number,
-                psid = %profile.firmware_spec.psid,
-                error = %e,
-                "failed to create FirmwareFlasher"
-            );
+            emit(ScoutMlxFirmwareFlasherInitializationFailed::new(
+                device.to_string(),
+                profile.firmware_spec.part_number.clone(),
+                profile.firmware_spec.psid.clone(),
+                firmware_error_context(&e.to_string(), profile),
+            ));
             return None;
         }
     };
@@ -1113,22 +1271,21 @@ pub async fn apply_firmware(
                 device = %device,
                 part_number = %profile.firmware_spec.part_number,
                 psid = %profile.firmware_spec.psid,
-                firmware_url = %profile.flash_spec.firmware_url,
+                firmware_url = %firmware_url.as_str(),
                 target_version = %profile.firmware_spec.version,
                 "firmware flash successful"
             );
             Some(result.into())
         }
         Err(e) => {
-            tracing::error!(
-                device = %device,
-                part_number = %profile.firmware_spec.part_number,
-                psid = %profile.firmware_spec.psid,
-                firmware_url = %profile.flash_spec.firmware_url,
-                target_version = %profile.firmware_spec.version,
-                error = %e,
-                "firmware flash failed"
-            );
+            emit(ScoutMlxFirmwareFlashFailed::execute(
+                device.to_string(),
+                profile.firmware_spec.part_number.clone(),
+                profile.firmware_spec.psid.clone(),
+                firmware_url.as_str().to_string(),
+                profile.firmware_spec.version.clone(),
+                firmware_error_context(&e.to_string(), profile),
+            ));
             None
         }
     }
@@ -1149,11 +1306,10 @@ pub(crate) fn apply_profile(
     // Always reset to factory defaults first.
     let applier = MlxConfigApplier::new(device);
     if let Err(e) = applier.reset_config() {
-        tracing::error!(
-            device = %device,
-            error = %e,
-            "mlxconfig reset failed"
-        );
+        emit(ScoutMlxProfileResetFailed::execute(
+            device.to_string(),
+            e.to_string(),
+        ));
         return (profile.map(|p| p.name), Some(false));
     }
     tracing::info!(device = %device, "mlxconfig reset to factory defaults");
@@ -1176,12 +1332,11 @@ pub(crate) fn apply_profile(
             (Some(name), Some(true))
         }
         Err(e) => {
-            tracing::error!(
-                device = %device,
-                profile = %name,
-                error = %e,
-                "mlxconfig profile sync failed"
-            );
+            emit(ScoutMlxProfileApplyFailed::execute(
+                device.to_string(),
+                name.clone(),
+                e.to_string(),
+            ));
             (Some(name), Some(false))
         }
     }
@@ -1210,6 +1365,7 @@ fn load_and_compare_profile(
 mod tests {
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
+    use libmlx::firmware::config::{FirmwareSpec, FlashOptions, FlashSpec};
 
     use super::*;
 
@@ -1218,11 +1374,14 @@ mod tests {
     const REGISTRY: &str = "missing-registry";
 
     #[derive(Clone, Copy)]
-    enum ReadFailure {
-        MissingProfile,
+    enum HandlerFailure {
+        MissingProfileCompare,
+        MissingProfileSync,
         MissingRegistry,
         QueryMissingRegistry,
         CompareMissingRegistry,
+        SetMissingRegistry,
+        SyncMissingRegistry,
     }
 
     #[derive(Debug, PartialEq)]
@@ -1245,20 +1404,23 @@ mod tests {
         counter_delta: f64,
     }
 
-    impl ReadFailure {
+    impl HandlerFailure {
         fn metric_labels(self) -> [(&'static str, &'static str); 3] {
             let operation = match self {
-                Self::MissingProfile => "profile_compare",
+                Self::MissingProfileCompare => "profile_compare",
+                Self::MissingProfileSync => "profile_sync",
                 Self::MissingRegistry => "registry_show",
                 Self::QueryMissingRegistry => "config_query",
                 Self::CompareMissingRegistry => "config_compare",
+                Self::SetMissingRegistry => "config_set",
+                Self::SyncMissingRegistry => "config_sync",
             };
             let failure_stage = match self {
-                Self::MissingProfile => "validate",
+                Self::MissingProfileCompare | Self::MissingProfileSync => "validate",
                 _ => "lookup",
             };
             let failure_kind = match self {
-                Self::MissingProfile => "invalid_request",
+                Self::MissingProfileCompare | Self::MissingProfileSync => "invalid_request",
                 _ => "not_found",
             };
             [
@@ -1270,7 +1432,7 @@ mod tests {
 
         fn invoke(self) -> mlx_device_pb::MlxDeviceStreamError {
             match self {
-                Self::MissingProfile => {
+                Self::MissingProfileCompare => {
                     let response =
                         handle_profile_compare(mlx_device_pb::MlxDeviceProfileCompareRequest {
                             device_id: DEVICE_ID.to_string(),
@@ -1282,6 +1444,20 @@ mod tests {
                             error,
                         )) => error,
                         _ => panic!("missing profile should return an error"),
+                    }
+                }
+                Self::MissingProfileSync => {
+                    let response =
+                        handle_profile_sync(mlx_device_pb::MlxDeviceProfileSyncRequest {
+                            device_id: DEVICE_ID.to_string(),
+                            profile_name: "default".to_string(),
+                            serializable_profile: None,
+                        });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_profile_sync_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing sync profile should return an error"),
                     }
                 }
                 Self::MissingRegistry => {
@@ -1324,12 +1500,38 @@ mod tests {
                         _ => panic!("missing compare registry should return an error"),
                     }
                 }
+                Self::SetMissingRegistry => {
+                    let response = handle_config_set(mlx_device_pb::MlxDeviceConfigSetRequest {
+                        device_id: DEVICE_ID.to_string(),
+                        registry_name: REGISTRY.to_string(),
+                        assignments: Vec::new(),
+                    });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_config_set_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing set registry should return an error"),
+                    }
+                }
+                Self::SyncMissingRegistry => {
+                    let response = handle_config_sync(mlx_device_pb::MlxDeviceConfigSyncRequest {
+                        device_id: DEVICE_ID.to_string(),
+                        registry_name: REGISTRY.to_string(),
+                        assignments: Vec::new(),
+                    });
+                    match response.reply {
+                        Some(mlx_device_pb::mlx_device_config_sync_response::Reply::Error(
+                            error,
+                        )) => error,
+                        _ => panic!("missing sync registry should return an error"),
+                    }
+                }
             }
         }
     }
 
     #[test]
-    fn read_handlers_preserve_responses_and_classify_failures() {
+    fn mlx_handlers_preserve_responses_and_classify_failures() {
         let internal = mlx_device_pb::MlxDeviceStreamErrorStatus::Internal as i32;
         let missing_config = || {
             format!("config registry not found (device_id:{DEVICE_ID}, registry_name:{REGISTRY})")
@@ -1339,7 +1541,17 @@ mod tests {
             [
                 Check {
                     scenario: "profile comparison requires profile data",
-                    input: ReadFailure::MissingProfile,
+                    input: HandlerFailure::MissingProfileCompare,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: "no serializable profile data in message".to_string(),
+                        events: Vec::new(),
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "profile synchronization requires profile data",
+                    input: HandlerFailure::MissingProfileSync,
                     expect: HandlerObservation {
                         response_status: internal,
                         response_message: "no serializable profile data in message".to_string(),
@@ -1349,7 +1561,7 @@ mod tests {
                 },
                 Check {
                     scenario: "registry show rejects an unknown registry",
-                    input: ReadFailure::MissingRegistry,
+                    input: HandlerFailure::MissingRegistry,
                     expect: HandlerObservation {
                         response_status: internal,
                         response_message: format!("registry not found: {REGISTRY}"),
@@ -1369,7 +1581,7 @@ mod tests {
                 },
                 Check {
                     scenario: "config query rejects an unknown registry",
-                    input: ReadFailure::QueryMissingRegistry,
+                    input: HandlerFailure::QueryMissingRegistry,
                     expect: HandlerObservation {
                         response_status: internal,
                         response_message: missing_config(),
@@ -1389,7 +1601,7 @@ mod tests {
                 },
                 Check {
                     scenario: "config comparison rejects an unknown registry",
-                    input: ReadFailure::CompareMissingRegistry,
+                    input: HandlerFailure::CompareMissingRegistry,
                     expect: HandlerObservation {
                         response_status: internal,
                         response_message: missing_config(),
@@ -1399,6 +1611,46 @@ mod tests {
                                 .to_string(),
                             event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
                             operation: Some("config_compare".to_string()),
+                            failure_stage: Some("lookup".to_string()),
+                            failure_kind: Some("not_found".to_string()),
+                            device_id: Some(DEVICE_ID.to_string()),
+                            registry_name: Some(REGISTRY.to_string()),
+                        }],
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "config set rejects an unknown registry",
+                    input: HandlerFailure::SetMissingRegistry,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: missing_config(),
+                        events: vec![EventObservation {
+                            level: tracing::Level::WARN,
+                            message: "[scout_stream::mlx_device] config registry not found"
+                                .to_string(),
+                            event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
+                            operation: Some("config_set".to_string()),
+                            failure_stage: Some("lookup".to_string()),
+                            failure_kind: Some("not_found".to_string()),
+                            device_id: Some(DEVICE_ID.to_string()),
+                            registry_name: Some(REGISTRY.to_string()),
+                        }],
+                        counter_delta: 1.0,
+                    },
+                },
+                Check {
+                    scenario: "config synchronization rejects an unknown registry",
+                    input: HandlerFailure::SyncMissingRegistry,
+                    expect: HandlerObservation {
+                        response_status: internal,
+                        response_message: missing_config(),
+                        events: vec![EventObservation {
+                            level: tracing::Level::WARN,
+                            message: "[scout_stream::mlx_device] config registry not found"
+                                .to_string(),
+                            event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
+                            operation: Some("config_sync".to_string()),
                             failure_stage: Some("lookup".to_string()),
                             failure_kind: Some("not_found".to_string()),
                             device_id: Some(DEVICE_ID.to_string()),
@@ -1440,6 +1692,190 @@ mod tests {
                         .counter_delta(MLX_FAILURE_METRIC, &fixture.metric_labels()),
                 }
             },
+        );
+    }
+
+    #[test]
+    fn lockdown_error_context_removes_valid_keys() {
+        struct RedactionCase {
+            error: MlxError,
+            key: &'static str,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "dry-run commands do not retain the key",
+                    input: RedactionCase {
+                        error: MlxError::DryRun(
+                            "flint -d device hw_access enable deadbeef".to_string(),
+                        ),
+                        key: "deadbeef",
+                    },
+                    expect:
+                        "dry run - would have executed: flint -d device hw_access enable REDACTED"
+                            .to_string(),
+                },
+                Check {
+                    scenario: "tool output does not retain the key",
+                    input: RedactionCase {
+                        error: MlxError::CommandFailed("flint rejected key DEADBEEF".to_string()),
+                        key: "DEADBEEF",
+                    },
+                    expect: "command execution failed: flint rejected key REDACTED".to_string(),
+                },
+                Check {
+                    scenario: "invalid keys cannot rewrite ordinary diagnostics",
+                    input: RedactionCase {
+                        error: MlxError::InvalidKey,
+                        key: "a",
+                    },
+                    expect: "invalid key format or length".to_string(),
+                },
+            ],
+            |case| lockdown_error_context(&case.error, case.key),
+        );
+    }
+
+    fn firmware_profile(
+        firmware_url: &str,
+        firmware_credentials: Option<Credentials>,
+        device_conf_url: Option<&str>,
+        device_conf_credentials: Option<Credentials>,
+    ) -> FirmwareFlasherProfile {
+        FirmwareFlasherProfile {
+            firmware_spec: FirmwareSpec {
+                part_number: "part-number".to_string(),
+                psid: "psid".to_string(),
+                version: "1.2.3".to_string(),
+            },
+            flash_spec: FlashSpec {
+                firmware_url: firmware_url.to_string(),
+                firmware_credentials,
+                device_conf_url: device_conf_url.map(str::to_string),
+                device_conf_credentials,
+                verify_from_cache: false,
+                cache_dir: None,
+            },
+            flash_options: FlashOptions::default(),
+        }
+    }
+
+    #[test]
+    fn firmware_context_excludes_urls_and_credentials() {
+        const FIRMWARE_URL: &str =
+            "https://user:userinfo-secret@firmware.example/fw.bin?token=url-secret#download";
+        const DEVICE_CONF_URL: &str = "https://config.example/device.ini?token=config-secret#apply";
+        const BEARER: &str = "bearer-secret";
+        const PASSWORD: &str = "basic-password";
+
+        let profile = firmware_profile(
+            FIRMWARE_URL,
+            Some(Credentials::bearer_token(BEARER)),
+            Some(DEVICE_CONF_URL),
+            Some(Credentials::basic_auth("user", PASSWORD)),
+        );
+        let error = format!(
+            "firmware={FIRMWARE_URL}; config={DEVICE_CONF_URL}; bearer={BEARER}; password={PASSWORD}"
+        );
+        let context = firmware_error_context(&error, &profile);
+
+        assert_eq!(
+            LoggableFirmwareSource::new(FIRMWARE_URL).as_str(),
+            "https://firmware.example/fw.bin"
+        );
+        assert_eq!(
+            LoggableFirmwareSource::new(
+                "ftp://user:password@firmware.example/fw.bin?token=secret#download"
+            )
+            .as_str(),
+            "ftp://firmware.example/fw.bin"
+        );
+        let invalid_source = LoggableFirmwareSource::new("http://");
+        assert_eq!(invalid_source.as_str(), "<invalid firmware source>");
+        assert_eq!(
+            invalid_source.redact_from("upstream=http://other.example/fw.bin"),
+            "upstream=http://other.example/fw.bin"
+        );
+        assert_eq!(
+            context,
+            "firmware=https://firmware.example/fw.bin; \
+             config=https://config.example/device.ini; bearer=REDACTED; password=REDACTED"
+        );
+        for secret in [
+            "userinfo-secret",
+            "url-secret",
+            "config-secret",
+            BEARER,
+            PASSWORD,
+        ] {
+            assert!(!context.contains(secret));
+        }
+    }
+
+    #[test]
+    fn firmware_error_context_redacts_each_secret_credential_variant() {
+        #[derive(Clone, Copy)]
+        enum CredentialCase {
+            Bearer,
+            Basic,
+            Header,
+            SshPassphrase,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "bearer token",
+                    input: CredentialCase::Bearer,
+                    expect: "failure: REDACTED".to_string(),
+                },
+                Check {
+                    scenario: "basic password",
+                    input: CredentialCase::Basic,
+                    expect: "failure: REDACTED".to_string(),
+                },
+                Check {
+                    scenario: "custom header value",
+                    input: CredentialCase::Header,
+                    expect: "failure: REDACTED".to_string(),
+                },
+                Check {
+                    scenario: "SSH key passphrase",
+                    input: CredentialCase::SshPassphrase,
+                    expect: "failure: REDACTED".to_string(),
+                },
+            ],
+            |case| {
+                let (credentials, secret) = match case {
+                    CredentialCase::Bearer => {
+                        (Credentials::bearer_token("bearer-secret"), "bearer-secret")
+                    }
+                    CredentialCase::Basic => (
+                        Credentials::basic_auth("user", "basic-secret"),
+                        "basic-secret",
+                    ),
+                    CredentialCase::Header => (
+                        Credentials::header("X-Firmware-Token", "header-secret"),
+                        "header-secret",
+                    ),
+                    CredentialCase::SshPassphrase => (
+                        Credentials::ssh_key_with_passphrase("/key", "passphrase-secret"),
+                        "passphrase-secret",
+                    ),
+                };
+                let profile = firmware_profile("/firmware.bin", Some(credentials), None, None);
+
+                firmware_error_context(&format!("failure: {secret}"), &profile)
+            },
+        );
+    }
+
+    #[test]
+    fn firmware_secret_redaction_merges_overlapping_matches() {
+        assert_eq!(
+            mask_secret_values("prefix abcde suffix", ["abc", "cde"].into_iter()),
+            "prefix REDACTED suffix"
         );
     }
 }

--- a/docs/observability/core_metrics.md
+++ b/docs/observability/core_metrics.md
@@ -227,7 +227,7 @@ This file contains a list of metrics exported by NVIDIA Infra Controller (NICo).
 <tr><td>carbide_running_dpu_updates_count</td><td>gauge</td><td>Number of machines in the system that are currently running a DPU/NIC firmware update</td></tr>
 <tr><td>carbide_scout_actions_total</td><td>counter</td><td>Number of scout control-loop actions handled, by action and outcome.</td></tr>
 <tr><td>carbide_scout_firmware_download_attempt_failures_total</td><td>counter</td><td>Number of failed Scout firmware download attempts, by download kind and next action.</td></tr>
-<tr><td>carbide_scout_mlx_failures_total</td><td>counter</td><td>Number of Scout MLX observation and read failures, by operation, failure stage, and failure kind.</td></tr>
+<tr><td>carbide_scout_mlx_failures_total</td><td>counter</td><td>Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind.</td></tr>
 <tr><td>carbide_scout_storage_device_cleanup_duration_seconds</td><td>histogram</td><td>Duration of per-device scout storage cleanup operations, by device type and outcome.</td></tr>
 <tr><td>carbide_scout_stream_connections_total</td><td>counter</td><td>Number of scout stream connection attempts, by outcome.</td></tr>
 <tr><td>carbide_scout_stream_reconnects_total</td><td>counter</td><td>Number of scout stream reconnect cycles after a stream closed or errored.</td></tr>


### PR DESCRIPTION
#4163 handles Scout's firmware-download and MLX observation paths. The mutation side deliberately stayed separate because profile application, configuration changes, lockdown, firmware flashing, and reconciliation recovery overlap in the same code and make a much riskier review when mixed with the reads.

So, this finishes the remaining mutation and recovery paths with the same bounded Event family introduced in #4163. Every existing response, retry, control-flow, and log-level decision stays in place. Firmware URLs, userinfo, query and fragment data, credential values, and typed lockdown errors are redacted before they reach diagnostics.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4160

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-scout`
- `cargo clippy -p carbide-scout --all-targets -- -D warnings`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-event-names`
- `cargo xtask check-metric-docs`
- `cargo make check-format-nightly`

## Additional Notes

#4163 is now on main, so this PR contains only the standalone mutation and recovery delta. Existing INFO reconciliation diagnostics and request and response behavior remain unchanged. The generated core metric catalogue stays with this code change.

Closes #4160
