### PR TITLE
feat(nico-api): define rack profile, component manager and RMS ts globally

### DIFF
--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -61,11 +61,12 @@ nico-api:
   ## RMS (Rack Management Service) connectivity — enable on sites that deploy
   ## the standalone rack-manager chart so Core can use it for rack-level
   ## firmware upgrades, power sequencing, and rms-backed component-manager
-  ## operations. Defaults match the rack-manager chart's api-server Service.
+  ## operations. The chart defaults cover the standard mTLS deployment (RMS
+  ## api-server cert minted from vault-nico-issuer; nico-api authenticates
+  ## with its own SPIFFE cert — no extra mounts). Enabling before RMS is
+  ## deployed is safe: rack operations error cleanly until it comes up.
   # rms:
   #   enabled: true
-  #   apiUrl: "http://rms-api-server.rack-manager:8801"
-  #   enforceTls: false
 
   ## MetalLB VIP for the nico-api LoadBalancer service.
   ## Must be an IP within your external IPAddressPool (values/metallb-config.yaml).

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -58,17 +58,14 @@ nico-api:
     additionalIssuerCns:
       - "site-root"
 
-  ## Rack management — enable on sites that deploy the standalone
-  ## rack-manager chart. The two switches are independent: RMS connectivity
-  ## ([rms]) vs component manager ([component_manager], defaults to rms
-  ## backends). For the usual RMS-backed path, turn both on. Global config
-  ## already ships NVL72 / NVL72_GB300 rack_profiles; override vendors (or
-  ## add test profiles) in siteConfig. Chart defaults cover standard mTLS
-  ## (SPIFFE auto-discovery — no extra mounts).
+  ## Rack management — chart defaults enable both switches (RMS connectivity
+  ## and the component manager with rms backends). Override vendors or add
+  ## test profiles in siteConfig. Chart defaults cover standard mTLS (SPIFFE
+  ## auto-discovery — no extra mounts). Non-rack deployments opt out:
   # componentManager:
-  #   enabled: true
+  #   enabled: false
   # rms:
-  #   enabled: true
+  #   enabled: false
 
   ## MetalLB VIP for the nico-api LoadBalancer service.
   ## Must be an IP within your external IPAddressPool (values/metallb-config.yaml).

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -58,13 +58,13 @@ nico-api:
     additionalIssuerCns:
       - "site-root"
 
-  ## RMS (Rack Management Service) connectivity — enable on sites that deploy
-  ## the standalone rack-manager chart so Core can use it for rack-level
-  ## firmware upgrades, power sequencing, and rms-backed component-manager
-  ## operations. The chart defaults cover the standard mTLS deployment (RMS
-  ## api-server cert minted from vault-nico-issuer; nico-api authenticates
-  ## with its own SPIFFE cert — no extra mounts). Enabling before RMS is
-  ## deployed is safe: rack operations error cleanly until it comes up.
+  ## RMS (Rack Management Service) — enable on sites that deploy the
+  ## standalone rack-manager chart. Turns on [rms] connectivity and the
+  ## [component_manager] section (rms backends + state controllers). Global
+  ## config already ships NVL72 / NVL72_GB300 rack_profiles; override vendors
+  ## in siteConfig if your OEM differs. Chart defaults cover standard mTLS
+  ## (SPIFFE auto-discovery — no extra mounts). Safe to enable before RMS
+  ## is up: rack operations error cleanly until it comes up.
   # rms:
   #   enabled: true
 

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -58,13 +58,15 @@ nico-api:
     additionalIssuerCns:
       - "site-root"
 
-  ## RMS (Rack Management Service) — enable on sites that deploy the
-  ## standalone rack-manager chart. Turns on [rms] connectivity and the
-  ## [component_manager] section (rms backends + state controllers). Global
-  ## config already ships NVL72 / NVL72_GB300 rack_profiles; override vendors
-  ## in siteConfig if your OEM differs. Chart defaults cover standard mTLS
-  ## (SPIFFE auto-discovery — no extra mounts). Safe to enable before RMS
-  ## is up: rack operations error cleanly until it comes up.
+  ## Rack management — enable on sites that deploy the standalone
+  ## rack-manager chart. The two switches are independent: RMS connectivity
+  ## ([rms]) vs component manager ([component_manager], defaults to rms
+  ## backends). For the usual RMS-backed path, turn both on. Global config
+  ## already ships NVL72 / NVL72_GB300 rack_profiles; override vendors (or
+  ## add test profiles) in siteConfig. Chart defaults cover standard mTLS
+  ## (SPIFFE auto-discovery — no extra mounts).
+  # componentManager:
+  #   enabled: true
   # rms:
   #   enabled: true
 

