### PR TITLE
test: stop keeping three copies of the same test scaffolding

### DIFF
--- a/crates/api-core/Cargo.toml
+++ b/crates/api-core/Cargo.toml
@@ -34,6 +34,7 @@ path = "tests/integration/main.rs"
 # External dependencies. PLEASE KEEP ALPHABETIZED ORDER.
 bmc-vendor = { path = "../bmc-vendor" }
 carbide-api-model = { path = "../api-model", default-features = false }
+carbide-test-support = { path = "../test-support", optional = true }
 carbide-api-db = { path = "../api-db", default-features = false }
 carbide-authn = { path = "../authn" }
 carbide-dpa = { path = "../dpa" }
@@ -187,6 +188,7 @@ linux-build = ["tss-esapi"]
 # builds (resolver v2 keeps it out of the production `carbide-api` binary); only `carbide-api-web`'s
 # dev-dependency turns it on.
 test-support = [
+  "dep:carbide-test-support",
   "carbide-api-model/test-support",
   "carbide-ib-fabric/test-support",
   "carbide-machine-controller/test-support",

--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -49,38 +49,5 @@ impl Api {
 }
 
 pub fn setup_test_logging() {
-    use tracing::metadata::LevelFilter;
-    use tracing_subscriber::filter::EnvFilter;
-    use tracing_subscriber::fmt::TestWriter;
-    use tracing_subscriber::prelude::*;
-    use tracing_subscriber::util::SubscriberInitExt;
-
-    if let Err(e) = tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::Layer::default()
-                .compact()
-                .with_writer(TestWriter::new),
-        )
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy()
-                .add_directive("sqlx=warn".parse().unwrap())
-                .add_directive("tower=warn".parse().unwrap())
-                .add_directive("rustify=off".parse().unwrap())
-                .add_directive("rustls=warn".parse().unwrap())
-                .add_directive("hyper=warn".parse().unwrap())
-                .add_directive("h2=warn".parse().unwrap())
-                // Silence permissive mode related messages
-                .add_directive("carbide_api_core::auth=error".parse().unwrap()),
-        )
-        .try_init()
-    {
-        // Note: Resist the temptation to ignore this error. We really should only have one place in
-        // the test binary that initializes logging.
-        panic!(
-            "Failed to initialize trace logging for carbide-api tests. It's possible some earlier \
-            code path has already set a global default log subscriber: {e}"
-        );
-    }
+    carbide_test_support::setup_test_logging("carbide-api");
 }

--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -32,6 +32,7 @@ use tonic::Request;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
+use super::dpf_config;
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host_with_dpf, create_managed_host_with_dpf_bf4,
     create_test_env_with_overrides, get_config,
