### PR TITLE
docs(instrument): describe provider-aware metric caches

### DIFF
--- a/docs/observability/instrumentation.md
+++ b/docs/observability/instrumentation.md
@@ -106,9 +106,16 @@ level=WARN component=nico-api span_id=0x4f... event_name=power_control_failed me
 carbide_power_control_total{backend="rms",outcome="error"} 1
 ```
 
-Install the meter provider at startup **before the first emit** (every NICo binary
-already does, for its existing metrics); instruments resolve from the global meter once
-per event type.
+Install the process-global meter provider with `carbide_instrument::set_meter_provider`.
+Use this wrapper instead of `opentelemetry::global::set_meter_provider`: it notifies
+cached instruments after installation or replacement, and workspace Clippy disallows
+bypassing it. NICo binaries normally install the provider at startup before operational
+traffic, but Event and outbound-call rate/error/duration (RED) instrument caches also
+follow later provider changes. A metric observation before the first provider installation
+is dropped rather than buffered; the Event's configured log line still emits, and later
+metric observations use the installed provider normally. An observation that overlaps
+provider replacement might reach either provider, while later observations use the
+replacement.
 
 ## Log and metric options
 
@@ -309,8 +316,10 @@ with the semantics in attributes. The generated code:
 
 - Builds labels as a fixed-size array (no heap allocation on emit) with enum values
   rendering as `&'static str`
-- Caches the OTel instrument in a per-event-type `OnceLock` -- a metric-only emit is an
-  atomic load plus an `add()`
+- Caches the OTel instrument per Event type and refreshes it after provider installation
+  or replacement. Once the provider is stable, the cached-instrument lookup is two
+  lock-free loads; a metric-only emit then materializes the fixed-size label array above
+  and calls `add()`.
 - Emits the log via `tracing::event!` with real static field names, so `logfmt`, the
   admin-UI log stream, and every other subscriber layer see an ordinary tracing event in
   the surrounding span. Its tracing metadata name and structured `event_name` field are the


### PR DESCRIPTION
The Event guide still says each metric handle binds to the first global provider for the process lifetime, while https://github.com/NVIDIA/infra-controller/pull/4176 makes those caches follow provider installation and replacement.

This companion updates the quick start to name the framework setter, explains how early observations and provider replacement behave, and revises the steady-path cost. It also makes the wrapper requirement explicit so callers do not bypass the cache-generation update with OpenTelemetry's global setter.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4177

Parent code issue: https://github.com/NVIDIA/infra-controller/issues/4174

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Validation: `git diff --check`

## Additional Notes

This PR is the documentation half of https://github.com/NVIDIA/infra-controller/pull/4176 and must merge after that code PR. The generated `docs/observability/core_metrics.md` catalogue is intentionally unchanged because the code PR does not add or rename a metric.