--- a/helm-prereqs/values/nico-core.yaml
+++ b/helm-prereqs/values/nico-core.yaml
@@ -58,6 +58,15 @@ nico-api:
     additionalIssuerCns:
       - "site-root"
 
+  ## RMS (Rack Management Service) connectivity — enable on sites that deploy
+  ## the standalone rack-manager chart so Core can use it for rack-level
+  ## firmware upgrades, power sequencing, and rms-backed component-manager
+  ## operations. Defaults match the rack-manager chart's api-server Service.
+  # rms:
+  #   enabled: true
+  #   apiUrl: "http://rms-api-server.rack-manager:8801"
+  #   enforceTls: false
+
   ## MetalLB VIP for the nico-api LoadBalancer service.
   ## Must be an IP within your external IPAddressPool (values/metallb-config.yaml).
   ## This IP must resolve from your external DNS to the hostname above.

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -109,10 +109,18 @@ test_selection_mode = "EnableAll"
 [oem_manager_profiles.Dell.PowerEdge_R760.powerefficiency]
 "ServerPwr.1.PSRapidOn" = "Disabled"
 
-# Keyed by the rack_profile_id of an expected rack. Each count is the minimum
-# number of devices required to exit Created (present) and Discovering (ready).
-# Sites with a different OEM than the vendors below override the matching
-# rack_capabilities.<role>.vendor (or define their own profile) in site-config.
+# Qualified platform baselines, keyed by the rack_profile_id on an expected
+# rack. Each count is the minimum number of devices required to exit Created
+# (present) and Discovering (ready).
+#
+# Profile ids name the platform (NVL72 / NVL72_GB300), not a single OEM —
+# inventory references stay stable as vendors change. The vendor fields below
+# are the currently qualified defaults (e.g. Lenovo compute on GB300); they are
+# per-OEM facts, not properties of the topology. Figment merges site-config
+# over this file per-key, so a site with different hardware overrides only
+# rack_capabilities.<role>.vendor (or adds a new profile id for test / custom
+# racks) without forking the platform id. New production-supported platforms
+# land here through the normal qualification / PR process.
 [rack_profiles.NVL72]
 product_family = "gb200"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
@@ -149,10 +157,11 @@ count = 6
 enabled = {{ .Values.service.perObjectStateMetrics.enabled }}
 listen_address = "[::]:{{ .Values.service.perObjectStateMetrics.port }}"
 object_types = {{ default list .Values.service.perObjectStateMetrics.objectTypes | toJson }}
-{{- if .Values.rms.enabled }}
+{{- if .Values.componentManager.enabled }}
 
-# Defining this section is what enables the component manager. Rendered only
-# when rms.enabled is set — presence cannot be undone via site-config merge.
+# Presence of this section enables the component manager; site-config can
+# override fields but cannot un-define the section once rendered. Independent
+# of rms.enabled — pair with RMS when backends are "rms".
 [component_manager]
 compute_tray_backend = "rms"
 nv_switch_backend = "rms"
@@ -161,6 +170,8 @@ power_shelf_backend = "rms"
 nv_switch_use_state_controller = true
 power_shelf_use_state_controller = true
 compute_tray_use_state_controller = true
+{{- end }}
+{{- if .Values.rms.enabled }}
 
 # RMS (Rack Management Service) connectivity, used by the component manager
 # and rack controller for rack-level firmware upgrades and power sequencing.

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -109,11 +109,58 @@ test_selection_mode = "EnableAll"
 [oem_manager_profiles.Dell.PowerEdge_R760.powerefficiency]
 "ServerPwr.1.PSRapidOn" = "Disabled"
 
