### PR TITLE
Reclaim local-path PV directories during helm-prereqs teardown

### DIFF
--- a/helm-prereqs/README.md
+++ b/helm-prereqs/README.md
@@ -519,8 +519,29 @@ probes are reported without failing the run.
 
 ## Teardown
 
+> **This destroys Vault and PostgreSQL data.** `reclaimPolicy: Retain` protects
+> those volumes from pod restarts and scaling, not from `clean.sh` — teardown
+> deletes the PVs either way, and the final step makes the on-disk state match.
+> There is no undo. `SKIP_HOSTPATH_SWEEP=true` leaves `Retain` volume data on
+> disk but still deletes the PVs. Check `kubectl config current-context` first.
+
 ```bash
 ./clean.sh
 ```
 
-Removes all components in reverse dependency order: NICo REST → NICo Core → helmfile releases → CRDs → namespaces → PVs → local-path-provisioner.
+Removes all components in reverse dependency order: NICo REST → NICo Core → helmfile releases → CRDs → namespaces → PVs → local-path-provisioner → host-directory sweep.
+
+The final step reclaims the on-disk PV data under `/opt/local-path-provisioner`
+on every node. `local-path-persistent` PVs use `reclaimPolicy: Retain`, so their
+directories are not removed automatically; `clean.sh` flips them to `Delete` and
+lets the provisioner reclaim them, then sweeps directories orphaned by earlier
+runs. The sweep schedules one short-lived pod per node in `kube-system` and
+removes a `pvc-*` directory only when the namespace encoded in its name belongs
+to this stack *and* no live PV matches it — directories for PVs that still exist,
+and anything else on the shared host path, are left alone. Tune with:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CLEAN_SWEEP_IMAGE` | `busybox:1.36` | Sweep pod image — set to a mirrored image on air-gapped clusters |
+| `SKIP_HOSTPATH_SWEEP` | `false` | Set to `true` to leave the host directories of `Retain` volumes on disk. The PVs are still deleted. It cannot preserve `Delete`-policy volumes (the plain `local-path` class): those are reclaimed by the provisioner when their namespace goes away, before this step runs |
+| `LOCAL_PATH_DIR` | read from the cluster | Provisioner host path. Normally taken from the `local-path-config` ConfigMap, or a surviving PV; set this when re-running against a cluster where the provisioner is already gone and nodes use a non-default `nodePathMap` |

--- a/helm-prereqs/clean.sh
+++ b/helm-prereqs/clean.sh
@@ -27,8 +27,10 @@
 #   4. vault init secrets  (vault-cluster-keys, vaultunsealkeys, vaultroottoken)
 #   5. namespaces          (nico-system, cert-manager, vault, external-secrets,
 #                           postgres, dpf-operator-system)
-#   6. local-path-persistent PVs owned by this stack (Retain policy — not deleted with namespace)
+#   6. local-path-persistent PVs owned by this stack (Retain policy — not deleted with namespace;
+#                           flipped to Delete first so the provisioner reclaims the host directory)
 #   7. local-path-provisioner + StorageClass (applied via kubectl, not helm-managed)
+#   8. orphaned /opt/local-path-provisioner directories on every node (per-node sweep pod)
 # =============================================================================
 set -euo pipefail
 
@@ -344,25 +346,465 @@ kubectl delete pod -n kube-system -l ncx-preflight=true \
 #    Delete them explicitly for a clean reinstall.
 #    Scoped to namespaces owned by this stack to avoid removing PVs belonging
 #    to other components that share the local-path-persistent StorageClass.
+#
+#    Retain also means the provisioner never runs its teardown helper pod, so
+#    deleting the PV object alone leaves the backing directory on the node
+#    (/opt/local-path-provisioner/pvc-<uid>_<ns>_<pvc>) behind forever. Patch
+#    each PV to reclaimPolicy Delete first so local-path-provisioner reclaims
+#    the host directory, then wait for the PVs to actually disappear — the
+#    provisioner must still be running (it is removed in step 7).
+#
+#    Only local-path-persistent (Retain) PVs need this. PVs on the plain
+#    local-path StorageClass are already reclaimPolicy Delete and are reclaimed
+#    when step 5 deletes their namespace; if one is still in flight when step 7
+#    removes the provisioner, the step 8 sweep picks up its directory.
 # ---------------------------------------------------------------------------
 echo "=== [6/8] Removing Released PersistentVolumes owned by this stack ==="
-kubectl get pv -o json 2>/dev/null \
-    | jq -r '.items[] | select(
+
+# Host path backing the provisioner, used by the orphan sweep in step 8.
+# Sources in order of trust: an explicit override, the provisioner's own
+# ConfigMap, then the path of a surviving local-path PV. The last one matters
+# on a re-run: once the provisioner is uninstalled its ConfigMap is gone too,
+# and blindly assuming the chart default would sweep a directory this cluster
+# never used while leaving the real orphans in place.
+LOCAL_PATH_DIR="${LOCAL_PATH_DIR:-}"
+
+_OTHER_PATHS=""
+if [[ -z "${LOCAL_PATH_DIR}" ]]; then
+    _LPP_CONFIG="$(kubectl get configmap local-path-config -n local-path-storage \
+        -o jsonpath='{.data.config\.json}' 2>/dev/null || true)"
+    LOCAL_PATH_DIR="$(printf '%s' "${_LPP_CONFIG}" \
+        | jq -r '.nodePathMap[0].paths[0] // empty' 2>/dev/null || true)"
+    # This stack configures a single DEFAULT path. A nodePathMap with per-node
+    # entries or several paths is valid upstream but not something the sweep
+    # resolves per node, so name what it will not reach instead of silently
+    # cleaning one path and reporting success.
+    _OTHER_PATHS="$(printf '%s' "${_LPP_CONFIG}" \
+        | jq -r --arg first "${LOCAL_PATH_DIR}" \
+            '[.nodePathMap[].paths[]] | unique - [$first] | join(" ")' \
+        2>/dev/null || true)"
+fi
+
+if [[ -z "${LOCAL_PATH_DIR}" ]]; then
+    # Match the exact classes this stack creates, not any name that happens to
+    # begin with "local-path" — an unrelated class would point the sweep at a
+    # different volume's directory tree.
+    LOCAL_PATH_DIR="$(kubectl get pv -o json 2>/dev/null \
+        | jq -r '[.items[]
+            | select(.spec.storageClassName == "local-path-persistent"
+                     or .spec.storageClassName == "local-path")
+            | select((.metadata.annotations["pv.kubernetes.io/provisioned-by"] // "rancher.io/local-path")
+                     == "rancher.io/local-path")
+            | (.spec.hostPath.path // .spec.local.path // empty)][0] // empty' \
+        2>/dev/null || true)"
+    # PV path is <host dir>/<pvc dir>; the sweep wants the parent.
+    [[ -n "${LOCAL_PATH_DIR}" ]] && LOCAL_PATH_DIR="$(dirname "${LOCAL_PATH_DIR}")"
+fi
+# Only a real absolute path is usable — it is hostPath-mounted into the sweep
+# pod in step 8 and used as the root of an rm, so fall back to the chart default
+# rather than trust a malformed value. "/" itself is rejected: mounting the node
+# root into the sweep pod is never what the provisioner config meant.
+_LOCAL_PATH_RAW="${LOCAL_PATH_DIR}"
+while [[ "${LOCAL_PATH_DIR}" == */ ]]; do
+    LOCAL_PATH_DIR="${LOCAL_PATH_DIR%/}"
+done
+# Whitespace is rejected along with the rest: this value is interpolated into
+# the sweep pod manifest, where a newline would rewrite the YAML around it.
+if [[ "${LOCAL_PATH_DIR}" != /?* || "${LOCAL_PATH_DIR}" == *".."* \
+      || "${LOCAL_PATH_DIR}" == *[[:space:]]* ]]; then
+    # Say so rather than silently sweeping somewhere else — a typo in an
+    # explicit LOCAL_PATH_DIR would otherwise look like a successful run.
+    # Report what was supplied, not the normalized form — "/" normalizes to
+    # empty and would otherwise be rejected silently.
+    [[ -n "${_LOCAL_PATH_RAW}" ]] && \
+        echo "  WARNING: ignoring unusable host path '${_LOCAL_PATH_RAW}' — must be absolute, not '/', and contain no '..' or whitespace"
+    LOCAL_PATH_DIR=""
+fi
+
+if [[ -z "${LOCAL_PATH_DIR}" ]]; then
+    LOCAL_PATH_DIR="/opt/local-path-provisioner"
+    _LOCAL_PATH_ASSUMED=true
+else
+    _LOCAL_PATH_ASSUMED=false
+fi
+
+# Namespaces owned by this stack. Both the PV selection below and the host
+# directory sweep in step 8 are scoped to these so neither touches storage
+# belonging to other components sharing the same StorageClass / host path.
+#
+# Keep this in step with the namespaces the steps above delete — a namespace
+# missing here has its PVs left Retained and its host directories accumulating,
+# which is the bug this file exists to fix. loki and tempo in particular hold
+# real data. flow is included for the same reason even though it predated this
+# list: step 0 deletes that namespace.
+_STACK_NS="nico-system cert-manager vault external-secrets postgres \
+metallb-system dpf-operator-system nico-rest temporal flow \
+loki tempo monitoring otel"
+_STACK_NS="$(printf '%s' "${_STACK_NS}" | tr -s '[:space:]' ' ')"
+_STACK_NS_RE="^($(printf '%s' "${_STACK_NS}" | tr ' ' '|'))$"
+
+# Bound PVs are excluded: their claim is still alive, which after step 5 means a
+# namespace failed to terminate and something may still be writing. Both fallback
+# paths below force-delete the PV object, and once it is gone the step 8 sweep can
+# no longer tell that its directory was live — so the exclusion has to happen
+# here, not there. Such a directory is left for the next teardown.
+#
+# A failed query (API error, missing jq) must not look like "no PVs to reclaim"
+# and skip the block below silently — same handling as the sweep in step 8.
+if ! _STACK_PVS="$(kubectl get pv -o json 2>/dev/null \
+    | jq -r --arg ns_re "${_STACK_NS_RE}" '.items[] | select(
         .spec.storageClassName == "local-path-persistent" and
-        (.spec.claimRef.namespace // "" | test("^(nico-system|cert-manager|vault|external-secrets|postgres|metallb-system|dpf-operator-system|nico-rest|temporal|loki|tempo|monitoring|otel)$"))
-      ) | .metadata.name' \
-    | xargs -r kubectl delete pv --ignore-not-found 2>/dev/null || true
+        .status.phase != "Bound" and
+        (.spec.claimRef.namespace // "" | test($ns_re))
+      ) | .metadata.name')"; then
+    echo "  WARNING: could not list PersistentVolumes — retained PVs were not reclaimed"
+    _STACK_PVS=""
+fi
+
+# Delete a PV, then clear any finalizer still holding it. An external-provisioner
+# finalizer would keep it Terminating forever once step 7 removes the controller
+# that clears it. Nothing Bound reaches either caller, so no live claim can be
+# stranded by this.
+_force_delete_pv() {
+    kubectl delete pv "$1" --wait=false --ignore-not-found >/dev/null 2>&1 || true
+    # Only strip finalizers from a PV the API server actually accepted for
+    # deletion. Without the deletionTimestamp check, a delete refused by RBAC
+    # would still have its finalizers removed, leaving a live PV defenceless.
+    if [[ -n "$(kubectl get pv "$1" -o jsonpath='{.metadata.deletionTimestamp}' \
+        2>/dev/null || true)" ]]; then
+        kubectl patch pv "$1" -p '{"metadata":{"finalizers":null}}' \
+            >/dev/null 2>&1 || true
+    fi
+}
+
+if [[ -n "${_STACK_PVS}" && "${SKIP_HOSTPATH_SWEEP:-false}" == "true" ]]; then
+    # SKIP_HOSTPATH_SWEEP promises the host directories are left alone. Flipping
+    # the reclaim policy here would have the provisioner erase them regardless,
+    # so honour the flag: delete the PV objects only (the pre-existing behaviour)
+    # and leave the data on disk.
+    echo "  SKIP_HOSTPATH_SWEEP=true — deleting PV objects only, host directories left in place"
+    # Policy stays Retain, so this removes the object without touching the data.
+    for _pv in ${_STACK_PVS}; do
+        _force_delete_pv "${_pv}"
+    done
+    _STACK_PVS=""
+fi
+
+if [[ -n "${_STACK_PVS}" ]]; then
+    # Flip Retain → Delete so the provisioner's teardown helper pod runs
+    # `rm -rf $VOL_DIR` on the node that owns the data.
+    for _pv in ${_STACK_PVS}; do
+        kubectl patch pv "${_pv}" -p \
+            '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}' \
+            >/dev/null 2>&1 || true
+    done
+
+    # Only the provisioner can reclaim these, so waiting on it is pointless if
+    # it has no available replica (never installed, already removed, scaled to
+    # zero, crash-looping). Skip straight to the fallback instead of burning the
+    # full timeout — the step 8 sweep is what recovers the directories then.
+    _PROVISIONER_UP="$(kubectl get deploy local-path-provisioner \
+        -n local-path-storage -o jsonpath='{.status.availableReplicas}' \
+        2>/dev/null || true)"
+
+    if [[ -z "${_PROVISIONER_UP}" || "${_PROVISIONER_UP}" == "0" ]]; then
+        echo "  local-path-provisioner is not running — PV host directories are left to the step 8 sweep"
+        for _pv in ${_STACK_PVS}; do
+            _force_delete_pv "${_pv}"
+        done
+    else
+        # Let the provisioner drive the deletion: a Released PV with policy
+        # Delete is reclaimed (helper pod, then PV object removed) by the
+        # provisioner itself. Deleting the PV object here instead would race it
+        # and could drop the object before the host directory is touched.
+        # One shared deadline for the whole set — a per-PV timeout would
+        # multiply into 120s x PV count on exactly the failure path this
+        # fallback exists to handle.
+        echo "Waiting for local-path-provisioner to reclaim PV host directories..."
+        # shellcheck disable=SC2046,SC2086
+        if ! kubectl wait --for=delete $(printf 'pv/%s ' ${_STACK_PVS}) \
+            --timeout=120s >/dev/null 2>&1; then
+            for _pv in ${_STACK_PVS}; do
+                if kubectl get pv "${_pv}" >/dev/null 2>&1; then
+                    echo "  WARNING: pv/${_pv} did not finish reclaiming — step 8 sweeps its directory under ${LOCAL_PATH_DIR}"
+                    # Remove the leftover object so a later setup.sh is not blocked.
+                    _force_delete_pv "${_pv}"
+                fi
+            done
+        fi
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 # 7. local-path-provisioner + StorageClass (applied via kubectl in setup.sh)
 # ---------------------------------------------------------------------------
-echo "=== [7/7] Removing local-path-provisioner ==="
+echo "=== [7/8] Removing local-path-provisioner ==="
 kubectl delete -f operators/storageclass-local-path-persistent.yaml \
     --ignore-not-found 2>/dev/null || true
 kubectl delete -f operators/local-path-provisioner.yaml \
     --ignore-not-found 2>/dev/null || true
 kubectl delete ns local-path-storage --wait=false --ignore-not-found 2>/dev/null || true
 kubectl wait --for=delete ns/local-path-storage --timeout=60s 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 8. Orphaned host directories under ${LOCAL_PATH_DIR}.
+#
+#    Directories left by earlier runs (before step 6 reclaimed properly, or by
+#    a PV deleted while the provisioner was down) have no PV to reclaim them
+#    and accumulate across test cycles. Sweep every node with a short-lived pod
+#    that removes a directory only when BOTH hold:
+#      - the namespace encoded in its name is one this stack owns, and
+#      - no live PV of that name exists. A Bound PV counts as live and is left
+#        alone; one that is Released, Failed, or Terminating-and-unbound does
+#        not, since nothing can reclaim it once step 7 removed the provisioner.
+#    Everything else on the shared host path is left untouched.
+#
+#    Override the sweep image for air-gapped clusters:
+#      export CLEAN_SWEEP_IMAGE=my-registry.example.com/busybox:1.36
+#    Skip the sweep entirely with:
+#      export SKIP_HOSTPATH_SWEEP=true
+# ---------------------------------------------------------------------------
+echo "=== [8/8] Sweeping orphaned directories under ${LOCAL_PATH_DIR} ==="
+
+# Nothing left on the cluster identified the path, so a clean "removed 0" here
+# would be indistinguishable from sweeping a directory this cluster never used.
+if [[ "${_LOCAL_PATH_ASSUMED}" == "true" ]]; then
+    echo "  NOTE: could not read the provisioner host path from the cluster — assuming the default."
+    echo "        If nodes use a different nodePathMap, re-run with LOCAL_PATH_DIR=/your/path"
+fi
+if [[ -n "${_OTHER_PATHS}" ]]; then
+    echo "  NOTE: nodePathMap also configures ${_OTHER_PATHS} — not swept."
+    echo "        Re-run with LOCAL_PATH_DIR=<path> for each to clean those too."
+fi
+
+# Clear pods stranded by an interrupted run first, on every path through this
+# step. One of those still holds an outdated snapshot of which PVs were live, so
+# leaving it alive would contradict SKIP_HOSTPATH_SWEEP and outlive the branch
+# below that creates no pods of its own.
+# Blocking, unlike the other pod deletions here: a stale pod that is already
+# running could be mid-rm, and returning before it is gone would let it keep
+# deleting directories after this step decided not to.
+if ! kubectl delete pod -n kube-system -l nico-lpp-sweep=true \
+    --ignore-not-found --grace-period=0 --wait --timeout=30s >/dev/null 2>&1; then
+    echo "  WARNING: sweep pods from an earlier clean.sh did not terminate within 30s."
+    echo "           They may still be deleting directories under ${LOCAL_PATH_DIR}:"
+    echo "             kubectl delete pod -n kube-system -l nico-lpp-sweep=true"
+fi
+
+if [[ "${SKIP_HOSTPATH_SWEEP:-false}" == "true" ]]; then
+    echo "  SKIP_HOSTPATH_SWEEP=true — skipping"
+else
+    # Interpolated into the pod manifest, same as LOCAL_PATH_DIR — reject values
+    # that would rewrite the YAML around it.
+    _SWEEP_IMAGE="${CLEAN_SWEEP_IMAGE:-busybox:1.36}"
+    if [[ "${_SWEEP_IMAGE}" == *[[:space:]]* || "${_SWEEP_IMAGE}" == *'"'* ]]; then
+        echo "  WARNING: ignoring unusable CLEAN_SWEEP_IMAGE '${_SWEEP_IMAGE}' — using busybox:1.36"
+        _SWEEP_IMAGE="busybox:1.36"
+    fi
+    _SWEEP_NS="kube-system"
+    _SWEEP_TS="$(date +%s)"
+
+    # PVs whose directories are kept. Two categories are excluded, because
+    # step 7 removed the provisioner and nothing can reclaim them any more:
+    #   - Terminating and no longer Bound
+    #   - Released or Failed (their claim is already gone, so no pod is using
+    #     the data — this is what catches a plain local-path PV whose reclaim
+    #     was still in flight when the provisioner went away)
+    # A Bound PV is always kept, Terminating or not: if a stack namespace failed
+    # to terminate in step 5, its claim — and a pod writing to it — may still be
+    # alive, and rm -rf underneath that is worse than leaving the directory for
+    # the next teardown.
+    # Every Bound PV is kept regardless of StorageClass — NICO_STORAGE_CLASS lets
+    # a site back these PVCs with a differently named class on the same
+    # provisioner, and missing one of those would mean rm -rf under a live pod.
+    # The non-Bound half is restricted to this provisioner's own classes: nothing
+    # else can own a directory here, and this list goes into every sweep pod, so
+    # a cluster-wide one bloats the manifest for no gain.
+    # A failed query must NOT be treated as "no live PVs" (that would sweep every
+    # directory, including live ones), so bail out if the API call errors.
+    if ! _LIVE_PVS="$(kubectl get pv -o json 2>/dev/null \
+        | jq -r '.items[] | select(
+            .status.phase == "Bound" or
+            ((.spec.storageClassName == "local-path-persistent"
+              or .spec.storageClassName == "local-path")
+             and .metadata.deletionTimestamp == null
+             and .status.phase != "Released" and .status.phase != "Failed")
+          ) | .metadata.name')"; then
+        echo "  WARNING: could not list PersistentVolumes — skipping sweep to avoid removing live data"
+        _LIVE_PVS_OK=false
+    else
+        _LIVE_PVS_OK=true
+    fi
+
+    # Also tear the pods down if clean.sh is interrupted between creating them
+    # and the cleanup below; activeDeadlineSeconds is the backstop if the
+    # interruption takes this shell with it.
+    trap 'kubectl delete pod -n "${_SWEEP_NS}" -l "nico-lpp-run=${_SWEEP_TS}" \
+        --ignore-not-found --wait=false >/dev/null 2>&1 || true' EXIT
+
+    _SWEEP_PODS=()
+    _sweep_idx=0
+    _SWEEP_NODES=""
+    if [[ "${_LIVE_PVS_OK}" == "true" ]]; then
+        _SWEEP_NODES="$(kubectl get nodes \
+            -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)"
+        [[ -n "${_SWEEP_NODES}" ]] || \
+            echo "  WARNING: could not list nodes — sweep did not run; clean ${LOCAL_PATH_DIR} manually"
+    fi
+
+    for _node in ${_SWEEP_NODES}; do
+        # Lowercase via tr for portability (bash 3.2 on macOS lacks ${var,,}).
+        # Truncate to keep the whole name inside the 63-char DNS-1123 limit, and
+        # strip any trailing "-" left by truncation (not a legal name ending).
+        _safe="$(printf '%s' "${_node}" | tr '[:upper:]' '[:lower:]')"
+        _safe="${_safe//[^a-z0-9-]/-}"
+        _safe="${_safe:0:32}"
+        while [[ "${_safe}" == *- ]]; do _safe="${_safe%?}"; done
+        # A name that is all dashes leaves nothing behind, which would put a
+        # trailing "-" on the pod name and fail DNS-1123.
+        [[ -z "${_safe}" ]] && _safe="node"
+        # Node index disambiguates nodes whose names collide after truncation.
+        _sweep_idx=$(( _sweep_idx + 1 ))
+        _pod="nico-lpp-${_SWEEP_TS}-${_sweep_idx}-${_safe}"
+
+        if kubectl apply -f - >/dev/null 2>&1 <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${_pod}
+  namespace: ${_SWEEP_NS}
+  labels:
+    nico-lpp-sweep: "true"
+    nico-lpp-run: "${_SWEEP_TS}"
+spec:
+  nodeName: "${_node}"
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  # The pod carries a snapshot of which PVs were live when it was created. If it
+  # sat Pending (image pull failure) past a later setup.sh, that snapshot would
+  # be stale and it would delete freshly provisioned data. The cluster enforces
+  # this deadline even if clean.sh is interrupted or its host goes away.
+  activeDeadlineSeconds: 300
+  tolerations:
+  - operator: Exists
+  volumes:
+  - name: host
+    hostPath:
+      path: ${LOCAL_PATH_DIR}
+      type: DirectoryOrCreate
+  containers:
+  - name: sweep
+    image: ${_SWEEP_IMAGE}
+    # Least privilege for an rm on a hostPath: uid 0 plus only the two DAC
+    # capabilities needed to traverse workload-owned data (postgres pgdata is
+    # mode 0700 under a non-root uid — root alone cannot descend into it).
+    securityContext:
+      runAsUser: 0
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+        add: ["DAC_OVERRIDE", "DAC_READ_SEARCH"]
+    volumeMounts:
+    - name: host
+      mountPath: /host
+    env:
+    - name: LIVE_PVS
+      value: |
+${_LIVE_PVS:+$(printf '%s\n' "${_LIVE_PVS}" | sed 's/^/        /')}
+    - name: STACK_NS
+      value: "${_STACK_NS}"
+    # When LIVE_PVS was taken. Anything on disk newer than this was created
+    # after the snapshot, so the snapshot says nothing about whether it is live.
+    - name: SNAPSHOT_TS
+      value: "${_SWEEP_TS}"
+    command:
+    - sh
+    - -c
+    - |
+      printf "NODE=${_node}\n"
+      for d in /host/pvc-*; do
+        [ -d "\$d" ] || continue
+        b="\$(basename "\$d")"
+        # Directory name is "<pv-name>_<namespace>_<pvc-name>". A directory
+        # without that suffix (older provisioner layout) yields no namespace
+        # match and is left alone.
+        rest="\${b#*_}"
+        ns="\${rest%%_*}"
+        # Directories newer than the snapshot cannot be judged by it. This pod
+        # may have sat Pending while a setup.sh provisioned fresh volumes here,
+        # and deleting one of those would destroy live data. Ages only make this
+        # safer, so no cross-script locking is needed to rely on it. The
+        # snapshot second itself counts as newer — a directory created within it
+        # is equally unaccounted for. Assumes node clocks are roughly in step,
+        # which a cluster requires anyway.
+        mt="\$(stat -c %Y "\$d" 2>/dev/null || echo 0)"
+        if ! printf '%s\n' \$STACK_NS | grep -qxF "\$ns"; then
+          printf "skipped=%s\n" "\$b"
+        elif [ "\$mt" -ge "\$SNAPSHOT_TS" ]; then
+          printf "newer=%s\n" "\$b"
+        elif printf '%s\n' "\$LIVE_PVS" | grep -qxF "\${b%%_*}"; then
+          printf "kept=%s\n" "\$b"
+        elif rm -rf "\$d" 2>/dev/null; then
+          printf "removed=%s\n" "\$b"
+        else
+          printf "failed=%s\n" "\$b"
+        fi
+      done
+      printf "sweep=done\n"
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+EOF
+        then
+            _SWEEP_PODS+=("${_pod}")
+        else
+            echo "  WARNING: could not create sweep pod on node ${_node} — clean ${LOCAL_PATH_DIR} on it manually"
+        fi
+    done
+
+    if [[ -n "${_SWEEP_PODS[*]:-}" ]]; then
+        # One list call per tick rather than one per pod — on a large cluster
+        # the per-pod form is hundreds of API calls over the full timeout.
+        _deadline=$(( $(date +%s) + 120 ))
+        while [[ $(date +%s) -lt "${_deadline}" ]]; do
+            _phases="$(kubectl get pods -n "${_SWEEP_NS}" \
+                -l "nico-lpp-run=${_SWEEP_TS}" \
+                -o jsonpath='{range .items[*]}{.status.phase}{"\n"}{end}' \
+                2>/dev/null || true)"
+            _settled="$(printf '%s\n' "${_phases}" \
+                | grep -cE '^(Succeeded|Failed)$' || true)"
+            [[ "${_settled}" -ge "${#_SWEEP_PODS[@]}" ]] && break
+            sleep 5
+        done
+
+        for _pod in "${_SWEEP_PODS[@]}"; do
+            _logs="$(kubectl logs "${_pod}" -n "${_SWEEP_NS}" 2>/dev/null || true)"
+            _node_label="$(printf '%s' "${_logs}" | grep '^NODE=' | cut -d= -f2- || true)"
+            _removed="$(printf '%s' "${_logs}" | grep -c '^removed=' || true)"
+            _failed="$(printf '%s' "${_logs}" | grep -c '^failed=' || true)"
+            if [[ -z "${_logs}" ]] || ! printf '%s' "${_logs}" | grep -q '^sweep=done$'; then
+                echo "  WARNING: sweep on ${_node_label:-${_pod}} did not complete — set CLEAN_SWEEP_IMAGE to a pre-pulled image, or clean ${LOCAL_PATH_DIR} manually"
+            else
+                echo "  ${_node_label:-${_pod}}: removed ${_removed} orphaned director$([[ "${_removed}" == "1" ]] && echo y || echo ies)"
+                _newer="$(printf '%s' "${_logs}" | grep -c '^newer=' || true)"
+                if [[ "${_newer}" != "0" ]]; then
+                    echo "  NOTE: ${_newer} director$([[ "${_newer}" == "1" ]] && echo y || echo ies) on ${_node_label:-${_pod}} changed after the sweep started and were left alone"
+                fi
+                if [[ "${_failed}" != "0" ]]; then
+                    echo "  WARNING: ${_failed} director$([[ "${_failed}" == "1" ]] && echo y || echo ies) on ${_node_label:-${_pod}} could not be removed — clean them under ${LOCAL_PATH_DIR} manually:"
+                    printf '%s' "${_logs}" | sed -n 's/^failed=/    /p'
+                fi
+            fi
+        done
+
+        # This run's pods; anything stranded by an earlier one was cleared at the
+        # top of this step.
+        kubectl delete pod -n "${_SWEEP_NS}" -l "nico-lpp-run=${_SWEEP_TS}" \
+            --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    fi
+    trap - EXIT
+fi
 
 echo ""
 echo "=== Clean complete ==="

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -380,6 +380,34 @@ fi
 # ---------------------------------------------------------------------------
 _SETUP_PHASE="[1/6] local-path-provisioner"
 echo "=== [1/6] local-path-provisioner ==="
+
+# clean.sh sweeps orphaned host directories with a per-node pod that carries a
+# snapshot of which PVs were live when it was created. One left Pending by an
+# interrupted teardown (image pull, node offline) would still be holding that
+# stale snapshot, and could start after the PVs below exist and delete their
+# directories. Clear any before provisioning storage.
+# This check gates data loss, so it fails closed: a suppressed error here would
+# let storage be provisioned while such a pod is still able to delete it.
+if ! _STALE_SWEEP="$(kubectl get pods -n kube-system \
+    -l nico-lpp-sweep=true -o name 2>/dev/null)"; then
+    echo "ERROR: could not check for clean.sh sweep pods — refusing to provision storage" >&2
+    exit 1
+fi
+
+if [[ -n "${_STALE_SWEEP}" ]]; then
+    echo "  Removing sweep pods left by an interrupted clean.sh..."
+    kubectl delete pod -n kube-system -l nico-lpp-sweep=true \
+        --ignore-not-found --wait --timeout=60s 2>/dev/null || true
+
+    if ! _STALE_SWEEP="$(kubectl get pods -n kube-system \
+        -l nico-lpp-sweep=true -o name 2>/dev/null)" || [[ -n "${_STALE_SWEEP}" ]]; then
+        echo "ERROR: sweep pods from a previous clean.sh are still present in kube-system." >&2
+        echo "       They can delete newly provisioned PV directories. Remove them first:" >&2
+        echo "         kubectl delete pod -n kube-system -l nico-lpp-sweep=true" >&2
+        exit 1
+    fi
+fi
+
 kubectl apply -f operators/local-path-provisioner.yaml
 # StorageClass provisioner is immutable — delete before apply so a stale
 # provisioner from a previous install doesn't block the update.


### PR DESCRIPTION
`helm-prereqs/clean.sh` left PV data behind on every node, and it accumulated
indefinitely across test cycles. On a cluster used for repeated setup/teardown
runs, `/opt/local-path-provisioner/` had collected weeks' worth of directories
(`pvc-<uid>_vault_data-vault-0`, `pvc-<uid>_postgres_pgdata-*`, ...), none of
which anything would ever remove.

The cause is the `local-path-persistent` StorageClass, which uses
`reclaimPolicy: Retain` so Vault and PostgreSQL data survives pod restarts.
Retain means the provisioner never runs its teardown helper pod, so when
clean.sh deleted those PV objects directly the backing host directory was
simply orphaned. The provisioner was then removed immediately afterwards with
`--wait=false`, so even `Delete`-policy PVs could lose their helper pod
mid-reclaim.

Teardown now patches stack-owned PVs to `reclaimPolicy: Delete` and lets the
provisioner reclaim them while it is still running, waiting on the result. A
final per-node sweep clears directories orphaned by earlier runs, which no PV
can reclaim any more.

The sweep is deliberately conservative, since it runs `rm -rf` on a host path
that other components may share. It removes a directory only when the namespace
encoded in the directory name is one this stack owns *and* no live PV of that
name exists, and it skips itself entirely rather than guess if the PV list
cannot be read. A PV that is Terminating but still Bound is treated as live —
if a namespace failed to terminate, a pod may still be writing to it.

## Related issues

None.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified locally, not against a live cluster:

- The generated sweep pod spec was rendered exactly as clean.sh builds it and
  parsed as YAML, for both a populated and an empty live-PV list.
- The sweep's shell logic was run under `sh` against a fixture directory: it
  kept the directory backed by a live PV, removed the two stack-owned orphans,
  and skipped both a foreign-namespace directory and one with no namespace
  suffix. Non-`pvc-` entries were untouched.
- The live-PV jq predicate was checked against synthetic PV JSON covering
  Bound, Released, Terminating+Bound, and Terminating+Released.
- `bash -n` on the script.

The PV patch/wait path in step 6 has not been exercised end-to-end on a
cluster.

## Additional Notes

Two escape hatches for environments where the sweep is unwanted or cannot run:
`CLEAN_SWEEP_IMAGE` points it at a mirrored busybox for air-gapped clusters,
and `SKIP_HOSTPATH_SWEEP=true` disables it. Both are documented in
`helm-prereqs/README.md`.

Worth a careful look at the namespace list in `_STACK_NS` — it decides which
directories the sweep is allowed to delete. It now includes `flow`, which the
pre-existing PV selection in step 6 did not cover.