### PR TITLE
fix(sku): fix v5 SKU upgrade regressions that wedged pre-existing machines

### DIFF
--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -150,7 +150,10 @@ pub mod tests {
           "storage": [
             {
               "model": "Dell Ent NVMe CM6 RI 1.92TB",
-              "count": 1
+              "count": 1,
+              "min_size_mb": 1800000,
+              "max_size_mb": 2000000,
+              "pci_patterns": ["/devices/pci0000:00/0000:64:00.0/nvme/nvme0/nvme0n1"]
             }
           ],
           "tpm":

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -99,13 +99,13 @@ fn validate_storage_for_create(sku: &Sku) -> Result<(), DatabaseError> {
                 ))
             })?;
         }
-        if let (Some(min), Some(max)) = (storage.min_size_mb, storage.max_size_mb) {
-            if min > max {
-                return Err(DatabaseError::InvalidArgument(format!(
-                    "storage entry (model {:?}) has min_size_mb ({min}) greater than max_size_mb ({max})",
-                    storage.model
-                )));
-            }
+        if let (Some(min), Some(max)) = (storage.min_size_mb, storage.max_size_mb)
+            && min > max
+        {
+            return Err(DatabaseError::InvalidArgument(format!(
+                "storage entry (model {:?}) has min_size_mb ({min}) greater than max_size_mb ({max})",
+                storage.model
+            )));
         }
         if sku.schema_version >= SKU_VERSION_WITH_DRIVE_LOCATION
             && storage.pci_patterns.is_empty()

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -26,8 +26,9 @@ use model::machine::Machine;
 use model::machine::capabilities::{MachineCapabilitiesSet, MachineCapabilityInfiniband};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::sku::{
-    Sku, SkuComponentChassis, SkuComponentCpu, SkuComponentGpu, SkuComponentInfinibandDevices,
-    SkuComponentMemory, SkuComponentStorage, SkuComponentTpm, SkuComponents, diff_skus,
+    SKU_VERSION_WITH_DRIVE_LOCATION, Sku, SkuComponentChassis, SkuComponentCpu, SkuComponentGpu,
+    SkuComponentInfinibandDevices, SkuComponentMemory, SkuComponentStorage, SkuComponentTpm,
+    SkuComponents, diff_skus,
 };
 use sqlx::PgConnection;
 
@@ -80,10 +81,16 @@ pub async fn find_matching_with_exclusion(
     Ok(None)
 }
 
-/// Reject a SKU whose storage components carry an uncompilable PCI location
-/// pattern, so an invalid regex is caught at authoring time rather than at
-/// validation time.
-fn validate_storage_pci_patterns(sku: &Sku) -> Result<(), DatabaseError> {
+/// Validate storage components of an expected SKU being persisted.
+///
+/// Rejects uncompilable PCI patterns (caught at authoring time rather than at
+/// validation time), and rejects v5 storage entries that carry no constraints
+/// at all (no size bounds, no PCI patterns). Such entries would silently accept
+/// any drive at any location, providing weaker guarantees than v4 model
+/// matching. This most commonly occurs when a v5 SKU is auto-generated from
+/// hardware_info that predates the size_mb/pci_path fields; those SKUs should
+/// not be persisted until the hardware has been re-enumerated.
+fn validate_storage_for_create(sku: &Sku) -> Result<(), DatabaseError> {
     for storage in &sku.components.storage {
         for pattern in &storage.pci_patterns {
             regex::Regex::new(pattern).map_err(|err| {
@@ -91,6 +98,25 @@ fn validate_storage_pci_patterns(sku: &Sku) -> Result<(), DatabaseError> {
                     "invalid storage PCI pattern \"{pattern}\": {err}"
                 ))
             })?;
+        }
+        if let (Some(min), Some(max)) = (storage.min_size_mb, storage.max_size_mb) {
+            if min > max {
+                return Err(DatabaseError::InvalidArgument(format!(
+                    "storage entry (model {:?}) has min_size_mb ({min}) greater than max_size_mb ({max})",
+                    storage.model
+                )));
+            }
+        }
+        if sku.schema_version >= SKU_VERSION_WITH_DRIVE_LOCATION
+            && storage.pci_patterns.is_empty()
+            && storage.min_size_mb.is_none()
+            && storage.max_size_mb.is_none()
+        {
+            return Err(DatabaseError::InvalidArgument(format!(
+                "v5 storage entry (model {:?}) has no size bounds or PCI patterns; \
+                 re-enumerate the machine's hardware before creating this SKU",
+                storage.model
+            )));
         }
     }
     Ok(())
@@ -110,7 +136,7 @@ pub async fn create(txn: &mut PgConnection, sku: &Sku) -> Result<(), DatabaseErr
         ));
     }
 