+# Keyed by the rack_profile_id of an expected rack. Each count is the minimum
+# number of devices required to exit Created (present) and Discovering (ready).
+# Sites with a different OEM than the vendors below override the matching
+# rack_capabilities.<role>.vendor (or define their own profile) in site-config.
+[rack_profiles.NVL72]
+product_family = "gb200"
+rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72.rack_capabilities.compute]
+vendor = "NVIDIA"
+count = 18
+
+[rack_profiles.NVL72.rack_capabilities.switch]
+vendor = "NVIDIA"
+count = 9
+
+[rack_profiles.NVL72.rack_capabilities.power_shelf]
+vendor = "LiteOn"
+count = 8
+
+[rack_profiles.NVL72_GB300]
+product_family = "gb300"
+rack_hardware_topology = "gb300_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72_GB300.rack_capabilities.compute]
+vendor = "Lenovo"
+count = 18
+
+[rack_profiles.NVL72_GB300.rack_capabilities.switch]
+vendor = "NVIDIA"
+count = 9
+
+[rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
+vendor = "LiteOn"
+count = 6
+
 [observability.per_object_state_metrics]
 enabled = {{ .Values.service.perObjectStateMetrics.enabled }}
 listen_address = "[::]:{{ .Values.service.perObjectStateMetrics.port }}"
 object_types = {{ default list .Values.service.perObjectStateMetrics.objectTypes | toJson }}
 {{- if .Values.rms.enabled }}
+
+# Defining this section is what enables the component manager. Rendered only
+# when rms.enabled is set — presence cannot be undone via site-config merge.
+[component_manager]
+compute_tray_backend = "rms"
+nv_switch_backend = "rms"
+power_shelf_backend = "rms"
+
+nv_switch_use_state_controller = true
+power_shelf_use_state_controller = true
+compute_tray_use_state_controller = true
 
 # RMS (Rack Management Service) connectivity, used by the component manager
 # and rack controller for rack-level firmware upgrades and power sequencing.

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -163,13 +163,13 @@ object_types = {{ default list .Values.service.perObjectStateMetrics.objectTypes
 # override fields but cannot un-define the section once rendered. Independent
 # of rms.enabled — pair with RMS when backends are "rms".
 [component_manager]
-compute_tray_backend = "rms"
-nv_switch_backend = "rms"
-power_shelf_backend = "rms"
+compute_tray_backend = {{ .Values.componentManager.computeTrayBackend | quote }}
+nv_switch_backend = {{ .Values.componentManager.nvSwitchBackend | quote }}
+power_shelf_backend = {{ .Values.componentManager.powerShelfBackend | quote }}
 
-nv_switch_use_state_controller = true
-power_shelf_use_state_controller = true
-compute_tray_use_state_controller = true
+nv_switch_use_state_controller = {{ .Values.componentManager.nvSwitchUseStateController }}
+power_shelf_use_state_controller = {{ .Values.componentManager.powerShelfUseStateController }}
+compute_tray_use_state_controller = {{ .Values.componentManager.computeTrayUseStateController }}
 {{- end }}
 {{- if .Values.rms.enabled }}
 

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -113,3 +113,20 @@ test_selection_mode = "EnableAll"
 enabled = {{ .Values.service.perObjectStateMetrics.enabled }}
 listen_address = "[::]:{{ .Values.service.perObjectStateMetrics.port }}"
 object_types = {{ default list .Values.service.perObjectStateMetrics.objectTypes | toJson }}
+{{- if .Values.rms.enabled }}
+
+# RMS (Rack Management Service) connectivity, used by the component manager
+# and rack controller for rack-level firmware upgrades and power sequencing.
+[rms]
+api_url = {{ .Values.rms.apiUrl | quote }}
+enforce_tls = {{ .Values.rms.enforceTls }}
+{{- with .Values.rms.rootCaPath }}
+root_ca_path = {{ . | quote }}
+{{- end }}
+{{- with .Values.rms.clientCert }}
+client_cert = {{ . | quote }}
+{{- end }}
+{{- with .Values.rms.clientKey }}
+client_key = {{ . | quote }}
+{{- end }}
+{{- end }}

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -32,9 +32,43 @@ tests:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '(?m)^compute_tray_backend = "rms"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^compute_tray_use_state_controller = true$'
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
+
+  - it: renders non-default backends and state controller flags from values
+    documentIndex: 0
+    set:
+      componentManager:
+        enabled: true
+        computeTrayBackend: "core"
+        nvSwitchBackend: "nsm"
+        powerShelfBackend: "psm"
+        computeTrayUseStateController: false
+        nvSwitchUseStateController: false
+        powerShelfUseStateController: false
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^compute_tray_backend = "core"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^nv_switch_backend = "nsm"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^power_shelf_backend = "psm"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^compute_tray_use_state_controller = false$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^nv_switch_use_state_controller = false$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^power_shelf_use_state_controller = false$'
 
   - it: renders rms alone when only rms is enabled
     documentIndex: 0

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -11,11 +11,26 @@ tests:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
 
-  - it: renders the rms section with chart defaults when enabled
+  - it: renders the full mTLS block with chart defaults when enabled
     documentIndex: 0
     set:
       rms:
         enabled: true
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801".*enforce_tls = true.*root_ca_path = "/var/run/secrets/spiffe\.io/ca\.crt".*client_cert = "/var/run/secrets/spiffe\.io/tls\.crt".*client_key = "/var/run/secrets/spiffe\.io/tls\.key"'
+
+  - it: omits TLS material for a plain-HTTP RMS deployment
+    documentIndex: 0
+    set:
+      rms:
+        enabled: true
+        apiUrl: "http://rms-api-server.rack-manager:8801"
+        enforceTls: false
+        rootCaPath: ""
+        clientCert: ""
+        clientKey: ""
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
@@ -23,21 +38,6 @@ tests:
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: 'root_ca_path|client_cert|client_key'
-
-  - it: renders TLS material only when set
-    documentIndex: 0
-    set:
-      rms:
-        enabled: true
-        apiUrl: "https://rms-api-server.rack-manager:8801"
-        enforceTls: true
-        rootCaPath: "/etc/forge/rms/ca.pem"
-        clientCert: "/etc/forge/rms/client.pem"
-        clientKey: "/etc/forge/rms/client.key"
-    asserts:
-      - matchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager:8801".*enforce_tls = true.*root_ca_path = "/etc/forge/rms/ca\.pem".*client_cert = "/etc/forge/rms/client\.pem".*client_key = "/etc/forge/rms/client\.key"'
 
   - it: keeps the rms section out of the site-config ConfigMap
     set:

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -40,13 +40,20 @@ tests:
           pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager:8801".*enforce_tls = true.*root_ca_path = "/etc/forge/rms/ca\.pem".*client_cert = "/etc/forge/rms/client\.pem".*client_key = "/etc/forge/rms/client\.key"'
 
   - it: keeps the rms section out of the site-config ConfigMap
-    documentIndex: 0
     set:
       rms:
         enabled: true
       siteConfig:
         enabled: true
+        nicoApiSiteConfig: |
+          [site_explorer]
+          run_interval = "30s"
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
+        documentIndex: 0
+      - notMatchRegex:
+          path: data["carbide-api-site-config.toml"]
+          pattern: '\[rms\]'
+        documentIndex: 1

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -4,14 +4,23 @@ templates:
 release:
   namespace: nico-system
 tests:
-  - it: renders no rms section by default
+  - it: renders rack profiles by default without rms or component_manager
     documentIndex: 0
     asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[rack_profiles\.NVL72\]'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[rack_profiles\.NVL72_GB300\]'
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[component_manager\]'
 
-  - it: renders only api_url and enforce_tls with chart defaults when enabled
+  - it: renders component_manager and rms together when enabled
     documentIndex: 0
     set:
       rms:
@@ -19,7 +28,19 @@ tests:
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
-          pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801".*enforce_tls = true'
+          pattern: '(?m)^\[component_manager\]$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^compute_tray_backend = "rms"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^\[rms\]$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^enforce_tls = true$'
       # No cert paths by default: nv-rms-client auto-discovers the SPIFFE
       # mount (/var/run/secrets/spiffe.io) when they are unset.
       - notMatchRegex:
@@ -37,7 +58,13 @@ tests:
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
-          pattern: '(?s)\[rms\].*root_ca_path = "/etc/forge/rms/ca\.pem".*client_cert = "/etc/forge/rms/client\.pem".*client_key = "/etc/forge/rms/client\.key"'
+          pattern: '(?m)^root_ca_path = "/etc/forge/rms/ca\.pem"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^client_cert = "/etc/forge/rms/client\.pem"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^client_key = "/etc/forge/rms/client\.key"$'
 
   - it: keeps the rms section out of the site-config ConfigMap
     set:

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -4,7 +4,7 @@ templates:
 release:
   namespace: nico-system
 tests:
-  - it: renders rack profiles by default without rms or component_manager
+  - it: renders rack profiles, component_manager, and rms by default
     documentIndex: 0
     asserts:
       - matchRegex:
@@ -13,6 +13,38 @@ tests:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[rack_profiles\.NVL72_GB300\]'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^\[component_manager\]$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^compute_tray_backend = "rms"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^compute_tray_use_state_controller = true$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^\[rms\]$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801"$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^enforce_tls = true$'
+      # No cert paths by default: nv-rms-client auto-discovers the SPIFFE
+      # mount (/var/run/secrets/spiffe.io) when they are unset.
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'root_ca_path|client_cert|client_key'
+
+  - it: omits both sections when both switches are disabled
+    documentIndex: 0
+    set:
+      componentManager:
+        enabled: false
+      rms:
+        enabled: false
+    asserts:
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
@@ -25,6 +57,8 @@ tests:
     set:
       componentManager:
         enabled: true
+      rms:
+        enabled: false
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
@@ -32,9 +66,6 @@ tests:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '(?m)^compute_tray_backend = "rms"$'
-      - matchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: '(?m)^compute_tray_use_state_controller = true$'
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
@@ -50,6 +81,8 @@ tests:
         computeTrayUseStateController: false
         nvSwitchUseStateController: false
         powerShelfUseStateController: false
+      rms:
+        enabled: false
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
@@ -73,6 +106,8 @@ tests:
   - it: renders rms alone when only rms is enabled
     documentIndex: 0
     set:
+      componentManager:
+        enabled: false
       rms:
         enabled: true
     asserts:
@@ -82,32 +117,9 @@ tests:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '(?m)^api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801"$'
-      - matchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: '(?m)^enforce_tls = true$'
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: '\[component_manager\]'
-      # No cert paths by default: nv-rms-client auto-discovers the SPIFFE
-      # mount (/var/run/secrets/spiffe.io) when they are unset.
-      - notMatchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: 'root_ca_path|client_cert|client_key'
-
-  - it: renders both sections when both switches are enabled
-    documentIndex: 0
-    set:
-      componentManager:
-        enabled: true
-      rms:
-        enabled: true
-    asserts:
-      - matchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: '(?m)^\[component_manager\]$'
-      - matchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: '(?m)^\[rms\]$'
 
   - it: renders explicit mTLS material overrides when set
     documentIndex: 0
@@ -130,8 +142,6 @@ tests:
 
   - it: keeps the rms section out of the site-config ConfigMap
     set:
-      rms:
-        enabled: true
       siteConfig:
         enabled: true
         nicoApiSiteConfig: |

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -11,7 +11,7 @@ tests:
           path: data["nico-api-config.toml"]
           pattern: '\[rms\]'
 
-  - it: renders the full mTLS block with chart defaults when enabled
+  - it: renders only api_url and enforce_tls with chart defaults when enabled
     documentIndex: 0
     set:
       rms:
@@ -19,25 +19,25 @@ tests:
     asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
-          pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801".*enforce_tls = true.*root_ca_path = "/var/run/secrets/spiffe\.io/ca\.crt".*client_cert = "/var/run/secrets/spiffe\.io/tls\.crt".*client_key = "/var/run/secrets/spiffe\.io/tls\.key"'
-
-  - it: omits TLS material for a plain-HTTP RMS deployment
-    documentIndex: 0
-    set:
-      rms:
-        enabled: true
-        apiUrl: "http://rms-api-server.rack-manager:8801"
-        enforceTls: false
-        rootCaPath: ""
-        clientCert: ""
-        clientKey: ""
-    asserts:
-      - matchRegex:
-          path: data["nico-api-config.toml"]
-          pattern: '(?s)\[rms\].*api_url = "http://rms-api-server\.rack-manager:8801".*enforce_tls = false'
+          pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager\.svc\.cluster\.local:8801".*enforce_tls = true'
+      # No cert paths by default: nv-rms-client auto-discovers the SPIFFE
+      # mount (/var/run/secrets/spiffe.io) when they are unset.
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: 'root_ca_path|client_cert|client_key'
+
+  - it: renders explicit mTLS material overrides when set
+    documentIndex: 0
+    set:
+      rms:
+        enabled: true
+        rootCaPath: "/etc/forge/rms/ca.pem"
+        clientCert: "/etc/forge/rms/client.pem"
+        clientKey: "/etc/forge/rms/client.key"
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?s)\[rms\].*root_ca_path = "/etc/forge/rms/ca\.pem".*client_cert = "/etc/forge/rms/client\.pem".*client_key = "/etc/forge/rms/client\.key"'
 
   - it: keeps the rms section out of the site-config ConfigMap
     set:

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -1,0 +1,52 @@
+suite: RMS connectivity application config
+templates:
+  - configmap.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: renders no rms section by default
+    documentIndex: 0
+    asserts:
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[rms\]'
+
+  - it: renders the rms section with chart defaults when enabled
+    documentIndex: 0
+    set:
+      rms:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?s)\[rms\].*api_url = "http://rms-api-server\.rack-manager:8801".*enforce_tls = false'
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: 'root_ca_path|client_cert|client_key'
+
+  - it: renders TLS material only when set
+    documentIndex: 0
+    set:
+      rms:
+        enabled: true
+        apiUrl: "https://rms-api-server.rack-manager:8801"
+        enforceTls: true
+        rootCaPath: "/etc/forge/rms/ca.pem"
+        clientCert: "/etc/forge/rms/client.pem"
+        clientKey: "/etc/forge/rms/client.key"
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?s)\[rms\].*api_url = "https://rms-api-server\.rack-manager:8801".*enforce_tls = true.*root_ca_path = "/etc/forge/rms/ca\.pem".*client_cert = "/etc/forge/rms/client\.pem".*client_key = "/etc/forge/rms/client\.key"'
+
+  - it: keeps the rms section out of the site-config ConfigMap
+    documentIndex: 0
+    set:
+      rms:
+        enabled: true
+      siteConfig:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[rms\]'

