### PR TITLE
fix(dpf): start without the site-wide BMC root credential

### DIFF
--- a/crates/dpf/src/repository/kube.rs
+++ b/crates/dpf/src/repository/kube.rs
@@ -611,16 +611,13 @@ impl K8sConfigRepository for KubeRepository {
         }
     }
 
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         name: &str,
         namespace: &str,
         data: BTreeMap<String, Vec<u8>>,
     ) -> Result<(), DpfError> {
         let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
-        if api.get_opt(name).await?.is_some() {
-            return Ok(());
-        }
         let secret = Secret {
             metadata: kube::core::ObjectMeta {
                 name: Some(name.to_string()),
@@ -634,7 +631,15 @@ impl K8sConfigRepository for KubeRepository {
             ),
             ..Default::default()
         };
-        api.create(&PostParams::default(), &secret).await?;
+        // Server-side apply, matching `apply_configmap`: creates the Secret when
+        // absent and overwrites the data when present, so a rotated credential
+        // actually reaches the cluster.
+        api.patch(
+            name,
+            &PatchParams::apply("carbide-dpf-sdk").force(),
+            &Patch::Apply(&secret),
+        )
+        .await?;
         Ok(())
     }
 }

--- a/crates/dpf/src/repository/traits.rs
+++ b/crates/dpf/src/repository/traits.rs
@@ -256,7 +256,11 @@ pub trait K8sConfigRepository: Send + Sync {
         name: &str,
         namespace: &str,
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError>;
-    async fn create_secret(
+    /// Create the Secret, or overwrite the data of an existing one. Callers
+    /// rewrite this Secret when the underlying credential rotates, so an
+    /// implementation that skips existing objects would silently pin the
+    /// cluster to the first value ever written.
+    async fn apply_secret(
         &self,
         name: &str,
         namespace: &str,

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -235,13 +235,35 @@ where
 {
     /// Fetch password, write the K8s BMC secret, spawn refresh task,
     /// and return the constructed SDK.
+    ///
+    /// The BMC password is not necessarily available the first time this runs.
+    /// It comes from the site-wide BMC root credential, which operators set
+    /// *through the API this SDK is initializing*, so on a fresh site the
+    /// credential does not exist yet. When a refresh interval is configured the
+    /// initial read is therefore best-effort: initialization continues without
+    /// the Secret, and the refresh task writes it as soon as the credential
+    /// appears — no restart needed. Without a refresh interval nothing would
+    /// ever retry, so there a failed read stays fatal.
     async fn init_secret_and_task(self) -> Result<DpfSdk<R, L>, DpfError> {
         let repo = Arc::new(self.repo);
         let namespace = self.namespace;
         let provider = self.bmc_password_provider;
 
-        let password = provider.get_bmc_password().await?;
-        write_bmc_secret::<R>(&repo, &namespace, &password).await?;
+        let password = match provider.get_bmc_password().await {
+            Ok(password) => {
+                write_bmc_secret::<R>(&repo, &namespace, &password).await?;
+                Some(password)
+            }
+            Err(error) if self.bmc_password_refresh_interval.is_some() => {
+                tracing::warn!(
+                    %error,
+                    secret = SECRET_NAME,
+                    "BMC password unavailable; DPF secret will be written once the credential is set"
+                );
+                None
+            }
+            Err(error) => return Err(error),
+        };
 
         let guard = if let Some(interval) = self.bmc_password_refresh_interval {
             Some(spawn_bmc_refresh(
@@ -306,25 +328,30 @@ async fn write_bmc_secret<R: K8sConfigRepository>(
 ) -> Result<(), DpfError> {
     let mut data = BTreeMap::new();
     data.insert("password".to_string(), password.as_bytes().to_vec());
-    K8sConfigRepository::create_secret(repo, SECRET_NAME, namespace, data).await
+    K8sConfigRepository::apply_secret(repo, SECRET_NAME, namespace, data).await
 }
 
 /// Fetch the current BMC password from the provider and update the K8s
 /// secret when it differs from `last_password`. Returns the password
 /// value that should be remembered for the next comparison.
+///
+/// `last_password` is `None` when no password has been written yet — either
+/// because the credential was unset at startup, or because every write since
+/// has failed. That case writes on the next successful read, which is how a
+/// site that boots without the site-wide BMC root recovers on its own.
 async fn refresh_bmc_secret_if_changed<R: K8sConfigRepository>(
     repo: &R,
     namespace: &str,
     provider: &impl BmcPasswordProvider,
-    last_password: String,
-) -> String {
+    last_password: Option<String>,
+) -> Option<String> {
     match provider.get_bmc_password().await {
-        Ok(new_pw) if new_pw != last_password => {
+        Ok(new_pw) if Some(&new_pw) != last_password.as_ref() => {
             if let Err(e) = write_bmc_secret::<R>(repo, namespace, &new_pw).await {
                 tracing::error!(error = %e, "Failed to refresh BMC secret");
                 last_password
             } else {
-                new_pw
+                Some(new_pw)
             }
         }
         Err(e) => {
@@ -340,7 +367,7 @@ fn spawn_bmc_refresh<R, P>(
     repo: Arc<R>,
     namespace: String,
     provider: P,
-    password: String,
+    password: Option<String>,
     interval: Duration,
     join_set: Option<&mut tokio::task::JoinSet<()>>,
 ) -> Result<tokio_util::sync::DropGuard, DpfError>
@@ -2491,7 +2518,7 @@ mod tests {
         ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
             Ok(None)
         }
-        async fn create_secret(
+        async fn apply_secret(
             &self,
             _name: &str,
             _ns: &str,
@@ -3091,7 +3118,7 @@ mod tests {
         ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
             Ok(None)
         }
-        async fn create_secret(
+        async fn apply_secret(
             &self,
             _name: &str,
             _ns: &str,
@@ -3115,16 +3142,33 @@ mod tests {
         }
     }
 
+    /// Provider that always fails, standing in for a site where the site-wide
+    /// BMC root credential has not been set yet.
+    struct UnsetBmcPasswordProvider;
+
+    #[async_trait]
+    impl BmcPasswordProvider for UnsetBmcPasswordProvider {
+        async fn get_bmc_password(&self) -> Result<String, DpfError> {
+            Err(DpfError::InvalidState(
+                "Site wide BMC root credentials not set".into(),
+            ))
+        }
+    }
+
     #[tokio::test]
     async fn test_refresh_writes_secret_when_password_changes() {
         let mock = SecretTrackingMock::default();
         let provider = "new-password".to_string();
 
-        let result =
-            refresh_bmc_secret_if_changed(&mock, TEST_NAMESPACE, &provider, "old-password".into())
-                .await;
+        let result = refresh_bmc_secret_if_changed(
+            &mock,
+            TEST_NAMESPACE,
+            &provider,
+            Some("old-password".into()),
+        )
+        .await;
 
-        assert_eq!(result, "new-password");
+        assert_eq!(result.as_deref(), Some("new-password"));
         assert_eq!(
             mock.secrets_written.lock().unwrap().as_slice(),
             &["new-password"]
@@ -3137,9 +3181,10 @@ mod tests {
         let provider = "same".to_string();
 
         let result =
-            refresh_bmc_secret_if_changed(&mock, TEST_NAMESPACE, &provider, "same".into()).await;
+            refresh_bmc_secret_if_changed(&mock, TEST_NAMESPACE, &provider, Some("same".into()))
+                .await;
 
-        assert_eq!(result, "same");
+        assert_eq!(result.as_deref(), Some("same"));
         assert!(mock.secrets_written.lock().unwrap().is_empty());
     }
 
@@ -3151,11 +3196,80 @@ mod tests {
         };
         let provider = "new-password".to_string();
 
+        let result = refresh_bmc_secret_if_changed(
+            &mock,
+            TEST_NAMESPACE,
+            &provider,
+            Some("old-password".into()),
+        )
+        .await;
+
+        assert_eq!(result.as_deref(), Some("old-password"));
+    }
+
+    /// The recovery path for a site that booted before the site-wide BMC root
+    /// credential was set: nothing has been written yet, so the first
+    /// successful read must write the Secret.
+    #[tokio::test]
+    async fn test_refresh_writes_secret_when_no_password_written_yet() {
+        let mock = SecretTrackingMock::default();
+        let provider = "first-password".to_string();
+
+        let result = refresh_bmc_secret_if_changed(&mock, TEST_NAMESPACE, &provider, None).await;
+
+        assert_eq!(result.as_deref(), Some("first-password"));
+        assert_eq!(
+            mock.secrets_written.lock().unwrap().as_slice(),
+            &["first-password"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_refresh_stays_unwritten_while_password_unavailable() {
+        let mock = SecretTrackingMock::default();
+
         let result =
-            refresh_bmc_secret_if_changed(&mock, TEST_NAMESPACE, &provider, "old-password".into())
+            refresh_bmc_secret_if_changed(&mock, TEST_NAMESPACE, &UnsetBmcPasswordProvider, None)
                 .await;
 
-        assert_eq!(result, "old-password");
+        assert_eq!(result, None);
+        assert!(mock.secrets_written.lock().unwrap().is_empty());
+    }
+
+    /// A fresh site sets the site-wide BMC root credential *through* the API,
+    /// so initialization must survive the credential being unset, leaving the
+    /// Secret to the refresh task.
+    #[tokio::test]
+    async fn test_build_succeeds_when_bmc_password_unset_and_refresh_configured() {
+        let mock = SecretTrackingMock::default();
+
+        let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NAMESPACE, UnsetBmcPasswordProvider)
+            .with_bmc_password_refresh_interval(Duration::from_secs(3600))
+            .build_without_resources()
+            .await
+            .expect("initialization tolerates an unset BMC password");
+
+        assert_eq!(sdk.namespace(), TEST_NAMESPACE);
+        assert!(mock.secrets_written.lock().unwrap().is_empty());
+    }
+
+    /// Without a refresh task nothing would ever retry the read, so an unset
+    /// credential stays fatal rather than leaving the Secret permanently absent.
+    #[tokio::test]
+    async fn test_build_fails_when_bmc_password_unset_and_no_refresh_configured() {
+        let mock = SecretTrackingMock::default();
+
+        let Err(error) = DpfSdkBuilder::new(mock, TEST_NAMESPACE, UnsetBmcPasswordProvider)
+            .build_without_resources()
+            .await
+        else {
+            panic!("an unset BMC password with no refresh task is fatal");
+        };
+
+        assert!(
+            matches!(error, DpfError::InvalidState(msg) if msg.contains("BMC root credentials")),
+            "unexpected error"
+        );
     }
 
     fn terminating_timestamp() -> k8s_openapi::apimachinery::pkg::apis::meta::v1::Time {

--- a/crates/dpf/src/test/helpers.rs
+++ b/crates/dpf/src/test/helpers.rs
@@ -307,7 +307,7 @@ impl K8sConfigRepository for ConfigMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(None)
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         _: &str,
         _: &str,

--- a/crates/dpf/src/test/maintenance_flow.rs
+++ b/crates/dpf/src/test/maintenance_flow.rs
@@ -234,7 +234,7 @@ impl K8sConfigRepository for MaintenanceFlowMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(None)
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         _: &str,
         _: &str,

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -166,7 +166,7 @@ impl K8sConfigRepository for DeviceRegistrationMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(None)
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         _: &str,
         _: &str,

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -339,7 +339,7 @@ impl K8sConfigRepository for InitializationMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(self.secrets.get(&ns_key(ns, name)).map(|r| r.clone()))
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         name: &str,
         ns: &str,

--- a/crates/dpf/src/test/sdk_maintenance_hold.rs
+++ b/crates/dpf/src/test/sdk_maintenance_hold.rs
@@ -102,7 +102,7 @@ impl K8sConfigRepository for MaintenanceHoldMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(None)
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         _: &str,
         _: &str,

--- a/crates/dpf/src/test/sdk_provisioning_flow.rs
+++ b/crates/dpf/src/test/sdk_provisioning_flow.rs
@@ -195,7 +195,7 @@ impl K8sConfigRepository for ProvisioningFlowMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(None)
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         _: &str,
         _: &str,

--- a/crates/dpf/src/test/sdk_reboot_annotation.rs
+++ b/crates/dpf/src/test/sdk_reboot_annotation.rs
@@ -117,7 +117,7 @@ impl K8sConfigRepository for RebootAnnotationMock {
     ) -> Result<Option<BTreeMap<String, Vec<u8>>>, DpfError> {
         Ok(None)
     }
-    async fn create_secret(
+    async fn apply_secret(
         &self,
         _: &str,
         _: &str,

--- a/docs/getting-started/prerequisites/bmc-oob-setup.md
+++ b/docs/getting-started/prerequisites/bmc-oob-setup.md
@@ -64,7 +64,7 @@ Before ingesting hosts, you must also configure the credentials NICo will set on
 
 These are configured via `nico-admin-cli` after NICo is deployed. Refer to the [Ingesting Hosts](../../provisioning/ingesting-hosts.md) page for the credential setup commands.
 
-Host ingestion does not start until they are set: Site Explorer verifies the
+Host ingestion does not start until these credentials are set. Site Explorer verifies the
 site-wide BMC root and both UEFI site defaults before contacting any BMC, and
 aborts each run with `MissingCredentials` while any of them is missing. They can
 also be seeded directly into the credential store before NICo is deployed —

--- a/docs/getting-started/prerequisites/bmc-oob-setup.md
+++ b/docs/getting-started/prerequisites/bmc-oob-setup.md
@@ -64,6 +64,12 @@ Before ingesting hosts, you must also configure the credentials NICo will set on
 
 These are configured via `nico-admin-cli` after NICo is deployed. Refer to the [Ingesting Hosts](../../provisioning/ingesting-hosts.md) page for the credential setup commands.
 
+Host ingestion does not start until they are set: Site Explorer verifies the
+site-wide BMC root and both UEFI site defaults before contacting any BMC, and
+aborts each run with `MissingCredentials` while any of them is missing. They can
+also be seeded directly into the credential store before NICo is deployed —
+refer to [Set the site-wide BMC root credential](../../manuals/dpf.md#36-set-the-site-wide-bmc-root-credential).
+
 ## BMC Redfish Requirements
 
 NICo communicates with host BMCs and DPU BMCs exclusively via Redfish. The BMC must support the following Redfish operations:

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -577,10 +577,13 @@ Configure the credentials NICo will apply to BMCs and UEFI after ingestion:
 nico-admin-cli -a <api-url> credential add-bmc --kind=site-wide-root --password='<password>'
 nico-admin-cli -a <api-url> host generate-host-uefi-password
 nico-admin-cli -a <api-url> credential add-uefi --kind=host --password='<password>'
+nico-admin-cli -a <api-url> credential add-uefi --kind=dpu --password='<password>'
 ```
 
-Site Explorer will not run until all of these are set — it checks them before
-contacting any BMC and fails each iteration with `MissingCredentials` otherwise.
+Site Explorer requires all three — the site-wide BMC root and both the `host`
+and `dpu` UEFI site defaults. It checks them before contacting any BMC and fails
+each iteration with `MissingCredentials` while any one is missing.
+
 When DPF is enabled, the site-wide BMC root credential is also mirrored into the
 DPF `bmc-shared-password` Secret; refer to
 [Set the site-wide BMC root credential](../manuals/dpf.md#36-set-the-site-wide-bmc-root-credential)

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -580,6 +580,13 @@ nico-admin-cli -a <api-url> credential add-uefi --kind=host --password='<passwor
 nico-admin-cli -a <api-url> credential add-uefi --kind=dpu --password='<password>'
 ```
 
+<Warning>
+`nico-admin-cli` accepts these passwords only as command-line arguments, so each
+one lands in your shell history and is visible in the process argument list
+while the command runs. Run them from a shell with history disabled, and clear
+any history file that captured them.
+</Warning>
+
 Site Explorer requires all three — the site-wide BMC root and both the `host`
 and `dpu` UEFI site defaults. It checks them before contacting any BMC and fails
 each iteration with `MissingCredentials` while any one is missing.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -579,6 +579,13 @@ nico-admin-cli -a <api-url> host generate-host-uefi-password
 nico-admin-cli -a <api-url> credential add-uefi --kind=host --password='<password>'
 ```
 
+Site Explorer will not run until all of these are set — it checks them before
+contacting any BMC and fails each iteration with `MissingCredentials` otherwise.
+When DPF is enabled, the site-wide BMC root credential is also mirrored into the
+DPF `bmc-shared-password` Secret; refer to
+[Set the site-wide BMC root credential](../manuals/dpf.md#36-set-the-site-wide-bmc-root-credential)
+for the DPF-specific details and for how to seed it ahead of time instead.
+
 ### Upload the Expected Machines Manifest
 
 Prepare an `expected_machines.json` with the BMC MAC address, factory default credentials, and chassis serial number for each host:

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -780,10 +780,19 @@ Configure it either through the API or by seeding the credential store directly.
 nico-admin-cli -a <api-url> credential add-bmc --kind=site-wide-root --password='<password>'
 ```
 
-carbide-api starts whether or not the credential is present. While it is
-missing, carbide-api logs a warning and leaves `bmc-shared-password` unwritten;
-it writes the Secret on the next refresh tick after the credential is set, with
-no restart required.
+`nico-admin-cli` takes the password only as an argument, so it lands in shell
+history and in the process argument list. Run it from a shell with history
+disabled, or use the seeding path below, which avoids both.
+
+This works on a site that is already running: when a BMC password refresh
+interval is configured, carbide-api starts whether or not the credential is
+present. While it is missing it logs a warning and leaves
+`bmc-shared-password` unwritten, then writes the Secret on the next refresh
+tick after the credential is set, with no restart required.
+
+Without a refresh interval there is nothing to retry the read, so a missing
+credential is fatal to startup and must be seeded before carbide-api first
+runs, as below.
 
 **By seeding the credential store**, to have the credential in place before
 carbide-api first starts. For a Vault-backed site:

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -789,9 +789,16 @@ no restart required.
 carbide-api first starts. For a Vault-backed site:
 
 ```bash
-echo '{"UsernamePassword":{"username":"root","password":"<password>"}}' \
+read -rs -p 'Site-wide BMC root password: ' BMC_ROOT_PASSWORD && echo
+printf '{"UsernamePassword":{"username":"root","password":"%s"}}' \
+  "${BMC_ROOT_PASSWORD}" \
   | vault kv put <kv-mount>/machines/bmc/site/root -
+unset BMC_ROOT_PASSWORD
 ```
+
+`read -rs` keeps the password off the terminal and out of shell history, and
+`printf` is a shell builtin, so the value never appears in a process argument
+list.
 
 Until the credential is set, DPU provisioning cannot proceed and Site Explorer
 does not run: it requires this credential plus the host and DPU UEFI site

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -991,7 +991,11 @@ service stack against the configured one. The full set is listed below.
 > rediscovery the host reverts to whatever its expected-machine entry says.
 > To persist the per-host DPF setting, update the expected-machines table
 > (see section 3.7). This is useful when you want to reprovision a host that
-> was not previously managed by DPF, using the DPF framework.
+<Tip>
+All `dpf enable` changes are written to the machine's metadata only. **They are wiped on force-delete** and on rediscovery the host reverts to whatever its expected-machine entry says.
+
+To persist the per-host DPF setting, update the expected-machines table (refer to [Mark hosts as DPF-managed in expected machines](#37-mark-hosts-as-dpf-managed-in-expected-machines)). This is useful when you want to reprovision a host that was not previously managed by DPF, using the DPF framework.
+</Tip>
 
 ### `dpf enable` — turn DPF on for a host
 

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -764,7 +764,48 @@ longer presents a client certificate for mutual TLS. It does not authenticate
 the preceding artifact or provisioning chain. Those inputs still require
 integrity protection and a trusted boot mechanism such as Secure Boot.
 
-### 3.6. Mark hosts as DPF-managed in expected machines
+### 3.6. Set the site-wide BMC root credential
+
+DPF provisions DPUs out-of-band over Redfish, so it needs the BMC password NICo
+applies to managed hardware. carbide-api reads the **site-wide BMC root**
+credential and mirrors it into the `bmc-shared-password` Secret in
+`dpf-operator-system` (section 4), refreshing it every 60 seconds so a rotated
+credential propagates without a restart.
+
+Configure it either through the API or by seeding the credential store directly.
+
+**Through the API**, once carbide-api is running:
+
+```bash
+nico-admin-cli -a <api-url> credential add-bmc --kind=site-wide-root --password='<password>'
+```
+
+carbide-api starts whether or not the credential is present. While it is
+missing, carbide-api logs a warning and leaves `bmc-shared-password` unwritten;
+it writes the Secret on the next refresh tick after the credential is set, with
+no restart required.
+
+**By seeding the credential store**, to have the credential in place before
+carbide-api first starts. For a Vault-backed site:
+
+```bash
+echo '{"UsernamePassword":{"username":"root","password":"<password>"}}' \
+  | vault kv put <kv-mount>/machines/bmc/site/root -
+```
+
+Until the credential is set, DPU provisioning cannot proceed and Site Explorer
+does not run: it requires this credential plus the host and DPU UEFI site
+defaults, and fails each iteration with `MissingCredentials` until all three are
+present.
+
+<Note>
+This is a site secret that must survive at all costs — it is also the input to
+SuperNIC lockdown key derivation. Refer to
+[SuperNIC Lockdown Key Management](../architecture/supernic_lockdown_key_management.md)
+for the backup and recovery requirements.
+</Note>
+
+### 3.7. Mark hosts as DPF-managed in expected machines
 
 Whether a given host is provisioned via DPF or via iPXE is decided per host,
 in the *expected machines* list that NICo loads on startup. The relevant
@@ -777,7 +818,7 @@ provisioned via DPF only when **both** of the following are true:
 There are several operator paths that can set this field. They are described
 below in the order an operator typically uses them.
 
-#### 3.6.a. `nico-admin-cli expected-machine add` — create a new entry
+#### 3.7.a. `nico-admin-cli expected-machine add` — create a new entry
 
 Adds a new expected-machine row. `--dpf-enabled` is optional; **omitting it
 stores `true`**.
@@ -791,7 +832,7 @@ nico-admin-cli expected-machine add \
   --dpf-enabled true
 ```
 
-#### 3.6.b. `nico-admin-cli expected-machine patch` — partial update via flags
+#### 3.7.b. `nico-admin-cli expected-machine patch` — partial update via flags
 
 Updates an existing entry in place. The lookup key is `--bmc-mac-address`
 (or `--id <UUID>`). Omitting `--dpf-enabled` **preserves** the existing
@@ -804,7 +845,7 @@ nico-admin-cli expected-machine patch \
   --dpf-enabled true
 ```
 
-#### 3.6.c. `nico-admin-cli expected-machine update --filename` — single-host update from JSON
+#### 3.7.c. `nico-admin-cli expected-machine update --filename` — single-host update from JSON
 
 Updates one entry from a JSON file. The JSON shape uses
 `chassis_serial_number` (not `serial_number`) and any field omitted from the
@@ -829,7 +870,7 @@ nico-admin-cli expected-machine update --filename em.json
 This is the most ergonomic path for "toggle DPF on one already-existing
 expected machine without touching anything else."
 
-#### 3.6.d. `nico-admin-cli expected-machine replace-all --filename` — destructive full reload
+#### 3.7.d. `nico-admin-cli expected-machine replace-all --filename` — destructive full reload
 
 Wipes the entire `expected_machines` table and re-creates it from the file.
 The file shape is a wrapper object whose `expected_machines` array uses the
@@ -859,7 +900,7 @@ nico-admin-cli expected-machine replace-all --filename em-all.json
 This is not a merge. Any expected-machine row that is not present in the file is **deleted**. Each entry is then re-created using the same path as `add`, so any entry whose `dpf_enabled` is omitted is re-inserted with `dpf_enabled = true`.
 </Warning>
 
-#### 3.6.e. Quick reference
+#### 3.7.e. Quick reference
 
 | Goal | Path |
 | --- | --- |
@@ -869,7 +910,7 @@ This is not a merge. Any expected-machine row that is not present in the file is
 | Replace the entire inventory | `nico-admin-cli expected-machine replace-all --filename em-all.json` |
 | Inspect current value | `nico-admin-cli expected-machine show <bmc-mac>` |
 
-### 3.7 Enabling DPF for Existing (Ingested) Nodes
+### 3.8 Enabling DPF for Existing (Ingested) Nodes
 
 You can enable the DPF flag on an already discovered host without force-deleting or recreating it by using:
 
@@ -931,7 +972,7 @@ service stack against the configured one. The full set is listed below.
 > machine's metadata only. **They are wiped on force-delete** and on
 > rediscovery the host reverts to whatever its expected-machine entry says.
 > To persist the per-host DPF setting, update the expected-machines table
-> (see section 3.6). This is useful when you want to reprovision a host that
+> (see section 3.7). This is useful when you want to reprovision a host that
 > was not previously managed by DPF, using the DPF framework.
 
 ### `dpf enable` — turn DPF on for a host

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -780,9 +780,11 @@ Configure it either through the API or by seeding the credential store directly.
 nico-admin-cli -a <api-url> credential add-bmc --kind=site-wide-root --password='<password>'
 ```
 
+<Warning>
 `nico-admin-cli` takes the password only as an argument, so it lands in shell
 history and in the process argument list. Run it from a shell with history
 disabled, or use the seeding path below, which avoids both.
+</Warning>
 
 This works on a site that is already running: when a BMC password refresh
 interval is configured, carbide-api starts whether or not the credential is


### PR DESCRIPTION
Operators set the site-wide BMC root credential through the API, so on a fresh
site it does not exist when nico-api first boots. DPF SDK initialization read
that credential unconditionally and propagated the failure out of setup,
aborting the boot before the listener started — which left no way to set the
credential that would have let the next boot succeed. A fresh site with DPF
enabled could not be brought up at all.

This makes the initial read best-effort when a BMC password refresh interval is
configured: initialization continues without the Secret, and the existing 60s
refresh task writes it as soon as the credential appears, so no restart is
needed. With no refresh task configured nothing would ever retry, so there the
failure stays fatal.

The refresh task could not have recovered as written: `create_secret` returned
early when the Secret already existed, so a rotated password was never
propagated to the cluster. It is renamed to `apply_secret` and implemented as a
server-side apply, matching `apply_configmap`.

## Related issues

Fixes #4130

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Four new unit tests cover the refresh task writing the Secret once the password
appears, staying unwritten while it is unavailable, and build succeeding vs.
failing when the password is unset with and without a refresh interval
configured. `cargo test -p carbide-dpf`: 103 passed, 0 failed.

Verified manually against a local kind cluster running the DPF operator
(v26.4.0), with nico-api pointed at a freshly created Vault KV mount that holds
the UEFI site defaults but no `machines/bmc/site/root`. Startup reaches DPF SDK
initialization instead of aborting at the credential read:

```
level=ERROR  The Vault server returned an error (status code 404)
level=WARN   site-wide BMC root not set; deferring lockdown IKM seed until it is configured
level=INFO   Initializing DPF SDK
```

## Additional Notes

Docs updates ride along: the credential is documented as a DPF setup step, and
the Site Explorer precondition is noted on the two getting-started pages that
previously implied "after deploy" was the only option.

The devspace support for installing the DPF operator locally, which was
originally part of this PR, has moved to a follow-up branch: it needs further
fixes before it works end-to-end, and they should not hold up this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

