### PR TITLE
test: fix tests that pass no matter what the code does

### DIFF
--- a/crates/api-core/src/tests/dpu_reprovisioning.rs
+++ b/crates/api-core/src/tests/dpu_reprovisioning.rs
@@ -1680,12 +1680,12 @@ async fn test_restart_dpu_reprov(pool: sqlx::PgPool) {
             .restart_reprovision_requested_at
     );
 
-    let _expected_state = ManagedHostState::DPUReprovision {
-        dpu_states: model::machine::DpuReprovisionStates {
-            states: HashMap::from([(mh.dpu().id, ReprovisionState::WaitingForNetworkInstall)]),
-        },
-    };
-    assert!(matches!(dpu.current_state(), _expected_state));
+    assert_eq!(
+        dpu.current_state(),
+        &mh.new_dpu_reprovision_state(ReprovisionState::InstallDpuOs {
+            substate: InstallDpuOsState::InstallingBFB
+        }),
+    );
 
     // change the mode
     mh.host()

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -936,7 +936,12 @@ async fn test_admin_force_delete_with_instance_type(pool: sqlx::PgPool) {
         .unwrap();
 
     // Delete should succeed now.
-    _ = force_delete(&env, &tmp_machine_id);
+    let response = force_delete(&env, &tmp_machine_id).await;
+    assert!(
+        response.all_done,
+        "the machine should delete once its instance type association is cleared"
+    );
+    assert!(env.find_machine(tmp_machine_id).await.is_empty());
 }
 
 /// Force delete with DPF: the node_id and dpu_device_names passed to

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -2927,7 +2927,6 @@ async fn attach_bare_instance(
 // the DPUs are expected to proxy the DHCP on the host's behalf. This preserves
 // the long-standing behavior that predates zero-DPU support.
 #[crate::sqlx_test]
-#[ignore = "temporarily ignored while the DPU-ful host DHCP behavior is reconciled on this branch"]
 async fn test_dhcp_rejects_dpu_host_with_instance(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-core/src/tests/machine_find.rs
+++ b/crates/api-core/src/tests/machine_find.rs
@@ -579,10 +579,11 @@ async fn test_attached_dpu_machine_ids_multi_dpu(pool: sqlx::PgPool) {
         dpu_ids.len()
     );
 
-    for ref dpu_id in dpu_ids.iter() {
+    for n in 0..2 {
+        let dpu_id = mh.dpu_n(n).id;
         assert!(
-            dpu_ids.contains(dpu_id),
-            "host machine has an unexpected associated_dpu_machine_id {dpu_id}"
+            dpu_ids.contains(&dpu_id),
+            "host machine is missing associated_dpu_machine_id {dpu_id}"
         );
     }
 }

--- a/crates/api-core/src/tests/machine_interfaces.rs
+++ b/crates/api-core/src/tests/machine_interfaces.rs
@@ -740,11 +740,11 @@ async fn test_delete_interface(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         .unwrap();
 
     let mut txn = env.pool.begin().await?;
-    let _interface = db::machine_interface::find_one(txn.as_mut(), interface_id).await;
-    assert!(matches!(
-        DatabaseError::FindOneReturnedNoResultsError(interface_id.into()),
-        _interface
-    ));
+    let found = db::machine_interface::find_one(txn.as_mut(), interface_id).await;
+    assert!(
+        matches!(found, Err(DatabaseError::FindOneReturnedNoResultsError(_))),
+        "the interface row should be gone once delete_interface succeeds"
+    );
 
     txn.commit().await?;
 

--- a/crates/api-db/src/expected_power_shelf/tests.rs
+++ b/crates/api-db/src/expected_power_shelf/tests.rs
@@ -66,7 +66,24 @@ async fn test_lookup_by_mac(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
         .expect("unable to create transaction on database pool");
     let shelves = create_expected_power_shelves(&mut txn).await;
 
-    assert_eq!(shelves[0].serial_number, "PS-SN-001");
+    // This used to assert `shelves[0].serial_number == "PS-SN-001"` -- the string the
+    // fixture had just built with `format!` -- so the finder this test is named for never
+    // ran at all.
+    let found =
+        db::expected_power_shelf::find_by_bmc_mac_address(&mut txn, shelves[0].bmc_mac_address)
+            .await?
+            .expect("the power shelf we just created should be findable by its BMC MAC");
+    assert_eq!(found.bmc_mac_address, shelves[0].bmc_mac_address);
+    assert_eq!(found.serial_number, shelves[0].serial_number);
+
+    // 0xff is past the six shelves the fixture creates.
+    let unknown_mac = mac_address::MacAddress::new([0x44, 0x44, 0x22, 0x22, 0x00, 0xff]);
+    assert!(
+        db::expected_power_shelf::find_by_bmc_mac_address(&mut txn, unknown_mac)
+            .await?
+            .is_none()
+    );
+
     Ok(())
 }
 

--- a/crates/api-db/src/expected_switch/tests.rs
+++ b/crates/api-db/src/expected_switch/tests.rs
@@ -89,7 +89,23 @@ async fn test_lookup_by_mac(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     let mut txn = pool.begin().await.unwrap();
     let switches = create_expected_switches(&mut txn).await;
 
-    assert_eq!(switches[0].serial_number, "SW-SN-001");
+    // This used to assert `switches[0].serial_number == "SW-SN-001"` -- the string the
+    // fixture had just built with `format!` -- so the finder this test is named for never
+    // ran at all.
+    let found = db::expected_switch::find_by_bmc_mac_address(&mut txn, switches[0].bmc_mac_address)
+        .await?
+        .expect("the switch we just created should be findable by its BMC MAC");
+    assert_eq!(found.bmc_mac_address, switches[0].bmc_mac_address);
+    assert_eq!(found.serial_number, switches[0].serial_number);
+
+    // 0xff is past the six switches the fixture creates.
+    let unknown_mac = mac_address::MacAddress::new([0x44, 0x44, 0x11, 0x11, 0x00, 0xff]);
+    assert!(
+        db::expected_switch::find_by_bmc_mac_address(&mut txn, unknown_mac)
+            .await?
+            .is_none()
+    );
+
     Ok(())
 }
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -3241,6 +3241,12 @@ request_timeout = "45s"
 
     #[test]
     fn test_nvue_config_explicit_disable() {
+        // nvue is already off by default (test_nvue_config_disabled_by_default), so
+        // merging a bare `enabled = false` over the defaults would pass even if the key
+        // were ignored outright. Populating `[collectors.nvue.rest]` is what makes this
+        // worth running -- on its own that turns nvue *on*
+        // (test_nvue_config_rest_only), so this pins the half that can actually break:
+        // an explicit `enabled = false` still wins over a populated sub-table.
         let toml_content = r#"
 [endpoint_sources.carbide_api]
 enabled = false
@@ -3250,6 +3256,9 @@ enabled = false
 
 [collectors.nvue]
 enabled = false
+
+[collectors.nvue.rest]
+poll_interval = "1m"
 "#;
 
         let config: Config = Figment::new()

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -855,6 +855,10 @@ mod tests {
             "NVUE leakage" {
                 ReportSource::NvueLeakage => "nvue-leakage",
             }
+
+            "GPU inventory" {
+                ReportSource::GpuInventory => "gpu-inventory",
+            }
         );
     }
 
@@ -893,6 +897,17 @@ mod tests {
                 Probe::NvueLeakage => ProbeSummary {
                     as_str: "NvueLeakage",
                     health_report_id: "NvueLeakage".to_string(),
+                },
+            }
+
+            // GpuInventory is the one probe whose id is not just its own name -- it
+            // deliberately reuses "SkuValidation" so out-of-band GPU-count alerts dedup
+            // against the machine-controller's in-band SKU alerts. That makes it the row
+            // most worth pinning, and it was the only one missing.
+            "GPU inventory reuses the SkuValidation probe id" {
+                Probe::GpuInventory => ProbeSummary {
+                    as_str: "SkuValidation",
+                    health_report_id: "SkuValidation".to_string(),
                 },
             }
         );

--- a/crates/ipxe-renderer/src/lib.rs
+++ b/crates/ipxe-renderer/src/lib.rs
@@ -1345,15 +1345,12 @@ mod tests {
     #[test]
     fn test_unreplaced_placeholders() {
         let renderer = DefaultIpxeScriptRenderer::new();
-        let mut ipxeos = create_test_ipxeos();
-        // Remove the required parameter to cause unreplaced placeholder
-        ipxeos.parameters.clear();
-        ipxeos.hash = renderer.hash(&ipxeos);
 
-        // Validation will fail first, but let's test the unreplaced check by using a template
-        // that doesn't require this param
-        ipxeos.ipxe_template_id = "ea756ddd-add3-5e42-a202-44bfc2d5aac2".to_string();
-        ipxeos.parameters = vec![]; // Missing image_url
+        // render() never reaches the placeholder check -- required-parameter validation
+        // rejects the script first, which this test's own comment used to admit while
+        // asserting nothing more than "some error came back". Pin that rejection for real...
+        let mut ipxeos = create_test_ipxeos();
+        ipxeos.parameters.clear();
         ipxeos.hash = renderer.hash(&ipxeos);
 
         let reserved_params = vec![
@@ -1367,9 +1364,26 @@ mod tests {
             },
         ];
 
-        let result = renderer.render(&ipxeos, &reserved_params);
-        // Will fail on required parameter validation first
-        assert!(result.is_err());
+        assert!(matches!(
+            renderer.render(&ipxeos, &reserved_params),
+            Err(IpxeScriptError::RequiredParameterMissing(_))
+        ));
+
+        // ...and then reach `check_unreplaced_placeholders` directly, because nothing else
+        // in the suite does. Without this, `UnreplacedPlaceholders` is a variant we build
+        // and never assert.
+        let err = renderer
+            .check_unreplaced_placeholders("#!ipxe\nkernel {{image_url}} initrd={{initrd}}\n")
+            .expect_err("leftover {{...}} placeholders should be rejected");
+        assert!(matches!(
+            err,
+            IpxeScriptError::UnreplacedPlaceholders(ref found)
+                if found == "{{image_url}}, {{initrd}}"
+        ));
+
+        renderer
+            .check_unreplaced_placeholders("#!ipxe\nkernel http://pxe.local/vmlinuz\n")
+            .expect("a fully substituted script has nothing left to flag");
     }
 
     #[test]

--- a/crates/libmlx/tests/profile/test_serialization.rs
+++ b/crates/libmlx/tests/profile/test_serialization.rs
@@ -38,46 +38,23 @@ fn assert_same_profile(got: &SerializableProfile, want: &SerializableProfile) {
     assert_eq!(got.config.len(), want.config.len());
 }
 
-// to_proto mirrors the TryInto conversion: each YAML config value is serialized to a
-// trimmed string. The real conversion lives in the crate; the tests re-create it so
-// they can assert the wire shape independently.
+// to_proto hands the profile to the crate's own conversion, `impl
+// TryFrom<&SerializableProfile> for SerializableMlxConfigProfilePb`. These helpers used to
+// re-create that conversion here so the tests could assert the wire shape independently --
+// but re-creating it meant the real impl was never exercised by anything, which is the
+// opposite of what these tests are for.
 fn to_proto(profile: &SerializableProfile) -> SerializableMlxConfigProfilePb {
-    let config = profile
-        .config
-        .iter()
-        .map(|(key, yaml_value)| {
-            let value_str = serde_yaml::to_string(yaml_value).expect("Should serialize YAML value");
-            (key.clone(), value_str.trim().to_string())
-        })
-        .collect();
-
-    SerializableMlxConfigProfilePb {
-        name: profile.name.clone(),
-        registry_name: profile.registry_name.clone(),
-        description: profile.description.clone(),
-        config,
-    }
+    profile
+        .try_into()
+        .expect("a profile built in these tests should convert to its protobuf form")
 }
 
-// from_proto mirrors the TryFrom conversion: each stringified config value is parsed
-// back into a YAML value.
+// from_proto is the same idea in the other direction, through `impl
+// TryFrom<SerializableMlxConfigProfilePb> for SerializableProfile`.
 fn from_proto(proto: SerializableMlxConfigProfilePb) -> SerializableProfile {
-    let config = proto
-        .config
-        .into_iter()
-        .map(|(key, value_str)| {
-            let yaml_value: serde_yaml::Value =
-                serde_yaml::from_str(&value_str).expect("Should parse YAML value");
-            (key, yaml_value)
-        })
-        .collect();
-
-    SerializableProfile {
-        name: proto.name,
-        registry_name: proto.registry_name,
-        description: proto.description,
-        config,
-    }
+    proto
+        .try_into()
+        .expect("a protobuf built in these tests should convert back to a profile")
 }
 
 #[test]

--- a/crates/site-explorer/tests/integration/power_shelf.rs
+++ b/crates/site-explorer/tests/integration/power_shelf.rs
@@ -1414,7 +1414,7 @@ async fn test_power_shelf_state_history_multiple(
 
     // Test state history for multiple power shelves
     let mut txn = env.pool.begin().await?;
-    let _history_by_ids = db::state_history::find_by_object_ids(
+    let history_by_ids = db::state_history::find_by_object_ids(
         &mut txn,
         db::state_history::StateHistoryTableId::PowerShelf,
         &[power_shelf1_id, power_shelf2_id],
@@ -1422,9 +1422,14 @@ async fn test_power_shelf_state_history_multiple(
     .await?;
     txn.commit().await?;
 
-    // println!("history_by_ids: {:?}", history_by_ids);
-    // assert!(history_by_ids.contains_key(&power_shelf1_id));
-    // assert!(history_by_ids.contains_key(&power_shelf2_id));
+    // Nothing has run a controller iteration yet -- the state machine still isn't wired up
+    // (see the TODO further down) -- so neither shelf has any history to find. The
+    // commented-out assertions this replaces looked the ids up directly, but the map is
+    // keyed by the *stringified* id, so they could not have compiled as written.
+    assert!(
+        history_by_ids.is_empty(),
+        "no power shelf should have state history before a controller iteration runs"
+    );
 
     // Test individual power shelf state history
     let mut txn = env.pool.begin().await?;


### PR DESCRIPTION
I went looking for duplicated tests across the suite and kept turning up a different problem instead -- tests that are green because they *can't* fail. `assert!(matches!(dpu.current_state(), _expected_state))` reads like a comparison, but `_expected_state` in pattern position is just a binding, so it matches anything and the `let` above it is dead code. An `async fn` called without `.await` builds a future and drops it on the floor, and the `_ =` in front of it hides the warning you'd otherwise get.

So, each of these now exercises the thing its name promises. It's all test-side -- no product behavior changes here.

The `dpu_reprovisioning` one is the reason this was worth doing. Once that `matches!` actually compares, the test **fails**: after a `Mode::Restart` the DPU isn't in `WaitingForNetworkInstall` at all, it's in `InstallDpuOs { substate: InstallingBFB }` -- which is the restart doing its job, picking the BFB path in `next_substate_based_on_bfb_support`. So the assertion wasn't just unenforced, it named the wrong state. The giveaway that it's a copy-paste and not a behavior change: the very next block of the *same* test does the same restart with `update_firmware: false` and already asserts `InstallDpuOs { InstallingBFB }` for real, and has been passing the whole time.

The rest of the set: `libmlx`'s `test_serialization.rs` declared its own `to_proto`/`from_proto` and tested *those*, so 200-odd lines of tests that looked like they covered the real conversions covered none of them. `health`'s `probe_conversions` and `report_source_strings` were missing `GpuInventory` -- the one probe whose id isn't its own name, since it deliberately reuses `"SkuValidation"` so out-of-band GPU-count alerts dedup against the machine-controller's in-band SKU alerts. `check_unreplaced_placeholders` in `ipxe-renderer` is reachable from a test for the first time. Both `test_lookup_by_mac` tests in `api-db` look up by MAC now instead of asserting the serial number their own fixture had just built with `format!`. And `test_dhcp_rejects_dpu_host_with_instance` comes off an `#[ignore]` it went in under back in April on #987, so the only coverage we have for that reject arm has been idle for three months.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4171

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Each fix was checked to fail *without* it. The `health` mapping I proved directly, by flipping `Probe::GpuInventory`'s id and watching `probe_conversions` go red. The rest went through a function-level coverage A/B across the seven touched crates, comparing `main` against this branch.

Function granularity is the honest way to measure this one: plain line coverage *rises* when you touch test lines, and `--ignore-filename-regex` can't reach inside an inline `#[cfg(test)]` module, so the percentage would have looked fine either way.

```
cargo llvm-cov -p carbide-api-core -p carbide-api-db -p carbide-libmlx -p carbide-health \
               -p carbide-ipxe-renderer -p carbide-site-explorer -p carbide-agent --json
```

- `carbide-api-core`: 1454 passed, 0 failed, **4 ignored** (down from 5 -- that's the un-ignore landing). `api-db` 241, `health` 393, `libmlx` 158, `site-explorer` 66, `agent` 94, `ipxe-renderer` 35. All green.
- **No production function lost coverage.**
- `TryFrom<&SerializableProfile> for SerializableMlxConfigProfile` goes from **0 executions to 2** -- the libmlx fix proving itself.

## Additional Notes

Two things I deliberately left alone, both worth a second opinion:

- The owned `TryFrom<SerializableProfile>` at `libmlx/src/profile/serialization.rs:249` is *still* uncovered. It only delegates to the reference impl, and adding a call purely to light it up felt like exactly the sort of thing this PR is trying to remove.
- `site-explorer/tests/integration/power_shelf.rs` has five `if 1 == 1 { return Ok(()); }` guards, each under a `TODO(chet)` about the power-shelf state machine not being wired up yet. The `if 1 == 1` form is dodging the `unreachable_code` lint a bare `return` would trip, so it's deliberate -- but four of those tests report PASS while their state-transition half never runs. `#[ignore]` would be more honest, except it would also disable the live assertions *above* each guard. Left as-is; flagging it for whenever that state machine lands.

Also of note for the follow-on PRs in this series: two things I'd originally scoped into this one turned out to be *redundant* rather than *wrong* -- `sku.rs:395` and the `agent` nvue bridge test, whose golden is byte-identical to its sibling's. Those belong in the deletion PR, not here.


Closes #4171