--- a/helm/charts/nico-api/tests/rms_config_test.yaml
+++ b/helm/charts/nico-api/tests/rms_config_test.yaml
@@ -20,10 +20,10 @@ tests:
           path: data["nico-api-config.toml"]
           pattern: '\[component_manager\]'
 
-  - it: renders component_manager and rms together when enabled
+  - it: renders component_manager alone when only componentManager is enabled
     documentIndex: 0
     set:
-      rms:
+      componentManager:
         enabled: true
     asserts:
       - matchRegex:
@@ -32,6 +32,16 @@ tests:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '(?m)^compute_tray_backend = "rms"$'
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[rms\]'
+
+  - it: renders rms alone when only rms is enabled
+    documentIndex: 0
+    set:
+      rms:
+        enabled: true
+    asserts:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '(?m)^\[rms\]$'
@@ -41,11 +51,29 @@ tests:
       - matchRegex:
           path: data["nico-api-config.toml"]
           pattern: '(?m)^enforce_tls = true$'
+      - notMatchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '\[component_manager\]'
       # No cert paths by default: nv-rms-client auto-discovers the SPIFFE
       # mount (/var/run/secrets/spiffe.io) when they are unset.
       - notMatchRegex:
           path: data["nico-api-config.toml"]
           pattern: 'root_ca_path|client_cert|client_key'
