### PR TITLE
fix: dpf: Allow user to configure imagePullSecret for hbn and dts services as well

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -585,7 +585,7 @@ events, so consumers handle them identically.
 | `enabled` | `bool` | `false` | Enable DPF Kubernetes deployment. |
 | `dpu_agent_bootstrap_ca` | `DpfDpuAgentBootstrapCa` | `legacy_download` | Bootstrap trust for the containerized DPU agent. Supports `legacy_download` and `mounted`, as described in the following examples. |
 | `services` | `Box<DpfMandatoryServicesConfig>` | built-in mandatory-service defaults | Helm chart, image, and pull-secret settings for the six mandatory DPF services. |
-| `docker_image_pull_secret` | `Option<String>` | — | Override for the Kubernetes `imagePullSecrets` entry used to pull mandatory-service images (applied to every mandatory service except `dts` and `doca_hbn`). |
+| `docker_image_pull_secret` | `Option<String>` | — | Override for the Kubernetes `imagePullSecrets` entry used to pull mandatory-service images (applied to every mandatory service except `dts` and `doca_hbn`, which take a pull secret only from their per-service config). |
 | `proxy` | `Option<DpfProxyDetails>` | — | Proxy configuration for the DPU. When set, containerd on the DPU routes outbound HTTPS traffic through it. |
 | `deployments` | `DpfDeploymentsConfig` | *(default)* | Per-generation DPUDeployment configurations. BF3 is always present with defaults; BF4Generic is opt-in via `[dpf.deployments.bf4_generic]`. |
 

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -1358,8 +1358,9 @@ pub struct DpfConfig {
     pub enabled: bool,
     /// Optional override for the Kubernetes `imagePullSecrets` entry used to pull the
     /// docker images of the mandatory services. When set, it is applied to every
-    /// mandatory service except `dts` and `doca_hbn`. This also overrides if
-    /// docker_image_pull_secret is set in services sections as well.
+    /// mandatory service except `dts` and `doca_hbn`, which take a pull secret only
+    /// from their per-service config. This also overrides any `docker_image_pull_secret`
+    /// set in those per-service sections.
     #[serde(default)]
     pub docker_image_pull_secret: Option<String>,
     /// Selects how the DPF-managed DPU agent obtains the API trust anchor.
@@ -1381,8 +1382,8 @@ pub struct DpfConfig {
 impl DpfConfig {
     /// Returns the top-level mandatory services with the optional
     /// [`Self::docker_image_pull_secret`] override applied. The override affects every
-    /// mandatory service except `dts` and `doca_hbn`, which keep their own configured
-    /// pull secret.
+    /// mandatory service except `dts` and `doca_hbn`, which take a pull secret only
+    /// from their per-service config.
     pub fn resolved_mandatory_services(&self) -> DpfMandatoryServicesConfig {
         let mut services = (*self.services).clone();
         self.apply_pull_secret_override(&mut services);
@@ -1407,14 +1408,15 @@ impl DpfConfig {
     }
 
     /// Applies the optional [`Self::docker_image_pull_secret`] override to every
-    /// mandatory service except `dts` and `doca_hbn`, which keep their own configured
-    /// pull secret. No-op when the override is unset.
+    /// mandatory service except `dts` and `doca_hbn`, which take a pull secret only
+    /// from their per-service config. No-op when the override is unset.
     fn apply_pull_secret_override(&self, services: &mut DpfMandatoryServicesConfig) {
         if let Some(secret) = &self.docker_image_pull_secret {
+            let secret = Some(secret.clone());
             services.dpu_agent.docker_image_pull_secret = secret.clone();
             services.dhcp_server.docker_image_pull_secret = secret.clone();
             services.fmds.docker_image_pull_secret = secret.clone();
-            services.otel.docker_image_pull_secret = secret.clone();
+            services.otel.docker_image_pull_secret = secret;
         }
     }
 }
@@ -1469,13 +1471,6 @@ impl Default for DpfMandatoryServicesConfig {
     }
 }
 
-/// Default name for the Kubernetes `imagePullSecrets` entry used by DPF workload charts.
-pub(crate) const DEFAULT_DPF_IMAGE_PULL_SECRET: &str = "dpf-pull-secret";
-
-fn default_dpf_image_pull_secret() -> String {
-    DEFAULT_DPF_IMAGE_PULL_SECRET.to_string()
-}
-
 /// Configuration for a single Helm-based DPF service.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DpfServiceConfig {
@@ -1491,9 +1486,11 @@ pub struct DpfServiceConfig {
     pub docker_repo_url: String,
     /// Version of docker image
     pub docker_image_tag: String,
-    /// Secret to use to pull the docker images.
-    #[serde(default = "default_dpf_image_pull_secret")]
-    pub docker_image_pull_secret: String,
+    /// Secret to use to pull the docker images. `None` when the service pulls from
+    /// a public registry (`dts` and `doca_hbn` default to this); when set, an
+    /// `imagePullSecrets` entry is emitted in the service's Helm values.
+    #[serde(default)]
+    pub docker_image_pull_secret: Option<String>,
 }
 
 /// Per-deployment DPF configuration for named entries under `[dpf.deployments]`.
@@ -5547,48 +5544,40 @@ object_kind = "secret"
         let services = cfg.resolved_mandatory_services();
 
         // Override applies to every mandatory service ...
-        assert_eq!(
-            services.dpu_agent.docker_image_pull_secret,
-            "my-custom-secret"
-        );
-        assert_eq!(
-            services.dhcp_server.docker_image_pull_secret,
-            "my-custom-secret"
-        );
-        assert_eq!(services.fmds.docker_image_pull_secret, "my-custom-secret");
-        assert_eq!(services.otel.docker_image_pull_secret, "my-custom-secret");
+        for secret in [
+            &services.dpu_agent.docker_image_pull_secret,
+            &services.dhcp_server.docker_image_pull_secret,
+            &services.fmds.docker_image_pull_secret,
+            &services.otel.docker_image_pull_secret,
+        ] {
+            assert_eq!(secret.as_deref(), Some("my-custom-secret"));
+        }
 
-        // ... except dts and doca_hbn, which keep the default.
-        assert_eq!(
-            services.dts.docker_image_pull_secret,
-            DEFAULT_DPF_IMAGE_PULL_SECRET
-        );
-        assert_eq!(
-            services.doca_hbn.docker_image_pull_secret,
-            DEFAULT_DPF_IMAGE_PULL_SECRET
-        );
+        // ... except dts and doca_hbn, which take a pull secret only from their
+        // per-service config (and default to none).
+        assert_eq!(services.dts.docker_image_pull_secret, None);
+        assert_eq!(services.doca_hbn.docker_image_pull_secret, None);
     }
 
     #[test]
-    fn dpf_docker_image_pull_secret_unset_keeps_per_service_secrets() {
-        // No global override -> services keep their own configured secret.
+    fn dpf_docker_image_pull_secret_unset_leaves_all_services_without_a_secret() {
+        // With no top-level override and no per-service value, every mandatory service
+        // defaults to no pull secret (public-registry pulls) and emits no imagePullSecrets.
         let cfg = DpfConfig::default();
         assert!(cfg.docker_image_pull_secret.is_none());
 
         let services = cfg.resolved_mandatory_services();
 
-        assert_eq!(
-            services.dpu_agent.docker_image_pull_secret,
-            DEFAULT_DPF_IMAGE_PULL_SECRET
-        );
-        assert_eq!(
-            services.dts.docker_image_pull_secret,
-            DEFAULT_DPF_IMAGE_PULL_SECRET
-        );
-        assert_eq!(
-            services.doca_hbn.docker_image_pull_secret,
-            DEFAULT_DPF_IMAGE_PULL_SECRET
-        );
+        for secret in [
+            &services.dpu_agent.docker_image_pull_secret,
+            &services.dhcp_server.docker_image_pull_secret,
+            &services.fmds.docker_image_pull_secret,
+            &services.otel.docker_image_pull_secret,
+            &services.dts.docker_image_pull_secret,
+            &services.doca_hbn.docker_image_pull_secret,
+        ] {
+            assert_eq!(*secret, None);
+        }
     }
 
     // Verifies that a [secrets] config section with KMS, routing, and import settings

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -31,8 +31,7 @@ use carbide_dpf::{
 };
 
 use crate::cfg::file::{
-    DEFAULT_DPF_IMAGE_PULL_SECRET, DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa,
-    DpfMandatoryServicesConfig, DpfServiceConfig,
+    DpfBootstrapCaObjectKind, DpfDpuAgentBootstrapCa, DpfMandatoryServicesConfig, DpfServiceConfig,
 };
 
 /// Default DOCA helm registry (DPUServiceTemplate source.repoURL).
@@ -150,7 +149,7 @@ pub(crate) fn default_dts_service() -> DpfServiceConfig {
         helm_version: DTS_SERVICE_HELM_VERSION.to_string(),
         docker_repo_url: String::new(),
         docker_image_tag: String::new(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+        docker_image_pull_secret: None,
     }
 }
 
@@ -162,7 +161,7 @@ pub(crate) fn default_doca_hbn_service() -> DpfServiceConfig {
         helm_version: DOCA_HBN_SERVICE_HELM_VERSION.to_string(),
         docker_repo_url: format!("{DEFAULT_DOCA_IMAGE_REGISTRY}/{DOCA_HBN_SERVICE_IMAGE_NAME}"),
         docker_image_tag: DOCA_HBN_SERVICE_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+        docker_image_pull_secret: None,
     }
 }
 
@@ -174,7 +173,7 @@ pub(crate) fn default_dpu_agent_service() -> DpfServiceConfig {
         helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
         docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{DPU_AGENT_SERVICE_IMAGE_NAME}"),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+        docker_image_pull_secret: None,
     }
 }
 
