### PR TITLE
fix(ssh-console): export generated RPC metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ dependencies = [
  "bmc-vendor",
  "bytes",
  "carbide-api-test-helper",
+ "carbide-instrument",
  "carbide-machine-a-tron",
  "carbide-rpc",
  "carbide-ssh-console-mock-api-server",

--- a/crates/ssh-console/Cargo.toml
+++ b/crates/ssh-console/Cargo.toml
@@ -77,6 +77,7 @@ size = { features = ["serde"], workspace = true }
 
 [dev-dependencies]
 bmc-mock = { path = "../bmc-mock" }
+carbide-instrument = { path = "../instrument" }
 carbide-machine-a-tron = { path = "../machine-a-tron" }
 carbide-test-support = { path = "../test-support" }
 temp-dir = { workspace = true }

--- a/crates/ssh-console/src/metrics.rs
+++ b/crates/ssh-console/src/metrics.rs
@@ -148,6 +148,8 @@ impl Default for MetricsState {
 }
 
 impl MetricsState {
+    /// `MetricsState::new` creates ssh-console's registry and installs the
+    /// same provider globally for generated Forge-client RED metrics.
     pub fn new() -> Self {
         let registry = prometheus::Registry::new();
         let exporter = opentelemetry_prometheus::exporter()
@@ -159,6 +161,12 @@ impl MetricsState {
         let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             .with_reader(exporter)
             .build();
+
+        // Generated Forge clients record RED through
+        // `opentelemetry::global::meter`, while this registry is what
+        // `/metrics` exports. Install the same provider before the first
+        // client call so those measurements land here.
+        opentelemetry::global::set_meter_provider(meter_provider.clone());
         let meter = meter_provider.meter("ssh-console");
 
         Self {
@@ -166,5 +174,80 @@ impl MetricsState {
             registry,
             _meter_provider: meter_provider,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use super::*;
+
+    const CHILD_PROCESS_ENV: &str = "CARBIDE_SSH_CONSOLE_METRICS_TEST_CHILD";
+
+    #[test]
+    fn metrics_state_exports_global_red_metrics() {
+        if std::env::var_os(CHILD_PROCESS_ENV).is_some() {
+            assert_global_red_metrics_exported();
+            return;
+        }
+
+        // `MetricsState::new` installs process-global state, and RED caches
+        // its histogram. Run the assertion in a fresh process so parallel
+        // tests cannot inherit or replace either one.
+        let output = Command::new(std::env::current_exe().expect("current test executable"))
+            .args([
+                "--exact",
+                "metrics::tests::metrics_state_exports_global_red_metrics",
+                "--nocapture",
+            ])
+            .env(CHILD_PROCESS_ENV, "1")
+            .output()
+            .expect("run ssh-console metrics test child");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success() && stdout.contains("1 passed; 0 failed"),
+            "ssh-console metrics child failed\nstdout:\n{}\nstderr:\n{}",
+            stdout,
+            stderr,
+        );
+    }
+
+    fn assert_global_red_metrics_exported() {
+        let state = MetricsState::new();
+        carbide_instrument::red::record("ssh-console-test", "connect", "ok", 1.0);
+
+        let family = state
+            .registry
+            .gather()
+            .into_iter()
+            .find(|family| family.name() == "carbide_external_call_duration_milliseconds")
+            .expect("RED histogram should use the ssh-console registry");
+        let expected_labels = [
+            ("backend", "ssh-console-test"),
+            ("operation", "connect"),
+            ("outcome", "ok"),
+        ];
+        let metric = family
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                expected_labels.iter().all(|(name, value)| {
+                    metric
+                        .get_label()
+                        .iter()
+                        .any(|label| label.name() == *name && label.value() == *value)
+                })
+            })
+            .expect("RED histogram should contain the recorded series");
+
+        assert_eq!(
+            metric.get_label().len(),
+            expected_labels.len(),
+            "RED histogram should not expose unexpected labels",
+        );
+        assert_eq!(metric.get_histogram().get_sample_count(), 1);
     }
 }


### PR DESCRIPTION
ssh-console already builds the Prometheus registry served by `/metrics`, but its generated Forge clients record RED through OpenTelemetry's global meter provider. Since ssh-console never installed its provider globally, `carbide_external_call_duration_milliseconds` could not reach the registry it exports.

This installs that existing provider during `MetricsState::new`, before the first generated client call. The registry, endpoint, metric name, and labels stay unchanged.

Tests added! The regression runs in a child process, records one RED observation through the same helper used by generated clients, and verifies that the exact series appears in ssh-console's registry without changing global state in the parent test process.

## Related issues

Closes #4182

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed locally:

- `cargo test -p carbide-ssh-console metrics_state_exports_global_red_metrics --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo xtask check-workspace-deps`
- `cargo make check-licenses`
- `cargo make check-bans`

## Additional Notes

- ssh-console runs one metrics state per production process. Its integration test binary can start more than one instance concurrently, but none currently asserts an individual RED registry. This PR therefore avoids adding test serialization or provider-replacement machinery.
- This is separate from #4174. That broader OpenTelemetry initialization-order hardening is deferred in Backlog.