+
+  - it: renders both sections when both switches are enabled
+    documentIndex: 0
+    set:
+      componentManager:
+        enabled: true
+      rms:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^\[component_manager\]$'
+      - matchRegex:
+          path: data["nico-api-config.toml"]
+          pattern: '(?m)^\[rms\]$'
 
   - it: renders explicit mTLS material overrides when set
     documentIndex: 0

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -186,19 +186,26 @@ dsxExchangeEventBusConfig: ""
 ## so a site that enables this and has rack profiles configured starts using
 ## RMS for those roles without further component_manager config.
 rms:
+  ## Off by default until RMS ships in the standard install path. Enabling
+  ## this WITHOUT RMS deployed is safe: the client is constructed lazily and
+  ## every RMS-backed operation guards on it, so Core runs healthy and rack
+  ## operations report a clean error until RMS comes up at apiUrl.
   enabled: false
   ## RMS API server URL. The default matches the rack-manager chart's
-  ## api-server Service in its default namespace (port 8801).
-  apiUrl: "http://rms-api-server.rack-manager:8801"
-  ## Enforce TLS when connecting to RMS. The rack-manager chart ships with
-  ## TLS disabled, matching the plain-HTTP in-cluster URL above; set true
-  ## (plus the paths below) for TLS/mTLS deployments.
-  enforceTls: false
-  ## Optional TLS material — paths inside the nico-api container. Only
-  ## rendered when non-empty.
-  rootCaPath: ""
-  clientCert: ""
-  clientKey: ""
+  ## api-server Service in its default namespace (port 8801), TLS enabled.
+  apiUrl: "https://rms-api-server.rack-manager.svc.cluster.local:8801"
+  ## Enforce TLS when connecting to RMS. The standard RMS deployment serves
+  ## mTLS (apiServer.tls.enabled + caEnabled) with a certificate minted from
+  ## the same vault-nico-issuer that signs nico-api's SPIFFE cert.
+  enforceTls: true
+  ## mTLS material — paths inside the nico-api container. The defaults are
+  ## nico-api's own SPIFFE certificate mount, which shares a CA with the RMS
+  ## api-server certificate, so mTLS works both ways with no extra mounts.
+  ## Set all three to "" for a plain-HTTP RMS deployment (with enforceTls
+  ## false and an http:// apiUrl).
+  rootCaPath: "/var/run/secrets/spiffe.io/ca.crt"
+  clientCert: "/var/run/secrets/spiffe.io/tls.crt"
+  clientKey: "/var/run/secrets/spiffe.io/tls.key"
 
 extraEnv: []
 

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -175,18 +175,30 @@ env:
 dsxExchangeEventBusConfig: ""
 
 ## =============================================================================
