### PR TITLE
fix: continue boot setup when jobs complete before scheduling

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -2534,6 +2534,61 @@ async fn test_bios_config_job_happy_path(pool: sqlx::PgPool) {
     );
 }
 
+/// A BIOS job that completes before the scheduling check skips the redundant
+/// reboot and moves directly to BIOS verification.
+#[crate::sqlx_test]
+async fn test_wait_for_bios_job_scheduled_skips_reboot_for_completed_job(pool: sqlx::PgPool) {
+    const RETRY_COUNT: u32 = 2;
+    const TEST_BIOS_JOB_ID: &str = "JID_BIOS_ALREADY_COMPLETED";
+
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    env.redfish_sim
+        .set_job_state_sequence(vec![libredfish::JobState::Completed]);
+    set_host_controller_state_stuck_in(
+        &env,
+        mh.host().id,
+        &ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForBiosJob {
+                bios_config_info: BiosConfigInfo {
+                    bios_job_id: Some(TEST_BIOS_JOB_ID.to_string()),
+                    bios_config_state: BiosConfigState::WaitForBiosJobScheduled,
+                    retry_count: RETRY_COUNT,
+                },
+            },
+        },
+        0,
+    )
+    .await;
+
+    let redfish_timepoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert_eq!(
+        host.current_state(),
+        &ManagedHostState::HostInit {
+            machine_state: MachineState::PollingBiosSetup {
+                retry_count: RETRY_COUNT,
+            },
+        }
+    );
+
+    let actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    assert!(
+        actions.iter().all(|action| !matches!(
+            action,
+            RedfishSimAction::Power(libredfish::SystemPowerControl::ForceRestart)
+        )),
+        "an already-completed BIOS job should not trigger another reboot, got: {actions:?}"
+    );
+}
+
 /// When HostInit/PollingBiosSetup is stuck, enter HandleBiosJobFailure recovery.
 #[crate::sqlx_test]
 async fn test_polling_bios_setup_stuck_enters_handle_bios_job_failure(pool: sqlx::PgPool) {
@@ -3107,6 +3162,48 @@ async fn test_wait_for_set_boot_order_job_scheduled_advances_to_reboot(pool: sql
             set_boot_order_state: SetBootOrderState::RebootHost,
             retry_count: RETRY_COUNT,
         }
+    );
+}
+
+/// A completed boot-order job skips the redundant reboot and moves directly
+/// to final verification with its job and retry context intact.
+#[crate::sqlx_test]
+async fn test_wait_for_set_boot_order_job_scheduled_skips_reboot_for_completed_job(
+    pool: sqlx::PgPool,
+) {
+    const RETRY_COUNT: u32 = 2;
+
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    let redfish_timepoint = env.redfish_sim.timepoint();
+    let set_boot_order_info = run_wait_for_set_boot_order_job_scheduled(
+        &env,
+        &mh,
+        libredfish::JobState::Completed,
+        RETRY_COUNT,
+    )
+    .await;
+
+    assert_eq!(
+        set_boot_order_info,
+        SetBootOrderInfo {
+            set_boot_order_jid: Some(TEST_BOOT_ORDER_JOB_ID.to_string()),
+            set_boot_order_state: SetBootOrderState::CheckBootOrder,
+            retry_count: RETRY_COUNT,
+        }
+    );
+
+    let actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    assert!(
+        actions.iter().all(|action| !matches!(
+            action,
+            RedfishSimAction::Power(libredfish::SystemPowerControl::ForceRestart)
+        )),
+        "an already-completed boot-order job should not trigger another reboot, got: {actions:?}"
     );
 }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11610,6 +11610,20 @@ async fn set_host_boot_order(
                     }));
                 }
 
+                if matches!(job_state, libredfish::JobState::Completed) {
+                    tracing::info!(
+                        %job_id,
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        "SetBootOrder: job completed before scheduling was observed; skipping reboot",
+                    );
+
+                    return Ok(SetBootOrderOutcome::Continue(SetBootOrderInfo {
+                        set_boot_order_jid: set_boot_order_info.set_boot_order_jid.clone(),
+                        set_boot_order_state: SetBootOrderState::CheckBootOrder,
+                        retry_count: set_boot_order_info.retry_count,
+                    }));
+                }
+
                 if !matches!(job_state, libredfish::JobState::Scheduled) {
                     return Err(StateHandlerError::GenericError(eyre::eyre!(
                         "waiting for job {:#?} to be scheduled; current state: {job_state:#?}",

--- a/crates/machine-controller/src/handler/bios_config.rs
+++ b/crates/machine-controller/src/handler/bios_config.rs
@@ -194,6 +194,14 @@ pub(super) async fn advance_bios_config_job(
                 )?
                 .into());
             }
+            if matches!(job_state, libredfish::JobState::Completed) {
+                tracing::info!(
+                    %job_id,
+                    machine_id = %mh_snapshot.host_snapshot.id,
+                    "BIOS job completed before scheduling was observed; skipping reboot",
+                );
+                return Ok(BiosConfigJobAdvanceOutcome::Done);
+            }
             if !matches!(job_state, libredfish::JobState::Scheduled) {
                 return Err(StateHandlerError::GenericError(eyre!(
                     "waiting for BIOS job {:#?} to be scheduled; current state: {job_state:#?}",


### PR DESCRIPTION
Normally, machine-controller waits for a Redfish BIOS or boot-order job to reach `Scheduled`, reboots the host, and then waits for `Completed`. If another actor applies the job first, the scheduling check sees a successful `Completed` state but keeps retrying because the persisted state never changes.

So, let both waits treat `Completed` as already applied. BIOS moves to `PollingBiosSetup`, boot order moves to `CheckBootOrder`, and both paths preserve their retry context while skipping the redundant reboot.

The focused tests verify the next state and confirm that Redfish did not receive another `ForceRestart`.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4181

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo test -p carbide-api-core skips_reboot_for_completed_job --lib`

`cargo test -p carbide-api-core wait_for_set_boot_order_job_scheduled --lib`

`cargo test -p carbide-api-core bios_config_job --lib`

`cargo test -p carbide-machine-controller --lib`

`cargo make format-nightly`

`cargo make clippy`

`cargo make carbide-lints`

## Additional Notes

`Scheduled`, `Running`, `Unknown`, and terminal error handling remain unchanged. This PR does not add serialized states or change retry budgets.

Closes #4181