-    validate_storage_pci_patterns(sku)?;
+    validate_storage_for_create(sku)?;
 
     let mut inner_txn = Transaction::begin_inner(txn).await?;
 
@@ -241,7 +267,7 @@ pub async fn replace(txn: &mut PgConnection, sku: &Sku) -> Result<Sku, DatabaseE
         ));
     }
 
-    validate_storage_pci_patterns(sku)?;
+    validate_storage_for_create(sku)?;
 
     let mut inner_txn = Transaction::begin_inner(txn).await?;
 
@@ -776,29 +802,28 @@ pub async fn generate_sku_from_machine_at_version_5(
     // authored from this can then widen the size range or replace the literal
     // path with a regex. Drives are ordered by path for deterministic output.
     //
-    // Both fields are required: a missing size or PCI path would produce an
-    // unconstrained storage entry that validates any drive at any location or
-    // capacity. Since a generated SKU can be persisted as an expected SKU,
-    // reject generation rather than silently authoring a permissive v5 SKU.
+    // size_mb and pci_path may be absent on hardware_info records that predate
+    // the v5 fields (discovered before PR #3717). Rather than failing generation
+    // and wedging the machine, we include the drive with whatever fields are
+    // present. A drive without a path will not match any location-constrained
+    // expected group (which is correct — the mismatch is reported as a diff),
+    // and a drive without a size satisfies only unconstrained size ranges. The
+    // machine self-heals once hardware re-enumeration populates the new fields.
     let mut storage: Vec<SkuComponentStorage> = hardware_info
         .nvme_devices
         .iter()
-        .map(|nvme| {
-            let (Some(size_mb), Some(pci_path)) = (nvme.size_mb, nvme.pci_path.as_ref()) else {
-                return Err(DatabaseError::InvalidArgument(format!(
-                    "generate sku (v5): nvme drive (model {:?}, serial {:?}) is missing size or PCI path",
-                    nvme.model, nvme.serial
-                )));
-            };
-            Ok(SkuComponentStorage {
-                model: nvme.model.clone(),
-                count: 1,
-                min_size_mb: Some(size_mb),
-                max_size_mb: Some(size_mb),
-                pci_patterns: vec![pci_path.clone()],
-            })
+        .map(|nvme| SkuComponentStorage {
+            model: nvme.model.clone(),
+            count: 1,
+            min_size_mb: nvme.size_mb,
+            max_size_mb: nvme.size_mb,
+            pci_patterns: nvme
+                .pci_path
+                .as_ref()
+                .map(|p| vec![p.clone()])
+                .unwrap_or_default(),
         })
-        .collect::<Result<_, _>>()?;
+        .collect();
     storage.sort();
     sku.components.storage = storage;
 

--- a/crates/api-model/src/sku.rs
+++ b/crates/api-model/src/sku.rs
@@ -403,12 +403,15 @@ pub fn diff_skus(actual_sku: &Sku, expected_sku: &Sku) -> Vec<String> {
 /// Legacy (schema version < 5) storage comparison: match discovered storage to
 /// expected storage by model and compare counts.
 fn diff_storage_by_model(actual_sku: &Sku, expected_sku: &Sku, diffs: &mut Vec<String>) {
-    let mut actual_storage: HashMap<String, SkuComponentStorage> = actual_sku
-        .components
-        .storage
-        .iter()
-        .map(|s| (s.model.clone(), s.clone()))
-        .collect();
+    // v5 actual SKUs have one entry per drive; aggregate by model so the count
+    // comparison against a v4 expected SKU (grouped by model) is correct.
+    let mut actual_storage: HashMap<String, SkuComponentStorage> = HashMap::new();
+    for s in &actual_sku.components.storage {
+        actual_storage
+            .entry(s.model.clone())
+            .and_modify(|e| e.count += s.count)
+            .or_insert_with(|| s.clone());
+    }
 
     for es in &expected_sku.components.storage {
         if let Some(actual_storage) = actual_storage.remove(&es.model) {
@@ -972,5 +975,22 @@ mod tests {
             diffs.iter().any(|d| d.contains("Missing storage config")),
             "got {diffs:?}"
         );
+    }
+
+    #[test]
+    fn v5_actual_matches_v4_expected_by_model() {
+        // A v5 actual SKU (one entry per drive, count=1 each) must match a v4
+        // expected SKU (grouped by model) correctly. The regression: HashMap
+        // collection clobbered duplicate models, leaving count=1 instead of 2.
+        let actual_v5 = vec![drive(PATH_A, 3_840_000), drive(PATH_B, 3_840_000)];
+        let expected_v4 = vec![SkuComponentStorage {
+            model: "nvme".to_string(),
+            count: 2,
+            min_size_mb: None,
+            max_size_mb: None,
+            pci_patterns: Vec::new(),
+        }];
+        let diffs = diff_skus(&sku(5, actual_v5), &sku(4, expected_v4));
+        assert!(diffs.is_empty(), "expected no diffs, got {diffs:?}");
     }
 }


### PR DESCRIPTION
PR #3717 introduced three bugs that broke machines on upgrade to v2.1.

## Description

**Bug 1 — v5 generation hard-failed on pre-existing hardware, wedging machines at `MatchingSku`**

`generate_sku_from_machine_at_version_5` rejected NVMe drives missing `size_mb` or `pci_path`, which are absent on `hardware_info` records discovered before #3717. Any unassigned machine hit this on upgrade, propagated the error as a `StateHandlerError`, and wedged permanently in `MatchingSku` with no recovery path short of a reboot. Generation now includes the drive with whatever fields are present; machines self-heal once hardware re-enumeration populates the new fields.

**Bug 2 — `diff_storage_by_model` clobbered duplicate models from v5 actual SKUs**

`diff_storage_by_model` (used when the expected SKU is v4) built its map with a plain `HashMap` collect, silently dropping duplicate model keys. A v5 actual SKU has one entry per drive (count=1 each), so two drives of the same model left only one entry with count=1. Compared against a v4 expected with count=2, this produced a false diff and prevented `find_matching` from ever finding a match for those machines. Fixed by aggregating counts via `and_modify`.

**Bug 3 — graceful degradation allowed unconstrained v5 entries to be auto-created as expected SKUs**

The fix for Bug 1 meant `generate_missing_sku_for_machine` could now generate and persist a v5 expected SKU where every storage entry had no `pci_patterns` and no size bounds — silently accepting any drive at any location, weaker than v4 model matching. `validate_storage_for_create` now rejects v5 entries with no constraints. Also adds a `min_size_mb > max_size_mb` inversion check (caught by CodeRabbit review).

The `VerifyingSku` path was unaffected by all three bugs — it generates at `expected_sku.schema_version`, so v4 expected SKUs always generated v4 actuals.

## Related issues

Fixes #6520848

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Regression test `v5_actual_matches_v4_expected_by_model` covers Bug 2. Existing 15 SKU unit tests in `crates/api-model/src/sku.rs` cover Bug 1 and Bug 3 indirectly (generation no longer errors; unconstrained entries are rejected at the `create` layer). All 16 tests pass.

## Additional Notes

The three bugs form a chain: Bug 1 wedges unassigned machines; Bug 2 prevents assigned machines from re-matching after upgrade; Bug 3 would have allowed a degraded auto-generated expected SKU to persist once Bug 1 was fixed. All three need to land together.