+## Component manager
+## =============================================================================
+## Renders the [component_manager] section into the global application config.
+## Presence of that section is what enables the component manager; site-config
+## can override fields but cannot remove the section once rendered — hence the
+## Helm gate (default off). Independent of rms.enabled below.
+##
+## The chart defaults use rms backends + state controllers (recommended path).
+## Enabling this with rms backends requires rms.enabled=true (or an equivalent
+## [rms] block in site-config); otherwise Core leaves the component manager
+## uninitialized and logs a build error.
+componentManager:
+  enabled: false
+
+## =============================================================================
 ## RMS (Rack Management Service) connectivity
 ## =============================================================================
 ## RMS deploys as its own Helm chart (rack-manager); Core only needs the
-## connection details to use it for rack-level firmware upgrades, power
-## sequencing, and rms-backed component-manager operations. When disabled,
-## neither [rms] nor [component_manager] is rendered (presence of the latter
-## is what enables the component manager, and site-config cannot un-define
-## it). Standard NVL72 / NVL72_GB300 rack_profiles always ship in the global
-## config so sites only override OEM-specific vendors when needed.
+## connection details for rack-level firmware upgrades, power sequencing, and
+## rms-backed component-manager operations. When disabled, no [rms] section is
+## rendered. Independent of componentManager.enabled.
 ##
