### PR TITLE
[draft] feat(machine-controller): reconcile selected boot interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6812,7 +6812,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.45.1#7d6a335f7ebe1e489c574f075a9adc1ce171a1bf"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.0#31d74b58c7048602c45f53b4b7dacb97ec851da4"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.45.1" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.0" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 

--- a/crates/admin-cli/src/boot_interface/candidates/cmd.rs
+++ b/crates/admin-cli/src/boot_interface/candidates/cmd.rs
@@ -19,7 +19,7 @@
 //! offers (managed `machine_interfaces` rows and pre-first-lease predictions),
 //! annotated with the picks the system computes among them. The picks --
 //! current, default (primary flag masked), predicted, and the explored
-//! endpoint default -- all arrive server-computed on the
+//! endpoint evaluation target -- all arrive server-computed on the
 //! `GetMachineBootInterfaces` response; this module only matches rows against
 //! them, it never re-derives selection logic.
 
@@ -28,6 +28,7 @@ use std::fmt::Write as _;
 use ::rpc::admin_cli::OutputFormat;
 use ::rpc::forge as forgerpc;
 use carbide_uuid::machine::MachineId;
+use model::network_segment::NetworkSegmentType;
 use prettytable::{Cell, Row, Table};
 use serde::Serialize;
 
@@ -61,9 +62,8 @@ struct CandidateRow {
     network_segment_type: Option<String>,
     source: CandidateSource,
     primary_interface: bool,
-    /// Whether the selection considers this row at all. Mirrors the pick
-    /// functions' one exclusion -- underlay rows are never boot candidates --
-    /// for display only; the actual picks are server-computed.
+    /// Whether an operator may explicitly select this row as the host boot
+    /// interface. The write API enforces the same model predicate.
     eligible: bool,
     /// This NIC is what resolution targets right now: the effective managed
     /// pick, or the predicted pick while no managed row offers a candidate.
@@ -71,8 +71,8 @@ struct CandidateRow {
     /// This NIC is the automatic pick with the primary flag masked -- what
     /// the system would choose if nothing were declared.
     default: bool,
-    /// This NIC matches site-explorer's stored default for one of the
-    /// machine's BMC endpoints.
+    /// This NIC matches the stored evaluation target for one of the machine's
+    /// BMC endpoints.
     explored_default: bool,
 }
 
@@ -92,14 +92,14 @@ struct CandidatesReport {
     /// The `pick_boot_prediction` result for the pre-first-lease window.
     predicted_boot_interface_mac: Option<String>,
     predicted_boot_interface_id: Option<String>,
-    /// Every boot pair recorded on the machine's explored BMC endpoints --
-    /// the MAC plus the Redfish interface id when captured.
+    /// Every evaluation target recorded on the machine's explored BMC
+    /// endpoints -- the MAC plus the Redfish interface id when captured.
     explored_boot_interfaces: Vec<ExploredDefault>,
     divergent: bool,
 }
 
-/// An explored-endpoint default: the pair site-explorer recorded for one of
-/// the machine's BMC endpoints.
+/// An explored-endpoint evaluation target recorded for one of the machine's
+/// BMC endpoints.
 #[derive(Debug, Serialize)]
 struct ExploredDefault {
     mac_address: String,
@@ -127,24 +127,31 @@ impl From<forgerpc::GetMachineBootInterfacesResponse> for CandidatesReport {
             .as_ref()
             .and_then(|b| b.interface_id.clone());
 
-        // The current pick follows the resolvers' order: managed rows first,
-        // predictions only when the managed rows offer nothing.
-        let (current_mac, current_id, current_source) = if r.effective_boot_interface_mac.is_some()
-        {
+        // New servers report the cross-store effective pick directly. Infer
+        // its source from the rows so a declared primary prediction that
+        // outranks an interim owned row is still labeled correctly. The
+        // predicted fallback keeps this view useful with older servers.
+        let (current_mac, current_id) = if r.effective_boot_interface_mac.is_some() {
             (
                 r.effective_boot_interface_mac.clone(),
                 r.effective_boot_interface_id.clone(),
-                Some(CandidateSource::Managed),
             )
         } else if predicted_mac.is_some() {
-            (
-                predicted_mac.clone(),
-                predicted_id.clone(),
-                Some(CandidateSource::Predicted),
-            )
+            (predicted_mac.clone(), predicted_id.clone())
         } else {
-            (None, None, None)
+            (None, None)
         };
+        let current_source = current_mac.as_ref().map(|mac| {
+            let has_owned_row = r
+                .machine_interfaces
+                .iter()
+                .any(|interface| interface.mac_address == *mac);
+            if predicted_mac.as_ref() == Some(mac) && !has_owned_row {
+                CandidateSource::Predicted
+            } else {
+                CandidateSource::Managed
+            }
+        });
 
         let explored_defaults: Vec<ExploredDefault> = r
             .explored_endpoints
@@ -162,12 +169,14 @@ impl From<forgerpc::GetMachineBootInterfacesResponse> for CandidatesReport {
             .collect();
 
         let mark = |mac: &str, pick: &Option<String>| pick.as_deref() == Some(mac);
-        // The one exclusion the pick functions apply, matched against the
-        // segment type's wire form (`NetworkSegmentType` serializes `Underlay`
-        // as "tor"). Display only -- the picks themselves arrive
-        // server-computed.
-        let underlay = model::network_segment::NetworkSegmentType::Underlay.to_string();
-        let eligible = |segment: Option<&str>| segment != Some(underlay.as_str());
+        // Operator selection is limited to host management segments. Display
+        // only -- the picks themselves arrive server-computed, and the write
+        // API enforces the same model predicate.
+        let eligible = |segment: Option<&str>| {
+            segment
+                .and_then(|segment| segment.parse::<NetworkSegmentType>().ok())
+                .is_some_and(|segment| segment.supports_host_boot())
+        };
 
         let mut candidates: Vec<CandidateRow> = r
             .machine_interfaces
@@ -289,7 +298,11 @@ fn render_candidates(report: &CandidatesReport) -> String {
                 CandidateSource::Managed => "managed",
                 CandidateSource::Predicted => "predicted",
             };
-            let eligible = if c.eligible { "yes" } else { "no (underlay)" };
+            let eligible = if c.eligible {
+                "yes"
+            } else {
+                "no (not a host boot segment)"
+            };
             table.add_row(Row::new(vec![
                 Cell::new(&c.mac_address),
                 Cell::new(&dash(&c.interface_id)),
@@ -377,7 +390,7 @@ fn render_candidates(report: &CandidatesReport) -> String {
     }
     let _ = writeln!(
         out,
-        "Explored default(s):     {}",
+        "Explored target(s):      {}",
         if report.explored_boot_interfaces.is_empty() {
             "-".to_string()
         } else {
@@ -399,8 +412,8 @@ mod tests {
     use super::*;
 
     /// A response with a managed primary (current), a lower-MAC managed row the
-    /// masked pick prefers (default), an underlay row (ineligible), and a
-    /// prediction; the explored default names the primary's MAC.
+    /// masked pick prefers (default), two non-host rows (ineligible), and a
+    /// prediction; the explored target names the primary's MAC.
     fn sample_response() -> forgerpc::GetMachineBootInterfacesResponse {
         forgerpc::GetMachineBootInterfacesResponse {
             machine_id: None,
@@ -424,6 +437,13 @@ mod tests {
                     primary_interface: false,
                     boot_interface_id: None,
                     network_segment_type: Some("tor".to_string()),
+                    interface_id: None,
+                },
+                forgerpc::MachineInterfaceBootInterface {
+                    mac_address: "aa:bb:cc:00:00:03".to_string(),
+                    primary_interface: false,
+                    boot_interface_id: None,
+                    network_segment_type: Some("tenant".to_string()),
                     interface_id: None,
                 },
             ],
@@ -458,7 +478,7 @@ mod tests {
         let report = CandidatesReport::from(sample_response());
 
         // Owned rows first, predictions after.
-        assert_eq!(report.candidates.len(), 4);
+        assert_eq!(report.candidates.len(), 5);
 
         let primary = &report.candidates[0];
         assert!(primary.current, "the managed primary is the current pick");
@@ -468,13 +488,22 @@ mod tests {
 
         let lower = &report.candidates[1];
         assert!(!lower.current);
-        assert!(lower.default, "the lower non-underlay MAC is the default");
+        assert!(lower.default, "the lower eligible MAC is the default");
 
         let underlay = &report.candidates[2];
-        assert!(!underlay.eligible, "underlay rows are never candidates");
+        assert!(
+            !underlay.eligible,
+            "underlay rows cannot be selected for host boot"
+        );
         assert!(!underlay.current && !underlay.default);
 
-        let prediction = &report.candidates[3];
+        let tenant = &report.candidates[3];
+        assert!(
+            !tenant.eligible,
+            "tenant rows cannot be selected for host boot"
+        );
+
+        let prediction = &report.candidates[4];
         assert_eq!(prediction.source, CandidateSource::Predicted);
         assert!(
             !prediction.current,
@@ -523,15 +552,38 @@ mod tests {
     }
 
     #[test]
+    fn effective_primary_prediction_is_labeled_predicted() {
+        let mut response = sample_response();
+        response.predicted_interfaces[0].primary_interface = true;
+        let response = forgerpc::GetMachineBootInterfacesResponse {
+            effective_boot_interface_mac: Some("aa:bb:cc:00:00:09".to_string()),
+            effective_boot_interface_id: None,
+            ..response
+        };
+
+        let report = CandidatesReport::from(response);
+
+        assert_eq!(report.current_source, Some(CandidateSource::Predicted));
+        assert_eq!(
+            report.current_boot_interface_mac.as_deref(),
+            Some("aa:bb:cc:00:00:09"),
+        );
+        assert!(
+            render_candidates(&report).contains("(from a prediction -- not yet leased)"),
+            "the cross-store effective pick should identify its prediction source",
+        );
+    }
+
+    #[test]
     fn ascii_render_shows_markers_and_summary() {
         let rendered = render_candidates(&CandidatesReport::from(sample_response()));
 
         assert!(rendered.contains("current,explored"));
-        assert!(rendered.contains("no (underlay)"));
+        assert!(rendered.contains("no (not a host boot segment)"));
         assert!(rendered.contains("Current boot interface:  aa:bb:cc:00:00:02 (NIC.Slot.2-1-1)\n"));
         assert!(rendered.contains("Default (auto) pick:     aa:bb:cc:00:00:01 (NIC.Slot.1-1-1)\n"));
         assert!(rendered.contains("Predicted pick:          aa:bb:cc:00:00:09"));
-        assert!(rendered.contains("Explored default(s):     aa:bb:cc:00:00:02 (NIC.Slot.2-1-1)"));
+        assert!(rendered.contains("Explored target(s):      aa:bb:cc:00:00:02 (NIC.Slot.2-1-1)"));
         assert!(rendered.contains("Stores diverge on boot MAC: false"));
     }
 
@@ -608,7 +660,8 @@ mod tests {
         assert_eq!(value["candidates"][0]["source"], "managed");
         assert_eq!(value["candidates"][1]["default"], true);
         assert_eq!(value["candidates"][2]["eligible"], false);
-        assert_eq!(value["candidates"][3]["source"], "predicted");
+        assert_eq!(value["candidates"][3]["eligible"], false);
+        assert_eq!(value["candidates"][4]["source"], "predicted");
         assert_eq!(value["current_source"], "managed");
         assert_eq!(
             value["explored_boot_interfaces"][0]["mac_address"],

--- a/crates/admin-cli/src/boot_interface/mod.rs
+++ b/crates/admin-cli/src/boot_interface/mod.rs
@@ -42,8 +42,9 @@ pub enum Cmd {
         long_about = "Gather the boot-interface view for one machine from all four stores and \
             print them together: the managed `machine_interfaces` rows (authoritative for a \
             managed machine), `predicted_machine_interfaces` (pre-first-lease candidates), \
-            the `explored_endpoints` default (for endpoints without a machine), and the \
-            retained post-deletion pairs (including stale records). Also reports the \
+            the `explored_endpoints` evaluation target (an inferred default before ownership \
+            and the managed selection afterward), and the retained post-deletion pairs \
+            (including stale records). Also reports the \
             effective boot interface the system would select and flags when the stores \
             disagree. Read-only."
     )]
@@ -53,10 +54,11 @@ pub enum Cmd {
         long_about = "List every NIC that could be the boot interface for a machine -- the \
             managed `machine_interfaces` rows and the pre-first-lease predictions -- and \
             mark the picks among them: `current` (what resolution targets now: the primary \
-            interface if one is set, else the lowest-MAC non-underlay interface), `default` \
+            boot-capable interface if one is set, else the lowest-MAC boot-capable interface), `default` \
             (what the automatic selection would choose if no primary interface were set), \
-            and `explored` (the default site-explorer recorded for the BMC endpoint of the \
-            machine). Underlay rows are listed but marked ineligible. Every pick is computed \
+            and `explored` (the evaluation target stored for the BMC endpoint of the machine). \
+            Only Admin and HostInband rows are eligible for operator selection; other \
+            rows are listed but marked ineligible. Every pick is computed \
             server-side by the same selection code the machine-controller acts on. Read-only."
     )]
     Candidates(candidates::Args),
@@ -64,10 +66,16 @@ pub enum Cmd {
         about = "Set the boot interface for a machine (promotes it to the primary interface)",
         long_about = "Make an interface the boot interface for a machine by promoting it to \
             the primary interface -- the designation every boot flow keys on. This is the \
-            same operation as `managed-host set-primary-interface`: the BMC boot order is \
-            updated first, then the primary flag moves in the database. The interface can be \
-            named by machine-interface UUID or by MAC address; a MAC must match exactly one \
-            managed interface row on the machine."
+            same operation as `managed-host set-primary-interface`: the selected interface and \
+            synchronization target are committed together, then machine-controller applies any \
+            required BMC changes. Unassigned hosts synchronize automatically. For an assigned \
+            host, `--reboot` applies the selection now and restarts only if required; without it, \
+            applying the selection is deferred and pending authorization is canceled before \
+            synchronization starts. Once synchronization has started, wait for it to finish \
+            before changing the selection without `--reboot`. The \
+            interface can be named by machine-interface \
+            UUID or by MAC address; a MAC must match exactly one managed interface row on the \
+            machine."
     )]
     Set(set::Args),
 }

--- a/crates/admin-cli/src/boot_interface/set/args.rs
+++ b/crates/admin-cli/src/boot_interface/set/args.rs
@@ -32,7 +32,7 @@ Set it by machine-interface UUID (exact, works even with duplicate MACs):
     $ nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 \
     abcdef01-2345-6789-abcd-ef0123456789
 
-Set and reboot the host so the new boot order takes effect immediately:
+Apply the selection while the host is assigned (restarts only if required):
     $ nico-admin-cli boot-interface set 12345678-1234-5678-90ab-cdef01234567 \
     00:11:22:33:44:55 --reboot
 
@@ -43,7 +43,10 @@ pub struct Args {
     pub machine: MachineId,
     #[clap(help = "The interface to boot from -- a machine-interface UUID or a MAC address")]
     pub interface: InterfaceSelector,
-    #[clap(long, help = "Reboot the host after the update")]
+    #[clap(
+        long,
+        help = "On an assigned host, authorize applying this exact selection now; the controller restarts only if required. Without the flag, defer applying it and clear pending authorization before synchronization starts; once it has started, wait for it to finish. Ready unassigned hosts begin synchronization immediately; hosts in other unassigned states begin when they next reach the Ready gate"
+    )]
     pub reboot: bool,
 }
 

--- a/crates/admin-cli/src/boot_interface/set/cmd.rs
+++ b/crates/admin-cli/src/boot_interface/set/cmd.rs
@@ -18,9 +18,10 @@
 //! Set a machine's boot interface by promoting the chosen interface to the
 //! machine's primary -- the designation `pick_boot_interface` keys on. A thin
 //! front for the same `SetPrimaryInterface` RPC behind
-//! `managed-host set-primary-interface`: the server updates the BMC boot
-//! order first, then moves the primary flag. The only client-side work is
-//! resolving an operator-entered MAC to its managed interface row.
+//! `managed-host set-primary-interface`: the server commits the selected row
+//! and machine-controller synchronizes Redfish from that desired state. The
+//! only client-side work is resolving an operator-entered MAC to its managed
+//! interface row.
 
 use ::rpc::forge as forgerpc;
 use carbide_uuid::machine::MachineInterfaceId;

--- a/crates/admin-cli/src/boot_interface/show/cmd.rs
+++ b/crates/admin-cli/src/boot_interface/show/cmd.rs
@@ -18,8 +18,9 @@
 //! Render one machine's boot-interface view (the `GetMachineBootInterfaces`
 //! RPC) as an ASCII table, JSON, or YAML. The view gathers the four stores a
 //! host's boot interface can live in -- managed interface rows, predictions, the
-//! explored endpoint default, and the retained post-deletion pairs -- plus the
-//! effective boot interface the system would select and a divergence flag.
+//! explored endpoint evaluation target, and the retained post-deletion pairs
+//! -- plus the effective boot interface the system would select and a
+//! divergence flag.
 
 use std::fmt::Write as _;
 
@@ -224,12 +225,9 @@ fn render_tables(report: &BootInterfacesReport) -> String {
     }
     let _ = write!(out, "{predicted}");
 
-    // Store 3: explored endpoint default (machine-less default; shown for the
-    // machine's BMC endpoints).
-    let _ = writeln!(
-        out,
-        "\nexplored_endpoints (default for endpoints without a machine):"
-    );
+    // Store 3: the endpoint evaluation target: an inferred default before
+    // ownership and the managed selection afterward.
+    let _ = writeln!(out, "\nexplored_endpoints (evaluation target):");
     let mut explored = Table::new();
     explored.set_titles(Row::new(
         [
@@ -340,7 +338,7 @@ mod tests {
         // Section labels.
         assert!(table.contains("machine_interfaces (managed rows):"));
         assert!(table.contains("predicted_machine_interfaces:"));
-        assert!(table.contains("explored_endpoints"));
+        assert!(table.contains("explored_endpoints (evaluation target):"));
         assert!(table.contains("retained_boot_interfaces"));
 
         // The boot_interface_id of the managed row.

--- a/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_dpu/args.rs
@@ -27,7 +27,7 @@ Set the primary DPU for a host:
     $ nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 \
     abcdef01-2345-6789-abcd-ef0123456789
 
-Set the primary DPU and reboot the host afterward:
+Apply the selection while the host is assigned (restarts only if required):
     $ nico-admin-cli managed-host set-primary-dpu 12345678-1234-5678-90ab-cdef01234567 \
     abcdef01-2345-6789-abcd-ef0123456789 --reboot
 
@@ -37,7 +37,10 @@ pub struct Args {
     pub host_machine_id: MachineId,
     #[clap(help = "ID of the DPU machine to make primary")]
     pub dpu_machine_id: MachineId,
-    #[clap(long, help = "Reboot the host after the update")]
+    #[clap(
+        long,
+        help = "On an assigned host, authorize applying this exact selection now; the controller restarts only if required. Without the flag, defer applying it and clear pending authorization before synchronization starts; once it has started, wait for it to finish. Ready unassigned hosts begin synchronization immediately; hosts in other unassigned states begin when they next reach the Ready gate"
+    )]
     pub reboot: bool,
 }
 

--- a/crates/admin-cli/src/managed_host/set_primary_interface/args.rs
+++ b/crates/admin-cli/src/managed_host/set_primary_interface/args.rs
@@ -24,11 +24,11 @@ use rpc::forge as forgerpc;
 EXAMPLES:
 
 Make a host interface the primary (boot) interface:
-    $ carbide-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 \
+    $ nico-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 \
     abcdef01-2345-6789-abcd-ef0123456789
 
-Promote an interface and reboot the host afterward:
-    $ carbide-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 \
+Apply the selection while the host is assigned (restarts only if required):
+    $ nico-admin-cli managed-host set-primary-interface 12345678-1234-5678-90ab-cdef01234567 \
     abcdef01-2345-6789-abcd-ef0123456789 --reboot
 
 Tip: list a host's interface ids with 'managed-host show <HOST_MACHINE_ID>'.
@@ -38,7 +38,10 @@ pub struct Args {
     pub host_machine_id: MachineId,
     #[clap(help = "ID of the machine interface to make primary (the boot device)")]
     pub interface_id: MachineInterfaceId,
-    #[clap(long, help = "Reboot the host after the update")]
+    #[clap(
+        long,
+        help = "On an assigned host, authorize applying this exact selection now; the controller restarts only if required. Without the flag, defer applying it and clear pending authorization before synchronization starts; once it has started, wait for it to finish. Ready unassigned hosts begin synchronization immediately; hosts in other unassigned states begin when they next reach the Ready gate"
+    )]
     pub reboot: bool,
 }
 

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -378,7 +378,7 @@ Extends `StateControllerConfig` with:
 | `scout_reporting_timeout` | `Duration` | `5m`    | Duration without scout report before host is unhealthy. |
 | `waiting_for_measurements_timeout` | `Duration` | `4h`    | How long a host may remain in WaitingForMeasurements before being escalated to Failed. |
 | `uefi_boot_wait` | `Duration` | `5m`    | Wait time for UEFI boot completion after host reboot. |
-| `max_bios_config_retries` | `u32` | `3` | Shared retry budget for automated host boot-configuration convergence across BIOS recovery and boot-order verification. |
+| `max_bios_config_retries` | `u32` | `3` | Maximum retry count applied independently to BIOS/boot-order retries and complete synchronization passes whose final observation still reports a mismatch. |
 | `polling_bios_setup_stuck_threshold` | `Duration` | `15m` | Time in PollingBiosSetup with `is_bios_setup == false` before recovery escalation. |
 | `controller` | `StateControllerConfig` | *(default)* | Common state controller timing (see [StateControllerConfig](#statecontrollerconfig)). |
 

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -28,7 +28,9 @@ use libredfish::RoleId;
 use mac_address::MacAddress;
 use model::expected_entity::ExpectedEntity;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{LoadSnapshotOptions, MachineInterfaceSnapshot};
+use model::machine::{
+    LoadSnapshotOptions, MachineInterfaceSnapshot, pick_boot_interface_candidate,
+};
 use model::machine_boot_interface::MachineBootInterface;
 use model::predicted_machine_interface::PredictedMachineInterface;
 use model::site_explorer::{BlueFieldOperatingMode, PreingestionState};
@@ -42,25 +44,12 @@ use crate::handlers::utils::resolve_bmc_address;
 /// Resolve the boot interface an admin Redfish action should target, the same
 /// way the machine-controller resolves it.
 ///
-/// When a machine exists for the endpoint, its interfaces alone decide:
-/// `pick_boot_interface` selects the machine's primary interface -- the same
-/// row the machine-controller configures boot from -- and the row's own
-/// captured id completes the [`MachineBootInterface`], or the action targets
-/// only the MAC ([`BootInterfaceTarget::MacOnly`]), exactly like the
-/// controller's `boot_interface_target`.
-///
-/// A machine with no `machine_interfaces` rows yet (a zero-DPU/NIC-mode
-/// machine awaiting its first DHCP lease) resolves from its
-/// `predicted_machine_interfaces` instead: the predicted NIC's MAC and
-/// recorded Redfish interface id form the same [`MachineBootInterface`] the
-/// real row will hold once the lease promotes it. The candidate is chosen by
-/// the shared `pick_boot_prediction` -- the declared `ExpectedHostNic.primary`
-/// (recorded on the prediction), else the sole non-underlay prediction. With
-/// several (e.g. a host whose report lists SuperNICs alongside the boot NIC) and
-/// none declared primary the boot NIC is unknowable; resolution refuses to guess
-/// and the action keeps requiring an explicit MAC, which the matching
-/// prediction's recorded id completes. The machine-controller resolves the same
-/// way, through the same `pick_boot_prediction`.
+/// An owned machine resolves through the shared candidate picker used by
+/// machine-controller. A declared primary prediction wins while that NIC is
+/// waiting for its first lease, including when ingestion created an interim
+/// DPU-backed primary. Otherwise the owned selection wins. A sole non-primary
+/// prediction answers only when no owned row is selectable; several undeclared
+/// predictions remain ambiguous.
 ///
 /// Site-explorer's stored default (`ExploredEndpoint::boot_interface()`)
 /// answers only for endpoints no machine owns. An owned machine resolves
@@ -111,20 +100,12 @@ fn resolve_admin_boot_interface_target(
                 // answers, when site-explorer has recorded one.
                 return stored.map(BootInterfaceTarget::Pair);
             };
-            if let Some(picked) = model::machine::pick_boot_interface(&candidates.interfaces) {
-                // The machine's own row decides, exactly like the
-                // machine-controller's boot_interface_target.
-                return Some(target_for(picked.mac_address, picked.boot_interface()));
-            }
-            // The rows offered no boot candidate: the machine's predicted NICs
-            // answer, via the shared `pick_boot_prediction` -- the declared
-            // primary, else the sole non-underlay prediction. With several and
-            // none declared primary the boot NIC is unknowable, so it returns
-            // `None` and the action keeps requiring an explicit MAC.
-            if let Some(predicted) = model::machine::pick_boot_prediction(&candidates.predicted) {
+            if let Some(candidate) =
+                pick_boot_interface_candidate(&candidates.interfaces, &candidates.predicted)
+            {
                 return Some(target_for(
-                    predicted.mac_address,
-                    predicted.boot_interface(),
+                    candidate.mac_address(),
+                    candidate.boot_interface(),
                 ));
             }
             // An owned machine resolves from its own data alone: no
@@ -139,14 +120,10 @@ fn resolve_admin_boot_interface_target(
 /// real `machine_interfaces` rows, and -- for the window before a NIC's first
 /// DHCP lease creates a real row -- its `predicted_machine_interfaces`.
 pub(crate) struct BootInterfaceCandidates {
-    /// The machine's non-BMC `machine_interfaces` rows. When they offer a
-    /// boot candidate (the machine-controller's own `pick_boot_interface`
-    /// selection), it alone decides.
+    /// The machine's non-BMC `machine_interfaces` rows.
     pub interfaces: Vec<MachineInterfaceSnapshot>,
-    /// The machine's predicted interfaces, consulted only when the rows
-    /// offer no boot candidate -- none exist yet (zero-DPU/NIC-mode machines
-    /// awaiting their first lease), or none are selectable (e.g. only
-    /// underlay-typed declared NICs).
+    /// The machine's predicted interfaces. A declared primary may outrank an
+    /// interim row until first-lease promotion deletes the prediction.
     pub predicted: Vec<PredictedMachineInterface>,
 }
 
@@ -1206,6 +1183,7 @@ mod tests {
         let mut row = MachineInterfaceSnapshot::mock_with_mac(mac.parse().unwrap());
         row.primary_interface = primary;
         row.boot_interface_id = boot_interface_id.map(String::from);
+        row.network_segment_type = Some(NetworkSegmentType::HostInband);
         row
     }
 
@@ -1327,9 +1305,7 @@ mod tests {
     }
 
     #[test]
-    fn no_mac_real_rows_beat_predicted_interfaces() {
-        // Once any real machine_interfaces row exists, predictions are out of
-        // the running -- even a fully-populated one.
+    fn no_mac_owned_row_beats_a_non_primary_prediction() {
         let c = BootInterfaceCandidates {
             interfaces: vec![row("00:00:5e:00:53:02", true, Some("NIC.Slot.7-1-1"))],
             predicted: vec![predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1"))],
@@ -1339,6 +1315,26 @@ mod tests {
             Some(BootInterfaceTarget::Pair(pair(
                 "00:00:5e:00:53:02",
                 "NIC.Slot.7-1-1"
+            ))),
+        );
+    }
+
+    #[test]
+    fn no_mac_declared_primary_prediction_beats_an_interim_owned_primary() {
+        let declared_primary = PredictedMachineInterface {
+            primary_interface: true,
+            ..predicted("00:00:5e:00:53:01", Some("NIC.Embedded.1-1-1"))
+        };
+        let c = BootInterfaceCandidates {
+            interfaces: vec![row("00:00:5e:00:53:02", true, Some("NIC.Slot.7-1-1"))],
+            predicted: vec![declared_primary],
+        };
+
+        assert_eq!(
+            resolve_admin_boot_interface_target(None, Some(&c), None),
+            Some(BootInterfaceTarget::Pair(pair(
+                "00:00:5e:00:53:01",
+                "NIC.Embedded.1-1-1"
             ))),
         );
     }
@@ -1398,12 +1394,10 @@ mod tests {
 
     #[test]
     fn no_mac_multiple_predictions_refuse_to_guess_a_boot_device() {
-        // These predictions are non-primary and this resolver doesn't consult
-        // the primary flag yet, so with several (a report listing SuperNICs
-        // alongside the boot NIC) the declared intent is unknowable: resolution
-        // refuses to guess rather than silently programming boot order against
-        // whichever NIC sorts lowest. The operator's explicit MAC still
-        // resolves, completed from the matching prediction.
+        // With several non-primary predictions (a report listing SuperNICs
+        // alongside the boot NIC), the declared intent is unknowable:
+        // resolution refuses to guess. The operator's explicit MAC still
+        // resolves and is completed from the matching prediction.
         let c = BootInterfaceCandidates {
             interfaces: vec![],
             predicted: vec![

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -106,7 +106,7 @@ pub(crate) async fn add(
         data: db_data,
     };
 
-    validate_expected_machine_for_insert(&machine)?;
+    validate_expected_machine(&machine)?;
 
     let mut txn = api.txn_begin().await?;
     db::expected_machine::create(&mut txn, machine).await?;
@@ -116,13 +116,12 @@ pub(crate) async fn add(
     Ok(tonic::Response::new(()))
 }
 
-/// Validate the ExpectedMachine payload prior to insert.
-/// Shared between the `add` gRPC handler and the
-/// `expected_machines.json` import flow.
-pub(crate) fn validate_expected_machine_for_insert(
-    machine: &ExpectedMachine,
-) -> Result<(), CarbideError> {
-    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
+/// Validates an ExpectedMachine payload before it is persisted.
+///
+/// Shared by the single-object, batch, and `expected_machines.json` paths so
+/// every write accepts the same boot-interface and BMC allocation semantics.
+pub(crate) fn validate_expected_machine(machine: &ExpectedMachine) -> Result<(), CarbideError> {
+    validate_primary_host_nic(&machine.data.host_nics)?;
     machine
         .data
         .bmc_ip_allocation
@@ -133,9 +132,9 @@ pub(crate) fn validate_expected_machine_for_insert(
 }
 
 /// Create missing expected_machines that aren't already in the database,
-/// calling `validate_expected_machine_for_insert` for each new entry. This is currently
+/// calling `validate_expected_machine` for each new entry. This is currently
 /// purely used by the expected_machines.json import path only, but lives
-/// here so it can re-leverage `validate_expected_machine_for_insert` and share the
+/// here so it can re-leverage `validate_expected_machine` and share the
 /// same validation codepath as the API handler.
 pub(crate) async fn create_missing_from(
     txn: &mut sqlx::PgConnection,
@@ -156,7 +155,7 @@ pub(crate) async fn create_missing_from(
             );
             continue;
         }
-        validate_expected_machine_for_insert(expected_machine)?;
+        validate_expected_machine(expected_machine)?;
         db::expected_machine::create(&mut *txn, expected_machine.clone()).await?;
     }
 
@@ -223,12 +222,7 @@ pub(crate) async fn update(
         data,
     };
 
-    validate_at_most_one_primary_host_nic(&machine.data.host_nics)?;
-    machine
-        .data
-        .bmc_ip_allocation
-        .validate(machine.data.bmc_ip_address.is_some())
-        .map_err(|msg| CarbideError::InvalidArgument(msg.to_string()))?;
+    validate_expected_machine(&machine)?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -351,23 +345,35 @@ pub(crate) async fn delete_all(
     Ok(tonic::Response::new(()))
 }
 
-/// Rejects an ExpectedMachine payload that declares more than one host NIC
-/// with `primary: true`, returning an InvalidArgument if found.
-fn validate_at_most_one_primary_host_nic(
-    host_nics: &[ExpectedHostNic],
-) -> Result<(), CarbideError> {
+/// Validate the one host NIC an ExpectedMachine may declare for boot.
+fn validate_primary_host_nic(host_nics: &[ExpectedHostNic]) -> Result<(), CarbideError> {
     let primaries: Vec<_> = host_nics
         .iter()
         .filter(|n| n.primary == Some(true))
-        .map(|n| n.mac_address.to_string())
         .collect();
     if primaries.len() > 1 {
         return Err(CarbideError::InvalidArgument(format!(
             "at most one host_nic may be flagged primary=true, got {}: {}",
             primaries.len(),
-            primaries.join(", ")
+            primaries
+                .iter()
+                .map(|nic| nic.mac_address.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
         )));
     }
+
+    if let Some(primary) = primaries.first()
+        && let Some(segment_type) = primary.resolved_network_segment_type()
+        && !segment_type.supports_host_boot()
+    {
+        return Err(CarbideError::InvalidArgument(format!(
+            "host_nic {} is flagged primary=true with segment type {segment_type}; a host boot \
+             interface must use the admin or host_inband segment",
+            primary.mac_address,
+        )));
+    }
+
     Ok(())
 }
 
@@ -435,7 +441,7 @@ async fn create_expected_machine(
         data: db_data,
     };
 
-    validate_expected_machine_for_insert(&expected_machine)?;
+    validate_expected_machine(&expected_machine)?;
     db::expected_machine::create(txn, expected_machine).await?;
 
     Ok(())
@@ -457,6 +463,8 @@ async fn update_expected_machine(
         bmc_mac_address: parsed_mac,
         data,
     };
+
+    validate_expected_machine(&expected_machine)?;
 
     if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
         update_preallocated_machine_interface(

--- a/crates/api-core/src/handlers/machine_boot_interfaces.rs
+++ b/crates/api-core/src/handlers/machine_boot_interfaces.rs
@@ -18,9 +18,9 @@
 //! One machine's boot-interface view, gathered from every store that records
 //! it. This is a read-only troubleshooting projection: it reports the four
 //! places a host's boot interface can live -- owned `machine_interfaces` rows,
-//! `predicted_machine_interfaces`, the `explored_endpoints` default, and the
-//! post-deletion `retained_boot_interfaces` pairs -- alongside the effective
-//! boot interface the system would select via `pick_boot_interface`, and a
+//! `predicted_machine_interfaces`, the `explored_endpoints` evaluation target,
+//! and the post-deletion `retained_boot_interfaces` pairs -- alongside the effective
+//! boot interface the system would select via `pick_boot_interface_candidate`, and a
 //! divergence flag for when the stores disagree about which NIC boots.
 
 use std::collections::BTreeSet;
@@ -35,9 +35,8 @@ use crate::handlers::utils::convert_and_log_machine_id;
 /// Gather the boot-interface view for one machine across all four stores.
 ///
 /// All four stores are read within a single read transaction. The effective
-/// boot interface is the same
-/// `pick_boot_interface` selection every other flow acts on, applied to the
-/// owned `machine_interfaces` rows.
+/// boot interface uses the same cross-store candidate selection as the
+/// controller and admin Redfish flows.
 pub(crate) async fn get_machine_boot_interfaces(
     api: &Api,
     request: Request<rpc::GetMachineBootInterfacesRequest>,
@@ -60,8 +59,9 @@ pub(crate) async fn get_machine_boot_interfaces(
     let predicted_interfaces =
         db::predicted_machine_interface::find_by_machine_id(txn.as_mut(), &machine_id).await?;
 
-    // Store 3: the explored endpoint default. The machine's BMC IP(s) map it to
-    // the explored endpoints site-explorer recorded a default against.
+    // Store 3: the explored endpoint evaluation target. The machine's BMC
+    // IP(s) map it to the endpoint where the inferred pre-ownership default or
+    // managed selection is stored.
     let bmc_pairs =
         db::machine_topology::find_machine_bmc_pairs_by_machine_id(txn.as_mut(), vec![machine_id])
             .await?;
@@ -105,12 +105,12 @@ pub(crate) async fn get_machine_boot_interfaces(
 
     txn.commit().await?;
 
-    // The effective boot interface: `pick_boot_interface` over the owned rows
-    // (primary wins, else the lowest-MAC non-underlay NIC). This is what the
-    // controller and admin actions resolve.
-    let effective = model::machine::pick_boot_interface(&owned_interfaces);
-    let effective_mac = effective.map(|i| i.mac_address);
-    let effective_boot_interface = effective.and_then(|i| i.boot_interface());
+    // A declared primary prediction can answer before first-lease promotion;
+    // otherwise the owned row selection wins.
+    let effective =
+        model::machine::pick_boot_interface_candidate(&owned_interfaces, &predicted_interfaces);
+    let effective_mac = effective.map(|candidate| candidate.mac_address());
+    let effective_boot_interface = effective.and_then(|candidate| candidate.boot_interface());
 
     // The default pick: the same selection with the primary flag masked --
     // what the automation would choose if nothing were declared. Reported so
@@ -131,12 +131,11 @@ pub(crate) async fn get_machine_boot_interfaces(
         predicted_pick.and_then(|p| p.boot_interface()),
     );
 
-    // Divergence: do the stores agree on which MAC boots this machine? We
-    // compare the boot-MAC signals each store offers -- the effective owned
-    // pick, every explored endpoint's recorded default, and any predicted NIC
-    // flagged primary -- and flag a disagreement when more than one distinct
-    // MAC turns up. (Retained rows are post-deletion history, shown for context
-    // but not part of the agreement check.) A single signal, or none, is not a
+    // Divergence: do the active boot-MAC signals agree? We compare the
+    // effective cross-store pick, every explored endpoint's evaluation target,
+    // and each primary prediction. More than one distinct MAC is a
+    // disagreement. Retained rows are post-deletion history, shown for context
+    // but not part of the comparison. A single signal, or none, is not a
     // divergence.
     let mut boot_macs: BTreeSet<MacAddress> = BTreeSet::new();
     if let Some(mac) = effective_mac {

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-use std::net::SocketAddr;
-
 use ::rpc::forge as rpc;
-use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
-use model::machine::LoadSnapshotOptions;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine_boot_interface::MachineBootInterface;
+use model::machine::{
+    BootConfigSynchronizationState, BootConfigSynchronizationTarget, InstanceState,
+    LoadSnapshotOptions, ManagedHostState, pick_boot_interface_candidate,
+};
+use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::network_segment::NetworkSegmentType;
 use tonic::{Request, Response, Status};
 
@@ -37,6 +37,11 @@ pub(crate) async fn set_primary_dpu(
 ) -> Result<Response<()>, Status> {
     log_request_data(&request);
 
+    let initiator = request
+        .extensions()
+        .get::<AuthContext>()
+        .and_then(AuthContext::get_external_user_name)
+        .map(String::from);
     let request = request.into_inner();
     let host_machine_id = request
         .host_machine_id
@@ -90,7 +95,9 @@ pub(crate) async fn set_primary_dpu(
         api,
         host_machine_id,
         new_primary_interface_id,
+        Some(dpu_machine_id),
         request.reboot,
+        initiator,
     )
     .await
 }
@@ -104,6 +111,11 @@ pub(crate) async fn set_primary_interface(
 ) -> Result<Response<()>, Status> {
     log_request_data(&request);
 
+    let initiator = request
+        .extensions()
+        .get::<AuthContext>()
+        .and_then(AuthContext::get_external_user_name)
+        .map(String::from);
     let request = request.into_inner();
     let host_machine_id = request
         .host_machine_id
@@ -114,44 +126,109 @@ pub(crate) async fn set_primary_interface(
 
     log_machine_id(&host_machine_id);
 
-    set_primary_interface_core(api, host_machine_id, interface_id, request.reboot).await
+    set_primary_interface_core(
+        api,
+        host_machine_id,
+        interface_id,
+        None,
+        request.reboot,
+        initiator,
+    )
+    .await
 }
 
-// Move the primary (boot) interface flag to `new_primary_interface_id` and point
-// the host's boot device at it. Shared by `set_primary_dpu` and
-// `set_primary_interface`.
-//
-// Originally a work-around for FORGE-7085: a host BMC can report the primary DPU
-// as something other than the lowest-slot DPU, and because the host names
-// interfaces by PCI address the behavior differs between identical machines.
-//
-// Broken into the following parts:
-// 1. collect interface and bmc information
-// 2. set the boot device
-// 3. update the primary interface and network config versions.
-// 4. reboot the host if requested.
-//
-// No transaction should be held during 2 or 4 since they are requests to the host bmc.
-async fn set_primary_interface_core(
+/// Selects a host boot interface and hands Redfish synchronization to
+/// machine-controller.
+///
+/// Called by both the DPU-specific alias and the generic interface API. The
+/// selected row, endpoint target, selection generation, assigned-host
+/// authorization, and affected network versions commit together. No Redfish
+/// operation is performed on the API request path.
+pub(crate) async fn set_primary_interface_core(
     api: &Api,
     host_machine_id: MachineId,
     new_primary_interface_id: MachineInterfaceId,
+    expected_attached_dpu_machine_id: Option<MachineId>,
     reboot: bool,
+    initiator: Option<String>,
 ) -> Result<Response<()>, Status> {
-    // `host_machine_id` must be a host machine. Reject DPU (or other non-host) ids
-    // up front -- before any DB load or BMC side effect -- so callers get a clear
-    // InvalidArgument instead of a confusing failure deeper in interface/BMC lookup.
-    // `set_primary_dpu` resolves its DPU to the host's interface and also passes a
-    // host id here, so this guards both entry points.
-    if !host_machine_id.machine_type().is_host() {
+    // Site Explorer owns a host under a PredictedHost id until Scout replaces
+    // it with the stable Host id. Both are valid boot-selection targets; a DPU
+    // id is not.
+    let machine_type = host_machine_id.machine_type();
+    if !(machine_type.is_host() || machine_type.is_predicted_host()) {
         return Err(CarbideError::InvalidArgument(format!(
-            "machine {host_machine_id} is not a host machine; set-primary-interface can \
-             only promote an interface on a host"
+            "machine {host_machine_id} has type {machine_type}; set-primary-interface can \
+             only promote an interface on a host or predicted host"
         ))
         .into());
     }
 
     let mut txn = api.txn_begin().await?;
+
+    // Match discovery's interface-before-machine order while putting the
+    // endpoint first for Site Explorer: admin-segment advisory locks, explored
+    // endpoint, machine-interface rows, then the machine row.
+    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
+    let initial_machine =
+        db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
+            .await?
+            .ok_or_else(|| CarbideError::NotFoundError {
+                kind: "Machine",
+                id: host_machine_id.to_string(),
+            })?;
+    let bmc_addr =
+        initial_machine
+            .status
+            .bmc_info
+            .ip
+            .ok_or_else(|| CarbideError::NotFoundError {
+                kind: "BMC IP",
+                id: host_machine_id.to_string(),
+            })?;
+    db::explored_endpoints::find_by_ip_for_update(bmc_addr, &mut txn).await?;
+    db::machine_interface::lock_for_machine(&mut txn, host_machine_id).await?;
+    let current_selection_version =
+        db::machine::lock_boot_interface_selection_version(&mut txn, host_machine_id).await?;
+    db::predicted_machine_interface::lock_for_machine(&mut txn, host_machine_id).await?;
+    let machine = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "Machine",
+            id: host_machine_id.to_string(),
+        })?;
+    // The initial machine read only locates the endpoint without reversing the
+    // endpoint-before-machine lock order. State transitions while those locks
+    // are acquired are expected and the locked read above is authoritative;
+    // only a BMC-address change invalidates the endpoint row we locked.
+    if machine.status.bmc_info.ip != Some(bmc_addr) {
+        return Err(CarbideError::ConcurrentModificationError(
+            "machine",
+            initial_machine.state.version.to_string(),
+        )
+        .into());
+    }
+    let assigned = matches!(&machine.state.value, ManagedHostState::Assigned { .. });
+    let unassigned_ready = matches!(&machine.state.value, ManagedHostState::Ready);
+    if assigned
+        && !reboot
+        && matches!(
+            &machine.state.value,
+            ManagedHostState::Assigned {
+                instance_state:
+                    InstanceState::BootConfigSynchronization {
+                        synchronization_state,
+                        ..
+                    },
+            } if synchronization_state.host_changes_started()
+        )
+    {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "boot-interface synchronization has already started for host {host_machine_id}; \
+             wait for it to finish before changing the selection without reboot authorization"
+        ))
+        .into());
+    }
 
     let interface_map =
         db::machine_interface::find_by_machine_ids(&mut txn, &[host_machine_id]).await?;
@@ -162,189 +239,148 @@ async fn set_primary_interface_core(
                 kind: "Machine",
                 id: host_machine_id.to_string(),
             })?;
-
-    // Find the current primary and the requested new primary before the db
-    // update, since the "only one primary" constraint will fail if the new
-    // interface is set before the old one is cleared.
-    let mut current_primary_interface = None;
-    let mut new_primary_interface = None;
-    for interface_snapshot in interface_snapshots {
-        if interface_snapshot.id == new_primary_interface_id {
-            new_primary_interface = Some(interface_snapshot);
-        } else if interface_snapshot.primary_interface {
-            current_primary_interface = Some(interface_snapshot);
-        }
-    }
-    let current_primary_interface_id = current_primary_interface.map(|interface| interface.id);
-    // Whether the host currently has an Admin-segment primary. Drives whether the
-    // pre-move admin reconciliation below is needed (see its comment).
-    let current_primary_is_admin = current_primary_interface
-        .is_some_and(|interface| interface.network_segment_type == Some(NetworkSegmentType::Admin));
-
-    let new_primary_interface = new_primary_interface.ok_or_else(|| {
-        CarbideError::InvalidArgument(format!(
-            "interface {new_primary_interface_id} not found on host {host_machine_id}"
-        ))
-    })?;
-    if new_primary_interface.primary_interface {
-        return Err(CarbideError::InvalidArgument(
-            "requested interface is already primary".to_string(),
-        )
-        .into());
-    }
-
-    // On a DPU-managed host the primary interface must stay on the Admin segment:
-    // the host's admin DHCP address and DNS identity follow the primary, and
-    // `reconcile_admin_addresses_for_host` (below) errors if a host with
-    // DPU-backed admin interfaces is left with no primary admin interface.
-    // Promoting a non-admin interface would trip that *after* the BMC boot order
-    // was already changed, leaving the BMC and the database disagreeing. Zero-DPU
-    // hosts have no DPU-backed admin interface, so this never constrains them.
-    let host_has_dpu_backed_admin_interface = interface_snapshots.iter().any(|interface| {
-        interface
-            .attached_dpu_machine_id
-            .is_some_and(|dpu| dpu != host_machine_id)
-            && interface.network_segment_type == Some(NetworkSegmentType::Admin)
-    });
-    if host_has_dpu_backed_admin_interface
-        && new_primary_interface.network_segment_type != Some(NetworkSegmentType::Admin)
+    let predicted_interfaces =
+        db::predicted_machine_interface::find_by_machine_id(&mut txn, &host_machine_id).await?;
+    let current_primary_interface = interface_snapshots
+        .iter()
+        .find(|interface| interface.primary_interface);
+    let new_primary_interface = interface_snapshots
+        .iter()
+        .find(|interface| interface.id == new_primary_interface_id)
+        .ok_or_else(|| {
+            CarbideError::InvalidArgument(format!(
+                "interface {new_primary_interface_id} not found on host {host_machine_id}"
+            ))
+        })?;
+    if let Some(expected_dpu_machine_id) = expected_attached_dpu_machine_id
+        && new_primary_interface.attached_dpu_machine_id != Some(expected_dpu_machine_id)
     {
         return Err(CarbideError::InvalidArgument(format!(
-            "interface {new_primary_interface_id} is not on the admin segment; a \
-             DPU-managed host's primary interface must be an admin interface"
+            "DPU {expected_dpu_machine_id} has no interface on host {host_machine_id}"
         ))
         .into());
     }
+    if !new_primary_interface
+        .network_segment_type
+        .as_ref()
+        .is_some_and(NetworkSegmentType::supports_host_boot)
+    {
+        let segment = new_primary_interface
+            .network_segment_type
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| "none".to_string());
+        return Err(CarbideError::InvalidArgument(format!(
+            "interface {new_primary_interface_id} uses segment type {segment}; a host boot \
+             interface must use the admin or host_inband segment"
+        ))
+        .into());
+    }
+    let current_effective_interface_id =
+        pick_boot_interface_candidate(interface_snapshots, &predicted_interfaces)
+            .and_then(|candidate| candidate.machine_interface_id());
+    let selection_changed = !new_primary_interface.primary_interface
+        || current_effective_interface_id != Some(new_primary_interface_id);
+    let current_primary_interface_id = current_primary_interface.map(|interface| interface.id);
+    let current_primary_is_admin = current_primary_interface
+        .is_some_and(|interface| interface.network_segment_type == Some(NetworkSegmentType::Admin));
+    let boot_target = MachineBootInterfaceTarget::from_parts(
+        Some(new_primary_interface.mac_address),
+        new_primary_interface.boot_interface_id.clone(),
+    )
+    .expect("a machine interface always has a MAC address");
+    db::predicted_machine_interface::clear_primary_for_machine(&mut txn, host_machine_id).await?;
 
-    let primary_interface_mac_address = new_primary_interface.mac_address;
-    let boot_interface_id = new_primary_interface.boot_interface_id.clone();
+    let synchronization_requested = selection_changed || reboot;
+    let minimum_report_version = if selection_changed || (unassigned_ready && reboot) {
+        db::explored_endpoints::request_boot_interface_observation(bmc_addr, &boot_target, &mut txn)
+            .await?
+    } else {
+        db::explored_endpoints::set_boot_interface_target(bmc_addr, &boot_target, &mut txn).await?
+    };
 
     tracing::info!(
         machine_id = %host_machine_id,
-        new_primary = %new_primary_interface_id,
-        previous_primary = ?current_primary_interface_id,
-        "moving the host's primary (boot) interface",
+        machine_interface_id = %new_primary_interface_id,
+        previous_machine_interface_id = ?current_primary_interface_id,
+        selection_changed,
+        synchronization_requested,
+        assigned_synchronization_authorized = reboot && assigned,
+        synchronization_deferred =
+            synchronization_requested
+                && ((assigned && !reboot) || (!assigned && !unassigned_ready)),
+        controller_state = ?machine.state.value,
+        "Selected the host boot interface",
     );
 
-    // we need to set the boot device or the host will no longer be able to boot.  we need BMC info.
-    // the same BMC info is used if a reboot was requested.
-    let machine = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
-        .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "Machine",
-            id: host_machine_id.to_string(),
-        })?;
-
-    let bmc_addr = machine
-        .status
-        .bmc_info
-        .ip
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "BMC IP",
-            id: host_machine_id.to_string(),
-        })?;
-
-    let bmc_socket_addr = SocketAddr::new(bmc_addr, 443);
-
-    let bmc_interface = db::machine_interface::find_by_ip(&mut txn, bmc_addr)
-        .await?
-        .ok_or_else(|| CarbideError::NotFoundError {
-            kind: "BMC Interface",
-            id: bmc_addr.to_string(),
-        })?;
-
-    txn.rollback().await?;
-
-    // The new primary row already stores `boot_interface_id`, so give
-    // `libredfish` both identifiers as one target. Rows without an ID still
-    // target the MAC alone.
-    let boot_target = match boot_interface_id {
-        Some(interface_id) => BootInterfaceTarget::Pair(MachineBootInterface {
-            mac_address: primary_interface_mac_address,
-            interface_id,
-        }),
-        None => BootInterfaceTarget::MacOnly(primary_interface_mac_address),
-    };
-    api.endpoint_explorer
-        .set_boot_order_dpu_first(bmc_socket_addr, &bmc_interface, &boot_target)
-        .await
-        .map_err(|e| CarbideError::internal(e.to_string()))?;
-
-    let mut txn = api.txn_begin().await?;
-
-    // Advisory-lock the admin segments before the `set_primary_interface`
-    // row writes below, so this transaction holds locks in the allocator
-    // order (segment advisory lock first, then interface rows) on both
-    // branches -- the reconcile passes re-acquire the same locks as no-ops.
-    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
-
-    // Normalize the current admin primary's address before moving the flag, so the
-    // active DHCP address is one reconciliation can move onto the new primary --
-    // but only when there IS a current admin primary to preserve. If the host has
-    // no admin primary (e.g. a DPU-backed host whose primary was cleared or sits
-    // off the Admin segment -- an off-happy-path state), this pre-move pass would
-    // error on that broken state *after* the BMC boot order was already changed,
-    // leaving the BMC and database disagreeing. Skipping it lets set_primary_interface
-    // repair such a host; the post-move pass below sets the new primary's admin
-    // ownership from scratch.
-    if current_primary_is_admin {
+    // Normalize the current admin primary before moving the flag so its active
+    // DHCP address can move to the selected interface. When there is no current
+    // admin primary, the post-move pass below establishes address ownership
+    // directly from the new selection.
+    if selection_changed && current_primary_is_admin {
         db::machine_interface::reconcile_admin_addresses_for_host(&mut txn, &host_machine_id)
             .await?;
     }
 
-    // update the primary interface: clear the old primary (if any), then set the new.
-    if let Some(current_primary_interface_id) = current_primary_interface_id {
-        db::machine_interface::set_primary_interface(
-            &current_primary_interface_id,
-            false,
-            &mut txn,
-        )
-        .await?;
+    if selection_changed {
+        db::machine_interface::demote_primary_interfaces_for_machine(&host_machine_id, &mut txn)
+            .await?;
+        db::machine_interface::set_primary_interface(&new_primary_interface_id, true, &mut txn)
+            .await?;
     }
-    db::machine_interface::set_primary_interface(&new_primary_interface_id, true, &mut txn).await?;
 
-    // Reconcile admin address ownership after the primary flag moves.
-    db::machine_interface::reconcile_admin_addresses_for_host(&mut txn, &host_machine_id).await?;
-
-    let (network_config, network_config_version) =
-        db::machine::get_network_config(txn.as_pgconn(), &host_machine_id)
-            .await?
-            .take();
-    db::machine::try_update_network_config(
+    // Reconcile admin address ownership after the primary flag moves and
+    // publish the resulting host-group and instance network configuration.
+    db::machine_interface::reconcile_admin_addresses_after_boot_interface_selection(
         &mut txn,
         &host_machine_id,
-        network_config_version,
-        &network_config,
+        selection_changed,
     )
     .await?;
 
-    // if there is an instance, update the instances network config version so the DPUs pick up the new config
-    if let Some(instance) = db::instance::find_by_machine_id(&mut txn, &host_machine_id).await? {
-        db::instance::update_network_config(
+    let selection_version = db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        host_machine_id,
+        current_selection_version,
+        new_primary_interface_id,
+        selection_changed,
+        // Assigned selection is intentionally non-disruptive until the caller
+        // authorizes controller-owned Redfish work with `reboot=true`.
+        reboot && assigned,
+        initiator,
+    )
+    .await?;
+
+    if unassigned_ready && synchronization_requested {
+        let old_state_version = machine.state.version;
+        let updated = db::machine::update_state_if_version_matches(
             &mut txn,
-            instance.id,
-            instance.network_config_version,
-            &instance.config.network,
-            true,
+            &host_machine_id,
+            old_state_version,
+            old_state_version.increment(),
+            &ManagedHostState::BootConfigSynchronization {
+                synchronization_state:
+                    BootConfigSynchronizationState::WaitingForInitialObservation {
+                        target: BootConfigSynchronizationTarget {
+                            machine_interface_id: Some(new_primary_interface_id),
+                            boot_interface: boot_target,
+                            selection_version,
+                        },
+                        minimum_report_version,
+                    },
+                synchronization_retry_count: 0,
+            },
         )
         .await?;
+        if !updated {
+            return Err(CarbideError::internal(format!(
+                "host {host_machine_id} changed state while selecting its boot interface"
+            ))
+            .into());
+        }
     }
 
     txn.commit().await?;
-
-    // optionally reboot the host.  if there is an instance, this is probably a required step,
-    // but an operator will need to make that call.  The scout image handles this pretty well,
-    // albeit with a leftover IP on the unused interface
-    if reboot {
-        api.endpoint_explorer
-            .redfish_power_control(
-                bmc_socket_addr,
-                &bmc_interface,
-                libredfish::SystemPowerControl::ForceRestart,
-            )
-            .await
-            .map_err(|e| CarbideError::internal(e.to_string()))?;
-    }
     Ok(Response::new(()))
 }
 

--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -468,6 +468,7 @@ exit ||
 
         let pxe_script = match &machine.current_state() {
             ManagedHostState::Ready
+            | ManagedHostState::BootConfigSynchronization { .. }
             | ManagedHostState::HostInit { .. }
             | ManagedHostState::BomValidating { .. }
             | ManagedHostState::Measuring {
@@ -508,7 +509,7 @@ exit ||
                 machine.id.machine_type(),
             ),
             ManagedHostState::Assigned { instance_state } => match instance_state {
-                InstanceState::Ready => {
+                InstanceState::Ready | InstanceState::BootConfigSynchronization { .. } => {
                     let instance = db::instance::find_by_machine_id(txn, &machine_id)
                         .await?
                         .ok_or(CarbideError::NotFoundError {

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -19,6 +19,7 @@
 
 use std::collections::HashMap;
 use std::default::Default;
+use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -93,9 +94,10 @@ use model::hardware_info::{HardwareInfo, TpmEkCertificate};
 use model::instance_type::InstanceTypeMachineCapabilityFilter;
 use model::machine::capabilities::MachineCapabilityType;
 use model::machine::{
-    FailureDetails, Machine, MachineLastRebootRequested, MachineValidatingState, ManagedHostState,
-    ValidationState,
+    BootConfigSynchronizationState, FailureDetails, InstanceState, Machine,
+    MachineLastRebootRequested, MachineValidatingState, ManagedHostState, ValidationState,
 };
+use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::metadata::Metadata;
 use model::network_security_group;
 use model::rack_type::{
@@ -104,6 +106,9 @@ use model::rack_type::{
 };
 use model::resource_pool::common::CommonPools;
 use model::resource_pool::{self};
+use model::site_explorer::{
+    MACHINE_SETUP_VERIFICATION_VERSION, MachineSetupDiff, MachineSetupStatus,
+};
 use model::tenant::TenantOrganizationId;
 use model::test_support::dpu::{DPU_BF3_INFO_JSON, DPU_BF4_INFO_JSON};
 use model::test_support::{DpuConfig, HardwareInfoTemplate, ManagedHostConfig};
@@ -312,6 +317,32 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
+    pub fn register_boot_config_observation(
+        &self,
+        bmc_ip: IpAddr,
+        target: MachineBootInterfaceTarget,
+        is_done: bool,
+        diffs: Vec<MachineSetupDiff>,
+    ) {
+        let report = self
+            .endpoint_explorer
+            .reports
+            .lock()
+            .unwrap()
+            .get(&bmc_ip)
+            .cloned()
+            .expect("host exploration report should be registered");
+        let mut report = report.expect("host exploration report should be successful");
+        report.machine_setup_status = Some(MachineSetupStatus {
+            is_done,
+            diffs,
+            verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
+            evaluated_boot_interface: Some(target),
+        });
+        self.endpoint_explorer
+            .insert_endpoint_result(bmc_ip, Ok(report));
+    }
+
     /// Returns the default admin network segment used by most tests.
     pub fn admin_segment(&self) -> NetworkSegmentId {
         *self
@@ -423,6 +454,7 @@ impl TestEnv {
                 ManagedHostState::HostInit { machine_state: mc }
             }
             ManagedHostState::Ready => state.clone(),
+            ManagedHostState::BootConfigSynchronization { .. } => state.clone(),
             ManagedHostState::Maintenance { .. } => state.clone(),
             ManagedHostState::Assigned { .. } => state.clone(),
             ManagedHostState::WaitingForCleanup { .. } => state.clone(),
@@ -518,7 +550,11 @@ impl TestEnv {
         max_iterations: u32,
         state_check: impl Fn(&Machine) -> bool,
     ) -> ManagedHostState {
-        for _ in 0..max_iterations {
+        const MAX_BOOT_CONFIG_SYNCHRONIZATION_ITERATIONS: u32 = 20;
+
+        let mut iterations = 0;
+        let mut boot_config_synchronization_iterations = 0;
+        while iterations < max_iterations {
             self.machine_state_controller
                 .lock()
                 .await
@@ -539,6 +575,58 @@ impl TestEnv {
 
             if state_check(&machine) {
                 return machine.state.value;
+            }
+
+            let boot_config_synchronization_state = match machine.current_state() {
+                ManagedHostState::BootConfigSynchronization {
+                    synchronization_state,
+                    ..
+                }
+                | ManagedHostState::Assigned {
+                    instance_state:
+                        InstanceState::BootConfigSynchronization {
+                            synchronization_state,
+                            ..
+                        },
+                } => Some(synchronization_state),
+                _ => None,
+            };
+            let boot_config_observation = match boot_config_synchronization_state {
+                Some(
+                    BootConfigSynchronizationState::WaitingForInitialObservation { target, .. }
+                    | BootConfigSynchronizationState::WaitingForFinalObservation { target, .. },
+                ) => machine
+                    .status
+                    .bmc_info
+                    .ip
+                    .map(|bmc_ip| (bmc_ip, target.boot_interface.clone())),
+                _ => None,
+            };
+            drop(txn);
+
+            if boot_config_synchronization_state.is_some() {
+                boot_config_synchronization_iterations += 1;
+                assert!(
+                    boot_config_synchronization_iterations
+                        <= MAX_BOOT_CONFIG_SYNCHRONIZATION_ITERATIONS,
+                    "Boot-interface synchronization did not complete after \
+                     {MAX_BOOT_CONFIG_SYNCHRONIZATION_ITERATIONS} fixture iterations"
+                );
+
+                if let Some((bmc_ip, target)) = boot_config_observation {
+                    // MockEndpointExplorer replays the report registered during
+                    // discovery. Keep that report aligned with the target that
+                    // a live explorer receives before it reads from Redfish.
+                    self.register_boot_config_observation(bmc_ip, target, true, Vec::new());
+                }
+
+                // The production controller waits on Site Explorer's persisted
+                // observation. Run the observer between synchronization ticks
+                // so fixture-created hosts can cross the same Ready gate.
+                self.run_site_explorer_iteration().await;
+            } else {
+                boot_config_synchronization_iterations = 0;
+                iterations += 1;
             }
         }
         let mut txn = self.pool.begin().await.unwrap();

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -885,10 +885,9 @@ impl<'a> MockExploredHost<'a> {
             return self;
         }
 
-        // Zero-DPU hosts skip the WaitForDPUUp lockdown state and land
-        // directly in BomValidating (see `has_managed_dpus` short-circuit in
-        // `LockdownState::TimeWaitForDPUDown`). There are no DPUs to
-        // signal as configured, so skip the network_configured handshake.
+        // Zero-DPU hosts skip the DPU down/up waits and poll the lockdown
+        // result from the first reboot. There are no DPUs to signal as
+        // configured, so skip the `network_configured` handshake.
         if !self.dpu_machine_ids.is_empty() {
             // We use carbide-dpu-agent health reporting as a signal that
             // DPU has rebooted.

--- a/crates/api-core/src/tests/dpu_reprovisioning.rs
+++ b/crates/api-core/src/tests/dpu_reprovisioning.rs
@@ -260,6 +260,24 @@ async fn assert_dpu_reprovision_host_boot_repair(
     terminal_machine
 }
 
+async fn assert_dpu_reprovision_finishes_ready(
+    env: &TestEnv,
+    mh: &TestManagedHost,
+    dpu_machine: &TestMachine,
+) {
+    mh.host().forge_agent_control().await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.id,
+        4,
+        ManagedHostState::Ready,
+    )
+    .await;
+
+    let mut txn = env.db_txn().await;
+    let dpu = dpu_machine.db_machine(&mut txn).await;
+    assert!(matches!(dpu.current_state(), &ManagedHostState::Ready));
+}
+
 async fn prepare_dpu_reprovision_host_boot_check(
     env: &TestEnv,
     mh: &TestManagedHost,
@@ -460,9 +478,7 @@ async fn test_dpu_for_reprovisioning_with_firmware_upgrade(pool: sqlx::PgPool) {
         }
     ));
 
-    let _response = mh.host().forge_agent_control().await;
-    let dpu = dpu_machine.next_iteration_machine(&env).await;
-    assert!(matches!(dpu.current_state(), &ManagedHostState::Ready));
+    assert_dpu_reprovision_finishes_ready(&env, &mh, &dpu_machine).await;
 }
 
 #[crate::sqlx_test]
@@ -856,9 +872,7 @@ async fn test_dpu_for_reprovisioning_with_no_firmware_upgrade(pool: sqlx::PgPool
         }
     ));
 
-    let _response = mh.host().forge_agent_control().await;
-    let dpu = dpu_machine.next_iteration_machine(&env).await;
-    assert!(matches!(dpu.current_state(), &ManagedHostState::Ready));
+    assert_dpu_reprovision_finishes_ready(&env, &mh, &dpu_machine).await;
 }
 
 #[crate::sqlx_test]
@@ -1901,10 +1915,7 @@ async fn test_dpu_for_reprovisioning_with_firmware_upgrade_multidpu_onedpu_repro
         }
     ));
 
-    let _response = mh.host().forge_agent_control().await;
-
-    let dpu = dpu_machine.next_iteration_machine(&env).await;
-    assert!(matches!(dpu.current_state(), &ManagedHostState::Ready));
+    assert_dpu_reprovision_finishes_ready(&env, &mh, &dpu_machine).await;
 }
 
 #[crate::sqlx_test]
@@ -2052,9 +2063,7 @@ async fn test_dpu_for_reprovisioning_with_firmware_upgrade_multidpu_bothdpu(pool
         }
     ));
 
-    mh.host().forge_agent_control().await;
-    let dpu = dpu_machine.next_iteration_machine(&env).await;
-    assert!(matches!(dpu.current_state(), &ManagedHostState::Ready));
+    assert_dpu_reprovision_finishes_ready(&env, &mh, &dpu_machine).await;
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -2489,6 +2489,117 @@ async fn test_add_rejects_multiple_primary_host_nics(
     Ok(())
 }
 
+/// A declared boot NIC must use one of the two segments that can reach the
+/// host boot path.
+#[crate::sqlx_test]
+async fn test_add_rejects_primary_host_nic_on_ineligible_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    for (index, segment_type) in [
+        rpc::forge::NetworkSegmentType::Tenant,
+        rpc::forge::NetworkSegmentType::Underlay,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let result = env
+            .api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: None,
+                bmc_mac_address: format!("9A:9B:9C:9D:A0:{index:02X}"),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: format!("EM-INVALID-BOOT-SEGMENT-{index}"),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    network_segment_type: Some(segment_type as i32),
+                    mac_address: format!("9A:9B:9C:9D:A1:{index:02X}"),
+                    nic_type: None,
+                    fixed_ip: None,
+                    fixed_mask: None,
+                    fixed_gateway: None,
+                    primary: Some(true),
+                }],
+                ..Default::default()
+            }))
+            .await;
+
+        let error = result.expect_err("ineligible primary host NIC should be rejected");
+        assert_eq!(error.code(), tonic::Code::InvalidArgument);
+        assert!(error.message().contains("host boot interface"));
+    }
+
+    Ok(())
+}
+
+/// Batch updates use the same boot-interface validation as single-object
+/// writes, so they cannot persist a primary declaration that the resolver
+/// would later ignore.
+#[crate::sqlx_test]
+async fn test_batch_update_rejects_primary_host_nic_on_ineligible_segment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let id = Uuid::new_v4();
+    let base = rpc::forge::ExpectedMachine {
+        id: Some(rpc::common::Uuid {
+            value: id.to_string(),
+        }),
+        bmc_mac_address: "9A:9B:9C:9D:A2:00".to_string(),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        chassis_serial_number: "EM-BATCH-INVALID-BOOT-SEGMENT".into(),
+        metadata: Some(rpc::forge::Metadata::default()),
+        ..Default::default()
+    };
+    env.api
+        .add_expected_machine(tonic::Request::new(base.clone()))
+        .await?;
+
+    let error = env
+        .api
+        .update_expected_machines(tonic::Request::new(
+            rpc::forge::BatchExpectedMachineOperationRequest {
+                expected_machines: Some(rpc::forge::ExpectedMachineList {
+                    expected_machines: vec![rpc::forge::ExpectedMachine {
+                        host_nics: vec![rpc::forge::ExpectedHostNic {
+                            network_segment_type: Some(
+                                rpc::forge::NetworkSegmentType::Underlay as i32,
+                            ),
+                            mac_address: "9A:9B:9C:9D:A2:01".to_string(),
+                            primary: Some(true),
+                            ..Default::default()
+                        }],
+                        ..base.clone()
+                    }],
+                }),
+                accept_partial_results: false,
+            },
+        ))
+        .await
+        .expect_err("batch update should reject an ineligible primary boot NIC");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("host boot interface"));
+
+    let stored = env
+        .api
+        .get_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachineRequest {
+            bmc_mac_address: String::new(),
+            id: Some(rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+        }))
+        .await?
+        .into_inner();
+    assert!(
+        stored.host_nics.is_empty(),
+        "a rejected batch update must leave the stored declaration unchanged",
+    );
+
+    Ok(())
+}
+
 /// The declared primary survives whichever order its NICs DHCP in: leasing the
 /// non-primary NIC first, then the declared primary, still lands the declared
 /// primary as `primary_interface` and the other as non-primary.

--- a/crates/api-core/src/tests/ipxe.rs
+++ b/crates/api-core/src/tests/ipxe.rs
@@ -26,7 +26,8 @@ use db::{self};
 use futures_util::FutureExt;
 use mac_address::MacAddress;
 use model::machine::{
-    CleanupContext, DpuInitState, HostReprovisionState, MachineState, ManagedHostState,
+    BootConfigSynchronizationState, CleanupContext, DpuInitState, HostReprovisionState,
+    InstanceState, MachineState, ManagedHostState,
 };
 use model::test_support::ManagedHostConfig;
 use rpc::forge::CloudInitInstructionsRequest;
@@ -343,6 +344,25 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
 
     move_machine_to_needed_state(
         host_id,
+        &ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+            synchronization_retry_count: 0,
+        },
+        &env.pool,
+    )
+    .await;
+
+    let instructions = get_pxe_instructions(
+        &env,
+        host_interface_id,
+        rpc::forge::MachineArchitecture::X86,
+        None,
+    )
+    .await;
+    assert!(instructions.pxe_script.contains("x86_64/scout.efi"));
+
+    move_machine_to_needed_state(
+        host_id,
         &ManagedHostState::HostReprovision {
             reprovision_state: HostReprovisionState::WaitingForManualUpgrade {
                 manual_upgrade_started: Utc::now(),
@@ -401,11 +421,36 @@ async fn test_pxe_instance(pool: sqlx::PgPool) {
         .build()
         .await;
 
+    move_machine_to_needed_state(
+        mh.host().id,
+        &ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+                synchronization_retry_count: 0,
+            },
+        },
+        &env.pool,
+    )
+    .await;
+
     let instructions = host_interface
         .get_pxe_instructions(rpc::forge::MachineArchitecture::X86)
         .await;
 
     assert_eq!(instructions.pxe_script, "SomeRandomiPxe".to_string());
+
+    let instructions = host_interface
+        .get_pxe_instructions(rpc::forge::MachineArchitecture::X86)
+        .await;
+
+    assert!(
+        instructions
+            .pxe_script
+            .contains("Current state: Assigned/BootConfigSynchronization/Initialize")
+    );
+    assert!(instructions.pxe_script.contains(
+        "This state assumes an OS is provisioned and will exit into the OS in 5 seconds."
+    ));
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/machine_history.rs
+++ b/crates/api-core/src/tests/machine_history.rs
@@ -17,11 +17,14 @@
 use common::api_fixtures::{create_managed_host, create_test_env};
 use config_version::ConfigVersion;
 use db::{self};
+use model::hardware_info::HardwareInfo;
 use model::machine::ManagedHostState;
+use model::machine::machine_id::from_hardware_info;
 use model::state_history::StateHistoryRecord;
 use rpc::forge::forge_server::Forge;
 
 use crate::tests::common;
+use crate::tests::common::api_fixtures::dpu::create_dpu_machine;
 
 #[crate::sqlx_test]
 async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
@@ -224,6 +227,206 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         .unwrap();
 
     assert!(!rpc_history.records.is_empty());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_machine_state_writers_lock_row_before_history(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
+    let machine = db::machine::find_one(
+        &env.pool,
+        &host_machine_id,
+        model::machine::machine_search_config::MachineSearchConfig::default(),
+    )
+    .await?
+    .expect("managed host should exist");
+
+    // Hold the machine row while a second transaction starts a normal state
+    // write. That writer must block before it reaches the history trigger's
+    // per-object advisory lock.
+    let mut blocker = env.pool.begin().await?;
+    let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(blocker.as_mut())
+        .await?;
+    sqlx::query("SELECT id FROM machines WHERE id = $1 FOR UPDATE")
+        .bind(host_machine_id)
+        .fetch_one(blocker.as_mut())
+        .await?;
+    let independent_history_version =
+        ConfigVersion::new(machine.current_version().version_nr() + 100);
+    let writer_pool = env.pool.clone();
+    let (writer_pid_tx, writer_pid_rx) = tokio::sync::oneshot::channel();
+    let writer = tokio::spawn(async move {
+        let mut txn = writer_pool.begin().await.unwrap();
+        let writer_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(txn.as_mut())
+            .await
+            .unwrap();
+        writer_pid_tx.send(writer_pid).unwrap();
+        db::machine::advance(&machine, txn.as_mut(), &ManagedHostState::Ready, None)
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+    });
+    let writer_pid = writer_pid_rx.await?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let waiting_on_row: bool = sqlx::query_scalar("SELECT $2 = ANY(pg_blocking_pids($1))")
+                .bind(writer_pid)
+                .bind(blocker_pid)
+                .fetch_one(&env.pool)
+                .await
+                .unwrap();
+            if waiting_on_row {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("machine state writer should block on the held machine row");
+
+    // A history write in the row-owning transaction must remain possible. If
+    // the other writer took history first, these two transactions deadlock.
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        db::state_history::persist(
+            blocker.as_mut(),
+            db::state_history::StateHistoryTableId::Machine,
+            &host_machine_id,
+            &ManagedHostState::Ready,
+            independent_history_version,
+        ),
+    )
+    .await
+    .expect("machine-row ownership should not be blocked by a later history writer")?;
+    blocker.commit().await?;
+    writer.await?;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_stable_id_sync_locks_machine_before_history(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let host_config = env.managed_host_config();
+    let stable_machine_id = from_hardware_info(&HardwareInfo::from(&host_config))?;
+    let dpu_machine_id = create_dpu_machine(&env, &host_config).await;
+    let mut txn = env.pool.begin().await?;
+    let predicted_host = db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine_id)
+        .await?
+        .expect("DPU should have a predicted host");
+    txn.commit().await?;
+    assert!(predicted_host.id.machine_type().is_predicted_host());
+
+    // Fill retention so the next history insert must touch rows that a
+    // concurrent stable-ID promotion would rename.
+    let mut txn = env.pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO machine_state_history (object_id, state, state_version) \
+         SELECT $1, to_jsonb(sequence), $2 \
+         FROM generate_series(1, 250) AS sequence",
+    )
+    .bind(predicted_host.id.to_string())
+    .bind(ConfigVersion::initial())
+    .execute(txn.as_mut())
+    .await?;
+    txn.commit().await?;
+
+    // Hold the machine row and let stable-ID promotion reach that lock. A
+    // correctly ordered promotion has not touched history yet, so this
+    // transaction can complete a normal state write without deadlocking.
+    let mut blocker = env.pool.begin().await?;
+    let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(blocker.as_mut())
+        .await?;
+    sqlx::query("SELECT id FROM machines WHERE id = $1 FOR UPDATE")
+        .bind(predicted_host.id)
+        .fetch_one(blocker.as_mut())
+        .await?;
+
+    let rename_pool = env.pool.clone();
+    let current_machine_id = predicted_host.id;
+    let (rename_pid_tx, rename_pid_rx) = tokio::sync::oneshot::channel();
+    let rename = tokio::spawn(async move {
+        let mut txn = rename_pool.begin().await.unwrap();
+        let rename_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(txn.as_mut())
+            .await
+            .unwrap();
+        rename_pid_tx.send(rename_pid).unwrap();
+        let renamed = db::machine::try_sync_stable_id_with_current_machine_id_for_host(
+            txn.as_mut(),
+            &Some(current_machine_id),
+            &stable_machine_id,
+        )
+        .await
+        .unwrap();
+        assert_eq!(renamed, stable_machine_id);
+        txn.commit().await.unwrap();
+    });
+    let rename_pid = rename_pid_rx.await?;
+
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let blocked_by_writer: bool =
+                sqlx::query_scalar("SELECT $2 = ANY(pg_blocking_pids($1))")
+                    .bind(rename_pid)
+                    .bind(blocker_pid)
+                    .fetch_one(&env.pool)
+                    .await
+                    .unwrap();
+            if blocked_by_writer {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("stable-ID promotion should block on the held machine row");
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        db::machine::advance(
+            &predicted_host,
+            blocker.as_mut(),
+            &ManagedHostState::Ready,
+            None,
+        ),
+    )
+    .await
+    .expect("machine state writing must not deadlock with stable-ID promotion")?;
+    blocker.commit().await?;
+    tokio::time::timeout(std::time::Duration::from_secs(10), rename)
+        .await
+        .expect("stable-ID promotion should finish after the state writer commits")?;
+
+    let mut txn = env.pool.begin().await?;
+    assert!(
+        db::machine::find_one(
+            txn.as_mut(),
+            &predicted_host.id,
+            model::machine::machine_search_config::MachineSearchConfig::default(),
+        )
+        .await?
+        .is_none()
+    );
+    assert!(
+        db::machine::find_one(
+            txn.as_mut(),
+            &stable_machine_id,
+            model::machine::machine_search_config::MachineSearchConfig::default(),
+        )
+        .await?
+        .is_some()
+    );
 
     Ok(())
 }

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -28,7 +28,7 @@ use carbide_redfish::libredfish::test_support::RedfishSimAction;
 use carbide_site_explorer::MachineCreator;
 use carbide_site_explorer::config::SiteExplorerConfig;
 use carbide_utils::arch::CpuArchitecture;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::machine_validation::MachineValidationId;
 use chrono::Duration;
 use common::api_fixtures::dpu::{
@@ -44,6 +44,7 @@ use common::api_fixtures::{
     TestEnv, TestManagedHost, create_managed_host, create_managed_host_with_config,
     create_test_env, create_test_env_with_overrides, get_config,
 };
+use config_version::ConfigVersion;
 use health_report::HealthReport;
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
@@ -51,21 +52,30 @@ use measured_boot::bundle::MeasurementBundle;
 use measured_boot::pcr::PcrRegisterValue;
 use measured_boot::records::MeasurementBundleState;
 use measured_boot::report::MeasurementReport;
+use model::allocation_type::AllocationType;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
 use model::hardware_info::TpmEkCertificate;
+use model::instance::config::network::InstanceNetworkConfigUpdate;
 use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    BiosConfigInfo, BiosConfigState, CleanupContext, CleanupState, DpuDiscoveringState,
-    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
-    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
-    MachineValidatingState, ManagedHostState, MeasuringState, PowerState, SetBootOrderInfo,
-    SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
+    BiosConfigInfo, BiosConfigState, BootConfigSynchronizationCompletion,
+    BootConfigSynchronizationState, BootConfigSynchronizationTarget, CleanupContext, CleanupState,
+    DpuDiscoveringState, DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails,
+    FailureSource, HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownInfo,
+    LockdownMode, LockdownState, MachineState, MachineValidatingState, ManagedHostState,
+    MeasuringState, NetworkConfigUpdateState, PowerState, SetBootOrderInfo, SetBootOrderState,
+    SetSecureBootState, SpdmMeasuringState, StateMachineArea, UnlockHostState, ValidationState,
+    pick_boot_interface,
 };
+use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::machine_validation::MachineValidationState;
 use model::network_segment::NetworkSegmentType;
-use model::site_explorer::{EndpointExplorationReport, ExploredDpu, ExploredManagedHost};
+use model::site_explorer::{
+    EndpointExplorationReport, ExploredDpu, ExploredManagedHost,
+    MACHINE_SETUP_VERIFICATION_VERSION, MachineSetupDiff, MachineSetupStatus,
+};
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{HealthReportEntry, InsertMachineHealthReportRequest, TpmCaCert, TpmCaCertId};
@@ -73,7 +83,7 @@ use rpc::forge_agent_control_response::{Action, LegacyAction};
 use rpc::machine_discovery::AttestKeyInfo;
 use rpc::{DiscoveryData, DiscoveryInfo};
 use state_controller::db_write_batch::DbWriteBatch;
-use state_controller::state_handler::StateHandlerContext;
+use state_controller::state_handler::{StateHandler, StateHandlerContext, StateHandlerOutcome};
 use tonic::{Code, Request};
 
 use crate::cfg::file::DpuConfig as InitialDpuConfig;
@@ -1497,6 +1507,9 @@ async fn test_managed_host_version_metrics(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
     common::api_fixtures::create_managed_host(&env).await;
     common::api_fixtures::create_managed_host(&env).await;
+    // A transition to Ready reports metrics for the state loaded at the start
+    // of that controller pass. Run once more to measure both settled hosts.
+    env.run_machine_state_controller_iteration().await;
 
     assert_eq!(
         env.test_meter
@@ -1510,19 +1523,17 @@ async fn test_managed_host_version_metrics(pool: sqlx::PgPool) {
             .unwrap(),
         r#"{fresh="true"} 0"#
     );
-    // TODO: For some reason the 2nd created Host stays in state `Discovered`
-    // and never becomes ready. Once it does, the test should be updated.
     assert_eq!(
         env.test_meter
             .formatted_metric("carbide_hosts_usable_count")
             .unwrap(),
-        r#"{fresh="true"} 1"#
+        r#"{fresh="true"} 2"#
     );
     assert_eq!(
         env.test_meter
             .formatted_metric("carbide_gpus_usable_count")
             .unwrap(),
-        r#"{fresh="true"} 1"#
+        r#"{fresh="true"} 2"#
     );
     assert_eq!(
         env.test_meter
@@ -1877,9 +1888,12 @@ async fn test_measurement_failed_state_transition(pool: sqlx::PgPool) {
     txn.commit().await.unwrap();
 
     // ..and now flip it back.
-    for _ in 0..3 {
-        env.run_machine_state_controller_iteration().await;
-    }
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.id,
+        3,
+        ManagedHostState::Ready,
+    )
+    .await;
 
     let mut txn = env.db_txn().await;
     let host = mh.host().db_machine(&mut txn).await;
@@ -2060,9 +2074,12 @@ async fn test_measurement_ready_to_retired_to_ca_fail_to_revoked_to_ready(pool: 
     txn.commit().await.unwrap();
 
     // ... and trigger the state transition
-    for _ in 0..3 {
-        env.run_machine_state_controller_iteration().await;
-    }
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.id,
+        3,
+        ManagedHostState::Ready,
+    )
+    .await;
 
     let mut txn = env.db_txn().await;
     let host = mh.host().db_machine(&mut txn).await;
@@ -2861,6 +2878,96 @@ async fn test_polling_bios_setup_full_recovery_reruns_machine_setup_and_succeeds
 /// the boot-order phase can resolve. Mirrors `test_dhcp_allows_zero_dpu_host`.
 async fn create_zero_dpu_test_env(pool: sqlx::PgPool) -> TestEnv {
     create_zero_dpu_test_env_with_overrides(pool, TestEnvOverrides::default()).await
+}
+
+/// A zero-DPU host skips the DPU-specific wait, but still checks the lockdown
+/// result so `Disable` resumes setup and `Enable` proceeds to BOM validation.
+#[crate::sqlx_test]
+async fn test_zero_dpu_lockdown_preserves_mode_after_reboot(pool: sqlx::PgPool) {
+    use carbide_test_support::Outcome::Yields;
+    use carbide_test_support::{Case, check_cases_async};
+
+    let env = create_zero_dpu_test_env(pool).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let host_id = mh.host().id;
+
+    check_cases_async(
+        [
+            Case {
+                scenario: "disable resumes platform setup",
+                input: LockdownMode::Disable,
+                expect: Yields(ManagedHostState::HostInit {
+                    machine_state: MachineState::WaitingForPlatformConfiguration { retry_count: 0 },
+                }),
+            },
+            Case {
+                scenario: "enable proceeds to BOM validation",
+                input: LockdownMode::Enable,
+                expect: Yields(ManagedHostState::BomValidating {
+                    bom_validating_state: model::machine::BomValidating::MatchingSku(
+                        model::machine::BomValidatingContext {
+                            machine_validation_context: Some(
+                                model::machine::MachineValidationContext::Discovery,
+                            ),
+                            ..Default::default()
+                        },
+                    ),
+                }),
+            },
+        ],
+        |mode| {
+            let env = &env;
+            let mh = &mh;
+            async move {
+                let simulated_lockdown = match &mode {
+                    LockdownMode::Enable => libredfish::EnabledDisabled::Enabled,
+                    LockdownMode::Disable => libredfish::EnabledDisabled::Disabled,
+                };
+                env.redfish_sim.set_lockdown(simulated_lockdown);
+                set_host_controller_state_stuck_in(
+                    env,
+                    host_id,
+                    &ManagedHostState::HostInit {
+                        machine_state: MachineState::WaitingForLockdown {
+                            lockdown_info: LockdownInfo {
+                                state: LockdownState::TimeWaitForDPUDown,
+                                mode: mode.clone(),
+                            },
+                        },
+                    },
+                    0,
+                )
+                .await;
+
+                env.run_machine_state_controller_iteration().await;
+                {
+                    let mut txn = env.db_txn().await;
+                    let host = mh.host().db_machine(&mut txn).await;
+                    if !matches!(
+                        host.current_state(),
+                        ManagedHostState::HostInit {
+                            machine_state: MachineState::WaitingForLockdown {
+                                lockdown_info: LockdownInfo {
+                                    state: LockdownState::PollingLockdownStatus,
+                                    mode: polling_mode,
+                                },
+                            },
+                        } if polling_mode == &mode
+                    ) {
+                        return Err(format!(
+                            "zero-DPU host must poll {mode:?} lockdown after its reboot, got: {:?}",
+                            host.current_state()
+                        ));
+                    }
+                }
+
+                env.run_machine_state_controller_iteration().await;
+                let mut txn = env.db_txn().await;
+                Ok(mh.host().db_machine(&mut txn).await.current_state().clone())
+            }
+        },
+    )
+    .await;
 }
 
 async fn create_zero_dpu_test_env_with_overrides(
@@ -4513,6 +4620,18 @@ async fn test_host_discovery_without_tpm_cert_does_not_downgrade_existing_tpm_id
 /// for an assigned host (which would otherwise bail early if
 /// `mh_snapshot.instance` is `None`).
 async fn zero_dpu_host_with_instance(pool: sqlx::PgPool) -> (TestEnv, TestManagedHost) {
+    let (env, mh) = host_with_instance_config(pool, ManagedHostConfig::zero_dpu()).await;
+    assert!(
+        mh.dpu_ids.is_empty(),
+        "zero-DPU fixture should produce no DPU machines"
+    );
+    (env, mh)
+}
+
+async fn host_with_instance_config(
+    pool: sqlx::PgPool,
+    host_config: ManagedHostConfig,
+) -> (TestEnv, TestManagedHost) {
     let env = create_test_env_with_overrides(
         pool,
         TestEnvOverrides {
@@ -4534,11 +4653,7 @@ async fn zero_dpu_host_with_instance(pool: sqlx::PgPool) -> (TestEnv, TestManage
     .await;
     create_host_inband_network_segment(&env.api, None).await;
 
-    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
-    assert!(
-        mh.dpu_ids.is_empty(),
-        "zero-DPU fixture should produce no DPU machines"
-    );
+    let mh = create_managed_host_with_config(&env, host_config).await;
 
     // Provide valid empty configs explicitly so the state controller can
     // load the snapshot.
@@ -4587,6 +4702,1896 @@ async fn load_host_state(env: &TestEnv, host_id: &MachineId) -> ManagedHostState
     .expect("host should exist")
     .current_state()
     .clone()
+}
+
+async fn selected_boot_config_target(
+    env: &TestEnv,
+    mh: &TestManagedHost,
+) -> (
+    MachineInterfaceId,
+    MachineBootInterfaceTarget,
+    ConfigVersion,
+    IpAddr,
+) {
+    let mut txn = env.db_txn().await;
+    let snapshot = mh.snapshot(&mut txn).await;
+    let interface = pick_boot_interface(&snapshot.host_snapshot.status.interfaces)
+        .expect("managed host should have a selected boot interface");
+    let target = interface.boot_interface().map_or(
+        MachineBootInterfaceTarget::MacOnly(interface.mac_address),
+        MachineBootInterfaceTarget::Pair,
+    );
+    let bmc_ip = snapshot
+        .host_snapshot
+        .status
+        .bmc_info
+        .ip
+        .expect("managed host should have a BMC IP");
+
+    (
+        interface.id,
+        target,
+        snapshot.host_snapshot.boot_interface_selection_version,
+        bmc_ip,
+    )
+}
+
+#[crate::sqlx_test]
+async fn test_assignment_boundary_rechecks_boot_config_after_selection_change(pool: sqlx::PgPool) {
+    let (env, mh) =
+        host_with_instance_config(pool, ManagedHostConfig::default().with_dpu_count(2)).await;
+    let (original_interface_id, _, _, _) = selected_boot_config_target(&env, &mh).await;
+    let replacement_interface_id = {
+        let mut txn = env.db_txn().await;
+        db::machine_interface::find_by_machine_ids(&mut txn, &[mh.id])
+            .await
+            .unwrap()
+            .remove(&mh.id)
+            .expect("the host should have interface rows")
+            .into_iter()
+            .find(|interface| {
+                interface.id != original_interface_id
+                    && interface
+                        .network_segment_type
+                        .as_ref()
+                        .is_some_and(NetworkSegmentType::supports_host_boot)
+            })
+            .expect("the host should have a second boot-capable interface")
+            .id
+    };
+    set_host_controller_state_stuck_in(&env, mh.id, &ManagedHostState::StartAssignmentCycle, 0)
+        .await;
+
+    // Model the writer-first side of the assignment race: selection commits
+    // after Ready but before StartAssignmentCycle crosses into Assigned.
+    env.api
+        .set_primary_interface(tonic::Request::new(
+            rpc::forge::SetPrimaryInterfaceRequest {
+                host_machine_id: Some(mh.id),
+                interface_id: Some(replacement_interface_id),
+                reboot: false,
+            },
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::StartAssignmentCycle,
+        "the selection API leaves the transitional state for its transactional assignment gate",
+    );
+    let (selected_interface_id, target, selection_version, _) =
+        selected_boot_config_target(&env, &mh).await;
+    assert_eq!(selected_interface_id, replacement_interface_id);
+
+    env.run_machine_state_controller_iteration().await;
+
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::Initialize {
+                target: Some(BootConfigSynchronizationTarget {
+                    machine_interface_id: Some(replacement_interface_id),
+                    boot_interface: target,
+                    selection_version,
+                }),
+            },
+            synchronization_retry_count: 0,
+        },
+        "assignment must not consume a boot selection that has not been synchronized",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_assignment_boundary_rejects_endpoint_from_stale_bmc_address(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_host_controller_state_stuck_in(&env, mh.id, &ManagedHostState::StartAssignmentCycle, 0)
+        .await;
+
+    // Load the controller's view before the BMC-address writer commits. The
+    // endpoint at this address contains otherwise valid boot-config evidence.
+    let mut txn = env.db_txn().await;
+    let mut stale_snapshot = mh.snapshot(&mut txn).await;
+    let stale_state = stale_snapshot.managed_state.clone();
+    let old_bmc_ip = stale_snapshot
+        .host_snapshot
+        .status
+        .bmc_info
+        .ip
+        .expect("managed host should have a BMC IP");
+    let bmc_interface_id = db::machine_interface::find_by_ip(txn.as_mut(), old_bmc_ip)
+        .await
+        .unwrap()
+        .expect("managed host should have a BMC interface")
+        .id;
+    txn.rollback().await.unwrap();
+
+    let replacement_bmc_ip: IpAddr = "192.0.2.250".parse().unwrap();
+    let mut txn = env.db_txn().await;
+    db::machine_interface_address::delete(txn.as_mut(), &bmc_interface_id)
+        .await
+        .unwrap();
+    db::machine_interface_address::insert(
+        txn.as_mut(),
+        bmc_interface_id,
+        replacement_bmc_ip,
+        AllocationType::Dhcp,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let live_machine = db::machine::find_one(&env.pool, &mh.id, MachineSearchConfig::default())
+        .await
+        .unwrap()
+        .expect("host should still exist");
+    assert_eq!(live_machine.status.bmc_info.ip, Some(replacement_bmc_ip));
+    assert_ne!(Some(old_bmc_ip), live_machine.status.bmc_info.ip);
+
+    let handler = MachineStateHandlerBuilder::builder()
+        .dpu_up_threshold(chrono::Duration::minutes(1))
+        .hardware_models(env.config.get_firmware_config())
+        .reachability_params(env.reachability_params)
+        .attestation_enabled(env.attestation_enabled)
+        .dpu_enable_secure_boot(env.config.dpu_config.dpu_enable_secure_boot)
+        .power_options_config(env.config.power_manager_options.clone().into())
+        .build();
+    let mut services = env.machine_state_handler_services();
+    let mut metrics = MachineMetrics::default();
+    let mut write_batch = DbWriteBatch::new();
+    let mut ctx = StateHandlerContext::<MachineStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut write_batch,
+    };
+
+    let outcome = handler
+        .handle_object_state(&mh.id, &mut stale_snapshot, &stale_state, &mut ctx)
+        .await
+        .unwrap();
+    let StateHandlerOutcome::Transition {
+        next_state, txn, ..
+    } = outcome
+    else {
+        panic!("assignment should transition through boot-config synchronization");
+    };
+    assert!(
+        matches!(
+            next_state,
+            ManagedHostState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::Initialize {
+                    target: Some(_),
+                },
+                ..
+            }
+        ),
+        "the stale endpoint must not authorize assignment: {next_state:?}",
+    );
+    if let Some(txn) = txn {
+        txn.rollback().await.unwrap();
+    }
+}
+
+#[crate::sqlx_test]
+async fn test_assignment_boundary_clears_stale_boot_config_authorization(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let (interface_id, _, selection_version, _) = selected_boot_config_target(&env, &mh).await;
+    let mut txn = env.db_txn().await;
+    let locked_version = db::machine::lock_boot_interface_selection_version(&mut txn, mh.id)
+        .await
+        .unwrap();
+    assert_eq!(locked_version, selection_version);
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        locked_version,
+        interface_id,
+        false,
+        true,
+        Some("previous-assignment".to_string()),
+    )
+    .await
+    .unwrap();
+    db::machine::update_state(
+        txn.as_mut(),
+        &mh.id,
+        &ManagedHostState::StartAssignmentCycle,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned { .. },
+    ));
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_none(),
+        "authorization from an earlier assignment must not cross into the next tenant",
+    );
+}
+
+async fn next_assigned_boot_config_state(
+    env: &TestEnv,
+    host_id: &MachineId,
+) -> BootConfigSynchronizationState {
+    env.run_machine_state_controller_iteration().await;
+    match load_host_state(env, host_id).await {
+        ManagedHostState::Assigned {
+            instance_state:
+                InstanceState::BootConfigSynchronization {
+                    synchronization_state,
+                    ..
+                },
+        } => synchronization_state,
+        state => panic!("expected assigned boot-config synchronization, got {state:?}"),
+    }
+}
+
+#[crate::sqlx_test]
+async fn test_unassigned_ready_waits_for_fresh_exact_boot_config_observation(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let (_interface_id, target, _selection_version, bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+
+    // Leave the endpoint target current but remove the observation that proves
+    // the selected interface is configured.
+    let mut txn = env.db_txn().await;
+    let report_version =
+        db::explored_endpoints::set_boot_interface_target(bmc_ip, &target, &mut txn)
+            .await
+            .unwrap();
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert_eq!(endpoint.report_version, report_version);
+    let mut report = endpoint.report;
+    report.machine_setup_status = None;
+    assert!(
+        db::explored_endpoints::try_update(bmc_ip, report_version, &report, false, &mut txn)
+            .await
+            .unwrap()
+    );
+    txn.commit().await.unwrap();
+    set_host_controller_state_stuck_in(&env, mh.id, &ManagedHostState::Ready, 0).await;
+
+    // Ready is a gate: without matching evidence, the host enters the durable
+    // synchronization parent and requests an observation.
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+            ..
+        }
+    ));
+
+    env.run_machine_state_controller_iteration().await;
+    let state = load_host_state(&env, &mh.id).await;
+    let (pinned_target, minimum_report_version) = match state {
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state:
+                BootConfigSynchronizationState::WaitingForInitialObservation {
+                    target,
+                    minimum_report_version,
+                },
+            ..
+        } => (target, minimum_report_version),
+        state => panic!("expected to wait for an initial boot-config observation, got {state:?}"),
+    };
+    assert_eq!(pinned_target.boot_interface, target);
+
+    // Even exact evidence cannot satisfy this request if its report version
+    // was not advanced after the controller established the baseline.
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert_eq!(endpoint.report_version, minimum_report_version);
+    let mut report = endpoint.report;
+    report.machine_setup_status = Some(MachineSetupStatus {
+        is_done: true,
+        diffs: Vec::new(),
+        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
+        evaluated_boot_interface: Some(target.clone()),
+    });
+    sqlx::query(
+        "UPDATE explored_endpoints \
+         SET exploration_report = $1, waiting_for_explorer_refresh = false, \
+             exploration_requested = false \
+         WHERE address = $2 AND version = $3",
+    )
+    .bind(sqlx::types::Json(&report))
+    .bind(bmc_ip)
+    .bind(minimum_report_version)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::WaitingForInitialObservation { .. },
+            ..
+        }
+    ));
+
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert_eq!(endpoint.report_version, minimum_report_version);
+    assert!(
+        endpoint.exploration_requested,
+        "stale evidence should request another Site Explorer run"
+    );
+    assert!(
+        db::explored_endpoints::try_update(
+            bmc_ip,
+            endpoint.report_version,
+            &report,
+            false,
+            &mut txn,
+        )
+        .await
+        .unwrap()
+    );
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Ready,
+        "only a newer exact observation should release the Ready gate"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_ready_boot_config_observation_survives_site_explorer_refresh(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let (_interface_id, _target, _selection_version, bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    assert_eq!(load_host_state(&env, &mh.id).await, ManagedHostState::Ready);
+
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert!(
+        db::explored_endpoints::re_explore_if_version_matches(
+            bmc_ip,
+            endpoint.report_version,
+            txn.as_mut(),
+        )
+        .await
+        .unwrap()
+    );
+    txn.commit().await.unwrap();
+
+    let exploration_count = env.endpoint_explorer.explore_endpoint_call_count();
+    env.run_site_explorer_iteration().await;
+    assert!(
+        env.endpoint_explorer.explore_endpoint_call_count() > exploration_count,
+        "the requested Site Explorer refresh should run"
+    );
+
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Ready,
+        "a later Site Explorer refresh should preserve the correlated Ready evidence"
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_unassigned_boot_config_completion_clears_assigned_authorization(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let (interface_id, target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let stale_interface_id: MachineInterfaceId =
+        "11111111-1111-1111-1111-111111111111".parse().unwrap();
+    assert_ne!(stale_interface_id, interface_id);
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        stale_interface_id,
+        false,
+        true,
+        Some("released-instance-test".to_string()),
+    )
+    .await
+    .unwrap();
+    db::machine::update_state(
+        txn.as_mut(),
+        &mh.id,
+        &ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::WaitingForInitialObservation {
+                target: BootConfigSynchronizationTarget {
+                    machine_interface_id: Some(interface_id),
+                    boot_interface: target,
+                    selection_version,
+                },
+                minimum_report_version: ConfigVersion::invalid(),
+            },
+            synchronization_retry_count: 0,
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(load_host_state(&env, &mh.id).await, ManagedHostState::Ready);
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_none(),
+        "authorization from a previous assigned lifecycle must be cleared before unassigned Ready",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_boot_config_wait_restores_pinned_endpoint_target(pool: sqlx::PgPool) {
+    let env = create_zero_dpu_test_env(pool).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let (interface_id, target, selection_version, bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    let minimum_report_version = endpoint.report_version;
+    sqlx::query(
+        "UPDATE explored_endpoints \
+         SET boot_interface_mac = $1, boot_interface_id = NULL, \
+             waiting_for_explorer_refresh = false, exploration_requested = false \
+         WHERE address = $2",
+    )
+    .bind("02:00:00:00:ff:ff".parse::<MacAddress>().unwrap())
+    .bind(bmc_ip)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    set_host_controller_state_stuck_in(
+        &env,
+        mh.id,
+        &ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::WaitingForInitialObservation {
+                target: BootConfigSynchronizationTarget {
+                    machine_interface_id: Some(interface_id),
+                    boot_interface: target.clone(),
+                    selection_version,
+                },
+                minimum_report_version,
+            },
+            synchronization_retry_count: 0,
+        },
+        0,
+    )
+    .await;
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert_eq!(endpoint.boot_interface_target(), Some(target));
+    assert!(
+        endpoint.report_version.version_nr() > minimum_report_version.version_nr(),
+        "restoring the pinned target should create a new report-version barrier",
+    );
+    assert!(endpoint.waiting_for_explorer_refresh);
+    assert!(endpoint.exploration_requested);
+    txn.rollback().await.unwrap();
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::WaitingForInitialObservation { .. },
+            ..
+        }
+    ));
+}
+
+#[crate::sqlx_test]
+async fn test_prediction_change_blocks_stale_final_boot_config_completion(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_zero_dpu_test_env(pool).await;
+    let mock_host = ManagedHostConfig::zero_dpu();
+    let inband_mac = *mock_host.non_dpu_macs.first().unwrap();
+    let mock = common::api_fixtures::site_explorer::ingest_zero_dpu_host_awaiting_first_lease(
+        &env, mock_host,
+    )
+    .await?;
+    let bmc_ip = mock
+        .host_bmc_ip
+        .expect("zero-DPU ingestion should discover the host BMC");
+    let search_config = MachineSearchConfig {
+        include_predicted_host: true,
+        ..Default::default()
+    };
+
+    let (prediction_id, machine_id, pinned_target) = {
+        let mut txn = env.db_txn().await;
+        let prediction = db::predicted_machine_interface::find_by_mac_address(&mut txn, inband_mac)
+            .await?
+            .expect("zero-DPU ingestion should mint a predicted interface");
+        let machine =
+            db::machine::find_one(txn.as_mut(), &prediction.machine_id, search_config.clone())
+                .await?
+                .expect("the predicted host machine should exist");
+        let boot_interface = prediction.boot_interface().map_or(
+            MachineBootInterfaceTarget::MacOnly(prediction.mac_address),
+            MachineBootInterfaceTarget::Pair,
+        );
+        let target = BootConfigSynchronizationTarget {
+            machine_interface_id: None,
+            boot_interface,
+            selection_version: machine.boot_interface_selection_version,
+        };
+        let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+            .await?
+            .pop()
+            .expect("host explored endpoint should exist");
+        let target_version = db::explored_endpoints::set_boot_interface_target(
+            bmc_ip,
+            &target.boot_interface,
+            &mut txn,
+        )
+        .await?;
+        let mut report = endpoint.report;
+        report.machine_setup_status = Some(MachineSetupStatus {
+            is_done: true,
+            diffs: Vec::new(),
+            verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
+            evaluated_boot_interface: Some(target.boot_interface.clone()),
+        });
+        assert!(
+            db::explored_endpoints::try_update(bmc_ip, target_version, &report, false, &mut txn,)
+                .await?,
+            "the exact final observation should be persisted",
+        );
+        db::machine::update_state(
+            txn.as_mut(),
+            &prediction.machine_id,
+            &ManagedHostState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::WaitingForFinalObservation {
+                    target: target.clone(),
+                    minimum_report_version: ConfigVersion::invalid(),
+                },
+                synchronization_retry_count: 0,
+            },
+        )
+        .await?;
+        txn.commit().await?;
+        (prediction.id, prediction.machine_id, target)
+    };
+
+    // Match first-lease promotion's lock order: associating the new interface
+    // takes a key-share lock on its machine before promotion deletes the
+    // prediction. Final verification must wait on that machine lock before it
+    // locks the prediction, then re-read the newer target after this commits.
+    let replacement_interface_id = "NIC.Integrated.99-1-1";
+    let mut mutator = env.db_txn().await;
+    let mutator_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(mutator.as_mut())
+        .await?;
+    sqlx::query("SELECT id FROM machines WHERE id = $1 FOR KEY SHARE")
+        .bind(machine_id)
+        .execute(mutator.as_mut())
+        .await?;
+
+    let controller_iteration = env.run_machine_state_controller_iteration();
+    let pool = env.pool.clone();
+    let release_mutation = async move {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                let waiting_for_prediction_lock: bool = sqlx::query_scalar(
+                    "SELECT EXISTS ( \
+                         SELECT 1 FROM pg_stat_activity AS activity \
+                         WHERE activity.datname = current_database() \
+                           AND activity.wait_event_type = 'Lock' \
+                           AND $1 = ANY(pg_blocking_pids(activity.pid)) \
+                     )",
+                )
+                .bind(mutator_pid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+                if waiting_for_prediction_lock {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("controller should wait for the first-lease machine lock");
+        sqlx::query("UPDATE predicted_machine_interfaces SET boot_interface_id = $1 WHERE id = $2")
+            .bind(replacement_interface_id)
+            .bind(prediction_id)
+            .execute(mutator.as_mut())
+            .await
+            .expect("first-lease lock order must not deadlock with final verification");
+        mutator.commit().await.unwrap();
+    };
+    tokio::join!(controller_iteration, release_mutation);
+
+    let machine = db::machine::find_one(&env.pool, &machine_id, search_config)
+        .await?
+        .expect("the predicted host machine should still exist");
+    match machine.current_state() {
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state:
+                BootConfigSynchronizationState::Initialize {
+                    target: Some(current_target),
+                },
+            ..
+        } => {
+            assert_eq!(current_target.machine_interface_id, None);
+            assert_eq!(
+                current_target.selection_version,
+                pinned_target.selection_version
+            );
+            match &current_target.boot_interface {
+                MachineBootInterfaceTarget::Pair(interface) => {
+                    assert_eq!(interface.mac_address, inband_mac);
+                    assert_eq!(interface.interface_id, replacement_interface_id);
+                }
+                target => panic!("expected the replacement pair target, got {target:?}"),
+            }
+        }
+        state => panic!("expected synchronization to retarget, got {state:?}"),
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_ready_requires_current_boot_config_authorization(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(&env, &mh.id, InstanceState::Ready).await;
+    let (interface_id, _target, initial_selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    ));
+
+    // Simulate an authorization that lost a race with a newer selection
+    // generation. It must be consumed without starting Redfish work.
+    let mut txn = env.db_txn().await;
+    let stale_version = db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        initial_selection_version,
+        interface_id,
+        false,
+        true,
+        Some("state-controller-test".to_string()),
+    )
+    .await
+    .unwrap();
+    let current_selection_version = stale_version.increment();
+    sqlx::query("UPDATE machines SET boot_interface_selection_version = $1 WHERE id = $2")
+        .bind(current_selection_version)
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    ));
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_none(),
+        "a stale authorization should be discarded"
+    );
+    txn.commit().await.unwrap();
+
+    // An authorization for the current interface and generation starts the
+    // assigned synchronization parent. It remains durable until final
+    // verification so temporary Ready-state work can preempt and resume it.
+    let mut txn = env.db_txn().await;
+    let locked_version = db::machine::lock_boot_interface_selection_version(&mut txn, mh.id)
+        .await
+        .unwrap();
+    assert_eq!(locked_version, current_selection_version);
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        locked_version,
+        interface_id,
+        false,
+        true,
+        Some("state-controller-test".to_string()),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    let state = load_host_state(&env, &mh.id).await;
+    let target = match state {
+        ManagedHostState::Assigned {
+            instance_state:
+                InstanceState::BootConfigSynchronization {
+                    synchronization_state:
+                        BootConfigSynchronizationState::Initialize {
+                            target: Some(target),
+                        },
+                    ..
+                },
+        } => target,
+        state => panic!("expected assigned boot-config synchronization, got {state:?}"),
+    };
+    assert_eq!(target.machine_interface_id, Some(interface_id));
+    assert_eq!(target.selection_version, current_selection_version);
+
+    let mut txn = env.db_txn().await;
+    let persisted_request = mh
+        .host()
+        .db_machine(&mut txn)
+        .await
+        .boot_config_synchronization_requested
+        .expect("a matching authorization should remain durable during synchronization");
+    assert_eq!(
+        persisted_request.interface_id, interface_id,
+        "the persisted authorization should still name the pinned interface",
+    );
+    assert_eq!(
+        persisted_request.selection_version, current_selection_version,
+        "the persisted authorization should still name the pinned generation",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_boot_config_synchronization_converges_and_consumes_authorization(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(&env, &mh.id, InstanceState::Ready).await;
+    let (interface_id, target, selection_version, bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let boot_nic_mac = match &target {
+        MachineBootInterfaceTarget::Pair(interface) => interface.mac_address,
+        MachineBootInterfaceTarget::MacOnly(mac_address) => *mac_address,
+    };
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("state-controller-simulator-test".to_string()),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    // Model a locked host whose HTTP boot device and boot order both drifted.
+    // The BIOS write returns a Dell-style job, so this run also exercises the
+    // persisted job and reboot substates shared with the lifecycle adapters.
+    env.redfish_sim.set_is_bios_setup(false);
+    env.redfish_sim.set_is_boot_order_setup(false);
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Enabled);
+    env.redfish_sim
+        .set_machine_setup_bios_job_id(Some("JID_BOOT_CONFIG_SYNC".to_string()));
+    env.redfish_sim.set_job_state_sequence(vec![
+        libredfish::JobState::Scheduled,
+        libredfish::JobState::Completed,
+    ]);
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    let state = next_assigned_boot_config_state(&env, &mh.id).await;
+    assert_eq!(
+        state,
+        BootConfigSynchronizationState::Initialize {
+            target: Some(BootConfigSynchronizationTarget {
+                machine_interface_id: Some(interface_id),
+                boot_interface: target.clone(),
+                selection_version,
+            }),
+        },
+    );
+
+    let state = next_assigned_boot_config_state(&env, &mh.id).await;
+    let minimum_initial_report_version = match state {
+        BootConfigSynchronizationState::WaitingForInitialObservation {
+            target: observed_target,
+            minimum_report_version,
+        } => {
+            assert_eq!(observed_target.machine_interface_id, Some(interface_id));
+            assert_eq!(observed_target.boot_interface, target);
+            assert_eq!(observed_target.selection_version, selection_version);
+            minimum_report_version
+        }
+        state => panic!("expected the initial observation barrier, got {state:?}"),
+    };
+
+    env.register_boot_config_observation(
+        bmc_ip,
+        target.clone(),
+        false,
+        vec![MachineSetupDiff {
+            key: "HttpDev1".to_string(),
+            expected: "Enabled".to_string(),
+            actual: "Disabled".to_string(),
+        }],
+    );
+    env.run_site_explorer_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert!(
+        endpoint.report_version.version_nr() > minimum_initial_report_version.version_nr(),
+        "Site Explorer should persist the drift observation past the initial barrier",
+    );
+    txn.rollback().await.unwrap();
+
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::PrepareHost { .. },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::UnlockHost {
+            unlock_host_state: UnlockHostState::DisableLockdown,
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::CheckHostConfig { .. },
+    ));
+    assert!(
+        env.redfish_sim
+            .lockdown_states()
+            .iter()
+            .all(|state| *state == libredfish::EnabledDisabled::Disabled),
+        "the shared Redfish phases should run only after lockdown is disabled",
+    );
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::ConfigureBios { retry_count: 0, .. },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::WaitingForBiosJob {
+            bios_config_info: BiosConfigInfo {
+                bios_config_state: BiosConfigState::WaitForBiosJobScheduled,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::WaitingForBiosJob {
+            bios_config_info: BiosConfigInfo {
+                bios_config_state: BiosConfigState::RebootHost,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::WaitingForBiosJob {
+            bios_config_info: BiosConfigInfo {
+                bios_config_state: BiosConfigState::WaitForBiosJobCompletion,
+                ..
+            },
+            ..
+        },
+    ));
+
+    // The scheduled job's reboot applies the BIOS update in the simulator.
+    env.redfish_sim.set_is_bios_setup(true);
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::PollingBiosSetup { retry_count: 0, .. },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::SetBootOrder {
+            set_boot_order_info: SetBootOrderInfo {
+                set_boot_order_state: SetBootOrderState::SetBootOrder,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::SetBootOrder {
+            set_boot_order_info: SetBootOrderInfo {
+                set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::SetBootOrder {
+            set_boot_order_info: SetBootOrderInfo {
+                set_boot_order_state: SetBootOrderState::RebootHost,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::SetBootOrder {
+            set_boot_order_info: SetBootOrderInfo {
+                set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobCompletion,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::SetBootOrder {
+            set_boot_order_info: SetBootOrderInfo {
+                set_boot_order_state: SetBootOrderState::CheckBootOrder,
+                ..
+            },
+            ..
+        },
+    ));
+    assert!(matches!(
+        next_assigned_boot_config_state(&env, &mh.id).await,
+        BootConfigSynchronizationState::LockHost { .. },
+    ));
+    let state = next_assigned_boot_config_state(&env, &mh.id).await;
+    let minimum_final_report_version = match state {
+        BootConfigSynchronizationState::WaitingForFinalObservation {
+            target: final_target,
+            minimum_report_version,
+        } => {
+            assert_eq!(final_target.boot_interface, target);
+            minimum_report_version
+        }
+        state => panic!("expected the final observation barrier, got {state:?}"),
+    };
+    assert!(
+        env.redfish_sim
+            .lockdown_states()
+            .iter()
+            .all(|state| *state == libredfish::EnabledDisabled::Enabled),
+        "the controller should restore lockdown before requesting final evidence",
+    );
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_some(),
+        "authorization should remain durable until final verification",
+    );
+    txn.rollback().await.unwrap();
+
+    env.register_boot_config_observation(bmc_ip, target.clone(), true, Vec::new());
+    env.run_site_explorer_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+        .await
+        .unwrap()
+        .pop()
+        .expect("host explored endpoint should exist");
+    assert!(
+        endpoint.report_version.version_nr() > minimum_final_report_version.version_nr(),
+        "final Site Explorer evidence should be newer than the relock barrier",
+    );
+    txn.rollback().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    );
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_none(),
+        "successful final verification should consume the exact authorization",
+    );
+    txn.rollback().await.unwrap();
+
+    let actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    let machine_setup_index = actions
+        .iter()
+        .position(|action| {
+            matches!(
+                action,
+                RedfishSimAction::MachineSetup {
+                    boot_interface_mac: Some(mac_address),
+                    ..
+                } if mac_address == &boot_nic_mac.to_string()
+            )
+        })
+        .expect("BIOS synchronization should target the selected boot interface");
+    let set_boot_order_index = actions
+        .iter()
+        .position(|action| {
+            matches!(
+                action,
+                RedfishSimAction::SetBootOrderDpuFirst {
+                    boot_interface_mac,
+                } if boot_interface_mac == &boot_nic_mac.to_string()
+            )
+        })
+        .expect("boot-order synchronization should target the selected boot interface");
+    let restart_indices = actions
+        .iter()
+        .enumerate()
+        .filter_map(|(index, action)| {
+            matches!(
+                action,
+                RedfishSimAction::Power(libredfish::SystemPowerControl::ForceRestart)
+            )
+            .then_some(index)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        restart_indices.len(),
+        2,
+        "BIOS-job application and boot-order application should each restart the host: {actions:?}",
+    );
+    assert!(
+        machine_setup_index < restart_indices[0]
+            && restart_indices[0] < set_boot_order_index
+            && set_boot_order_index < restart_indices[1],
+        "Redfish mutations and their application reboots should stay ordered: {actions:?}",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_final_boot_config_observation_respects_configured_convergence_budget(
+    pool: sqlx::PgPool,
+) {
+    let mut config = get_config();
+    config.machine_state_controller.max_bios_config_retries = 1;
+    let env =
+        create_zero_dpu_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await;
+    let mh = create_managed_host_with_config(&env, ManagedHostConfig::zero_dpu()).await;
+    let (interface_id, target, selection_version, bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let synchronization_target = BootConfigSynchronizationTarget {
+        machine_interface_id: Some(interface_id),
+        boot_interface: target.clone(),
+        selection_version,
+    };
+
+    env.register_boot_config_observation(
+        bmc_ip,
+        target.clone(),
+        false,
+        vec![MachineSetupDiff {
+            key: "HttpDev1".to_string(),
+            expected: "Enabled".to_string(),
+            actual: "Disabled".to_string(),
+        }],
+    );
+    env.run_site_explorer_iteration().await;
+
+    let waiting_for_final_observation =
+        |synchronization_retry_count| ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::WaitingForFinalObservation {
+                target: synchronization_target.clone(),
+                minimum_report_version: ConfigVersion::invalid(),
+            },
+            synchronization_retry_count,
+        };
+    set_host_controller_state_stuck_in(&env, mh.id, &waiting_for_final_observation(0), 0).await;
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::PrepareHost { .. },
+            synchronization_retry_count: 1,
+        }
+    ));
+
+    set_host_controller_state_stuck_in(&env, mh.id, &waiting_for_final_observation(1), 0).await;
+    let redfish_timepoint = env.redfish_sim.timepoint();
+    env.run_machine_state_controller_iteration().await;
+
+    {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert_eq!(
+            host.current_state(),
+            &waiting_for_final_observation(1),
+            "an exhausted full-pass budget must remain at final verification",
+        );
+        assert!(
+            matches!(
+                host.controller_state_outcome.as_ref(),
+                Some(PersistentStateHandlerOutcome::Error { err, .. })
+                    if err.contains("manual intervention required")
+                        && err.contains("max_retries: 1")
+            ),
+            "expected final-observation exhaustion to report the configured limit, got: {:?}",
+            host.controller_state_outcome,
+        );
+    }
+    assert!(
+        env.redfish_sim
+            .actions_since(&redfish_timepoint)
+            .all_hosts()
+            .is_empty(),
+        "an exhausted full-pass budget must not issue another Redfish operation",
+    );
+
+    env.register_boot_config_observation(bmc_ip, target, true, Vec::new());
+    env.run_site_explorer_iteration().await;
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(load_host_state(&env, &mh.id).await, ManagedHostState::Ready);
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_final_boot_config_retry_exhaustion_preserves_authorization(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let (interface_id, target, selection_version, bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let synchronization_target = BootConfigSynchronizationTarget {
+        machine_interface_id: Some(interface_id),
+        boot_interface: target.clone(),
+        selection_version,
+    };
+    let retry_count = env.config.machine_state_controller.max_bios_config_retries;
+    let waiting_for_final_observation = ManagedHostState::Assigned {
+        instance_state: InstanceState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::WaitingForFinalObservation {
+                target: synchronization_target,
+                minimum_report_version: ConfigVersion::invalid(),
+            },
+            synchronization_retry_count: retry_count,
+        },
+    };
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("assigned-retry-budget-test".to_string()),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.register_boot_config_observation(
+        bmc_ip,
+        target.clone(),
+        false,
+        vec![MachineSetupDiff {
+            key: "HttpDev1".to_string(),
+            expected: "Enabled".to_string(),
+            actual: "Disabled".to_string(),
+        }],
+    );
+    env.run_site_explorer_iteration().await;
+    set_host_controller_state_stuck_in(&env, mh.id, &waiting_for_final_observation, 0).await;
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    env.run_machine_state_controller_iteration().await;
+
+    {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert_eq!(
+            host.current_state(),
+            &waiting_for_final_observation,
+            "assigned retry exhaustion must remain at final verification",
+        );
+        assert!(
+            matches!(
+                host.controller_state_outcome.as_ref(),
+                Some(PersistentStateHandlerOutcome::Error { err, .. })
+                    if err.contains("manual intervention required")
+            ),
+            "expected assigned retry exhaustion to request manual intervention, got: {:?}",
+            host.controller_state_outcome,
+        );
+        assert_eq!(
+            host.boot_config_synchronization_requested
+                .as_ref()
+                .map(|request| (request.interface_id, request.selection_version)),
+            Some((interface_id, selection_version)),
+            "assigned retry exhaustion must preserve the exact authorization",
+        );
+    }
+    assert!(
+        env.redfish_sim
+            .actions_since(&redfish_timepoint)
+            .all_hosts()
+            .is_empty(),
+        "assigned retry exhaustion must not issue another Redfish operation",
+    );
+
+    env.register_boot_config_observation(bmc_ip, target, true, Vec::new());
+    env.run_site_explorer_iteration().await;
+    env.run_machine_state_controller_iteration().await;
+
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    ));
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_none(),
+        "successful assigned verification must consume the matching authorization",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_boot_config_authorization_recheck_blocks_revoked_request(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(&env, &mh.id, InstanceState::Ready).await;
+    let (interface_id, _target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("authorization-race-test".to_string()),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    // Keep revocation uncommitted while the controller loads its snapshot.
+    // Its exact-request lock must wait, recheck the row after this transaction
+    // commits, and refuse the stale transition.
+    let mut revoker = env.db_txn().await;
+    let revoker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(revoker.as_mut())
+        .await
+        .unwrap();
+    assert!(
+        db::machine::consume_boot_config_synchronization_request(
+            &mut revoker,
+            mh.id,
+            interface_id,
+            selection_version,
+        )
+        .await
+        .unwrap()
+    );
+
+    let controller_iteration = env.run_machine_state_controller_iteration();
+    let pool = env.pool.clone();
+    let release_revocation = async move {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                let waiting_for_request_lock: bool = sqlx::query_scalar(
+                    "SELECT EXISTS ( \
+                         SELECT 1 FROM pg_stat_activity AS activity \
+                         WHERE activity.datname = current_database() \
+                           AND activity.wait_event_type = 'Lock' \
+                           AND $1 = ANY(pg_blocking_pids(activity.pid)) \
+                     )",
+                )
+                .bind(revoker_pid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+                if waiting_for_request_lock {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("controller should block while revalidating the authorization");
+        revoker.commit().await.unwrap();
+    };
+    tokio::join!(controller_iteration, release_revocation);
+
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    ));
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_none(),
+        "revoked authorization must not start assigned synchronization",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_boot_config_active_sync_rejects_non_disruptive_cancellation(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let (interface_id, target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let pinned_target = BootConfigSynchronizationTarget {
+        machine_interface_id: Some(interface_id),
+        boot_interface: target,
+        selection_version,
+    };
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("active-revocation-test".to_string()),
+    )
+    .await
+    .unwrap();
+    db::machine::update_state(
+        txn.as_mut(),
+        &mh.id,
+        &ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::ConfigureBios {
+                    target: pinned_target.clone(),
+                    retry_count: 0,
+                },
+                synchronization_retry_count: 0,
+            },
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Disabled);
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    // Once Redfish work has started, reboot=false cannot promise that no
+    // external effect races the cancellation. Reject it instead of claiming a
+    // stronger contract than a database-only API can provide.
+    let error = env
+        .api
+        .set_primary_interface(tonic::Request::new(
+            rpc::forge::SetPrimaryInterfaceRequest {
+                host_machine_id: Some(mh.id),
+                interface_id: Some(interface_id),
+                reboot: false,
+            },
+        ))
+        .await
+        .expect_err("active synchronization should reject reboot=false cancellation");
+    assert_eq!(
+        error.code(),
+        tonic::Code::FailedPrecondition,
+        "the API should make the too-late cancellation boundary explicit",
+    );
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::ConfigureBios {
+                    target: pinned_target,
+                    retry_count: 0,
+                },
+                synchronization_retry_count: 0,
+            },
+        },
+    );
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_some(),
+        "a rejected cancellation must preserve the active authorization",
+    );
+    let actions = env
+        .redfish_sim
+        .actions_since(&redfish_timepoint)
+        .all_hosts();
+    assert!(
+        actions.is_empty(),
+        "the rejected API request must not perform Redfish work: {actions:?}",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_boot_config_target_loss_restores_lockdown_before_leaving_synchronization(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let (interface_id, target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let pinned_target = BootConfigSynchronizationTarget {
+        machine_interface_id: Some(interface_id),
+        boot_interface: target,
+        selection_version,
+    };
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("target-loss-test".to_string()),
+    )
+    .await
+    .unwrap();
+    db::machine::update_state(
+        txn.as_mut(),
+        &mh.id,
+        &ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::ConfigureBios {
+                    target: pinned_target,
+                    retry_count: 0,
+                },
+                synchronization_retry_count: 0,
+            },
+        },
+    )
+    .await
+    .unwrap();
+    // Model the selected NIC disappearing after the controller has disabled
+    // lockdown. Neither its old row nor a pending prediction can now resolve
+    // the pinned target.
+    sqlx::query(
+        "UPDATE machine_interfaces \
+         SET segment_id = ( \
+             SELECT mi.segment_id \
+             FROM machine_interfaces AS mi \
+             JOIN network_segments AS ns ON ns.id = mi.segment_id \
+             WHERE mi.machine_id = $2 \
+               AND ns.network_segment_type = 'underlay' \
+             LIMIT 1 \
+         ), primary_interface = false \
+         WHERE id = $1",
+    )
+    .bind(interface_id)
+    .bind(mh.id)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    sqlx::query("DELETE FROM predicted_machine_interfaces WHERE machine_id = $1")
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Disabled);
+
+    env.run_machine_state_controller_iteration().await;
+
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::RestoreLockdown {
+                    completion: BootConfigSynchronizationCompletion::TargetChanged,
+                },
+                ..
+            },
+        },
+    ));
+
+    env.run_machine_state_controller_iteration().await;
+
+    assert_eq!(
+        env.redfish_sim.lockdown_states(),
+        vec![libredfish::EnabledDisabled::Enabled],
+        "the controller must restore lockdown before completing target-loss cleanup",
+    );
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_terminal_boot_config_error_restores_lockdown_before_it_is_surfaced(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let completion = BootConfigSynchronizationCompletion::ManualInterventionRequired {
+        error: "terminal boot-config failure".to_string(),
+    };
+    set_assigned_state(
+        &env,
+        &mh.id,
+        InstanceState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::RestoreLockdown {
+                completion: completion.clone(),
+            },
+            synchronization_retry_count: 0,
+        },
+    )
+    .await;
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Disabled);
+
+    env.run_machine_state_controller_iteration().await;
+
+    let lockdown_states = env.redfish_sim.lockdown_states();
+    assert!(
+        !lockdown_states.is_empty()
+            && lockdown_states
+                .iter()
+                .all(|state| *state == libredfish::EnabledDisabled::Enabled),
+        "terminal failure must not surface until the BMC is locked again: {lockdown_states:?}",
+    );
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::RestoreLockdown {
+                    completion,
+                },
+                synchronization_retry_count: 0,
+            },
+        },
+        "surfacing the terminal error leaves the durable cleanup state available for retry",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_boot_config_preemption_waits_for_bios_power_recovery(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    let (interface_id, target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+    let pinned_target = BootConfigSynchronizationTarget {
+        machine_interface_id: Some(interface_id),
+        boot_interface: target,
+        selection_version,
+    };
+    let recovering = |power_state| InstanceState::BootConfigSynchronization {
+        synchronization_state: BootConfigSynchronizationState::WaitingForBiosJob {
+            target: pinned_target.clone(),
+            bios_config_info: BiosConfigInfo {
+                bios_job_id: None,
+                bios_config_state: BiosConfigState::HandleBiosJobFailure {
+                    failure: "simulated BIOS job failure".to_string(),
+                    power_state,
+                },
+                retry_count: 1,
+            },
+        },
+        synchronization_retry_count: 0,
+    };
+
+    let mut txn = env.db_txn().await;
+    db::machine::update_state(
+        txn.as_mut(),
+        &mh.id,
+        &ManagedHostState::Assigned {
+            instance_state: recovering(PowerState::Off),
+        },
+    )
+    .await
+    .unwrap();
+    // A network update requests temporary preemption, while the absent
+    // authorization models revocation. Both must wait until recovery returns
+    // the controller-owned host power to On.
+    sqlx::query(
+        "UPDATE instances \
+         SET update_network_config_request = $1 \
+         WHERE machine_id = $2",
+    )
+    .bind(sqlx::types::Json(InstanceNetworkConfigUpdate::default()))
+    .bind(mh.id)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+    env.redfish_sim
+        .set_lockdown(libredfish::EnabledDisabled::Disabled);
+
+    // ForceOff is issued, but the durable recovery state is retained while the
+    // simulated host reaches Off.
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: recovering(PowerState::Off),
+        },
+    );
+
+    // Once Off, reset the BMC and persist the On half of recovery.
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: recovering(PowerState::On),
+        },
+    );
+
+    let host = {
+        let mut txn = env.db_txn().await;
+        mh.host().db_machine(&mut txn).await
+    };
+    update_time_params(&env.pool, &host, 1, None).await;
+
+    // Power On is issued, but pending preemption and revocation still cannot
+    // replace recovery during this iteration.
+    env.run_machine_state_controller_iteration().await;
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: recovering(PowerState::On),
+        },
+    );
+
+    // The next pass observes On and leaves the recovery substate. Only the
+    // following iteration may honor the pending interruption.
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::ConfigureBios { .. },
+                ..
+            },
+        },
+    ));
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::RestoreLockdown {
+                    completion: BootConfigSynchronizationCompletion::ReturnToReady { .. },
+                },
+                ..
+            },
+        },
+    ));
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_network_update_precedes_boot_config_synchronization(pool: sqlx::PgPool) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(&env, &mh.id, InstanceState::Ready).await;
+    let (interface_id, _target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("network-priority-test".to_string()),
+    )
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE instances \
+         SET update_network_config_request = $1 \
+         WHERE machine_id = $2",
+    )
+    .bind(sqlx::types::Json(InstanceNetworkConfigUpdate::default()))
+    .bind(mh.id)
+    .execute(txn.as_mut())
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    assert_eq!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::NetworkConfigUpdate {
+                network_config_update_state:
+                    NetworkConfigUpdateState::WaitingForNetworkSegmentToBeReady,
+            },
+        },
+    );
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_some(),
+        "higher-priority network work must preserve boot synchronization authorization",
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_assigned_boot_config_authorization_survives_network_update_preemption(
+    pool: sqlx::PgPool,
+) {
+    let (env, mh) = zero_dpu_host_with_instance(pool).await;
+    set_assigned_state(&env, &mh.id, InstanceState::Ready).await;
+    let (interface_id, _target, selection_version, _bmc_ip) =
+        selected_boot_config_target(&env, &mh).await;
+
+    let mut txn = env.db_txn().await;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        mh.id,
+        selection_version,
+        interface_id,
+        false,
+        true,
+        Some("network-preemption-test".to_string()),
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization { .. },
+        }
+    ));
+
+    sqlx::query(
+        "UPDATE instances \
+         SET update_network_config_request = $1 \
+         WHERE machine_id = $2",
+    )
+    .bind(sqlx::types::Json(InstanceNetworkConfigUpdate::default()))
+    .bind(mh.id)
+    .execute(&env.pool)
+    .await
+    .unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        }
+    ));
+    let mut txn = env.db_txn().await;
+    assert!(
+        mh.host()
+            .db_machine(&mut txn)
+            .await
+            .boot_config_synchronization_requested
+            .is_some(),
+        "temporary network work must preserve the exact authorization",
+    );
+    sqlx::query("UPDATE instances SET update_network_config_request = NULL WHERE machine_id = $1")
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+    assert!(matches!(
+        load_host_state(&env, &mh.id).await,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization { .. },
+        }
+    ));
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/set_primary_dpu.rs
+++ b/crates/api-core/src/tests/set_primary_dpu.rs
@@ -21,7 +21,7 @@ use model::test_support::ManagedHostConfig;
 use rpc::forge;
 use rpc::forge::forge_server::Forge;
 
-use crate::test_support::fixture_config::ManagedHostConfigExt as _;
+use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::tests::common::api_fixtures;
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
@@ -106,6 +106,54 @@ async fn test_set_primary_dpu_rejects_zero_dpu_host(
             "Expected zero-DPU host to reject set_primary_dpu with FailedPrecondition, got: {result:?}"
         ),
     };
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_set_primary_dpu_revalidates_attachment_during_locked_handoff(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
+    let host_id = host.host_snapshot.id;
+    let interface = host
+        .host_snapshot
+        .status
+        .interfaces
+        .iter()
+        .find(|interface| interface.attached_dpu_machine_id.is_some())
+        .expect("managed host should have a DPU-backed interface");
+    let expected_dpu_machine_id = interface
+        .attached_dpu_machine_id
+        .expect("selected test interface should be DPU-backed");
+
+    // Model topology changing after the alias resolves its DPU but before the
+    // core transaction locks and reloads the selected interface.
+    sqlx::query("UPDATE machine_interfaces SET attached_dpu_machine_id = NULL WHERE id = $1")
+        .bind(interface.id)
+        .execute(&env.pool)
+        .await?;
+
+    let error = crate::handlers::managed_host::set_primary_interface_core(
+        &env.api,
+        host_id,
+        interface.id,
+        Some(expected_dpu_machine_id),
+        false,
+        None,
+    )
+    .await
+    .expect_err("the locked handoff should reject a detached DPU interface");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error
+            .message()
+            .contains(&expected_dpu_machine_id.to_string()),
+        "the error should identify the DPU whose attachment changed: {error}",
+    );
 
     Ok(())
 }

--- a/crates/api-core/src/tests/set_primary_interface.rs
+++ b/crates/api-core/src/tests/set_primary_interface.rs
@@ -17,20 +17,55 @@
 
 use std::str::FromStr;
 
-use carbide_uuid::machine::MachineInterfaceId;
-use ipnetwork::IpNetwork;
+use carbide_test_support::Outcome::Yields;
+use carbide_test_support::{Case, check_cases_async};
+use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::network::NetworkSegmentId;
+use config_version::ConfigVersion;
+use mac_address::MacAddress;
+use model::address_selection_strategy::AddressSelectionStrategy;
+use model::machine::machine_search_config::MachineSearchConfig;
+use model::machine::{
+    BootConfigSynchronizationRequest, BootConfigSynchronizationState, ManagedHostState,
+};
+use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
+use model::predicted_machine_interface::NewPredictedMachineInterface;
 use model::test_support::ManagedHostConfig;
 use rpc::forge;
 use rpc::forge::forge_server::Forge;
 
 use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::tests::common::api_fixtures;
-use crate::tests::common::api_fixtures::network_segment::{
-    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
-    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY, create_admin_network_segment,
-    create_host_inband_network_segment, create_underlay_network_segment,
-};
+use crate::tests::common::api_fixtures::TestEnv;
+use crate::tests::common::api_fixtures::network_segment::FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY;
+
+#[derive(Debug, sqlx::FromRow)]
+struct BootSelectionState {
+    boot_interface_selection_version: ConfigVersion,
+    boot_config_synchronization_requested:
+        Option<sqlx::types::Json<BootConfigSynchronizationRequest>>,
+    network_config_version: ConfigVersion,
+}
+
+async fn boot_selection_state(env: &TestEnv, host_id: MachineId) -> BootSelectionState {
+    sqlx::query_as(
+        "SELECT boot_interface_selection_version, \
+                boot_config_synchronization_requested, network_config_version \
+         FROM machines WHERE id = $1",
+    )
+    .bind(host_id)
+    .fetch_one(&env.pool)
+    .await
+    .expect("load boot-interface selection state")
+}
+
+fn zero_dpu_host_at_synchronization_entry() -> ManagedHostConfig {
+    ManagedHostConfig::zero_dpu().with_expected_state(ManagedHostState::BootConfigSynchronization {
+        synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+        synchronization_retry_count: 0,
+    })
+}
 
 // Unlike `set_primary_dpu`, `set_primary_interface` has no zero-DPU guard -- a
 // zero-DPU host is a first-class target. So on a zero-DPU host the call must get
@@ -41,48 +76,13 @@ use crate::tests::common::api_fixtures::network_segment::{
 async fn test_set_primary_interface_does_not_apply_the_zero_dpu_guard(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Zero-DPU host ingestion needs a HostInband network segment whose CIDR
-    // covers the relay address; the default test env doesn't define one.
-    let env = api_fixtures::create_test_env_with_overrides(
-        pool,
-        api_fixtures::TestEnvOverrides {
-            site_prefixes: Some(vec![
-                IpNetwork::new(
-                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
-                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
-                )
-                .unwrap(),
-                IpNetwork::new(
-                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
-                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
-                )
-                .unwrap(),
-                IpNetwork::new(
-                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),
-                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.prefix(),
-                )
-                .unwrap(),
-            ]),
-            create_network_segments: Some(false),
-            ..Default::default()
-        },
-    )
-    .await;
-    // HostInband segments must live in a Flat VPC. The test doesn't otherwise
-    // need a non-Flat VPC, so create only a Flat one for the segment.
-    let flat_vpc_id = api_fixtures::network_segment::create_default_flat_vpc(
-        &env.api,
-        "set-primary-interface flat vpc",
-    )
-    .await;
-    create_underlay_network_segment(&env.api).await;
-    create_admin_network_segment(&env.api).await;
-    create_host_inband_network_segment(&env.api, Some(flat_vpc_id)).await;
-    env.run_network_segment_controller_iteration().await;
-    env.run_network_segment_controller_iteration().await;
+    let env = api_fixtures::create_test_env_with_host_inband(pool).await;
 
+    // Stop at the Ready gate so this API validation test does not also depend
+    // on driving the observer/controller synchronization fixture.
     let zero_dpu_host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
+        api_fixtures::site_explorer::new_host(&env, zero_dpu_host_at_synchronization_entry())
+            .await?;
 
     // A well-formed but non-existent interface id: the handler must try to look
     // it up -- which is only reachable once it's past the would-be zero-DPU
@@ -119,22 +119,144 @@ async fn test_set_primary_interface_does_not_apply_the_zero_dpu_guard(
     Ok(())
 }
 
-// Success path: `set_primary_interface` promotes any interface (by id) to be the
-// host's primary boot interface. A two-DPU host starts with one primary host
-// interface and one non-primary one; promoting the non-primary by id must move
-// the primary flag onto it. The handler sets the host's boot order on the BMC
-// *before* moving the flag, so a successful promotion already implies the
-// boot-order call ran (it would have errored out before the flag move otherwise).
 #[crate::sqlx_test]
-async fn test_set_primary_interface_promotes_a_non_primary_interface(
+async fn test_set_primary_interface_uses_the_state_loaded_after_waiting_for_locks(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
+    let host = api_fixtures::create_managed_host_with_config(
+        &env,
+        ManagedHostConfig::default().with_dpu_count(2),
+    )
+    .await;
+    let host_id = host.id;
+    let (bmc_ip, promote_interface_id) = {
+        let mut txn = env.db_txn().await;
+        let snapshot = host.snapshot(&mut txn).await;
+        let bmc_ip = snapshot
+            .host_snapshot
+            .status
+            .bmc_info
+            .ip
+            .expect("managed host should have a BMC IP");
+        let promote_interface_id = snapshot
+            .host_snapshot
+            .status
+            .interfaces
+            .iter()
+            .find(|interface| {
+                !interface.primary_interface && interface.attached_dpu_machine_id.is_some()
+            })
+            .expect("managed host should have a non-primary host interface to promote")
+            .id;
+        (bmc_ip, promote_interface_id)
+    };
 
-    let host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
-            .await?;
-    let host_id = host.host_snapshot.id;
+    // Hold the endpoint row after the RPC's initial machine read but before its
+    // machine-row lock. A normal controller transition remains free to commit
+    // while the RPC waits.
+    let mut blocker = env.db_txn().await;
+    let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(blocker.as_mut())
+        .await?;
+    db::explored_endpoints::find_by_ip_for_update(bmc_ip, blocker.as_mut()).await?;
+
+    let request =
+        env.api
+            .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+                host_machine_id: Some(host_id),
+                interface_id: Some(promote_interface_id),
+                reboot: false,
+            }));
+    let pool = env.pool.clone();
+    let transition_while_blocked = async move {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                let request_is_blocked: bool = sqlx::query_scalar(
+                    "SELECT EXISTS ( \
+                         SELECT 1 FROM pg_stat_activity AS activity \
+                         WHERE activity.datname = current_database() \
+                           AND activity.wait_event_type = 'Lock' \
+                           AND $1 = ANY(pg_blocking_pids(activity.pid)) \
+                     )",
+                )
+                .bind(blocker_pid)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+                if request_is_blocked {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("set-primary-interface should wait on the explored endpoint");
+
+        let next_state = ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+            synchronization_retry_count: 0,
+        };
+        let mut txn = pool.begin().await.unwrap();
+        db::machine::update_state(txn.as_mut(), &host_id, &next_state)
+            .await
+            .unwrap();
+        txn.commit().await.unwrap();
+        blocker.commit().await.unwrap();
+    };
+    let (request_result, ()) = tokio::join!(request, transition_while_blocked);
+    request_result?;
+
+    let machine = db::machine::find_one(&env.pool, &host_id, MachineSearchConfig::default())
+        .await?
+        .expect("managed host should still exist");
+    assert_eq!(
+        machine.current_state(),
+        &ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+            synchronization_retry_count: 0,
+        },
+        "the RPC should use and preserve the state loaded after acquiring its locks",
+    );
+
+    let mut txn = env.db_txn().await;
+    let primaries = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+        .await?
+        .remove(&host_id)
+        .expect("managed host should still have interface rows")
+        .into_iter()
+        .filter(|interface| interface.primary_interface)
+        .map(|interface| interface.id)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        primaries,
+        vec![promote_interface_id],
+        "the RPC should promote the requested interface after waiting for its locks",
+    );
+
+    Ok(())
+}
+
+// Selecting a different interface commits desired state without disrupting an
+// assigned host unless the caller explicitly authorizes synchronization.
+#[crate::sqlx_test]
+async fn test_set_primary_interface_persists_deferred_selection_without_redfish(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env(pool).await;
+    let tenant_segment_id = env.create_vpc_and_tenant_segment().await;
+
+    let host = api_fixtures::create_managed_host_with_config(
+        &env,
+        ManagedHostConfig::default().with_dpu_count(2),
+    )
+    .await;
+    let instance = host
+        .instance_builer(&env)
+        .single_interface_network_config(tenant_segment_id)
+        .build()
+        .await;
+    let host_id = host.id;
 
     // One host interface is primary; pick a different (non-primary) host NIC to promote.
     let (original_primary_id, promote_id) = {
@@ -156,6 +278,13 @@ async fn test_set_primary_interface_promotes_a_non_primary_interface(
         (original_primary_id, promote_id)
     };
 
+    let before = boot_selection_state(&env, host_id).await;
+    let before_instance_network_version = {
+        let mut txn = env.db_txn().await;
+        instance.db_instance(&mut txn).await.network_config_version
+    };
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
     env.api
         .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
             host_machine_id: Some(host_id),
@@ -164,7 +293,8 @@ async fn test_set_primary_interface_promotes_a_non_primary_interface(
         }))
         .await?;
 
-    // The primary flag moved onto the promoted interface, and off the old one.
+    // The selected row, generation, and network versions move together while
+    // the assigned-host authorization remains empty.
     let after = {
         let mut txn = env.pool.begin().await?;
         db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
@@ -191,126 +321,429 @@ async fn test_set_primary_interface_promotes_a_non_primary_interface(
         "the previously-primary interface should no longer be primary",
     );
 
-    Ok(())
-}
-
-// A DPU-managed host's primary must stay on the Admin segment (the admin DHCP
-// address + DNS identity follow it, and admin-address reconciliation requires a
-// primary among the host's DPU-backed admin interfaces). set_primary_interface
-// rejects a non-admin target up-front -- BEFORE touching the BMC -- rather than
-// failing deeper in reconciliation with the boot order already changed.
-#[crate::sqlx_test]
-async fn test_set_primary_interface_rejects_non_admin_interface_on_dpu_host(
-    pool: sqlx::PgPool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let env = api_fixtures::create_test_env(pool).await;
-
-    let host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
-            .await?;
-    let host_id = host.host_snapshot.id;
-
-    // A non-primary host interface to target. The host's other DPU interface
-    // stays the Admin primary, so the host still has a DPU-backed admin link.
-    let promote_id = {
-        let mut txn = env.pool.begin().await?;
-        db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
-            .await?
-            .remove(&host_id)
-            .expect("host should have interface rows")
-            .into_iter()
-            .find(|i| !i.primary_interface && i.attached_dpu_machine_id.is_some())
-            .expect("host should have a non-primary host interface")
-            .id
+    let selected = boot_selection_state(&env, host_id).await;
+    assert_eq!(
+        selected.boot_interface_selection_version.version_nr(),
+        before.boot_interface_selection_version.version_nr() + 1,
+        "a changed selection should create a new generation",
+    );
+    assert_eq!(
+        selected.network_config_version.version_nr(),
+        before.network_config_version.version_nr() + 1,
+        "a changed selection should publish a new machine network config",
+    );
+    let selected_instance_network_version = {
+        let mut txn = env.db_txn().await;
+        instance.db_instance(&mut txn).await.network_config_version
     };
+    assert_eq!(
+        selected_instance_network_version.version_nr(),
+        before_instance_network_version.version_nr() + 1,
+        "a changed selection should publish a new instance network config",
+    );
+    assert!(
+        selected.boot_config_synchronization_requested.is_none(),
+        "reboot=false should leave the changed assigned selection deferred",
+    );
+    assert!(
+        env.redfish_sim
+            .actions_since(&redfish_timepoint)
+            .all_hosts()
+            .is_empty(),
+        "the API path must leave Redfish synchronization to machine-controller",
+    );
 
-    // Craft the (off-happy-path) mixed shape: move that interface onto a
-    // non-admin segment so it is no longer Admin-segment.
-    sqlx::query(
-        "UPDATE machine_interfaces SET segment_id = \
-         (SELECT id FROM network_segments WHERE network_segment_type <> 'admin' LIMIT 1) \
-         WHERE id = $1",
-    )
-    .bind(promote_id)
-    .execute(&env.pool)
-    .await?;
+    // The same already-primary selection can be authorized later without
+    // pretending that desired state changed again.
+    env.api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: true,
+        }))
+        .await?;
+    let authorized = boot_selection_state(&env, host_id).await;
+    let authorization = authorized
+        .boot_config_synchronization_requested
+        .as_deref()
+        .expect("reboot=true should authorize the already-primary selection");
+    assert_eq!(authorization.interface_id, promote_id);
+    assert_eq!(
+        authorization.selection_version, selected.boot_interface_selection_version,
+        "the authorization must name the exact selected generation",
+    );
+    assert_eq!(
+        authorized.boot_interface_selection_version,
+        selected.boot_interface_selection_version,
+    );
+    assert_eq!(
+        authorized.network_config_version,
+        selected.network_config_version,
+    );
+    let authorized_instance_network_version = {
+        let mut txn = env.db_txn().await;
+        instance.db_instance(&mut txn).await.network_config_version
+    };
+    assert_eq!(
+        authorized_instance_network_version,
+        selected_instance_network_version,
+    );
 
-    let err = env
-        .api
+    // Re-selecting without authorization revokes the pending work without
+    // publishing another selection or network version.
+    env.api
         .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
             host_machine_id: Some(host_id),
             interface_id: Some(promote_id),
             reboot: false,
         }))
-        .await
-        .expect_err("promoting a non-admin interface on a DPU host should be rejected");
-
+        .await?;
+    let cleared = boot_selection_state(&env, host_id).await;
+    assert!(
+        cleared.boot_config_synchronization_requested.is_none(),
+        "reboot=false should clear a prior authorization",
+    );
     assert_eq!(
-        err.code(),
-        tonic::Code::InvalidArgument,
-        "expected an up-front InvalidArgument, got {}: {}",
-        err.code(),
-        err.message(),
+        cleared.boot_interface_selection_version,
+        selected.boot_interface_selection_version,
+    );
+    assert_eq!(
+        cleared.network_config_version,
+        selected.network_config_version,
+    );
+    let cleared_instance_network_version = {
+        let mut txn = env.db_txn().await;
+        instance.db_instance(&mut txn).await.network_config_version
+    };
+    assert_eq!(
+        cleared_instance_network_version,
+        selected_instance_network_version,
     );
     assert!(
-        err.message().contains("admin segment"),
-        "expected the Admin-segment guard message, got: {}",
-        err.message(),
+        env.redfish_sim
+            .actions_since(&redfish_timepoint)
+            .all_hosts()
+            .is_empty(),
+        "selecting, authorizing, and revoking should not call Redfish from the API path",
     );
 
     Ok(())
 }
 
-// Success path on a ZERO-DPU host -- the case this feature exists to enable. A
-// zero-DPU host has no DPU-backed admin interface, so neither the zero-DPU guard
-// nor the Admin-segment constraint applies, and set_primary_interface can promote
-// its plain HostInband NIC. (A zero-DPU host has no primary flag set at ingestion,
-// so this records the first primary.)
+// An integrated host may select its HostInband NIC while the DPU-backed Admin
+// links remain present but dormant. Address reconciliation supports this
+// configuration, so the API must not impose an Admin-only primary restriction.
+#[crate::sqlx_test]
+async fn test_set_primary_interface_allows_host_inband_interface_on_dpu_host(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = api_fixtures::create_test_env_with_host_inband(pool).await;
+
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
+    let host_id = host.host_snapshot.id;
+    let stale_prediction_mac = MacAddress::from_str("9a:9b:9c:9d:9e:b4")?;
+
+    // Add a physical NIC owned directly by the host. Unlike the DPU-backed
+    // Admin links, an integrated NIC has no attached DPU machine.
+    let promote_id = {
+        let mut txn = env.pool.begin().await?;
+        let host_inband_gateway = FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.ip();
+        let host_inband_segment = db::network_segment::for_segment_type_all(
+            txn.as_mut(),
+            std::slice::from_ref(&host_inband_gateway),
+            NetworkSegmentType::HostInband,
+        )
+        .await?
+        .into_iter()
+        .next()
+        .expect("the HostInband fixture segment should exist");
+        let host_nic = db::machine_interface::create(
+            txn.as_mut(),
+            std::slice::from_ref(&host_inband_segment),
+            &MacAddress::from_str("9a:9b:9c:9d:9e:b3")?,
+            false,
+            AddressSelectionStrategy::NextAvailableIp,
+            None,
+        )
+        .await?;
+        db::machine_interface::associate_interface_with_machine(
+            &host_nic.id,
+            MachineInterfaceAssociation::Machine(host_id),
+            txn.as_mut(),
+        )
+        .await?;
+        db::machine_interface::demote_primary_interfaces_for_machine(&host_id, txn.as_mut())
+            .await?;
+        db::machine_interface::set_primary_interface(&host_nic.id, true, txn.as_mut()).await?;
+        db::machine_interface::reconcile_admin_addresses_for_host(txn.as_mut(), &host_id).await?;
+        db::predicted_machine_interface::create(
+            NewPredictedMachineInterface {
+                machine_id: &host_id,
+                mac_address: stale_prediction_mac,
+                expected_network_segment_type: NetworkSegmentType::HostInband,
+                boot_interface_id: Some("NIC.Integrated.9-1-1".to_string()),
+                primary_interface: true,
+            },
+            txn.as_mut(),
+        )
+        .await?;
+        txn.commit().await?;
+        host_nic.id
+    };
+
+    {
+        let mut txn = env.pool.begin().await?;
+        let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("host should have interface rows");
+        let integrated_nic = interfaces
+            .iter()
+            .find(|interface| interface.id == promote_id)
+            .expect("the integrated NIC should belong to the host");
+        assert!(integrated_nic.attached_dpu_machine_id.is_none());
+        assert!(integrated_nic.primary_interface);
+    }
+
+    // Model a stale assigned-host authorization. Unassigned selection owns
+    // synchronization through its parent state, so the API must clear this
+    // request instead of leaving it reusable.
+    let mut txn = env.pool.begin().await?;
+    let selection_version =
+        db::machine::lock_boot_interface_selection_version(&mut txn, host_id).await?;
+    db::machine::set_boot_config_synchronization_request(
+        &mut txn,
+        host_id,
+        selection_version,
+        promote_id,
+        false,
+        true,
+        Some("set-primary-interface-test".to_string()),
+    )
+    .await?;
+    txn.commit().await?;
+
+    env.api
+        .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_id),
+            interface_id: Some(promote_id),
+            reboot: false,
+        }))
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+        .await?
+        .remove(&host_id)
+        .expect("host should still have interface rows");
+    let selected = interfaces
+        .iter()
+        .find(|interface| interface.primary_interface)
+        .expect("host should have a selected primary interface");
+    assert_eq!(selected.id, promote_id);
+    assert!(selected.attached_dpu_machine_id.is_none());
+    assert_eq!(
+        selected.network_segment_type,
+        Some(NetworkSegmentType::HostInband),
+    );
+    let dpu_admin_interfaces = interfaces
+        .iter()
+        .filter(|interface| {
+            interface.network_segment_type == Some(NetworkSegmentType::Admin)
+                && interface.attached_dpu_machine_id.is_some()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(dpu_admin_interfaces.len(), 2);
+    assert!(
+        dpu_admin_interfaces
+            .iter()
+            .all(|interface| !interface.primary_interface && interface.addresses.is_empty()),
+        "the DPU Admin links should remain present but dormant",
+    );
+    let stale_prediction =
+        db::predicted_machine_interface::find_by_mac_address(txn.as_mut(), stale_prediction_mac)
+            .await?
+            .expect("the pending integrated-NIC prediction should remain available");
+    assert!(
+        !stale_prediction.primary_interface,
+        "the explicit owned-row selection should clear older predicted primary intent",
+    );
+
+    let machine = db::machine::find_one(txn.as_mut(), &host_id, MachineSearchConfig::default())
+        .await?
+        .expect("host machine should still exist");
+    assert_eq!(
+        machine.boot_interface_selection_version.version_nr(),
+        selection_version.version_nr() + 1,
+        "clearing a higher-precedence primary prediction changes the effective selection",
+    );
+    assert!(
+        machine.boot_config_synchronization_requested.is_none(),
+        "an unassigned selection should clear assigned-host authorization",
+    );
+    match machine.current_state() {
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state:
+                BootConfigSynchronizationState::WaitingForInitialObservation { target, .. },
+            ..
+        } => {
+            assert_eq!(target.machine_interface_id, Some(promote_id));
+            assert_eq!(
+                target.selection_version,
+                machine.boot_interface_selection_version,
+            );
+        }
+        state => panic!("an unassigned selection should start synchronization, got {state:?}"),
+    }
+
+    Ok(())
+}
+
+/// Operator selection may target either supported host-management topology,
+/// but it must never turn an infrastructure or tenant row into the host's
+/// primary boot interface.
+#[crate::sqlx_test]
+async fn test_set_primary_interface_rejects_non_host_boot_segments(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    #[derive(Clone, Copy)]
+    struct IneligibleSegment {
+        id: NetworkSegmentId,
+        segment_type: NetworkSegmentType,
+    }
+
+    let env = api_fixtures::create_test_env(pool).await;
+    let tenant_segment_id = env.create_vpc_and_tenant_segment().await;
+    let underlay_segment_id = {
+        let mut txn = env.db_txn().await;
+        db::network_segment::list_segment_ids(txn.as_mut(), Some(NetworkSegmentType::Underlay))
+            .await?
+            .into_iter()
+            .next()
+            .expect("the test environment must have an Underlay segment")
+    };
+    let host =
+        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(2))
+            .await?;
+    let host_id = host.host_snapshot.id;
+    let (original_primary_id, candidate_id) = {
+        let mut txn = env.db_txn().await;
+        let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+            .await?
+            .remove(&host_id)
+            .expect("the host must have interface rows");
+        (
+            interfaces
+                .iter()
+                .find(|interface| interface.primary_interface)
+                .expect("the host must have a primary interface")
+                .id,
+            interfaces
+                .iter()
+                .find(|interface| {
+                    !interface.primary_interface && interface.attached_dpu_machine_id.is_some()
+                })
+                .expect("the host must have another selectable physical interface")
+                .id,
+        )
+    };
+    let selection_version = boot_selection_state(&env, host_id)
+        .await
+        .boot_interface_selection_version;
+
+    check_cases_async(
+        [
+            Case {
+                scenario: "Underlay infrastructure interface",
+                input: IneligibleSegment {
+                    id: underlay_segment_id,
+                    segment_type: NetworkSegmentType::Underlay,
+                },
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "Tenant workload interface",
+                input: IneligibleSegment {
+                    id: tenant_segment_id,
+                    segment_type: NetworkSegmentType::Tenant,
+                },
+                expect: Yields(()),
+            },
+        ],
+        |case| {
+            let env = &env;
+            async move {
+                sqlx::query("UPDATE machine_interfaces SET segment_id = $1 WHERE id = $2")
+                    .bind(case.id)
+                    .bind(candidate_id)
+                    .execute(&env.pool)
+                    .await
+                    .expect("move the candidate onto the segment under test");
+
+                let error = env
+                    .api
+                    .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
+                        host_machine_id: Some(host_id),
+                        interface_id: Some(candidate_id),
+                        reboot: false,
+                    }))
+                    .await
+                    .expect_err("a non-host segment must be rejected");
+                assert_eq!(error.code(), tonic::Code::InvalidArgument);
+                assert!(
+                    error.message().contains(&case.segment_type.to_string()),
+                    "the error should identify the rejected segment: {}",
+                    error.message(),
+                );
+
+                let mut txn = env.db_txn().await;
+                let interfaces =
+                    db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
+                        .await
+                        .expect("reload the host interfaces")
+                        .remove(&host_id)
+                        .expect("the host must still have interface rows");
+                assert_eq!(
+                    interfaces
+                        .iter()
+                        .find(|interface| interface.primary_interface)
+                        .map(|interface| interface.id),
+                    Some(original_primary_id),
+                    "a rejected selection must preserve the current primary interface",
+                );
+                assert_eq!(
+                    boot_selection_state(env, host_id)
+                        .await
+                        .boot_interface_selection_version,
+                    selection_version,
+                    "a rejected selection must not publish a new desired generation",
+                );
+
+                Ok::<_, ()>(())
+            }
+        },
+    )
+    .await;
+
+    Ok(())
+}
+
+// Success path on a zero-DPU host: it has no DPU-backed Admin interface, and
+// set_primary_interface can select its plain HostInband NIC. A zero-DPU host
+// has no primary flag at ingestion, so this records the first selection.
 #[crate::sqlx_test]
 async fn test_set_primary_interface_promotes_a_zero_dpu_host_interface(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Zero-DPU host ingestion needs a HostInband segment whose CIDR covers the
-    // relay address; the default test env doesn't define one.
-    let env = api_fixtures::create_test_env_with_overrides(
-        pool,
-        api_fixtures::TestEnvOverrides {
-            site_prefixes: Some(vec![
-                IpNetwork::new(
-                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.network(),
-                    FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY.prefix(),
-                )
-                .unwrap(),
-                IpNetwork::new(
-                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.network(),
-                    FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.prefix(),
-                )
-                .unwrap(),
-                IpNetwork::new(
-                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.network(),
-                    FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.prefix(),
-                )
-                .unwrap(),
-            ]),
-            create_network_segments: Some(false),
-            ..Default::default()
-        },
-    )
-    .await;
-    // HostInband segments must live in a Flat VPC.
-    let flat_vpc_id = api_fixtures::network_segment::create_default_flat_vpc(
-        &env.api,
-        "set-primary-interface zero-dpu flat vpc",
-    )
-    .await;
-    create_underlay_network_segment(&env.api).await;
-    create_admin_network_segment(&env.api).await;
-    create_host_inband_network_segment(&env.api, Some(flat_vpc_id)).await;
-    env.run_network_segment_controller_iteration().await;
-    env.run_network_segment_controller_iteration().await;
+    let env = api_fixtures::create_test_env_with_host_inband(pool).await;
 
+    // Stop at the Ready gate so this test can inspect the database handoff
+    // independently from the controller synchronization tests.
     let zero_dpu_host =
-        api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
+        api_fixtures::site_explorer::new_host(&env, zero_dpu_host_at_synchronization_entry())
+            .await?;
     let host_id = zero_dpu_host.host_snapshot.id;
 
     // A zero-DPU host's plain NIC lands on the HostInband segment and is not flagged
@@ -359,13 +792,11 @@ async fn test_set_primary_interface_promotes_a_zero_dpu_host_interface(
     Ok(())
 }
 
-// Regression for the pre-move reconcile ordering: on a DPU-backed host left with NO
-// admin primary (an off-happy-path state), promoting a valid Admin interface must
-// SUCCEED -- repairing the host -- rather than erroring in admin reconciliation
-// after the BMC boot order was already changed. set_primary_interface skips the
-// pre-move reconcile when there is no admin primary to preserve.
+// Regression for the pre-move reconcile ordering: on a DPU-backed host left with
+// no Admin primary, selecting a valid Admin interface must succeed rather than
+// fail before address ownership can be restored.
 #[crate::sqlx_test]
-async fn test_set_primary_interface_repairs_dpu_host_with_no_admin_primary(
+async fn test_set_primary_interface_restores_dpu_host_with_no_admin_primary(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
@@ -402,7 +833,7 @@ async fn test_set_primary_interface_repairs_dpu_host_with_no_admin_primary(
         .execute(&env.pool)
         .await?;
 
-    // Promoting the Admin interface must succeed (repair), not error after the BMC call.
+    // Selecting the Admin interface must restore the primary designation.
     env.api
         .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
             host_machine_id: Some(host_id),

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -29,7 +29,8 @@ use model::hardware_info::HardwareInfo;
 use model::machine::ManagedHostStateSnapshot;
 use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::site_explorer::{
-    Chassis, EndpointExplorationError, EndpointExplorationReport, MachineSetupStatus,
+    Chassis, EndpointExplorationError, EndpointExplorationReport,
+    MACHINE_SETUP_VERIFICATION_VERSION, MachineSetupStatus,
 };
 use model::test_support::{DpuConfig, ManagedHostConfig};
 use rpc::forge::forge_server::Forge;
@@ -820,6 +821,7 @@ fn report_with_evaluated_boot_interface(
     report.machine_setup_status = Some(MachineSetupStatus {
         is_done: true,
         diffs: Vec::new(),
+        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
         evaluated_boot_interface: target.map(MachineBootInterfaceTarget::from),
     });
     report
@@ -1082,6 +1084,7 @@ async fn test_refresh_endpoint_report_rejects_concurrent_report_update(
     concurrent_report.machine_setup_status = Some(MachineSetupStatus {
         is_done: false,
         diffs: Vec::new(),
+        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
         evaluated_boot_interface: Some(concurrent_target.clone()),
     });
     let mut txn = env.pool.begin().await?;
@@ -1138,6 +1141,7 @@ async fn test_refresh_endpoint_report_failure_persists_error_and_bumps_version(
     initial.report.machine_setup_status = Some(MachineSetupStatus {
         is_done: true,
         diffs: Vec::new(),
+        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
         evaluated_boot_interface: Some(preserved_target.clone()),
     });
     let mut txn = env.pool.begin().await?;

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -1227,45 +1227,26 @@ pub mod tests {
 
         let mut txn = pool.begin().await?;
 
-        let machine = mh.host().db_machine(&mut txn).await;
         let machine_id = mh.host().id;
 
         db::machine::update_sku_status_verify_request_time(&mut txn, &machine_id).await?;
 
         txn.commit().await?;
 
-        let mut state = machine.current_state().clone();
+        handle_inventory_update(&pool, &env, &mh).await;
 
-        for _ in 0..20 {
-            env.run_machine_state_controller_iteration().await;
-            state = get_machine_state(&pool, &mh).await;
-            assert!(!matches!(
-                state,
-                ManagedHostState::Validation {
-                    validation_state: ValidationState::MachineValidation {
-                        machine_validation: MachineValidatingState::MachineValidating { .. }
-                    }
-                }
-            ));
-            if state == ManagedHostState::Ready {
-                break;
-            }
-            if matches!(
-                state,
-                ManagedHostState::BomValidating {
-                    bom_validating_state: BomValidating::UpdatingInventory(..)
-                }
-            ) {
-                let mut txn = pool.begin().await?;
-
-                db::machine::update_discovery_time(&machine.id, &mut txn)
-                    .await
-                    .unwrap();
-                txn.commit().await.unwrap();
-            }
-        }
-
-        assert_eq!(state, ManagedHostState::Ready);
+        env.run_machine_state_controller_iteration_until_state_condition(
+            &machine_id,
+            20,
+            |machine| {
+                assert!(!matches!(
+                    machine.current_state(),
+                    ManagedHostState::Validation { .. }
+                ));
+                machine.current_state() == &ManagedHostState::Ready
+            },
+        )
+        .await;
 
         Ok(())
     }
@@ -1365,11 +1346,7 @@ pub mod tests {
             |machine| {
                 assert!(!matches!(
                     machine.current_state(),
-                    ManagedHostState::Validation {
-                        validation_state: ValidationState::MachineValidation {
-                            machine_validation: MachineValidatingState::MachineValidating { .. }
-                        }
-                    }
+                    ManagedHostState::Validation { .. }
                 ));
                 matches!(
                     machine.current_state(),
@@ -1382,25 +1359,19 @@ pub mod tests {
         .await;
         mh.host().forge_agent_control().await;
 
-        let mut state = get_machine_state(&pool, &mh).await;
-        for _ in 0..3 {
-            env.run_machine_state_controller_iteration().await;
+        env.run_machine_state_controller_iteration_until_state_condition(
+            &machine_id,
+            3,
+            |machine| {
+                assert!(!matches!(
+                    machine.current_state(),
+                    ManagedHostState::Validation { .. }
+                ));
+                machine.current_state() == &ManagedHostState::Ready
+            },
+        )
+        .await;
 
-            state = get_machine_state(&pool, &mh).await;
-            assert!(!matches!(
-                state,
-                ManagedHostState::Validation {
-                    validation_state: ValidationState::MachineValidation {
-                        machine_validation: MachineValidatingState::MachineValidating { .. }
-                    }
-                }
-            ));
-            if state == ManagedHostState::Ready {
-                break;
-            }
-        }
-
-        assert_eq!(state, ManagedHostState::Ready);
         Ok(())
     }
 

--- a/crates/api-core/tests/integration/machine_boot_interfaces.rs
+++ b/crates/api-core/tests/integration/machine_boot_interfaces.rs
@@ -17,9 +17,9 @@
 
 //! `GetMachineBootInterfaces` gathers one machine's boot-interface view from
 //! all four stores -- owned interface rows, predictions, the explored endpoint
-//! default, and the retained post-deletion pairs -- and reports the effective
-//! boot interface plus a divergence flag. These tests seed the stores for one
-//! host and assert the gathered view.
+//! evaluation target, and the retained post-deletion pairs -- and reports the
+//! effective boot interface plus a divergence flag. These tests seed the
+//! stores for one host and assert the gathered view.
 
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::{
@@ -57,9 +57,9 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
     // topology, and explored endpoints -- stores 1 and 3.
     let host_id = host.host.id;
 
-    // Read the owned rows the host ended up with: the primary is the effective
-    // boot interface `pick_boot_interface` selects, and we reuse its MAC to
-    // seed a retained record (store 4).
+    // Read the owned rows the host ended up with. We reuse its primary MAC to
+    // seed the explored and retained stores while a declared prediction tests
+    // the cross-store precedence.
     let primary_mac = {
         let mut txn = env.db_txn().await;
         let interfaces = db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
@@ -73,14 +73,14 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
             .expect("a DPU host has a primary interface")
             .mac_address
     };
-    // A DPU host's primary carries a boot-interface id; seed a known one so the
-    // effective-pick contract is asserted against a concrete value -- a regression
-    // to no id then fails loudly instead of defaulting the assertion away.
+    // Give the owned primary a known boot-interface id so the report proves
+    // that store's complete pair survives alongside the selected prediction.
     let primary_boot_id = "NIC.Primary.1-1-1";
 
-    // Store 2: a prediction for this host, flagged primary, on a MAC that is
-    // NOT the owned effective pick -- two disagreeing boot-MAC signals, so the
-    // view must flag divergence.
+    // Store 2: a declared primary prediction for a different MAC. It is the
+    // effective selection until its first lease promotes it, while the
+    // explored endpoint still names the owned primary, so the view must flag
+    // divergence.
     let predicted_mac: MacAddress = "aa:bb:cc:dd:ee:01".parse()?;
     // Store 4: a retained pair on the primary's MAC, aged well past any window.
     // `find_records_by_macs` ignores the window, so the troubleshooting view
@@ -99,18 +99,17 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
         )
         .await?;
 
-        // Seed the owned primary's boot-interface id so the effective pick has a
-        // concrete value to assert.
+        // Seed the owned primary's boot-interface id so its reported store has
+        // a concrete value to assert.
         db::machine_interface::set_boot_interface_id(primary_mac, primary_boot_id, txn.as_mut())
             .await?;
 
         // Store 3: give the host's explored BMC endpoint a recorded boot
         // interface so the explored-endpoint store has concrete data to
         // surface. Resolve the BMC IP the same way the handler does (machine ->
-        // BMC pairs -> explored endpoint at that address) and set its default to
-        // the owned primary -- naming the same boot NIC, so it adds no new
-        // distinct boot-MAC signal and leaves the divergence verdict to the
-        // conflicting prediction.
+        // BMC pairs -> explored endpoint at that address) and leave its
+        // evaluation target on the owned primary. That recorded target now
+        // disagrees with the declared prediction selected above.
         let bmc_ip: std::net::IpAddr =
             db::machine_topology::find_machine_bmc_pairs_by_machine_id(txn.as_mut(), vec![host_id])
                 .await?
@@ -186,7 +185,7 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
         .explored_endpoints
         .iter()
         .find(|e| e.boot_interface_mac.as_deref() == Some(primary_mac.to_string().as_str()))
-        .expect("the host's explored endpoint default should be reported");
+        .expect("the host's explored endpoint evaluation target should be reported");
     assert_eq!(
         reported_explored.boot_interface_id.as_deref(),
         Some(primary_boot_id),
@@ -206,22 +205,24 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
         "the retained record should carry recorded_at"
     );
 
-    // Effective pick: the owned primary's MAC.
+    // Effective pick: declared primary intent remains authoritative until its
+    // first DHCP lease promotes the prediction into an owned row.
     assert_eq!(
         report.effective_boot_interface_mac.as_deref(),
-        Some(primary_mac.to_string().as_str()),
-        "the effective boot interface is the owned primary"
+        Some(predicted_mac.to_string().as_str()),
+        "the declared primary prediction should outrank the interim owned primary"
     );
     assert_eq!(
         report.effective_boot_interface_id.as_deref(),
-        Some(primary_boot_id),
-        "the effective boot interface id is the primary row's captured boot-interface id"
+        Some("NIC.Predicted.1-1-1"),
+        "the effective boot interface id should come from the selected prediction"
     );
 
-    // Divergence: the predicted primary disagrees with the owned pick.
+    // Divergence: the endpoint evaluation target still names the owned
+    // primary, while the selected prediction names a different MAC.
     assert!(
         report.divergent,
-        "a predicted primary on a different MAC than the owned pick is a divergence"
+        "the selected prediction and endpoint evaluation target should diverge"
     );
 
     // Every owned row reports its `machine_interfaces` row id, so a candidate
@@ -235,22 +236,26 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
     );
 
     // The default pick (primary flag masked) names one of the machine's own
-    // non-underlay rows. Its exact identity is the selection logic's business
+    // boot-capable rows. Its exact identity is the selection logic's business
     // (unit-tested in api-model); here we assert the wiring.
     let default_mac = report
         .default_boot_interface
         .as_ref()
         .map(|b| b.mac_address.as_str())
-        .expect("a host with non-underlay rows has a default pick");
+        .expect("a host with boot-capable rows has a default pick");
     let default_row = report
         .machine_interfaces
         .iter()
         .find(|i| i.mac_address == default_mac)
         .expect("the default pick names an owned row");
-    assert_ne!(
-        default_row.network_segment_type.as_deref(),
-        Some(NetworkSegmentType::Underlay.to_string().as_str()),
-        "the default pick never lands on an underlay row"
+    assert!(
+        [
+            NetworkSegmentType::Admin.to_string(),
+            NetworkSegmentType::HostInband.to_string(),
+        ]
+        .iter()
+        .any(|segment_type| default_row.network_segment_type.as_ref() == Some(segment_type)),
+        "the default pick lands on an Admin or HostInband row"
     );
 
     // The predicted pick is the seeded primary-flagged prediction, id and all.

--- a/crates/api-db/migrations/20260727060000_boot_config_synchronization.sql
+++ b/crates/api-db/migrations/20260727060000_boot_config_synchronization.sql
@@ -1,0 +1,6 @@
+-- Track the selected boot-interface generation separately from the interface
+-- row so an assigned-host authorization cannot be reused after A -> B -> A.
+ALTER TABLE machines
+    ADD COLUMN boot_interface_selection_version VARCHAR(64)
+        NOT NULL DEFAULT 'V1-T1666644937952267',
+    ADD COLUMN boot_config_synchronization_requested JSONB;

--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -21,7 +21,8 @@ use config_version::ConfigVersion;
 use const_format::concatcp;
 use mac_address::MacAddress;
 use model::firmware::FirmwareComponentType;
-use model::machine_boot_interface::MachineBootInterface;
+use model::machine::pick_boot_interface_candidate;
+use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 use model::site_explorer::{
     EndpointExplorationReport, ExploredEndpoint, InitialBmcResetPhase, InitialResetPhase,
     PowerDrainState, PreingestionState, TimeSyncResetPhase,
@@ -62,6 +63,13 @@ struct DbExploredEndpoint {
     /// The MAC address of the boot interface (primary interface) for this host endpoint
     boot_interface_mac: Option<MacAddress>,
     /// The vendor-native Redfish interface id of the boot interface
+    boot_interface_id: Option<String>,
+}
+
+#[derive(Debug, FromRow)]
+struct LockedBootInterfaceTarget {
+    report_version: ConfigVersion,
+    boot_interface_mac: Option<MacAddress>,
     boot_interface_id: Option<String>,
 }
 
@@ -151,6 +159,37 @@ pub async fn find_by_ips(
         .await
         .map(|endpoints| endpoints.into_iter().map(Into::into).collect())
         .map_err(|e| DatabaseError::new("explored_endpoints::find_by_ips", e))
+}
+
+/// Finds and locks one endpoint for a transaction that will also update its
+/// managed machine interfaces.
+///
+/// Call this before locking `machine_interfaces` so boot-interface writers use
+/// the same endpoint-before-interface lock order as Site Explorer.
+pub async fn find_by_ip_for_update(
+    address: IpAddr,
+    txn: &mut PgConnection,
+) -> Result<ExploredEndpoint, DatabaseError> {
+    find_by_ip_for_update_optional(address, txn)
+        .await?
+        .ok_or_else(|| DatabaseError::NotFoundError {
+            kind: "explored endpoint",
+            id: address.to_string(),
+        })
+}
+
+/// Finds and locks one endpoint when its absence is an expected wait state.
+pub async fn find_by_ip_for_update_optional(
+    address: IpAddr,
+    txn: &mut PgConnection,
+) -> Result<Option<ExploredEndpoint>, DatabaseError> {
+    let query = "SELECT * FROM explored_endpoints WHERE address = $1 FOR UPDATE";
+    let endpoint = sqlx::query_as::<_, DbExploredEndpoint>(query)
+        .bind(address)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    Ok(endpoint.map(Into::into))
 }
 
 /// Fetches explored DPU endpoints whose reported system serial number is in
@@ -891,20 +930,186 @@ pub async fn set_pause_remediation(
     Ok(())
 }
 
+/// Stores a complete boot-interface pair through the same version barrier as
+/// [`set_boot_interface_target`].
 pub async fn set_boot_interface(
     address: IpAddr,
     boot_interface: &MachineBootInterface,
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
-    let query = "UPDATE explored_endpoints SET boot_interface_mac = $1, boot_interface_id = $2 WHERE address = $3";
-    sqlx::query(query)
-        .bind(boot_interface.mac_address)
-        .bind(&boot_interface.interface_id)
+    set_boot_interface_target(
+        address,
+        &MachineBootInterfaceTarget::Pair(boot_interface.clone()),
+        txn,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Stores the endpoint's desired boot-interface target.
+///
+/// The endpoint row is locked before its target is compared or updated. A
+/// target change increments the report version and requests another
+/// exploration, making the returned version a baseline that the next
+/// correlated observation must exceed.
+pub async fn set_boot_interface_target(
+    address: IpAddr,
+    target: &MachineBootInterfaceTarget,
+    txn: &mut PgConnection,
+) -> Result<ConfigVersion, DatabaseError> {
+    let locked = lock_boot_interface_target(address, txn).await?;
+    update_boot_interface_target(address, target, locked, false, txn).await
+}
+
+/// Requests a fresh observation of `target`, even when the endpoint already
+/// stores that target.
+///
+/// The returned post-update version is the baseline for deciding whether a
+/// later report was produced in response to this request.
+pub async fn request_boot_interface_observation(
+    address: IpAddr,
+    target: &MachineBootInterfaceTarget,
+    txn: &mut PgConnection,
+) -> Result<ConfigVersion, DatabaseError> {
+    let locked = lock_boot_interface_target(address, txn).await?;
+    update_boot_interface_target(address, target, locked, true, txn).await
+}
+
+/// Persists Site Explorer's inferred boot interface until a managed machine's
+/// selected interface owns the endpoint target.
+///
+/// The endpoint, materialized interfaces, machine selection version, and
+/// predictions are locked in that order before resolving the same cross-store
+/// candidate used by the API and machine controller. An operator selection
+/// therefore cannot be overwritten by a stale inferred default, while a
+/// declared primary prediction can become the target before its first lease.
+pub async fn set_boot_interface_default(
+    address: IpAddr,
+    inferred_default: &MachineBootInterface,
+    txn: &mut PgConnection,
+) -> Result<ConfigVersion, DatabaseError> {
+    let locked = lock_boot_interface_target(address, txn).await?;
+    let stored_target = MachineBootInterfaceTarget::from_parts(
+        locked.boot_interface_mac,
+        locked.boot_interface_id.clone(),
+    );
+    let machine_id =
+        crate::machine_topology::find_machine_id_by_bmc_ip(&mut *txn, &address.to_string()).await?;
+
+    let target = match machine_id {
+        Some(machine_id) => {
+            crate::machine_interface::lock_for_machine(txn, machine_id).await?;
+            crate::machine::lock_boot_interface_selection_version(txn, machine_id).await?;
+            crate::predicted_machine_interface::lock_for_machine(txn, machine_id).await?;
+
+            let interfaces = crate::machine_interface::find_by_machine_ids(txn, &[machine_id])
+                .await?
+                .remove(&machine_id)
+                .unwrap_or_default();
+            let predictions =
+                crate::predicted_machine_interface::find_by_machine_id(txn, &machine_id).await?;
+            let Some(primary) = pick_boot_interface_candidate(&interfaces, &predictions) else {
+                // A zero-DPU host can legitimately rely on the fallback
+                // selection before and after its first in-band lease. Its
+                // controller-owned endpoint target must remain unchanged.
+                tracing::debug!(
+                    %machine_id,
+                    bmc_ip_address = %address,
+                    "Managed host has no boot-capable primary interface row; preserving its endpoint boot-interface target",
+                );
+                return Ok(locked.report_version);
+            };
+            let mac_address = primary.mac_address();
+            let interface_id = primary
+                .boot_interface()
+                .map(|boot_interface| boot_interface.interface_id);
+
+            match MachineBootInterfaceTarget::from_parts(Some(mac_address), interface_id)
+                .expect("a machine interface always has a MAC address")
+            {
+                MachineBootInterfaceTarget::MacOnly(_)
+                    if inferred_default.mac_address == mac_address =>
+                {
+                    MachineBootInterfaceTarget::Pair(inferred_default.clone())
+                }
+                MachineBootInterfaceTarget::MacOnly(_) => stored_target
+                    .filter(|stored| match stored {
+                        MachineBootInterfaceTarget::Pair(boot_interface) => {
+                            boot_interface.mac_address == mac_address
+                        }
+                        MachineBootInterfaceTarget::MacOnly(stored_mac_address) => {
+                            *stored_mac_address == mac_address
+                        }
+                    })
+                    .unwrap_or(MachineBootInterfaceTarget::MacOnly(mac_address)),
+                target @ MachineBootInterfaceTarget::Pair(_) => target,
+            }
+        }
+        None => MachineBootInterfaceTarget::Pair(inferred_default.clone()),
+    };
+
+    update_boot_interface_target(address, &target, locked, false, txn).await
+}
+
+async fn lock_boot_interface_target(
+    address: IpAddr,
+    txn: &mut PgConnection,
+) -> Result<LockedBootInterfaceTarget, DatabaseError> {
+    let query = "SELECT version AS report_version, boot_interface_mac, boot_interface_id \
+                 FROM explored_endpoints WHERE address = $1 FOR UPDATE";
+    sqlx::query_as(query)
         .bind(address)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?
+        .ok_or_else(|| DatabaseError::NotFoundError {
+            kind: "explored endpoint",
+            id: address.to_string(),
+        })
+}
+
+async fn update_boot_interface_target(
+    address: IpAddr,
+    target: &MachineBootInterfaceTarget,
+    locked: LockedBootInterfaceTarget,
+    force_observation: bool,
+    txn: &mut PgConnection,
+) -> Result<ConfigVersion, DatabaseError> {
+    let current =
+        MachineBootInterfaceTarget::from_parts(locked.boot_interface_mac, locked.boot_interface_id);
+    if !force_observation && current.as_ref() == Some(target) {
+        return Ok(locked.report_version);
+    }
+
+    let (mac_address, interface_id) = match target {
+        MachineBootInterfaceTarget::Pair(boot_interface) => (
+            boot_interface.mac_address,
+            Some(boot_interface.interface_id.as_str()),
+        ),
+        MachineBootInterfaceTarget::MacOnly(mac_address) => (*mac_address, None),
+    };
+    let new_version = locked.report_version.increment();
+    let query = "UPDATE explored_endpoints \
+                 SET version = $1, boot_interface_mac = $2, boot_interface_id = $3, \
+                     waiting_for_explorer_refresh = true, exploration_requested = true \
+                 WHERE address = $4 AND version = $5";
+    let result = sqlx::query(query)
+        .bind(new_version)
+        .bind(mac_address)
+        .bind(interface_id)
+        .bind(address)
+        .bind(locked.report_version)
         .execute(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))?;
-    Ok(())
+    if result.rows_affected() != 1 {
+        return Err(DatabaseError::ConcurrentModificationError(
+            "ExploredEndpoint",
+            locked.report_version.version_string(),
+        ));
+    }
+
+    Ok(new_version)
 }
 
 pub async fn set_pause_ingestion_and_poweron(
@@ -1007,5 +1212,99 @@ mod count_preingest_tests {
         assert_eq!(rows.len(), 2, "two endpoints are installing firmware");
         assert_eq!(count, 2, "count agrees with the row count");
         assert_eq!(count, rows.len() as i64);
+    }
+}
+
+#[cfg(test)]
+mod boot_interface_target_tests {
+    use super::*;
+
+    const ADDRESS: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 2, 1));
+
+    async fn endpoint(txn: &mut PgConnection) -> ExploredEndpoint {
+        find_all_by_ip(ADDRESS, txn)
+            .await
+            .expect("query endpoint")
+            .into_iter()
+            .next()
+            .expect("seeded endpoint")
+    }
+
+    async fn clear_observation_request(txn: &mut PgConnection) {
+        sqlx::query(
+            "UPDATE explored_endpoints \
+             SET waiting_for_explorer_refresh = false, exploration_requested = false \
+             WHERE address = $1",
+        )
+        .bind(ADDRESS)
+        .execute(txn)
+        .await
+        .expect("clear observation request");
+    }
+
+    #[crate::sqlx_test]
+    async fn target_changes_and_forced_observations_create_version_barriers(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.expect("begin transaction");
+        let stale_report = EndpointExplorationReport::default();
+        insert(ADDRESS, &stale_report, false, &mut txn)
+            .await
+            .expect("seed endpoint");
+        let initial_version = find_by_ip_for_update(ADDRESS, &mut txn)
+            .await
+            .expect("lock endpoint")
+            .report_version;
+        let boot_interface = MachineBootInterface {
+            mac_address: "02:00:00:00:02:01".parse().expect("valid MAC"),
+            interface_id: "NIC.Slot.2-1-1".to_string(),
+        };
+        let pair = MachineBootInterfaceTarget::Pair(boot_interface.clone());
+
+        let pair_baseline = set_boot_interface_target(ADDRESS, &pair, &mut txn)
+            .await
+            .expect("set complete target");
+        assert!(
+            !try_update(ADDRESS, initial_version, &stale_report, false, &mut txn,)
+                .await
+                .expect("reject stale report"),
+            "a report using the pre-target version must lose its compare-and-swap update",
+        );
+        let stored_pair = endpoint(&mut txn).await;
+        assert!(pair_baseline.version_nr() > initial_version.version_nr());
+        assert_eq!(stored_pair.report_version, pair_baseline);
+        assert_eq!(stored_pair.boot_interface_target(), Some(pair.clone()));
+        assert!(stored_pair.waiting_for_explorer_refresh);
+        assert!(stored_pair.exploration_requested);
+
+        clear_observation_request(&mut txn).await;
+        let unchanged_baseline = set_boot_interface_target(ADDRESS, &pair, &mut txn)
+            .await
+            .expect("retain complete target");
+        let unchanged = endpoint(&mut txn).await;
+        assert_eq!(unchanged_baseline, pair_baseline);
+        assert!(!unchanged.waiting_for_explorer_refresh);
+        assert!(!unchanged.exploration_requested);
+
+        let forced_baseline = request_boot_interface_observation(ADDRESS, &pair, &mut txn)
+            .await
+            .expect("request fresh observation");
+        let forced = endpoint(&mut txn).await;
+        assert!(forced_baseline.version_nr() > pair_baseline.version_nr());
+        assert_eq!(forced.report_version, forced_baseline);
+        assert_eq!(forced.boot_interface_target(), Some(pair));
+        assert!(forced.waiting_for_explorer_refresh);
+        assert!(forced.exploration_requested);
+
+        clear_observation_request(&mut txn).await;
+        let mac_only =
+            MachineBootInterfaceTarget::MacOnly("02:00:00:00:02:02".parse().expect("valid MAC"));
+        let mac_only_baseline = set_boot_interface_target(ADDRESS, &mac_only, &mut txn)
+            .await
+            .expect("set MAC-only target");
+        let stored_mac_only = endpoint(&mut txn).await;
+        assert!(mac_only_baseline.version_nr() > forced_baseline.version_nr());
+        assert_eq!(stored_mac_only.report_version, mac_only_baseline);
+        assert_eq!(stored_mac_only.boot_interface_target(), Some(mac_only));
+        assert!(stored_mac_only.waiting_for_explorer_refresh);
+        assert!(stored_mac_only.exploration_requested);
     }
 }

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 
 use carbide_uuid::dpa_interface::DpaInterfaceId;
 use carbide_uuid::instance_type::InstanceTypeId;
-use carbide_uuid::machine::{MachineId, MachineType};
+use carbide_uuid::machine::{MachineId, MachineInterfaceId, MachineType};
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use chrono::{DateTime, Utc};
@@ -48,10 +48,11 @@ use model::machine::nvlink::MachineNvLinkStatusObservation;
 use model::machine::spx::MachineSpxStatusObservation;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::machine::{
-    Dpf, DpuInfo, DpuInfoStatusObservation, DpuOsOperationalState, DpuRepresentorStatus,
-    FailureDetails, HostProfile, Machine, MachineInterfaceSnapshot, MachineLastRebootRequested,
-    MachineLastRebootRequestedMode, MachineMaintenanceOperation, MachineValidationContext,
-    ManagedHostState, ReprovisionRequest, UpgradeDecision,
+    BootConfigSynchronizationRequest, Dpf, DpuInfo, DpuInfoStatusObservation,
+    DpuOsOperationalState, DpuRepresentorStatus, FailureDetails, HostProfile, Machine,
+    MachineInterfaceSnapshot, MachineLastRebootRequested, MachineLastRebootRequestedMode,
+    MachineMaintenanceOperation, MachineValidationContext, ManagedHostState, ReprovisionRequest,
+    UpgradeDecision,
 };
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::metadata::Metadata;
@@ -228,7 +229,19 @@ pub async fn advance(
     // Get current version
     let version = version.unwrap_or_else(|| machine.state.version.increment());
 
-    // Store history of machine state changes.
+    let _id: (String,) = sqlx::query_as(
+            "UPDATE machines SET controller_state_version=$1, controller_state=$2 WHERE id=$3 RETURNING id",
+        )
+        .bind(version)
+        .bind(sqlx::types::Json(state))
+        .bind(machine.id.to_string())
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::new("update machines state", e))?;
+
+    // Persist history after locking the machine row. The compare-and-swap
+    // writer uses the same order so concurrent state writers cannot invert
+    // the machine-row and per-object history locks.
     crate::state_history::persist(
         txn,
         crate::state_history::StateHistoryTableId::Machine,
@@ -237,16 +250,6 @@ pub async fn advance(
         version,
     )
     .await?;
-
-    let _id: (String,) = sqlx::query_as(
-            "UPDATE machines SET controller_state_version=$1, controller_state=$2 WHERE id=$3 RETURNING id",
-        )
-        .bind(version)
-        .bind(sqlx::types::Json(state))
-        .bind(machine.id.to_string())
-        .fetch_one(txn)
-        .await
-        .map_err(|e| DatabaseError::new("update machines state", e))?;
 
     Ok(true)
 }
@@ -1489,6 +1492,16 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
         };
     }
 
+    // Lock the machine before its history rows, matching every state writer.
+    // Otherwise stable-ID promotion can hold history rows while waiting for a
+    // state writer that already holds the machine row.
+    let query = "SELECT id FROM machines WHERE id=$1 FOR UPDATE";
+    sqlx::query_scalar::<_, MachineId>(query)
+        .bind(current_machine_id)
+        .fetch_one(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
     // Update the machine state and health history to account for the rename
     crate::state_history::update_object_ids(
         txn,
@@ -2174,6 +2187,52 @@ pub async fn update_state(
     Ok(())
 }
 
+/// Updates a managed host state only when its controller version still matches.
+///
+/// The state controller and API-triggered lifecycle handoffs share this
+/// compare-and-swap path so a handler result computed from an older snapshot
+/// cannot overwrite a newer state. Associated DPU rows and state history are
+/// updated only after the host comparison succeeds.
+pub async fn update_state_if_version_matches(
+    txn: &mut PgConnection,
+    host_id: &MachineId,
+    old_version: ConfigVersion,
+    new_version: ConfigVersion,
+    new_state: &ManagedHostState,
+) -> Result<bool, DatabaseError> {
+    let query = "UPDATE machines \
+                 SET controller_state_version = $1, controller_state = $2 \
+                 WHERE id = $3 AND controller_state_version = $4 \
+                 RETURNING id";
+    let updated = sqlx::query_as::<_, MachineId>(query)
+        .bind(new_version)
+        .bind(sqlx::types::Json(new_state))
+        .bind(host_id)
+        .bind(old_version)
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?
+        .is_some();
+    if !updated {
+        return Ok(false);
+    }
+
+    crate::state_history::persist(
+        txn,
+        crate::state_history::StateHistoryTableId::Machine,
+        host_id,
+        new_state,
+        new_version,
+    )
+    .await?;
+
+    for dpu in find_dpus_by_host_machine_id(txn, host_id).await? {
+        advance(&dpu, txn, new_state, Some(new_version)).await?;
+    }
+
+    Ok(true)
+}
+
 pub async fn update_machine_validation_time(
     machine_id: &MachineId,
     txn: &mut PgConnection,
@@ -2630,6 +2689,139 @@ pub async fn clear_machine_maintenance_requested(
         .await
         .map_err(|e| DatabaseError::new("clear_machine_maintenance_requested", e))?;
     Ok(())
+}
+
+/// Locks a machine's selected boot-interface generation.
+///
+/// Boot-interface writers take endpoint and machine-interface locks before
+/// this machine-row lock, matching Scout discovery's interface-before-machine
+/// order. The returned version remains current until the surrounding
+/// transaction commits or rolls back.
+pub async fn lock_boot_interface_selection_version(
+    txn: &mut PgConnection,
+    machine_id: MachineId,
+) -> DatabaseResult<ConfigVersion> {
+    let query = "SELECT boot_interface_selection_version FROM machines WHERE id = $1 FOR UPDATE";
+    let version: String = sqlx::query_scalar(query)
+        .bind(machine_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+    version.parse().map_err(|e| {
+        DatabaseError::internal(format!(
+            "invalid boot-interface selection version for machine {machine_id}: {e}"
+        ))
+    })
+}
+
+/// Persists a selected boot-interface generation and its assigned-host
+/// authorization while the machine row is locked by
+/// [`lock_boot_interface_selection_version`].
+pub async fn set_boot_config_synchronization_request(
+    txn: &mut PgConnection,
+    machine_id: MachineId,
+    current_selection_version: ConfigVersion,
+    interface_id: MachineInterfaceId,
+    selection_changed: bool,
+    authorize_synchronization: bool,
+    initiator: Option<String>,
+) -> DatabaseResult<ConfigVersion> {
+    let selection_version = if selection_changed {
+        current_selection_version.increment()
+    } else {
+        current_selection_version
+    };
+    let request = authorize_synchronization.then(|| BootConfigSynchronizationRequest {
+        interface_id,
+        selection_version,
+        requested_at: Utc::now(),
+        initiator,
+    });
+
+    let query = "UPDATE machines \
+                 SET boot_interface_selection_version = $2, \
+                     boot_config_synchronization_requested = $3 \
+                 WHERE id = $1 AND boot_interface_selection_version = $4 \
+                 RETURNING id";
+    sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .bind(selection_version)
+        .bind(request.map(sqlx::types::Json))
+        .bind(current_selection_version)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(selection_version)
+}
+
+/// Locks and validates the exact assigned-host synchronization authorization.
+///
+/// A controller transition uses this lock in the same transaction as its
+/// state compare-and-swap so a concurrent API request cannot revoke or replace
+/// the authorization between validation and state persistence.
+pub async fn lock_boot_config_synchronization_request(
+    txn: &mut PgConnection,
+    machine_id: MachineId,
+    interface_id: MachineInterfaceId,
+    selection_version: ConfigVersion,
+) -> DatabaseResult<bool> {
+    let query = "SELECT id FROM machines \
+                 WHERE id = $1 \
+                   AND boot_config_synchronization_requested->>'interface_id' = $2 \
+                   AND boot_config_synchronization_requested->>'selection_version' = $3 \
+                 FOR UPDATE";
+    sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .bind(interface_id.to_string())
+        .bind(selection_version.version_string())
+        .fetch_optional(txn)
+        .await
+        .map(|row| row.is_some())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Clears an assigned-host synchronization authorization only when it still
+/// names the exact selected interface generation being handled.
+pub async fn consume_boot_config_synchronization_request(
+    txn: &mut PgConnection,
+    machine_id: MachineId,
+    interface_id: MachineInterfaceId,
+    selection_version: ConfigVersion,
+) -> DatabaseResult<bool> {
+    let query = "UPDATE machines \
+                 SET boot_config_synchronization_requested = NULL \
+                 WHERE id = $1 \
+                   AND boot_config_synchronization_requested->>'interface_id' = $2 \
+                   AND boot_config_synchronization_requested->>'selection_version' = $3 \
+                 RETURNING id";
+    sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .bind(interface_id.to_string())
+        .bind(selection_version.version_string())
+        .fetch_optional(txn)
+        .await
+        .map(|row| row.is_some())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Clears authorization left by an assigned lifecycle before an unassigned
+/// host becomes Ready again.
+pub async fn clear_boot_config_synchronization_request(
+    txn: &mut PgConnection,
+    machine_id: MachineId,
+) -> DatabaseResult<bool> {
+    let query = "UPDATE machines \
+                 SET boot_config_synchronization_requested = NULL \
+                 WHERE id = $1 \
+                   AND boot_config_synchronization_requested IS NOT NULL \
+                 RETURNING id";
+    sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .fetch_optional(txn)
+        .await
+        .map(|row| row.is_some())
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 pub async fn update_dpu_asns(

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -484,6 +484,42 @@ pub async fn find_by_machine_ids(
     )
 }
 
+/// Locks every interface row currently owned by a machine.
+///
+/// Callers that also update an explored endpoint lock that endpoint first.
+/// Re-reading with [`find_by_machine_ids`] after this call gives the selected
+/// interface state that remains stable for the transaction.
+pub async fn lock_for_machine(txn: &mut PgConnection, machine_id: MachineId) -> DatabaseResult<()> {
+    let query = "SELECT id FROM machine_interfaces WHERE machine_id = $1 ORDER BY id FOR UPDATE";
+    sqlx::query_scalar::<_, MachineInterfaceId>(query)
+        .bind(machine_id)
+        .fetch_all(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Locks every interface row for the supplied MACs in row-id order.
+///
+/// Batch writers use this before updating per-MAC boot metadata so they cannot
+/// deadlock with a concurrent path that locks all rows for one machine.
+pub async fn lock_for_mac_addresses(
+    txn: &mut PgConnection,
+    mac_addresses: &[MacAddress],
+) -> DatabaseResult<()> {
+    if mac_addresses.is_empty() {
+        return Ok(());
+    }
+    let query =
+        "SELECT id FROM machine_interfaces WHERE mac_address = ANY($1) ORDER BY id FOR UPDATE";
+    sqlx::query_scalar::<_, MachineInterfaceId>(query)
+        .bind(mac_addresses)
+        .fetch_all(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 /// Counts the machine interfaces bound to a given segment.
 ///
 /// Keep this predicate in sync with
@@ -1905,9 +1941,21 @@ pub async fn lock_network_segments_exclusive(
 /// Later acquisitions of the same locks in the same transaction (reconcile's
 /// own pass) are no-ops.
 pub async fn lock_all_admin_segments(txn: &mut PgConnection) -> DatabaseResult<()> {
-    let segment_ids =
+    lock_network_segments_and_all_admin_segments(txn, &[]).await
+}
+
+/// Advisory-lock the supplied segments and every admin segment as one sorted
+/// set. Promotion uses this before taking interface or machine row locks: its
+/// exact DHCP segment may not be admin, while the resulting primary change can
+/// still make DPU-backed admin links dormant.
+pub async fn lock_network_segments_and_all_admin_segments(
+    txn: &mut PgConnection,
+    segment_ids: &[NetworkSegmentId],
+) -> DatabaseResult<()> {
+    let mut all_segment_ids =
         db_network_segment::list_segment_ids(&mut *txn, Some(NetworkSegmentType::Admin)).await?;
-    lock_network_segments_exclusive(txn, &segment_ids).await
+    all_segment_ids.extend_from_slice(segment_ids);
+    lock_network_segments_exclusive(txn, &all_segment_ids).await
 }
 
 pub async fn allocate_svi_ip(
@@ -2128,10 +2176,43 @@ pub async fn move_predicted_machine_interface_to_machine(
         relay_ip_address = %relay_ip,
         "Got DHCP from predicted machine interface, moving to machine"
     );
+
     let Some(network_segment) = crate::network_segment::for_relay(txn, relay_ip).await? else {
         return Err(DatabaseError::internal(format!(
             "No network segment defined for relay address: {relay_ip}"
         )));
+    };
+
+    // Serialize first-lease promotion with interface selection and address
+    // allocation using the repository-wide order: segment advisory lock,
+    // owned interfaces, machine row, then predictions. Reload after the locks
+    // so a selection that cleared this prediction's primary flag cannot be
+    // overwritten from the caller's stale snapshot.
+    if predicted_machine_interface.primary_interface {
+        lock_network_segments_and_all_admin_segments(
+            txn,
+            std::slice::from_ref(&network_segment.id),
+        )
+        .await?;
+    } else {
+        lock_network_segments_exclusive(txn, std::slice::from_ref(&network_segment.id)).await?;
+    }
+    lock_for_machine(txn, predicted_machine_interface.machine_id).await?;
+    crate::machine::lock_boot_interface_selection_version(
+        txn,
+        predicted_machine_interface.machine_id,
+    )
+    .await?;
+    crate::predicted_machine_interface::lock_for_machine(
+        txn,
+        predicted_machine_interface.machine_id,
+    )
+    .await?;
+    let Some(predicted_machine_interface) =
+        crate::predicted_machine_interface::find_by_id(txn, predicted_machine_interface.id).await?
+    else {
+        // A concurrent first lease already promoted this prediction.
+        return Ok(());
     };
 
     if network_segment.config.segment_type
@@ -2272,7 +2353,16 @@ pub async fn move_predicted_machine_interface_to_machine(
         .await?;
     }
 
-    crate::predicted_machine_interface::delete(predicted_machine_interface, txn).await?;
+    crate::predicted_machine_interface::delete(&predicted_machine_interface, txn).await?;
+
+    if predicted_machine_interface.primary_interface {
+        reconcile_admin_addresses_after_boot_interface_selection(
+            txn,
+            &predicted_machine_interface.machine_id,
+            true,
+        )
+        .await?;
+    }
     Ok(())
 }
 
@@ -2403,7 +2493,7 @@ pub async fn reconcile_admin_addresses_for_host(
     // from a non-admin primary (a HostInband integrated NIC on a managed-DPU host)
     // has no primary in the admin set, which is valid, not broken: every DPU
     // admin link is then dormant and only gets cleaned up below. A host with no
-    // primary interface at all is the genuine error.
+    // primary interface at all is the configuration error.
     let primary_to_repair = match interfaces
         .iter()
         .position(|interface| interface.primary_interface)
@@ -2602,6 +2692,56 @@ pub async fn reconcile_admin_addresses_for_host(
 
     txn.commit().await?;
     Ok(active_config_changed)
+}
+
+/// Reconciles admin address ownership after a boot-interface selection and
+/// publishes the resulting network configuration to the host group and any
+/// assigned instance.
+///
+/// `selection_changed` matters even when reconciliation only removes addresses
+/// from dormant DPU links: the selected interface itself is part of the
+/// externally visible network configuration. Callers must acquire every admin
+/// segment advisory lock before taking interface or machine row locks.
+pub async fn reconcile_admin_addresses_after_boot_interface_selection(
+    txn: &mut PgConnection,
+    host_machine_id: &MachineId,
+    selection_changed: bool,
+) -> DatabaseResult<()> {
+    let active_config_changed = reconcile_admin_addresses_for_host(txn, host_machine_id).await?;
+    if !selection_changed && !active_config_changed {
+        return Ok(());
+    }
+
+    let (network_config, network_config_version) =
+        crate::machine::get_network_config(&mut *txn, host_machine_id)
+            .await?
+            .take();
+    if !crate::machine::try_update_network_config(
+        txn,
+        host_machine_id,
+        network_config_version,
+        &network_config,
+    )
+    .await?
+    {
+        return Err(DatabaseError::ConcurrentModificationError(
+            "machine",
+            network_config_version.to_string(),
+        ));
+    }
+
+    if let Some(instance) = crate::instance::find_by_machine_id(txn, host_machine_id).await? {
+        crate::instance::update_network_config(
+            txn,
+            instance.id,
+            instance.network_config_version,
+            &instance.config.network,
+            true,
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 /// Finds host-owned admin interfaces and locks the interface rows.

--- a/crates/api-db/src/predicted_machine_interface.rs
+++ b/crates/api-db/src/predicted_machine_interface.rs
@@ -96,6 +96,78 @@ pub async fn find_by_machine_id(
     find_by(txn, ObjectColumnFilter::One(MachineIdColumn, machine_id)).await
 }
 
+pub async fn find_by_id(
+    txn: &mut PgConnection,
+    id: uuid::Uuid,
+) -> Result<Option<PredictedMachineInterface>, DatabaseError> {
+    let query = "SELECT * FROM predicted_machine_interfaces WHERE id = $1";
+    sqlx::query_as(query)
+        .bind(id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Locks every predicted interface currently associated with a machine.
+///
+/// Callers take an explored-endpoint lock first when needed, followed by the
+/// machine lock and then this one. A following [`find_by_machine_id`] sees a
+/// target that prediction updates and promotion cannot change until the
+/// transaction completes.
+pub async fn lock_for_machine(
+    txn: &mut PgConnection,
+    machine_id: carbide_uuid::machine::MachineId,
+) -> Result<(), DatabaseError> {
+    let query =
+        "SELECT id FROM predicted_machine_interfaces WHERE machine_id = $1 ORDER BY id FOR UPDATE";
+    sqlx::query_scalar::<_, uuid::Uuid>(query)
+        .bind(machine_id)
+        .fetch_all(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Locks predictions for the supplied MACs in row-id order.
+///
+/// Site Explorer takes owned-interface locks first, then this lock, matching
+/// first-lease promotion and explicit selection.
+pub async fn lock_for_mac_addresses(
+    txn: &mut PgConnection,
+    mac_addresses: &[MacAddress],
+) -> Result<(), DatabaseError> {
+    if mac_addresses.is_empty() {
+        return Ok(());
+    }
+    let query = "SELECT id FROM predicted_machine_interfaces WHERE mac_address = ANY($1) ORDER BY id FOR UPDATE";
+    sqlx::query_scalar::<_, uuid::Uuid>(query)
+        .bind(mac_addresses)
+        .fetch_all(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Clears pending primary designations after an operator selects an owned row.
+///
+/// Callers lock the machine and its predictions first. The predictions remain
+/// available for identity and first-lease adoption, but no longer outrank the
+/// operator-selected interface in cross-store boot resolution.
+pub async fn clear_primary_for_machine(
+    txn: &mut PgConnection,
+    machine_id: carbide_uuid::machine::MachineId,
+) -> Result<(), DatabaseError> {
+    let query = "UPDATE predicted_machine_interfaces \
+                 SET primary_interface = false \
+                 WHERE machine_id = $1 AND primary_interface = true";
+    sqlx::query(query)
+        .bind(machine_id)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
 pub async fn find_by_mac_address(
     txn: &mut PgConnection,
     mac_address: MacAddress,

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -167,11 +167,9 @@ pub struct ExpectedHostNic {
     pub fixed_gateway: Option<IpAddr>,
     /// When true, `primary` flags this NIC as the host's boot (primary)
     /// interface. At most one NIC per ExpectedMachine may be marked primary
-    /// (which is enforced in the API). This ultimately propagates into the
-    /// machine_interfaces table, but, in today's world, only really applies
-    /// to zero-DPU. A machine *with* a DPU will end up taking over when
-    /// site-explorer finds a DPU for the machine (and update the primary
-    /// interface accordingly).
+    /// (which is enforced in the API). Site Explorer preserves this intent
+    /// through a predicted interface until the NIC's first lease, including
+    /// for hosts that keep their DPUs under management.
     #[serde(default)]
     pub primary: Option<bool>,
 }
@@ -268,6 +266,16 @@ pub struct ExpectedMachineData {
 // the expected machines on api startup
 
 impl ExpectedMachineData {
+    /// The one host NIC the operator declared as this machine's boot
+    /// interface.
+    ///
+    /// The API enforces at most one `primary` declaration, so callers can use
+    /// the returned NIC's MAC and segment intent together without repeating
+    /// the selection rule.
+    pub fn declared_primary_nic(&self) -> Option<&ExpectedHostNic> {
+        self.host_nics.iter().find(|nic| nic.primary == Some(true))
+    }
+
     /// The MAC the operator declared as this host's boot interface via
     /// `ExpectedHostNic.primary`. This is the single source of declared boot
     /// intent the writers consult -- site-explorer ingestion, DHCP, and
@@ -276,10 +284,7 @@ impl ExpectedMachineData {
     /// declaration. `None` leaves the boot interface to today's automation
     /// (DPU takeover during ingestion, else the `pick_boot_interface` fallback).
     pub fn declared_primary_mac(&self) -> Option<MacAddress> {
-        self.host_nics
-            .iter()
-            .find(|nic| nic.primary == Some(true))
-            .map(|nic| nic.mac_address)
+        self.declared_primary_nic().map(|nic| nic.mac_address)
     }
 }
 
@@ -913,14 +918,15 @@ mod tests {
             None
         );
 
-        // The declared NIC wins.
+        // The declared NIC and all of its metadata remain available together.
+        let data = ExpectedMachineData {
+            host_nics: vec![nic(mac_a, Some(false)), nic(mac_b, Some(true))],
+            ..Default::default()
+        };
+        assert_eq!(data.declared_primary_mac(), Some(mac_b));
         assert_eq!(
-            ExpectedMachineData {
-                host_nics: vec![nic(mac_a, Some(false)), nic(mac_b, Some(true))],
-                ..Default::default()
-            }
-            .declared_primary_mac(),
-            Some(mac_b)
+            data.declared_primary_nic().map(|nic| nic.mac_address),
+            Some(mac_b),
         );
     }
 

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -35,9 +35,10 @@ use crate::machine::nvlink::MachineNvLinkStatusObservation;
 use crate::machine::spx::MachineSpxStatusObservation;
 use crate::machine::topology::MachineTopology;
 use crate::machine::{
-    Dpf, FailureDetails, HostProfile, HostReprovisionRequest, Machine, MachineConfig,
-    MachineInterfaceSnapshot, MachineLastRebootRequested, MachineMaintenanceRequest, MachineStatus,
-    ManagedHostState, ReprovisionRequest, UpgradeDecision,
+    BootConfigSynchronizationRequest, Dpf, FailureDetails, HostProfile, HostReprovisionRequest,
+    Machine, MachineConfig, MachineInterfaceSnapshot, MachineLastRebootRequested,
+    MachineMaintenanceRequest, MachineStatus, ManagedHostState, ReprovisionRequest,
+    UpgradeDecision,
 };
 use crate::metadata::Metadata;
 use crate::power_manager::PowerOptions;
@@ -75,6 +76,8 @@ pub struct MachineSnapshotPgJson {
     pub reprovisioning_requested: Option<ReprovisionRequest>,
     pub host_reprovisioning_requested: Option<HostReprovisionRequest>,
     pub machine_maintenance_requested: Option<MachineMaintenanceRequest>,
+    pub boot_interface_selection_version: String,
+    pub boot_config_synchronization_requested: Option<BootConfigSynchronizationRequest>,
     pub manual_firmware_upgrade_completed: Option<DateTime<Utc>>,
     pub bios_password_set_time: Option<DateTime<Utc>>,
     pub last_machine_validation_time: Option<DateTime<Utc>>,
@@ -236,6 +239,14 @@ impl TryFrom<MachineSnapshotPgJson> for Machine {
             host_profile: value.host_profile,
             rack_fw_details: value.rack_fw_details,
             machine_maintenance_requested: value.machine_maintenance_requested,
+            boot_interface_selection_version: value
+                .boot_interface_selection_version
+                .parse()
+                .map_err(|e| sqlx::error::Error::ColumnDecode {
+                    index: "boot_interface_selection_version".to_string(),
+                    source: Box::new(e),
+                })?,
+            boot_config_synchronization_requested: value.boot_config_synchronization_requested,
             manual_firmware_upgrade_completed: value.manual_firmware_upgrade_completed,
         })
     }

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -42,7 +42,7 @@ use super::StateSla;
 use super::instance::snapshot::InstanceSnapshot;
 use super::instance::status::extension_service::InstanceExtensionServiceStatusObservation;
 use super::instance::status::network::InstanceNetworkStatusObservation;
-use super::machine_boot_interface::MachineBootInterface;
+use super::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
 use super::metadata::Metadata;
 use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::dpa_interface::DpaInterface;
@@ -258,14 +258,14 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
 /// without constructing a full `ManagedHostStateSnapshot`.
 ///
 /// Ordering:
-/// 1. Any interface with `primary_interface == true` wins. This is the
-///    path operators can drive explicitly via `ExpectedHostNic.primary`,
+/// 1. Any boot-capable interface with `primary_interface == true` wins. This
+///    is the path operators can drive explicitly via `ExpectedHostNic.primary`,
 ///    in the case of zero DPU hosts, and is also how hosts with DPU(s)
 ///    end up with a boot MAC automatically during site-explorer ingestion.
-/// 2. If there's no primary interface, the interface outside the management
-///    segment with the "smallest" MAC address wins -- mainly so we can
-///    have some sense of a stable MAC for zero-DPU hosts where no operator
-///    explicitly declared a primary NIC (and ingestion didn't assign one either).
+/// 2. If there's no eligible primary interface, the boot-capable interface
+///    with the "smallest" MAC address wins -- mainly so we can have a stable
+///    MAC for zero-DPU hosts where no operator explicitly declared a primary
+///    NIC (and ingestion didn't assign one either).
 /// 3. `None` -- This is the "I don't have any candidate interfaces yet" case,
 ///    so it's on the caller to figure out. What this usually means is the
 ///    caller passes `boot_interface_mac: None` to machine_setup, and then
@@ -277,16 +277,19 @@ impl From<ManagedHostStateSnapshotError> for sqlx::Error {
 pub fn pick_boot_interface(
     interfaces: &[MachineInterfaceSnapshot],
 ) -> Option<&MachineInterfaceSnapshot> {
-    // The primary wins!
-    if let Some(primary) = interfaces.iter().find(|x| x.primary_interface) {
+    // The eligible primary wins.
+    if let Some(primary) = interfaces
+        .iter()
+        .find(|interface| interface.primary_interface && interface.supports_host_boot())
+    {
         return Some(primary);
     }
-    // ..no primary, so lets try to find *some* interface.
+    // No eligible primary, so use the deterministic eligible fallback.
     pick_default_boot_interface(interfaces)
 }
 
 /// What [`pick_boot_interface`] falls back to when no row is flagged primary:
-/// the lowest-MAC non-underlay interface (ordering rationale in its docs).
+/// the lowest-MAC host-boot interface (ordering rationale in its docs).
 ///
 /// Public so the admin boot-interface view can report this pick alongside the
 /// effective one: comparing the two shows whether a primary designation is
@@ -296,8 +299,8 @@ pub fn pick_default_boot_interface(
 ) -> Option<&MachineInterfaceSnapshot> {
     interfaces
         .iter()
-        .filter(|x| x.network_segment_type != Some(NetworkSegmentType::Underlay))
-        .min_by_key(|x| x.mac_address)
+        .filter(|interface| interface.supports_host_boot())
+        .min_by_key(|interface| interface.mac_address)
 }
 
 fn pick_boot_interface_mac(
@@ -319,9 +322,10 @@ fn pick_boot_interface_pair(
 /// its first DHCP lease creates a real `machine_interfaces` row. Mirrors
 /// `pick_boot_interface`'s precedence, one step down -- predictions, not rows:
 ///
-/// 1. A prediction flagged `primary_interface` wins -- the declared
-///    `ExpectedHostNic.primary`, recorded onto the prediction at minting.
-/// 2. Otherwise the sole non-underlay prediction. With several and none
+/// 1. A boot-capable prediction flagged `primary_interface` wins -- the
+///    declared `ExpectedHostNic.primary`, recorded onto the prediction at
+///    minting.
+/// 2. Otherwise the sole boot-capable prediction. With several and none
 ///    declared primary the boot NIC is unknowable (e.g. a host whose report
 ///    lists SuperNICs alongside the boot NIC), so this returns `None` rather
 ///    than guess against whichever NIC happens to sort first.
@@ -333,18 +337,84 @@ fn pick_boot_interface_pair(
 pub fn pick_boot_prediction(
     predictions: &[PredictedMachineInterface],
 ) -> Option<&PredictedMachineInterface> {
-    // The declared primary wins, exactly as in `pick_boot_interface`.
-    if let Some(primary) = predictions.iter().find(|p| p.primary_interface) {
+    if let Some(primary) = pick_primary_boot_prediction(predictions) {
         return Some(primary);
     }
-    // Otherwise only a sole non-underlay prediction is unambiguous.
-    let mut non_underlay = predictions
-        .iter()
-        .filter(|p| p.expected_network_segment_type != NetworkSegmentType::Underlay);
-    match (non_underlay.next(), non_underlay.next()) {
+    // Otherwise only a sole eligible prediction is unambiguous.
+    let mut eligible = predictions.iter().filter(|prediction| {
+        prediction
+            .expected_network_segment_type
+            .supports_host_boot()
+    });
+    match (eligible.next(), eligible.next()) {
         (Some(only), None) => Some(only),
         _ => None,
     }
+}
+
+fn pick_primary_boot_prediction(
+    predictions: &[PredictedMachineInterface],
+) -> Option<&PredictedMachineInterface> {
+    predictions.iter().find(|prediction| {
+        prediction.primary_interface
+            && prediction
+                .expected_network_segment_type
+                .supports_host_boot()
+    })
+}
+
+/// The source selected for a host's desired boot interface.
+#[derive(Debug, Clone, Copy)]
+pub enum BootInterfaceCandidate<'a> {
+    /// A materialized interface owned by the host.
+    Interface(&'a MachineInterfaceSnapshot),
+    /// A declared interface still waiting for its first DHCP lease.
+    Prediction(&'a PredictedMachineInterface),
+}
+
+impl BootInterfaceCandidate<'_> {
+    pub fn mac_address(&self) -> MacAddress {
+        match self {
+            Self::Interface(interface) => interface.mac_address,
+            Self::Prediction(prediction) => prediction.mac_address,
+        }
+    }
+
+    pub fn boot_interface(&self) -> Option<MachineBootInterface> {
+        match self {
+            Self::Interface(interface) => interface.boot_interface(),
+            Self::Prediction(prediction) => prediction.boot_interface(),
+        }
+    }
+
+    pub fn machine_interface_id(&self) -> Option<MachineInterfaceId> {
+        match self {
+            Self::Interface(interface) => Some(interface.id),
+            Self::Prediction(_) => None,
+        }
+    }
+}
+
+/// Select the boot interface across materialized rows and pending predictions.
+///
+/// A boot-capable primary prediction is declared intent that has not
+/// materialized yet, so it outranks an interim or fallback row. This is how a
+/// managed-DPU host can target its declared integrated HostInband NIC before
+/// that NIC's first lease; promotion deletes the prediction and the new row
+/// then becomes authoritative. Without that declaration, an owned row wins.
+/// A non-primary prediction is used only when no row is selectable and it is
+/// the sole boot-capable prediction.
+pub fn pick_boot_interface_candidate<'a>(
+    interfaces: &'a [MachineInterfaceSnapshot],
+    predictions: &'a [PredictedMachineInterface],
+) -> Option<BootInterfaceCandidate<'a>> {
+    if let Some(prediction) = pick_primary_boot_prediction(predictions) {
+        return Some(BootInterfaceCandidate::Prediction(prediction));
+    }
+    if let Some(interface) = pick_boot_interface(interfaces) {
+        return Some(BootInterfaceCandidate::Interface(interface));
+    }
+    pick_boot_prediction(predictions).map(BootInterfaceCandidate::Prediction)
 }
 
 impl ManagedHostStateSnapshot {
@@ -402,13 +472,13 @@ impl ManagedHostStateSnapshot {
     /// For hosts with DPUs, this is the DPU-facing "primary" `machine_interface`,
     /// flagged as `primary_interface: true` during site-explorer ingestion.
     ///
-    /// For zero-DPU hosts, the `primary_interface` flag is not (yet) set at
-    /// ingestion time, so this method "falls back" to the first non-underlay
-    /// `machine_interface` (i.e. not the BMC) sorted deterministically by MAC.
+    /// For zero-DPU hosts without a declared primary, this method falls back to
+    /// the first Admin or HostInband `machine_interface`, sorted
+    /// deterministically by MAC.
     ///
-    /// Returns `None` if the host has no non-underlay interfaces yet -- e.g.
-    /// only the BMC has been discovered, or the host's primary NIC hasn't
-    /// DHCP'd yet.
+    /// Returns `None` if the host has no boot-capable interfaces yet -- e.g.
+    /// only the BMC or tenant-facing NICs have been discovered, or the host's
+    /// primary NIC hasn't DHCP'd yet.
     ///
     /// This helper exists to centralize the boot MAC selection logic that used
     /// to be duplicated at every state controller callsite needing to pass a MAC
@@ -811,6 +881,14 @@ pub struct Machine {
     /// [`ManagedHostState::Maintenance`] to execute the requested operation.
     pub machine_maintenance_requested: Option<MachineMaintenanceRequest>,
 
+    /// Identifies the current selected boot interface, including repeated
+    /// selections that return to an earlier interface.
+    pub boot_interface_selection_version: ConfigVersion,
+
+    /// Authorizes machine-controller to apply the selected boot interface while
+    /// the host is assigned. Unassigned hosts synchronize automatically.
+    pub boot_config_synchronization_requested: Option<BootConfigSynchronizationRequest>,
+
     /// Does the forge-dpu-agent on this DPU need upgrading?
     pub dpu_agent_upgrade_requested: Option<UpgradeDecision>,
 
@@ -1158,6 +1236,16 @@ pub enum ManagedHostState {
     },
     /// Host is Ready for instance creation.
     Ready,
+
+    /// The selected boot interface is being synchronized with host Redfish
+    /// before the host becomes available for assignment.
+    BootConfigSynchronization {
+        synchronization_state: BootConfigSynchronizationState,
+        /// Number of complete synchronization passes retried after a fresh
+        /// final observation still reported a mismatch.
+        #[serde(default)]
+        synchronization_retry_count: u32,
+    },
 
     /// Host is executing an operator-requested maintenance operation.
     Maintenance {
@@ -2063,6 +2151,15 @@ pub enum InstanceState {
     WaitingForExtensionServicesConfig,
     WaitingForRebootToReady,
     Ready,
+    /// An operator authorized the selected boot interface to be applied to this
+    /// assigned host.
+    BootConfigSynchronization {
+        synchronization_state: BootConfigSynchronizationState,
+        /// Number of complete synchronization passes retried after a fresh
+        /// final observation still reported a mismatch.
+        #[serde(default)]
+        synchronization_retry_count: u32,
+    },
     HostPlatformConfiguration {
         platform_config_state: HostPlatformConfigurationState,
     },
@@ -2132,6 +2229,144 @@ pub enum UnlockHostState {
     DisableLockdown,
     RebootHost,
     WaitForUefiBoot,
+}
+
+/// A durable authorization to apply the selected boot interface to an assigned
+/// host.
+///
+/// The selection version prevents an older request for interface A from being
+/// reused after a later A-to-B-to-A selection sequence.
+///
+/// `api-db` queries the serialized `interface_id` and `selection_version`
+/// fields directly; their JSON names are part of the database contract.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct BootConfigSynchronizationRequest {
+    pub interface_id: MachineInterfaceId,
+    pub selection_version: ConfigVersion,
+    pub requested_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initiator: Option<String>,
+}
+
+/// The exact selected interface and generation being synchronized.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct BootConfigSynchronizationTarget {
+    /// `None` is valid before a predicted boot interface has taken its first
+    /// lease and become a machine-interface row.
+    pub machine_interface_id: Option<MachineInterfaceId>,
+    pub boot_interface: MachineBootInterfaceTarget,
+    pub selection_version: ConfigVersion,
+}
+
+/// What to do after restoring BMC lockdown on an interrupted synchronization.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "completion", rename_all = "lowercase")]
+pub enum BootConfigSynchronizationCompletion {
+    /// The selected row gained or refreshed its Redfish interface identity.
+    Retarget {
+        target: BootConfigSynchronizationTarget,
+    },
+    /// Resume synchronization after a safety cleanup interrupted Redfish work.
+    ResumeSynchronization {
+        target: Option<BootConfigSynchronizationTarget>,
+    },
+    /// The selected interface changed while Redfish work was in progress.
+    TargetChanged,
+    /// An assigned instance needs to resume higher-priority Ready-state work.
+    /// The pinned target identifies the authorization that should survive a
+    /// temporary interruption.
+    ReturnToReady {
+        target: BootConfigSynchronizationTarget,
+    },
+    /// An unassigned maintenance request takes precedence over synchronization.
+    Maintenance {
+        operation: MachineMaintenanceOperation,
+    },
+    /// A machine or DPU failure detected outside the synchronization driver.
+    MachineFailed {
+        machine_id: MachineId,
+        details: FailureDetails,
+    },
+    /// A terminal host-configuration failure must be recorded after lockdown
+    /// is restored.
+    Failed { error: String },
+    /// A terminal stage error must be surfaced only after lockdown is restored.
+    ManualInterventionRequired { error: String },
+}
+
+/// Restart-safe progress for synchronizing a selected boot interface.
+///
+/// Both unassigned and assigned parent states use this state. The parent
+/// decides whether synchronization is automatic or requires an exact durable
+/// authorization, while these phases keep the Redfish sequence identical.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum BootConfigSynchronizationState {
+    Initialize {
+        /// Assigned synchronization pins the exact target that was authorized.
+        /// Unassigned lifecycle gates leave this empty and resolve the current
+        /// target when the state first runs.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target: Option<BootConfigSynchronizationTarget>,
+    },
+    WaitingForInitialObservation {
+        target: BootConfigSynchronizationTarget,
+        minimum_report_version: ConfigVersion,
+    },
+    PrepareHost {
+        target: BootConfigSynchronizationTarget,
+    },
+    UnlockHost {
+        target: BootConfigSynchronizationTarget,
+        #[serde(default)]
+        unlock_host_state: UnlockHostState,
+    },
+    CheckHostConfig {
+        target: BootConfigSynchronizationTarget,
+    },
+    ConfigureBios {
+        target: BootConfigSynchronizationTarget,
+        #[serde(default)]
+        retry_count: u32,
+    },
+    WaitingForBiosJob {
+        target: BootConfigSynchronizationTarget,
+        bios_config_info: BiosConfigInfo,
+    },
+    PollingBiosSetup {
+        target: BootConfigSynchronizationTarget,
+        #[serde(default)]
+        retry_count: u32,
+    },
+    SetBootOrder {
+        target: BootConfigSynchronizationTarget,
+        set_boot_order_info: SetBootOrderInfo,
+    },
+    /// Restores lockdown before leaving work that may have disabled it.
+    RestoreLockdown {
+        completion: BootConfigSynchronizationCompletion,
+    },
+    LockHost {
+        target: BootConfigSynchronizationTarget,
+    },
+    WaitingForFinalObservation {
+        target: BootConfigSynchronizationTarget,
+        minimum_report_version: ConfigVersion,
+    },
+}
+
+impl BootConfigSynchronizationState {
+    /// Whether this phase may already have changed host Redfish or power.
+    ///
+    /// Before this boundary an assigned authorization can be withdrawn without
+    /// racing an external effect. Once preparation starts, the controller must
+    /// finish its cleanup path before accepting a non-disruptive cancellation.
+    pub fn host_changes_started(&self) -> bool {
+        !matches!(
+            self,
+            Self::Initialize { .. } | Self::WaitingForInitialObservation { .. }
+        )
+    }
 }
 
 /// Struct to store information if Reprovision is requested.
@@ -2206,9 +2441,35 @@ impl Display for MachineState {
     }
 }
 
+impl Display for BootConfigSynchronizationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let phase = match self {
+            Self::Initialize { .. } => "Initialize",
+            Self::WaitingForInitialObservation { .. } => "WaitingForInitialObservation",
+            Self::PrepareHost { .. } => "PrepareHost",
+            Self::UnlockHost { .. } => "UnlockHost",
+            Self::CheckHostConfig { .. } => "CheckHostConfig",
+            Self::ConfigureBios { .. } => "ConfigureBios",
+            Self::WaitingForBiosJob { .. } => "WaitingForBiosJob",
+            Self::PollingBiosSetup { .. } => "PollingBiosSetup",
+            Self::SetBootOrder { .. } => "SetBootOrder",
+            Self::RestoreLockdown { .. } => "RestoreLockdown",
+            Self::LockHost { .. } => "LockHost",
+            Self::WaitingForFinalObservation { .. } => "WaitingForFinalObservation",
+        };
+        f.write_str(phase)
+    }
+}
+
 impl Display for InstanceState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self, f)
+        match self {
+            Self::BootConfigSynchronization {
+                synchronization_state,
+                ..
+            } => write!(f, "BootConfigSynchronization/{synchronization_state}"),
+            _ => std::fmt::Debug::fmt(self, f),
+        }
     }
 }
 
@@ -2345,6 +2606,10 @@ impl Display for ManagedHostState {
                 write!(f, "HostInitializing/{machine_state}")
             }
             ManagedHostState::Ready => write!(f, "Ready"),
+            ManagedHostState::BootConfigSynchronization {
+                synchronization_state,
+                ..
+            } => write!(f, "BootConfigSynchronization/{synchronization_state}"),
             ManagedHostState::Maintenance { operation } => {
                 write!(f, "Maintenance({operation:?})")
             }
@@ -2440,6 +2705,10 @@ impl ManagedHostState {
                 format!("HostInitializing/{machine_state}")
             }
             ManagedHostState::Ready => "Ready".to_string(),
+            ManagedHostState::BootConfigSynchronization {
+                synchronization_state,
+                ..
+            } => format!("BootConfigSynchronization/{synchronization_state}"),
             ManagedHostState::Maintenance { operation } => {
                 format!("Maintenance({operation:?})")
             }
@@ -2536,6 +2805,13 @@ pub struct MachineInterfaceSnapshot {
 }
 
 impl MachineInterfaceSnapshot {
+    /// Whether this interface belongs to a segment that can boot the host.
+    pub fn supports_host_boot(&self) -> bool {
+        self.network_segment_type
+            .as_ref()
+            .is_some_and(NetworkSegmentType::supports_host_boot)
+    }
+
     /// This row's [`MachineBootInterface`]: its MAC plus its captured Redfish
     /// interface id. `None` until site-explorer has recorded the id from an
     /// exploration report.
@@ -2642,11 +2918,17 @@ pub fn state_sla(
             _ => StateSla::with_sla(slas::HOST_INIT, time_in_state),
         },
         ManagedHostState::Ready => StateSla::no_sla(),
+        ManagedHostState::BootConfigSynchronization { .. } => {
+            StateSla::with_sla(slas::BOOT_CONFIG_SYNCHRONIZATION, time_in_state)
+        }
         ManagedHostState::Maintenance { .. } => {
             StateSla::with_sla(slas::MAINTENANCE, time_in_state)
         }
         ManagedHostState::Assigned { instance_state } => match instance_state {
             InstanceState::Ready => StateSla::no_sla(),
+            InstanceState::BootConfigSynchronization { .. } => {
+                StateSla::with_sla(slas::BOOT_CONFIG_SYNCHRONIZATION, time_in_state)
+            }
             InstanceState::BootingWithDiscoveryImage { retry } => {
                 if retry.count > 1 {
                     StateSla::with_sla(std::time::Duration::ZERO, time_in_state)
@@ -3523,6 +3805,60 @@ mod tests {
         );
     }
 
+    #[test]
+    fn boot_config_synchronization_display_uses_only_the_phase() {
+        let target = BootConfigSynchronizationTarget {
+            machine_interface_id: Some(MachineInterfaceId::from(uuid::Uuid::nil())),
+            boot_interface: MachineBootInterfaceTarget::from_parts(
+                Some(MacAddress::from_str("00:11:22:33:44:55").unwrap()),
+                Some("NIC.Integrated.1-1-1".to_string()),
+            )
+            .unwrap(),
+            selection_version: ConfigVersion::invalid(),
+        };
+        let synchronization_state = BootConfigSynchronizationState::PrepareHost { target };
+        assert_eq!(synchronization_state.to_string(), "PrepareHost");
+
+        let unassigned = ManagedHostState::BootConfigSynchronization {
+            synchronization_state: synchronization_state.clone(),
+            synchronization_retry_count: 2,
+        };
+        assert_eq!(
+            unassigned.to_string(),
+            "BootConfigSynchronization/PrepareHost",
+        );
+
+        let assigned = ManagedHostState::Assigned {
+            instance_state: InstanceState::BootConfigSynchronization {
+                synchronization_state,
+                synchronization_retry_count: 2,
+            },
+        };
+        assert_eq!(
+            assigned.to_string(),
+            "Assigned/BootConfigSynchronization/PrepareHost",
+        );
+    }
+
+    #[test]
+    fn boot_config_synchronization_request_preserves_database_json_keys() {
+        let request = BootConfigSynchronizationRequest {
+            interface_id: MachineInterfaceId::from(uuid::Uuid::nil()),
+            selection_version: ConfigVersion::invalid(),
+            requested_at: DateTime::default(),
+            initiator: None,
+        };
+        let serialized = serde_json::to_value(request).unwrap();
+        let object = serialized
+            .as_object()
+            .expect("boot-config synchronization request should serialize as a JSON object");
+
+        assert_eq!(object.len(), 3);
+        assert!(object.contains_key("interface_id"));
+        assert!(object.contains_key("selection_version"));
+        assert!(object.contains_key("requested_at"));
+    }
+
     // The remaining `ManagedHostState` JSON blobs each deserialize to a specific
     // variant; the parsed value (PartialEq) is the whole assertion.
     #[test]
@@ -3533,6 +3869,26 @@ mod tests {
 
         scenarios!(
             run = |s| serde_json::from_str::<ManagedHostState>(s).map_err(drop);
+            "unassigned boot-config synchronization, default retry count" {
+                r#"{"state":"bootconfigsynchronization","synchronization_state":{"state":"initialize","target":null}}"# => Yields(ManagedHostState::BootConfigSynchronization {
+                    synchronization_state: BootConfigSynchronizationState::Initialize {
+                        target: None,
+                    },
+                    synchronization_retry_count: 0,
+                }),
+            }
+
+            "assigned boot-config synchronization, default retry count" {
+                r#"{"state":"assigned","instance_state":{"state":"bootconfigsynchronization","synchronization_state":{"state":"initialize","target":null}}}"# => Yields(ManagedHostState::Assigned {
+                    instance_state: InstanceState::BootConfigSynchronization {
+                        synchronization_state: BootConfigSynchronizationState::Initialize {
+                            target: None,
+                        },
+                        synchronization_retry_count: 0,
+                    },
+                }),
+            }
+
             "assigned booting with discovery image, default retry" {
                 r#"{"state":"assigned","instance_state":{"state":"bootingwithdiscoveryimage"}}"# => Yields(ManagedHostState::Assigned {
                     instance_state: InstanceState::BootingWithDiscoveryImage {
@@ -4121,11 +4477,11 @@ mod tests {
     }
 
     // This is our zero DPU fallback case -- no interface is flagged primary,
-    // so pick the lowest-MAC non-underlay interface. Verifies (a) the underlay
+    // so pick the lowest-MAC host-boot interface. Verifies (a) the underlay
     // BMC interface is excluded, and (b) ordering is deterministic across
-    // multiple non-underlay candidates.
+    // multiple eligible candidates.
     #[test]
-    fn pick_boot_interface_mac_falls_back_to_lowest_non_underlay_mac_when_no_primary() {
+    fn pick_boot_interface_mac_falls_back_to_lowest_eligible_mac_when_no_primary() {
         let bmc_mac = "01:00:00:00:00:01"; // numerically lowest, but BMC!
         let onboard_mac_lo = "10:00:00:00:00:01";
         let onboard_mac_hi = "20:00:00:00:00:01";
@@ -4161,22 +4517,43 @@ mod tests {
         assert_eq!(
             pick_default_boot_interface(&interfaces).map(|i| i.mac_address),
             Some(lower_mac.parse().unwrap()),
-            "the default pick masks the primary flag and takes the lowest non-underlay MAC"
+            "the default pick masks the primary flag and takes the lowest eligible MAC"
         );
     }
 
-    // Underlay rows are never default-pick candidates, and an all-underlay set
-    // yields no default at all.
+    // Tenant, Underlay, and untyped rows are never host-boot candidates.
     #[test]
-    fn pick_default_boot_interface_excludes_underlay_rows() {
-        let underlay_mac = "01:00:00:00:00:01";
-        let interfaces = vec![build_mock_interface(
-            underlay_mac,
-            false,
+    fn pick_boot_interface_excludes_ineligible_segments() {
+        for segment_type in [
+            Some(NetworkSegmentType::Tenant),
             Some(NetworkSegmentType::Underlay),
-        )];
+            None,
+        ] {
+            let interfaces = vec![build_mock_interface(
+                "01:00:00:00:00:01",
+                true,
+                segment_type,
+            )];
 
-        assert!(pick_default_boot_interface(&interfaces).is_none());
+            assert!(pick_boot_interface(&interfaces).is_none());
+            assert!(pick_default_boot_interface(&interfaces).is_none());
+        }
+    }
+
+    // A stale or malformed primary flag cannot make a workload segment the
+    // desired Redfish target; selection falls back to an eligible host NIC.
+    #[test]
+    fn pick_boot_interface_ignores_an_ineligible_primary() {
+        let eligible_mac = "10:00:00:00:00:01";
+        let interfaces = vec![
+            build_mock_interface("01:00:00:00:00:01", true, Some(NetworkSegmentType::Tenant)),
+            build_mock_interface(eligible_mac, false, Some(NetworkSegmentType::HostInband)),
+        ];
+
+        assert_eq!(
+            pick_boot_interface(&interfaces).map(|interface| interface.mac_address),
+            Some(eligible_mac.parse().unwrap()),
+        );
     }
 
     // boot_interface() derives the full pair from the SAME primary row that the
@@ -4246,9 +4623,9 @@ mod tests {
         );
     }
 
-    // With no declared primary, a sole non-underlay prediction is unambiguous.
+    // With no declared primary, a sole eligible prediction is unambiguous.
     #[test]
-    fn pick_boot_prediction_returns_the_sole_non_underlay_prediction() {
+    fn pick_boot_prediction_returns_the_sole_eligible_prediction() {
         let predictions = vec![
             build_mock_prediction("01:00:00:00:00:01", false, NetworkSegmentType::Underlay),
             build_mock_prediction("10:00:00:00:00:01", false, NetworkSegmentType::HostInband),
@@ -4259,7 +4636,7 @@ mod tests {
         );
     }
 
-    // Several non-underlay predictions and none declared primary: the boot NIC
+    // Several eligible predictions and none declared primary: the boot NIC
     // is unknowable, so refuse to guess rather than program boot order against
     // whichever sorts first (the Gigawatt SuperNIC safety case).
     #[test]
@@ -4271,15 +4648,78 @@ mod tests {
         assert!(pick_boot_prediction(&predictions).is_none());
     }
 
-    // Underlay predictions are never a boot candidate on their own.
+    // Tenant and Underlay predictions are never boot candidates, even when
+    // declared primary.
     #[test]
-    fn pick_boot_prediction_ignores_underlay_only_predictions() {
-        let predictions = vec![build_mock_prediction(
-            "01:00:00:00:00:01",
-            false,
-            NetworkSegmentType::Underlay,
+    fn pick_boot_prediction_ignores_ineligible_predictions() {
+        for segment_type in [NetworkSegmentType::Tenant, NetworkSegmentType::Underlay] {
+            let predictions = vec![build_mock_prediction(
+                "01:00:00:00:00:01",
+                true,
+                segment_type,
+            )];
+            assert!(pick_boot_prediction(&predictions).is_none());
+        }
+    }
+
+    #[test]
+    fn primary_prediction_outranks_an_interim_owned_primary() {
+        let interfaces = vec![build_mock_interface(
+            "10:00:00:00:00:01",
+            true,
+            Some(NetworkSegmentType::Admin),
         )];
-        assert!(pick_boot_prediction(&predictions).is_none());
+        let predictions = vec![build_mock_prediction(
+            "20:00:00:00:00:01",
+            true,
+            NetworkSegmentType::HostInband,
+        )];
+
+        assert!(matches!(
+            pick_boot_interface_candidate(&interfaces, &predictions),
+            Some(BootInterfaceCandidate::Prediction(prediction))
+                if prediction.mac_address == "20:00:00:00:00:01".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn owned_interface_outranks_a_non_primary_prediction() {
+        let interfaces = vec![build_mock_interface(
+            "10:00:00:00:00:01",
+            false,
+            Some(NetworkSegmentType::HostInband),
+        )];
+        let predictions = vec![build_mock_prediction(
+            "20:00:00:00:00:01",
+            false,
+            NetworkSegmentType::HostInband,
+        )];
+
+        assert!(matches!(
+            pick_boot_interface_candidate(&interfaces, &predictions),
+            Some(BootInterfaceCandidate::Interface(interface))
+                if interface.mac_address == "10:00:00:00:00:01".parse().unwrap()
+        ));
+    }
+
+    #[test]
+    fn sole_prediction_answers_when_no_owned_interface_is_selectable() {
+        let interfaces = vec![build_mock_interface(
+            "10:00:00:00:00:01",
+            true,
+            Some(NetworkSegmentType::Underlay),
+        )];
+        let predictions = vec![build_mock_prediction(
+            "20:00:00:00:00:01",
+            false,
+            NetworkSegmentType::HostInband,
+        )];
+
+        assert!(matches!(
+            pick_boot_interface_candidate(&interfaces, &predictions),
+            Some(BootInterfaceCandidate::Prediction(prediction))
+                if prediction.mac_address == "20:00:00:00:00:01".parse().unwrap()
+        ));
     }
 
     // Check the case  where only the BMC has been discovered so far (which

--- a/crates/api-model/src/machine/slas.rs
+++ b/crates/api-model/src/machine/slas.rs
@@ -29,6 +29,8 @@ pub const DPUINIT_NOTINIT: Duration = Duration::from_secs(30 * 60);
 // EnableIpmiOverLan WaitingForPlatformConfiguration PollingBiosSetup UefiSetup Discovered Lockdown PollingLockdownStatus MachineValidating
 pub const HOST_INIT: Duration = Duration::from_secs(30 * 60);
 
+pub const BOOT_CONFIG_SYNCHRONIZATION: Duration = Duration::from_secs(90 * 60);
+
 pub const WAITING_FOR_CLEANUP: Duration = Duration::from_secs(30 * 60);
 
 pub const CREATED: Duration = Duration::from_secs(30 * 60);

--- a/crates/api-model/src/machine_boot_interface.rs
+++ b/crates/api-model/src/machine_boot_interface.rs
@@ -71,11 +71,11 @@ impl MachineBootInterface {
 ///
 /// Newer endpoint records retain the complete [`MachineBootInterface`] pair.
 /// Older records may only have the MAC, which remains a valid selector but
-/// must stay distinguishable from a pair. A backend may match with only the
-/// identifiers its read path supports -- NvRedfish currently uses the MAC --
-/// while this value keeps the `Pair` identity NICo requested. The state
-/// controller can therefore compare the logical target with its current target
-/// before trusting the associated setup status.
+/// must stay distinguishable from a pair. Site Explorer passes this target to
+/// the same LibRedfish vendor implementation used to apply boot configuration,
+/// then records the exact value it evaluated. The state controller compares
+/// that value with the current desired target before trusting the associated
+/// setup status.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub enum MachineBootInterfaceTarget {

--- a/crates/api-model/src/network_segment/mod.rs
+++ b/crates/api-model/src/network_segment/mod.rs
@@ -267,6 +267,15 @@ impl NetworkSegmentType {
             NetworkSegmentType::Tenant | NetworkSegmentType::HostInband
         )
     }
+
+    /// Whether a host interface on this segment can be selected for boot.
+    ///
+    /// Host operating-system boot uses either the DPU-served Admin overlay or
+    /// a plain NIC on HostInband. Underlay is reserved for infrastructure
+    /// endpoints, and Tenant segments serve assigned workload traffic.
+    pub fn supports_host_boot(&self) -> bool {
+        matches!(self, Self::Admin | Self::HostInband)
+    }
 }
 
 /// Controls how IP addresses are assigned via DHCP on a network segment,
@@ -478,6 +487,27 @@ mod tests {
         NetworkSegmentControllerState::Deleting {
             deletion_state: NetworkSegmentDeletionState::DrainAllocatedIps { delete_at },
         }
+    }
+
+    #[test]
+    fn only_host_management_segments_support_host_boot() {
+        value_scenarios!(run = |segment: NetworkSegmentType| segment.supports_host_boot();
+            "Admin" {
+                NetworkSegmentType::Admin => true,
+            }
+
+            "HostInband" {
+                NetworkSegmentType::HostInband => true,
+            }
+
+            "Underlay" {
+                NetworkSegmentType::Underlay => false,
+            }
+
+            "Tenant" {
+                NetworkSegmentType::Tenant => false,
+            }
+        );
     }
 
     fn dbdelete_state() -> NetworkSegmentControllerState {

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1673,6 +1673,13 @@ pub struct Inventory {
     pub release_date: Option<String>,
 }
 
+/// Current semantics for newly produced machine-setup observations.
+pub const MACHINE_SETUP_VERIFICATION_VERSION: u32 = 1;
+
+fn is_zero(value: &u32) -> bool {
+    *value == 0
+}
+
 /// The result of one Redfish machine-setup check.
 ///
 /// `is_done` and `diffs` mirror the vendor result. The evaluated boot interface
@@ -1684,11 +1691,16 @@ pub struct Inventory {
 pub struct MachineSetupStatus {
     pub is_done: bool,
     pub diffs: Vec<MachineSetupDiff>,
+    /// Version of the verification semantics that produced this status.
+    ///
+    /// Reports written before the pair-aware LibRedfish verifier omit this
+    /// field and deserialize as zero, so they cannot satisfy synchronization
+    /// after an upgrade.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub verification_version: u32,
     /// The logical boot-interface target NICo asked the backend to assess.
     ///
-    /// This does not claim that the backend used every identifier in the
-    /// target: a backend may match with a subset (NvRedfish currently uses the
-    /// MAC) while retaining the requested `Pair` identity. This lives inside
+    /// The pair-aware verifier receives this exact target. This lives inside
     /// `MachineSetupStatus` so the report's versioned JSON stores the
     /// observation and its target together. Reports written before target
     /// capture leave it as `None`, which tells a later controller not to treat
@@ -2681,6 +2693,7 @@ mod tests {
                 MachineSetupStatus {
                     is_done: true,
                     diffs: Vec::new(),
+                    verification_version: 0,
                     evaluated_boot_interface: None,
                 } => (
                     serde_json::json!({
@@ -2690,6 +2703,7 @@ mod tests {
                     MachineSetupStatus {
                         is_done: true,
                         diffs: Vec::new(),
+                        verification_version: 0,
                         evaluated_boot_interface: None,
                     },
                 ),
@@ -2699,6 +2713,7 @@ mod tests {
                 MachineSetupStatus {
                     is_done: false,
                     diffs: Vec::new(),
+                    verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                     evaluated_boot_interface: Some(MachineBootInterfaceTarget::Pair(
                         MachineBootInterface {
                             mac_address: mac,
@@ -2709,6 +2724,7 @@ mod tests {
                     serde_json::json!({
                         "IsDone": false,
                         "Diffs": [],
+                        "VerificationVersion": MACHINE_SETUP_VERIFICATION_VERSION,
                         "EvaluatedBootInterface": {
                             "Pair": {
                                 "MacAddress": "02:00:00:00:00:01",
@@ -2719,6 +2735,7 @@ mod tests {
                     MachineSetupStatus {
                         is_done: false,
                         diffs: Vec::new(),
+                        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                         evaluated_boot_interface: Some(MachineBootInterfaceTarget::Pair(
                             MachineBootInterface {
                                 mac_address: mac,
@@ -2733,11 +2750,13 @@ mod tests {
                 MachineSetupStatus {
                     is_done: true,
                     diffs: Vec::new(),
+                    verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                     evaluated_boot_interface: Some(MachineBootInterfaceTarget::MacOnly(mac)),
                 } => (
                     serde_json::json!({
                         "IsDone": true,
                         "Diffs": [],
+                        "VerificationVersion": MACHINE_SETUP_VERIFICATION_VERSION,
                         "EvaluatedBootInterface": {
                             "MacOnly": "02:00:00:00:00:01",
                         },
@@ -2745,6 +2764,7 @@ mod tests {
                     MachineSetupStatus {
                         is_done: true,
                         diffs: Vec::new(),
+                        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                         evaluated_boot_interface: Some(MachineBootInterfaceTarget::MacOnly(mac)),
                     },
                 ),
@@ -2754,6 +2774,7 @@ mod tests {
         let legacy: MachineSetupStatus = serde_json::from_str(r#"{"IsDone":true,"Diffs":[]}"#)
             .expect("reports written before target capture still deserialize");
         assert_eq!(legacy.evaluated_boot_interface, None);
+        assert_eq!(legacy.verification_version, 0);
     }
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/api-model/src/test_support/machine_snapshot.rs
+++ b/crates/api-model/src/test_support/machine_snapshot.rs
@@ -281,6 +281,7 @@ fn host_interfaces(machine_id: MachineId) -> Vec<MachineInterfaceSnapshot> {
             };
             let segment_type = match i {
                 0 => None,
+                1 | 2 => Some(NetworkSegmentType::Admin),
                 3 | 4 => Some(NetworkSegmentType::HostInband),
                 _ => Some(NetworkSegmentType::Tenant),
             };
@@ -362,6 +363,8 @@ pub fn machine_snapshot_pg_json(machine_id: MachineId) -> MachineSnapshotPgJson 
 
     MachineSnapshotPgJson {
         machine_maintenance_requested: None,
+        boot_interface_selection_version: config_version(1).version_string(),
+        boot_config_synchronization_requested: None,
         id: machine_id,
         rack_id: Some("rack-bench-01".parse().expect("valid rack id")),
         created: fixture_time(0),

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -73,18 +73,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         system: ComputerSystem<B>,
         config: &Config<'_, B>,
     ) -> Result<Self, Error<B>> {
-        let boot_options = if let Some(collection) = system
-            .boot_options()
-            .await
-            .map_err(Error::nv_redfish("boot options"))?
-        {
-            collection
-                .members()
-                .await
-                .map_err(Error::nv_redfish("boot options members"))?
-        } else {
-            vec![]
-        };
+        let boot_options = Self::fetch_boot_options(&system, config).await?;
 
         let bios = Self::fetch_bios(&system, config).await?;
 
@@ -114,6 +103,38 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             oem_nvidia_bluefield,
             secure_boot,
         })
+    }
+
+    async fn fetch_boot_options(
+        system: &ComputerSystem<B>,
+        config: &Config<'_, B>,
+    ) -> Result<Vec<BootOption<B>>, Error<B>> {
+        let collection = match system.boot_options().await {
+            Ok(collection) => collection,
+            Err(error) if unsupported_standard_boot_options(&error, config) => {
+                tracing::warn!(
+                    "BMC rejected the standard BootOptions resource; continuing inventory \
+                     without standard boot options"
+                );
+                return Ok(Vec::new());
+            }
+            Err(error) => return Err(Error::nv_redfish("boot options")(error)),
+        };
+        let Some(collection) = collection else {
+            return Ok(Vec::new());
+        };
+
+        match collection.members().await {
+            Ok(options) => Ok(options),
+            Err(error) if unsupported_standard_boot_options(&error, config) => {
+                tracing::warn!(
+                    "BMC rejected the standard BootOptions collection; continuing inventory \
+                     without standard boot options"
+                );
+                Ok(Vec::new())
+            }
+            Err(error) => Err(Error::nv_redfish("boot options members")(error)),
+        }
     }
 
     async fn fetch_bios(
@@ -589,6 +610,18 @@ fn is_uefi_tree_child(
     }
 }
 
+fn unsupported_standard_boot_options<B: Bmc>(
+    error: &nv_redfish::Error<B>,
+    config: &Config<'_, B>,
+) -> bool {
+    matches!(
+        error,
+        nv_redfish::Error::Bmc(error)
+            if (config.explore.error_classifier)(error)
+                == Some(ErrorClass::BootOrderPropertyUnknown)
+    )
+}
+
 fn pcie_device_to_model<B: Bmc>(
     hw_type: Option<hw::HwType>,
     dev: &PcieDevice<B>,
@@ -656,4 +689,106 @@ fn pcie_device_to_model<B: Bmc>(
                 .unwrap_or("".into()),
         }),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axum::http::StatusCode;
+    use axum::routing::get;
+    use axum::{Json, Router};
+    use bmc_mock::test_support::axum_http_client::{AxumRouterHttpClient, Error as TestBmcError};
+    use bmc_mock::test_support::{NoopCallbacks, TEST_MAC_POOL};
+    use bmc_mock::{HostHardwareType, HostMachineInfo, MachineInfo, machine_router};
+    use nv_redfish::ServiceRoot;
+    use nv_redfish::bmc_http::{BmcCredentials, CacheSettings, HttpBmc};
+    use serde_json::json;
+
+    use super::*;
+
+    fn error_classifier(error: &TestBmcError) -> Option<ErrorClass> {
+        match error {
+            TestBmcError::InvalidResponse { status, text, .. }
+                if *status == StatusCode::BAD_REQUEST
+                    && text.contains("PropertyUnknown")
+                    && text.contains("BootOrder") =>
+            {
+                Some(ErrorClass::BootOrderPropertyUnknown)
+            }
+            _ => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn explore_continues_when_boot_options_rejects_boot_order() {
+        let machine_info = {
+            let mut pool = TEST_MAC_POOL.lock().unwrap();
+            let hardware_macs = pool.allocate_range_config().unwrap();
+            MachineInfo::Host(HostMachineInfo::new(
+                HostHardwareType::GenericAmi,
+                Vec::new(),
+                &mut pool,
+                hardware_macs,
+            ))
+        };
+        let (router, _) = machine_router(
+            &machine_info,
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+        );
+        let router = Router::new()
+            .route(
+                "/redfish/v1/Systems/Self/BootOptions",
+                get(|| async {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({
+                            "error": {
+                                "code": "Base.1.0.PropertyUnknown",
+                                "message": "The property BootOrder is unknown"
+                            }
+                        })),
+                    )
+                }),
+            )
+            .fallback_service(router);
+        let bmc = Arc::new(HttpBmc::new(
+            AxumRouterHttpClient::new(router),
+            "https://bmc-mock.local".parse().unwrap(),
+            BmcCredentials::new("root".to_string(), "password".to_string()),
+            CacheSettings::with_capacity(32),
+        ));
+        let root = ServiceRoot::new(bmc).await.unwrap();
+        let system = root
+            .systems()
+            .await
+            .unwrap()
+            .unwrap()
+            .members()
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let explore_config = ExploreConfig {
+            boot_interface_mac: None,
+            error_classifier: &error_classifier,
+            retry_timeout: Duration::ZERO,
+        };
+        let config = Config {
+            need_oem_nvidia_bluefield: false,
+            ignore_500_on_bios_fetch: false,
+            retry_404_on_eth_interfaces: false,
+            explore: &explore_config,
+        };
+
+        let explored = ExploredComputerSystem::explore(system, &config)
+            .await
+            .unwrap();
+
+        assert!(explored.boot_options.is_empty());
+    }
 }

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -55,10 +55,13 @@ pub use nv_redfish::service_root::Product;
 use nv_redfish::service_root::Vendor;
 use nv_redfish::{Bmc, Resource, ServiceRoot};
 
-#[derive(PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ErrorClass {
     NotFound,
     InternalServerError,
+    /// The BMC rejects the standard BootOptions resource because its active
+    /// boot order lives behind an OEM resource.
+    BootOrderPropertyUnknown,
 }
 
 pub type ErrorClassifier<'a, B> = &'a (dyn Fn(&<B as Bmc>::Error) -> Option<ErrorClass> + Sync);
@@ -275,6 +278,7 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
                 expected: "can detect".into(),
                 actual: "cannot detect".into(),
             }],
+            verification_version: 0,
             evaluated_boot_interface: None,
         });
 
@@ -352,6 +356,7 @@ async fn build_delta_powershelf_report<B: Bmc>(
         machine_setup_status: Some(MachineSetupStatus {
             is_done: true,
             diffs: vec![],
+            verification_version: 0,
             evaluated_boot_interface: None,
         }),
         secure_boot_status: None,
@@ -1093,6 +1098,7 @@ fn machine_setup_status<B: Bmc>(
     MachineSetupStatus {
         is_done: diffs.is_empty(),
         diffs,
+        verification_version: 0,
         evaluated_boot_interface: None,
     }
 }

--- a/crates/bmc-explorer/src/test_support.rs
+++ b/crates/bmc-explorer/src/test_support.rs
@@ -158,9 +158,12 @@ fn explorer_config() -> Config<'static, TestBmc> {
 
 fn error_classifier(err: &TestBmcError) -> Option<ErrorClass> {
     match err {
-        TestBmcError::InvalidResponse { status, .. } => match status.as_u16() {
+        TestBmcError::InvalidResponse { status, text, .. } => match status.as_u16() {
             404 => Some(ErrorClass::NotFound),
             500 => Some(ErrorClass::InternalServerError),
+            400 if text.contains("PropertyUnknown") && text.contains("BootOrder") => {
+                Some(ErrorClass::BootOrderPropertyUnknown)
+            }
             _ => None,
         },
         _ => None,

--- a/crates/bmc-explorer/tests/integration/common.rs
+++ b/crates/bmc-explorer/tests/integration/common.rs
@@ -26,9 +26,14 @@ use bmc_mock::test_support::axum_http_client::Error as TestBmcError;
 
 pub fn error_classifier(err: &<TestBmc as nv_redfish::Bmc>::Error) -> Option<ErrorClass> {
     match err {
-        TestBmcError::InvalidResponse { status, .. } => match *status {
+        TestBmcError::InvalidResponse { status, text, .. } => match *status {
             StatusCode::NOT_FOUND => Some(ErrorClass::NotFound),
             StatusCode::INTERNAL_SERVER_ERROR => Some(ErrorClass::InternalServerError),
+            StatusCode::BAD_REQUEST
+                if text.contains("PropertyUnknown") && text.contains("BootOrder") =>
+            {
+                Some(ErrorClass::BootOrderPropertyUnknown)
+            }
             _ => None,
         },
         _ => None,

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -16,6 +16,7 @@
  */
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -59,6 +60,14 @@ pub fn reset_target(system_id: &str) -> String {
     )
 }
 
+fn hpe_boot_resource(system_id: &str) -> String {
+    format!("{}/Bios/oem/hpe/boot", resource(system_id).odata_id)
+}
+
+fn hpe_boot_settings_target(system_id: &str) -> String {
+    format!("{}/settings", hpe_boot_resource(system_id))
+}
+
 pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> Router<BmcState> {
     const SYSTEM_ID: &str = "{system_id}";
     const ETH_ID: &str = "{eth_id}";
@@ -66,7 +75,8 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
     const LOG_SERVICE_ID: &str = "{log_service_id}";
     const PROCESSOR_ID: &str = "{processor_id}";
     let bios = redfish::bios::resource(SYSTEM_ID);
-    r.route(&collection().odata_id, get(get_system_collection))
+    let routes = r
+        .route(&collection().odata_id, get(get_system_collection))
         .route(
             &resource(SYSTEM_ID).odata_id,
             get(get_system).patch(patch_system),
@@ -132,7 +142,22 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
         .route(
             &redfish::bios::change_password_target(&bios),
             post(change_bios_password_action),
-        )
+        );
+
+    match bmc_vendor {
+        redfish::oem::BmcVendor::Ami => routes.route(
+            &bmc_vendor
+                .make_settings_odata_id(&redfish::boot_option::resource(SYSTEM_ID, BOOT_OPTION_ID)),
+            patch(patch_boot_option_settings),
+        ),
+        redfish::oem::BmcVendor::Hpe => routes
+            .route(&hpe_boot_resource(SYSTEM_ID), get(get_hpe_boot))
+            .route(
+                &hpe_boot_settings_target(SYSTEM_ID),
+                patch(patch_hpe_boot_settings),
+            ),
+        _ => routes,
+    }
 }
 
 pub struct SingleSystemConfig {
@@ -173,7 +198,9 @@ pub struct BootSourceOverride {
 pub struct SingleSystemState {
     config: SingleSystemConfig,
     boot_order_override: Mutex<Option<Vec<String>>>,
+    boot_option_enabled_overrides: Mutex<HashMap<String, bool>>,
     boot_source_override: Mutex<BootSourceOverride>,
+    hpe_boot_order_override: Mutex<Option<Vec<String>>>,
     secure_boot_enabled: Arc<AtomicBool>,
     bios_overrides: Arc<Mutex<serde_json::Value>>,
 }
@@ -233,7 +260,9 @@ impl SingleSystemState {
         Self {
             config,
             boot_order_override: Mutex::new(None),
+            boot_option_enabled_overrides: Mutex::new(HashMap::new()),
             boot_source_override: Mutex::new(BootSourceOverride::default()),
+            hpe_boot_order_override: Mutex::new(None),
             secure_boot_enabled: Arc::new(AtomicBool::new(false)),
             bios_overrides: Arc::new(Mutex::new(serde_json::json!({}))),
         }
@@ -262,12 +291,75 @@ impl SingleSystemState {
             .find(|v| v.id == option_id)
     }
 
+    fn boot_option_json(&self, option_id: &str) -> Option<serde_json::Value> {
+        let boot_option = self.find_boot_option(option_id)?;
+        let mut value = boot_option.to_json();
+        if let Some(enabled) = self
+            .boot_option_enabled_overrides
+            .lock()
+            .unwrap()
+            .get(option_id)
+        {
+            value = value.patch(json!({ "BootOptionEnabled": enabled }));
+        }
+        Some(value)
+    }
+
+    fn set_boot_option_enabled(&self, option_id: &str, enabled: bool) -> bool {
+        if self.find_boot_option(option_id).is_none() {
+            return false;
+        }
+        self.boot_option_enabled_overrides
+            .lock()
+            .unwrap()
+            .insert(option_id.to_string(), enabled);
+        true
+    }
+
     fn set_boot_order_override(&self, boot_order: Vec<String>) {
         *self.boot_order_override.lock().unwrap() = Some(boot_order);
     }
 
     fn boot_order_override(&self) -> Option<Vec<String>> {
         self.boot_order_override.lock().unwrap().clone()
+    }
+
+    fn hpe_default_boot_order(&self) -> Option<Vec<String>> {
+        self.config
+            .boot_options
+            .as_ref()
+            .map(|_| vec!["PcieSlotNic".to_string(), "EmbeddedStorage".to_string()])
+    }
+
+    fn initial_hpe_persistent_boot_order(&self) -> Option<Vec<String>> {
+        self.config.boot_options.as_ref().map(|options| {
+            options
+                .iter()
+                .enumerate()
+                .map(|(index, option)| match option.kind {
+                    BootOptionKind::Network => {
+                        format!("NIC.Slot.{}.1.Httpv4", index + 1)
+                    }
+                    BootOptionKind::Disk => format!("HD.Slot.{}.1", index + 1),
+                })
+                .collect()
+        })
+    }
+
+    fn hpe_boot_order(&self) -> Option<Vec<String>> {
+        self.hpe_boot_order_override
+            .lock()
+            .unwrap()
+            .clone()
+            .or_else(|| self.initial_hpe_persistent_boot_order())
+    }
+
+    fn set_hpe_boot_order(&self, boot_order: Vec<String>) -> bool {
+        if self.config.boot_options.is_none() {
+            return false;
+        }
+        *self.hpe_boot_order_override.lock().unwrap() = Some(boot_order);
+        true
     }
 
     fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
@@ -668,9 +760,79 @@ async fn get_boot_option(
     state
         .system_state
         .find(&system_id)
-        .and_then(|system_state| system_state.find_boot_option(&boot_option_id))
-        .map(|boot_option| boot_option.to_json().into_ok_response())
+        .and_then(|system_state| system_state.boot_option_json(&boot_option_id))
+        .map(JsonExt::into_ok_response)
         .unwrap_or_else(http::not_found)
+}
+
+async fn patch_boot_option_settings(
+    State(state): State<BmcState>,
+    Path((system_id, boot_option_id)): Path<(String, String)>,
+    Json(settings): Json<serde_json::Value>,
+) -> Response {
+    let Some(enabled) = settings
+        .get("BootOptionEnabled")
+        .and_then(serde_json::Value::as_bool)
+    else {
+        return http::bad_request("BootOptionEnabled must be a boolean");
+    };
+    let Some(system_state) = state.system_state.find(&system_id) else {
+        return http::not_found();
+    };
+    if !system_state.set_boot_option_enabled(&boot_option_id, enabled) {
+        return http::not_found();
+    }
+    http::ok_no_content()
+}
+
+async fn get_hpe_boot(State(state): State<BmcState>, Path(system_id): Path<String>) -> Response {
+    let Some(system_state) = state.system_state.find(&system_id) else {
+        return http::not_found();
+    };
+    let Some(default_boot_order) = system_state.hpe_default_boot_order() else {
+        return http::not_found();
+    };
+    let Some(persistent_boot_order) = system_state.hpe_boot_order() else {
+        return http::not_found();
+    };
+    json!({
+        "@odata.context": "/redfish/v1/$metadata#HpeServerBootSettings.HpeServerBootSettings",
+        "@odata.id": hpe_boot_resource(&system_id),
+        "@odata.type": "#HpeServerBootSettings.v2_0_0.HpeServerBootSettings",
+        "Id": "boot",
+        "Name": "Boot Order Current Settings",
+        "BootSources": [],
+        "DefaultBootOrder": default_boot_order,
+        "PersistentBootConfigOrder": persistent_boot_order,
+    })
+    .into_ok_response()
+}
+
+async fn patch_hpe_boot_settings(
+    State(state): State<BmcState>,
+    Path(system_id): Path<String>,
+    Json(settings): Json<serde_json::Value>,
+) -> Response {
+    let Some(order) = settings
+        .get("PersistentBootConfigOrder")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|order| {
+            order
+                .iter()
+                .map(serde_json::Value::as_str)
+                .map(|entry| entry.map(ToString::to_string))
+                .collect::<Option<Vec<_>>>()
+        })
+    else {
+        return http::bad_request("PersistentBootConfigOrder must be an array of strings");
+    };
+    let Some(system_state) = state.system_state.find(&system_id) else {
+        return http::not_found();
+    };
+    if !system_state.set_hpe_boot_order(order) {
+        return http::not_found();
+    }
+    json!({}).into_ok_response()
 }
 
 async fn get_log_services_collection(

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -309,8 +309,11 @@ mod test {
 
     use axum::Router;
     use axum::body::Body;
-    use axum::http::{Request, StatusCode};
+    use axum::http::header::CONTENT_TYPE;
+    use axum::http::{Method, Request, StatusCode};
+    use http_body_util::BodyExt;
     use nv_redfish::bmc_http::{BmcCredentials, HttpClient};
+    use serde_json::json;
     use tower::ServiceExt;
     use url::Url;
 
@@ -318,6 +321,34 @@ mod test {
     use crate::injection::{Action, InjectionStore, Rule, RuleId, Selector};
     use crate::test_support::axum_http_client::Error;
     use crate::test_support::host_info;
+
+    async fn json_request(
+        router: &Router,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> (StatusCode, serde_json::Value) {
+        let mut request = Request::builder().method(method).uri(path);
+        let body = if let Some(body) = body {
+            request = request.header(CONTENT_TYPE, "application/json");
+            Body::from(serde_json::to_vec(&body).unwrap())
+        } else {
+            Body::empty()
+        };
+        let response = router
+            .clone()
+            .oneshot(request.body(body).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body = if bytes.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap()
+        };
+        (status, body)
+    }
 
     #[tokio::test]
     async fn caller_provided_injection_store_is_active() {
@@ -407,5 +438,93 @@ mod test {
             }
             other => panic!("expected invalid response error, got: {other}"),
         }
+    }
+
+    #[tokio::test]
+    async fn ami_boot_option_settings_persist_enablement() {
+        let router = machine_router(
+            &host_info(HostHardwareType::LenovoGB300Nvl),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+        )
+        .0;
+        let resource = "/redfish/v1/Systems/System_0/BootOptions/0004";
+
+        let (status, initial) = json_request(&router, Method::GET, resource, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(initial.get("BootOptionEnabled"), None);
+
+        for enabled in [true, false] {
+            let (status, _) = json_request(
+                &router,
+                Method::PATCH,
+                &format!("{resource}/SD"),
+                Some(json!({ "BootOptionEnabled": enabled })),
+            )
+            .await;
+            assert_eq!(status, StatusCode::NO_CONTENT);
+
+            let (status, current) = json_request(&router, Method::GET, resource, None).await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(
+                current.get("BootOptionEnabled").and_then(|v| v.as_bool()),
+                Some(enabled)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn hpe_boot_settings_persist_oem_order_separately() {
+        let router = machine_router(
+            &host_info(HostHardwareType::HpeProliantDl380aGen11),
+            Arc::new(NoopCallbacks),
+            "test-host-id".to_string(),
+            false,
+        )
+        .0;
+        let system_resource = "/redfish/v1/Systems/1";
+        let boot_resource = "/redfish/v1/Systems/1/Bios/oem/hpe/boot";
+
+        let (status, system) = json_request(&router, Method::GET, system_resource, None).await;
+        assert_eq!(status, StatusCode::OK);
+        let standard_order = system["Boot"]["BootOrder"].clone();
+
+        let (status, initial) = json_request(&router, Method::GET, boot_resource, None).await;
+        assert_eq!(status, StatusCode::OK);
+        let initial_order = initial["PersistentBootConfigOrder"]
+            .as_array()
+            .expect("HPE persistent boot order must be an array");
+        assert!(initial_order.iter().any(|entry| {
+            entry
+                .as_str()
+                .is_some_and(|entry| entry.starts_with("NIC."))
+        }));
+        assert!(
+            initial_order
+                .iter()
+                .any(|entry| { entry.as_str().is_some_and(|entry| entry.starts_with("HD.")) })
+        );
+
+        let new_order = json!(["HD.Slot.1.1", "NIC.Slot.1.1.Httpv4"]);
+        let (status, _) = json_request(
+            &router,
+            Method::PATCH,
+            &format!("{boot_resource}/settings"),
+            Some(json!({ "PersistentBootConfigOrder": new_order })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, current) = json_request(&router, Method::GET, boot_resource, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            current["PersistentBootConfigOrder"],
+            json!(["HD.Slot.1.1", "NIC.Slot.1.1.Httpv4"])
+        );
+
+        let (status, system) = json_request(&router, Method::GET, system_resource, None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(system["Boot"]["BootOrder"], standard_order);
     }
 }

--- a/crates/machine-controller/src/boot_interface.rs
+++ b/crates/machine-controller/src/boot_interface.rs
@@ -17,63 +17,68 @@
 //! Resolving how to target a host's boot interface for Redfish setup calls.
 
 use carbide_redfish::boot_interface::BootInterfaceTarget;
-use mac_address::MacAddress;
-use model::machine::{ManagedHostStateSnapshot, pick_boot_prediction};
-use model::machine_boot_interface::MachineBootInterface;
+use carbide_uuid::machine::MachineInterfaceId;
+use model::machine::{
+    BootInterfaceCandidate, MachineInterfaceSnapshot, ManagedHostStateSnapshot,
+    pick_boot_interface_candidate,
+};
 use model::predicted_machine_interface::PredictedMachineInterface;
 
-/// Resolve how to target this host's boot interface for Redfish setup calls.
+/// A selected boot-interface target and whether it already has an owned row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBootInterface {
+    pub machine_interface_id: Option<MachineInterfaceId>,
+    pub target: BootInterfaceTarget,
+}
+
+/// Resolve the host's selected boot interface across owned rows and pending
+/// predictions.
 ///
-/// The host's own `machine_interface` row wins the moment it exists: when that
-/// row has a captured `boot_interface_id`, the full pair is supplied to
-/// `libredfish` in one operation; otherwise the target contains only the MAC.
-/// Both identifiers come from the same row, so the pair cannot name a different
-/// interface than the MAC.
+/// The shared candidate picker lets a declared primary prediction outrank an
+/// interim owned row until the declared NIC takes its first lease. Otherwise an
+/// owned row wins, with a sole non-primary prediction used only when no row is
+/// selectable. A captured Redfish interface id completes the target pair; until
+/// then the target contains only the selected MAC.
 ///
-/// Before that first DHCP lease creates a row -- the window a zero-DPU or
-/// NIC-mode host sits in, since it gets no primary row at ingestion -- the host's
-/// `predictions` answer instead, via `pick_boot_prediction` (the declared
-/// primary, else the sole non-underlay prediction). The predicted MAC and
-/// recorded id form the same pair the real row will hold once the lease promotes
-/// it.
+/// `machine_interface_id` remains `None` for a prediction, allowing the durable
+/// synchronization state to notice first-lease promotion and retarget to the
+/// newly owned row.
+pub fn resolved_boot_interface(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    predictions: &[PredictedMachineInterface],
+) -> Option<ResolvedBootInterface> {
+    resolved_boot_interface_from_stores(&mh_snapshot.host_snapshot.status.interfaces, predictions)
+}
+
+/// Resolve from freshly loaded owned rows and predictions.
 ///
-/// Returns `None` only when the host has no boot interface at all -- no row and
-/// no usable prediction (e.g. only the BMC has been discovered, or several
-/// predictions with no declared primary).
+/// Transactional callers use this after locking both stores so first-lease
+/// promotion cannot leave them resolving against an older machine snapshot.
+pub fn resolved_boot_interface_from_stores(
+    interfaces: &[MachineInterfaceSnapshot],
+    predictions: &[PredictedMachineInterface],
+) -> Option<ResolvedBootInterface> {
+    pick_boot_interface_candidate(interfaces, predictions).map(resolved_from_candidate)
+}
+
+fn resolved_from_candidate(candidate: BootInterfaceCandidate<'_>) -> ResolvedBootInterface {
+    let mac_address = candidate.mac_address();
+    ResolvedBootInterface {
+        machine_interface_id: candidate.machine_interface_id(),
+        target: candidate.boot_interface().map_or(
+            BootInterfaceTarget::MacOnly(mac_address),
+            BootInterfaceTarget::Pair,
+        ),
+    }
+}
+
+/// Resolve only the Redfish target for callers that do not need to distinguish
+/// a pending prediction from an owned interface.
 pub fn boot_interface_target(
     mh_snapshot: &ManagedHostStateSnapshot,
     predictions: &[PredictedMachineInterface],
 ) -> Option<BootInterfaceTarget> {
-    boot_interface_target_from(
-        mh_snapshot.boot_interface(),
-        mh_snapshot.boot_interface_mac(),
-        predictions,
-    )
-}
-
-/// The boot-target decision, split out from the snapshot lookup so it can be
-/// unit-tested directly without constructing a full `ManagedHostStateSnapshot`
-/// -- the same split `pick_boot_interface_mac`/`_pair` use in api-model. The
-/// host's own row wins (its captured pair, else its MAC alone); only when it
-/// owns no boot row does the predicted boot interface answer.
-fn boot_interface_target_from(
-    row_pair: Option<MachineBootInterface>,
-    row_mac: Option<MacAddress>,
-    predictions: &[PredictedMachineInterface],
-) -> Option<BootInterfaceTarget> {
-    if let Some(pair) = row_pair {
-        return Some(BootInterfaceTarget::Pair(pair));
-    }
-    if let Some(mac) = row_mac {
-        return Some(BootInterfaceTarget::MacOnly(mac));
-    }
-    // No real row yet -- fall back to the host's predicted boot interface.
-    pick_boot_prediction(predictions).map(|prediction| {
-        prediction.boot_interface().map_or(
-            BootInterfaceTarget::MacOnly(prediction.mac_address),
-            BootInterfaceTarget::Pair,
-        )
-    })
+    resolved_boot_interface(mh_snapshot, predictions).map(|resolved| resolved.target)
 }
 
 /// What a Redfish boot step should do with a host's boot interface.
@@ -83,11 +88,11 @@ fn boot_interface_target_from(
 /// after the host comes up, so until then it has no boot interface to resolve --
 /// the controller should wait, not fail. A host with managed DPUs always has its
 /// DPU-facing primary set at promotion, so a missing boot interface there is a
-/// genuine fault.
+/// configuration fault.
 #[derive(Debug)]
 pub enum BootInterfaceResolution {
     /// The boot interface resolved; target it.
-    Ready(BootInterfaceTarget),
+    Ready(ResolvedBootInterface),
     /// A zero-DPU host with no boot interface yet -- neither a real row nor a
     /// usable prediction -- so wait for its boot NIC to appear.
     AwaitingNic,
@@ -102,7 +107,7 @@ pub fn resolve_boot_interface(
     predictions: &[PredictedMachineInterface],
 ) -> BootInterfaceResolution {
     classify_boot_interface(
-        boot_interface_target(mh_snapshot, predictions),
+        resolved_boot_interface(mh_snapshot, predictions),
         mh_snapshot.has_managed_dpus(),
     )
 }
@@ -110,7 +115,7 @@ pub fn resolve_boot_interface(
 /// The decision behind [`resolve_boot_interface`], split out from the snapshot
 /// lookup so it can be unit-tested directly.
 fn classify_boot_interface(
-    boot_interface: Option<BootInterfaceTarget>,
+    boot_interface: Option<ResolvedBootInterface>,
     has_managed_dpus: bool,
 ) -> BootInterfaceResolution {
     match boot_interface {
@@ -123,6 +128,7 @@ fn classify_boot_interface(
 #[cfg(test)]
 mod tests {
     use mac_address::MacAddress;
+    use model::machine_boot_interface::MachineBootInterface;
     use model::network_segment::NetworkSegmentType;
 
     use super::*;
@@ -140,55 +146,31 @@ mod tests {
         }
     }
 
-    // The host's own row wins over any prediction: a captured id gives the pair.
     #[test]
-    fn boot_target_prefers_the_owned_row_over_predictions() {
-        let pair = MachineBootInterface {
-            mac_address: "10:00:00:00:00:01".parse().unwrap(),
-            interface_id: "NIC.Slot.5-1".to_string(),
-        };
+    fn predicted_pair_keeps_its_pending_row_identity() {
+        let prediction = prediction("20:00:00:00:00:01", Some("NIC.Embedded.1-1-1"));
         assert_eq!(
-            boot_interface_target_from(
-                Some(pair.clone()),
-                Some("10:00:00:00:00:01".parse().unwrap()),
-                &[prediction("20:00:00:00:00:01", Some("NIC.Embedded.1-1-1"))],
-            ),
-            Some(BootInterfaceTarget::Pair(pair)),
+            resolved_from_candidate(BootInterfaceCandidate::Prediction(&prediction)),
+            ResolvedBootInterface {
+                machine_interface_id: None,
+                target: BootInterfaceTarget::Pair(MachineBootInterface {
+                    mac_address: "20:00:00:00:00:01".parse().unwrap(),
+                    interface_id: "NIC.Embedded.1-1-1".to_string(),
+                }),
+            },
         );
     }
 
-    // No owned row yet: the predicted boot interface answers (pre-first-lease),
-    // as a full pair when the prediction carries the Redfish id.
     #[test]
-    fn boot_target_falls_back_to_the_prediction_before_the_first_lease() {
+    fn prediction_without_an_id_targets_only_its_mac() {
+        let prediction = prediction("20:00:00:00:00:01", None);
         assert_eq!(
-            boot_interface_target_from(
-                None,
-                None,
-                &[prediction("20:00:00:00:00:01", Some("NIC.Embedded.1-1-1"))],
-            ),
-            Some(BootInterfaceTarget::Pair(MachineBootInterface {
-                mac_address: "20:00:00:00:00:01".parse().unwrap(),
-                interface_id: "NIC.Embedded.1-1-1".to_string(),
-            })),
+            resolved_from_candidate(BootInterfaceCandidate::Prediction(&prediction)),
+            ResolvedBootInterface {
+                machine_interface_id: None,
+                target: BootInterfaceTarget::MacOnly("20:00:00:00:00:01".parse().unwrap(),),
+            },
         );
-    }
-
-    // A prediction with no captured id targets the MAC alone.
-    #[test]
-    fn boot_target_prediction_without_id_is_mac_only() {
-        assert_eq!(
-            boot_interface_target_from(None, None, &[prediction("20:00:00:00:00:01", None)]),
-            Some(BootInterfaceTarget::MacOnly(
-                "20:00:00:00:00:01".parse().unwrap()
-            )),
-        );
-    }
-
-    // No row and no usable prediction: nothing to target, so the caller waits.
-    #[test]
-    fn boot_target_is_none_without_row_or_prediction() {
-        assert_eq!(boot_interface_target_from(None, None, &[]), None);
     }
 
     #[test]
@@ -213,7 +195,10 @@ mod tests {
 
     #[test]
     fn classify_uses_the_resolved_interface_when_present() {
-        let target = BootInterfaceTarget::MacOnly(MacAddress::new([0, 0, 0, 0, 0, 1]));
+        let target = ResolvedBootInterface {
+            machine_interface_id: None,
+            target: BootInterfaceTarget::MacOnly(MacAddress::new([0, 0, 0, 0, 0, 1])),
+        };
         assert!(matches!(
             classify_boot_interface(Some(target), false),
             BootInterfaceResolution::Ready(_)

--- a/crates/machine-controller/src/config/controller.rs
+++ b/crates/machine-controller/src/config/controller.rs
@@ -79,9 +79,9 @@ pub struct MachineStateControllerConfig {
         serialize_with = "as_duration"
     )]
     pub uefi_boot_wait: Duration,
-    /// Retry budget for automated host boot-configuration convergence, shared
-    /// across BIOS recovery and boot-order verification. The field name is
-    /// retained for configuration compatibility.
+    /// Maximum retry count applied independently to BIOS/boot-order retries and
+    /// complete synchronization passes whose final observation still reports a mismatch.
+    /// The field name is retained for configuration compatibility.
     #[serde(default = "MachineStateControllerConfig::max_bios_config_retries_default")]
     pub max_bios_config_retries: u32,
     /// How long PollingBiosSetup may sit on Ok(false) before escalating into

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -71,18 +71,19 @@ use model::machine::LockdownMode::{self, Enable};
 use model::machine::infiniband::{IbConfigNotSyncedReason, ib_config_synced};
 use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
-    AttestationMode, BomValidating, BomValidatingContext, CleanupContext, CleanupState,
-    CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver,
-    DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
-    HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
-    InstanceState, LockdownInfo, LockdownState, MAX_FIRMWARE_UPGRADE_RETRIES, Machine,
-    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineNextStateResolver,
-    MachineState, MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot,
-    MeasuringState, NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation,
-    PowerDrainState, PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext,
-    SecureEraseBossState, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
-    SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState, UnlockHostState,
-    ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
+    AttestationMode, BomValidating, BomValidatingContext, BootConfigSynchronizationState,
+    CleanupContext, CleanupState, CreateBossVolumeContext, CreateBossVolumeState,
+    DpuDiscoveringState, DpuInitNextStateResolver, DpuInitState, FailureCause, FailureDetails,
+    FailureSource, HostPlatformConfigurationState, HostReprovisionState, InitialResetPhase,
+    InstallDpuOsState, InstanceNextStateResolver, InstanceState, LockdownInfo, LockdownState,
+    MAX_FIRMWARE_UPGRADE_RETRIES, Machine, MachineLastRebootRequested,
+    MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState,
+    MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
+    NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
+    PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext, SecureEraseBossState,
+    SetBootOrderInfo, SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea,
+    UefiSetupInfo, UefiSetupState, UnlockHostState, ValidationState,
+    dpf_based_dpu_provisioning_possible, get_display_ids,
 };
 use model::power_manager::PowerHandlingOutcome;
 use model::predicted_machine_interface::PredictedMachineInterface;
@@ -99,6 +100,8 @@ use tokio::sync::Semaphore;
 use tracing::instrument;
 use version_compare::Cmp;
 
+#[cfg(test)]
+use crate::boot_interface::ResolvedBootInterface;
 use crate::boot_interface::{BootInterfaceResolution, resolve_boot_interface};
 use crate::config::{
     FirmwareGlobal, MachineStateHandlerSiteConfig, MachineValidationConfig, TimePeriod,
@@ -116,6 +119,7 @@ use crate::{MeasuringOutcome, get_measuring_prerequisites, handle_measuring_stat
 
 pub mod attestation;
 mod bios_config;
+mod boot_config_sync;
 mod dpf;
 mod firmware_artifact;
 mod helpers;
@@ -128,13 +132,20 @@ mod sku;
 mod test_machine_setup;
 
 use bios_config::handle_bios_setup_failed_recovery;
+use boot_config_sync::{
+    AssignedSynchronizationPreemption, BootConfigSynchronizationOwner,
+    assigned_ready_synchronization_transition, assignment_boot_config_gate,
+    handle_boot_config_synchronization, is_boot_config_cleanup_barrier,
+    is_boot_config_synchronization, machine_failure_transition, missing_dpu_cleanup_transition,
+    unassigned_ready_needs_synchronization,
+};
 use helpers::{
     DpuDiscoveringStateHelper, DpuInitStateHelper, ManagedHostStateHelper, NextState,
     ReprovisionStateHelper, all_equal,
 };
 use host_boot_config::{
     HostBootConfigCheckOutcome, HostBootConfigDecision, HostBootConfigDpuFreshness,
-    HostBootConfigOutcome, HostBootConfigStage, check_host_boot_config,
+    HostBootConfigOutcome, HostBootConfigStage, HostBootInterfaceSource, check_host_boot_config,
     initial_set_boot_order_info, run_host_boot_config_stage, should_skip_boot_order_remediation,
 };
 use state_controller::db_write_batch::DbWriteBatch;
@@ -731,11 +742,19 @@ impl MachineStateHandler {
             }
         }
 
-        if let Some(outcome) = handle_restart_verification(mh_snapshot, ctx).await? {
+        // Boot synchronization owns its restart pacing and, more importantly,
+        // its durable cleanup barriers. Global restart verification must not
+        // prevent an active phase from restoring lockdown after cancellation
+        // or failure.
+        if !is_boot_config_synchronization(&mh_state)
+            && let Some(outcome) = handle_restart_verification(mh_snapshot, ctx).await?
+        {
             return Ok(outcome);
         }
 
-        if dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots) {
+        if !is_boot_config_synchronization(&mh_state)
+            && dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots)
+        {
             // Reprovision is started and user requested for restart of reprovision.
             let restart_reprov = can_restart_reprovision(
                 &mh_snapshot.dpu_snapshots,
@@ -755,27 +774,32 @@ impl MachineStateHandler {
         if !matches!(mh_state, ManagedHostState::Failed { .. })
             && let Some((machine_id, details)) = get_failed_state(mh_snapshot)
         {
-            tracing::error!(
-                host_id = %mh_snapshot.host_snapshot.id,
-                dpu_ids = %get_display_ids(&mh_snapshot.dpu_snapshots),
-                failed_machine_id = %machine_id,
-                ?details,
-                "ManagedHost is moved to Failed state",
-            );
-            let next_state = match mh_state {
-                ManagedHostState::Assigned { .. } => ManagedHostState::Assigned {
-                    instance_state: InstanceState::Failed {
-                        details,
-                        machine_id,
-                    },
-                },
-                _ => ManagedHostState::Failed {
-                    details,
-                    machine_id,
-                    retry_count: 0,
-                },
-            };
-            return Ok(StateHandlerOutcome::transition(next_state));
+            let next_state = machine_failure_transition(mh_snapshot, machine_id, details.clone())
+                .or_else(|| {
+                    (!is_boot_config_cleanup_barrier(&mh_state)).then_some(match &mh_state {
+                        ManagedHostState::Assigned { .. } => ManagedHostState::Assigned {
+                            instance_state: InstanceState::Failed {
+                                details,
+                                machine_id,
+                            },
+                        },
+                        _ => ManagedHostState::Failed {
+                            details,
+                            machine_id,
+                            retry_count: 0,
+                        },
+                    })
+                });
+            if let Some(next_state) = next_state {
+                tracing::error!(
+                    host_id = %mh_snapshot.host_snapshot.id,
+                    dpu_ids = %get_display_ids(&mh_snapshot.dpu_snapshots),
+                    failed_machine_id = %machine_id,
+                    next_state = ?next_state,
+                    "Managed host failure changed its controller state",
+                );
+                return Ok(StateHandlerOutcome::transition(next_state));
+            }
         }
 
         match &mh_state {
@@ -848,6 +872,17 @@ impl MachineStateHandler {
                 if let Some(outcome) = maintenance::maintenance_transition_if_requested(mh_snapshot)
                 {
                     return Ok(outcome);
+                }
+
+                if unassigned_ready_needs_synchronization(mh_snapshot, ctx).await? {
+                    return Ok(StateHandlerOutcome::transition(
+                        ManagedHostState::BootConfigSynchronization {
+                            synchronization_state: BootConfigSynchronizationState::Initialize {
+                                target: None,
+                            },
+                            synchronization_retry_count: 0,
+                        },
+                    ));
                 }
 
                 // Check if instance to be created.
@@ -1018,6 +1053,22 @@ impl MachineStateHandler {
                 }
 
                 Ok(StateHandlerOutcome::do_nothing())
+            }
+
+            ManagedHostState::BootConfigSynchronization {
+                synchronization_state,
+                synchronization_retry_count,
+            } => {
+                handle_boot_config_synchronization(
+                    mh_snapshot,
+                    ctx,
+                    &self.host_handler.host_handler_params.reachability_params,
+                    BootConfigSynchronizationOwner::Unassigned,
+                    *synchronization_retry_count,
+                    synchronization_state,
+                    AssignedSynchronizationPreemption::None,
+                )
+                .await
             }
 
             ManagedHostState::Assigned { instance_state: _ } => {
@@ -1703,6 +1754,11 @@ impl MachineStateHandler {
                 // Instance is requested by user. Let's configure it.
                 let mut txn = ctx.services.db_pool.begin().await?;
 
+                if let Some(next_state) = assignment_boot_config_gate(mh_snapshot, &mut txn).await?
+                {
+                    return Ok(StateHandlerOutcome::transition(next_state).with_txn(txn));
+                }
+
                 // Clear if any reprovision (dpu or host) is set due to race scenario.
                 Self::clear_host_update_alert_and_reprov(mh_snapshot, &mut txn).await?;
 
@@ -2026,6 +2082,39 @@ fn dpu_reprovisioning_needed(dpu_snapshots: &[Machine]) -> bool {
         .any(|x| x.reprovision_requested.is_some())
 }
 
+/// Approved host and DPU work that can preempt assigned synchronization.
+struct ApprovedAssignedReprovisioning {
+    dpu_reprovisioning: bool,
+    host_reprovisioning: bool,
+}
+
+/// Resolves the approved reprovisioning work that takes precedence over an
+/// assigned boot-interface synchronization.
+///
+/// Both `InstanceState::Ready` and an in-progress synchronization use this
+/// exact predicate so an unapproved request does not consume the synchronization
+/// authorization without starting the requested update.
+fn approved_assigned_reprovisioning(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    is_auto_approved: bool,
+) -> ApprovedAssignedReprovisioning {
+    let dpu_reprovisioning = dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots)
+        && mh_snapshot
+            .dpu_snapshots
+            .iter()
+            .filter_map(|dpu| dpu.reprovision_requested.as_ref())
+            .all(|request| request.user_approval_received || is_auto_approved);
+    let host_reprovisioning = mh_snapshot
+        .host_snapshot
+        .host_reprovision_requested
+        .as_ref()
+        .is_some_and(|request| request.user_approval_received || is_auto_approved);
+    ApprovedAssignedReprovisioning {
+        dpu_reprovisioning,
+        host_reprovisioning,
+    }
+}
+
 async fn handle_restart_verification(
     mh_snapshot: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
@@ -2345,12 +2434,12 @@ impl StateHandler for MachineStateHandler {
     // Note: extra_logfmt_logging_fields function to add additional
     // parameters that should be logged for each event inside span
     // crated by tracing instrumentation of handle_object_state.
-    #[instrument(skip_all, fields(object_id=%host_machine_id, state=%_mh_state))]
+    #[instrument(skip_all, fields(object_id=%host_machine_id, state=%mh_state))]
     async fn handle_object_state(
         &self,
         host_machine_id: &MachineId,
         mh_snapshot: &mut ManagedHostStateSnapshot,
-        _mh_state: &Self::ControllerState, // mh_snapshot above already contains it
+        mh_state: &Self::ControllerState, // mh_snapshot above already contains it
         ctx: &mut StateHandlerContext<Self::ContextObjects>,
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
         // Refresh the per-object info/association series before any early
@@ -2362,16 +2451,24 @@ impl StateHandler for MachineStateHandler {
             per_object_info.record(mh_snapshot);
         }
 
-        if !mh_snapshot
+        let managed_dpus_missing = !mh_snapshot
             .host_snapshot
             .associated_dpu_machine_ids()
             .is_empty()
-            && mh_snapshot.dpu_snapshots.is_empty()
-        {
-            tracing::error!("No DPU snapshot found for host {}", host_machine_id);
-            return Err(StateHandlerError::GenericError(eyre!(
-                "no DPU snapshot found"
-            )));
+            && mh_snapshot.dpu_snapshots.is_empty();
+        if managed_dpus_missing {
+            if let Some(next_state) = missing_dpu_cleanup_transition(mh_snapshot) {
+                return Ok(StateHandlerOutcome::transition(next_state));
+            }
+            if !is_boot_config_cleanup_barrier(mh_state) {
+                tracing::error!(
+                    machine_id = %host_machine_id,
+                    "No DPU snapshot found for host",
+                );
+                return Err(StateHandlerError::GenericError(eyre!(
+                    "no DPU snapshot found"
+                )));
+            }
         }
 
         self.record_metrics(mh_snapshot, ctx);
@@ -2382,19 +2479,27 @@ impl StateHandler for MachineStateHandler {
             power_options,
             continue_state_machine,
             msg,
-        } = match mh_snapshot.host_snapshot.state.value {
+        } = match mh_state {
             // A pending maintenance request takes precedence over power-manager
             // handling: `handle_power` can return `continue_state_machine = false`
             // (e.g. desired state Off), which would keep `attempt_state_transition`
             // -- and therefore `maintenance_transition_if_requested` -- from ever
-            // running, starving the queued operation. Skipping power handling here
-            // lets the request reach the Maintenance transition.
+            // running, starving the queued operation. Boot-interface synchronization
+            // yields to desired power through PrepareHost, before Redfish work starts.
+            // After unlocking, it restores lockdown and completes final observation
+            // before power handling resumes.
             ManagedHostState::Ready
-                if self.power_options_config.enabled
-                    && mh_snapshot
-                        .host_snapshot
-                        .machine_maintenance_requested
-                        .is_none() =>
+            | ManagedHostState::BootConfigSynchronization {
+                synchronization_state:
+                    BootConfigSynchronizationState::Initialize { .. }
+                    | BootConfigSynchronizationState::WaitingForInitialObservation { .. }
+                    | BootConfigSynchronizationState::PrepareHost { .. },
+                ..
+            } if self.power_options_config.enabled
+                && mh_snapshot
+                    .host_snapshot
+                    .machine_maintenance_requested
+                    .is_none() =>
             {
                 power::handle_power(mh_snapshot, ctx, &self.power_options_config).await?
             }
@@ -2404,7 +2509,9 @@ impl StateHandler for MachineStateHandler {
         // Clone the pool before we borrow ctx mutably
         let power_options_pool = ctx.services.db_pool.clone();
 
-        let was_ready = matches!(mh_snapshot.managed_state, ManagedHostState::Ready);
+        let was_ready = matches!(mh_state, ManagedHostState::Ready);
+        let was_unassigned_boot_config_synchronization =
+            matches!(mh_state, ManagedHostState::BootConfigSynchronization { .. });
 
         if !mh_snapshot.host_snapshot.config.dpf.used_for_ingestion {
             tracing::debug!(
@@ -2424,6 +2531,19 @@ impl StateHandler for MachineStateHandler {
                 msg.unwrap_or_default()
             )))
         };
+
+        // Every ordinary route to unassigned Ready crosses the same exact
+        // observation gate. Synchronization completion is the sole bypass so
+        // its verified Ready transition does not loop back into itself.
+        if !was_unassigned_boot_config_synchronization
+            && let Ok(StateHandlerOutcome::Transition { next_state, .. }) = &mut result
+            && matches!(next_state, ManagedHostState::Ready)
+        {
+            *next_state = ManagedHostState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+                synchronization_retry_count: 0,
+            };
+        }
 
         if was_ready && let Ok(outcome) = result {
             if matches!(&outcome, StateHandlerOutcome::Transition { .. }) {
@@ -3215,7 +3335,7 @@ async fn handle_dpu_reprovision(
         ReprovisionState::CheckHostBootConfig => {
             // WaitingForNetworkConfig already accepted the DPU observation. Do
             // not require a newer observation just because the host state
-            // version advanced while entering host boot repair.
+            // version advanced while entering host boot synchronization.
             handle_dpu_reprovision_host_boot_config_check(
                 ctx,
                 state,
@@ -3430,6 +3550,7 @@ async fn handle_dpu_reprovision_host_boot_config_check(
         state,
         reachability_params,
         dpu_freshness,
+        HostBootInterfaceSource::ResolveSelected,
         ctx,
     )
     .await?
@@ -3478,6 +3599,7 @@ async fn handle_dpu_reprovision_host_boot_config_stage(
         reachability_params,
         redfish_client.as_ref(),
         state,
+        HostBootInterfaceSource::ResolveSelected,
         stage,
     )
     .await?
@@ -3560,20 +3682,24 @@ fn dpu_reprovision_host_boot_failed_state(
     }
 }
 
-/// Load the host's predicted boot-interface candidates -- the interfaces a
-/// zero-DPU or NIC-mode host offers before its first DHCP lease creates real
-/// `machine_interfaces` rows. Empty once the host owns its rows (and for DPU
-/// hosts, which get their primary row at attach), so the resolver simply finds
-/// no prediction to fall back to.
+/// Load the host's predicted boot-interface candidates.
+///
+/// A declared primary prediction remains authoritative until its first DHCP
+/// lease promotes it, even when ingestion created an interim DPU-backed primary
+/// row. Callers therefore need both stores for the shared resolver to preserve
+/// that pending intent.
 async fn load_boot_predictions(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
-    machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Result<Vec<PredictedMachineInterface>, StateHandlerError> {
     // A pooled read connection, not a transaction -- this read-only lookup runs
     // on the frequently-invoked boot-config path and needs no transaction.
     let mut conn = ctx.services.db_pool.acquire().await?;
-    let predictions =
-        db::predicted_machine_interface::find_by_machine_id(&mut conn, machine_id).await?;
+    let predictions = db::predicted_machine_interface::find_by_machine_id(
+        &mut conn,
+        &mh_snapshot.host_snapshot.id,
+    )
+    .await?;
     Ok(predictions)
 }
 
@@ -4951,7 +5077,9 @@ fn map_boot_interface_resolution<W>(
     wait: impl FnOnce(String) -> W,
 ) -> Result<RequiredBootInterface<W>, StateHandlerError> {
     match resolution {
-        BootInterfaceResolution::Ready(target) => Ok(RequiredBootInterface::Ready(target)),
+        BootInterfaceResolution::Ready(resolved) => {
+            Ok(RequiredBootInterface::Ready(resolved.target))
+        }
         BootInterfaceResolution::AwaitingNic => Ok(RequiredBootInterface::Wait(wait(format!(
             "Waiting for zero-DPU host {host_id} to discover its boot NIC before {activity}."
         )))),
@@ -4976,7 +5104,10 @@ mod require_boot_interface_tests {
     fn ready_passes_the_target_through() {
         let target = BootInterfaceTarget::MacOnly("20:00:00:00:00:01".parse().unwrap());
         let resolved = map_boot_interface_resolution::<String>(
-            BootInterfaceResolution::Ready(target.clone()),
+            BootInterfaceResolution::Ready(ResolvedBootInterface {
+                machine_interface_id: None,
+                target: target.clone(),
+            }),
             &host_id(),
             "setting boot order",
             |msg| msg,
@@ -5393,8 +5524,15 @@ async fn handle_host_init_boot_config_stage(
     redfish_client: &dyn Redfish,
     stage: HostBootConfigStage,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    match run_host_boot_config_stage(ctx, reachability_params, redfish_client, mh_snapshot, stage)
-        .await?
+    match run_host_boot_config_stage(
+        ctx,
+        reachability_params,
+        redfish_client,
+        mh_snapshot,
+        HostBootInterfaceSource::ResolveSelected,
+        stage,
+    )
+    .await?
     {
         HostBootConfigOutcome::Continue(stage) => {
             let machine_state = match stage {
@@ -5725,6 +5863,17 @@ async fn handle_host_uefi_setup(
                 },
             },
         )),
+    }
+}
+
+fn polling_lockdown_state(mode: LockdownMode) -> ManagedHostState {
+    ManagedHostState::HostInit {
+        machine_state: MachineState::WaitingForLockdown {
+            lockdown_info: LockdownInfo {
+                state: LockdownState::PollingLockdownStatus,
+                mode,
+            },
+        },
     }
 }
 
@@ -6079,23 +6228,14 @@ impl StateHandler for HostMachineStateHandler {
                         }
                         LockdownState::TimeWaitForDPUDown => {
                             if !mh_snapshot.has_managed_dpus() {
-                                // No DPU to wait for going down/up -- skip
-                                // straight to BomValidating. Covers
-                                // `Nic`/`Ignore` hosts and anything else
-                                // with no DPU snapshots; otherwise we'd
-                                // wait `dpu_wait_time` for a DPU that's
-                                // never going to come up.
-                                let next_state = ManagedHostState::BomValidating {
-                                    bom_validating_state: BomValidating::MatchingSku(
-                                        BomValidatingContext {
-                                            machine_validation_context: Some(
-                                                MachineValidationContext::Discovery,
-                                            ),
-                                            reboot_retry_count: None,
-                                        },
-                                    ),
-                                };
-                                return Ok(StateHandlerOutcome::transition(next_state));
+                                // There is no managed DPU to wait for on
+                                // `Nic`/`Ignore` or zero-DPU hosts, but the
+                                // first reboot still needs its lockdown result
+                                // checked. The mode then decides whether we
+                                // continue setup or move to BOM validation.
+                                return Ok(StateHandlerOutcome::transition(
+                                    polling_lockdown_state(lockdown_info.mode.clone()),
+                                ));
                             }
                             // Lets wait for some time before checking if DPU is up or not.
                             // Waiting is needed because DPU takes some time to go down. If we check DPU
@@ -6142,15 +6282,9 @@ impl StateHandler for HostMachineStateHandler {
                                 )
                                 .await?;
 
-                                let next_state = ManagedHostState::HostInit {
-                                    machine_state: MachineState::WaitingForLockdown {
-                                        lockdown_info: LockdownInfo {
-                                            state: LockdownState::PollingLockdownStatus,
-                                            mode: lockdown_info.mode.clone(),
-                                        },
-                                    },
-                                };
-                                Ok(StateHandlerOutcome::transition(next_state))
+                                Ok(StateHandlerOutcome::transition(polling_lockdown_state(
+                                    lockdown_info.mode.clone(),
+                                )))
                             } else {
                                 // The DPU can only come up while the host is
                                 // powered on.
@@ -6583,6 +6717,28 @@ impl StateHandler for InstanceStateHandler {
                         return Ok(StateHandlerOutcome::transition(next_state));
                     }
 
+                    let approved_reprovisioning =
+                        approved_assigned_reprovisioning(mh_snapshot, is_auto_approved);
+                    let boot_with_custom_ipxe = instance.custom_pxe_reboot_requested;
+                    let assigned_preemption = if instance.deleted.is_some()
+                        || approved_reprovisioning.dpu_reprovisioning
+                        || approved_reprovisioning.host_reprovisioning
+                        || boot_with_custom_ipxe
+                    {
+                        AssignedSynchronizationPreemption::Discard
+                    } else {
+                        AssignedSynchronizationPreemption::None
+                    };
+                    if let Some(outcome) = assigned_ready_synchronization_transition(
+                        mh_snapshot,
+                        ctx,
+                        assigned_preemption,
+                    )
+                    .await?
+                    {
+                        return Ok(outcome);
+                    }
+
                     // Run cleanup here so fully terminated extension services are
                     // removed from persisted instance config.
                     let mut txn_opt = None;
@@ -6610,34 +6766,10 @@ impl StateHandler for InstanceStateHandler {
                         }
                     }
 
-                    let reprov_can_be_started =
-                        if dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots) {
-                            // Usually all DPUs are updated with user_approval_received field as true
-                            // if `invoke_instance_power` is called.
-                            // TODO: multidpu: Move this field to `instances` table and unset on
-                            // reprovision is completed.
-                            mh_snapshot
-                                .dpu_snapshots
-                                .iter()
-                                .filter(|x| x.reprovision_requested.is_some())
-                                .all(|x| {
-                                    x.reprovision_requested
-                                        .as_ref()
-                                        .map(|x| x.user_approval_received || is_auto_approved)
-                                        .unwrap_or_default()
-                                })
-                        } else {
-                            false
-                        };
-                    let host_firmware_requested = if let Some(request) =
-                        &mh_snapshot.host_snapshot.host_reprovision_requested
+                    if is_auto_approved
+                        && (approved_reprovisioning.dpu_reprovisioning
+                            || approved_reprovisioning.host_reprovisioning)
                     {
-                        request.user_approval_received || is_auto_approved
-                    } else {
-                        false
-                    };
-
-                    if is_auto_approved && (reprov_can_be_started || host_firmware_requested) {
                         tracing::info!(machine_id = %host_machine_id, "Auto rebooting host for reprovision/upgrade due to being in approved time period");
                     }
 
@@ -6648,11 +6780,9 @@ impl StateHandler for InstanceStateHandler {
                     // before rebooting. The WaitingForRebootToReady handler will clear this flag
                     // and set use_custom_pxe_on_boot, which the iPXE handler uses to serve the
                     // tenant's script.
-                    let boot_with_custom_ipxe = instance.custom_pxe_reboot_requested;
-
                     if instance.deleted.is_some()
-                        || reprov_can_be_started
-                        || host_firmware_requested
+                        || approved_reprovisioning.dpu_reprovisioning
+                        || approved_reprovisioning.host_reprovisioning
                         || boot_with_custom_ipxe
                     {
                         for dpu_snapshot in &mh_snapshot.dpu_snapshots {
@@ -6715,7 +6845,7 @@ impl StateHandler for InstanceStateHandler {
                             ctx.services.db_pool.begin().await?
                         };
 
-                        if host_firmware_requested {
+                        if approved_reprovisioning.host_reprovisioning {
                             let health_override = create_host_update_health_report_hostfw();
                             let machine_id = *host_machine_id;
                             // The health report alert gets generated here, the machine update manager retains responsibilty for clearing it when we're done.
@@ -6729,7 +6859,7 @@ impl StateHandler for InstanceStateHandler {
                             .await?;
                         }
 
-                        if reprov_can_be_started {
+                        if approved_reprovisioning.dpu_reprovisioning {
                             let health_override = create_host_update_health_report_dpufw();
                             let machine_id = *host_machine_id;
                             // Mark the Host as in update.
@@ -6749,6 +6879,35 @@ impl StateHandler for InstanceStateHandler {
                     } else {
                         Ok(StateHandlerOutcome::do_nothing())
                     }
+                }
+                InstanceState::BootConfigSynchronization {
+                    synchronization_state,
+                    synchronization_retry_count,
+                } => {
+                    let is_auto_approved = self.host_upgrade.is_auto_approved();
+                    let approved_reprovisioning =
+                        approved_assigned_reprovisioning(mh_snapshot, is_auto_approved);
+                    let assigned_preemption = if instance.deleted.is_some()
+                        || instance.custom_pxe_reboot_requested
+                        || approved_reprovisioning.dpu_reprovisioning
+                        || approved_reprovisioning.host_reprovisioning
+                    {
+                        AssignedSynchronizationPreemption::Discard
+                    } else if instance.update_network_config_request.is_some() {
+                        AssignedSynchronizationPreemption::ResumeAfterReady
+                    } else {
+                        AssignedSynchronizationPreemption::None
+                    };
+                    handle_boot_config_synchronization(
+                        mh_snapshot,
+                        ctx,
+                        &self.reachability_params,
+                        BootConfigSynchronizationOwner::Assigned,
+                        *synchronization_retry_count,
+                        synchronization_state,
+                        assigned_preemption,
+                    )
+                    .await
                 }
                 InstanceState::HostPlatformConfiguration {
                     platform_config_state,
@@ -11003,8 +11162,15 @@ async fn handle_instance_host_boot_config_stage(
     redfish_client: &dyn Redfish,
     stage: HostBootConfigStage,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    match run_host_boot_config_stage(ctx, reachability_params, redfish_client, mh_snapshot, stage)
-        .await?
+    match run_host_boot_config_stage(
+        ctx,
+        reachability_params,
+        redfish_client,
+        mh_snapshot,
+        HostBootInterfaceSource::ResolveSelected,
+        stage,
+    )
+    .await?
     {
         HostBootConfigOutcome::Continue(stage) => {
             let platform_config_state = match stage {
@@ -11287,6 +11453,7 @@ async fn handle_instance_host_platform_config(
                 mh_snapshot,
                 reachability_params,
                 HostBootConfigDpuFreshness::CurrentHostState,
+                HostBootInterfaceSource::ResolveSelected,
                 ctx,
             )
             .await?
@@ -11404,9 +11571,9 @@ async fn set_host_boot_order(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    boot_interface_source: &HostBootInterfaceSource,
     set_boot_order_info: SetBootOrderInfo,
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
-    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
             // There used to be a `force_dpu_nic_mode`-gated short-circuit
@@ -11426,12 +11593,15 @@ async fn set_host_boot_order(
             // HostInband lease creates a real row, a zero-DPU/NIC-mode host
             // resolves via its predictions; it waits only when neither a real row
             // nor a usable prediction exists.
-            let boot_interface = match require_boot_interface(
-                mh_snapshot,
-                &predictions,
-                "setting boot order",
-                SetBootOrderOutcome::Wait,
-            )? {
+            let boot_interface = match boot_interface_source
+                .resolve_required(
+                    ctx,
+                    mh_snapshot,
+                    "setting boot order",
+                    SetBootOrderOutcome::Wait,
+                )
+                .await?
+            {
                 RequiredBootInterface::Ready(target) => target,
                 RequiredBootInterface::Wait(outcome) => return Ok(outcome),
             };
@@ -11566,12 +11736,15 @@ async fn set_host_boot_order(
             const HTTP_BOOT_DEVICE_APPLY_WAIT_MINUTES: i64 = 10;
             const MAX_HTTP_BOOT_DEVICE_APPLY_RETRIES: u32 = 3;
 
-            let boot_interface = match require_boot_interface(
-                mh_snapshot,
-                &predictions,
-                "verifying the re-asserted HTTP boot device",
-                SetBootOrderOutcome::Wait,
-            )? {
+            let boot_interface = match boot_interface_source
+                .resolve_required(
+                    ctx,
+                    mh_snapshot,
+                    "verifying the re-asserted HTTP boot device",
+                    SetBootOrderOutcome::Wait,
+                )
+                .await?
+            {
                 RequiredBootInterface::Ready(target) => target,
                 RequiredBootInterface::Wait(outcome) => return Ok(outcome),
             };
@@ -11876,12 +12049,15 @@ async fn set_host_boot_order(
                 .machine_state_controller
                 .max_bios_config_retries;
 
-            let boot_interface = match require_boot_interface(
-                mh_snapshot,
-                &predictions,
-                "verifying boot order",
-                SetBootOrderOutcome::Wait,
-            )? {
+            let boot_interface = match boot_interface_source
+                .resolve_required(
+                    ctx,
+                    mh_snapshot,
+                    "verifying boot order",
+                    SetBootOrderOutcome::Wait,
+                )
+                .await?
+            {
                 RequiredBootInterface::Ready(target) => target,
                 RequiredBootInterface::Wait(outcome) => return Ok(outcome),
             };

--- a/crates/machine-controller/src/handler/bios_config.rs
+++ b/crates/machine-controller/src/handler/bios_config.rs
@@ -17,6 +17,7 @@
 
 //! BIOS configuration: machine_setup, Dell job wait/recovery, and PollingBiosSetup escalation.
 
+use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_error;
 use chrono::Utc;
 use eyre::eyre;
@@ -24,7 +25,6 @@ use libredfish::{Redfish, SystemPowerControl};
 use model::machine::{
     BiosConfigInfo, BiosConfigState, ManagedHostState, ManagedHostStateSnapshot, PowerState,
 };
-use model::predicted_machine_interface::PredictedMachineInterface;
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -89,14 +89,12 @@ pub(super) async fn configure_host_bios(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    boot_interface: Option<&BootInterfaceTarget>,
     retry_count: u32,
 ) -> Result<BiosConfigOutcome, StateHandlerError> {
-    let predictions = super::load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
-    let boot_interface = boot_interface_target(mh_snapshot, &predictions);
-
     let bios_job_id = match call_machine_setup_and_handle_no_dpu_error(
         redfish_client,
-        boot_interface.as_ref(),
+        boot_interface,
         mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
         &ctx.services.site_config,
     )
@@ -397,12 +395,11 @@ pub(super) async fn advance_polling_bios_setup(
     mh_snapshot: &ManagedHostStateSnapshot,
     retry_count: u32,
     machine_controller_config: &MachineStateControllerConfig,
-    predictions: &[PredictedMachineInterface],
+    boot_interface: Option<&BootInterfaceTarget>,
 ) -> Result<PollingBiosSetupOutcome, StateHandlerError> {
-    let boot_interface = boot_interface_target(mh_snapshot, predictions);
     let stuck_for = mh_snapshot.host_snapshot.state.version.since_state_change();
 
-    let is_bios_setup_result = match &boot_interface {
+    let is_bios_setup_result = match boot_interface {
         Some(target) => {
             target
                 .run(|bi| redfish_client.is_bios_setup(Some(bi)))
@@ -476,7 +473,7 @@ pub(super) async fn handle_bios_setup_failed_recovery(
     mh_snapshot: &ManagedHostStateSnapshot,
     recovered_state: ManagedHostState,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let predictions = super::load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    let predictions = super::load_boot_predictions(ctx, mh_snapshot).await?;
     let boot_interface = boot_interface_target(mh_snapshot, &predictions);
     let redfish_client = ctx
         .services

--- a/crates/machine-controller/src/handler/boot_config_sync.rs
+++ b/crates/machine-controller/src/handler/boot_config_sync.rs
@@ -1,0 +1,2224 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Durable synchronization of a host's selected boot interface.
+//!
+//! The unassigned parent runs automatically before `Ready`; the assigned
+//! parent is entered only after an operator authorization for the exact
+//! interface generation is validated. Both parents use the shared
+//! boot-configuration driver and require a target-correlated Site Explorer
+//! observation before returning to their respective Ready state.
+
+use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_error;
+use config_version::ConfigVersion;
+use libredfish::{EnabledDisabled, RedfishError, SystemPowerControl};
+use model::machine::machine_search_config::MachineSearchConfig;
+use model::machine::{
+    BootConfigSynchronizationCompletion, BootConfigSynchronizationState,
+    BootConfigSynchronizationTarget, FailureCause, FailureDetails, FailureSource, InstanceState,
+    ManagedHostState, ManagedHostStateSnapshot, StateMachineArea, UnlockHostState,
+};
+use model::machine_boot_interface::MachineBootInterfaceTarget;
+use model::site_explorer::{
+    ExploredEndpoint, MACHINE_SETUP_VERIFICATION_VERSION, MachineSetupStatus,
+};
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+use super::host_boot_config::{
+    HostBootConfigCheckOutcome, HostBootConfigDecision, HostBootConfigDpuFreshness,
+    HostBootConfigOutcome, HostBootConfigStage, HostBootInterfaceSource, check_host_boot_config,
+    initial_set_boot_order_info, run_host_boot_config_stage, should_skip_boot_order_remediation,
+};
+use super::{
+    ReachabilityParams, host_power_control, load_boot_predictions, resolve_boot_interface, wait,
+};
+use crate::boot_interface::{
+    BootInterfaceResolution, ResolvedBootInterface, resolved_boot_interface_from_stores,
+};
+use crate::context::{MachineStateHandlerContextObjects, MachineStateHandlerServices};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum BootConfigSynchronizationOwner {
+    Unassigned,
+    Assigned,
+}
+
+impl BootConfigSynchronizationOwner {
+    fn ready_state(self) -> ManagedHostState {
+        match self {
+            Self::Unassigned => ManagedHostState::Ready,
+            Self::Assigned => ManagedHostState::Assigned {
+                instance_state: InstanceState::Ready,
+            },
+        }
+    }
+
+    fn target_changed_state(self) -> ManagedHostState {
+        match self {
+            Self::Unassigned => ManagedHostState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+                synchronization_retry_count: 0,
+            },
+            Self::Assigned => self.ready_state(),
+        }
+    }
+
+    fn failure_state(
+        self,
+        machine_id: carbide_uuid::machine::MachineId,
+        error: String,
+    ) -> ManagedHostState {
+        let details = FailureDetails {
+            cause: FailureCause::BiosSetupFailed { err: error },
+            failed_at: chrono::Utc::now(),
+            source: FailureSource::StateMachineArea(match self {
+                Self::Unassigned => StateMachineArea::MainFlow,
+                Self::Assigned => StateMachineArea::AssignedInstance,
+            }),
+        };
+        self.machine_failure_state(machine_id, details)
+    }
+
+    fn machine_failure_state(
+        self,
+        machine_id: carbide_uuid::machine::MachineId,
+        details: FailureDetails,
+    ) -> ManagedHostState {
+        match self {
+            Self::Unassigned => ManagedHostState::Failed {
+                details,
+                machine_id,
+                retry_count: 0,
+            },
+            Self::Assigned => ManagedHostState::Assigned {
+                instance_state: InstanceState::Failed {
+                    details,
+                    machine_id,
+                },
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BootConfigSynchronizationDriver {
+    owner: BootConfigSynchronizationOwner,
+    retry_count: u32,
+}
+
+impl BootConfigSynchronizationDriver {
+    fn new(owner: BootConfigSynchronizationOwner) -> Self {
+        Self {
+            owner,
+            retry_count: 0,
+        }
+    }
+
+    fn resume(owner: BootConfigSynchronizationOwner, retry_count: u32) -> Self {
+        Self { owner, retry_count }
+    }
+
+    fn retry(self) -> Self {
+        Self {
+            retry_count: self.retry_count + 1,
+            ..self
+        }
+    }
+
+    fn state(self, synchronization_state: BootConfigSynchronizationState) -> ManagedHostState {
+        match self.owner {
+            BootConfigSynchronizationOwner::Unassigned => {
+                ManagedHostState::BootConfigSynchronization {
+                    synchronization_state,
+                    synchronization_retry_count: self.retry_count,
+                }
+            }
+            BootConfigSynchronizationOwner::Assigned => ManagedHostState::Assigned {
+                instance_state: InstanceState::BootConfigSynchronization {
+                    synchronization_state,
+                    synchronization_retry_count: self.retry_count,
+                },
+            },
+        }
+    }
+
+    fn ready_state(self) -> ManagedHostState {
+        self.owner.ready_state()
+    }
+
+    fn target_changed_state(self) -> ManagedHostState {
+        self.owner.target_changed_state()
+    }
+
+    fn failure_state(
+        self,
+        machine_id: carbide_uuid::machine::MachineId,
+        error: String,
+    ) -> ManagedHostState {
+        self.owner.failure_state(machine_id, error)
+    }
+
+    fn machine_failure_state(
+        self,
+        machine_id: carbide_uuid::machine::MachineId,
+        details: FailureDetails,
+    ) -> ManagedHostState {
+        self.owner.machine_failure_state(machine_id, details)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum AssignedSynchronizationPreemption {
+    None,
+    ResumeAfterReady,
+    Discard,
+}
+
+fn synchronization_owner_and_state(
+    state: &ManagedHostState,
+) -> Option<(
+    BootConfigSynchronizationDriver,
+    &BootConfigSynchronizationState,
+)> {
+    match state {
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state,
+            synchronization_retry_count,
+        } => Some((
+            BootConfigSynchronizationDriver::resume(
+                BootConfigSynchronizationOwner::Unassigned,
+                *synchronization_retry_count,
+            ),
+            synchronization_state,
+        )),
+        ManagedHostState::Assigned {
+            instance_state:
+                InstanceState::BootConfigSynchronization {
+                    synchronization_state,
+                    synchronization_retry_count,
+                },
+        } => Some((
+            BootConfigSynchronizationDriver::resume(
+                BootConfigSynchronizationOwner::Assigned,
+                *synchronization_retry_count,
+            ),
+            synchronization_state,
+        )),
+        _ => None,
+    }
+}
+
+/// Identifies both the unassigned parent and assigned nested synchronization.
+///
+/// The outer machine handler uses this to keep unrelated lifecycle shortcuts
+/// from bypassing the synchronization cleanup barrier.
+pub(super) fn is_boot_config_synchronization(state: &ManagedHostState) -> bool {
+    synchronization_owner_and_state(state).is_some()
+}
+
+/// Returns whether boot synchronization must finish safety cleanup before an
+/// outer lifecycle transition may replace it.
+///
+/// This covers both lockdown restoration and BIOS-job recovery that has
+/// deliberately powered the host off. Health, maintenance, and authorization
+/// changes remain pending until the host is powered back on and lockdown can
+/// be restored.
+pub(super) fn is_boot_config_cleanup_barrier(state: &ManagedHostState) -> bool {
+    synchronization_owner_and_state(state).is_some_and(|(_, state)| {
+        matches!(
+            state,
+            BootConfigSynchronizationState::RestoreLockdown { .. }
+        ) || power_recovery_in_progress(state)
+    })
+}
+
+/// Routes an outer machine/DPU failure through lockdown restoration when
+/// Redfish work may have disabled it.
+pub(super) fn machine_failure_transition(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    machine_id: carbide_uuid::machine::MachineId,
+    details: FailureDetails,
+) -> Option<ManagedHostState> {
+    let (owner, state) = synchronization_owner_and_state(&mh_snapshot.managed_state)?;
+    if power_recovery_in_progress(state) {
+        return None;
+    }
+    if matches!(
+        state,
+        BootConfigSynchronizationState::RestoreLockdown {
+            completion: BootConfigSynchronizationCompletion::MachineFailed { .. },
+        }
+    ) {
+        return None;
+    }
+    let completion = BootConfigSynchronizationCompletion::MachineFailed {
+        machine_id,
+        details,
+    };
+    let lockdown_may_be_disabled = state_may_require_lockdown_restore(state)
+        || matches!(
+            state,
+            BootConfigSynchronizationState::RestoreLockdown { .. }
+        );
+    if lockdown_may_be_disabled && !mh_snapshot.host_snapshot.host_profile.disable_lockdown {
+        Some(owner.state(BootConfigSynchronizationState::RestoreLockdown { completion }))
+    } else {
+        Some(completion_state(
+            owner,
+            completion,
+            mh_snapshot.host_snapshot.id,
+        ))
+    }
+}
+
+/// Moves an active Redfish phase into lockdown restoration when its managed
+/// DPU snapshots disappear.
+///
+/// After cleanup, the same parent restarts with its pinned target and waits for
+/// the missing observations before doing more boot-configuration work.
+pub(super) fn missing_dpu_cleanup_transition(
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Option<ManagedHostState> {
+    let (owner, state) = synchronization_owner_and_state(&mh_snapshot.managed_state)?;
+    if power_recovery_in_progress(state) {
+        return None;
+    }
+    if mh_snapshot.host_snapshot.host_profile.disable_lockdown
+        || !state_may_require_lockdown_restore(state)
+    {
+        return None;
+    }
+    Some(
+        owner.state(BootConfigSynchronizationState::RestoreLockdown {
+            completion: BootConfigSynchronizationCompletion::ResumeSynchronization {
+                target: state_target(state).cloned(),
+            },
+        }),
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ObservationProgress {
+    Waiting,
+    Configured,
+    NeedsSynchronization,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ObservationEvaluation {
+    progress: ObservationProgress,
+    reason: String,
+    request_exploration: bool,
+}
+
+impl ObservationEvaluation {
+    fn waiting(reason: impl Into<String>, request_exploration: bool) -> Self {
+        Self {
+            progress: ObservationProgress::Waiting,
+            reason: reason.into(),
+            request_exploration,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ObservationPolicy {
+    allow_disabled_lockdown: bool,
+    skip_boot_order: bool,
+}
+
+impl ObservationPolicy {
+    fn for_host(mh_snapshot: &ManagedHostStateSnapshot) -> Self {
+        Self {
+            allow_disabled_lockdown: mh_snapshot.host_snapshot.host_profile.disable_lockdown,
+            skip_boot_order: should_skip_boot_order_remediation(mh_snapshot),
+        }
+    }
+
+    fn accepts(self, status: &MachineSetupStatus) -> bool {
+        status.is_done
+            || (!status.diffs.is_empty()
+                && status.diffs.iter().all(|diff| {
+                    (self.allow_disabled_lockdown && diff.key == "lockdown")
+                        || (self.skip_boot_order && diff.key == "boot_first")
+                }))
+    }
+}
+
+struct LockedBootConfigView {
+    endpoint: Option<ExploredEndpoint>,
+    target: Option<BootConfigSynchronizationTarget>,
+}
+
+async fn lock_boot_config_view(
+    txn: &mut sqlx::PgConnection,
+    machine_id: carbide_uuid::machine::MachineId,
+    address: std::net::IpAddr,
+) -> Result<LockedBootConfigView, StateHandlerError> {
+    // This order matches explicit selection and first-lease promotion.
+    // Loading both interface stores after every lock makes promotion and
+    // Redfish-id enrichment visible to the same transaction.
+    let endpoint =
+        db::explored_endpoints::find_by_ip_for_update_optional(address, &mut *txn).await?;
+    db::machine_interface::lock_for_machine(&mut *txn, machine_id).await?;
+    let selection_version =
+        db::machine::lock_boot_interface_selection_version(&mut *txn, machine_id).await?;
+    db::predicted_machine_interface::lock_for_machine(&mut *txn, machine_id).await?;
+    let live_bmc_address =
+        db::machine::find_one(&mut *txn, &machine_id, MachineSearchConfig::default())
+            .await?
+            .and_then(|machine| machine.status.bmc_info.ip);
+    let endpoint = if live_bmc_address == Some(address) {
+        endpoint
+    } else {
+        tracing::warn!(
+            %machine_id,
+            snapshot_bmc_address = %address,
+            live_bmc_address = ?live_bmc_address,
+            "Ignoring a boot-config endpoint loaded from a stale machine snapshot",
+        );
+        None
+    };
+    let interfaces = db::machine_interface::find_by_machine_ids(&mut *txn, &[machine_id])
+        .await?
+        .remove(&machine_id)
+        .unwrap_or_default();
+    let predictions =
+        db::predicted_machine_interface::find_by_machine_id(&mut *txn, &machine_id).await?;
+    let target = resolved_boot_interface_from_stores(&interfaces, &predictions)
+        .map(|resolved| synchronization_target(&resolved, selection_version));
+    Ok(LockedBootConfigView { endpoint, target })
+}
+
+/// Revalidates boot configuration in the transaction that crosses the
+/// unassigned-to-assigned boundary.
+///
+/// A concurrent explicit selection either commits before these locks and is
+/// evaluated here, or waits until the state transition commits and then uses
+/// assigned-host semantics. First-lease promotion and Redfish-id enrichment
+/// use the same locks but preserve the selection generation and MAC; if they
+/// follow the gate, they can safely finish as metadata enrichment without
+/// changing the boot device.
+pub(super) async fn assignment_boot_config_gate(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    txn: &mut sqlx::PgConnection,
+) -> Result<Option<ManagedHostState>, StateHandlerError> {
+    let machine_id = mh_snapshot.host_snapshot.id;
+    let Some(address) = mh_snapshot.host_snapshot.status.bmc_info.ip else {
+        return Err(StateHandlerError::MissingData {
+            object_id: machine_id.to_string(),
+            missing: "BMC IP",
+        });
+    };
+    let locked = lock_boot_config_view(txn, machine_id, address).await?;
+    // Authorization belongs to one assigned lifecycle. Never let a deferred
+    // request from an earlier tenant cross this unassigned boundary.
+    db::machine::clear_boot_config_synchronization_request(txn, machine_id).await?;
+    let (configured, reason) = match (locked.endpoint.as_ref(), locked.target.as_ref()) {
+        (Some(endpoint), Some(target)) => {
+            let evaluation = evaluate_observation(
+                endpoint,
+                target,
+                ConfigVersion::invalid(),
+                ObservationPolicy::for_host(mh_snapshot),
+            );
+            (
+                evaluation.progress == ObservationProgress::Configured,
+                evaluation.reason,
+            )
+        }
+        (None, _) => (false, format!("explored endpoint {address} is missing")),
+        (_, None) => (false, "selected boot interface is unresolved".to_string()),
+    };
+    if configured {
+        return Ok(None);
+    }
+
+    tracing::info!(
+        %machine_id,
+        reason,
+        target = ?locked.target,
+        "Boot-interface synchronization is required before assignment",
+    );
+    Ok(Some(ManagedHostState::BootConfigSynchronization {
+        synchronization_state: BootConfigSynchronizationState::Initialize {
+            target: locked.target,
+        },
+        synchronization_retry_count: 0,
+    }))
+}
+
+/// Returns whether an unassigned Ready host needs to enter boot-interface
+/// synchronization.
+///
+/// Called before instance assignment. A matching successful observation keeps
+/// the host Ready; missing, stale, failed, or mismatched evidence routes it
+/// through the durable parent state.
+pub(super) async fn unassigned_ready_needs_synchronization(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<bool, StateHandlerError> {
+    let Some(target) = resolve_current_target(mh_snapshot, ctx)
+        .await?
+        .into_option()
+    else {
+        return Ok(true);
+    };
+    let Some(endpoint) = find_endpoint(mh_snapshot, ctx.services).await? else {
+        return Ok(true);
+    };
+    let evaluation = evaluate_observation(
+        &endpoint,
+        &target,
+        ConfigVersion::invalid(),
+        ObservationPolicy::for_host(mh_snapshot),
+    );
+    Ok(evaluation.progress != ObservationProgress::Configured)
+}
+
+/// Enters synchronization for a matching assigned-host authorization.
+///
+/// Called from `InstanceState::Ready` after higher-priority network updates.
+/// The exact request remains persisted until synchronization succeeds so a
+/// temporary preemption can return to Ready and resume it. Stale or
+/// destructive requests are cleared with a conditional database update.
+pub(super) async fn assigned_ready_synchronization_transition(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    preemption: AssignedSynchronizationPreemption,
+) -> Result<Option<StateHandlerOutcome<ManagedHostState>>, StateHandlerError> {
+    let Some(request) = mh_snapshot
+        .host_snapshot
+        .boot_config_synchronization_requested
+        .as_ref()
+    else {
+        return Ok(None);
+    };
+
+    if preemption == AssignedSynchronizationPreemption::Discard {
+        let mut txn = ctx.services.db_pool.begin().await?;
+        let consumed = db::machine::consume_boot_config_synchronization_request(
+            &mut txn,
+            mh_snapshot.host_snapshot.id,
+            request.interface_id,
+            request.selection_version,
+        )
+        .await?;
+        if !consumed {
+            txn.rollback().await?;
+            return Ok(None);
+        }
+        tracing::info!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            "Discarded assigned boot-interface synchronization authorization for higher-priority instance work",
+        );
+        return Ok(Some(StateHandlerOutcome::do_nothing().with_txn(txn)));
+    }
+    if preemption == AssignedSynchronizationPreemption::ResumeAfterReady {
+        return Ok(None);
+    }
+
+    let current_target = resolve_current_target(mh_snapshot, ctx)
+        .await?
+        .into_option();
+    let request_matches = current_target.as_ref().is_some_and(|target| {
+        target.machine_interface_id == Some(request.interface_id)
+            && target.selection_version == request.selection_version
+    });
+    if !request_matches {
+        let mut txn = ctx.services.db_pool.begin().await?;
+        let consumed = db::machine::consume_boot_config_synchronization_request(
+            &mut txn,
+            mh_snapshot.host_snapshot.id,
+            request.interface_id,
+            request.selection_version,
+        )
+        .await?;
+        if !consumed {
+            txn.rollback().await?;
+            return Ok(None);
+        }
+        tracing::info!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            requested_machine_interface_id = %request.interface_id,
+            requested_selection_version = %request.selection_version,
+            current_target = ?current_target,
+            "Discarded stale assigned boot-interface synchronization authorization",
+        );
+        return Ok(Some(StateHandlerOutcome::do_nothing().with_txn(txn)));
+    }
+
+    let target = current_target.expect("checked as present above");
+    tracing::info!(
+        machine_id = %mh_snapshot.host_snapshot.id,
+        machine_interface_id = ?target.machine_interface_id,
+        boot_interface = ?target.boot_interface,
+        selection_version = %target.selection_version,
+        "Starting authorized assigned boot-interface synchronization",
+    );
+    let mut txn = ctx.services.db_pool.begin().await?;
+    if !db::machine::lock_boot_config_synchronization_request(
+        &mut txn,
+        mh_snapshot.host_snapshot.id,
+        request.interface_id,
+        request.selection_version,
+    )
+    .await?
+    {
+        txn.rollback().await?;
+        return Ok(None);
+    }
+    Ok(Some(
+        StateHandlerOutcome::transition(
+            BootConfigSynchronizationDriver::new(BootConfigSynchronizationOwner::Assigned).state(
+                BootConfigSynchronizationState::Initialize {
+                    target: Some(target),
+                },
+            ),
+        )
+        .with_txn(txn),
+    ))
+}
+
+/// Handles one persisted boot-interface synchronization phase.
+///
+/// Called by both the top-level unassigned parent and the nested assigned
+/// parent. Every active phase first compares its pinned target with the current
+/// selected interface generation, so work for an older selection cannot count
+/// as completion for a newer one. Lockdown restoration is deliberately
+/// target-independent so missing selection data cannot prevent cleanup.
+pub(super) async fn handle_boot_config_synchronization(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    reachability_params: &ReachabilityParams,
+    owner: BootConfigSynchronizationOwner,
+    synchronization_retry_count: u32,
+    state: &BootConfigSynchronizationState,
+    assigned_preemption: AssignedSynchronizationPreemption,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let driver = BootConfigSynchronizationDriver::resume(owner, synchronization_retry_count);
+    if owner == BootConfigSynchronizationOwner::Assigned
+        && assigned_preemption == AssignedSynchronizationPreemption::Discard
+        && let Some(target) = authorization_target(state)
+        && let Some(interface_id) = target.machine_interface_id
+        && mh_snapshot
+            .host_snapshot
+            .boot_config_synchronization_requested
+            .as_ref()
+            .is_some_and(|request| {
+                request.interface_id == interface_id
+                    && request.selection_version == target.selection_version
+            })
+    {
+        let mut txn = ctx.services.db_pool.begin().await?;
+        if db::machine::consume_boot_config_synchronization_request(
+            &mut txn,
+            mh_snapshot.host_snapshot.id,
+            interface_id,
+            target.selection_version,
+        )
+        .await?
+        {
+            return Ok(StateHandlerOutcome::do_nothing().with_txn(txn));
+        }
+        txn.rollback().await?;
+    }
+
+    if owner == BootConfigSynchronizationOwner::Assigned
+        && !matches!(
+            state,
+            BootConfigSynchronizationState::RestoreLockdown { .. }
+        )
+        && !power_recovery_in_progress(state)
+    {
+        let Some(target) = state_target(state) else {
+            tracing::warn!(
+                machine_id = %mh_snapshot.host_snapshot.id,
+                "Stopping assigned boot-interface synchronization without a pinned target",
+            );
+            return Ok(StateHandlerOutcome::transition(driver.ready_state()));
+        };
+        if !assigned_authorization_matches(mh_snapshot, target) {
+            let request = mh_snapshot
+                .host_snapshot
+                .boot_config_synchronization_requested
+                .as_ref();
+            tracing::info!(
+                machine_id = %mh_snapshot.host_snapshot.id,
+                machine_interface_id = ?target.machine_interface_id,
+                selection_version = %target.selection_version,
+                authorized_machine_interface_id = ?request.map(|request| request.interface_id),
+                authorized_selection_version = ?request.map(|request| request.selection_version),
+                "Stopping assigned boot-interface synchronization because its authorization is no longer current",
+            );
+            let completion = BootConfigSynchronizationCompletion::ReturnToReady {
+                target: target.clone(),
+            };
+            let next_state = if state_may_require_lockdown_restore(state)
+                && !mh_snapshot.host_snapshot.host_profile.disable_lockdown
+            {
+                driver.state(BootConfigSynchronizationState::RestoreLockdown { completion })
+            } else {
+                completion_state(driver, completion, mh_snapshot.host_snapshot.id)
+            };
+            return Ok(StateHandlerOutcome::transition(next_state));
+        }
+    }
+
+    if let Some(completion) = preemption_completion(mh_snapshot, owner, state, assigned_preemption)
+    {
+        if state_may_require_lockdown_restore(state)
+            && !mh_snapshot.host_snapshot.host_profile.disable_lockdown
+        {
+            return Ok(StateHandlerOutcome::transition(driver.state(
+                BootConfigSynchronizationState::RestoreLockdown { completion },
+            )));
+        } else {
+            return Ok(StateHandlerOutcome::transition(completion_state(
+                driver,
+                completion,
+                mh_snapshot.host_snapshot.id,
+            )));
+        }
+    }
+
+    // Lockdown restoration is a cleanup barrier and deliberately needs no
+    // selected interface. Resolving one here could strand a disabled BMC when
+    // the target data that interrupted synchronization is missing.
+    let should_resolve_current_target = uses_current_target(state);
+    let current_target = if should_resolve_current_target {
+        match resolve_current_target(mh_snapshot, ctx).await? {
+            CurrentTargetResolution::Ready(target) => Some(target),
+            CurrentTargetResolution::AwaitingNic => None,
+            CurrentTargetResolution::Missing if state_target(state).is_some() => None,
+            CurrentTargetResolution::Missing => {
+                return Err(StateHandlerError::GenericError(eyre::eyre!(
+                    "missing selected boot interface for managed-DPU host {}",
+                    mh_snapshot.host_snapshot.id
+                )));
+            }
+        }
+    } else {
+        None
+    };
+    if should_resolve_current_target
+        && let Some(expected_target) = state_target(state)
+        && current_target.as_ref() != Some(expected_target)
+    {
+        let completion = target_mismatch_completion(expected_target, current_target);
+        tracing::warn!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            expected_target = ?expected_target,
+            completion = ?completion,
+            "Selected boot interface changed during synchronization",
+        );
+        let next_state = if state_may_require_lockdown_restore(state)
+            && !mh_snapshot.host_snapshot.host_profile.disable_lockdown
+        {
+            driver.state(BootConfigSynchronizationState::RestoreLockdown { completion })
+        } else {
+            completion_state(driver, completion, mh_snapshot.host_snapshot.id)
+        };
+        return Ok(StateHandlerOutcome::transition(next_state));
+    }
+
+    match state {
+        BootConfigSynchronizationState::Initialize { target } => {
+            let Some(target) = target.clone().or(current_target) else {
+                return Ok(StateHandlerOutcome::wait(format!(
+                    "Waiting for host {} to expose a selected boot interface",
+                    mh_snapshot.host_snapshot.id
+                )));
+            };
+            request_observation(mh_snapshot, ctx, driver, target, ObservationPhase::Initial).await
+        }
+        BootConfigSynchronizationState::WaitingForInitialObservation {
+            target,
+            minimum_report_version,
+        } => {
+            let evaluation =
+                observe_target(mh_snapshot, ctx, target, *minimum_report_version).await?;
+            match evaluation.progress {
+                ObservationProgress::Waiting => {
+                    wait_for_observation(mh_snapshot, ctx, driver, target, evaluation).await
+                }
+                ObservationProgress::Configured => {
+                    tracing::info!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        boot_interface = ?target.boot_interface,
+                        selection_version = %target.selection_version,
+                        "Selected boot interface is configured",
+                    );
+                    finish_synchronization(
+                        mh_snapshot,
+                        ctx,
+                        driver,
+                        target,
+                        *minimum_report_version,
+                        ObservationPhase::Initial,
+                    )
+                    .await
+                }
+                ObservationProgress::NeedsSynchronization => Ok(StateHandlerOutcome::transition(
+                    driver.state(BootConfigSynchronizationState::PrepareHost {
+                        target: target.clone(),
+                    }),
+                )),
+            }
+        }
+        BootConfigSynchronizationState::PrepareHost { target } => {
+            prepare_host(mh_snapshot, ctx, driver, target.clone()).await
+        }
+        BootConfigSynchronizationState::UnlockHost {
+            target,
+            unlock_host_state,
+        } => {
+            unlock_host(
+                mh_snapshot,
+                ctx,
+                reachability_params,
+                driver,
+                target.clone(),
+                unlock_host_state,
+            )
+            .await
+        }
+        BootConfigSynchronizationState::CheckHostConfig { target } => {
+            check_host(
+                mh_snapshot,
+                ctx,
+                reachability_params,
+                driver,
+                target.clone(),
+            )
+            .await
+        }
+        BootConfigSynchronizationState::ConfigureBios {
+            target,
+            retry_count,
+        } => {
+            run_stage(
+                mh_snapshot,
+                ctx,
+                reachability_params,
+                driver,
+                target.clone(),
+                HostBootConfigStage::ConfigureBios {
+                    retry_count: *retry_count,
+                },
+            )
+            .await
+        }
+        BootConfigSynchronizationState::WaitingForBiosJob {
+            target,
+            bios_config_info,
+        } => {
+            run_stage(
+                mh_snapshot,
+                ctx,
+                reachability_params,
+                driver,
+                target.clone(),
+                HostBootConfigStage::WaitingForBiosJob {
+                    bios_config_info: bios_config_info.clone(),
+                },
+            )
+            .await
+        }
+        BootConfigSynchronizationState::PollingBiosSetup {
+            target,
+            retry_count,
+        } => {
+            run_stage(
+                mh_snapshot,
+                ctx,
+                reachability_params,
+                driver,
+                target.clone(),
+                HostBootConfigStage::PollingBiosSetup {
+                    retry_count: *retry_count,
+                },
+            )
+            .await
+        }
+        BootConfigSynchronizationState::SetBootOrder {
+            target,
+            set_boot_order_info,
+        } => {
+            run_stage(
+                mh_snapshot,
+                ctx,
+                reachability_params,
+                driver,
+                target.clone(),
+                HostBootConfigStage::SetBootOrder {
+                    set_boot_order_info: set_boot_order_info.clone(),
+                },
+            )
+            .await
+        }
+        BootConfigSynchronizationState::RestoreLockdown { completion } => {
+            restore_lockdown(mh_snapshot, ctx, driver, completion).await
+        }
+        BootConfigSynchronizationState::LockHost { target } => {
+            lock_host_and_request_final_observation(mh_snapshot, ctx, driver, target.clone()).await
+        }
+        BootConfigSynchronizationState::WaitingForFinalObservation {
+            target,
+            minimum_report_version,
+        } => {
+            let evaluation =
+                observe_target(mh_snapshot, ctx, target, *minimum_report_version).await?;
+            match evaluation.progress {
+                ObservationProgress::Waiting => {
+                    wait_for_observation(mh_snapshot, ctx, driver, target, evaluation).await
+                }
+                ObservationProgress::Configured => {
+                    tracing::info!(
+                        machine_id = %mh_snapshot.host_snapshot.id,
+                        boot_interface = ?target.boot_interface,
+                        selection_version = %target.selection_version,
+                        "Verified the synchronized boot interface",
+                    );
+                    finish_synchronization(
+                        mh_snapshot,
+                        ctx,
+                        driver,
+                        target,
+                        *minimum_report_version,
+                        ObservationPhase::Final,
+                    )
+                    .await
+                }
+                ObservationProgress::NeedsSynchronization => {
+                    let next_state = retry_after_final_mismatch(
+                        mh_snapshot,
+                        ctx,
+                        driver,
+                        target,
+                        &evaluation.reason,
+                    )?;
+                    Ok(StateHandlerOutcome::transition(next_state))
+                }
+            }
+        }
+    }
+}
+
+fn uses_current_target(state: &BootConfigSynchronizationState) -> bool {
+    !matches!(
+        state,
+        BootConfigSynchronizationState::RestoreLockdown { .. }
+    ) && !power_recovery_in_progress(state)
+}
+
+fn preemption_completion(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    owner: BootConfigSynchronizationOwner,
+    state: &BootConfigSynchronizationState,
+    assigned_preemption: AssignedSynchronizationPreemption,
+) -> Option<BootConfigSynchronizationCompletion> {
+    if matches!(
+        state,
+        BootConfigSynchronizationState::RestoreLockdown { .. }
+    ) || power_recovery_in_progress(state)
+    {
+        return None;
+    }
+    match owner {
+        BootConfigSynchronizationOwner::Unassigned => mh_snapshot
+            .host_snapshot
+            .machine_maintenance_requested
+            .as_ref()
+            .map(|request| BootConfigSynchronizationCompletion::Maintenance {
+                operation: request.operation,
+            }),
+        BootConfigSynchronizationOwner::Assigned => {
+            if assigned_preemption == AssignedSynchronizationPreemption::None {
+                None
+            } else {
+                state_target(state).map(|target| {
+                    BootConfigSynchronizationCompletion::ReturnToReady {
+                        target: target.clone(),
+                    }
+                })
+            }
+        }
+    }
+}
+
+fn state_target(
+    state: &BootConfigSynchronizationState,
+) -> Option<&BootConfigSynchronizationTarget> {
+    match state {
+        BootConfigSynchronizationState::Initialize { target } => target.as_ref(),
+        BootConfigSynchronizationState::WaitingForInitialObservation { target, .. }
+        | BootConfigSynchronizationState::PrepareHost { target }
+        | BootConfigSynchronizationState::UnlockHost { target, .. }
+        | BootConfigSynchronizationState::CheckHostConfig { target }
+        | BootConfigSynchronizationState::ConfigureBios { target, .. }
+        | BootConfigSynchronizationState::WaitingForBiosJob { target, .. }
+        | BootConfigSynchronizationState::PollingBiosSetup { target, .. }
+        | BootConfigSynchronizationState::SetBootOrder { target, .. }
+        | BootConfigSynchronizationState::LockHost { target }
+        | BootConfigSynchronizationState::WaitingForFinalObservation { target, .. } => Some(target),
+        BootConfigSynchronizationState::RestoreLockdown { .. } => None,
+    }
+}
+
+fn authorization_target(
+    state: &BootConfigSynchronizationState,
+) -> Option<&BootConfigSynchronizationTarget> {
+    state_target(state).or(match state {
+        BootConfigSynchronizationState::RestoreLockdown {
+            completion: BootConfigSynchronizationCompletion::ReturnToReady { target },
+        } => Some(target),
+        _ => None,
+    })
+}
+
+fn assigned_authorization_matches(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    target: &BootConfigSynchronizationTarget,
+) -> bool {
+    let Some(interface_id) = target.machine_interface_id else {
+        return false;
+    };
+    mh_snapshot
+        .host_snapshot
+        .boot_config_synchronization_requested
+        .as_ref()
+        .is_some_and(|request| {
+            request.interface_id == interface_id
+                && request.selection_version == target.selection_version
+        })
+}
+
+fn state_may_require_lockdown_restore(state: &BootConfigSynchronizationState) -> bool {
+    matches!(
+        state,
+        BootConfigSynchronizationState::UnlockHost { .. }
+            | BootConfigSynchronizationState::CheckHostConfig { .. }
+            | BootConfigSynchronizationState::ConfigureBios { .. }
+            | BootConfigSynchronizationState::WaitingForBiosJob { .. }
+            | BootConfigSynchronizationState::PollingBiosSetup { .. }
+            | BootConfigSynchronizationState::SetBootOrder { .. }
+            | BootConfigSynchronizationState::LockHost { .. }
+    )
+}
+
+fn power_recovery_in_progress(state: &BootConfigSynchronizationState) -> bool {
+    match state {
+        BootConfigSynchronizationState::WaitingForBiosJob {
+            bios_config_info, ..
+        } => matches!(
+            bios_config_info.bios_config_state,
+            model::machine::BiosConfigState::HandleBiosJobFailure { .. }
+        ),
+        BootConfigSynchronizationState::SetBootOrder {
+            set_boot_order_info,
+            ..
+        } => matches!(
+            set_boot_order_info.set_boot_order_state,
+            model::machine::SetBootOrderState::HandleJobFailure { .. }
+        ),
+        _ => false,
+    }
+}
+
+fn same_selection(
+    expected: &BootConfigSynchronizationTarget,
+    current: &BootConfigSynchronizationTarget,
+) -> bool {
+    // A first lease promotes the predicted interface into a machine-interface
+    // row, and later exploration may enrich its Redfish id. The selection
+    // generation and MAC remain the durable identity across both changes.
+    expected.selection_version == current.selection_version
+        && boot_interface_mac(&expected.boot_interface)
+            == boot_interface_mac(&current.boot_interface)
+}
+
+fn boot_interface_mac(target: &MachineBootInterfaceTarget) -> mac_address::MacAddress {
+    match target {
+        MachineBootInterfaceTarget::Pair(interface) => interface.mac_address,
+        MachineBootInterfaceTarget::MacOnly(mac_address) => *mac_address,
+    }
+}
+
+fn target_mismatch_completion(
+    expected: &BootConfigSynchronizationTarget,
+    current: Option<BootConfigSynchronizationTarget>,
+) -> BootConfigSynchronizationCompletion {
+    current
+        .filter(|current| same_selection(expected, current))
+        .map_or(
+            BootConfigSynchronizationCompletion::TargetChanged,
+            |target| BootConfigSynchronizationCompletion::Retarget { target },
+        )
+}
+
+fn completion_state(
+    driver: BootConfigSynchronizationDriver,
+    completion: BootConfigSynchronizationCompletion,
+    machine_id: carbide_uuid::machine::MachineId,
+) -> ManagedHostState {
+    match completion {
+        BootConfigSynchronizationCompletion::Retarget { target } => {
+            driver.state(BootConfigSynchronizationState::Initialize {
+                target: Some(target),
+            })
+        }
+        BootConfigSynchronizationCompletion::ResumeSynchronization { target } => {
+            driver.state(BootConfigSynchronizationState::Initialize { target })
+        }
+        BootConfigSynchronizationCompletion::TargetChanged => driver.target_changed_state(),
+        BootConfigSynchronizationCompletion::ReturnToReady { .. } => driver.ready_state(),
+        BootConfigSynchronizationCompletion::Maintenance { operation } => {
+            ManagedHostState::maintenance_for_operation(operation)
+        }
+        BootConfigSynchronizationCompletion::MachineFailed {
+            machine_id,
+            details,
+        } => driver.machine_failure_state(machine_id, details),
+        BootConfigSynchronizationCompletion::Failed { error } => {
+            driver.failure_state(machine_id, error)
+        }
+        BootConfigSynchronizationCompletion::ManualInterventionRequired { error } => {
+            driver.failure_state(machine_id, error)
+        }
+    }
+}
+
+enum CurrentTargetResolution {
+    Ready(BootConfigSynchronizationTarget),
+    AwaitingNic,
+    Missing,
+}
+
+impl CurrentTargetResolution {
+    fn into_option(self) -> Option<BootConfigSynchronizationTarget> {
+        match self {
+            Self::Ready(target) => Some(target),
+            Self::AwaitingNic | Self::Missing => None,
+        }
+    }
+}
+
+async fn resolve_current_target(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<CurrentTargetResolution, StateHandlerError> {
+    let predictions = load_boot_predictions(ctx, mh_snapshot).await?;
+    match resolve_boot_interface(mh_snapshot, &predictions) {
+        BootInterfaceResolution::Ready(resolved) => {
+            Ok(CurrentTargetResolution::Ready(synchronization_target(
+                &resolved,
+                mh_snapshot.host_snapshot.boot_interface_selection_version,
+            )))
+        }
+        BootInterfaceResolution::AwaitingNic => Ok(CurrentTargetResolution::AwaitingNic),
+        BootInterfaceResolution::Missing => Ok(CurrentTargetResolution::Missing),
+    }
+}
+
+fn synchronization_target(
+    resolved: &ResolvedBootInterface,
+    selection_version: ConfigVersion,
+) -> BootConfigSynchronizationTarget {
+    BootConfigSynchronizationTarget {
+        machine_interface_id: resolved.machine_interface_id,
+        boot_interface: (&resolved.target).into(),
+        selection_version,
+    }
+}
+
+async fn find_endpoint(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    services: &mut MachineStateHandlerServices,
+) -> Result<Option<ExploredEndpoint>, StateHandlerError> {
+    let Some(address) = mh_snapshot.host_snapshot.status.bmc_info.ip else {
+        return Err(StateHandlerError::MissingData {
+            object_id: mh_snapshot.host_snapshot.id.to_string(),
+            missing: "BMC IP",
+        });
+    };
+    Ok(
+        db::explored_endpoints::find_by_ips(&mut services.db_reader, vec![address])
+            .await?
+            .into_iter()
+            .next(),
+    )
+}
+
+#[derive(Clone, Copy)]
+enum ObservationPhase {
+    Initial,
+    Final,
+}
+
+async fn request_observation(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    target: BootConfigSynchronizationTarget,
+    phase: ObservationPhase,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let Some(address) = mh_snapshot.host_snapshot.status.bmc_info.ip else {
+        return Err(StateHandlerError::MissingData {
+            object_id: mh_snapshot.host_snapshot.id.to_string(),
+            missing: "BMC IP",
+        });
+    };
+    if find_endpoint(mh_snapshot, ctx.services).await?.is_none() {
+        return Ok(StateHandlerOutcome::wait(format!(
+            "Waiting for explored endpoint {address} before observing the selected boot interface"
+        )));
+    }
+
+    // State persistence later uses this same transaction. Lock the endpoint
+    // before the machine row, matching Site Explorer and Scout discovery.
+    let mut txn = ctx.services.db_pool.begin().await?;
+    if db::explored_endpoints::find_by_ip_for_update_optional(address, &mut txn)
+        .await?
+        .is_none()
+    {
+        return Ok(StateHandlerOutcome::wait(format!(
+            "Waiting for explored endpoint {address} before observing the selected boot interface"
+        ))
+        .with_txn(txn));
+    }
+    let current_selection_version =
+        db::machine::lock_boot_interface_selection_version(&mut txn, mh_snapshot.host_snapshot.id)
+            .await?;
+    if current_selection_version != target.selection_version {
+        txn.rollback().await?;
+        return Ok(StateHandlerOutcome::transition(
+            driver.target_changed_state(),
+        ));
+    }
+    let minimum_report_version = db::explored_endpoints::request_boot_interface_observation(
+        address,
+        &target.boot_interface,
+        &mut txn,
+    )
+    .await?;
+    let next = match phase {
+        ObservationPhase::Initial => BootConfigSynchronizationState::WaitingForInitialObservation {
+            target,
+            minimum_report_version,
+        },
+        ObservationPhase::Final => BootConfigSynchronizationState::WaitingForFinalObservation {
+            target,
+            minimum_report_version,
+        },
+    };
+    Ok(StateHandlerOutcome::transition(driver.state(next)).with_txn(txn))
+}
+
+async fn observe_target(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    target: &BootConfigSynchronizationTarget,
+    minimum_report_version: ConfigVersion,
+) -> Result<ObservationEvaluation, StateHandlerError> {
+    let Some(endpoint) = find_endpoint(mh_snapshot, ctx.services).await? else {
+        return Ok(ObservationEvaluation::waiting(
+            "Waiting for the host's explored endpoint",
+            false,
+        ));
+    };
+    Ok(evaluate_observation(
+        &endpoint,
+        target,
+        minimum_report_version,
+        ObservationPolicy::for_host(mh_snapshot),
+    ))
+}
+
+async fn finish_synchronization(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    target: &BootConfigSynchronizationTarget,
+    minimum_report_version: ConfigVersion,
+    phase: ObservationPhase,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let machine_id = mh_snapshot.host_snapshot.id;
+    let Some(address) = mh_snapshot.host_snapshot.status.bmc_info.ip else {
+        return Err(StateHandlerError::MissingData {
+            object_id: machine_id.to_string(),
+            missing: "BMC IP",
+        });
+    };
+    let mut txn = ctx.services.db_pool.begin().await?;
+    let locked = lock_boot_config_view(&mut txn, machine_id, address).await?;
+    let Some(endpoint) = locked.endpoint else {
+        return Ok(StateHandlerOutcome::wait(format!(
+            "Waiting for explored endpoint {address} before completing boot-interface synchronization"
+        ))
+        .with_txn(txn));
+    };
+    let current_target = locked
+        .target
+        .filter(|current| current.selection_version == target.selection_version);
+
+    if current_target.as_ref() != Some(target) {
+        let completion = target_mismatch_completion(target, current_target);
+        return Ok(StateHandlerOutcome::transition(completion_state(
+            driver, completion, machine_id,
+        ))
+        .with_txn(txn));
+    }
+
+    let evaluation = evaluate_observation(
+        &endpoint,
+        target,
+        minimum_report_version,
+        ObservationPolicy::for_host(mh_snapshot),
+    );
+    match evaluation.progress {
+        ObservationProgress::Configured => {
+            if driver.owner == BootConfigSynchronizationOwner::Assigned
+                && let Some(interface_id) = target.machine_interface_id
+            {
+                // A replacement authorization names a newer request and must
+                // remain available when this older synchronization completes.
+                db::machine::consume_boot_config_synchronization_request(
+                    &mut txn,
+                    machine_id,
+                    interface_id,
+                    target.selection_version,
+                )
+                .await?;
+            } else if driver.owner == BootConfigSynchronizationOwner::Unassigned {
+                // Assigned authorization cannot cross the unassigned Ready
+                // boundary and become usable by a later tenant.
+                db::machine::clear_boot_config_synchronization_request(&mut txn, machine_id)
+                    .await?;
+            }
+            Ok(StateHandlerOutcome::transition(driver.ready_state()).with_txn(txn))
+        }
+        ObservationProgress::NeedsSynchronization => {
+            let next_state = match phase {
+                ObservationPhase::Initial => {
+                    driver.state(BootConfigSynchronizationState::PrepareHost {
+                        target: target.clone(),
+                    })
+                }
+                ObservationPhase::Final => retry_after_final_mismatch(
+                    mh_snapshot,
+                    ctx,
+                    driver,
+                    target,
+                    &evaluation.reason,
+                )?,
+            };
+            Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
+        }
+        ObservationProgress::Waiting => {
+            if evaluation.request_exploration {
+                request_target_observation(address, &endpoint, target, &mut txn).await?;
+            }
+            Ok(StateHandlerOutcome::wait(evaluation.reason).with_txn(txn))
+        }
+    }
+}
+
+fn retry_after_final_mismatch(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    target: &BootConfigSynchronizationTarget,
+    mismatch: &str,
+) -> Result<ManagedHostState, StateHandlerError> {
+    let max_retries = ctx
+        .services
+        .site_config
+        .machine_state_controller
+        .max_bios_config_retries;
+    if driver.retry_count >= max_retries {
+        return Err(StateHandlerError::ManualInterventionRequired(format!(
+            "Selected boot interface is still not configured for host {} after automated boot-config synchronization; retry budget exhausted (retry_count: {}, max_retries: {}); {}",
+            mh_snapshot.host_snapshot.id, driver.retry_count, max_retries, mismatch,
+        )));
+    }
+
+    let next_driver = driver.retry();
+    tracing::warn!(
+        machine_id = %mh_snapshot.host_snapshot.id,
+        boot_interface = ?target.boot_interface,
+        selection_version = %target.selection_version,
+        retry_count = next_driver.retry_count,
+        max_retries,
+        mismatch = %mismatch,
+        "Selected boot interface is still not configured after final verification; synchronizing again",
+    );
+    Ok(
+        next_driver.state(BootConfigSynchronizationState::PrepareHost {
+            target: target.clone(),
+        }),
+    )
+}
+
+fn evaluate_observation(
+    endpoint: &ExploredEndpoint,
+    target: &BootConfigSynchronizationTarget,
+    minimum_report_version: ConfigVersion,
+    policy: ObservationPolicy,
+) -> ObservationEvaluation {
+    if !version_is_newer(endpoint.report_version, minimum_report_version) {
+        return ObservationEvaluation::waiting(
+            format!(
+                "Waiting for a boot-interface observation newer than {}",
+                minimum_report_version
+            ),
+            !endpoint.exploration_requested,
+        );
+    }
+    if let Some(error) = endpoint.report.last_exploration_error.as_ref() {
+        return ObservationEvaluation::waiting(
+            format!("Waiting for Site Explorer after exploration error: {error}"),
+            !endpoint.exploration_requested,
+        );
+    }
+    if endpoint.waiting_for_explorer_refresh {
+        return ObservationEvaluation::waiting(
+            "Waiting for Site Explorer to refresh the boot-interface observation",
+            !endpoint.exploration_requested,
+        );
+    }
+    if endpoint.exploration_requested {
+        return ObservationEvaluation::waiting(
+            "Waiting for the requested Site Explorer run",
+            false,
+        );
+    }
+    if endpoint.boot_interface_target().as_ref() != Some(&target.boot_interface) {
+        return ObservationEvaluation::waiting(
+            "Waiting for Site Explorer to evaluate the current endpoint target",
+            true,
+        );
+    }
+    let Some(status) = endpoint.report.machine_setup_status.as_ref() else {
+        return ObservationEvaluation::waiting("Waiting for a machine-setup observation", true);
+    };
+    if status.verification_version < MACHINE_SETUP_VERIFICATION_VERSION {
+        return ObservationEvaluation::waiting(
+            format!(
+                "Waiting for machine-setup verification version {}",
+                MACHINE_SETUP_VERIFICATION_VERSION
+            ),
+            true,
+        );
+    }
+    if status.evaluated_boot_interface.as_ref() != Some(&target.boot_interface) {
+        return ObservationEvaluation::waiting(
+            "Waiting for a machine-setup observation of the selected boot interface",
+            true,
+        );
+    }
+
+    if policy.accepts(status) {
+        ObservationEvaluation {
+            progress: ObservationProgress::Configured,
+            reason: "Selected boot interface is configured".to_string(),
+            request_exploration: false,
+        }
+    } else {
+        ObservationEvaluation {
+            progress: ObservationProgress::NeedsSynchronization,
+            reason: format!(
+                "machine-setup differences for the selected boot interface: {:?}",
+                status.diffs
+            ),
+            request_exploration: false,
+        }
+    }
+}
+
+// Either component can advance independently when an endpoint row is
+// recreated, so freshness intentionally uses OR rather than tuple ordering.
+fn version_is_newer(report: ConfigVersion, minimum: ConfigVersion) -> bool {
+    report.version_nr() > minimum.version_nr() || report.timestamp() > minimum.timestamp()
+}
+
+async fn wait_for_observation(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    target: &BootConfigSynchronizationTarget,
+    evaluation: ObservationEvaluation,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    if !evaluation.request_exploration {
+        return Ok(StateHandlerOutcome::wait(evaluation.reason));
+    }
+
+    let Some(address) = mh_snapshot.host_snapshot.status.bmc_info.ip else {
+        return Err(StateHandlerError::MissingData {
+            object_id: mh_snapshot.host_snapshot.id.to_string(),
+            missing: "BMC IP",
+        });
+    };
+    let mut txn = ctx.services.db_pool.begin().await?;
+    let Some(endpoint) =
+        db::explored_endpoints::find_by_ip_for_update_optional(address, &mut txn).await?
+    else {
+        return Ok(StateHandlerOutcome::wait(evaluation.reason).with_txn(txn));
+    };
+    let current_selection_version =
+        db::machine::lock_boot_interface_selection_version(&mut txn, mh_snapshot.host_snapshot.id)
+            .await?;
+    if current_selection_version != target.selection_version {
+        txn.rollback().await?;
+        return Ok(StateHandlerOutcome::transition(
+            driver.target_changed_state(),
+        ));
+    }
+    request_target_observation(address, &endpoint, target, &mut txn).await?;
+    Ok(StateHandlerOutcome::wait(evaluation.reason).with_txn(txn))
+}
+
+/// Reasserts the pinned endpoint target before requesting another observation.
+///
+/// A recreated or concurrently changed endpoint can lose its target while the
+/// controller is waiting. Re-exploration alone would keep evaluating the wrong
+/// interface, so a mismatch crosses a new version barrier first.
+async fn request_target_observation(
+    address: std::net::IpAddr,
+    endpoint: &ExploredEndpoint,
+    target: &BootConfigSynchronizationTarget,
+    txn: &mut sqlx::PgConnection,
+) -> Result<(), StateHandlerError> {
+    if endpoint.boot_interface_target().as_ref() != Some(&target.boot_interface) {
+        db::explored_endpoints::set_boot_interface_target(address, &target.boot_interface, txn)
+            .await?;
+    } else {
+        db::explored_endpoints::re_explore_if_version_matches(
+            address,
+            endpoint.report_version,
+            txn,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn prepare_host(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    target: BootConfigSynchronizationTarget,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+    let next = match redfish_client.lockdown_status().await {
+        Err(RedfishError::NotSupported(_)) => {
+            BootConfigSynchronizationState::CheckHostConfig { target }
+        }
+        Err(error) => {
+            tracing::warn!(
+                machine_id = %mh_snapshot.host_snapshot.id,
+                error = %error,
+                "Failed to read BMC lockdown before boot-interface synchronization",
+            );
+            return Ok(StateHandlerOutcome::wait(format!(
+                "Failed to read BMC lockdown: {error}"
+            )));
+        }
+        Ok(status) if !status.is_fully_disabled() => BootConfigSynchronizationState::UnlockHost {
+            target,
+            unlock_host_state: UnlockHostState::DisableLockdown,
+        },
+        Ok(_) => BootConfigSynchronizationState::CheckHostConfig { target },
+    };
+    Ok(StateHandlerOutcome::transition(driver.state(next)))
+}
+
+async fn unlock_host(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    reachability_params: &ReachabilityParams,
+    driver: BootConfigSynchronizationDriver,
+    target: BootConfigSynchronizationTarget,
+    unlock_host_state: &UnlockHostState,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+    let next = match unlock_host_state {
+        UnlockHostState::DisableLockdown => {
+            match redfish_client.lockdown_bmc(EnabledDisabled::Disabled).await {
+                Ok(()) | Err(RedfishError::NotSupported(_)) => {}
+                Err(error) => return Err(redfish_error("lockdown_bmc", error)),
+            }
+            if mh_snapshot.host_snapshot.bmc_vendor().is_supermicro() {
+                BootConfigSynchronizationState::UnlockHost {
+                    target,
+                    unlock_host_state: UnlockHostState::RebootHost,
+                }
+            } else {
+                BootConfigSynchronizationState::CheckHostConfig { target }
+            }
+        }
+        UnlockHostState::RebootHost => {
+            host_power_control(
+                redfish_client.as_ref(),
+                &mh_snapshot.host_snapshot,
+                SystemPowerControl::ForceRestart,
+                ctx,
+            )
+            .await
+            .map_err(|error| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "failed to restart host after disabling BMC lockdown: {error}"
+                ))
+            })?;
+            BootConfigSynchronizationState::UnlockHost {
+                target,
+                unlock_host_state: UnlockHostState::WaitForUefiBoot,
+            }
+        }
+        UnlockHostState::WaitForUefiBoot => {
+            let entered_at = mh_snapshot.host_snapshot.state.version.timestamp();
+            if wait(&entered_at, reachability_params.uefi_boot_wait) {
+                return Ok(StateHandlerOutcome::wait(format!(
+                    "Waiting for UEFI boot on {} after disabling BMC lockdown",
+                    mh_snapshot.host_snapshot.id
+                )));
+            }
+            BootConfigSynchronizationState::CheckHostConfig { target }
+        }
+    };
+    Ok(StateHandlerOutcome::transition(driver.state(next)))
+}
+
+async fn check_host(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    reachability_params: &ReachabilityParams,
+    driver: BootConfigSynchronizationDriver,
+    target: BootConfigSynchronizationTarget,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+    let next = match check_host_boot_config(
+        redfish_client.as_ref(),
+        mh_snapshot,
+        reachability_params,
+        HostBootConfigDpuFreshness::CurrentHostState,
+        HostBootInterfaceSource::Pinned(target.boot_interface.clone().into()),
+        ctx,
+    )
+    .await?
+    {
+        HostBootConfigCheckOutcome::Wait(reason) => {
+            return Ok(StateHandlerOutcome::wait(reason));
+        }
+        HostBootConfigCheckOutcome::Ready(HostBootConfigDecision::ConfigureBios) => {
+            BootConfigSynchronizationState::ConfigureBios {
+                target,
+                retry_count: 0,
+            }
+        }
+        HostBootConfigCheckOutcome::Ready(HostBootConfigDecision::SetBootOrder) => {
+            BootConfigSynchronizationState::SetBootOrder {
+                target,
+                set_boot_order_info: initial_set_boot_order_info(),
+            }
+        }
+        HostBootConfigCheckOutcome::Ready(HostBootConfigDecision::Complete) => {
+            BootConfigSynchronizationState::LockHost { target }
+        }
+    };
+    Ok(StateHandlerOutcome::transition(driver.state(next)))
+}
+
+async fn run_stage(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    reachability_params: &ReachabilityParams,
+    driver: BootConfigSynchronizationDriver,
+    target: BootConfigSynchronizationTarget,
+    stage: HostBootConfigStage,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+    let stage_outcome = match run_host_boot_config_stage(
+        ctx,
+        reachability_params,
+        redfish_client.as_ref(),
+        mh_snapshot,
+        HostBootInterfaceSource::Pinned(target.boot_interface.clone().into()),
+        stage,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(StateHandlerError::ManualInterventionRequired(error)) => {
+            if mh_snapshot.host_snapshot.host_profile.disable_lockdown {
+                return Err(StateHandlerError::ManualInterventionRequired(error));
+            }
+            return Ok(StateHandlerOutcome::transition(driver.state(
+                BootConfigSynchronizationState::RestoreLockdown {
+                    completion: BootConfigSynchronizationCompletion::ManualInterventionRequired {
+                        error,
+                    },
+                },
+            )));
+        }
+        Err(error) => return Err(error),
+    };
+    match stage_outcome {
+        HostBootConfigOutcome::Continue(stage) => {
+            let next = match stage {
+                HostBootConfigStage::ConfigureBios { retry_count } => {
+                    BootConfigSynchronizationState::ConfigureBios {
+                        target,
+                        retry_count,
+                    }
+                }
+                HostBootConfigStage::WaitingForBiosJob { bios_config_info } => {
+                    BootConfigSynchronizationState::WaitingForBiosJob {
+                        target,
+                        bios_config_info,
+                    }
+                }
+                HostBootConfigStage::PollingBiosSetup { retry_count } => {
+                    BootConfigSynchronizationState::PollingBiosSetup {
+                        target,
+                        retry_count,
+                    }
+                }
+                HostBootConfigStage::SetBootOrder {
+                    set_boot_order_info,
+                } => BootConfigSynchronizationState::SetBootOrder {
+                    target,
+                    set_boot_order_info,
+                },
+            };
+            Ok(StateHandlerOutcome::transition(driver.state(next)))
+        }
+        HostBootConfigOutcome::Complete => Ok(StateHandlerOutcome::transition(
+            driver.state(BootConfigSynchronizationState::LockHost { target }),
+        )),
+        HostBootConfigOutcome::Wait(reason) => Ok(StateHandlerOutcome::wait(reason)),
+        HostBootConfigOutcome::Failed { failure } => {
+            let next = if mh_snapshot.host_snapshot.host_profile.disable_lockdown {
+                driver.failure_state(mh_snapshot.host_snapshot.id, failure)
+            } else {
+                driver.state(BootConfigSynchronizationState::RestoreLockdown {
+                    completion: BootConfigSynchronizationCompletion::Failed { error: failure },
+                })
+            };
+            Ok(StateHandlerOutcome::transition(next))
+        }
+    }
+}
+
+async fn restore_lockdown(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    completion: &BootConfigSynchronizationCompletion,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    enable_lockdown(mh_snapshot, ctx).await?;
+    if let BootConfigSynchronizationCompletion::ManualInterventionRequired { error } = completion {
+        return Err(StateHandlerError::ManualInterventionRequired(error.clone()));
+    }
+    let next = completion_state(driver, completion.clone(), mh_snapshot.host_snapshot.id);
+    Ok(StateHandlerOutcome::transition(next))
+}
+
+async fn enable_lockdown(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<(), StateHandlerError> {
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+    match redfish_client.lockdown_bmc(EnabledDisabled::Enabled).await {
+        Ok(()) | Err(RedfishError::NotSupported(_)) => Ok(()),
+        Err(error) => Err(redfish_error("lockdown_bmc", error)),
+    }
+}
+
+async fn lock_host_and_request_final_observation(
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    driver: BootConfigSynchronizationDriver,
+    target: BootConfigSynchronizationTarget,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    if mh_snapshot.host_snapshot.host_profile.disable_lockdown {
+        tracing::info!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            "Skipping BMC lockdown after boot-interface synchronization per host profile",
+        );
+    } else {
+        enable_lockdown(mh_snapshot, ctx).await?;
+    }
+    request_observation(mh_snapshot, ctx, driver, target, ObservationPhase::Final).await
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use mac_address::MacAddress;
+    use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
+    use model::network_segment::NetworkSegmentType;
+    use model::site_explorer::{
+        EndpointExplorationError, EndpointExplorationReport, MachineSetupDiff, MachineSetupStatus,
+        PreingestionState,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    enum ObservationCase {
+        OlderReport,
+        EqualReportVersion,
+        IncrementWithEarlierTimestamp,
+        RecreatedEndpointWithNewerTimestamp,
+        WaitingForRefresh,
+        ExplorationRequested,
+        ExplorationError,
+        EndpointTargetMismatch,
+        MissingSetupStatus,
+        LegacyVerification,
+        MissingEvaluatedTarget,
+        PairEvaluatedAsMacOnly,
+        MacOnlyEvaluatedAsPair,
+        NeedsSynchronization,
+        AllowedDisabledLockdown,
+        AllowedSkippedBootOrder,
+        PolicyDoesNotHideOtherDiffs,
+        Configured,
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct EvaluationSummary {
+        progress: ObservationProgress,
+        request_exploration: bool,
+    }
+
+    fn pair(interface_id: &str) -> MachineBootInterfaceTarget {
+        MachineBootInterfaceTarget::Pair(MachineBootInterface {
+            mac_address: MacAddress::new([0x02, 0, 0, 0, 0, 1]),
+            interface_id: interface_id.to_string(),
+        })
+    }
+
+    fn mac_only() -> MachineBootInterfaceTarget {
+        MachineBootInterfaceTarget::MacOnly(MacAddress::new([0x02, 0, 0, 0, 0, 1]))
+    }
+
+    fn synchronization_target_for_test(
+        machine_interface_id: Option<carbide_uuid::machine::MachineInterfaceId>,
+        boot_interface: MachineBootInterfaceTarget,
+        selection_version: ConfigVersion,
+    ) -> BootConfigSynchronizationTarget {
+        BootConfigSynchronizationTarget {
+            machine_interface_id,
+            boot_interface,
+            selection_version,
+        }
+    }
+
+    fn evaluate(case: ObservationCase) -> EvaluationSummary {
+        let mut target = BootConfigSynchronizationTarget {
+            machine_interface_id: None,
+            boot_interface: pair("NIC.Slot.7-1-1"),
+            selection_version: ConfigVersion::new(7),
+        };
+        let mut endpoint_target = target.boot_interface.clone();
+        let minimum_report_version = "V2-T100".parse().expect("valid minimum version");
+        let mut report_version = "V3-T101".parse().expect("valid newer version");
+        let mut waiting_for_explorer_refresh = false;
+        let mut exploration_requested = false;
+        let mut last_exploration_error = None;
+        let mut machine_setup_status = Some(MachineSetupStatus {
+            is_done: true,
+            diffs: Vec::new(),
+            verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
+            evaluated_boot_interface: Some(target.boot_interface.clone()),
+        });
+        let mut policy = ObservationPolicy::default();
+
+        match case {
+            ObservationCase::OlderReport => {
+                report_version = "V1-T99".parse().expect("valid older version");
+            }
+            ObservationCase::EqualReportVersion => report_version = minimum_report_version,
+            ObservationCase::IncrementWithEarlierTimestamp => {
+                report_version = "V3-T99".parse().expect("valid clock-regressed version");
+            }
+            ObservationCase::RecreatedEndpointWithNewerTimestamp => {
+                report_version = "V1-T101".parse().expect("valid recreated version");
+            }
+            ObservationCase::WaitingForRefresh => waiting_for_explorer_refresh = true,
+            ObservationCase::ExplorationRequested => exploration_requested = true,
+            ObservationCase::ExplorationError => {
+                last_exploration_error = Some(EndpointExplorationError::ConnectionTimeout {
+                    details: "test timeout".to_string(),
+                });
+            }
+            ObservationCase::EndpointTargetMismatch => {
+                endpoint_target = pair("NIC.Slot.8-1-1");
+            }
+            ObservationCase::MissingSetupStatus => machine_setup_status = None,
+            ObservationCase::LegacyVerification => {
+                machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present")
+                    .verification_version = 0;
+            }
+            ObservationCase::MissingEvaluatedTarget => {
+                machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present")
+                    .evaluated_boot_interface = None;
+            }
+            ObservationCase::PairEvaluatedAsMacOnly => {
+                machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present")
+                    .evaluated_boot_interface = Some(mac_only());
+            }
+            ObservationCase::MacOnlyEvaluatedAsPair => {
+                target.boot_interface = mac_only();
+                endpoint_target = mac_only();
+            }
+            ObservationCase::NeedsSynchronization => {
+                machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present")
+                    .is_done = false;
+            }
+            ObservationCase::AllowedDisabledLockdown => {
+                let status = machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present");
+                status.is_done = false;
+                status.diffs.push(MachineSetupDiff {
+                    key: "lockdown".to_string(),
+                    expected: "Enabled".to_string(),
+                    actual: "Disabled".to_string(),
+                });
+                policy.allow_disabled_lockdown = true;
+            }
+            ObservationCase::AllowedSkippedBootOrder => {
+                let status = machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present");
+                status.is_done = false;
+                status.diffs.push(MachineSetupDiff {
+                    key: "boot_first".to_string(),
+                    expected: "selected interface".to_string(),
+                    actual: "another interface".to_string(),
+                });
+                policy.skip_boot_order = true;
+            }
+            ObservationCase::PolicyDoesNotHideOtherDiffs => {
+                let status = machine_setup_status
+                    .as_mut()
+                    .expect("setup status starts present");
+                status.is_done = false;
+                status.diffs.push(MachineSetupDiff {
+                    key: "bios_setting".to_string(),
+                    expected: "expected".to_string(),
+                    actual: "actual".to_string(),
+                });
+                policy.allow_disabled_lockdown = true;
+                policy.skip_boot_order = true;
+            }
+            ObservationCase::Configured => {}
+        }
+
+        let (boot_interface_mac, boot_interface_id) = match endpoint_target {
+            MachineBootInterfaceTarget::Pair(interface) => {
+                (Some(interface.mac_address), Some(interface.interface_id))
+            }
+            MachineBootInterfaceTarget::MacOnly(mac_address) => (Some(mac_address), None),
+        };
+        let endpoint = ExploredEndpoint {
+            address: "192.0.2.10".parse().expect("test address is valid"),
+            report: EndpointExplorationReport {
+                last_exploration_error,
+                machine_setup_status,
+                ..Default::default()
+            },
+            report_version,
+            preingestion_state: PreingestionState::Initial,
+            waiting_for_explorer_refresh,
+            exploration_requested,
+            last_redfish_bmc_reset: None,
+            last_ipmitool_bmc_reset: None,
+            last_redfish_reboot: None,
+            last_redfish_powercycle: None,
+            pause_ingestion_and_poweron: false,
+            pause_remediation: false,
+            boot_interface_mac,
+            boot_interface_id,
+        };
+        let evaluation = evaluate_observation(&endpoint, &target, minimum_report_version, policy);
+
+        EvaluationSummary {
+            progress: evaluation.progress,
+            request_exploration: evaluation.request_exploration,
+        }
+    }
+
+    #[test]
+    fn observation_evaluation_requires_fresh_target_correlated_evidence() {
+        value_scenarios!(evaluate:
+            "stale reports wait and request another exploration" {
+                ObservationCase::OlderReport => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::EqualReportVersion => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+            }
+
+            "in-flight exploration waits without duplicating a request" {
+                ObservationCase::WaitingForRefresh => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::ExplorationRequested => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: false,
+                },
+            }
+
+            "failed or incomplete reports request another exploration" {
+                ObservationCase::ExplorationError => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::EndpointTargetMismatch => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::MissingSetupStatus => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::LegacyVerification => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::MissingEvaluatedTarget => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+            }
+
+            "pair and MAC-only observations must match exactly" {
+                ObservationCase::PairEvaluatedAsMacOnly => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+                ObservationCase::MacOnlyEvaluatedAsPair => EvaluationSummary {
+                    progress: ObservationProgress::Waiting,
+                    request_exploration: true,
+                },
+            }
+
+            "exact observations determine whether synchronization is needed" {
+                ObservationCase::IncrementWithEarlierTimestamp => EvaluationSummary {
+                    progress: ObservationProgress::Configured,
+                    request_exploration: false,
+                },
+                ObservationCase::RecreatedEndpointWithNewerTimestamp => EvaluationSummary {
+                    progress: ObservationProgress::Configured,
+                    request_exploration: false,
+                },
+                ObservationCase::NeedsSynchronization => EvaluationSummary {
+                    progress: ObservationProgress::NeedsSynchronization,
+                    request_exploration: false,
+                },
+                ObservationCase::PolicyDoesNotHideOtherDiffs => EvaluationSummary {
+                    progress: ObservationProgress::NeedsSynchronization,
+                    request_exploration: false,
+                },
+                ObservationCase::AllowedDisabledLockdown => EvaluationSummary {
+                    progress: ObservationProgress::Configured,
+                    request_exploration: false,
+                },
+                ObservationCase::AllowedSkippedBootOrder => EvaluationSummary {
+                    progress: ObservationProgress::Configured,
+                    request_exploration: false,
+                },
+                ObservationCase::Configured => EvaluationSummary {
+                    progress: ObservationProgress::Configured,
+                    request_exploration: false,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn interrupted_redfish_work_restores_lockdown_before_leaving_synchronization() {
+        let mut snapshot = model::test_support::machine_snapshot::managed_host_state_snapshot();
+        let target = BootConfigSynchronizationTarget {
+            machine_interface_id: None,
+            boot_interface: pair("NIC.Slot.7-1-1"),
+            selection_version: ConfigVersion::new(7),
+        };
+        snapshot.managed_state = ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::ConfigureBios {
+                target: target.clone(),
+                retry_count: 0,
+            },
+            synchronization_retry_count: 2,
+        };
+        let failed_machine_id = snapshot.dpu_snapshots[0].id;
+        let details = FailureDetails {
+            cause: FailureCause::BiosSetupFailed {
+                err: "test failure".to_string(),
+            },
+            failed_at: chrono::Utc::now(),
+            source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+        };
+
+        let failure_transition =
+            machine_failure_transition(&snapshot, failed_machine_id, details.clone())
+                .expect("synchronization should intercept the failure");
+        snapshot.managed_state = failure_transition.clone();
+        assert!(
+            machine_failure_transition(&snapshot, failed_machine_id, details.clone()).is_none(),
+            "the persisted cleanup state must be allowed to restore lockdown"
+        );
+        let ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::RestoreLockdown { completion },
+            synchronization_retry_count: 2,
+        } = failure_transition
+        else {
+            panic!("failure must restore lockdown before leaving synchronization");
+        };
+        assert_eq!(
+            completion,
+            BootConfigSynchronizationCompletion::MachineFailed {
+                machine_id: failed_machine_id,
+                details: details.clone(),
+            }
+        );
+        assert_eq!(
+            completion_state(
+                BootConfigSynchronizationDriver::resume(
+                    BootConfigSynchronizationOwner::Unassigned,
+                    2,
+                ),
+                completion,
+                snapshot.host_snapshot.id,
+            ),
+            ManagedHostState::Failed {
+                details,
+                machine_id: failed_machine_id,
+                retry_count: 0,
+            }
+        );
+
+        snapshot.managed_state = ManagedHostState::BootConfigSynchronization {
+            synchronization_state: BootConfigSynchronizationState::ConfigureBios {
+                target: target.clone(),
+                retry_count: 0,
+            },
+            synchronization_retry_count: 2,
+        };
+        let missing_dpu_transition = missing_dpu_cleanup_transition(&snapshot)
+            .expect("missing DPUs should also enter the cleanup barrier");
+        assert!(matches!(
+            missing_dpu_transition,
+            ManagedHostState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::RestoreLockdown {
+                    completion:
+                        BootConfigSynchronizationCompletion::ResumeSynchronization {
+                            target: Some(resume_target),
+                        },
+                },
+                synchronization_retry_count: 2,
+            } if resume_target == target
+        ));
+    }
+
+    #[test]
+    fn lockdown_restoration_does_not_require_a_selected_target() {
+        let state = BootConfigSynchronizationState::RestoreLockdown {
+            completion: BootConfigSynchronizationCompletion::TargetChanged,
+        };
+
+        assert!(!uses_current_target(&state));
+    }
+
+    #[test]
+    fn promoted_interface_retargets_the_same_selection() {
+        let selection_version = ConfigVersion::new(7);
+        let expected = synchronization_target_for_test(None, mac_only(), selection_version);
+        let mut promoted_interface = model::machine::MachineInterfaceSnapshot::mock_with_mac(
+            boot_interface_mac(&expected.boot_interface),
+        );
+        promoted_interface.boot_interface_id = Some("NIC.Slot.7-1-1".to_string());
+        promoted_interface.network_segment_type = Some(NetworkSegmentType::HostInband);
+        let resolved = resolved_boot_interface_from_stores(&[promoted_interface], &[])
+            .expect("the freshly loaded owned row should resolve");
+        let current = synchronization_target(&resolved, selection_version);
+
+        assert_eq!(
+            target_mismatch_completion(&expected, Some(current.clone())),
+            BootConfigSynchronizationCompletion::Retarget { target: current },
+            "promoting a prediction and enriching its Redfish identity must preserve synchronization progress",
+        );
+    }
+
+    #[test]
+    fn logical_selection_requires_the_same_mac_and_generation() {
+        let selection_version = ConfigVersion::new(7);
+        let expected = synchronization_target_for_test(None, mac_only(), selection_version);
+        let different_mac = synchronization_target_for_test(
+            None,
+            MachineBootInterfaceTarget::MacOnly(MacAddress::new([0x02, 0, 0, 0, 0, 2])),
+            selection_version,
+        );
+        let newer_generation =
+            synchronization_target_for_test(None, pair("NIC.Slot.7-1-1"), ConfigVersion::new(8));
+
+        assert!(!same_selection(&expected, &different_mac));
+        assert!(!same_selection(&expected, &newer_generation));
+        assert_eq!(
+            target_mismatch_completion(&expected, Some(different_mac)),
+            BootConfigSynchronizationCompletion::TargetChanged,
+        );
+        assert_eq!(
+            target_mismatch_completion(&expected, Some(newer_generation)),
+            BootConfigSynchronizationCompletion::TargetChanged,
+            "the generation must prevent an A-to-B-to-A selection from reusing old progress",
+        );
+    }
+}

--- a/crates/machine-controller/src/handler/host_boot_config.rs
+++ b/crates/machine-controller/src/handler/host_boot_config.rs
@@ -47,6 +47,7 @@ use super::{
     are_dpus_up_trigger_reboot_if_needed, is_dpu_observed_since, load_boot_predictions,
     log_host_config, require_boot_interface, set_host_boot_order, trigger_reboot_if_needed,
 };
+use crate::boot_interface::boot_interface_target;
 use crate::context::MachineStateHandlerContextObjects;
 
 /// Runtime projection of the persisted BIOS and boot-order states shared by
@@ -109,6 +110,57 @@ pub(super) enum HostBootConfigDpuFreshness {
     CurrentHostState,
     /// Require observations newer than the most recent host reboot request.
     SinceLastHostRebootRequest,
+}
+
+/// Where a shared host boot-config stage gets the Redfish target it acts on.
+///
+/// Existing lifecycle states continue resolving their current selection at
+/// each stage. Durable boot-config synchronization instead supplies the exact
+/// target persisted in its state so first-lease promotion or prediction
+/// deletion cannot redirect an in-flight Redfish operation.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) enum HostBootInterfaceSource {
+    ResolveSelected,
+    Pinned(BootInterfaceTarget),
+}
+
+impl HostBootInterfaceSource {
+    pub(super) async fn resolve_optional(
+        &self,
+        ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+        mh_snapshot: &ManagedHostStateSnapshot,
+    ) -> Result<Option<BootInterfaceTarget>, StateHandlerError> {
+        match self {
+            Self::ResolveSelected => {
+                let predictions = load_boot_predictions(ctx, mh_snapshot).await?;
+                Ok(self.select(boot_interface_target(mh_snapshot, &predictions)))
+            }
+            Self::Pinned(_) => Ok(self.select(None)),
+        }
+    }
+
+    pub(super) async fn resolve_required<W>(
+        &self,
+        ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+        mh_snapshot: &ManagedHostStateSnapshot,
+        activity: &str,
+        wait: impl FnOnce(String) -> W,
+    ) -> Result<RequiredBootInterface<W>, StateHandlerError> {
+        match self {
+            Self::Pinned(target) => Ok(RequiredBootInterface::Ready(target.clone())),
+            Self::ResolveSelected => {
+                let predictions = load_boot_predictions(ctx, mh_snapshot).await?;
+                require_boot_interface(mh_snapshot, &predictions, activity, wait)
+            }
+        }
+    }
+
+    fn select(&self, selected: Option<BootInterfaceTarget>) -> Option<BootInterfaceTarget> {
+        match self {
+            Self::ResolveSelected => selected,
+            Self::Pinned(target) => Some(target.clone()),
+        }
+    }
 }
 
 /// Actual host boot settings read from Redfish.
@@ -176,6 +228,7 @@ pub(super) async fn check_host_boot_config(
     mh_snapshot: &ManagedHostStateSnapshot,
     reachability_params: &ReachabilityParams,
     dpu_freshness: HostBootConfigDpuFreshness,
+    boot_interface_source: HostBootInterfaceSource,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<HostBootConfigCheckOutcome, StateHandlerError> {
     if should_wait_for_dpus_before_host_boot_config(
@@ -191,13 +244,15 @@ pub(super) async fn check_host_boot_config(
         ));
     }
 
-    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
-    let boot_interface = match require_boot_interface(
-        mh_snapshot,
-        &predictions,
-        "configuring boot",
-        HostBootConfigCheckOutcome::Wait,
-    )? {
+    let boot_interface = match boot_interface_source
+        .resolve_required(
+            ctx,
+            mh_snapshot,
+            "configuring boot",
+            HostBootConfigCheckOutcome::Wait,
+        )
+        .await?
+    {
         RequiredBootInterface::Ready(target) => target,
         RequiredBootInterface::Wait(outcome) => return Ok(outcome),
     };
@@ -248,15 +303,20 @@ pub(super) async fn run_host_boot_config_stage(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    boot_interface_source: HostBootInterfaceSource,
     stage: HostBootConfigStage,
 ) -> Result<HostBootConfigOutcome, StateHandlerError> {
     match stage {
         HostBootConfigStage::ConfigureBios { retry_count } => {
+            let boot_interface = boot_interface_source
+                .resolve_optional(ctx, mh_snapshot)
+                .await?;
             match configure_host_bios(
                 ctx,
                 reachability_params,
                 redfish_client,
                 mh_snapshot,
+                boot_interface.as_ref(),
                 retry_count,
             )
             .await?
@@ -301,13 +361,15 @@ pub(super) async fn run_host_boot_config_stage(
             }
         }
         HostBootConfigStage::PollingBiosSetup { retry_count } => {
-            let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+            let boot_interface = boot_interface_source
+                .resolve_optional(ctx, mh_snapshot)
+                .await?;
             match advance_polling_bios_setup(
                 redfish_client,
                 mh_snapshot,
                 retry_count,
                 &ctx.services.site_config.machine_state_controller,
-                &predictions,
+                boot_interface.as_ref(),
             )
             .await?
             {
@@ -342,6 +404,7 @@ pub(super) async fn run_host_boot_config_stage(
                 reachability_params,
                 redfish_client,
                 mh_snapshot,
+                &boot_interface_source,
                 set_boot_order_info,
             )
             .await?
@@ -390,7 +453,7 @@ fn set_boot_order_info(retry_count: u32) -> SetBootOrderInfo {
     }
 }
 
-/// Carry one bounded convergence budget when boot-order work discovers that
+/// Use one bounded convergence budget when boot-order work discovers that
 /// BIOS must be repaired again. Existing owner states already persist this
 /// counter through both phases, so no serialized wrapper is required.
 fn next_boot_config_retry_count(retry_count: u32, max_retries: u32) -> Option<u32> {
@@ -463,7 +526,9 @@ async fn should_wait_for_dpus_before_host_boot_config(
 
 #[cfg(test)]
 mod tests {
+    use carbide_redfish::boot_interface::BootInterfaceTarget;
     use carbide_test_support::value_scenarios;
+    use mac_address::MacAddress;
 
     use super::*;
 
@@ -538,6 +603,22 @@ mod tests {
                     retry_count: 4,
                     max_retries: 1,
                 } => None,
+            }
+        );
+    }
+
+    #[test]
+    fn pinned_boot_interface_ignores_the_current_selection() {
+        let pinned = BootInterfaceTarget::MacOnly(MacAddress::new([0, 0, 0, 0, 0, 0x0a]));
+        let current = BootInterfaceTarget::MacOnly(MacAddress::new([0, 0, 0, 0, 0, 0x0b]));
+        let source = HostBootInterfaceSource::Pinned(pinned.clone());
+
+        value_scenarios!(run = |selected| source.select(selected);
+            "a different current target cannot redirect the stage" {
+                Some(current) => Some(pinned.clone()),
+            }
+            "a missing current target cannot erase the pinned target" {
+                None => Some(pinned),
             }
         );
     }

--- a/crates/machine-controller/src/handler/machine_validation.rs
+++ b/crates/machine-controller/src/handler/machine_validation.rs
@@ -30,8 +30,9 @@ use super::{HostHandlerParams, is_machine_validation_requested, machine_validati
 use crate::context::{MachineStateHandlerContextObjects, MachineStateHandlerServices};
 use crate::handler::host_boot_config::{
     HostBootConfigCheckOutcome, HostBootConfigDecision, HostBootConfigDpuFreshness,
-    HostBootConfigOutcome, HostBootConfigStage, check_host_boot_config, decide_host_boot_config,
-    initial_set_boot_order_info, inspect_host_boot_config, run_host_boot_config_stage,
+    HostBootConfigOutcome, HostBootConfigStage, HostBootInterfaceSource, check_host_boot_config,
+    decide_host_boot_config, initial_set_boot_order_info, inspect_host_boot_config,
+    run_host_boot_config_stage,
 };
 use crate::handler::{
     RequiredBootInterface, handler_host_power_control, host_power_control, load_boot_predictions,
@@ -70,6 +71,7 @@ async fn handle_validation_boot_config_stage(
         &host_handler_params.reachability_params,
         redfish_client.as_ref(),
         mh_snapshot,
+        HostBootInterfaceSource::ResolveSelected,
         stage,
     )
     .await?
@@ -245,7 +247,7 @@ pub(crate) async fn handle_machine_validation_state(
                 // during the reboot's POST -- the host can't boot into the
                 // validation environment, and further reboots can't restore a
                 // setting that is gone. Correct it instead of pacing forever.
-                let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+                let predictions = load_boot_predictions(ctx, mh_snapshot).await?;
                 if let RequiredBootInterface::Ready(boot_interface) = require_boot_interface(
                     mh_snapshot,
                     &predictions,
@@ -481,6 +483,7 @@ pub(crate) async fn handle_machine_validation_state(
                 mh_snapshot,
                 &host_handler_params.reachability_params,
                 HostBootConfigDpuFreshness::CurrentHostState,
+                HostBootInterfaceSource::ResolveSelected,
                 ctx,
             )
             .await?

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -129,17 +129,23 @@ impl StateControllerIO for MachineStateControllerIO {
         &self,
         txn: &mut PgConnection,
         object_id: &Self::ObjectId,
-        _old_version: ConfigVersion,
-        _new_version: ConfigVersion,
+        old_version: ConfigVersion,
+        new_version: ConfigVersion,
         new_state: &Self::ControllerState,
     ) -> Result<bool, DatabaseError> {
-        db::machine::update_state(txn, object_id, new_state).await?;
-        Ok(true)
+        db::machine::update_state_if_version_matches(
+            txn,
+            object_id,
+            old_version,
+            new_version,
+            new_state,
+        )
+        .await
     }
 
     /// State history for machines (including DPUs) is persisted internally by
-    /// `db::machine::advance()` inside `update_state`, so this is actually a
-    /// no-op for now.
+    /// `db::machine::update_state_if_version_matches`, so this is a no-op for
+    /// now.
     // TODO(chet): Pull this in as well.
     async fn persist_state_history(
         &self,
@@ -220,6 +226,7 @@ impl StateControllerIO for MachineStateControllerIO {
                 }
                 InstanceState::WaitingForRebootToReady => "waitingforreboottoready",
                 InstanceState::Ready => "ready",
+                InstanceState::BootConfigSynchronization { .. } => "bootconfigsynchronization",
                 InstanceState::BootingWithDiscoveryImage { .. } => "bootingwithdiscoveryimage",
                 InstanceState::SwitchToAdminNetwork => "switchtoadminnetwork",
                 InstanceState::WaitingForNetworkReconfig => "waitingfornetworkreconfig",
@@ -299,6 +306,7 @@ impl StateControllerIO for MachineStateControllerIO {
                 ("hostnotready", machine_state_name(machine_state))
             }
             ManagedHostState::Ready => ("ready", ""),
+            ManagedHostState::BootConfigSynchronization { .. } => ("bootconfigsynchronization", ""),
             ManagedHostState::Maintenance { operation } => {
                 let op = match operation {
                     MachineMaintenanceOperation::PowerOn => "power_on",

--- a/crates/machine-controller/tests/integration/firmware_upgrade_completion.rs
+++ b/crates/machine-controller/tests/integration/firmware_upgrade_completion.rs
@@ -55,6 +55,10 @@ impl TestContext {
             .build()
             .await
             .0;
+        site_explorer
+            .run_single_iteration()
+            .await
+            .expect("Site Explorer iteration should succeed");
         Self { env, mh }
     }
 }

--- a/crates/machine-controller/tests/integration/maintenance.rs
+++ b/crates/machine-controller/tests/integration/maintenance.rs
@@ -142,7 +142,7 @@ struct ReconciliationCase {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ResultingState {
-    Ready,
+    BootConfigSynchronization,
     Failed,
 }
 
@@ -274,7 +274,11 @@ async fn reconcile(
     env.run_single_iteration().await;
     let machine = host.host.machine().await;
     let resulting_state = match machine.state.value {
-        ManagedHostState::Ready => ResultingState::Ready,
+        ManagedHostState::BootConfigSynchronization {
+            synchronization_state:
+                model::machine::BootConfigSynchronizationState::Initialize { target: None },
+            synchronization_retry_count: 0,
+        } => ResultingState::BootConfigSynchronization,
         ManagedHostState::Failed { .. } => ResultingState::Failed,
         other => return Err(format!("unexpected resulting state: {other:?}")),
     };
@@ -314,7 +318,7 @@ fn backend_cases() -> Vec<Case<ReconciliationCase, Observation, String>> {
                     expect: Outcome::Yields(Observation {
                         request_cleared: true,
                         resulting_state: if succeeds {
-                            ResultingState::Ready
+                            ResultingState::BootConfigSynchronization
                         } else {
                             ResultingState::Failed
                         },

--- a/crates/machine-controller/tests/integration/power_management.rs
+++ b/crates/machine-controller/tests/integration/power_management.rs
@@ -21,7 +21,12 @@ use carbide_redfish::libredfish::RedfishClientPool as _;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use carbide_utils::redfish::BmcAccessInfo;
-use model::machine::{MachineMaintenanceOperation, ManagedHostState};
+use config_version::ConfigVersion;
+use model::machine::{
+    BootConfigSynchronizationState, BootConfigSynchronizationTarget, MachineMaintenanceOperation,
+    ManagedHostState,
+};
+use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::power_manager::PowerState;
 use model::test_support::ManagedHostConfig;
 use rpc::forge::{
@@ -170,6 +175,64 @@ async fn desired_on_polls_powered_off_machine(
     assert_eq!(power_options[0].desired_power_state, PowerState::On);
     assert_eq!(power_options[0].last_fetched_power_state, PowerState::Off);
     txn.rollback().await?;
+
+    Ok(())
+}
+
+#[sqlx_test]
+async fn boot_config_synchronization_waits_for_desired_host_power(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let TestContext { mut env, mh } = TestContext::init(pool).await;
+    let bmc_access_info = mh.bmc_access_info().await;
+    let sim = env.redfish_sim.client_by_info(&bmc_access_info).await?;
+    let target = BootConfigSynchronizationTarget {
+        machine_interface_id: None,
+        boot_interface: MachineBootInterfaceTarget::MacOnly("02:00:00:00:00:01".parse()?),
+        selection_version: ConfigVersion::initial(),
+    };
+    let states = [
+        BootConfigSynchronizationState::Initialize { target: None },
+        BootConfigSynchronizationState::WaitingForInitialObservation {
+            target: target.clone(),
+            minimum_report_version: ConfigVersion::invalid(),
+        },
+        BootConfigSynchronizationState::PrepareHost { target },
+    ];
+
+    for synchronization_state in states {
+        let state = ManagedHostState::BootConfigSynchronization {
+            synchronization_state,
+            synchronization_retry_count: 0,
+        };
+        mh.advance_state(state.clone()).await;
+        sim.power(libredfish::SystemPowerControl::ForceOff).await?;
+        assert_eq!(sim.get_power_state().await?, libredfish::PowerState::Off);
+        mh.set_next_power_poll_now().await;
+
+        let mut txn = env.test_harness.db_txn().await;
+        let power_options = db::power_options::get_all(&mut txn).await?;
+        let off_counter = power_options[0].last_fetched_off_counter;
+        txn.rollback().await?;
+
+        env.run_single_iteration().await;
+
+        let machine = mh.host.machine().await;
+        assert_eq!(
+            machine.state.value, state,
+            "boot-interface work must wait while desired host power is not satisfied",
+        );
+        let mut txn = env.test_harness.db_txn().await;
+        let power_options = db::power_options::get_all(&mut txn).await?;
+        assert_eq!(power_options[0].desired_power_state, PowerState::On);
+        assert_eq!(power_options[0].last_fetched_power_state, PowerState::Off);
+        assert_eq!(
+            power_options[0].last_fetched_off_counter,
+            off_counter + 1,
+            "the synchronization state must process host power before Redfish boot work",
+        );
+        txn.rollback().await?;
+    }
 
     Ok(())
 }
@@ -365,14 +428,21 @@ async fn queued_power_off_runs_when_power_manager_gates_desired_off(
     );
 
     // Second iteration reconciles the PowerOff against the (succeeding) backend,
-    // clears the request, and returns the host to Ready -- confirming the queued
-    // operation runs to completion, not just that it entered Maintenance.
+    // clears the request, and enters the pre-Ready boot-config gate. This
+    // confirms the queued operation runs to completion, not just that it entered
+    // Maintenance.
     env.run_single_iteration().await;
 
     let machine = mh.host.machine().await;
     assert!(
-        matches!(machine.state.value, ManagedHostState::Ready),
-        "expected Ready after the PowerOff completes, got {:?}",
+        matches!(
+            machine.state.value,
+            ManagedHostState::BootConfigSynchronization {
+                synchronization_state: BootConfigSynchronizationState::Initialize { target: None },
+                synchronization_retry_count: 0,
+            }
+        ),
+        "expected boot-config synchronization after the PowerOff completes, got {:?}",
         machine.state.value,
     );
     assert!(

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -384,9 +384,10 @@ service Forge {
   rpc ClearMachineBootOverride(common.MachineInterfaceId) returns (google.protobuf.Empty);
 
   // Gather one machine's boot-interface view from every store that records it
-  // (owned interface rows, predictions, the explored endpoint default, and the
-  // retained post-deletion pairs), plus the effective boot interface the
-  // system would select. Read-only; built for troubleshooting and verification.
+  // (owned interface rows, predictions, the explored endpoint evaluation
+  // target, and the retained post-deletion pairs), plus the effective boot
+  // interface the system would select. Read-only; built for troubleshooting
+  // and verification.
   rpc GetMachineBootInterfaces(GetMachineBootInterfacesRequest) returns (GetMachineBootInterfacesResponse);
 
   // Get Network topology
@@ -8340,12 +8341,24 @@ message RemediationApplicationStatus {
 message SetPrimaryDpuRequest {
   common.MachineId host_machine_id = 1;
   common.MachineId dpu_machine_id = 2;
+  // Ready unassigned hosts begin synchronization immediately; hosts in other
+  // unassigned states begin when they next reach the Ready gate. For assigned
+  // hosts, false defers applying the selection and clears pending
+  // authorization before synchronization starts; once it has started, the
+  // request fails until synchronization finishes. True authorizes applying
+  // this exact selection now. The controller restarts only when required.
   bool reboot=3;
 }
 
 message SetPrimaryInterfaceRequest {
   common.MachineId host_machine_id = 1;
   common.MachineInterfaceId interface_id = 2;
+  // Ready unassigned hosts begin synchronization immediately; hosts in other
+  // unassigned states begin when they next reach the Ready gate. For assigned
+  // hosts, false defers applying the selection and clears pending
+  // authorization before synchronization starts; once it has started, the
+  // request fails until synchronization finishes. True authorizes applying
+  // this exact selection now. The controller restarts only when required.
   bool reboot = 3;
 }
 
@@ -9317,10 +9330,10 @@ message PredictedBootInterface {
   optional string network_segment_type = 4;
 }
 
-// An `explored_endpoints` row's boot interface: site-explorer's per-cycle
-// automatic pick for a BMC endpoint, used only for endpoints no machine owns.
+// An `explored_endpoints` row's boot-interface evaluation target: an inferred
+// default before the endpoint is owned and the managed selection afterward.
 message ExploredBootInterface {
-  // BMC endpoint address this explored default was recorded against.
+  // BMC endpoint address this evaluation target was recorded against.
   string address = 1;
   optional string boot_interface_mac = 2;
   optional string boot_interface_id = 3;
@@ -9345,30 +9358,34 @@ message GetMachineBootInterfacesResponse {
   repeated RetainedBootInterface retained_interfaces = 5;
 
   // The boot interface MAC the system would select for this machine right now,
-  // applying `pick_boot_interface` to the owned `machine_interfaces` rows.
-  // Absent when there is no owned candidate yet.
+  // applying `pick_boot_interface_candidate` across the owned
+  // `machine_interfaces` rows and pending `predicted_machine_interfaces`.
+  // Absent when neither store yields a boot-capable candidate.
   optional string effective_boot_interface_mac = 6;
-  // The fully-populated effective boot interface id (MAC + Redfish id), when
-  // the selected row has its interface id captured. Absent otherwise.
+  // The vendor-native Redfish interface id for the effective candidate, when
+  // captured on the selected owned row or prediction. Absent when the
+  // candidate has no captured id, or when there is no effective candidate.
   optional string effective_boot_interface_id = 7;
 
   // True when the stores do not all agree on the boot MAC -- a signal worth a
-  // closer look during troubleshooting (e.g. the explored default points at a
-  // different NIC than the effective owned pick, or a predicted primary
-  // disagrees). See the handler for the exact comparison.
+  // closer look during troubleshooting (e.g. the endpoint evaluation target
+  // points at a different NIC than the effective cross-store selection, or
+  // primary predictions disagree). See the handler for the exact comparison.
   bool divergent = 8;
 
   // What the automatic selection would choose if no row were flagged primary
-  // -- `pick_boot_interface`'s fallback of the lowest-MAC non-underlay row.
-  // Comparing this against the effective pick shows whether a primary
-  // designation is overriding the automatic choice. Absent when no managed
-  // row qualifies; `interface_id` absent until captured for that NIC.
+  // -- `pick_boot_interface`'s fallback of the lowest-MAC host-boot row
+  // (Admin or HostInband). Comparing this against the effective pick shows
+  // whether a primary designation is overriding the automatic choice. Absent
+  // when no owned row is boot-capable; `interface_id` absent until captured
+  // for that NIC.
   MachineBootInterface default_boot_interface = 9;
 
   // The prediction `pick_boot_prediction` would boot from for a machine still
-  // waiting on its first DHCP lease: the declared primary, else the sole
-  // non-underlay prediction. Absent when there are no predictions or when the
-  // pick refuses to guess among several undeclared NICs.
+  // waiting on its first DHCP lease: the declared boot-capable primary, else
+  // the sole boot-capable prediction (Admin or HostInband). Absent when there
+  // is no boot-capable prediction or when the pick refuses to guess among
+  // several undeclared NICs.
   MachineBootInterface predicted_boot_interface = 10;
 }
 

--- a/crates/rpc/proto/site_explorer.proto
+++ b/crates/rpc/proto/site_explorer.proto
@@ -319,11 +319,12 @@ message Inventory {
 message MachineSetupStatus {
   bool is_done = 1;
   repeated MachineSetupDiff diffs = 2;
-  // The logical boot-interface target NICo asked the backend to assess. A
-  // backend may match with a subset (NvRedfish currently uses the MAC) while
-  // retaining Pair identity. Reports written before target capture leave this
-  // unset.
+  // The logical boot-interface target NICo asked the pair-aware verifier to
+  // assess. Reports written before target capture leave this unset.
   MachineBootInterfaceTarget evaluated_boot_interface = 3;
+  // Version of the verification semantics that produced this status. Reports
+  // written before versioned verification leave this as zero.
+  uint32 verification_version = 4;
 }
 
 // The logical boot-interface target NICo asked a Redfish backend to assess. It

--- a/crates/rpc/src/model/instance/status/tenant.rs
+++ b/crates/rpc/src/model/instance/status/tenant.rs
@@ -118,9 +118,9 @@ pub fn instance_status_tenant_state(
             // When tenants request a custom pxe reboot, the managed hosts
             // will go through HostPlatformConfiguration and WaitingForDpusToUp
             // before going back to Ready
-            InstanceState::WaitingForDpusToUp | InstanceState::HostPlatformConfiguration { .. } => {
-                TenantState::Configuring
-            }
+            InstanceState::WaitingForDpusToUp
+            | InstanceState::HostPlatformConfiguration { .. }
+            | InstanceState::BootConfigSynchronization { .. } => TenantState::Configuring,
             InstanceState::BootingWithDiscoveryImage { .. }
             | InstanceState::DPUReprovision { .. }
             | InstanceState::HostReprovision { .. } => TenantState::Updating,
@@ -182,8 +182,8 @@ mod tests {
     use model::health::HealthReportSources;
     use model::instance::status::SyncState;
     use model::machine::{
-        DpuReprovisionStates, FailureCause, FailureDetails, FailureSource, InstanceState,
-        ManagedHostState,
+        BootConfigSynchronizationState, DpuReprovisionStates, FailureCause, FailureDetails,
+        FailureSource, InstanceState, ManagedHostState,
     };
 
     use super::*;
@@ -268,6 +268,19 @@ mod tests {
                         instance_state: InstanceState::Ready,
                     },
                     SyncState::Pending,
+                ) => Yields(TenantState::Configuring),
+            }
+
+            "boot config synchronization with repair merge" {
+                (
+                    ManagedHostState::Assigned {
+                        instance_state: InstanceState::BootConfigSynchronization {
+                            synchronization_state:
+                                BootConfigSynchronizationState::Initialize { target: None },
+                            synchronization_retry_count: 0,
+                        },
+                    },
+                    SyncState::Synced,
                 ) => Yields(TenantState::Configuring),
             }
 

--- a/crates/rpc/src/model/site_explorer.rs
+++ b/crates/rpc/src/model/site_explorer.rs
@@ -373,6 +373,7 @@ impl From<MachineSetupStatus> for rpc::site_explorer::MachineSetupStatus {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
+            verification_version: machine_setup_status.verification_version,
             evaluated_boot_interface: machine_setup_status
                 .evaluated_boot_interface
                 .map(Into::into),
@@ -461,7 +462,10 @@ mod tests {
     use chrono::{DateTime, TimeZone as _, Utc};
     use model::firmware::FirmwareComponentType;
     use model::machine_boot_interface::MachineBootInterface;
-    use model::site_explorer::{EndpointExplorationError, EndpointType, PreingestionState};
+    use model::site_explorer::{
+        EndpointExplorationError, EndpointType, MACHINE_SETUP_VERIFICATION_VERSION,
+        PreingestionState,
+    };
     use prost::Message;
 
     use super::*;
@@ -1223,6 +1227,7 @@ mod tests {
                 MachineSetupStatus {
                     is_done: true,
                     diffs: Vec::new(),
+                    verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                     evaluated_boot_interface: Some(MachineBootInterfaceTarget::Pair(
                         MachineBootInterface {
                             mac_address,
@@ -1232,6 +1237,7 @@ mod tests {
                 } => rpc::site_explorer::MachineSetupStatus {
                     is_done: true,
                     diffs: Vec::new(),
+                    verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                     evaluated_boot_interface: Some(
                         rpc::site_explorer::MachineBootInterfaceTarget {
                             target: Some(
@@ -1251,10 +1257,12 @@ mod tests {
                 MachineSetupStatus {
                     is_done: false,
                     diffs: Vec::new(),
+                    verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                     evaluated_boot_interface: Some(MachineBootInterfaceTarget::MacOnly(mac_address)),
                 } => rpc::site_explorer::MachineSetupStatus {
                     is_done: false,
                     diffs: Vec::new(),
+                    verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                     evaluated_boot_interface: Some(
                         rpc::site_explorer::MachineBootInterfaceTarget {
                             target: Some(
@@ -1370,6 +1378,7 @@ mod tests {
                     expected: "PXE".to_string(),
                     actual: "Disk".to_string(),
                 }],
+                verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
                 evaluated_boot_interface: None,
             }),
             secure_boot_status: Some(SecureBootStatus { is_enabled: true }),

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -35,6 +35,7 @@ use model::expected_switch::ExpectedSwitch;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{
     BlueFieldOperatingMode, EndpointExplorationError, EndpointExplorationReport, LockdownStatus,
+    MACHINE_SETUP_VERIFICATION_VERSION,
 };
 use sqlx::PgPool;
 
@@ -320,7 +321,7 @@ impl BmcEndpointExplorer {
                     .await;
                 let nvredfish = self
                     .redfish_client
-                    .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface)
+                    .nv_generate_raw_exploration_report(bmc_ip_address, credentials, boot_interface)
                     .await;
                 match (&libredfish, &nvredfish) {
                     (Ok(report), Ok(nv_report)) => warn_report_diff(report, nv_report),
@@ -1658,9 +1659,14 @@ fn warn_report_diff(report1: &EndpointExplorationReport, report2: &EndpointExplo
     } else if let Some(r1) = &report1.machine_setup_status
         && let Some(r2) = &report2.machine_setup_status
     {
-        // Both backends should retain the same logical target. Keep the target
-        // in this comparison so future backend changes cannot hide a mismatch.
-        if r1.is_done != r2.is_done || r1.evaluated_boot_interface != r2.evaluated_boot_interface {
+        // Compare target correlation only when both backends implement that
+        // verification contract. The legacy NvRedfish report is intentionally
+        // version 0 and targetless, so treating its missing target as a
+        // disagreement would make every targeted CompareResult probe warn.
+        let target_mismatch = r1.verification_version >= MACHINE_SETUP_VERIFICATION_VERSION
+            && r2.verification_version >= MACHINE_SETUP_VERIFICATION_VERSION
+            && r1.evaluated_boot_interface != r2.evaluated_boot_interface;
+        if r1.is_done != r2.is_done || target_mismatch {
             tracing::warn!(
                 libredfish_machine_setup_status = ?r1,
                 nvredfish_machine_setup_status = ?r2,
@@ -1770,17 +1776,19 @@ mod tests {
     use carbide_test_support::{Case, check_cases_async, value_scenarios};
     use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
     use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
-    use model::site_explorer::MachineSetupStatus;
+    use model::site_explorer::{MACHINE_SETUP_VERIFICATION_VERSION, MachineSetupStatus};
 
     use super::*;
 
     fn report_with_evaluated_target(
+        verification_version: u32,
         evaluated_boot_interface: Option<MachineBootInterfaceTarget>,
     ) -> EndpointExplorationReport {
         EndpointExplorationReport {
             machine_setup_status: Some(MachineSetupStatus {
                 is_done: true,
                 diffs: Vec::new(),
+                verification_version,
                 evaluated_boot_interface,
             }),
             ..Default::default()
@@ -1796,34 +1804,68 @@ mod tests {
         });
         let mac_only = MachineBootInterfaceTarget::MacOnly(mac_address);
 
-        value_scenarios!(run = |(libredfish_target, nvredfish_target)| {
-            let libredfish_report = report_with_evaluated_target(libredfish_target);
-            let nvredfish_report = report_with_evaluated_target(nvredfish_target);
+        value_scenarios!(run = |(libredfish_version, libredfish_target, nvredfish_version, nvredfish_target)| {
+            let libredfish_report =
+                report_with_evaluated_target(libredfish_version, libredfish_target);
+            let nvredfish_report =
+                report_with_evaluated_target(nvredfish_version, nvredfish_target);
             capture_logs(|| warn_report_diff(&libredfish_report, &nvredfish_report))
                 .into_iter()
                 .map(|log| log.message)
                 .collect::<Vec<_>>()
         };
             "same evaluated pair does not warn" {
-                (Some(pair.clone()), Some(pair)) => Vec::<String>::new(),
+                (
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    Some(pair.clone()),
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    Some(pair),
+                ) => Vec::<String>::new(),
             }
 
             "pair and MAC-only targets warn" {
-                (Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
-                    mac_address,
-                    interface_id: "NIC.Slot.7-1-1".to_string(),
-                })), Some(mac_only)) => vec!["machine setup statuses are not equal".to_string()],
+                (
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address,
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    })),
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    Some(mac_only),
+                ) => vec!["machine setup statuses are not equal".to_string()],
             }
 
             "two targetless statuses do not warn" {
-                (None, None) => Vec::<String>::new(),
+                (
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    None,
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    None,
+                ) => Vec::<String>::new(),
             }
 
-            "pair and targetless statuses warn" {
-                (Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
-                    mac_address,
-                    interface_id: "NIC.Slot.7-1-1".to_string(),
-                })), None) => vec!["machine setup statuses are not equal".to_string()],
+            "correlation-capable pair and targetless statuses warn" {
+                (
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address,
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    })),
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    None,
+                ) => vec!["machine setup statuses are not equal".to_string()],
+            }
+
+            "legacy targetless NvRedfish status does not warn" {
+                (
+                    MACHINE_SETUP_VERIFICATION_VERSION,
+                    Some(MachineBootInterfaceTarget::Pair(MachineBootInterface {
+                        mac_address,
+                        interface_id: "NIC.Slot.7-1-1".to_string(),
+                    })),
+                    0,
+                    None,
+                ) => Vec::<String>::new(),
             }
         );
     }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -1695,6 +1695,17 @@ impl SiteExplorer {
                         dpus_explored_for_host.insert(0, dpu);
                     }
                     is_sorted = true;
+                } else if declared_primary == Some(mac_address) {
+                    // An explicitly declared integrated NIC is a valid host
+                    // boot target even though it is not one of the managed
+                    // DPUs' host PFs. Keep the DPUs in their deterministic
+                    // fallback order; machine creation owns the declared NIC
+                    // separately as a prediction or materialized row.
+                    tracing::info!(
+                        %mac_address,
+                        host_bmc_ip_address = %ep.address,
+                        "Using declared non-DPU host boot interface",
+                    );
                 } else if !dpus_explored_for_host.is_empty() {
                     let all_mac = dpus_explored_for_host
                         .iter()
@@ -1782,10 +1793,27 @@ impl SiteExplorer {
         )
         .await?;
 
-        // Persist boot interface MACs for host endpoints
+        // Persist inferred boot-interface defaults for host endpoints. The DB
+        // helper locks each endpoint before checking whether a managed
+        // machine's selected primary interface now owns the target.
         for (address, boot_interface) in &boot_interfaces {
-            db::explored_endpoints::set_boot_interface(*address, boot_interface, &mut txn).await?;
+            db::explored_endpoints::set_boot_interface_default(*address, boot_interface, &mut txn)
+                .await?;
         }
+
+        // Lock every row this batch may update in one stable order. The
+        // managed-host defaults above already established the shared
+        // endpoint-before-interface order; this also covers complete NICs from
+        // reports that did not produce a managed-host default this cycle.
+        let mut boot_interface_macs = nic_boot_interfaces
+            .iter()
+            .map(|boot_interface| boot_interface.mac_address)
+            .collect_vec();
+        boot_interface_macs.sort_unstable();
+        boot_interface_macs.dedup();
+        db::machine_interface::lock_for_mac_addresses(&mut txn, &boot_interface_macs).await?;
+        db::predicted_machine_interface::lock_for_mac_addresses(&mut txn, &boot_interface_macs)
+            .await?;
 
         // Record each host NIC's Redfish id on its machine_interfaces row so the
         // primary-flagged row is the host's complete boot interface (MAC + id).

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -618,7 +618,10 @@ impl MachineCreator {
                     NewPredictedMachineInterface {
                         machine_id,
                         mac_address,
-                        expected_network_segment_type: NetworkSegmentType::HostInband,
+                        expected_network_segment_type: predicted_network_segment_type(
+                            machine_data,
+                            mac_address,
+                        ),
                         boot_interface_id,
                         primary_interface: is_primary,
                     },
@@ -632,11 +635,10 @@ impl MachineCreator {
     }
 
     /// Owns a declared integrated (non-DPU) host NIC as a managed-DPU host's
-    /// HostInband boot interface, so a host with managed DPUs can still boot from
-    /// an integrated NIC. The NIC carries `primary` into `machine_interfaces` on
-    /// its first DHCP; the DPUs stay explored and linked, and their admin links
-    /// go dormant in `reconcile_admin_addresses_for_host` once this NIC is the
-    /// primary.
+    /// boot interface, so a host with managed DPUs can still boot from an
+    /// integrated NIC. The prediction retains the declared Admin or HostInband
+    /// segment and preserves `primary` in `machine_interfaces` on its first
+    /// DHCP; the DPUs stay explored and linked.
     ///
     /// Mirrors the host-NIC ownership in `create_zero_dpu_machine`, but for the
     /// one declared NIC reached from the managed-DPU path. No-op when nothing is
@@ -649,9 +651,14 @@ impl MachineCreator {
         report: &EndpointExplorationReport,
         machine_data: Option<&ExpectedMachineData>,
     ) -> SiteExplorerResult<()> {
-        let Some(declared_mac) = machine_data.and_then(|data| data.declared_primary_mac()) else {
+        let Some(declared_nic) = machine_data.and_then(ExpectedMachineData::declared_primary_nic)
+        else {
             return Ok(());
         };
+        let declared_mac = declared_nic.mac_address;
+        let expected_network_segment_type = declared_nic
+            .resolved_network_segment_type()
+            .unwrap_or(NetworkSegmentType::HostInband);
 
         if let Some(existing) = db::machine_interface::find_by_mac_address(&mut *txn, declared_mac)
             .await?
@@ -709,9 +716,9 @@ impl MachineCreator {
             return Ok(());
         }
 
-        // Not yet leased: mint a HostInband prediction carrying primary, so the
-        // NIC is adopted and made primary on its first DHCP (the promotion demotes
-        // the interim DPU primary).
+        // Not yet leased: mint a prediction with the declared segment and
+        // primary intent, so first-lease promotion adopts the NIC without
+        // losing either.
         let boot_interface_id = report
             .find_interface_id_for_mac(declared_mac)
             .map(|id| id.to_string());
@@ -719,7 +726,7 @@ impl MachineCreator {
             NewPredictedMachineInterface {
                 machine_id: host_machine_id,
                 mac_address: declared_mac,
-                expected_network_segment_type: NetworkSegmentType::HostInband,
+                expected_network_segment_type,
                 boot_interface_id,
                 primary_interface: true,
             },
@@ -728,7 +735,8 @@ impl MachineCreator {
         .await?;
         tracing::info!(
             declared_mac_address = %declared_mac, %host_machine_id,
-            "Minted HostInband boot-NIC prediction for managed-DPU host's declared integrated primary",
+            %expected_network_segment_type,
+            "Minted boot-NIC prediction for managed-DPU host's declared integrated primary",
         );
         Ok(())
     }
@@ -1162,4 +1170,23 @@ fn host_mac_addresses_for_predicted_machine(
             })
             .unwrap_or_default(),
     }
+}
+
+/// Keep a declared NIC's segment intent attached to its prediction.
+///
+/// Redfish can expose interfaces that are not present in `ExpectedMachine`, so
+/// undeclared NICs retain the existing HostInband default. API validation
+/// limits a declared primary to Admin or HostInband.
+fn predicted_network_segment_type(
+    machine_data: Option<&ExpectedMachineData>,
+    mac_address: MacAddress,
+) -> NetworkSegmentType {
+    machine_data
+        .and_then(|data| {
+            data.host_nics
+                .iter()
+                .find(|nic| nic.mac_address == mac_address)
+        })
+        .and_then(|nic| nic.resolved_network_segment_type())
+        .unwrap_or(NetworkSegmentType::HostInband)
 }

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -38,8 +38,9 @@ use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::site_explorer::{
     BootOption, BootOrder, Chassis, ComputerSystem, ComputerSystemAttributes,
     EndpointExplorationError, EndpointExplorationReport, EndpointType, EthernetInterface,
-    InternalLockdownStatus, Inventory, LockdownStatus, MachineSetupDiff, MachineSetupStatus,
-    Manager, NetworkAdapter, PCIeDevice, SecureBootStatus, Service, UefiDevicePath,
+    InternalLockdownStatus, Inventory, LockdownStatus, MACHINE_SETUP_VERIFICATION_VERSION,
+    MachineSetupDiff, MachineSetupStatus, Manager, NetworkAdapter, PCIeDevice, SecureBootStatus,
+    Service, UefiDevicePath,
 };
 use regex::Regex;
 
@@ -298,49 +299,12 @@ impl RedfishClient {
         let service = fetch_service(client.as_ref())
             .await
             .map_err(map_redfish_error)?;
-        let is_dpu = system.id.to_lowercase().contains("bluefield");
-        let (machine_setup_status, remediation_error) = match fetch_machine_setup_status(
+        let (machine_setup_status, remediation_error) = observe_machine_setup_status(
             client.as_ref(),
             boot_interface,
+            system.id.to_lowercase().contains("bluefield"),
         )
-        .await
-        {
-            Ok(status) => (Some(status), None),
-            Err(error) if is_dpu && is_dpu_bios_attributes_not_ready(&error) => {
-                let details = format!(
-                    "DPU BMC BIOS attributes not ready ({error}); scheduling a force-restart to mitigate the known UEFI POST/BMC race"
-                );
-                let exploration_error = EndpointExplorationError::InvalidDpuRedfishBiosResponse {
-                    details,
-                    response_body: None,
-                    response_code: None,
-                };
-                let schema = exploration_error.operator_error_schema();
-                tracing::warn!(
-                    error = %error,
-                    error_code = %schema.error_code,
-                    mitigation = %schema.mitigation_for_log(),
-                    text = %schema.text,
-                    "Failed to fetch machine setup status"
-                );
-                (None, Some(exploration_error))
-            }
-            Err(error) => {
-                let schema = OperatorErrorSchema::new(
-                    ErrorCode::nico(ErrorSubsystem::SiteExplorer, 130),
-                    format!("Failed to fetch machine setup status: {error}"),
-                    None,
-                );
-                tracing::warn!(
-                    error = %error,
-                    error_code = %schema.error_code,
-                    mitigation = %schema.mitigation_for_log(),
-                    text = %schema.text,
-                    "Failed to fetch machine setup status"
-                );
-                (None, None)
-            }
-        };
+        .await;
 
         let secure_boot_status = fetch_secure_boot_status(client.as_ref())
             .await
@@ -389,6 +353,31 @@ impl RedfishClient {
         credentials: Credentials,
         boot_interface: Option<&BootInterfaceTarget>,
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
+        let mut report = self
+            .nv_generate_raw_exploration_report(bmc_ip_address, credentials.clone(), boot_interface)
+            .await?;
+
+        self.replace_nv_machine_setup_observation(
+            &mut report,
+            bmc_ip_address,
+            credentials,
+            boot_interface,
+        )
+        .await;
+
+        Ok(report)
+    }
+
+    /// Generate the native NvRedfish report without replacing its setup
+    /// status. Compare mode uses this to preserve a meaningful backend
+    /// comparison; normal NvRedfish mode adds the authoritative pair-aware
+    /// LibRedfish observation afterward.
+    pub(crate) async fn nv_generate_raw_exploration_report(
+        &self,
+        bmc_ip_address: SocketAddr,
+        credentials: Credentials,
+        boot_interface: Option<&BootInterfaceTarget>,
+    ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         let service_root = self
             .nv_redfish_client_pool
             .service_root_with_cache_predicate(bmc_ip_address, credentials, |root| {
@@ -408,16 +397,65 @@ impl RedfishClient {
                 details: format!("Cannot Redfish service root: {err}"),
             })?;
 
-        let mut report = bmc_explorer::nv_generate_exploration_report(
+        let report = bmc_explorer::nv_generate_exploration_report(
             service_root,
             &nv_bmc_explore_config(boot_interface),
         )
         .await
         .map_err(map_nv_redfish_explore_error)?;
 
-        record_evaluated_boot_interface(report.machine_setup_status.as_mut(), boot_interface);
-
         Ok(report)
+    }
+
+    async fn replace_nv_machine_setup_observation(
+        &self,
+        report: &mut EndpointExplorationReport,
+        bmc_ip_address: SocketAddr,
+        credentials: Credentials,
+        boot_interface: Option<&BootInterfaceTarget>,
+    ) {
+        // NvRedfish remains the inventory backend, while setup synchronization
+        // uses the same pair-aware LibRedfish verifier as the actuator. Keeping
+        // the read and write semantics together avoids a second set of vendor
+        // boot-option rules that can disagree about whether the selected NIC is
+        // configured.
+        let Some(boot_interface) = boot_interface else {
+            return;
+        };
+        match self
+            .create_direct_redfish_client(bmc_ip_address, credentials, None)
+            .await
+        {
+            Ok(client) => {
+                let is_dpu = report
+                    .systems
+                    .iter()
+                    .any(|system| system.id.to_lowercase().contains("bluefield"));
+                let (machine_setup_status, remediation_error) =
+                    observe_machine_setup_status(client.as_ref(), Some(boot_interface), is_dpu)
+                        .await;
+                report.machine_setup_status = machine_setup_status;
+                report.remediation_error = remediation_error;
+            }
+            Err(error) => {
+                let schema = OperatorErrorSchema::new(
+                    ErrorCode::nico(ErrorSubsystem::SiteExplorer, 130),
+                    format!("Failed to initialize the machine setup observation client: {error}"),
+                    None,
+                );
+                tracing::warn!(
+                    error = %error,
+                    error_code = %schema.error_code,
+                    mitigation = %schema.mitigation_for_log(),
+                    text = %schema.text,
+                    "Failed to initialize the machine setup observation client"
+                );
+                // Do not retain NvRedfish's less precise status: without the
+                // pair-aware verifier this report cannot prove that the
+                // selected interface was evaluated.
+                report.machine_setup_status = None;
+            }
+        }
     }
 
     pub async fn reset_bmc(
@@ -1220,15 +1258,23 @@ async fn fetch_boot_order(
         .boot_order
         .iter()
         .filter_map(|ref_id| {
-            all_boot_options
-                .iter()
-                .find(|opt| opt.boot_option_reference == *ref_id)
+            boot_option_for_order_identifier(&all_boot_options, ref_id)
                 .cloned()
                 .map(IntoModel::into_model)
         })
         .collect();
 
     Ok(BootOrder { boot_order })
+}
+
+fn boot_option_for_order_identifier<'a>(
+    boot_options: &'a [libredfish::model::BootOption],
+    identifier: &str,
+) -> Option<&'a libredfish::model::BootOption> {
+    let reference = libredfish::model::boot::boot_order_entry_reference(identifier);
+    boot_options
+        .iter()
+        .find(|option| option.boot_option_reference == reference || option.id == reference)
 }
 
 async fn fetch_pcie_devices(client: &dyn Redfish) -> Result<Vec<PCIeDevice>, RedfishError> {
@@ -1304,8 +1350,55 @@ async fn fetch_machine_setup_status(
     Ok(MachineSetupStatus {
         is_done: status.is_done,
         diffs,
+        verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
         evaluated_boot_interface: boot_interface.map(MachineBootInterfaceTarget::from),
     })
+}
+
+/// Read the setup observation and apply the shared error policy used by both
+/// inventory backends.
+async fn observe_machine_setup_status(
+    client: &dyn Redfish,
+    boot_interface: Option<&BootInterfaceTarget>,
+    is_dpu: bool,
+) -> (Option<MachineSetupStatus>, Option<EndpointExplorationError>) {
+    match fetch_machine_setup_status(client, boot_interface).await {
+        Ok(status) => (Some(status), None),
+        Err(error) if is_dpu && is_dpu_bios_attributes_not_ready(&error) => {
+            let details = format!(
+                "DPU BMC BIOS attributes not ready ({error}); scheduling a force-restart to mitigate the known UEFI POST/BMC race"
+            );
+            let exploration_error = EndpointExplorationError::InvalidDpuRedfishBiosResponse {
+                details,
+                response_body: None,
+                response_code: None,
+            };
+            let schema = exploration_error.operator_error_schema();
+            tracing::warn!(
+                error = %error,
+                error_code = %schema.error_code,
+                mitigation = %schema.mitigation_for_log(),
+                text = %schema.text,
+                "Failed to fetch machine setup status"
+            );
+            (None, Some(exploration_error))
+        }
+        Err(error) => {
+            let schema = OperatorErrorSchema::new(
+                ErrorCode::nico(ErrorSubsystem::SiteExplorer, 130),
+                format!("Failed to fetch machine setup status: {error}"),
+                None,
+            );
+            tracing::warn!(
+                error = %error,
+                error_code = %schema.error_code,
+                mitigation = %schema.mitigation_for_log(),
+                text = %schema.text,
+                "Failed to fetch machine setup status"
+            );
+            (None, None)
+        }
+    }
 }
 
 async fn fetch_secure_boot_status(client: &dyn Redfish) -> Result<SecureBootStatus, RedfishError> {
@@ -1442,13 +1535,25 @@ fn nv_error_classifier(
 ) -> Option<bmc_explorer::ErrorClass> {
     type BmcError = carbide_redfish::nv_redfish::BmcError;
     match err {
-        BmcError::InvalidResponse { status, .. } => match *status {
-            http::StatusCode::NOT_FOUND => Some(bmc_explorer::ErrorClass::NotFound),
-            http::StatusCode::INTERNAL_SERVER_ERROR => {
-                Some(bmc_explorer::ErrorClass::InternalServerError)
-            }
-            _ => None,
-        },
+        BmcError::InvalidResponse { status, text, .. } => classify_nv_error_response(*status, text),
+        _ => None,
+    }
+}
+
+fn classify_nv_error_response(
+    status: http::StatusCode,
+    response_body: &str,
+) -> Option<bmc_explorer::ErrorClass> {
+    match status {
+        http::StatusCode::NOT_FOUND => Some(bmc_explorer::ErrorClass::NotFound),
+        http::StatusCode::INTERNAL_SERVER_ERROR => {
+            Some(bmc_explorer::ErrorClass::InternalServerError)
+        }
+        http::StatusCode::BAD_REQUEST
+            if response_body.contains("PropertyUnknown") && response_body.contains("BootOrder") =>
+        {
+            Some(bmc_explorer::ErrorClass::BootOrderPropertyUnknown)
+        }
         _ => None,
     }
 }
@@ -1463,17 +1568,6 @@ fn nv_bmc_explore_config(
         // but not for too long relative to the total exploration
         // time.
         retry_timeout: Duration::from_millis(1000),
-    }
-}
-
-fn record_evaluated_boot_interface(
-    machine_setup_status: Option<&mut MachineSetupStatus>,
-    boot_interface: Option<&BootInterfaceTarget>,
-) {
-    if let Some(status) = machine_setup_status {
-        // NvRedfish currently matches by MAC, but the observation remains
-        // correlated with the complete logical target requested by NICo.
-        status.evaluated_boot_interface = boot_interface.map(MachineBootInterfaceTarget::from);
     }
 }
 
@@ -1566,18 +1660,24 @@ mod tests {
 
     use arc_swap::ArcSwap;
     use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
-    use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
+    use carbide_redfish::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
     use carbide_secrets::credentials::Credentials;
+    use carbide_secrets::test_support::credentials::TestCredentialManager;
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, check_cases_async, value_scenarios};
+    use libredfish::Redfish;
     use libredfish::model::service_root::RedfishVendor;
     use mac_address::MacAddress;
     use model::machine_boot_interface::{MachineBootInterface, MachineBootInterfaceTarget};
+    use model::site_explorer::{
+        EndpointExplorationReport, MACHINE_SETUP_VERIFICATION_VERSION, MachineSetupStatus,
+    };
 
     use super::{
-        BootInterfaceTarget, EndpointExplorationError, MachineSetupStatus, RedfishClient,
-        fetch_machine_setup_status, nv_bmc_explore_config, record_evaluated_boot_interface,
+        BootInterfaceTarget, EndpointExplorationError, RedfishClient,
+        boot_option_for_order_identifier, classify_nv_error_response, fetch_machine_setup_status,
+        nv_bmc_explore_config,
     };
 
     fn test_addr() -> SocketAddr {
@@ -1588,6 +1688,139 @@ mod tests {
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let nv_pool = Arc::new(NvRedfishClientPool::new(proxy_address));
         RedfishClient::new(sim, nv_pool)
+    }
+
+    #[derive(Default)]
+    struct FailingRedfishClientPool {
+        credential_manager: TestCredentialManager,
+    }
+
+    #[async_trait::async_trait]
+    impl RedfishClientPool for FailingRedfishClientPool {
+        async fn create_client(
+            &self,
+            _host: &str,
+            _port: Option<u16>,
+            _auth: RedfishAuth,
+            _vendor: Option<RedfishVendor>,
+        ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
+            Err(RedfishClientCreationError::MissingArgument(
+                "simulated client creation failure".to_string(),
+            ))
+        }
+
+        fn credential_reader(&self) -> &dyn carbide_secrets::credentials::CredentialReader {
+            &self.credential_manager
+        }
+    }
+
+    fn test_credentials() -> Credentials {
+        Credentials::UsernamePassword {
+            username: "root".to_string(),
+            password: "password".to_string(),
+        }
+    }
+
+    fn legacy_nv_report() -> EndpointExplorationReport {
+        EndpointExplorationReport {
+            machine_setup_status: Some(MachineSetupStatus {
+                is_done: false,
+                diffs: Vec::new(),
+                verification_version: 0,
+                evaluated_boot_interface: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn pair_target() -> BootInterfaceTarget {
+        BootInterfaceTarget::Pair(MachineBootInterface {
+            mac_address: MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]),
+            interface_id: "NIC.Slot.7-1-1".to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn nvredfish_mode_replaces_native_status_with_pair_aware_verification() {
+        let sim = Arc::new(RedfishSim::default());
+        let redfish = build_redfish_client(sim.clone());
+        let target = pair_target();
+        let mut report = legacy_nv_report();
+
+        redfish
+            .replace_nv_machine_setup_observation(
+                &mut report,
+                test_addr(),
+                test_credentials(),
+                Some(&target),
+            )
+            .await;
+
+        assert_eq!(
+            report.machine_setup_status,
+            Some(MachineSetupStatus {
+                is_done: true,
+                diffs: Vec::new(),
+                verification_version: MACHINE_SETUP_VERIFICATION_VERSION,
+                evaluated_boot_interface: Some(MachineBootInterfaceTarget::from(&target)),
+            }),
+        );
+        assert_eq!(sim.create_client_calls().len(), 1);
+        assert_eq!(
+            sim.machine_setup_status_targets(&test_addr().ip().to_string()),
+            vec![Some(RedfishSimBootInterfaceRef::Pair {
+                mac_address: target.mac_address(),
+                interface_id: "NIC.Slot.7-1-1".to_string(),
+            })],
+        );
+    }
+
+    #[tokio::test]
+    async fn nvredfish_mode_discards_native_status_when_pair_aware_client_is_unavailable() {
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let redfish = RedfishClient::new(
+            Arc::new(FailingRedfishClientPool::default()),
+            Arc::new(NvRedfishClientPool::new(proxy_address)),
+        );
+        let mut report = legacy_nv_report();
+
+        redfish
+            .replace_nv_machine_setup_observation(
+                &mut report,
+                test_addr(),
+                test_credentials(),
+                Some(&pair_target()),
+            )
+            .await;
+
+        assert!(
+            report.machine_setup_status.is_none(),
+            "the native NvRedfish status must not masquerade as pair-aware evidence",
+        );
+    }
+
+    #[tokio::test]
+    async fn nvredfish_mode_without_a_target_keeps_the_native_report_without_libredfish_io() {
+        let sim = Arc::new(RedfishSim::default());
+        let redfish = build_redfish_client(sim.clone());
+        let expected_status = legacy_nv_report().machine_setup_status;
+        let mut report = legacy_nv_report();
+
+        redfish
+            .replace_nv_machine_setup_observation(
+                &mut report,
+                test_addr(),
+                test_credentials(),
+                None,
+            )
+            .await;
+
+        assert_eq!(report.machine_setup_status, expected_status);
+        assert!(sim.create_client_calls().is_empty());
+        assert!(
+            sim.machine_setup_status_targets(&test_addr().ip().to_string())
+                .is_empty()
+        );
     }
 
     async fn machine_setup_status_target(
@@ -1655,7 +1888,43 @@ mod tests {
     }
 
     #[test]
-    fn nvredfish_projects_the_mac_and_records_the_logical_target() {
+    fn boot_order_accepts_option_references_and_resource_ids() {
+        let boot_options = [libredfish::model::BootOption {
+            odata: Default::default(),
+            alias: Some("UefiHttp".to_string()),
+            description: None,
+            boot_option_enabled: Some(true),
+            boot_option_reference: "Boot0004".to_string(),
+            display_name: "HTTP IPv4".to_string(),
+            id: "0004".to_string(),
+            name: "Boot0004".to_string(),
+            uefi_device_path: None,
+        }];
+
+        value_scenarios!(run = |identifier: &str| {
+            boot_option_for_order_identifier(&boot_options, identifier)
+                .map(|option| option.id.as_str())
+        };
+            "BootOptionReference" {
+                "Boot0004" => Some("0004"),
+            }
+
+            "decorated BootOptionReference" {
+                "Boot0004: HTTP IPv4" => Some("0004"),
+            }
+
+            "resource Id used by Vera Rubin and Supermicro" {
+                "0004" => Some("0004"),
+            }
+
+            "unknown identifier" {
+                "Boot9999" => None,
+            }
+        );
+    }
+
+    #[test]
+    fn nvredfish_inventory_config_projects_the_mac() {
         let mac_address = MacAddress::new([0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01]);
         let boot_interface = MachineBootInterface {
             mac_address,
@@ -1664,29 +1933,59 @@ mod tests {
 
         value_scenarios!(run = |target: Option<BootInterfaceTarget>| {
             let config = nv_bmc_explore_config(target.as_ref());
-            let mut status = MachineSetupStatus::default();
-            record_evaluated_boot_interface(Some(&mut status), target.as_ref());
-            (
-                config.boot_interface_mac,
-                status.evaluated_boot_interface,
-            )
+            config.boot_interface_mac
         };
             "complete pair" {
-                Some(BootInterfaceTarget::Pair(boot_interface.clone())) => (
-                    Some(mac_address),
-                    Some(MachineBootInterfaceTarget::Pair(boot_interface)),
-                ),
+                Some(BootInterfaceTarget::Pair(boot_interface)) => Some(mac_address),
             }
 
             "legacy MAC only" {
-                Some(BootInterfaceTarget::MacOnly(mac_address)) => (
-                    Some(mac_address),
-                    Some(MachineBootInterfaceTarget::MacOnly(mac_address)),
-                ),
+                Some(BootInterfaceTarget::MacOnly(mac_address)) => Some(mac_address),
             }
 
             "no boot interface" {
-                None => (None, None),
+                None => None,
+            }
+        );
+    }
+
+    #[test]
+    fn nv_error_classifier_narrowly_recognizes_unsupported_standard_boot_order() {
+        use bmc_explorer::ErrorClass;
+        use http::StatusCode;
+
+        value_scenarios!(run = |(status, body): (StatusCode, &str)| {
+            classify_nv_error_response(status, body)
+        };
+            "known Supermicro standard BootOrder rejection" {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Base.1.0.PropertyUnknown: The property BootOrder is not valid",
+                ) => Some(ErrorClass::BootOrderPropertyUnknown),
+            }
+
+            "an unrelated unknown property remains an error" {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Base.1.0.PropertyUnknown: The property Foo is not valid",
+                ) => None,
+            }
+
+            "an unrelated BootOrder bad request remains an error" {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "BootOrder has an invalid value",
+                ) => None,
+            }
+
+            "not found keeps its existing classification" {
+                (StatusCode::NOT_FOUND, "") => Some(ErrorClass::NotFound),
+            }
+
+            "internal server error keeps its existing classification" {
+                (StatusCode::INTERNAL_SERVER_ERROR, "") => {
+                    Some(ErrorClass::InternalServerError)
+                },
             }
         );
     }

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -1450,19 +1450,12 @@ async fn test_site_explorer_main(pool: PgPool) -> Result<(), Box<dyn std::error:
         .unwrap();
     txn.commit().await?;
     assert_eq!(explored.len(), 3);
-    let mut versions = Vec::new();
-    let mut versions_without_boot_target_barriers = Vec::new();
-    let mut boot_target_barriers = 0;
+    let boot_target_count = explored
+        .iter()
+        .filter(|report| report.boot_interface_target().is_some())
+        .count();
     for report in &explored {
-        versions.push(report.report_version.version_nr());
-        let boot_target_barrier = if report.boot_interface_target().is_some() {
-            1
-        } else {
-            0
-        };
-        boot_target_barriers += boot_target_barrier;
-        versions_without_boot_target_barriers
-            .push(report.report_version.version_nr() - boot_target_barrier);
+        assert!(report.report_version.version_nr() >= 2);
         assert_eq!(report.report.endpoint_type, EndpointType::Bmc);
         match report.address.to_string() {
             a if a == machines[0].ip => {
@@ -1488,16 +1481,16 @@ async fn test_site_explorer_main(pool: PgPool) -> Result<(), Box<dyn std::error:
             _ => panic!("No other endpoints should be discovered"),
         }
     }
-    // Four iterations perform eight scans. Normalize the one version barrier
-    // on every endpoint that selected an inferred boot target before checking
-    // the exact scan count without assuming how the oldest-first scheduler
-    // distributed those scans.
+    // Report versions also advance when boot targets change, so use the mock's
+    // test-local call history to verify that four iterations performed eight scans.
+    assert_eq!(
+        explorer.endpoint_explorer().explore_endpoint_call_count(),
+        8
+    );
     assert!(
-        (1..=2).contains(&boot_target_barriers),
+        (1..=2).contains(&boot_target_count),
         "one or both managed hosts should have selected an inferred boot target",
     );
-    assert_eq!(versions_without_boot_target_barriers.iter().sum::<u64>(), 8);
-    assert!(versions.iter().all(|version| *version >= 2));
 
     let report = fetch_exploration_report(api).await;
     assert_eq!(report.endpoints.len(), 3);

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -33,17 +33,20 @@ use db::ObjectFilter;
 use db::sku::CURRENT_SKU_VERSION;
 use itertools::Itertools;
 use mac_address::MacAddress;
-use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
+use model::expected_machine::{ExpectedHostNic, ExpectedMachine, ExpectedMachineData};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{LoadSnapshotOptions, Machine};
+use model::machine_boot_interface::MachineBootInterface;
 use model::metadata::Metadata;
+use model::network_segment::NetworkSegmentType;
 use model::site_explorer::{
     BlueFieldOperatingMode, Chassis, ComputerSystem, EndpointExplorationError,
     EndpointExplorationReport, EndpointType, ExploredDpu, ExploredManagedHost, NetworkAdapter,
     PreingestionState, UefiDevicePath,
 };
 use model::test_support::{DpuConfig, ManagedHostConfig};
-use rpc::forge::GetSiteExplorationRequest;
+use rpc::forge::forge_server::Forge;
+use rpc::forge::{GetSiteExplorationRequest, SetPrimaryInterfaceRequest};
 use rpc::site_explorer::ExploredDpu as RpcExploredDpu;
 use tonic::Request;
 
@@ -1448,8 +1451,18 @@ async fn test_site_explorer_main(pool: PgPool) -> Result<(), Box<dyn std::error:
     txn.commit().await?;
     assert_eq!(explored.len(), 3);
     let mut versions = Vec::new();
+    let mut versions_without_boot_target_barriers = Vec::new();
+    let mut boot_target_barriers = 0;
     for report in &explored {
         versions.push(report.report_version.version_nr());
+        let boot_target_barrier = if report.boot_interface_target().is_some() {
+            1
+        } else {
+            0
+        };
+        boot_target_barriers += boot_target_barrier;
+        versions_without_boot_target_barriers
+            .push(report.report_version.version_nr() - boot_target_barrier);
         assert_eq!(report.report.endpoint_type, EndpointType::Bmc);
         match report.address.to_string() {
             a if a == machines[0].ip => {
@@ -1475,9 +1488,15 @@ async fn test_site_explorer_main(pool: PgPool) -> Result<(), Box<dyn std::error:
             _ => panic!("No other endpoints should be discovered"),
         }
     }
-    // Four iterations perform eight scans. The oldest-first scheduler does not
-    // guarantee an even distribution, but every endpoint should be refreshed.
-    assert_eq!(versions.iter().sum::<u64>(), 8);
+    // Four iterations perform eight scans. Normalize the one version barrier
+    // on every endpoint that selected an inferred boot target before checking
+    // the exact scan count without assuming how the oldest-first scheduler
+    // distributed those scans.
+    assert!(
+        (1..=2).contains(&boot_target_barriers),
+        "one or both managed hosts should have selected an inferred boot target",
+    );
+    assert_eq!(versions_without_boot_target_barriers.iter().sum::<u64>(), 8);
     assert!(versions.iter().all(|version| *version >= 2));
 
     let report = fetch_exploration_report(api).await;
@@ -1809,8 +1828,15 @@ async fn test_site_explorer_audit_exploration_results(
     txn.commit().await?;
     assert_eq!(explored.len(), 7);
 
+    let mut boot_target_barriers = 0;
     for report in &explored {
-        assert_eq!(report.report_version.version_nr(), 2);
+        let expected_version = if report.boot_interface_target().is_some() {
+            boot_target_barriers += 1;
+            3
+        } else {
+            2
+        };
+        assert_eq!(report.report_version.version_nr(), expected_version);
         let guard = explorer.endpoint_explorer().reports.lock().unwrap();
         let res = guard.get(&report.address).unwrap().as_ref();
         if res.is_err() {
@@ -1827,6 +1853,10 @@ async fn test_site_explorer_audit_exploration_results(
             assert_eq!(res.unwrap().service, report.report.service);
         }
     }
+    assert_eq!(
+        boot_target_barriers, 1,
+        "the managed host's inferred boot target should create one version barrier",
+    );
 
     // Retrieve the report via gRPC
     let report = fetch_exploration_report(env.api()).await;
@@ -2557,6 +2587,275 @@ async fn test_fetch_host_primary_interface_mac(
             .unwrap(),
         expected_mac,
     );
+    Ok(())
+}
+
+/// A managed-DPU host may explicitly boot from an integrated NIC. Site
+/// Explorer must keep the host in the managed-DPU flow, seed the declared NIC
+/// as a cross-store primary prediction with its declared segment, preserve
+/// that selection through first-lease promotion, and then defer to a later
+/// explicit API selection.
+#[sqlx_test]
+async fn test_managed_dpu_host_uses_declared_integrated_boot_nic(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+    let domain = env.test_harness.test_domain().await;
+    let admin_segment = env
+        .test_harness
+        .network_controller()
+        .create_admin_segment(&domain)
+        .await;
+
+    let mock_host = ManagedHostConfig::default();
+    let dpu = mock_host.get_and_assert_single_dpu().clone();
+    let integrated_nic = *mock_host
+        .non_dpu_macs
+        .first()
+        .expect("the fixture host should expose an integrated NIC");
+    let integrated_boot_interface = MachineBootInterface {
+        mac_address: integrated_nic,
+        interface_id: "NIC.Embedded.1-1-1".to_string(),
+    };
+
+    let mut txn = env.pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: mock_host.bmc_mac_address,
+            data: ExpectedMachineData {
+                serial_number: mock_host.serial.clone(),
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: integrated_nic,
+                    network_segment_type: Some(NetworkSegmentType::Admin),
+                    primary: Some(true),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut host_bmc = env.new_machine(&mock_host.bmc_mac_address.to_string(), "SomeVendor");
+    let mut dpu_bmc = env.new_machine(&dpu.bmc_mac_address.to_string(), "NVIDIA/BF/BMC");
+    host_bmc.discover_dhcp(env.api()).await?;
+    dpu_bmc.discover_dhcp(env.api()).await?;
+    let host_bmc_ip: IpAddr = host_bmc.ip.parse()?;
+    let dpu_bmc_ip: IpAddr = dpu_bmc.ip.parse()?;
+
+    let explorer = env.test_site_explorer(SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        retained_boot_interface_window: None,
+        explorations_per_run: 10,
+        concurrent_explorations: 1,
+        run_interval: Duration::from_secs(1),
+        create_machines: Arc::new(true.into()),
+        ..Default::default()
+    });
+    explorer.insert_endpoints(
+        mock_host
+            .exploration_results(Some(host_bmc_ip), &[(0, dpu_bmc_ip)])?
+            .into_endpoints(),
+    );
+
+    explorer.run_single_iteration().await?;
+    let mut txn = env.pool.begin().await?;
+    for address in [host_bmc_ip, dpu_bmc_ip] {
+        db::explored_endpoints::set_preingestion_complete(address, &mut txn).await?;
+    }
+    txn.commit().await?;
+    explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let host_machine_id = db::machine::find_id_by_bmc_ip(&mut txn, &host_bmc_ip)
+        .await?
+        .expect("the declared integrated NIC must not exclude the managed host");
+    assert!(
+        host_machine_id.machine_type().is_predicted_host(),
+        "the pre-first-lease control path should operate on Site Explorer's predicted host",
+    );
+    let prediction = db::predicted_machine_interface::find_by_mac_address(&mut txn, integrated_nic)
+        .await?
+        .expect("the integrated NIC should remain predicted until its first lease");
+    assert_eq!(prediction.machine_id, host_machine_id);
+    assert!(prediction.primary_interface);
+    assert_eq!(
+        prediction.expected_network_segment_type,
+        NetworkSegmentType::Admin,
+        "the prediction should retain the declared segment",
+    );
+
+    let interfaces = db::machine_interface::find_by_machine_ids(&mut txn, &[host_machine_id])
+        .await?
+        .remove(&host_machine_id)
+        .expect("the managed host should own its DPU-backed interface");
+    let dpu_interface = interfaces
+        .iter()
+        .find(|interface| interface.attached_dpu_machine_id.is_some())
+        .expect("the managed host should retain its DPU-backed interface")
+        .clone();
+    let dpu_machine_id = dpu_interface
+        .attached_dpu_machine_id
+        .expect("the DPU-backed interface should identify its DPU");
+    assert!(
+        !dpu_interface.addresses.is_empty(),
+        "the initially selected DPU link should own its admin address",
+    );
+    let initial_host_network_version =
+        db::machine::get_network_config(txn.as_mut(), &host_machine_id)
+            .await?
+            .version;
+    let initial_dpu_network_version =
+        db::machine::get_network_config(txn.as_mut(), &dpu_machine_id)
+            .await?
+            .version;
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    assert_eq!(
+        endpoint.boot_interface(),
+        Some(integrated_boot_interface.clone()),
+        "the declared primary prediction should outrank the interim DPU row",
+    );
+    txn.rollback().await?;
+
+    // The first integrated-NIC lease materializes the prediction. Promotion
+    // must atomically move primary ownership, clean up the now-dormant DPU
+    // admin link, and publish the new network configuration to the group.
+    env.api()
+        .discover_dhcp(
+            rpc::forge::DhcpDiscovery::builder(integrated_nic, admin_segment.relay_address)
+                .vendor_string("Bluefield")
+                .tonic_request(),
+        )
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    assert!(
+        db::predicted_machine_interface::find_by_mac_address(&mut txn, integrated_nic)
+            .await?
+            .is_none(),
+        "the first lease should consume the integrated-NIC prediction",
+    );
+    let integrated_interface =
+        db::machine_interface::find_by_mac_address(txn.as_mut(), integrated_nic)
+            .await?
+            .into_iter()
+            .find(|interface| interface.machine_id == Some(host_machine_id))
+            .expect("the first lease should promote the integrated NIC");
+    assert!(
+        integrated_interface.primary_interface,
+        "the declared integrated NIC should promote as primary",
+    );
+    assert_eq!(
+        integrated_interface.boot_interface(),
+        Some(integrated_boot_interface.clone()),
+        "promotion should retain the exact Redfish boot-interface pair",
+    );
+    let promoted_dpu_interface =
+        db::machine_interface::find_one(txn.as_mut(), dpu_interface.id).await?;
+    assert!(
+        !promoted_dpu_interface.primary_interface,
+        "promotion should demote the prior DPU primary",
+    );
+    assert!(
+        promoted_dpu_interface.addresses.is_empty(),
+        "the dormant DPU admin link must not retain DHCP addresses",
+    );
+    let promoted_host_network_version =
+        db::machine::get_network_config(txn.as_mut(), &host_machine_id)
+            .await?
+            .version;
+    let promoted_dpu_network_version =
+        db::machine::get_network_config(txn.as_mut(), &dpu_machine_id)
+            .await?
+            .version;
+    assert_eq!(
+        promoted_host_network_version.version_nr(),
+        initial_host_network_version.version_nr() + 1,
+        "promotion should publish the host's changed network configuration",
+    );
+    assert_eq!(
+        promoted_dpu_network_version, promoted_host_network_version,
+        "promotion should advance every machine in the host group together",
+    );
+    assert_ne!(
+        promoted_dpu_network_version, initial_dpu_network_version,
+        "promotion should advance the DPU network configuration",
+    );
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    assert_eq!(
+        endpoint.boot_interface(),
+        Some(integrated_boot_interface.clone()),
+        "first-lease promotion must preserve the endpoint's exact target",
+    );
+    txn.rollback().await?;
+
+    explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let integrated_interface =
+        db::machine_interface::find_one(txn.as_mut(), integrated_interface.id).await?;
+    let promoted_dpu_interface =
+        db::machine_interface::find_one(txn.as_mut(), dpu_interface.id).await?;
+    assert!(integrated_interface.primary_interface);
+    assert!(!promoted_dpu_interface.primary_interface);
+    assert!(promoted_dpu_interface.addresses.is_empty());
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    assert_eq!(
+        endpoint.boot_interface(),
+        Some(integrated_boot_interface),
+        "a later exploration must preserve the promoted integrated target",
+    );
+    txn.rollback().await?;
+
+    // ExpectedMachine.primary seeds ingestion-time intent. Once the host
+    // exists, an explicit API selection is the source of truth; Site Explorer
+    // must not reapply the declaration on later steady-state passes.
+    env.api()
+        .set_primary_interface(Request::new(SetPrimaryInterfaceRequest {
+            host_machine_id: Some(host_machine_id),
+            interface_id: Some(dpu_interface.id),
+            reboot: false,
+        }))
+        .await?;
+    explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let integrated_interface =
+        db::machine_interface::find_one(txn.as_mut(), integrated_interface.id).await?;
+    assert!(
+        !integrated_interface.primary_interface,
+        "explicit selection should demote the integrated interface",
+    );
+    let selected_dpu_interface =
+        db::machine_interface::find_one(txn.as_mut(), dpu_interface.id).await?;
+    assert!(selected_dpu_interface.primary_interface);
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    assert_eq!(
+        endpoint.boot_interface(),
+        selected_dpu_interface.boot_interface(),
+        "a later Site Explorer pass must preserve the explicit API selection",
+    );
+    txn.rollback().await?;
+
     Ok(())
 }
 

--- a/crates/site-explorer/tests/integration/zero_dpu.rs
+++ b/crates/site-explorer/tests/integration/zero_dpu.rs
@@ -30,6 +30,7 @@ use model::expected_machine::{
     ExpectedHostNic, ExpectedMachine, ExpectedMachineData, HostDpuPolicy,
 };
 use model::machine_boot_interface::MachineBootInterface;
+use model::network_segment::NetworkSegmentType;
 use model::test_support::ManagedHostConfig;
 
 struct ZeroDpuEnv {
@@ -785,6 +786,7 @@ async fn test_zero_dpu_declared_primary_promotes_as_primary(
                 host_nics: vec![
                     ExpectedHostNic {
                         mac_address: primary_nic,
+                        network_segment_type: Some(NetworkSegmentType::HostInband),
                         primary: Some(true),
                         ..Default::default()
                     },
@@ -858,6 +860,11 @@ async fn test_zero_dpu_declared_primary_promotes_as_primary(
         predicted_primary.primary_interface,
         "the declared NIC's prediction should carry the primary intent"
     );
+    assert_eq!(
+        predicted_primary.expected_network_segment_type,
+        NetworkSegmentType::HostInband,
+        "the prediction should retain the declared host-inband segment",
+    );
     let predicted_other = db::predicted_machine_interface::find_by_mac_address(&mut txn, other_nic)
         .await?
         .expect("the non-declared NIC should have a prediction");
@@ -902,6 +909,93 @@ async fn test_zero_dpu_declared_primary_promotes_as_primary(
         primary_row.machine_id, other_row.machine_id,
         "both NICs should belong to the same host"
     );
+
+    // Once the host is managed, its selected row owns the endpoint target.
+    // Keep the endpoint on the declared default while selecting the other row,
+    // then verify the next Site Explorer pass follows the managed selection
+    // instead of restoring its inferred default.
+    let mut txn = env.pool.begin().await?;
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    db::explored_endpoints::set_boot_interface_target(
+        host_bmc_ip,
+        &endpoint
+            .boot_interface_target()
+            .expect("the endpoint should have a target"),
+        &mut txn,
+    )
+    .await?;
+    db::machine_interface::demote_primary_interfaces_for_machine(
+        &primary_row.machine_id.expect("the host should be managed"),
+        &mut txn,
+    )
+    .await?;
+    db::machine_interface::set_primary_interface(&other_row.id, true, &mut txn).await?;
+    txn.commit().await?;
+
+    env.site_explorer.run_single_iteration().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    assert_eq!(
+        endpoint.boot_interface(),
+        Some(MachineBootInterface {
+            mac_address: other_nic,
+            interface_id: "NIC.Embedded.2-1-1".to_string(),
+        }),
+        "Site Explorer must preserve the managed host's selected primary interface",
+    );
+    txn.rollback().await?;
+
+    // A stale primary flag on an ineligible segment must not let Site Explorer
+    // replace the controller-owned target. The shared resolver falls back to
+    // the remaining HostInband row.
+    let mut txn = env.pool.begin().await?;
+    let query = "UPDATE machine_interfaces SET segment_id = $1 WHERE id = $2";
+    sqlx::query(query)
+        .bind(env.underlay_segment.id)
+        .bind(primary_row.id)
+        .execute(txn.as_mut())
+        .await?;
+    db::machine_interface::demote_primary_interfaces_for_machine(
+        &primary_row.machine_id.expect("the host should be managed"),
+        &mut txn,
+    )
+    .await?;
+    db::machine_interface::set_primary_interface(&primary_row.id, true, &mut txn).await?;
+    db::explored_endpoints::set_boot_interface_default(
+        host_bmc_ip,
+        &MachineBootInterface {
+            mac_address: primary_nic,
+            interface_id: "NIC.Embedded.1-1-1".to_string(),
+        },
+        &mut txn,
+    )
+    .await?;
+    txn.commit().await?;
+
+    let mut txn = env.pool.begin().await?;
+    let endpoint = db::explored_endpoints::find_all_by_ip(host_bmc_ip, &mut txn)
+        .await?
+        .into_iter()
+        .next()
+        .expect("the host endpoint should exist");
+    assert_eq!(
+        endpoint.boot_interface(),
+        Some(MachineBootInterface {
+            mac_address: other_nic,
+            interface_id: "NIC.Embedded.2-1-1".to_string(),
+        }),
+        "an ineligible primary row must not replace the controller-owned target",
+    );
+    txn.rollback().await?;
 
     Ok(())
 }

--- a/crates/state-controller/src/controller/processor.rs
+++ b/crates/state-controller/src/controller/processor.rs
@@ -736,9 +736,12 @@ async fn process_object<IO: StateControllerIO>(
                 // (via the flag) to promptly act on the winner's state.
                 tracing::info!(state=?next, %object_id, "Transition skipped: state version changed concurrently");
                 metrics.common.transition_conflict = true;
-                next_state = None;
-                next_state_entered_at = None;
-                next_state_sla = None;
+                // The handler transaction may contain writes computed from the
+                // same stale snapshot. Discard all of them, and do not replace
+                // the concurrent writer's diagnostic result with a transition
+                // that never committed.
+                txn.rollback().await.ok();
+                return handler_outcome;
             }
         }
 

--- a/crates/state-controller/src/tests.rs
+++ b/crates/state-controller/src/tests.rs
@@ -447,7 +447,8 @@ async fn create_test_state_controller_tables(pool: &sqlx::PgPool) {
         id             varchar NOT NULL,
         controller_state         jsonb       NOT NULL,
         controller_state_version VARCHAR(64) NOT NULL,
-        controller_state_outcome JSONB
+        controller_state_outcome JSONB,
+        side_effect BOOLEAN NOT NULL DEFAULT false
     );",
     )
     .execute(&mut *txn)
@@ -1598,9 +1599,13 @@ impl StateHandler for TestLockLossStateHandler {
                 .execute(&self.pool)
                 .await
                 .unwrap();
-            Ok(StateHandlerOutcome::transition(
-                TestObjectControllerState::B,
-            ))
+            let mut txn = self.pool.begin().await.unwrap();
+            sqlx::query("UPDATE test_objects SET side_effect=true WHERE id=$1")
+                .bind(object_id)
+                .execute(&mut *txn)
+                .await
+                .unwrap();
+            Ok(StateHandlerOutcome::transition(TestObjectControllerState::B).with_txn(txn))
         } else {
             Ok(StateHandlerOutcome::do_nothing())
         }
@@ -1622,6 +1627,20 @@ async fn test_lock_loss_requeues_without_publishing_the_transition(
         .await?;
 
     controller.run_single_iteration().await;
+
+    let (state, outcome, side_effect): (
+        sqlx::types::Json<TestObjectControllerState>,
+        Option<sqlx::types::Json<PersistentStateHandlerOutcome>>,
+        bool,
+    ) = sqlx::query_as(
+        "SELECT controller_state, controller_state_outcome, side_effect \
+         FROM test_objects WHERE id='test-obj-1'",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(state.0, TestObjectControllerState::A);
+    assert!(outcome.is_none());
+    assert!(!side_effect, "stale handler writes must be rolled back");
 
     // The transition lost the version check: the state this iteration
     // observed is provably outdated, so nothing may be published (existing

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -52293,7 +52293,13 @@ type SetPrimaryDpuRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	HostMachineId *MachineId             `protobuf:"bytes,1,opt,name=host_machine_id,json=hostMachineId,proto3" json:"host_machine_id,omitempty"`
 	DpuMachineId  *MachineId             `protobuf:"bytes,2,opt,name=dpu_machine_id,json=dpuMachineId,proto3" json:"dpu_machine_id,omitempty"`
-	Reboot        bool                   `protobuf:"varint,3,opt,name=reboot,proto3" json:"reboot,omitempty"`
+	// Ready unassigned hosts begin synchronization immediately; hosts in other
+	// unassigned states begin when they next reach the Ready gate. For assigned
+	// hosts, false defers applying the selection and clears pending
+	// authorization before synchronization starts; once it has started, the
+	// request fails until synchronization finishes. True authorizes applying
+	// this exact selection now. The controller restarts only when required.
+	Reboot        bool `protobuf:"varint,3,opt,name=reboot,proto3" json:"reboot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -52353,7 +52359,13 @@ type SetPrimaryInterfaceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	HostMachineId *MachineId             `protobuf:"bytes,1,opt,name=host_machine_id,json=hostMachineId,proto3" json:"host_machine_id,omitempty"`
 	InterfaceId   *MachineInterfaceId    `protobuf:"bytes,2,opt,name=interface_id,json=interfaceId,proto3" json:"interface_id,omitempty"`
-	Reboot        bool                   `protobuf:"varint,3,opt,name=reboot,proto3" json:"reboot,omitempty"`
+	// Ready unassigned hosts begin synchronization immediately; hosts in other
+	// unassigned states begin when they next reach the Ready gate. For assigned
+	// hosts, false defers applying the selection and clears pending
+	// authorization before synchronization starts; once it has started, the
+	// request fails until synchronization finishes. True authorizes applying
+	// this exact selection now. The controller restarts only when required.
+	Reboot        bool `protobuf:"varint,3,opt,name=reboot,proto3" json:"reboot,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -59540,11 +59552,11 @@ func (x *PredictedBootInterface) GetNetworkSegmentType() string {
 	return ""
 }
 
-// An `explored_endpoints` row's boot interface: site-explorer's per-cycle
-// automatic pick for a BMC endpoint, used only for endpoints no machine owns.
+// An `explored_endpoints` row's boot-interface evaluation target: an inferred
+// default before the endpoint is owned and the managed selection afterward.
 type ExploredBootInterface struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// BMC endpoint address this explored default was recorded against.
+	// BMC endpoint address this evaluation target was recorded against.
 	Address          string  `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
 	BootInterfaceMac *string `protobuf:"bytes,2,opt,name=boot_interface_mac,json=bootInterfaceMac,proto3,oneof" json:"boot_interface_mac,omitempty"`
 	BootInterfaceId  *string `protobuf:"bytes,3,opt,name=boot_interface_id,json=bootInterfaceId,proto3,oneof" json:"boot_interface_id,omitempty"`
@@ -59675,27 +59687,31 @@ type GetMachineBootInterfacesResponse struct {
 	ExploredEndpoints   []*ExploredBootInterface         `protobuf:"bytes,4,rep,name=explored_endpoints,json=exploredEndpoints,proto3" json:"explored_endpoints,omitempty"`
 	RetainedInterfaces  []*RetainedBootInterface         `protobuf:"bytes,5,rep,name=retained_interfaces,json=retainedInterfaces,proto3" json:"retained_interfaces,omitempty"`
 	// The boot interface MAC the system would select for this machine right now,
-	// applying `pick_boot_interface` to the owned `machine_interfaces` rows.
-	// Absent when there is no owned candidate yet.
+	// applying `pick_boot_interface_candidate` across the owned
+	// `machine_interfaces` rows and pending `predicted_machine_interfaces`.
+	// Absent when neither store yields a boot-capable candidate.
 	EffectiveBootInterfaceMac *string `protobuf:"bytes,6,opt,name=effective_boot_interface_mac,json=effectiveBootInterfaceMac,proto3,oneof" json:"effective_boot_interface_mac,omitempty"`
-	// The fully-populated effective boot interface id (MAC + Redfish id), when
-	// the selected row has its interface id captured. Absent otherwise.
+	// The vendor-native Redfish interface id for the effective candidate, when
+	// captured on the selected owned row or prediction. Absent when the
+	// candidate has no captured id, or when there is no effective candidate.
 	EffectiveBootInterfaceId *string `protobuf:"bytes,7,opt,name=effective_boot_interface_id,json=effectiveBootInterfaceId,proto3,oneof" json:"effective_boot_interface_id,omitempty"`
 	// True when the stores do not all agree on the boot MAC -- a signal worth a
-	// closer look during troubleshooting (e.g. the explored default points at a
-	// different NIC than the effective owned pick, or a predicted primary
-	// disagrees). See the handler for the exact comparison.
+	// closer look during troubleshooting (e.g. the endpoint evaluation target
+	// points at a different NIC than the effective cross-store selection, or
+	// primary predictions disagree). See the handler for the exact comparison.
 	Divergent bool `protobuf:"varint,8,opt,name=divergent,proto3" json:"divergent,omitempty"`
 	// What the automatic selection would choose if no row were flagged primary
-	// -- `pick_boot_interface`'s fallback of the lowest-MAC non-underlay row.
-	// Comparing this against the effective pick shows whether a primary
-	// designation is overriding the automatic choice. Absent when no managed
-	// row qualifies; `interface_id` absent until captured for that NIC.
+	// -- `pick_boot_interface`'s fallback of the lowest-MAC host-boot row
+	// (Admin or HostInband). Comparing this against the effective pick shows
+	// whether a primary designation is overriding the automatic choice. Absent
+	// when no owned row is boot-capable; `interface_id` absent until captured
+	// for that NIC.
 	DefaultBootInterface *MachineBootInterface `protobuf:"bytes,9,opt,name=default_boot_interface,json=defaultBootInterface,proto3" json:"default_boot_interface,omitempty"`
 	// The prediction `pick_boot_prediction` would boot from for a machine still
-	// waiting on its first DHCP lease: the declared primary, else the sole
-	// non-underlay prediction. Absent when there are no predictions or when the
-	// pick refuses to guess among several undeclared NICs.
+	// waiting on its first DHCP lease: the declared boot-capable primary, else
+	// the sole boot-capable prediction (Admin or HostInband). Absent when there
+	// is no boot-capable prediction or when the pick refuses to guess among
+	// several undeclared NICs.
 	PredictedBootInterface *MachineBootInterface `protobuf:"bytes,10,opt,name=predicted_boot_interface,json=predictedBootInterface,proto3" json:"predicted_boot_interface,omitempty"`
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache

--- a/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
@@ -800,9 +800,10 @@ type ForgeClient interface {
 	SetMachineBootOverride(ctx context.Context, in *MachineBootOverride, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	ClearMachineBootOverride(ctx context.Context, in *MachineInterfaceId, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Gather one machine's boot-interface view from every store that records it
-	// (owned interface rows, predictions, the explored endpoint default, and the
-	// retained post-deletion pairs), plus the effective boot interface the
-	// system would select. Read-only; built for troubleshooting and verification.
+	// (owned interface rows, predictions, the explored endpoint evaluation
+	// target, and the retained post-deletion pairs), plus the effective boot
+	// interface the system would select. Read-only; built for troubleshooting
+	// and verification.
 	GetMachineBootInterfaces(ctx context.Context, in *GetMachineBootInterfacesRequest, opts ...grpc.CallOption) (*GetMachineBootInterfacesResponse, error)
 	// Get Network topology
 	GetNetworkTopology(ctx context.Context, in *NetworkTopologyRequest, opts ...grpc.CallOption) (*NetworkTopologyData, error)
@@ -6300,9 +6301,10 @@ type ForgeServer interface {
 	SetMachineBootOverride(context.Context, *MachineBootOverride) (*emptypb.Empty, error)
 	ClearMachineBootOverride(context.Context, *MachineInterfaceId) (*emptypb.Empty, error)
 	// Gather one machine's boot-interface view from every store that records it
-	// (owned interface rows, predictions, the explored endpoint default, and the
-	// retained post-deletion pairs), plus the effective boot interface the
-	// system would select. Read-only; built for troubleshooting and verification.
+	// (owned interface rows, predictions, the explored endpoint evaluation
+	// target, and the retained post-deletion pairs), plus the effective boot
+	// interface the system would select. Read-only; built for troubleshooting
+	// and verification.
 	GetMachineBootInterfaces(context.Context, *GetMachineBootInterfacesRequest) (*GetMachineBootInterfacesResponse, error)
 	// Get Network topology
 	GetNetworkTopology(context.Context, *NetworkTopologyRequest) (*NetworkTopologyData, error)

--- a/rest-api/proto/core/gen/v1/site_explorer_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/site_explorer_nico.pb.go
@@ -2179,13 +2179,14 @@ type MachineSetupStatus struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	IsDone bool                   `protobuf:"varint,1,opt,name=is_done,json=isDone,proto3" json:"is_done,omitempty"`
 	Diffs  []*MachineSetupDiff    `protobuf:"bytes,2,rep,name=diffs,proto3" json:"diffs,omitempty"`
-	// The logical boot-interface target NICo asked the backend to assess. A
-	// backend may match with a subset (NvRedfish currently uses the MAC) while
-	// retaining Pair identity. Reports written before target capture leave this
-	// unset.
+	// The logical boot-interface target NICo asked the pair-aware verifier to
+	// assess. Reports written before target capture leave this unset.
 	EvaluatedBootInterface *MachineBootInterfaceTarget `protobuf:"bytes,3,opt,name=evaluated_boot_interface,json=evaluatedBootInterface,proto3" json:"evaluated_boot_interface,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// Version of the verification semantics that produced this status. Reports
+	// written before versioned verification leave this as zero.
+	VerificationVersion uint32 `protobuf:"varint,4,opt,name=verification_version,json=verificationVersion,proto3" json:"verification_version,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *MachineSetupStatus) Reset() {
@@ -2237,6 +2238,13 @@ func (x *MachineSetupStatus) GetEvaluatedBootInterface() *MachineBootInterfaceTa
 		return x.EvaluatedBootInterface
 	}
 	return nil
+}
+
+func (x *MachineSetupStatus) GetVerificationVersion() uint32 {
+	if x != nil {
+		return x.VerificationVersion
+	}
+	return 0
 }
 
 // The logical boot-interface target NICo asked a Redfish backend to assess. It
@@ -3018,11 +3026,12 @@ const file_site_explorer_nico_proto_rawDesc = "" +
 	"\f_descriptionB\n" +
 	"\n" +
 	"\b_versionB\x0f\n" +
-	"\r_release_date\"\xc9\x01\n" +
+	"\r_release_date\"\xfc\x01\n" +
 	"\x12MachineSetupStatus\x12\x17\n" +
 	"\ais_done\x18\x01 \x01(\bR\x06isDone\x125\n" +
 	"\x05diffs\x18\x02 \x03(\v2\x1f.site_explorer.MachineSetupDiffR\x05diffs\x12c\n" +
-	"\x18evaluated_boot_interface\x18\x03 \x01(\v2).site_explorer.MachineBootInterfaceTargetR\x16evaluatedBootInterface\"\x82\x01\n" +
+	"\x18evaluated_boot_interface\x18\x03 \x01(\v2).site_explorer.MachineBootInterfaceTargetR\x16evaluatedBootInterface\x121\n" +
+	"\x14verification_version\x18\x04 \x01(\rR\x13verificationVersion\"\x82\x01\n" +
 	"\x1aMachineBootInterfaceTarget\x12=\n" +
 	"\x04pair\x18\x01 \x01(\v2'.site_explorer.MachineBootInterfacePairH\x00R\x04pair\x12\x1b\n" +
 	"\bmac_only\x18\x02 \x01(\tH\x00R\amacOnlyB\b\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -389,9 +389,10 @@ service Forge {
   rpc ClearMachineBootOverride(common.MachineInterfaceId) returns (google.protobuf.Empty);
 
   // Gather one machine's boot-interface view from every store that records it
-  // (owned interface rows, predictions, the explored endpoint default, and the
-  // retained post-deletion pairs), plus the effective boot interface the
-  // system would select. Read-only; built for troubleshooting and verification.
+  // (owned interface rows, predictions, the explored endpoint evaluation
+  // target, and the retained post-deletion pairs), plus the effective boot
+  // interface the system would select. Read-only; built for troubleshooting
+  // and verification.
   rpc GetMachineBootInterfaces(GetMachineBootInterfacesRequest) returns (GetMachineBootInterfacesResponse);
 
   // Get Network topology
@@ -8357,12 +8358,24 @@ message RemediationApplicationStatus {
 message SetPrimaryDpuRequest {
   common.MachineId host_machine_id = 1;
   common.MachineId dpu_machine_id = 2;
+  // Ready unassigned hosts begin synchronization immediately; hosts in other
+  // unassigned states begin when they next reach the Ready gate. For assigned
+  // hosts, false defers applying the selection and clears pending
+  // authorization before synchronization starts; once it has started, the
+  // request fails until synchronization finishes. True authorizes applying
+  // this exact selection now. The controller restarts only when required.
   bool reboot=3;
 }
 
 message SetPrimaryInterfaceRequest {
   common.MachineId host_machine_id = 1;
   common.MachineInterfaceId interface_id = 2;
+  // Ready unassigned hosts begin synchronization immediately; hosts in other
+  // unassigned states begin when they next reach the Ready gate. For assigned
+  // hosts, false defers applying the selection and clears pending
+  // authorization before synchronization starts; once it has started, the
+  // request fails until synchronization finishes. True authorizes applying
+  // this exact selection now. The controller restarts only when required.
   bool reboot = 3;
 }
 
@@ -9335,10 +9348,10 @@ message PredictedBootInterface {
   optional string network_segment_type = 4;
 }
 
-// An `explored_endpoints` row's boot interface: site-explorer's per-cycle
-// automatic pick for a BMC endpoint, used only for endpoints no machine owns.
+// An `explored_endpoints` row's boot-interface evaluation target: an inferred
+// default before the endpoint is owned and the managed selection afterward.
 message ExploredBootInterface {
-  // BMC endpoint address this explored default was recorded against.
+  // BMC endpoint address this evaluation target was recorded against.
   string address = 1;
   optional string boot_interface_mac = 2;
   optional string boot_interface_id = 3;
@@ -9363,30 +9376,34 @@ message GetMachineBootInterfacesResponse {
   repeated RetainedBootInterface retained_interfaces = 5;
 
   // The boot interface MAC the system would select for this machine right now,
-  // applying `pick_boot_interface` to the owned `machine_interfaces` rows.
-  // Absent when there is no owned candidate yet.
+  // applying `pick_boot_interface_candidate` across the owned
+  // `machine_interfaces` rows and pending `predicted_machine_interfaces`.
+  // Absent when neither store yields a boot-capable candidate.
   optional string effective_boot_interface_mac = 6;
-  // The fully-populated effective boot interface id (MAC + Redfish id), when
-  // the selected row has its interface id captured. Absent otherwise.
+  // The vendor-native Redfish interface id for the effective candidate, when
+  // captured on the selected owned row or prediction. Absent when the
+  // candidate has no captured id, or when there is no effective candidate.
   optional string effective_boot_interface_id = 7;
 
   // True when the stores do not all agree on the boot MAC -- a signal worth a
-  // closer look during troubleshooting (e.g. the explored default points at a
-  // different NIC than the effective owned pick, or a predicted primary
-  // disagrees). See the handler for the exact comparison.
+  // closer look during troubleshooting (e.g. the endpoint evaluation target
+  // points at a different NIC than the effective cross-store selection, or
+  // primary predictions disagree). See the handler for the exact comparison.
   bool divergent = 8;
 
   // What the automatic selection would choose if no row were flagged primary
-  // -- `pick_boot_interface`'s fallback of the lowest-MAC non-underlay row.
-  // Comparing this against the effective pick shows whether a primary
-  // designation is overriding the automatic choice. Absent when no managed
-  // row qualifies; `interface_id` absent until captured for that NIC.
+  // -- `pick_boot_interface`'s fallback of the lowest-MAC host-boot row
+  // (Admin or HostInband). Comparing this against the effective pick shows
+  // whether a primary designation is overriding the automatic choice. Absent
+  // when no owned row is boot-capable; `interface_id` absent until captured
+  // for that NIC.
   MachineBootInterface default_boot_interface = 9;
 
   // The prediction `pick_boot_prediction` would boot from for a machine still
-  // waiting on its first DHCP lease: the declared primary, else the sole
-  // non-underlay prediction. Absent when there are no predictions or when the
-  // pick refuses to guess among several undeclared NICs.
+  // waiting on its first DHCP lease: the declared boot-capable primary, else
+  // the sole boot-capable prediction (Admin or HostInband). Absent when there
+  // is no boot-capable prediction or when the pick refuses to guess among
+  // several undeclared NICs.
   MachineBootInterface predicted_boot_interface = 10;
 }
 

--- a/rest-api/proto/core/src/v1/site_explorer_nico.proto
+++ b/rest-api/proto/core/src/v1/site_explorer_nico.proto
@@ -325,11 +325,12 @@ message Inventory {
 message MachineSetupStatus {
   bool is_done = 1;
   repeated MachineSetupDiff diffs = 2;
-  // The logical boot-interface target NICo asked the backend to assess. A
-  // backend may match with a subset (NvRedfish currently uses the MAC) while
-  // retaining Pair identity. Reports written before target capture leave this
-  // unset.
+  // The logical boot-interface target NICo asked the pair-aware verifier to
+  // assess. Reports written before target capture leave this unset.
   MachineBootInterfaceTarget evaluated_boot_interface = 3;
+  // Version of the verification semantics that produced this status. Reports
+  // written before versioned verification leave this as zero.
+  uint32 verification_version = 4;
 }
 
 // The logical boot-interface target NICo asked a Redfish backend to assess. It


### PR DESCRIPTION
The selected boot interface is now durable desired state: Site Explorer proves the exact Redfish target, and machine-controller automatically synchronizes the host through one restart-safe workflow.

## Why

Previously, `SetPrimaryInterface` changed Redfish before the selected interface was committed. Once a managed host returned to `Ready`, there was no durable state-controller path to compare that saved selection with a fresh Redfish observation or synchronize a later mismatch.

## What changes

- The API commits the selected interface and a new selection generation first; the database is the source of truth.
- One shared resolver selects the same boot interface across predicted and owned rows, including the first-lease handoff.
- Site Explorer records a versioned observation for the exact endpoint and Redfish target being evaluated.
- The new `BootConfigSynchronizationState` coordinates BIOS setup, boot order, required restarts, power recovery, lockdown restoration, and final verification as persisted checkpoints.
- A final locked re-read prevents stale reports, target changes, and A-to-B-to-A selection sequences from completing the wrong request.

## Safety and operator control

Unassigned hosts synchronize automatically. Assigned hosts require an explicit `reboot=true` authorization for the current selection generation before disruptive work begins. A `reboot=false` request can withdraw pending authorization before host changes start; once synchronization has begun changing the host, the request is rejected instead of implying that in-flight Redfish work can be recalled.

Synchronization uses the configured convergence limit. Exhaustion stops additional Redfish work at final verification, leaves the state available for operator investigation, and still permits a later matching observation to complete the same authorized selection.

## Scope

Site Explorer continues to discover the initial boot interface and retains its current managed-host DPU-mode correction and power-cycle behavior. Moving that actuator ownership remains a separate follow-up.

## Related issues

Supports https://github.com/NVIDIA/infra-controller/issues/4193

## Type of Change

- [x] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)