### PR TITLE
fix(api-db-tests): isolate DPU ASN metric capture

### DIFF
--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -3281,6 +3281,7 @@ mod test {
             (VLANID.to_string(), integer_pool()),
             (VNI.to_string(), integer_pool()),
             (VPC_VNI.to_string(), integer_pool()),
+            (FNN_ASN.to_string(), integer_pool()),
         ]);
         if let Some(prefix) = loopback_ip_v6_prefix {
             definitions.insert(


### PR DESCRIPTION
`machine::test::dpu_creation_keeps_exhausted_fnn_asn_nonfatal` verifies that an exhausted FNN ASN pool emits exactly one failure event and increments its metric once.

The metric assertion was flaky under parallel execution:

```text
assertion `left == right` failed
  left: 2.0
 right: 1.0
```

`MetricsCapture` measures a process-global metric registry. Several IPv6 loopback tests also create DPUs using the shared `common_pools` fixture. That fixture did not seed `FNN_ASN`, so those unrelated tests could emit the same ASN exhaustion event while the target test's metric capture was active.

Separate SQLx databases do not isolate process-global metrics.

Validated with:

```sh
for run in {1..200}; do
  cargo test -p carbide-api-db --profile=ci-tests \
    -- --test-threads=16 || break
done
```

## Related issues

Fixes #4221

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)