@@ -188,7 +187,7 @@ pub(crate) fn default_dhcp_server_service() -> DpfServiceConfig {
             "{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{DHCP_SERVER_SERVICE_IMAGE_NAME}"
         ),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+        docker_image_pull_secret: None,
     }
 }
 
@@ -200,7 +199,7 @@ pub(crate) fn default_fmds_service() -> DpfServiceConfig {
         helm_version: COMPILE_TIME_HELM_VERSION.to_string(),
         docker_repo_url: format!("{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{FMDS_SERVICE_IMAGE_NAME}"),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+        docker_image_pull_secret: None,
     }
 }
 
@@ -214,34 +213,54 @@ pub(crate) fn default_otelcol_service() -> DpfServiceConfig {
             "{DEFAULT_CARBIDE_IMAGE_REGISTRY}/{OTEL_COLLECTOR_SERVICE_IMAGE_NAME}"
         ),
         docker_image_tag: COMPILE_TIME_IMAGE_TAG.to_string(),
-        docker_image_pull_secret: DEFAULT_DPF_IMAGE_PULL_SECRET.to_string(),
+        docker_image_pull_secret: None,
     }
+}
+
+/// Adds an `imagePullSecrets` block to a service's Helm values when the service has
+/// a configured pull secret, omitting it entirely otherwise. Mandatory services carry
+/// no pull secret by default (public-registry pulls); one is emitted only when set via
+/// the service's per-service config or the top-level `docker_image_pull_secret`
+/// override, and a `None` renders no `imagePullSecrets` rather than an invalid null.
+fn apply_image_pull_secrets(helm_values: &mut serde_json::Value, cfg: &DpfServiceConfig) {
+    let Some(secret) = cfg.docker_image_pull_secret.as_ref() else {
+        return;
+    };
+    helm_values
+        .as_object_mut()
+        .expect("service Helm values must be a JSON object")
+        .insert(
+            "imagePullSecrets".to_string(),
+            serde_json::json!([{ "name": secret }]),
+        );
 }
 
 /// DOCA HBN service definition.
 pub fn doca_hbn_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
     let interfaces = doca_hbn_service_interfaces();