@@ -49,21 +50,6 @@ fn default_mock(deployment_type: DpuDeploymentType) -> MockDpfOperations {
         .returning(move |_| Ok(deployment_type));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
     mock
-}
-
-/// DPF configuration shared by happy-path integration tests.
-fn dpf_config() -> crate::cfg::file::DpfConfig {
-    crate::cfg::file::DpfConfig {
-        enabled: true,
-        deployments: crate::cfg::file::DpfDeploymentsConfig {
-            bf3: crate::cfg::file::DpfDeploymentConfig {
-                bfb_url: Some("http://example.com/test.bfb".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    }
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/dpf/mod.rs
+++ b/crates/api-core/src/tests/dpf/mod.rs
@@ -19,3 +19,32 @@ mod happy_path;
 mod reprovisioning;
 mod stale_labels;
 mod waiting_for_ready;
+
+use model::machine::ManagedHostState;
+
+use crate::tests::common::api_fixtures::TestEnv;
+use crate::tests::common::api_fixtures::test_managed_host::TestManagedHost;
+
+// The DPF suites all want the same starting point: DPF on, with a BF3 BFB URL to hand out.
+// Each of the four files below had grown its own byte-identical copy of this.
+fn dpf_config() -> crate::cfg::file::DpfConfig {
+    crate::cfg::file::DpfConfig {
+        enabled: true,
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: Some("http://example.com/test.bfb".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+// Reads the host's committed state straight from the database rather than through the RPC
+// surface, which is what these suites assert transitions against.
+async fn get_host_state(env: &TestEnv, mh: &TestManagedHost) -> ManagedHostState {
+    let mut txn = env.db_txn().await;
+    let machine = mh.host().db_machine(&mut txn).await;
+    machine.state.value
+}

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -34,6 +34,7 @@ use model::machine::{
 };
 use tokio::time::timeout;
 
+use super::{dpf_config, get_host_state};
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
     create_managed_host_with_dpf_multi, create_test_env_with_overrides, get_config,
@@ -91,20 +92,6 @@ fn provisioning_mock_with_dpu_count(
         }
     });
     mock
-}
-
-fn dpf_config() -> crate::cfg::file::DpfConfig {
-    crate::cfg::file::DpfConfig {
-        enabled: true,
-        deployments: crate::cfg::file::DpfDeploymentsConfig {
-            bf3: crate::cfg::file::DpfDeploymentConfig {
-                bfb_url: Some("http://example.com/test.bfb".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    }
 }
 
 /// Build the DPU reprovision states map for the given DPF sub-state.
@@ -173,15 +160,6 @@ async fn set_assigned_reprovision_dpf_state(
         },
     };
     write_host_state(pool, host_id, &state).await;
-}
-
-async fn get_host_state(
-    env: &crate::tests::common::api_fixtures::TestEnv,
-    mh: &TestManagedHost,
-) -> ManagedHostState {
-    let mut txn = env.db_txn().await;
-    let machine = mh.host().db_machine(&mut txn).await;
-    machine.state.value
 }
 
 async fn dpu_device_names(pool: &sqlx::PgPool, mh: &TestManagedHost) -> HashSet<String> {

--- a/crates/api-core/src/tests/dpf/stale_labels.rs
+++ b/crates/api-core/src/tests/dpf/stale_labels.rs
@@ -33,26 +33,12 @@ use carbide_uuid::machine::MachineId;
 use model::machine::{DpfState, DpuInitState, FailureCause, FailureDetails, ManagedHostState};
 use tokio::time::timeout;
 
+use super::{dpf_config, get_host_state};
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
-    create_test_env_with_overrides, get_config,
+    TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides, get_config,
 };
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
-
-fn dpf_config() -> crate::cfg::file::DpfConfig {
-    crate::cfg::file::DpfConfig {
-        enabled: true,
-        deployments: crate::cfg::file::DpfDeploymentsConfig {
-            bf3: crate::cfg::file::DpfDeploymentConfig {
-                bfb_url: Some("http://example.com/test.bfb".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    }
-}
 
 fn provisioning_mock_with_labels_valid(labels_valid: Arc<AtomicBool>) -> MockDpfOperations {
     let mut mock = MockDpfOperations::new();
@@ -131,15 +117,6 @@ async fn reset_host_to_waiting_for_ready(
     .execute(pool)
     .await
     .unwrap();
-}
-
-async fn get_host_state(
-    env: &crate::tests::common::api_fixtures::TestEnv,
-    mh: &TestManagedHost,
-) -> ManagedHostState {
-    let mut txn = env.db_txn().await;
-    let machine = mh.host().db_machine(&mut txn).await;
-    machine.state.value
 }
 
 /// A node with stale labels during Provisioning transitions to Failed

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -32,8 +32,9 @@ use libredfish::SystemPowerControl;
 use model::machine::{DpfState, DpuInitState, ManagedHostState, PerformPowerOperation};
 use tokio::time::timeout;
 
+use super::{dpf_config, get_host_state};
 use crate::tests::common::api_fixtures::{
-    TestEnvOverrides, TestManagedHost, create_managed_host, create_managed_host_with_dpf,
+    TestEnvOverrides, create_managed_host, create_managed_host_with_dpf,
     create_test_env_with_overrides, get_config, reboot_completed,
 };
 
@@ -60,20 +61,6 @@ fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_deployment_type_for_dpu()
         .returning(|_| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
-}
-
-fn dpf_config() -> crate::cfg::file::DpfConfig {
-    crate::cfg::file::DpfConfig {
-        enabled: true,
-        deployments: crate::cfg::file::DpfDeploymentsConfig {
-            bf3: crate::cfg::file::DpfDeploymentConfig {
-                bfb_url: Some("http://example.com/test.bfb".to_string()),
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        ..Default::default()
-    }
 }
 
 /// Persists one DPU's DPF substate directly so tests can isolate a handler
@@ -124,15 +111,6 @@ async fn reset_host_to_waiting_for_ready(
         DpfState::WaitingForReady { phase_detail: None },
     )
     .await;
-}
-
-async fn get_host_state(
-    env: &crate::tests::common::api_fixtures::TestEnv,
-    mh: &TestManagedHost,
-) -> ManagedHostState {
-    let mut txn = env.db_txn().await;
-    let machine = mh.host().db_machine(&mut txn).await;
-    machine.state.value
 }
 
 /// WaitingForReady with reboot required:

--- a/crates/api-core/src/tests/expected_switch.rs
+++ b/crates/api-core/src/tests/expected_switch.rs
@@ -32,22 +32,14 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
 
     for mut expected_switch in [
         rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: "3A:3B:3C:3D:3E:3F".to_string(),
             nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:4F".to_string()],
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-TEST-001".into(),
-            nvos_username: None,
-            nvos_password: None,
-            metadata: None,
-            rack_id: None,
-            bmc_ip_address: String::new(),
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         },
         rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: "3A:3B:3C:3D:3E:40".to_string(),
             nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:40".to_string()],
             bmc_username: "ADMIN".into(),
@@ -56,13 +48,9 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
             nvos_username: Some("nvos_user".into()),
             nvos_password: Some("nvos_pass".into()),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_ip_address: String::new(),
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         },
         rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: "3A:3B:3C:3D:3E:41".to_string(),
             nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:41".to_string()],
             bmc_username: "ADMIN".into(),
@@ -85,9 +73,7 @@ async fn test_add_expected_switch(pool: sqlx::PgPool) {
                 ],
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
-            bmc_ip_address: String::new(),
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         },
     ] {
         env.api
@@ -183,19 +169,12 @@ async fn test_add_expected_switch_rejects_claimed_nvos_mac(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
 
     let mut expected_switch = rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: "3A:3B:3C:3D:3E:50".to_string(),
         nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:50".to_string()],
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         switch_serial_number: "SW-NVOS-DUP-001".into(),
-        nvos_username: None,
-        nvos_password: None,
-        metadata: None,
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
     env.api
         .add_expected_switch(tonic::Request::new(expected_switch.clone()))
@@ -225,7 +204,6 @@ async fn test_update_expected_switch_rejects_claimed_nvos_mac(pool: sqlx::PgPool
 
     // switches[1] tries to claim an NVOS MAC that switches[0] already holds.
     let update = rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: switches[1].bmc_mac_address.to_string(),
         nvos_mac_addresses: switches[0]
             .nvos_mac_addresses
@@ -235,13 +213,7 @@ async fn test_update_expected_switch_rejects_claimed_nvos_mac(pool: sqlx::PgPool
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         switch_serial_number: switches[1].serial_number.clone(),
-        nvos_username: None,
-        nvos_password: None,
-        metadata: None,
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
     let status = env
         .api
@@ -256,19 +228,12 @@ async fn test_replace_all_expected_switches_rejects_intra_list_nvos_dup(pool: sq
     let env = create_test_env(pool).await;
 
     let switch = |bmc: &str, serial: &str| rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: bmc.to_string(),
         nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:60".to_string()],
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         switch_serial_number: serial.into(),
-        nvos_username: None,
-        nvos_password: None,
-        metadata: None,
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     // Two switches in one replace list claiming the same NVOS MAC surface a
@@ -342,22 +307,14 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
         .collect();
     for mut updated_switch in [
         rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac_address.to_string(),
             nvos_mac_addresses: nvos_mac_addresses.clone(),
             bmc_username: "ADMIN_UPDATE".into(),
             bmc_password: "PASS_UPDATE".into(),
             switch_serial_number: "SW-UPD-001".into(),
-            nvos_username: None,
-            nvos_password: None,
-            metadata: None,
-            rack_id: None,
-            bmc_ip_address: String::new(),
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         },
         rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac_address.to_string(),
             nvos_mac_addresses: nvos_mac_addresses.clone(),
             bmc_username: "ADMIN_UPDATE".into(),
@@ -366,13 +323,9 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
             nvos_username: Some("nvos_upd_user".into()),
             nvos_password: Some("nvos_upd_pass".into()),
             metadata: Some(Default::default()),
-            rack_id: None,
-            bmc_ip_address: String::new(),
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         },
         rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac_address.to_string(),
             nvos_mac_addresses: nvos_mac_addresses.clone(),
             bmc_username: "ADMIN_UPDATE1".into(),
@@ -395,9 +348,7 @@ async fn test_update_expected_switch(pool: sqlx::PgPool) {
                 ],
             }),
             rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
-            bmc_ip_address: String::new(),
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         },
     ] {
         env.api
@@ -502,10 +453,7 @@ async fn test_get_expected_switch_by_id(pool: sqlx::PgPool) {
         nvos_username: Some("nvos_user".into()),
         nvos_password: Some("nvos_pass".into()),
         metadata: Some(rpc::forge::Metadata::default()),
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     env.api
@@ -542,13 +490,8 @@ async fn test_delete_expected_switch_by_id(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         switch_serial_number: "SW-DEL-ID-001".into(),
-        nvos_username: None,
-        nvos_password: None,
         metadata: Some(rpc::forge::Metadata::default()),
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     env.api
@@ -600,10 +543,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
         nvos_username: Some("nvos_user".into()),
         nvos_password: Some("nvos_pass".into()),
         metadata: Some(rpc::forge::Metadata::default()),
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     env.api
@@ -630,10 +570,7 @@ async fn test_update_expected_switch_by_id(pool: sqlx::PgPool) {
                 value: Some("staging".to_string()),
             }],
         }),
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     env.api
@@ -670,13 +607,8 @@ async fn test_create_expected_switch_with_explicit_id(pool: sqlx::PgPool) {
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         switch_serial_number: "SW-EXPLICIT-001".into(),
-        nvos_username: None,
-        nvos_password: None,
         metadata: Some(rpc::forge::Metadata::default()),
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     env.api
@@ -708,19 +640,13 @@ async fn test_create_expected_switch_auto_generates_id(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
 
     let expected_switch = rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: "3A:3B:3C:3D:3E:3F".to_string(),
         nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:3F".to_string()],
         bmc_username: "ADMIN".into(),
         bmc_password: "PASS".into(),
         switch_serial_number: "SW-AUTO-001".into(),
-        nvos_username: None,
-        nvos_password: None,
         metadata: Some(rpc::forge::Metadata::default()),
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     env.api
@@ -820,19 +746,12 @@ async fn test_update_expected_switch_error(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
     let bmc_mac_address: MacAddress = "2A:2B:2C:2D:2E:2F".parse().unwrap();
     let expected_switch = rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: bmc_mac_address.to_string(),
         nvos_mac_addresses: vec!["3A:3B:3C:3D:3E:3F".to_string()],
         bmc_username: "ADMIN_UPDATE".into(),
         bmc_password: "PASS_UPDATE".into(),
         switch_serial_number: "SW-UPD-001".into(),
-        nvos_username: None,
-        nvos_password: None,
-        metadata: None,
-        rack_id: None,
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     let err = env
@@ -931,7 +850,6 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
     };
 
     let expected_switch_1 = rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: "6A:6B:6C:6D:6E:6F".into(),
         nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:6F".to_string()],
         bmc_username: "ADMIN_NEW".into(),
@@ -941,25 +859,18 @@ async fn test_replace_all_expected_switches(pool: sqlx::PgPool) {
         nvos_password: Some("nvos_new_pass".into()),
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     let expected_switch_2 = rpc::forge::ExpectedSwitch {
-        expected_switch_id: None,
         bmc_mac_address: "7A:7B:7C:7D:7E:7F".into(),
         nvos_mac_addresses: vec!["4A:4B:4C:4D:4E:7F".to_string()],
         bmc_username: "ADMIN_NEW".into(),
         bmc_password: "PASS_NEW".into(),
         switch_serial_number: "SW-NEW-002".into(),
-        nvos_username: None,
-        nvos_password: None,
         metadata: Some(rpc::Metadata::default()),
         rack_id: Some(RackId::new(uuid::Uuid::new_v4().to_string())),
-        bmc_ip_address: String::new(),
-        bmc_retain_credentials: None,
-        nvos_ip_address: None,
+        ..Default::default()
     };
 
     expected_switch_list
@@ -1106,19 +1017,14 @@ async fn test_add_with_bmc_ip_creates_static_interface(
 
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-STATIC-001".into(),
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
             bmc_ip_address: bmc_ip.into(),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         }))
         .await?;
 
@@ -1173,19 +1079,13 @@ async fn test_add_without_bmc_ip_creates_no_interface(
 
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-NO-IP-001".into(),
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         }))
         .await?;
 
@@ -1210,19 +1110,14 @@ async fn test_add_expected_switch_with_bmc_retain_credentials(
 
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-RETAIN-001".into(),
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
             bmc_retain_credentials: Some(true),
-            nvos_ip_address: None,
+            ..Default::default()
         }))
         .await?;
 
@@ -1256,38 +1151,27 @@ async fn test_update_expected_switch_preserves_bmc_retain_credentials(
     // Create with bmc_retain_credentials = true.
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-RETAIN-UPD-001".into(),
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
             bmc_retain_credentials: Some(true),
-            nvos_ip_address: None,
+            ..Default::default()
         }))
         .await?;
 
     // Update without setting bmc_retain_credentials (None).
     env.api
         .update_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "NEW-ADMIN".into(),
             bmc_password: "NEW-PASS".into(),
             switch_serial_number: "SW-RETAIN-UPD-001".into(),
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
-            nvos_ip_address: None,
+            ..Default::default()
         }))
         .await?;
 
