### PR TITLE
fix(ci): disable buildx GHA cache for boot-artifacts images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1082,6 +1082,8 @@ jobs:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
+      # No RUN steps to cache, and the multi-GB blob COPY layer alone can exhaust the 10 GB per-repo Actions cache quota.
+      cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64:${{ needs.prepare.outputs.major_minor_version }}-latest
@@ -1116,6 +1118,8 @@ jobs:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
+      # No RUN steps to cache, and the multi-GB blob COPY layer alone can exhaust the 10 GB per-repo Actions cache quota.
+      cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -75,6 +75,11 @@ on:
         required: false
         default: false
         type: boolean
+      cache:
+        description: 'Use the GitHub Actions buildx layer cache. Turn off for images whose Dockerfile has no RUN steps.'
+        required: false
+        default: true
+        type: boolean
       timeout_minutes:
         description: 'Job timeout in minutes'
         required: false
@@ -229,8 +234,8 @@ jobs:
           provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
-          cache-from: type=gha
-          cache-to: ${{ inputs.push && 'type=gha,mode=max' || '' }}
+          cache-from: ${{ inputs.cache && 'type=gha' || '' }}
+          cache-to: ${{ inputs.cache && inputs.push && 'type=gha,mode=max' || '' }}
 
       - name: Login to target registry
         if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}


### PR DESCRIPTION
## Problem

`core-ci-pass` has been red on every `main` commit since 2026-07-24.

The only genuinely failing job is `build-release-artifacts-arm-host / build`:

```
#11 pushing manifest for .../boot-artifacts-aarch64:v2.1.0-pr-501-... 0.6s done
#11 DONE 454.7s              <- push succeeded
#12 exporting to GitHub Actions Cache
#12 ERROR: not_found
##[error]buildx failed with: ERROR: failed to build: failed to solve: not_found
```

Failing run: https://github.com/NVIDIA/infra-controller/actions/runs/30242036089

## Root cause

`cache-to: type=gha,mode=max` exports the arm image's single layer as a 9.8GB cache blob. GitHub's per-repo Actions cache quota is 10 GB.

## Why the cache isn't needed here

`dev/docker/Dockerfile.release-artifacts-{aarch64,x86_64}` are `FROM alpine` + one `COPY` + `CMD`, with **zero `RUN` steps**.

The cache never hits, so it buys nothing. A COPY's cache key is the content hash of its source tree - here, the per-commit boot blobs, freshly built each run and not bit-reproducible across builds. There are no RUN layers whose output could be reused, and the only other layer is FROM alpine, a ~3 MB registry pull the daemon handles independently of type=gha.

## Change

Add a `cache` boolean input to the shared `docker-build.yml` (default `true`) and set `cache: false` on the two boot-artifacts callers. `docker-build.yml` has 21 callers; the other 19 have real `RUN` layers that genuinely benefit, so the default preserves their behavior exactly and this diff leaves them untouched.

## Validation

- `actionlint` on both files: 49 findings before the change, 49 after - zero new.
- Diff review confirms the other 19 callers are unmodified.

The cache export only runs when `push: true`, so this can't be fully exercised until it lands on `main`. After merge, run and re-check `gh api repos/NVIDIA/infra-controller/actions/cache/usage`.