### PR TITLE
fix(dpu-agent): report unsupported extension services under DPF

### DIFF
--- a/crates/agent/src/extension_services/manager.rs
+++ b/crates/agent/src/extension_services/manager.rs
@@ -60,7 +60,12 @@ impl ExtensionServiceManager {
         self.service_handlers
             .get_mut(t)
             .map(|handler| handler.as_mut() as &mut dyn ExtensionServiceHandler)
-            .ok_or_else(|| eyre::eyre!("no handler for {:?}", t))
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "extension service type {:?} is not supported on this DPU",
+                    t
+                )
+            })
     }
 
     pub async fn update_desired_services(
@@ -108,8 +113,27 @@ impl ExtensionServiceManager {
 
         let mut service_statuses = Vec::with_capacity(service_configs.len());
         for service in service_configs {
-            let handler = self.get_handler_mut(&service.service_type).unwrap();
-            let status = handler.get_service_status(&service).await?;
+            let status = match self.get_handler_mut(&service.service_type) {
+                Ok(handler) => handler.get_service_status(&service).await?,
+                Err(err) => {
+                    tracing::error!(
+                        service_id = %service.id,
+                        error = %err,
+                        "Error getting extension service status"
+                    );
+                    rpc::DpuExtensionServiceStatusObservation {
+                        service_id: service.id.to_string(),
+                        service_type: service.service_type.into(),
+                        service_name: service.name,
+                        version: service.version.to_string(),
+                        removed: service.removed,
+                        state: rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceError
+                            .into(),
+                        components: vec![],
+                        message: err.to_string(),
+                    }
+                }
+            };
             service_statuses.push(status);
         }
 


### PR DESCRIPTION
Fixes an extension service issue under DPF. Previously, forge-dpu-agent running in DPF mode intentionally did not initialize extension service handlers because the existing `KubernetesPod` handler relies on direct host and `crictl` access. However, the service status path still attempted to `unwrap()` the missing handler, causing the agent to panic and crash-loop whenever an extension service was attached.

This MR replaces the unwrap() with explicit error handling. The agent now logs a clear error, reports the service to the API with DPU_EXTENSION_SERVICE_ERROR status, and continues running instead of crashing.

## Related issues
nvbug: https://nvbugspro.nvidia.com/bug/6522467

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