@@ -1322,19 +1206,14 @@ async fn test_add_expected_switch_rejects_nvos_ip_without_mac(
     let err = env
         .api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-NVOS-NO-MAC".into(),
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             nvos_ip_address: Some("192.0.2.250".into()),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
+            ..Default::default()
         }))
         .await
         .expect_err("add must reject nvos_ip_address with no nvos_mac_addresses");
@@ -1355,7 +1234,6 @@ async fn test_add_expected_switch_rejects_nvos_ip_with_multiple_macs(
     let err = env
         .api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
@@ -1364,13 +1242,9 @@ async fn test_add_expected_switch_rejects_nvos_ip_with_multiple_macs(
                 "8A:8B:8C:8D:8E:01".to_string(),
                 "8A:8B:8C:8D:8E:02".to_string(),
             ],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             nvos_ip_address: Some("192.0.2.251".into()),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
+            ..Default::default()
         }))
         .await
         .expect_err("add must reject nvos_ip_address with multiple nvos_mac_addresses");
@@ -1392,19 +1266,14 @@ async fn test_add_expected_switch_with_nvos_ip_round_trips(
 
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-NVOS-OK".into(),
             nvos_mac_addresses: vec![nvos_mac.to_string()],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             nvos_ip_address: Some(nvos_ip.into()),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
+            ..Default::default()
         }))
         .await?;
 
