### PR TITLE
test: assert results, not just that nothing panicked

### DIFF
--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -2093,10 +2093,20 @@ async fn flat_vpc_accepts_host_inband_segment(
         segment_type: rpc::forge::NetworkSegmentType::HostInband as i32,
     };
 
-    env.api
+    let created = env
+        .api
         .create_network_segment(Request::new(request))
         .await
-        .expect("Flat VPC + HostInband segment is the canonical pairing");
+        .expect("Flat VPC + HostInband segment is the canonical pairing")
+        .into_inner();
+
+    // Accepting the request is only half of it -- check the segment came back attached to
+    // the flat VPC, with the type we asked for.
+    assert_eq!(created.vpc_id, vpc.id);
+    assert_eq!(
+        created.segment_type,
+        rpc::forge::NetworkSegmentType::HostInband as i32
+    );
 
     Ok(())
 }

--- a/crates/api-core/src/tests/vpc_peering.rs
+++ b/crates/api-core/src/tests/vpc_peering.rs
@@ -741,6 +741,38 @@ async fn flat_vpc_can_peer_with_etv_under_exclusive_policy(
         .await
         .expect("Flat <-> ETV peering must be allowed under Exclusive policy");
 
+    // The create returning Ok only says the RPC didn't error. Read the peering back --
+    // and from *both* sides, because `find_vpc_peering_ids` filters on a single
+    // `vpc_id` while the row stores an ordered (vpc_id, peer_vpc_id) pair, so whether
+    // the flat side sees its own peering is a separate question.
+    let peerings = get_vpc_peerings(&env, etv_vpc.id.unwrap())
+        .await?
+        .into_inner()
+        .vpc_peerings;
+    assert_eq!(peerings.len(), 1);
+    // The stored row does not preserve the order the peering was created in, so assert
+    // the pair connects the two VPCs without assuming which side landed in `vpc_id`.
+    let pair = (peerings[0].vpc_id, peerings[0].peer_vpc_id);
+    assert!(
+        pair == (etv_vpc.id, flat_vpc.id) || pair == (flat_vpc.id, etv_vpc.id),
+        "peering should connect the two VPCs, got {pair:?}"
+    );
+
+    let from_flat = get_vpc_peerings(&env, flat_vpc.id.unwrap())
+        .await?
+        .into_inner()
+        .vpc_peerings;
+    assert_eq!(
+        from_flat.len(),
+        1,
+        "the flat side should see the peering too"
+    );
+    let pair = (from_flat[0].vpc_id, from_flat[0].peer_vpc_id);
+    assert!(
+        pair == (etv_vpc.id, flat_vpc.id) || pair == (flat_vpc.id, etv_vpc.id),
+        "the reverse lookup should name the same pair, got {pair:?}"
+    );
+
     Ok(())
 }
 
@@ -781,6 +813,38 @@ async fn flat_vpc_can_peer_with_fnn_under_exclusive_policy(
         .await
         .expect("Flat <-> FNN peering must be allowed under Exclusive policy");
 
+    // The create returning Ok only says the RPC didn't error. Read the peering back --
+    // and from *both* sides, because `find_vpc_peering_ids` filters on a single
+    // `vpc_id` while the row stores an ordered (vpc_id, peer_vpc_id) pair, so whether
+    // the flat side sees its own peering is a separate question.
+    let peerings = get_vpc_peerings(&env, fnn_vpc.id.unwrap())
+        .await?
+        .into_inner()
+        .vpc_peerings;
+    assert_eq!(peerings.len(), 1);
+    // The stored row does not preserve the order the peering was created in, so assert
+    // the pair connects the two VPCs without assuming which side landed in `vpc_id`.
+    let pair = (peerings[0].vpc_id, peerings[0].peer_vpc_id);
+    assert!(
+        pair == (fnn_vpc.id, flat_vpc.id) || pair == (flat_vpc.id, fnn_vpc.id),
+        "peering should connect the two VPCs, got {pair:?}"
+    );
+
+    let from_flat = get_vpc_peerings(&env, flat_vpc.id.unwrap())
+        .await?
+        .into_inner()
+        .vpc_peerings;
+    assert_eq!(
+        from_flat.len(),
+        1,
+        "the flat side should see the peering too"
+    );
+    let pair = (from_flat[0].vpc_id, from_flat[0].peer_vpc_id);
+    assert!(
+        pair == (fnn_vpc.id, flat_vpc.id) || pair == (flat_vpc.id, fnn_vpc.id),
+        "the reverse lookup should name the same pair, got {pair:?}"
+    );
+
     Ok(())
 }
 