-## Enabling this renders [component_manager] with rms backends + state
-## controllers, and [rms] with the connection settings below.
+## Qualified NVL72 / NVL72_GB300 rack_profiles always ship in the global toml;
+## override OEM vendors (or add test profiles) via site-config merge.
 rms:
   ## Off by default until RMS ships in the standard install path. Enabling
   ## this WITHOUT RMS deployed is safe: the client is constructed lazily and

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -188,6 +188,19 @@ dsxExchangeEventBusConfig: ""
 ## uninitialized and logs a build error.
 componentManager:
   enabled: false
+  ## Backend per role. computeTray: rms | core | mock. nvSwitch: rms | nsm |
+  ## mock. powerShelf: rms | psm | mock. The binary defaults all three to rms;
+  ## nsm/psm select the standalone managers instead of RMS.
+  computeTrayBackend: "rms"
+  nvSwitchBackend: "rms"
+  powerShelfBackend: "rms"
+  ## Route power control and firmware updates through the state controllers
+  ## rather than dispatching straight to the device. The binary's field default
+  ## is false (legacy direct dispatch); state-controlled dispatch is the
+  ## recommended mode, so the chart turns it on.
+  computeTrayUseStateController: true
+  nvSwitchUseStateController: true
+  powerShelfUseStateController: true
 
 ## =============================================================================
 ## RMS (Rack Management Service) connectivity

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -180,14 +180,15 @@ dsxExchangeEventBusConfig: ""
 ## Renders the [component_manager] section into the global application config.
 ## Presence of that section is what enables the component manager; site-config
 ## can override fields but cannot remove the section once rendered — hence the
-## Helm gate (default off). Independent of rms.enabled below.
+## Helm gate. Independent of rms.enabled below. On by default for the standard
+## rack-management path; set enabled: false on deployments that do not run it.
 ##
 ## The chart defaults use rms backends + state controllers (recommended path).
-## Enabling this with rms backends requires rms.enabled=true (or an equivalent
-## [rms] block in site-config); otherwise Core leaves the component manager
-## uninitialized and logs a build error.
+## With rms backends, keep rms.enabled=true (the chart default) or supply an
+## equivalent [rms] block in site-config; otherwise Core leaves the component
+## manager uninitialized and logs a build error.
 componentManager:
-  enabled: false
+  enabled: true
   ## Backend per role. computeTray: rms | core | mock. nvSwitch: rms | nsm |
   ## mock. powerShelf: rms | psm | mock. The binary defaults all three to rms;
   ## nsm/psm select the standalone managers instead of RMS.
@@ -208,16 +209,18 @@ componentManager:
 ## RMS deploys as its own Helm chart (rack-manager); Core only needs the
 ## connection details for rack-level firmware upgrades, power sequencing, and
 ## rms-backed component-manager operations. When disabled, no [rms] section is
-## rendered. Independent of componentManager.enabled.
+## rendered. Independent of componentManager.enabled. On by default for the
+## standard rack-management path; set enabled: false on deployments that do
+## not run RMS.
 ##
 ## Qualified NVL72 / NVL72_GB300 rack_profiles always ship in the global toml;
 ## override OEM vendors (or add test profiles) via site-config merge.
+##
+## Enabling BEFORE rack-manager is deployed is safe: the client is constructed
+## lazily and every RMS-backed operation guards on it, so Core runs healthy
+## and rack operations report a clean error until RMS comes up at apiUrl.
 rms:
-  ## Off by default until RMS ships in the standard install path. Enabling
-  ## this WITHOUT RMS deployed is safe: the client is constructed lazily and
-  ## every RMS-backed operation guards on it, so Core runs healthy and rack
-  ## operations report a clean error until RMS comes up at apiUrl.
-  enabled: false
+  enabled: true
   ## RMS API server URL. The default matches the rack-manager chart's
   ## api-server Service in its default namespace (port 8801), TLS enabled.
   apiUrl: "https://rms-api-server.rack-manager.svc.cluster.local:8801"

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -198,14 +198,15 @@ rms:
   ## mTLS (apiServer.tls.enabled + caEnabled) with a certificate minted from
   ## the same vault-nico-issuer that signs nico-api's SPIFFE cert.
   enforceTls: true
