### PR TITLE
docs(machine-a-tron): add version-availability note to the deployment guide

### DIFF
--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -5,6 +5,15 @@ servers via Redfish BMC, allowing end-to-end NICo flows without real hardware. T
 guide documents everything needed to build the container image and deploy it on a
 cluster.
 
+<Note title="Version availability">
+Everything in this guide — the `nico-machine-a-tron` Helm chart,
+`helm-prereqs/setup-machine-a-tron.sh`, and the values files it references —
+landed on `main` in July 2026 (#2764) and is **not present in v2.0.x
+releases**. If your checkout is a `v2.0.0` tag or the `release/v2.0` branch,
+these paths will not exist; use a checkout of `main` (or the first release
+that includes them) to follow this guide.
+</Note>
+
 ## Overview
 
 machine-a-tron runs in **Override Mode**: site-explorer redirects all Redfish traffic


### PR DESCRIPTION
Follow-up to the Slack question "Is the machine-a-tron deployment guide still relevant? The script referenced no longer seems to be in the repo."

**Investigation result: the guide is fully current — nothing is missing on `main`.** Every path it references (`helm-prereqs/setup-machine-a-tron.sh`, the `nico-machine-a-tron` chart, both values files, the Dockerfile) resolves on `main`. The confusion is version skew: the entire machine-a-tron stack landed in #2764 (July 17) *after* the `release/v2.0` branch cut, so none of it exists in any v2.0.x release — while the published docs render the guide under the v2.0 label. A reader on a v2.0 checkout reasonably concludes the script "is no longer in the repo" when it was never there.

This adds a version-availability `<Note>` at the top of the guide so it's self-explaining on any checkout. No content is removed — removing the page (the other option discussed) would be wrong since it accurately documents main.

cc @akorobkov-nvda (Slack thread), @dporokh-nvidia

## Related issues

None (Slack thread).

## Type of Change

- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] No testing required (docs only)

Verified every file reference in the guide against `origin/main` (all resolve) and against `release/v2.0` (doc, script, and chart all absent).