@@ -812,6 +876,34 @@ async fn flat_vpc_can_peer_with_flat_under_exclusive_policy(
         }))
         .await
         .expect("Flat <-> Flat peering must be allowed under Exclusive policy");
+
+    // The create returning Ok only says the RPC didn't error. Read the peering back --
+    // and from *both* sides, because `find_vpc_peering_ids` filters on a single
+    // `vpc_id` while the row stores an ordered (vpc_id, peer_vpc_id) pair, so whether
+    // the flat side sees its own peering is a separate question.
+    let peerings = get_vpc_peerings(&env, flat_a.id.unwrap())
+        .await?
+        .into_inner()
+        .vpc_peerings;
+    assert_eq!(peerings.len(), 1);
+    // The stored row does not preserve the order the peering was created in, so assert
+    // the pair connects the two VPCs without assuming which side landed in `vpc_id`.
+    let pair = (peerings[0].vpc_id, peerings[0].peer_vpc_id);
+    assert!(
+        pair == (flat_a.id, flat_b.id) || pair == (flat_b.id, flat_a.id),
+        "peering should connect the two VPCs, got {pair:?}"
+    );
+
+    let from_peer = get_vpc_peerings(&env, flat_b.id.unwrap())
+        .await?
+        .into_inner()
+        .vpc_peerings;
+    assert_eq!(from_peer.len(), 1, "the peer side should see it too");
+    let pair = (from_peer[0].vpc_id, from_peer[0].peer_vpc_id);
+    assert!(
+        pair == (flat_a.id, flat_b.id) || pair == (flat_b.id, flat_a.id),
+        "the reverse lookup should name the same pair, got {pair:?}"
+    );
 
     Ok(())
 }

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -1051,10 +1051,19 @@ async fn flat_vpc_accepts_ipv4_prefix(pool: PgPool) -> Result<(), Box<dyn std::e
         }),
     });
 
-    env.api
+    let created = env
+        .api
         .create_vpc_prefix(request)
         .await
-        .expect("Flat VPC should accept IPv4 prefix");
+        .expect("Flat VPC should accept IPv4 prefix")
+        .into_inner();
+
+    // Acceptance alone doesn't say the prefix landed on the right VPC, or landed at all.
+    assert_eq!(created.vpc_id, vpc.id);
+    assert_eq!(
+        created.config.as_ref().expect("prefix config").prefix,
+        "192.0.2.0/25"
+    );
 
     Ok(())
 }