-    ServiceDefinition {
-        helm_values: Some(serde_json::json!({
-            "image": {
-                "repository": cfg.docker_repo_url,
-                "tag": cfg.docker_image_tag,
-            },
-            "resources": {
-                "memory": "6Gi",
-                "nvidia.com/bf_sf": interfaces.len(),
-            },
-            "configuration": {
-                "user": {
-                    "create": true,
-                    "username": "carbide",
-                    "password": {
-                        "secretName": "hbn-user-password",
-                        "secretKey": "password",
-                    },
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        },
+        "resources": {
+            "memory": "6Gi",
+            "nvidia.com/bf_sf": interfaces.len(),
+        },
+        "configuration": {
+            "user": {
+                "create": true,
+                "username": "carbide",
+                "password": {
+                    "secretName": "hbn-user-password",
+                    "secretKey": "password",
                 },
-            }
-        })),
+            },
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
+    ServiceDefinition {
+        helm_values: Some(helm_values),
 
         config_values: Some(serde_json::json!({
             "configuration": {
@@ -264,10 +283,12 @@ pub fn doca_hbn_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
 
 /// DTS (DOCA Telemetry Service) service definition.
 pub fn dts_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "exposedPorts": { "ports": { "httpserverport": true } }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
     ServiceDefinition {
-        helm_values: Some(serde_json::json!({
-            "exposedPorts": { "ports": { "httpserverport": true } }
-        })),
+        helm_values: Some(helm_values),
         config_ports: Some(vec![ServiceConfigPort {
             name: "httpserverport".to_string(),
             port: 9189,
@@ -297,13 +318,9 @@ fn dpu_agent_helm_values(
             "nvue_https_address": "nvue",
             "nvue_credentials_secret_name": "hbn-user-password",
             "nvue_password_key": "password",
-        },
-        "imagePullSecrets": [
-            {
-                "name": cfg.docker_image_pull_secret
-            }
-        ]
+        }
     });
+    apply_image_pull_secrets(&mut values, cfg);
 
     let bootstrap_ca_values = match bootstrap_ca {
         DpfDpuAgentBootstrapCa::LegacyDownload { url: None } => None,
@@ -372,18 +389,15 @@ pub fn dpu_agent_service(
 
 /// Forge DHCP Server service definition.
 pub fn dhcp_server_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
     ServiceDefinition {
-        helm_values: Some(serde_json::json!({
-            "image": {
-                "repository": cfg.docker_repo_url,
-                "tag": cfg.docker_image_tag,
-            },
-            "imagePullSecrets": [
-                {
-                    "name": cfg.docker_image_pull_secret
-                }
-            ]
-        })),
+        helm_values: Some(helm_values),
 
         interfaces: dhcp_server_service_interfaces(),
 
@@ -408,18 +422,15 @@ pub fn dhcp_server_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
 
 /// Forge FMDS service definition.
 pub fn fmds_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
     ServiceDefinition {
-        helm_values: Some(serde_json::json!({
-            "image": {
-                "repository": cfg.docker_repo_url,
-                "tag": cfg.docker_image_tag,
-            },
-            "imagePullSecrets": [
-                {
-                    "name": cfg.docker_image_pull_secret
-                }
-            ]
-        })),
+        helm_values: Some(helm_values),
 
         interfaces: fmds_service_interfaces(),
 
@@ -444,18 +455,15 @@ pub fn fmds_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
 
 /// OTel service definition.
 pub fn otelcol_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
+    let mut helm_values = serde_json::json!({
+        "image": {
+            "repository": cfg.docker_repo_url,
+            "tag": cfg.docker_image_tag,
+        }
+    });
+    apply_image_pull_secrets(&mut helm_values, cfg);
     ServiceDefinition {
-        helm_values: Some(serde_json::json!({
-            "image": {
-                "repository": cfg.docker_repo_url,
-                "tag": cfg.docker_image_tag,
-            },
-            "imagePullSecrets": [
-                {
-                    "name": cfg.docker_image_pull_secret
-                }
-            ]
-        })),
+        helm_values: Some(helm_values),
         service_daemon_set_annotations: Some(BTreeMap::new()),
         config_values: Some(serde_json::json!({
             "nico_dpu_agent": "{{ (index .Services \"carbide-dpu-agent\").Name }}",
@@ -543,6 +551,70 @@ mod tests {
                     },
                 })),
             }
+        );
+    }
+
+    // ---- imagePullSecrets ----
+
+    #[test]
+    fn hbn_and_dts_omit_image_pull_secrets_by_default() {
+        // HBN and DTS pull from the public DOCA registry: no imagePullSecrets unless configured.
+        let hbn = doca_hbn_service(&default_doca_hbn_service());
+        assert!(
+            hbn.helm_values.unwrap().get("imagePullSecrets").is_none(),
+            "HBN must not emit imagePullSecrets without a configured secret"
+        );
+
+        let dts = dts_service(&default_dts_service());
+        assert!(
+            dts.helm_values.unwrap().get("imagePullSecrets").is_none(),
+            "DTS must not emit imagePullSecrets without a configured secret"
+        );
+    }
+
+    #[test]
+    fn hbn_and_dts_emit_image_pull_secrets_when_configured() {
+        let expected = serde_json::json!([{ "name": "private-pull-secret" }]);
+
+        let mut hbn_cfg = default_doca_hbn_service();
+        hbn_cfg.docker_image_pull_secret = Some("private-pull-secret".to_string());
+        assert_eq!(
+            doca_hbn_service(&hbn_cfg).helm_values.unwrap()["imagePullSecrets"],
+            expected
+        );
+
+        let mut dts_cfg = default_dts_service();
+        dts_cfg.docker_image_pull_secret = Some("private-pull-secret".to_string());
+        assert_eq!(
+            dts_service(&dts_cfg).helm_values.unwrap()["imagePullSecrets"],
+            expected
+        );
+    }
+
+    #[test]
+    fn carbide_service_image_pull_secrets_are_conditional() {
+        // By default a carbide service carries no pull secret and omits the block,
+        // rather than rendering the invalid imagePullSecrets: [{ name: null }].
+        let dpu_agent = dpu_agent_service(
+            &default_dpu_agent_service(),
+            &DpfDpuAgentBootstrapCa::default(),
+        );
+        assert!(
+            dpu_agent
+                .helm_values
+                .unwrap()
+                .get("imagePullSecrets")
+                .is_none(),
+            "a carbide service without a pull secret must omit imagePullSecrets"
+        );
+
+        // When a pull secret is configured, the block is emitted with its name.
+        let mut cfg = default_dpu_agent_service();
+        cfg.docker_image_pull_secret = Some("nico-pull-secret".to_string());
+        let agent = dpu_agent_service(&cfg, &DpfDpuAgentBootstrapCa::default());
+        assert_eq!(
+            agent.helm_values.unwrap()["imagePullSecrets"],
+            serde_json::json!([{ "name": "nico-pull-secret" }])
         );
     }
 

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -533,18 +533,13 @@ enabled = true
 docker_image_pull_secret = "nico-pull-secret"
 ```
 
-`docker_image_pull_secret` is an optional top-level override for the Kubernetes
-Secret used to pull the NICo (carbide-owned) service images — `dpu_agent`,
-`dhcp_server`, `fmds`, and `otel`. `dts` and `doca_hbn` are never affected by it;
-they take a pull secret only from their own per-service config — either
-`[dpf.services.*]` or a deployment's `[dpf.deployments.<name>.services.*]` override.
+`docker_image_pull_secret` is an optional top-level override for the Kubernetes Secret used to pull the NICo (carbide-owned) service images: `dpu_agent`, `dhcp_server`, `fmds`, and `otel`. The `dts` and `doca_hbn` images are never affected by it; they take a pull secret only from their own per-service config — either `[dpf.services.*]` or a deployment's `[dpf.deployments.<name>.services.*]` override.
 
-By default no mandatory service is given a pull secret, so their images are pulled
-from a **public registry**. Provide one only where a private registry needs it —
-via this top-level override (carbide services) or a service's own
-`docker_image_pull_secret` (any service). When referencing a private Secret such as
-`dpf-pull-secret`, ensure it is configured with a legacy NGC API key for better
-compatibility.
+By default, no mandatory service is given a pull secret, so their images are pulled from a **public registry**. Provide a pull secret only where a private registry needs it. You can use either this top-level override (carbide services only) or a service's own `docker_image_pull_secret` (any service).
+
+<Tip>
+When referencing a private Secret such as `dpf-pull-secret`, ensure it is configured with a legacy NGC API key for better compatibility.
+</Tip>
 
 `[dpf].services.*` sub-tables can additionally override the Helm chart and
 container image of each mandatory DPUService that carbide-api deploys

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -533,7 +533,18 @@ enabled = true
 docker_image_pull_secret = "nico-pull-secret"
 ```
 
-`docker_image_pull_secret` is an optional parameter that specifies the name of the Kubernetes Secret used to pull service container images for NICo services. If this field is omitted, NICo defaults to using the `dpf-pull-secret` for image pulls. In this scenario, ensure that the `dpf-pull-secret` is configured with a legacy NGC API key for better compatibility.
+`docker_image_pull_secret` is an optional top-level override for the Kubernetes
+Secret used to pull the NICo (carbide-owned) service images — `dpu_agent`,
+`dhcp_server`, `fmds`, and `otel`. `dts` and `doca_hbn` are never affected by it;
+they take a pull secret only from their own per-service config — either
+`[dpf.services.*]` or a deployment's `[dpf.deployments.<name>.services.*]` override.
+
+By default no mandatory service is given a pull secret, so their images are pulled
+from a **public registry**. Provide one only where a private registry needs it —
+via this top-level override (carbide services) or a service's own
+`docker_image_pull_secret` (any service). When referencing a private Secret such as
+`dpf-pull-secret`, ensure it is configured with a legacy NGC API key for better
+compatibility.
 
 `[dpf].services.*` sub-tables can additionally override the Helm chart and
 container image of each mandatory DPUService that carbide-api deploys
@@ -549,8 +560,12 @@ helm_chart              = "<helm chart name>"
 helm_version            = "<helm chart version>"   # empty → CI default
 docker_repo_url         = "<image registry+repo>"
 docker_image_tag        = "<image tag>"            # empty → CI default
-docker_image_pull_secret = "dpf-pull-secret"
+docker_image_pull_secret = "dpf-pull-secret"       # optional; omit for a public registry
 ```
+
+`docker_image_pull_secret` is optional per service and defaults to none: omitting
+it renders no `imagePullSecrets` for that service (public-registry pulls). Set it to
+a Kubernetes image-pull Secret name when the service is served from a private registry.
 
 #### Per-deployment configuration (`[dpf.deployments.*]`)
 
@@ -646,7 +661,7 @@ Field reference (all under `[dpf]`):
 | TOML key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `enabled` | bool | `false` | Master switch. Must be `true` to use DPF-based provisioning. |
-| `docker_image_pull_secret` | string | `dpf-pull-secret` | Pull Secret applied to every mandatory service except `dts` and `doca_hbn`. |
+| `docker_image_pull_secret` | string (optional) | none | Top-level override for the image-pull Secret of the carbide services (`dpu_agent`, `dhcp_server`, `fmds`, `otel`); never applied to `dts`/`doca_hbn`. Unset by default: services pull from a public registry (no `imagePullSecrets`) unless a secret is given here or per-service. |
 | `dpu_agent_bootstrap_ca` | tagged table | `source = "legacy_download"` | Selects legacy download or mounted-object bootstrap trust for the DPU agent. |
 | `services.<svc>` | table | per-service defaults | Helm/image overrides for each mandatory DPUService. |
 | `deployments.bf3` | table | BF3 defaults | BF3 DPUDeployment config; always active. |


### PR DESCRIPTION
Allow user to configure imagePullSecret for hbn and dts services as well

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [x] **This PR contains breaking changes**
 The mandatory DPF services no longer default to the dpf-pull-secret
 image-pull Secret — they now render no imagePullSecrets unless one is set 
 explicitly (per-service or via the top-level docker_image_pull_secret).

 Impact: None — the default-secret injection isn't relied on by any current 
 deployment, so this is a safe time to drop it; deployments needing a 
 public-registry for mandatory-services will be able to use it now.


## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
