### PR TITLE
chore(instrument): keep metrics current across provider changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ dependencies = [
 name = "carbide-instrument"
 version = "0.0.0"
 dependencies = [
+ "arc-swap",
  "carbide-instrument",
  "carbide-instrument-macros",
  "carbide-test-support",
@@ -3168,6 +3169,7 @@ dependencies = [
  "bmc-vendor",
  "bytes",
  "carbide-api-test-helper",
+ "carbide-instrument",
  "carbide-machine-a-tron",
  "carbide-rpc",
  "carbide-ssh-console-mock-api-server",

--- a/clippy.toml
+++ b/clippy.toml
@@ -15,4 +15,7 @@
 # limitations under the License.
 #
 avoid-breaking-exported-api = false
+disallowed-methods = [
+  { path = "opentelemetry::global::set_meter_provider", reason = "use carbide_instrument::set_meter_provider so Event and RED caches follow provider changes" },
+]
 enum-variant-name-threshold = 2

--- a/crates/agent/src/instrumentation/config.rs
+++ b/crates/agent/src/instrumentation/config.rs
@@ -77,7 +77,7 @@ impl InstrumentationSingleton {
         // but if there are other OpenTelemetry users in our dependencies, let's
         // make sure they pick up our provider.
         if set_global_meter {
-            opentelemetry::global::set_meter_provider(meter_provider.clone());
+            carbide_instrument::set_meter_provider(meter_provider.clone());
         }
 
         Ok(InstrumentationSingleton {
@@ -166,8 +166,8 @@ mod tests {
     #[test]
     fn test_singleton_init_function() {
         // `false` keeps this construction test from replacing the process-global
-        // provider. Event instruments cache that provider on first use, and the
-        // `MetricsCapture` tests in this binary must keep reading the same one.
+        // provider while the `MetricsCapture` tests in this binary read the
+        // shared test registry.
         let _s = InstrumentationSingleton::try_init_for_dpu_agent(false).expect(
             "The instrumentaion singleton's initialization function must not return an error",
         );

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -63,7 +63,7 @@ pub(crate) fn setup_metrics(spancount_reader: Option<SpanCountReader>) -> eyre::
         )?)
         .build();
     // After this call `global::meter()` will be available
-    opentelemetry::global::set_meter_provider(meter_provider.clone());
+    carbide_instrument::set_meter_provider(meter_provider.clone());
     let meter = meter_provider.meter("carbide-api");
 
     register_spancount_gauge(&meter, spancount_reader);

--- a/crates/bmc-proxy/src/setup.rs
+++ b/crates/bmc-proxy/src/setup.rs
@@ -172,9 +172,8 @@ mod tests {
     fn metrics_setup_initializes_health_controller() {
         // Mirrors setup_metrics() without its global-meter install: the
         // process-wide test meter (installed at load by
-        // carbide_instrument::testing) owns instrument bindings for this
-        // binary's event tests, and swapping the global provider mid-run
-        // would steal first-emit bindings from them.
+        // carbide_instrument::testing) owns the registry used by this binary's
+        // Event tests, and this assertion only needs the health controller.
         let setup =
             metrics_endpoint::new_metrics_setup("carbide-bmc-proxy", "carbide-system", false)
                 .expect("metrics setup succeeds");

--- a/crates/dhcp/src/metrics.rs
+++ b/crates/dhcp/src/metrics.rs
@@ -514,10 +514,8 @@ pub async fn start_readiness_monitoring() {
 /// True once [`metrics_server`] has installed the global meter provider and
 /// stored the initialized metrics state.
 ///
-/// Event instruments resolve from the global meter once per event type on
-/// first emit, so emitting before the provider install would bind that event
-/// type to the no-op meter for the process lifetime. The gate also keeps an
-/// endpointless configuration recording nothing, as before.
+/// The gate keeps an endpointless configuration from recording Event metrics
+/// and preserves the service's existing metrics lifecycle.
 fn metrics_initialized() -> bool {
     CONFIG
         .read()
@@ -982,8 +980,7 @@ mod tests {
     /// strings map onto the bounded taxonomy (unknown ones bucket), the raw
     /// Kea message-type codes map onto their family-specific reply labels,
     /// and nothing records until `metrics_server` has initialized metrics --
-    /// the gate that also guarantees the global meter provider is installed
-    /// before the first emit.
+    /// the same gate used by the production FFI entry points.
     #[test]
     fn ffi_increments_gate_on_initialization_and_map_their_arguments() {
         let metrics = MetricsCapture::start();

--- a/crates/fmds/src/http_request_metrics.rs
+++ b/crates/fmds/src/http_request_metrics.rs
@@ -115,7 +115,7 @@ pub fn init() -> eyre::Result<(Registry, HttpRequestMetrics)> {
         .with_resource(resource_attributes)
         .build();
 
-    opentelemetry::global::set_meter_provider(meter_provider);
+    carbide_instrument::set_meter_provider(meter_provider);
 
     Ok((prometheus_registry, HttpRequestMetrics { _private: () }))
 }

--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -813,11 +813,13 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
             #observation_fn
             #log_fn
 
-            fn __instrument(&self) -> &'static ::carbide_instrument::__private::CachedInstrument {
-                static INSTRUMENT: ::std::sync::OnceLock<
+            fn __instrument(&self) -> &'static ::carbide_instrument::__private::InstrumentCache<
+                ::carbide_instrument::__private::CachedInstrument,
+            > {
+                static INSTRUMENT: ::carbide_instrument::__private::InstrumentCache<
                     ::carbide_instrument::__private::CachedInstrument,
-                > = ::std::sync::OnceLock::new();
-                INSTRUMENT.get_or_init(::carbide_instrument::__private::new_instrument::<Self>)
+                > = ::carbide_instrument::__private::InstrumentCache::new();
+                &INSTRUMENT
             }
         }
     }

--- a/crates/instrument/Cargo.toml
+++ b/crates/instrument/Cargo.toml
@@ -23,6 +23,7 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
+arc-swap = { workspace = true }
 carbide-instrument-macros = { path = "../instrument-macros" }
 dashmap = { workspace = true }
 opentelemetry = { workspace = true }

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -187,11 +187,39 @@
 //! struct Demo {}
 //! ```
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 /// The derive macros: `#[derive(Event)]` and `#[derive(LabelValue)]`.
 pub use carbide_instrument_macros::{Event, LabelValue};
 use opentelemetry::{KeyValue, StringValue};
+
+static METER_PROVIDER_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// Installs the process-global OpenTelemetry meter provider used by Events.
+///
+/// NICo applications should use this instead of
+/// [`opentelemetry::global::set_meter_provider`]. Event and RED instruments
+/// stay bound to the provider that created them, so this also tells their
+/// caches to rebuild after the provider first becomes available or is later
+/// replaced. Metric observations made before the first call are not buffered;
+/// later observations use the installed provider normally.
+#[allow(clippy::disallowed_methods)]
+pub fn set_meter_provider<P>(new_provider: P)
+where
+    P: opentelemetry::metrics::MeterProvider + Send + Sync + 'static,
+{
+    opentelemetry::global::set_meter_provider(new_provider);
+
+    // OpenTelemetry binds each `Meter` to the provider active when it was
+    // created. Publish the generation only after the global provider changes,
+    // so a cache that sees the new value rebuilds from that provider.
+    METER_PROVIDER_GENERATION.fetch_add(1, Ordering::Release);
+}
+
+fn meter_provider_generation() -> u64 {
+    METER_PROVIDER_GENERATION.load(Ordering::Acquire)
+}
 
 /// Whether (and at which level) an event writes a log line.
 ///
@@ -339,51 +367,62 @@ pub trait Event {
     #[doc(hidden)]
     fn __log(&self, level: tracing::Level);
     #[doc(hidden)]
-    fn __instrument(&self) -> &'static __private::CachedInstrument;
+    fn __instrument(&self) -> &'static __private::InstrumentCache<__private::CachedInstrument>;
 }
 
 /// Emits an event: a log line and/or a metric, per the event's knobs.
 ///
-/// Never panics. The metric side resolves its instrument once per event type
-/// (a `OnceLock`) from the global OpenTelemetry meter -- install the meter
-/// provider at startup, before the first emit, as every NICo binary already
-/// does for its existing metrics.
+/// Never panics. The metric side caches its OpenTelemetry instrument per event
+/// type and refreshes it after [`set_meter_provider`] installs or replaces the
+/// global provider. An emit before provider setup still writes its configured
+/// log line, while its metric observation is dropped.
 pub fn emit<E: Event>(event: E) {
     if let LogAt::Level(level) = event.log_at() {
         event.__log(level);
     }
-    match event.__instrument() {
-        __private::CachedInstrument::Counter(counter) => {
-            counter.add(1, event.labels().as_ref());
-        }
-        __private::CachedInstrument::Histogram(histogram) => {
-            histogram.record(event.observation(), event.labels().as_ref());
-        }
-        __private::CachedInstrument::None => {}
+
+    if matches!(E::METRIC, MetricKind::None) {
+        return;
     }
+
+    event.__instrument().with(
+        __private::new_instrument::<E>,
+        |instrument| match instrument {
+            __private::CachedInstrument::Counter(counter) => {
+                counter.add(1, event.labels().as_ref());
+            }
+            __private::CachedInstrument::Histogram(histogram) => {
+                histogram.record(event.observation(), event.labels().as_ref());
+            }
+            __private::CachedInstrument::None => {}
+        },
+    );
 }
 
 /// `initialize_counter_series` exposes one Event counter label set at zero
 /// without writing the Event's log line. It uses the same cached instrument as
-/// [`emit`], so the global meter provider must already be installed before this
-/// call. Context fields are ignored; only the Event's bounded labels select the
+/// [`emit`]. A call before provider setup is dropped rather than buffered, and
+/// a later call after [`set_meter_provider`] registers the series normally.
+/// Context fields are ignored; only the Event's bounded labels select the
 /// series.
 ///
-/// Returns `false` without registering anything when `event` does not declare
-/// `metric = counter`.
+/// Returns `false` when `event` does not declare `metric = counter`. A `true`
+/// result reports the Event's metric kind; it does not mean a provider was
+/// installed or that the zero observation was exported.
 #[must_use = "a false result means the Event is not a counter"]
 pub fn initialize_counter_series<E: Event>(event: &E) -> bool {
     if !matches!(E::METRIC, MetricKind::Counter) {
         return false;
     }
 
-    match event.__instrument() {
-        __private::CachedInstrument::Counter(counter) => {
-            counter.add(0, event.labels().as_ref());
-            true
-        }
-        __private::CachedInstrument::Histogram(_) | __private::CachedInstrument::None => false,
-    }
+    event
+        .__instrument()
+        .with(__private::new_instrument::<E>, |instrument| {
+            if let __private::CachedInstrument::Counter(counter) = instrument {
+                counter.add(0, event.labels().as_ref());
+            }
+        });
+    true
 }
 
 /// The success-or-failure of an operation, as a bounded label.
@@ -424,11 +463,95 @@ pub mod testing;
 pub mod __private {
     //! Support for the derive-generated code; not a public API.
 
+    use std::sync::{Arc, Mutex};
+
+    use arc_swap::ArcSwapOption;
     pub use opentelemetry;
     pub use tracing;
 
-    /// The per-event-type instrument, resolved once and cached in a
-    /// `OnceLock` by the generated `__instrument()`.
+    struct Versioned<T> {
+        generation: u64,
+        instrument: T,
+    }
+
+    /// One provider-aware instrument cache generated for each Event type.
+    pub struct InstrumentCache<T> {
+        current: ArcSwapOption<Versioned<T>>,
+        refresh: Mutex<()>,
+    }
+
+    impl<T> InstrumentCache<T> {
+        /// Creates an empty cache suitable for a derive-generated static.
+        pub const fn new() -> Self {
+            Self {
+                current: ArcSwapOption::const_empty(),
+                refresh: Mutex::new(()),
+            }
+        }
+
+        /// Uses the instrument for the currently installed meter provider.
+        ///
+        /// Generation zero means no provider has been installed through
+        /// [`crate::set_meter_provider`], so the observation is dropped without
+        /// creating a permanent no-op handle. The refresh mutex is only used on
+        /// the first observation after a provider change; stable observations
+        /// take the lock-free path above it.
+        pub fn with(&self, build: impl Fn() -> T, record: impl FnOnce(&T)) {
+            let generation = crate::meter_provider_generation();
+            if generation == 0 {
+                return;
+            }
+
+            let current = self.current.load();
+            if let Some(current) = current
+                .as_ref()
+                .filter(|current| current.generation == generation)
+            {
+                record(&current.instrument);
+                return;
+            }
+            drop(current);
+
+            let _refresh = self.refresh.lock().unwrap_or_else(|p| p.into_inner());
+            loop {
+                let generation = crate::meter_provider_generation();
+                if generation == 0 {
+                    return;
+                }
+
+                let current = self.current.load();
+                if let Some(current) = current
+                    .as_ref()
+                    .filter(|current| current.generation == generation)
+                {
+                    record(&current.instrument);
+                    return;
+                }
+                drop(current);
+
+                let instrument = build();
+                if crate::meter_provider_generation() != generation {
+                    continue;
+                }
+
+                let current = Arc::new(Versioned {
+                    generation,
+                    instrument,
+                });
+                self.current.store(Some(current.clone()));
+                record(&current.instrument);
+                return;
+            }
+        }
+    }
+
+    impl<T> Default for InstrumentCache<T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    /// The per-event-type instrument stored in the generated cache.
     pub enum CachedInstrument {
         Counter(opentelemetry::metrics::Counter<u64>),
         Histogram(opentelemetry::metrics::Histogram<f64>),

--- a/crates/instrument/src/red.rs
+++ b/crates/instrument/src/red.rs
@@ -30,28 +30,28 @@
 //! stream's lifetime.
 
 use std::fmt::Display;
-use std::sync::OnceLock;
 use std::time::Instant;
 
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::Histogram;
 
+use crate::__private::InstrumentCache;
+
 /// The exposed name is `carbide_external_call_duration_milliseconds`; the
 /// exporter appends the unit suffix (the `carbide-instrument` convention).
 const INSTRUMENT_NAME: &str = "carbide_external_call_duration";
 
-fn histogram() -> &'static Histogram<f64> {
-    static HISTOGRAM: OnceLock<Histogram<f64>> = OnceLock::new();
-    HISTOGRAM.get_or_init(|| {
-        opentelemetry::global::meter("carbide-instrument")
-            .f64_histogram(INSTRUMENT_NAME)
-            .with_unit("ms")
-            .with_description(
-                "Duration of outbound calls by backend, operation, and outcome; the _count \
-                 series, split by outcome, gives the request and error rates.",
-            )
-            .build()
-    })
+static RED_HISTOGRAM: InstrumentCache<Histogram<f64>> = InstrumentCache::new();
+
+fn new_histogram() -> Histogram<f64> {
+    opentelemetry::global::meter("carbide-instrument")
+        .f64_histogram(INSTRUMENT_NAME)
+        .with_unit("ms")
+        .with_description(
+            "Duration of outbound calls by backend, operation, and outcome; the _count \
+             series, split by outcome, gives the request and error rates.",
+        )
+        .build()
 }
 
 /// Times `call`, records the RED histogram on every completion, and logs a
@@ -86,12 +86,14 @@ pub fn record(
     outcome: &'static str,
     elapsed_ms: f64,
 ) {
-    histogram().record(
-        elapsed_ms,
-        &[
-            KeyValue::new("backend", backend),
-            KeyValue::new("operation", operation),
-            KeyValue::new("outcome", outcome),
-        ],
-    );
+    RED_HISTOGRAM.with(new_histogram, |histogram| {
+        histogram.record(
+            elapsed_ms,
+            &[
+                KeyValue::new("backend", backend),
+                KeyValue::new("operation", operation),
+                KeyValue::new("outcome", outcome),
+            ],
+        );
+    });
 }

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -209,11 +209,14 @@ impl tracing::field::Visit for CaptureVisitor {
 
 /// A serialized window onto the process-global test meter.
 ///
-/// The first capture installs a Prometheus-backed meter provider as the
-/// global OpenTelemetry meter (instruments are cached per event type, so
-/// tests share one provider for the whole process); the mutex serializes
-/// metric-asserting tests, and deltas are measured against the snapshot taken
-/// at [`MetricsCapture::start`].
+/// Test binaries install a Prometheus-backed meter provider eagerly, and each
+/// capture reinstalls that same provider in case an earlier test replaced the
+/// global one. The mutex serializes metric-asserting tests, and deltas are
+/// measured against the snapshot taken at [`MetricsCapture::start`].
+///
+/// A test that installs another process-global provider must not run
+/// concurrently with a capture because its observations would use that
+/// provider until the next capture starts.
 pub struct MetricsCapture {
     _serialized: MutexGuard<'static, ()>,
     baseline: Snapshot,
@@ -224,7 +227,7 @@ impl MetricsCapture {
     pub fn start() -> Self {
         static SERIAL: Mutex<()> = Mutex::new(());
         let guard = SERIAL.lock().unwrap_or_else(|p| p.into_inner());
-        let registry = test_registry();
+        let registry = install_test_meter();
         Self {
             _serialized: guard,
             baseline: snapshot(registry),
@@ -313,20 +316,23 @@ fn snapshot(registry: &prometheus::Registry) -> Snapshot {
 }
 
 /// Installs the test meter at test-binary load, before any test (and so any
-/// `emit()`) runs. Instruments are cached per event type on first emit, so a
-/// test that emits without a `MetricsCapture` must still find the real
-/// provider installed -- otherwise that event type would bind to the no-op
-/// global meter and later counter assertions would sit at zero.
+/// `emit()`) runs. The provider-lifecycle regression test disables this in its
+/// child process so it can exercise the real no-provider starting state.
 #[ctor::ctor(unsafe)]
 fn install_test_meter_eagerly() {
-    let _ = test_registry();
+    if std::env::var_os("CARBIDE_INSTRUMENT_DISABLE_EAGER_TEST_METER").is_none() {
+        let _ = install_test_meter();
+    }
 }
 
-/// The process-global test registry, installing the global meter provider on
-/// first use.
-fn test_registry() -> &'static prometheus::Registry {
-    static REGISTRY: OnceLock<prometheus::Registry> = OnceLock::new();
-    REGISTRY.get_or_init(|| {
+struct TestMetrics {
+    registry: prometheus::Registry,
+    provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+}
+
+fn test_metrics() -> &'static TestMetrics {
+    static METRICS: OnceLock<TestMetrics> = OnceLock::new();
+    METRICS.get_or_init(|| {
         let registry = prometheus::Registry::new();
         let exporter = opentelemetry_prometheus::exporter()
             .with_registry(registry.clone())
@@ -337,7 +343,16 @@ fn test_registry() -> &'static prometheus::Registry {
         let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             .with_reader(exporter)
             .build();
-        opentelemetry::global::set_meter_provider(provider);
-        registry
+        TestMetrics { registry, provider }
     })
+}
+
+fn install_test_meter() -> &'static prometheus::Registry {
+    let metrics = test_metrics();
+    crate::set_meter_provider(metrics.provider.clone());
+    &metrics.registry
+}
+
+fn test_registry() -> &'static prometheus::Registry {
+    &test_metrics().registry
 }

--- a/crates/instrument/tests/provider_lifecycle.rs
+++ b/crates/instrument/tests/provider_lifecycle.rs
@@ -1,0 +1,211 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::process::Command;
+
+use carbide_instrument::testing::capture_logs;
+use carbide_instrument::{Event, emit, initialize_counter_series};
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+const CHILD_PROCESS_ENV: &str = "CARBIDE_INSTRUMENT_PROVIDER_LIFECYCLE_CHILD";
+const DISABLE_EAGER_TEST_METER_ENV: &str = "CARBIDE_INSTRUMENT_DISABLE_EAGER_TEST_METER";
+
+#[derive(Event)]
+#[event(
+    event_name = "provider_lifecycle_counter_test",
+    metric_name = "carbide_provider_lifecycle_counter_test_total",
+    component = "instrument-test",
+    log = warn,
+    metric = counter,
+    describe = "Number of provider lifecycle counter test events",
+    message = "provider lifecycle counter observed",
+)]
+struct ProviderCounter;
+
+#[derive(Event)]
+#[event(
+    event_name = "provider_lifecycle_histogram_test",
+    metric_name = "carbide_provider_lifecycle_test_milliseconds",
+    component = "instrument-test",
+    log = off,
+    metric = histogram,
+    describe = "Provider lifecycle test duration",
+)]
+struct ProviderHistogram {
+    #[observation]
+    elapsed_ms: f64,
+}
+
+#[derive(Event)]
+#[event(
+    event_name = "provider_lifecycle_initialization_test",
+    metric_name = "carbide_provider_lifecycle_initialization_test_total",
+    component = "instrument-test",
+    log = off,
+    metric = counter,
+    describe = "Number of initialized provider lifecycle test events",
+)]
+struct ProviderInitialization;
+
+#[test]
+fn cached_metric_handles_follow_provider_changes() {
+    if std::env::var_os(CHILD_PROCESS_ENV).is_some() {
+        run_provider_lifecycle_assertions();
+        return;
+    }
+
+    // `carbide-instrument` normally installs its test provider in a ctor. Run
+    // this contract in a new copy of the test binary so generation zero is a
+    // real no-provider state rather than an ordering assumption between tests.
+    let output = Command::new(std::env::current_exe().expect("current test executable"))
+        .args([
+            "--exact",
+            "cached_metric_handles_follow_provider_changes",
+            "--nocapture",
+        ])
+        .env(CHILD_PROCESS_ENV, "1")
+        .env(DISABLE_EAGER_TEST_METER_ENV, "1")
+        .output()
+        .expect("run provider lifecycle test child");
+
+    assert!(
+        output.status.success(),
+        "provider lifecycle child failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn run_provider_lifecycle_assertions() {
+    let logs = capture_logs(|| emit(ProviderCounter));
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].message, "provider lifecycle counter observed");
+
+    emit(ProviderHistogram { elapsed_ms: 5.0 });
+    assert!(initialize_counter_series(&ProviderInitialization));
+    carbide_instrument::red::record("lifecycle-test", "first", "ok", 5.0);
+
+    let first = TestMetrics::install();
+    emit(ProviderCounter);
+    emit(ProviderHistogram { elapsed_ms: 12.5 });
+    assert!(initialize_counter_series(&ProviderInitialization));
+    carbide_instrument::red::record("lifecycle-test", "first", "ok", 20.0);
+
+    assert_eq!(
+        first.counter("carbide_provider_lifecycle_counter_test_total"),
+        Some(1.0)
+    );
+    assert_eq!(
+        first.counter("carbide_provider_lifecycle_initialization_test_total"),
+        Some(0.0)
+    );
+    assert_eq!(
+        first.histogram("carbide_provider_lifecycle_test_milliseconds"),
+        Some((1, 12.5))
+    );
+    assert_eq!(
+        first.histogram("carbide_external_call_duration_milliseconds"),
+        Some((1, 20.0))
+    );
+
+    let second = TestMetrics::install();
+    emit(ProviderCounter);
+    emit(ProviderHistogram { elapsed_ms: 7.5 });
+    assert!(initialize_counter_series(&ProviderInitialization));
+    carbide_instrument::red::record("lifecycle-test", "second", "ok", 30.0);
+
+    // Provider replacement does not replay or redirect earlier observations.
+    assert_eq!(
+        first.counter("carbide_provider_lifecycle_counter_test_total"),
+        Some(1.0)
+    );
+    assert_eq!(
+        first.histogram("carbide_provider_lifecycle_test_milliseconds"),
+        Some((1, 12.5))
+    );
+    assert_eq!(
+        first.histogram("carbide_external_call_duration_milliseconds"),
+        Some((1, 20.0))
+    );
+
+    assert_eq!(
+        second.counter("carbide_provider_lifecycle_counter_test_total"),
+        Some(1.0)
+    );
+    assert_eq!(
+        second.counter("carbide_provider_lifecycle_initialization_test_total"),
+        Some(0.0)
+    );
+    assert_eq!(
+        second.histogram("carbide_provider_lifecycle_test_milliseconds"),
+        Some((1, 7.5))
+    );
+    assert_eq!(
+        second.histogram("carbide_external_call_duration_milliseconds"),
+        Some((1, 30.0))
+    );
+}
+
+struct TestMetrics {
+    registry: prometheus::Registry,
+    _provider: SdkMeterProvider,
+}
+
+impl TestMetrics {
+    fn install() -> Self {
+        let registry = prometheus::Registry::new();
+        let exporter = opentelemetry_prometheus::exporter()
+            .with_registry(registry.clone())
+            .without_scope_info()
+            .without_target_info()
+            .build()
+            .expect("test metrics exporter");
+        let provider = SdkMeterProvider::builder().with_reader(exporter).build();
+        carbide_instrument::set_meter_provider(provider.clone());
+
+        Self {
+            registry,
+            _provider: provider,
+        }
+    }
+
+    fn counter(&self, name: &str) -> Option<f64> {
+        self.registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family
+                    .get_metric()
+                    .first()
+                    .map(|metric| metric.get_counter().value())
+            })
+    }
+
+    fn histogram(&self, name: &str) -> Option<(u64, f64)> {
+        self.registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family.get_metric().first().map(|metric| {
+                    let histogram = metric.get_histogram();
+                    (histogram.get_sample_count(), histogram.get_sample_sum())
+                })
+            })
+    }
+}

--- a/crates/metrics-endpoint/src/lib.rs
+++ b/crates/metrics-endpoint/src/lib.rs
@@ -247,7 +247,7 @@ pub fn new_metrics_setup(
 
     if set_global_meter {
         // After this call `global::meter()` will be available
-        opentelemetry::global::set_meter_provider(meter_provider.clone());
+        carbide_instrument::set_meter_provider(meter_provider.clone());
     }
 
     Ok(MetricsSetup {

--- a/crates/ssh-console/Cargo.toml
+++ b/crates/ssh-console/Cargo.toml
@@ -33,6 +33,7 @@ path = "src/main.rs"
 [dependencies]
 
 # local dependencies
+carbide-instrument = { path = "../instrument" }
 carbide-rpc = { path = "../rpc" }
 carbide-uuid = { path = "../uuid" }
 carbide-tls = { path = "../tls" }

--- a/crates/ssh-console/src/metrics.rs
+++ b/crates/ssh-console/src/metrics.rs
@@ -148,6 +148,8 @@ impl Default for MetricsState {
 }
 
 impl MetricsState {
+    /// Creates the ssh-console registry and installs its meter provider
+    /// process-wide so generated client RED metrics use the same registry.
     pub fn new() -> Self {
         let registry = prometheus::Registry::new();
         let exporter = opentelemetry_prometheus::exporter()
@@ -159,6 +161,11 @@ impl MetricsState {
         let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             .with_reader(exporter)
             .build();
+
+        // Generated Forge clients use the global meter for RED
+        // instrumentation. Install the same provider here so those
+        // measurements reach this registry.
+        carbide_instrument::set_meter_provider(meter_provider.clone());
         let meter = meter_provider.meter("ssh-console");
 
         Self {
@@ -166,5 +173,73 @@ impl MetricsState {
             registry,
             _meter_provider: meter_provider,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    const CHILD_PROCESS_ENV: &str = "CARBIDE_SSH_CONSOLE_METRICS_TEST_CHILD";
+
+    #[test]
+    fn metrics_state_exports_global_red_metrics() {
+        if std::env::var_os(CHILD_PROCESS_ENV).is_some() {
+            assert_global_red_metrics_exported();
+            return;
+        }
+
+        // `MetricsState` installs a process-global provider. Keep that
+        // mutation in a child process so parallel unit tests cannot redirect
+        // its observation or inherit its provider.
+        let output = Command::new(std::env::current_exe().expect("current test executable"))
+            .args([
+                "--exact",
+                "metrics::tests::metrics_state_exports_global_red_metrics",
+                "--nocapture",
+            ])
+            .env(CHILD_PROCESS_ENV, "1")
+            .output()
+            .expect("run ssh-console metrics test child");
+
+        assert!(
+            output.status.success(),
+            "ssh-console metrics child failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn assert_global_red_metrics_exported() {
+        let state = MetricsState::new();
+        carbide_instrument::red::record("ssh-console-test", "connect", "ok", 1.0);
+
+        let family = state
+            .registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "carbide_external_call_duration_milliseconds")
+            .expect("RED histogram should use the ssh-console registry");
+        let expected_labels = [
+            ("backend", "ssh-console-test"),
+            ("operation", "connect"),
+            ("outcome", "ok"),
+        ];
+        let metric = family
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                expected_labels.iter().all(|(name, value)| {
+                    metric
+                        .get_label()
+                        .iter()
+                        .any(|label| label.name() == *name && label.value() == *value)
+                })
+            })
+            .expect("RED histogram should contain the recorded series");
+
+        assert_eq!(metric.get_histogram().get_sample_count(), 1);
     }
 }


### PR DESCRIPTION
`Event` and RED metric handles used to stay attached to whichever global meter provider existed on their first observation. NICo installs providers before operational traffic today, but that made startup ordering a permanent process rule: an early observation could bind a no-op handle, and replacing a provider could leave an already-used event writing to the old registry.

This hardens the instrumentation boundary around provider installation. `carbide-instrument` now owns the global setter, advances a provider generation, and rebuilds each cached Event or RED handle on the first observation after a provider change. Observations before initial setup remain intentionally unbuffered, while the normal path stays lock-free. A Clippy rule prevents new direct calls from bypassing the generation update.

It also connects ssh-console's generated Forge client RED measurements to the registry it already exports. Provider setup across the existing services now goes through the shared setter, and process-isolated tests cover observations before setup, counter-series initialization, provider replacement, and registry handoff.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4174

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The completed checks are:

- `cargo test -p carbide-instrument --tests`
- `cargo test -p carbide-ssh-console --lib`
- `cargo test -p metrics-endpoint -p carbide-fmds --lib`
- `cargo check -p carbide-agent -p carbide-api --all-targets`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-licenses`
- `cargo make check-bans`
- `cargo xtask check-workspace-deps`
- `cargo xtask check-metric-docs`

## Additional Notes

Observations made before provider installation are not replayed. An observation that overlaps provider replacement may reach either provider; later observations use the newly installed provider.

The operator-facing instrumentation guide will follow in a docs-only companion PR so tech-writer review does not gate this code.