### PR TITLE
feat(helm-prereqs): grant nico-vault-policy write access to rack maintenance credentials

### DIFF
--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -263,6 +263,12 @@ spec:
               path "{{ .Values.vault.kvMount }}/destroy/switch_nvos/*" {
                 capabilities = ["update"]
               }
+              path "{{ .Values.vault.kvMount }}/data/racks/+/maintenance/access-token" {
+                capabilities = ["create", "update", "read"]
+              }
+              path "{{ .Values.vault.kvMount }}/metadata/racks/+/maintenance/access-token" {
+                capabilities = ["delete", "read"]
+              }
               POLICY
 
               # ---- K8s auth role for cert-manager ----
@@ -277,8 +283,9 @@ spec:
               # ---- K8s auth role for nico-api ----
               # nico-api authenticates to in-cluster Vault via its SA JWT
               # (vault SDK auto-detects /var/run/secrets/kubernetes.io/serviceaccount/token)
-              # and manages machine credentials in the KV mount (nico-vault-policy
-              # grants read/list plus scoped writes for machine, UFM, and NMXM secrets).
+              # and manages credentials in the KV mount (nico-vault-policy grants
+              # read/list everywhere plus scoped writes under each credential prefix
+              # nico-api owns; see CredentialPrefix in crates/secrets).
               echo "Creating K8s auth role for nico-api..."
               vault write auth/kubernetes/role/{{ .Values.vault.nicoApiK8sAuth.serviceAccountName }} \
                 bound_service_account_names={{ .Values.vault.nicoApiK8sAuth.serviceAccountName }} \


### PR DESCRIPTION
`nico-vault-policy` never granted any write capability under `racks/`. It covers `machines*`, `ufm/*`, `nmxm/*`, `bgp/*` and `switch_nvos/*`; for `racks/` the only matching rule is the catch-all `secrets/data/*` with `["read", "list"]`. So the write that `set_credentials(CredentialKey::RackMaintenanceAccessToken { .. })` performs is refused by Vault, and a site cannot run rack maintenance that supplies an access token. This blocks standing up rack management on sites with `rack_management_enabled = true`.

This adds two rules covering the one secret nico-api stores per rack, `racks/<rack_id>/maintenance/access-token` (`crates/secrets/src/credentials.rs:748`), rather than the whole `racks/` subtree.

The rack id sits in a middle path segment, so the rules use `+` rather than `*`. Vault honours `*` as a glob only as the last character of a path and treats it literally anywhere else ([docs](https://developer.hashicorp.com/vault/docs/concepts/policies); `secret/*/123` is listed as invalid in [this HashiCorp article](https://support.hashicorp.com/hc/en-us/articles/38600861606931-Usage-of-Glob-and-Wildcard-in-Vault-Policies)), so `racks/*/maintenance/access-token` would never match a real rack and the permission error would persist with nothing to indicate why. `+` matches exactly one segment.

Capabilities follow the calls the credential manager makes for this key:
- `set_credentials` / `create_credentials` → `kv2::set` / `kv2::set_with_options` against `data/` → `create`, `update`.
- `get_credentials` → `kv2::read` against `data/` → `read`. This has to be listed explicitly: Vault resolves a request against the single highest-priority matching rule rather than the union, and this rule outranks the catch-all `secrets/data/*`, so `read` is not inherited from it.
- `delete_credentials` → `kv2::delete_metadata` (`crates/secrets/src/forge_vault.rs:939`) against `metadata/` → `delete`.
- No `list`, `patch` or `destroy`: nothing in the tree lists rack secrets (`list_secrets` is only exercised by integration tests, which use a root token), `kv2::set` is a write rather than a patch, and no call path destroys versions.


## Related issues
Closes #4196

## Type of Change 
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes 
- [ ] **This PR contains breaking changes**

## Testing 
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes 