@@ -1439,39 +1308,28 @@ async fn test_update_expected_switch_rejects_invalid_nvos_pairing(
 
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-NVOS-UPDATE".into(),
             nvos_mac_addresses: vec![nvos_mac.to_string()],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
-            nvos_ip_address: None,
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
+            ..Default::default()
         }))
         .await?;
 
     let err = env
         .api
         .update_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-NVOS-UPDATE".into(),
             // Drop the NVOS MAC but try to keep the IP -- pairing now invalid.
             nvos_mac_addresses: vec![],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             nvos_ip_address: Some("192.0.2.253".into()),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
+            ..Default::default()
         }))
         .await
         .expect_err("update must reject nvos_ip_address with no nvos_mac_addresses");
@@ -1496,19 +1354,14 @@ async fn test_dhcp_discover_preallocates_nvos_ip_for_unknown_mac(
 
     env.api
         .add_expected_switch(tonic::Request::new(rpc::forge::ExpectedSwitch {
-            expected_switch_id: None,
             bmc_mac_address: bmc_mac.to_string(),
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             switch_serial_number: "SW-NVOS-DHCP".into(),
             nvos_mac_addresses: vec![nvos_mac.to_string()],
-            nvos_username: None,
-            nvos_password: None,
-            bmc_ip_address: String::new(),
             nvos_ip_address: Some(nvos_ip.into()),
             metadata: Some(rpc::forge::Metadata::default()),
-            rack_id: None,
-            bmc_retain_credentials: None,
+            ..Default::default()
         }))
         .await?;
 

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -867,42 +867,7 @@ impl TransactionVending for PgPool {
 #[cfg(test)]
 #[ctor::ctor(unsafe)]
 fn setup_test_logging() {
-    use tracing::metadata::LevelFilter;
-    use tracing_subscriber::filter::EnvFilter;
-    use tracing_subscriber::fmt::TestWriter;
-    use tracing_subscriber::prelude::*;
-    use tracing_subscriber::util::SubscriberInitExt;
-
-    // This duplicates code from api-test-helper, but we don't want to take a dependency on that.
-    // Copy/pasting is fine.
-    if let Err(e) = tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::Layer::default()
-                .compact()
-                .with_writer(TestWriter::new),
-        )
-        .with(
-            EnvFilter::builder()
-                .with_default_directive(LevelFilter::INFO.into())
-                .from_env_lossy()
-                .add_directive("sqlx=warn".parse().unwrap())
-                .add_directive("tower=warn".parse().unwrap())
-                .add_directive("rustify=off".parse().unwrap())
-                .add_directive("rustls=warn".parse().unwrap())
-                .add_directive("hyper=warn".parse().unwrap())
-                .add_directive("h2=warn".parse().unwrap())
-                // Silence permissive mode related messages
-                .add_directive("carbide_api_core::auth=error".parse().unwrap()),
-        )
-        .try_init()
-    {
-        // Note: Resist the temptation to ignore this error. We really should only have one place in
-        // the test binary that initializes logging.
-        panic!(
-            "Failed to initialize trace logging for api-db tests. It's possible some earlier \
-            code path has already set a global default log subscriber: {e}"
-        );
-    }
+    carbide_test_support::setup_test_logging("api-db");
 }
 
 #[cfg(test)]

--- a/crates/test-support/Cargo.toml
+++ b/crates/test-support/Cargo.toml
@@ -28,7 +28,7 @@ name = "carbide_test_support"
 
 [dependencies]
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -458,6 +458,54 @@ macro_rules! value_scenarios {
     };
 }
 