--- a/crates/api-core/tests/integration/compute_allocation.rs
+++ b/crates/api-core/tests/integration/compute_allocation.rs
@@ -636,6 +636,36 @@ async fn test_create_instance_with_enough_allocations(
         .await
         .unwrap();
 
+    // Nothing in the suite had ever asked for allocation stats -- every test passed
+    // `include_allocation_stats: false`, and the only caller that passes `true` is
+    // production, over in `api-web/src/instance_type.rs`. So this is the first check on
+    // the numbers the web UI actually reads back: one allocation of one, fully consumed.
+    let instance_types = env
+        .api
+        .find_instance_types_by_ids(Request::new(rpc::forge::FindInstanceTypesByIdsRequest {
+            instance_type_ids: vec![instance_type_id.to_string()],
+            tenant_organization_id: Some(TENANT_ORG.to_string()),
+            include_allocation_stats: true,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .instance_types;
+
+    assert_eq!(instance_types.len(), 1);
+    let stats = instance_types[0]
+        .allocation_stats
+        .as_ref()
+        .expect("allocation stats should come back when include_allocation_stats is set");
+    assert_eq!(stats.max_allocatable, 1, "one allocation, sized one");
+    assert_eq!(stats.used, 1, "the instance we just allocated");
+    assert_eq!(stats.unused, 0, "which leaves nothing spare");
+    assert_eq!(
+        stats.unused_usable, 0,
+        "and nothing spare on a healthy host either -- this one is computed separately \
+         from `unused`, by filtering out unused machines in bad states"
+    );
+
     Ok(())
 }
 
@@ -929,6 +959,21 @@ async fn test_delete_allocation_when_instances_not_present_passes(
         .await
         .unwrap();
 
+    // The delete returning `Ok` only says the call didn't error -- check the row is
+    // actually gone, or this passes just as happily against a delete that does nothing.
+    let remaining = env
+        .api
+        .find_compute_allocation_ids(Request::new(rpc::forge::FindComputeAllocationIdsRequest {
+            name: Some(alloc_name),
+            tenant_organization_id: Some(TENANT_ORG.to_string()),
+            instance_type_id: Some(instance_type_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .ids;
+    assert!(remaining.is_empty(), "the allocation should be gone");
+
     Ok(())
 }
 
@@ -986,7 +1031,7 @@ async fn test_delete_allocation_when_instances_present_and_sufficient_remain_pas
     .await;
     // Second allocation keeps remaining cap >= use.
     // Expect success with valid tenant/type.
-    let _alloc_2 = create_compute_allocation(
+    let alloc_2 = create_compute_allocation(
         &env,
         &instance_type_id,
         1,
@@ -1010,6 +1055,51 @@ async fn test_delete_allocation_when_instances_present_and_sufficient_remain_pas
         )
         .await
         .unwrap();
+
+    // "Sufficient remain" is the claim in this test's name and nothing here was measuring
+    // it -- the delete returning `Ok` says only that the call didn't error. So check the
+    // row is actually gone, then prove the remaining capacity is genuinely one by deleting
+    // the *second* allocation and watching it get refused: with an instance still live,
+    // dropping to zero is exactly what the guard exists to stop.
+    let remaining = env
+        .api
+        .find_compute_allocation_ids(Request::new(rpc::forge::FindComputeAllocationIdsRequest {
+            name: None,
+            tenant_organization_id: Some(TENANT_ORG.to_string()),
+            instance_type_id: Some(instance_type_id.clone()),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .ids;
+    assert_eq!(remaining, vec![alloc_2.id.unwrap()]);
+
+    let status = env
+        .api
+        .delete_compute_allocation(
+            DeleteComputeAllocationRequest::builder(TENANT_ORG)
+                .id(alloc_2.id.unwrap())
+                .tonic_request(),
+        )
+        .await
+        .expect_err("deleting the last allocation under a live instance should be refused");
+    assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+
+    // And the refusal has to have left the row alone -- `FailedPrecondition` on its own
+    // would still come back from a handler that deleted the allocation and only then
+    // errored, which is the failure this guard exists to prevent.
+    let after_refusal = env
+        .api
+        .find_compute_allocation_ids(Request::new(rpc::forge::FindComputeAllocationIdsRequest {
+            name: None,
+            tenant_organization_id: Some(TENANT_ORG.to_string()),
+            instance_type_id: Some(instance_type_id),
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .ids;
+    assert_eq!(after_refusal, vec![alloc_2.id.unwrap()]);
 
     Ok(())
 }
@@ -1414,11 +1504,37 @@ async fn test_remove_machine_association(
         ))
         .await;
 
+    // Both branches used to stop at the status code, which left the association itself
+    // unchecked either way -- a handler that returned `Ok` without unbinding, or one that
+    // errored *after* committing the unbind, would both have gone unnoticed.
+    let bound_instance_type = env
+        .api
+        .find_machines_by_ids(Request::new(rpc::forge::MachinesByIdsRequest {
+            machine_ids: vec![host_to_remove.id],
+            ..Default::default()
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .machines
+        .remove(0)
+        .config
+        .expect("machine should have a config")
+        .instance_type_id;
+
     if should_pass {
         result.unwrap();
+        assert!(
+            bound_instance_type.is_none(),
+            "the association should be gone once removal succeeds"
+        );
     } else {
         let err = result.unwrap_err();
         assert_eq!(err.code(), Code::FailedPrecondition);
+        assert!(
+            bound_instance_type.is_some(),
+            "a refused removal should leave the association in place"
+        );
     }
 
     Ok(())

--- a/crates/libmlx/tests/runner/runner_integration_tests.rs
+++ b/crates/libmlx/tests/runner/runner_integration_tests.rs
@@ -18,7 +18,6 @@
 // tests/runner_integration_tests.rs
 // Integration tests for MlxConfigRunner functionality
 
-use std::fs;
 use std::time::Duration;
 
 use carbide_test_support::Outcome::*;
@@ -117,30 +116,32 @@ fn test_empty_assignments() {
     assert!(result.is_ok());
 }
 
-// The smoke tests below can't pin an outcome: without a mockable mlxconfig binary
-// the operation may succeed or fail depending on the host. Each one asserts the
-// weaker contract that the flow runs to completion without panicking. They stay
-// standalone (no outcome to fold into a table) but share `dry_run_runner`.
+// Everything below drives `dry_run_runner`, which short-circuits before mlxconfig is ever
+// invoked: `query` returns an empty result rather than shelling out, `set` returns `Ok(())`,
+// and `sync`/`compare` take their counts from the assignment list. That makes the results
+// fully determined and host-independent.
+//
+// The comment that used to sit here claimed the opposite -- that no outcome could be pinned
+// without a mockable mlxconfig -- and every test below discarded its result with `let _ =`
+// on the strength of it. Since a dry-run query reports no current values, `sync` and
+// `compare` can never find a variable to change, which is the interesting half of the
+// contract and is now asserted.
 
 #[test]
 fn test_sync_with_no_changes_needed() {
     let runner = dry_run_runner();
 
-    // Create a mock JSON response file that matches our desired values
-    let json_data = common::create_sample_json_response("01:00.0");
-    let temp_file = tempfile::NamedTempFile::new().unwrap();
-    let json_string = serde_json::to_string_pretty(&json_data).unwrap();
-    fs::write(temp_file.path(), json_string).unwrap();
+    let assignments = &[("SRIOV_EN", "true"), ("NUM_OF_VFS", "16")];
 
-    // Since we're in dry_run mode, the sync operation will attempt to parse
-    // but won't actually execute mlxconfig commands. We can't mock the command
-    // execution easily, but this exercises the basic sync flow setup.
-    let assignments = &[
-        ("SRIOV_EN", "true"), // Already true in mock JSON
-        ("NUM_OF_VFS", "16"), // Already 16 in mock JSON
-    ];
-
-    let _ = runner.sync(assignments);
+    let result = runner
+        .sync(assignments)
+        .expect("dry-run sync should succeed");
+    assert_eq!(result.variables_checked, 2);
+    assert_eq!(
+        result.variables_changed, 0,
+        "a dry-run query returns no current values, so nothing can be found to change"
+    );
+    assert!(result.changes_applied.is_empty());
 }
 
 #[test]
@@ -148,20 +149,27 @@ fn test_compare_operation() {
     let runner = dry_run_runner();
 
     let assignments = &[
-        ("SRIOV_EN", "false"), // Different from mock JSON (which has true)
-        ("NUM_OF_VFS", "32"),  // Different from mock JSON (which has 16)
-        ("POWER_MODE", "LOW"), // Different from mock JSON (which has HIGH)
+        ("SRIOV_EN", "false"),
+        ("NUM_OF_VFS", "32"),
+        ("POWER_MODE", "LOW"),
     ];
 
-    // Fails in the query phase (no mockable mlxconfig); exercises the compare setup.
-    let _ = runner.compare(assignments);
+    let result = runner
+        .compare(assignments)
+        .expect("dry-run compare should succeed");
+    assert_eq!(result.variables_checked, 3);
+    assert_eq!(
+        result.variables_needing_change, 0,
+        "nothing to compare against without a real query"
+    );
+    assert!(result.planned_changes.is_empty());
 }
 
 #[test]
 fn test_set_with_array_variables() {
     let runner = dry_run_runner();
 
-    // Test sparse array assignments
+    // Sparse indices, deliberately non-contiguous.
     let assignments = &[
         ("GPIO_ENABLED[0]", "true"),
         ("GPIO_ENABLED[2]", "false"),
@@ -169,33 +177,33 @@ fn test_set_with_array_variables() {
         ("GPIO_MODES[3]", "bidirectional"),
     ];
 
-    // In dry run mode, this should process the assignments and build the command
-    // but not actually execute it.
-    let _ = runner.set(assignments);
+    assert!(
+        runner.set(assignments).is_ok(),
+        "sparse array assignments should resolve against the registry and build a command"
+    );
 }
 
 #[test]
 fn test_query_all_variables() {
     let runner = dry_run_runner();
 
-    // Exercises the query_all flow (no mockable mlxconfig to actually execute).
-    let _ = runner.query_all();
+    let result = runner
+        .query_all()
+        .expect("dry-run query_all should succeed");
+    assert!(
+        result.variables.is_empty(),
+        "a dry run reports nothing back from the card"
+    );
 }
 
 #[test]
 fn test_query_specific_variables() {
     let runner = dry_run_runner();
 
-    // Exercises the query flow (no mockable mlxconfig to actually execute).
-    let _ = runner.query(["SRIOV_EN", "NUM_OF_VFS"]);
-}
-
-#[test]
-fn test_query_array_variables() {
-    let runner = dry_run_runner();
-
-    // Query array variables - should expand to individual indices.
-    let _ = runner.query(["GPIO_ENABLED", "THERMAL_SENSORS"]);
+    let result = runner
+        .query(["SRIOV_EN", "NUM_OF_VFS"])
+        .expect("dry-run query should succeed");
+    assert!(result.variables.is_empty());
 }
 
 #[test]
@@ -204,12 +212,18 @@ fn test_sync_vs_set_vs_compare_consistency() {
 
     let assignments = &[("SRIOV_EN", "true"), ("NUM_OF_VFS", "32")];
 
-    // All three operations accept the same assignments and run to completion without
-    // panicking. We can't pin their outcome (no mockable mlxconfig), and the original
-    // test deliberately tolerated mixed success/failure across the three.
-    let _ = runner.set(assignments);
-    let _ = runner.sync(assignments);
-    let _ = runner.compare(assignments);
+    // The point of the test is that all three agree on the same assignment list, so pin
+    // that rather than just running them: each accepts the two variables, and neither
+    // sync nor compare finds anything to do without a real query behind it.
+    assert!(runner.set(assignments).is_ok());
+
+    let synced = runner.sync(assignments).expect("sync should succeed");
+    assert_eq!(synced.variables_checked, 2);
+    assert_eq!(synced.variables_changed, 0);
+
+    let compared = runner.compare(assignments).expect("compare should succeed");
+    assert_eq!(compared.variables_checked, 2);
+    assert_eq!(compared.variables_needing_change, 0);
 }
 
 #[test]
@@ -225,11 +239,12 @@ fn test_different_device_identifiers() {
     ];
 
     for device in &devices {
-        // Construction should succeed for every device format, and a basic operation
-        // should run without panicking.
         let options = ExecOptions::new().with_dry_run(true);
         let runner = MlxConfigRunner::with_options(device.to_string(), registry.clone(), options);
-        let _ = runner.set([("SRIOV_EN", "true")]);
+        assert!(
+            runner.set([("SRIOV_EN", "true")]).is_ok(),
+            "device identifier {device} should be accepted"
+        );
     }
 }
 
@@ -251,10 +266,13 @@ fn test_execution_options_propagation() {
     ];
 
     for options in test_cases {
-        // The runner builds with each option combination and runs without panicking.
+        // Only the dry-run cases can be asserted here -- the others would shell out to a
+        // real mlxconfig. What this pins is that no option combination makes the runner
+        // reject an assignment it would otherwise accept.
+        let dry_run = options.clone().with_dry_run(true);
         let runner =
-            MlxConfigRunner::with_options("01:00.0".to_string(), registry.clone(), options);
-        let _ = runner.set([("SRIOV_EN", "true")]);
+            MlxConfigRunner::with_options("01:00.0".to_string(), registry.clone(), dry_run);
+        assert!(runner.set([("SRIOV_EN", "true")]).is_ok());
     }
 }
 
@@ -275,7 +293,7 @@ mod realistic_scenarios {
         // Typical SRIOV configuration
         let sriov_config = &[("SRIOV_EN", "true"), ("NUM_OF_VFS", "8")];
 
-        let _ = runner.set(sriov_config);
+        assert!(runner.set(sriov_config).is_ok());
     }
 
     #[test]
@@ -293,7 +311,7 @@ mod realistic_scenarios {
             ("GPIO_MODES[3]", "bidirectional"),
         ];
 
-        let _ = runner.set(gpio_config);
+        assert!(runner.set(gpio_config).is_ok());
     }
 
     #[test]
@@ -311,6 +329,8 @@ mod realistic_scenarios {
             ("PERFORMANCE_PRESET", "8"),
         ];
 
-        let _ = runner.sync(perf_config);
+        let result = runner.sync(perf_config).expect("sync should succeed");
+        assert_eq!(result.variables_checked, 4);
+        assert_eq!(result.variables_changed, 0);
     }
 }


### PR DESCRIPTION
Some of our tests run product code and never look at what it did -- they're green as long as nothing panics. `test_delete_allocation_when_instances_present_and_sufficient_remain_passes` is the one that sent me looking: eighty-odd lines that stand up two allocations and an instance, delete one allocation, and never check the delete happened or that the remaining capacity is what the name claims. It would have passed just as happily against a delete that quietly did nothing.

A mechanical sweep is no good for finding these -- it over-reports badly in both directions. Filter out anything calling an asserting helper and you get 8 tests; don't filter and you get 215. The real number is 44, and getting there meant reading them. The biggest false positive was `agent/src/instance_metadata_endpoint.rs` -- 17 tests, 605 lines, every one asserting through `send_request_and_check_response`, which checks status *and* body. Perfectly fine, all of it.

So these now check the effect, not just the absence of a panic. It's all test-side.

- **`InstanceTypeAllocationStats` had no coverage at all.** `include_allocation_stats: true` appears in exactly one place in the tree and it's production -- `api-web/src/instance_type.rs`. Every test passed `false`, so the numbers the web UI reads back were never asserted by anything.
- **The reference case gets the assertion its name promises.** After deleting one of two allocations, deleting the *second* must now be refused with `FailedPrecondition`, because an instance is still live. That's what "sufficient remain" means, and measuring it is the only way the test can tell 2 from 1.
- **`remove_machine_instance_type_association` is checked on both branches.** It only ever asserted the status code, so a handler that returned `Ok` without unbinding -- or one that errored *after* committing the unbind -- would both have sailed through. One helper, nine tests.
- **All 12 `libmlx` runner integration tests were discarding their results** with `let _ =`, on the strength of a comment saying nothing could be pinned down without a mockable mlxconfig. In dry run there's nothing to mock: `query` returns empty, `set` returns `Ok(())`, and `sync`/`compare` take their counts straight from the assignment list. The comment was wrong and had been load-bearing for a long time.
- **The VPC peering tests read the peering back, from both sides.** Worth knowing: the row does *not* come back in the order it was created. My first attempt asserted `vpc_id` was the VPC I'd passed as `vpc_id`, and all three tests failed on it. `find_vpc_peering_ids` filters on a single id while the row stores an ordered pair, so whether the other side sees its own peering was genuinely untested.

One deletion: `test_query_array_variables` promised to cover array-index expansion, but a dry-run query returns an empty result and cannot observe expansion at all. `variable_names_expand_full_arrays_to_indices` pins all ten expanded names for the same two inputs.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4190

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Green per suite: `api-core` 1,444 lib + 241 integration, `compute_allocation` 30, `vpc_peering` 12, `libmlx` 70 + 40 + 35. Lint gate green (`format-nightly`, `clippy`, `carbide-lints`), no `Cargo.lock` drift.

Two clippy findings of my own were fixed before commit -- a `clone` on a `Copy` type and a useless `.into()`.

A local full-suite run partway through this showed a burst of failures with the `TypeNotFound { type_name: "resource_pool_type" }` signature -- 205 of them. That's shared-template-database contention from a second `cargo test` running on the same box, not this change: every affected test passes in isolation, and none of them are in this diff. CI runs against its own Postgres in a container, so it's the authoritative check here.

## Additional Notes

The three highest-value fixes are the allocation-stats assertion, the second-delete refusal, and the both-branch check on `remove_machine_instance_type_association`. Those are where a real regression could previously have slipped through green.

Still outstanding, verified and specified but not in this PR: `dpf/sdk.rs` (3 tests -- assert the no-op branch really leaves the existing CR untouched), `mqttea/tests/client.rs` (4 -- two need a new public accessor before they can observe anything, and `test_bidirectional_communication` never connects, publishes or receives despite its name), and `health/tls.rs` (4 -- lowest value, since `?` on a `Result`-returning test already asserts the real contract there).

Separately worth its own ticket: `agent/src/tests/test_network_monitor.rs:54` asserts properly but returns `Ok(())` early when `REPO_ROOT`/`CONTAINER_REPO_ROOT` are unset, so it passes green having run nothing. Same silent-skip class as the `RUN_NMXC_SIMULATOR_TESTS` tests found during the original audit.


Closes #4190