-  ## mTLS material — paths inside the nico-api container. The defaults are
-  ## nico-api's own SPIFFE certificate mount, which shares a CA with the RMS
-  ## api-server certificate, so mTLS works both ways with no extra mounts.
-  ## Set all three to "" for a plain-HTTP RMS deployment (with enforceTls
-  ## false and an http:// apiUrl).
-  rootCaPath: "/var/run/secrets/spiffe.io/ca.crt"
-  clientCert: "/var/run/secrets/spiffe.io/tls.crt"
-  clientKey: "/var/run/secrets/spiffe.io/tls.key"
+  ## Optional mTLS material overrides — paths inside the nico-api container.
+  ## Leave empty: the RMS client (nv-rms-client) auto-discovers nico-api's
+  ## own SPIFFE certificate mount (/var/run/secrets/spiffe.io/{tls.crt,
+  ## tls.key,ca.crt}), which shares a CA with the RMS api-server certificate
+  ## — mTLS both ways with no extra mounts and no configuration. Set these
+  ## only to use different cert material.
+  rootCaPath: ""
+  clientCert: ""
+  clientKey: ""
 
 extraEnv: []
 

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -174,6 +174,32 @@ env:
 ## Optional Figment dictionary for CARBIDE_API_DSX_EXCHANGE_EVENT_BUS.
 dsxExchangeEventBusConfig: ""
 
+## =============================================================================
+## RMS (Rack Management Service) connectivity
+## =============================================================================
+## RMS deploys as its own Helm chart (rack-manager); Core only needs the
+## connection details to use it for rack-level firmware upgrades, power
+## sequencing, and rms-backed component-manager operations. When disabled,
+## no [rms] section is rendered and RMS-backed operations are unavailable.
+##
+## Note the component-manager backend fields DEFAULT to "rms" in the binary,
+## so a site that enables this and has rack profiles configured starts using
+## RMS for those roles without further component_manager config.
+rms:
+  enabled: false
+  ## RMS API server URL. The default matches the rack-manager chart's
+  ## api-server Service in its default namespace (port 8801).
+  apiUrl: "http://rms-api-server.rack-manager:8801"
+  ## Enforce TLS when connecting to RMS. The rack-manager chart ships with
+  ## TLS disabled, matching the plain-HTTP in-cluster URL above; set true
+  ## (plus the paths below) for TLS/mTLS deployments.
+  enforceTls: false
+  ## Optional TLS material — paths inside the nico-api container. Only
+  ## rendered when non-empty.
+  rootCaPath: ""
+  clientCert: ""
+  clientKey: ""
+
 extraEnv: []
 
 ## Authentication for the /admin WebUI. CARBIDE_WEB_AUTH_TYPE in extraEnv

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -180,11 +180,13 @@ dsxExchangeEventBusConfig: ""
 ## RMS deploys as its own Helm chart (rack-manager); Core only needs the
 ## connection details to use it for rack-level firmware upgrades, power
 ## sequencing, and rms-backed component-manager operations. When disabled,
-## no [rms] section is rendered and RMS-backed operations are unavailable.
+## neither [rms] nor [component_manager] is rendered (presence of the latter
+## is what enables the component manager, and site-config cannot un-define
+## it). Standard NVL72 / NVL72_GB300 rack_profiles always ship in the global
+## config so sites only override OEM-specific vendors when needed.
 ##
-## Note the component-manager backend fields DEFAULT to "rms" in the binary,
-## so a site that enables this and has rack profiles configured starts using
-## RMS for those roles without further component_manager config.
+## Enabling this renders [component_manager] with rms backends + state
+## controllers, and [rms] with the connection settings below.
 rms:
   ## Off by default until RMS ships in the standard install path. Enabling
   ## this WITHOUT RMS deployed is safe: the client is constructed lazily and


### PR DESCRIPTION
The rack profile, component manager and RMS sections only existed in per-site config, so every site running rack management had to restate all of them. Move a deployment-wide baseline into the global config so sites only override what actually differs.

rack_profiles carries the standard NVL72 bills of materials for GB200 and GB300. The component manager backends are rms, which is both the recommended backend for rack trays and what nico-api already defaults to. The state controller flags are on because state-controlled dispatch is the recommended mode; the field default of false is the legacy direct-dispatch path, which a site can still select.

The rack profile and component manager sections are coupled: an rms backend requires a non-empty rack_profiles and configuration loading fails without one.

Setting [rms].api_url here enables the component manager fleet-wide rather than only supplying a default. Its client is constructed lazily and never verifies connectivity, so a site that does not run RMS builds one too, and its rack operations fail against an unreachable endpoint instead of reporting that no component manager is configured. Sites can still point elsewhere through their own [rms].api_url.
 
## Related issues 
https://github.com/NVIDIA/infra-controller/issues/3299

## Type of Change 
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes 
- [ ] **This PR contains breaking changes**

## Testing 
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes 