+/// Install the shared test log subscriber, naming `component` in the failure message.
+///
+/// Every test binary that wants tracing output needs the same registry, the same
+/// `TestWriter`, and the same set of noise-suppressing directives. `api-db` and `api-core`
+/// each grew their own copy of it -- `api-db`'s carried a comment saying as much, and
+/// declining to depend on `api-test-helper` was the reason. This crate is a leaf with no
+/// such problem, so the copy lives here now and both call it.
+///
+/// `component` only appears in the panic text, to say which binary tripped over an
+/// already-installed subscriber.
+///
+/// Panics if a global subscriber is already set. That's deliberate -- a test binary should
+/// initialize logging in exactly one place, and swallowing this hides the second one.
+pub fn setup_test_logging(component: &str) {
+    use tracing::metadata::LevelFilter;
+    use tracing_subscriber::filter::EnvFilter;
+    use tracing_subscriber::fmt::TestWriter;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    if let Err(e) = tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::Layer::default()
+                .compact()
+                .with_writer(TestWriter::new),
+        )
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy()
+                .add_directive("sqlx=warn".parse().unwrap())
+                .add_directive("tower=warn".parse().unwrap())
+                .add_directive("rustify=off".parse().unwrap())
+                .add_directive("rustls=warn".parse().unwrap())
+                .add_directive("hyper=warn".parse().unwrap())
+                .add_directive("h2=warn".parse().unwrap())
+                // Silence permissive mode related messages
+                .add_directive("carbide_api_core::auth=error".parse().unwrap()),
+        )
+        .try_init()
+    {
+        panic!(
+            "Failed to initialize trace logging for {component} tests. It's possible some earlier \
+            code path has already set a global default log subscriber: {e}"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Outcome::*;


### PR DESCRIPTION
`api-db` had its own copy of `setup_test_logging`, and the comment above it said so out loud -- *"This duplicates code from api-test-helper, but we don't want to take a dependency on that. Copy/pasting is fine."* Fair enough at the time, but `carbide-test-support` is a leaf crate with nothing in it beyond `tracing` and `tracing-subscriber`, so there's no dependency to care about now. The two real implementations were identical apart from the crate name in the panic message, which is now a parameter.

The four `dpf/` suites had each taken on their own `dpf_config` and `get_host_state`, which were also identical. So now:

- `setup_test_logging` lives in `carbide-test-support` and takes the component name. `api-core` needed `carbide-test-support` promoted from a dev-dependency to an optional one behind its existing `test-support` feature, because `api-core::test_support` compiles into the *lib* when `carbide-api-web` turns that feature on, and a dev-dependency never reaches it.
- `dpf_config` and `get_host_state` move up into `dpf/mod.rs`; seven definitions become two.
- `expected_switch.rs` gives up **176 lines** of `field: None` across 29 `ExpectedSwitch` literals. It's a `::prost::Message`, so every field dropped defaults to exactly what was written -- `Option` to `None`, `String` to empty. The file already used `..Default::default()` twice; now it does so throughout.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4225

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Function-level coverage A/B over `api-core`, `api-db` and `test-support`, baselined against the same `06495cda5` this branch sits on:

```
production functions -- base 31454, after 24815
covered              -- base 12543, after 12542
NEWLY COVERED (1): carbide_test_support::setup_test_logging
```

2,020 tests pass on both sides -- same five binaries, same counts. Coverage is flat, with the new shared helper picked up as you'd expect.

The one function on the wrong side of that arithmetic is `machine_controller::handler::is_host_powered_off`, which nothing here can reach. It sits behind a race -- the host is only checked while a DPU has yet to report UP -- and its execution count has measured 8, 5, 7, 4, 1 and 0 across six runs on three different commits. It landed on 1 in this baseline and 0 in this run. I've added a note to the comparison script so the next person doesn't spend the twenty minutes I did on it.

Closes #4225
