### PR TITLE
test: convert the mechanical tables and finish the silent-test sweep

### DIFF
--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -307,7 +307,8 @@ mod tests {
 
     use carbide_instrument::emit;
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::{Check, check_values, value_scenarios};
+    use opentelemetry::StringValue;
     use tokio::time::timeout;
 
     use super::*;
@@ -596,80 +597,30 @@ mod tests {
     /// as its snake_case name, byte for byte.
     #[test]
     fn label_values_render_as_snake_case() {
-        check_values(
-            [
-                Check {
-                    scenario: "principal allow-list authorization layer",
-                    input: AuthorizationLayer::PrincipalAllowList.label_value(),
-                    expect: "principal_allow_list".to_string(),
-                },
-                Check {
-                    scenario: "request ACL authorization layer",
-                    input: AuthorizationLayer::RequestAcl.label_value(),
-                    expect: "request_acl".to_string(),
-                },
-                Check {
-                    scenario: "get",
-                    input: MethodLabel::Get.label_value(),
-                    expect: "get".to_string(),
-                },
-                Check {
-                    scenario: "head",
-                    input: MethodLabel::Head.label_value(),
-                    expect: "head".to_string(),
-                },
-                Check {
-                    scenario: "post",
-                    input: MethodLabel::Post.label_value(),
-                    expect: "post".to_string(),
-                },
-                Check {
-                    scenario: "put",
-                    input: MethodLabel::Put.label_value(),
-                    expect: "put".to_string(),
-                },
-                Check {
-                    scenario: "patch",
-                    input: MethodLabel::Patch.label_value(),
-                    expect: "patch".to_string(),
-                },
-                Check {
-                    scenario: "delete",
-                    input: MethodLabel::Delete.label_value(),
-                    expect: "delete".to_string(),
-                },
-                Check {
-                    scenario: "other method",
-                    input: MethodLabel::Other.label_value(),
-                    expect: "other".to_string(),
-                },
-                Check {
-                    scenario: "2xx class",
-                    input: UpstreamStatus::Http2xx.label_value(),
-                    expect: "http2xx".to_string(),
-                },
-                Check {
-                    scenario: "3xx class",
-                    input: UpstreamStatus::Http3xx.label_value(),
-                    expect: "http3xx".to_string(),
-                },
-                Check {
-                    scenario: "4xx class",
-                    input: UpstreamStatus::Http4xx.label_value(),
-                    expect: "http4xx".to_string(),
-                },
-                Check {
-                    scenario: "5xx class",
-                    input: UpstreamStatus::Http5xx.label_value(),
-                    expect: "http5xx".to_string(),
-                },
-                Check {
-                    scenario: "no response",
-                    input: UpstreamStatus::Error.label_value(),
-                    expect: "error".to_string(),
-                },
-            ],
-            |value| value.to_string(),
+        value_scenarios!(
+            run = |value: StringValue| value.to_string();
+            "authorization layer" {
+                AuthorizationLayer::PrincipalAllowList.label_value() => "principal_allow_list".to_string(),
+                AuthorizationLayer::RequestAcl.label_value() => "request_acl".to_string(),
+            }
+
+            "proxied method" {
+                MethodLabel::Get.label_value() => "get".to_string(),
+                MethodLabel::Head.label_value() => "head".to_string(),
+                MethodLabel::Post.label_value() => "post".to_string(),
+                MethodLabel::Put.label_value() => "put".to_string(),
+                MethodLabel::Patch.label_value() => "patch".to_string(),
+                MethodLabel::Delete.label_value() => "delete".to_string(),
+                MethodLabel::Other.label_value() => "other".to_string(),
+            }
+
+            "upstream status class" {
+                UpstreamStatus::Http2xx.label_value() => "http2xx".to_string(),
+                UpstreamStatus::Http3xx.label_value() => "http3xx".to_string(),
+                UpstreamStatus::Http4xx.label_value() => "http4xx".to_string(),
+                UpstreamStatus::Http5xx.label_value() => "http5xx".to_string(),
+                UpstreamStatus::Error.label_value() => "error".to_string(),
+            }
         );
     }
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -3371,6 +3371,11 @@ mod tests {
             is_primary: true,
         };
         sdk.register_dpu_device(info).await.unwrap();
+
+        // This branch is a deliberate no-op: an existing, non-terminating device is left
+        // alone. `.unwrap()` only said no error came back -- assert no second device was
+        // created alongside it, which is the whole of what "left alone" means here.
+        assert_eq!(mock.devices.read().unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -3448,6 +3453,9 @@ mod tests {
             deployment_type: DpuDeploymentType::Bf3,
         };
         sdk.register_dpu_node(info).await.unwrap();
+
+        // Same no-op branch for nodes.
+        assert_eq!(mock.nodes.read().unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -3599,12 +3607,14 @@ mod tests {
                 .unique_name(crate::flavor::DEFAULT_FLAVOR_NAME)
                 .unwrap(),
         );
+        let flavor_name = flavor.metadata.name.clone().unwrap();
         mock.flavors
             .write()
             .unwrap()
             .insert(SdkMock::key(&flavor), flavor);
 
-        create_dpu_flavor(
+        let expected_name = flavor_name.clone();
+        let returned = create_dpu_flavor(
             &mock,
             TEST_NAMESPACE,
             crate::flavor::DEFAULT_FLAVOR_NAME,
@@ -3613,6 +3623,12 @@ mod tests {
         )
         .await
         .unwrap();
+
+        // The whole contract of this branch is "reuse what's already there". `.unwrap()`
+        // only proved it didn't error -- so check it hands back the existing flavor's name
+        // and, more to the point, that it didn't quietly create a second one alongside it.
+        assert_eq!(returned, expected_name);
+        assert_eq!(mock.flavors.read().unwrap().len(), 1);
     }
 
     #[derive(Clone, Default)]

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -758,55 +758,22 @@ mod tests {
     /// covers `SystemPowerControl` variant for variant.
     #[test]
     fn power_operation_label_covers_every_system_power_control() {
-        check_values(
-            [
-                Check {
-                    scenario: "power on",
-                    input: PowerOperation::from(SystemPowerControl::On),
-                    expect: "on".to_string(),
-                },
-                Check {
-                    scenario: "graceful shutdown",
-                    input: PowerOperation::from(SystemPowerControl::GracefulShutdown),
-                    expect: "graceful_shutdown".to_string(),
-                },
-                Check {
-                    scenario: "force off",
-                    input: PowerOperation::from(SystemPowerControl::ForceOff),
-                    expect: "force_off".to_string(),
-                },
-                Check {
-                    scenario: "graceful restart",
-                    input: PowerOperation::from(SystemPowerControl::GracefulRestart),
-                    expect: "graceful_restart".to_string(),
-                },
-                Check {
-                    scenario: "force restart",
-                    input: PowerOperation::from(SystemPowerControl::ForceRestart),
-                    expect: "force_restart".to_string(),
-                },
-                Check {
-                    scenario: "AC powercycle",
-                    input: PowerOperation::from(SystemPowerControl::ACPowercycle),
-                    expect: "ac_powercycle".to_string(),
-                },
-                Check {
-                    scenario: "powercycle",
-                    input: PowerOperation::from(SystemPowerControl::PowerCycle),
-                    expect: "power_cycle".to_string(),
-                },
-                Check {
-                    scenario: "BMC reset",
-                    input: PowerOperation::BmcReset,
-                    expect: "bmc_reset".to_string(),
-                },
-                Check {
-                    scenario: "chassis reset",
-                    input: PowerOperation::ChassisReset,
-                    expect: "chassis_reset".to_string(),
-                },
-            ],
-            |operation| operation.label_value().to_string(),
+        value_scenarios!(
+            run = |operation: PowerOperation| operation.label_value().to_string();
+            "mapped from SystemPowerControl" {
+                PowerOperation::from(SystemPowerControl::On) => "on".to_string(),
+                PowerOperation::from(SystemPowerControl::GracefulShutdown) => "graceful_shutdown".to_string(),
+                PowerOperation::from(SystemPowerControl::ForceOff) => "force_off".to_string(),
+                PowerOperation::from(SystemPowerControl::GracefulRestart) => "graceful_restart".to_string(),
+                PowerOperation::from(SystemPowerControl::ForceRestart) => "force_restart".to_string(),
+                PowerOperation::from(SystemPowerControl::ACPowercycle) => "ac_powercycle".to_string(),
+                PowerOperation::from(SystemPowerControl::PowerCycle) => "power_cycle".to_string(),
+            }
+
+            "not reachable from SystemPowerControl" {
+                PowerOperation::BmcReset => "bmc_reset".to_string(),
+                PowerOperation::ChassisReset => "chassis_reset".to_string(),
+            }
         );
     }
 
@@ -814,65 +781,23 @@ mod tests {
     /// would: the variant's snake_case name, for every component type.
     #[test]
     fn firmware_component_label_renders_snake_case() {
-        check_values(
-            [
-                Check {
-                    scenario: "BMC",
-                    input: FirmwareComponentType::Bmc,
-                    expect: "bmc".to_string(),
-                },
-                Check {
-                    scenario: "CEC",
-                    input: FirmwareComponentType::Cec,
-                    expect: "cec".to_string(),
-                },
-                Check {
-                    scenario: "UEFI",
-                    input: FirmwareComponentType::Uefi,
-                    expect: "uefi".to_string(),
-                },
-                Check {
-                    scenario: "NIC",
-                    input: FirmwareComponentType::Nic,
-                    expect: "nic".to_string(),
-                },
-                Check {
-                    scenario: "CPLD MB",
-                    input: FirmwareComponentType::CpldMb,
-                    expect: "cpld_mb".to_string(),
-                },
-                Check {
-                    scenario: "CPLD PDB",
-                    input: FirmwareComponentType::CpldPdb,
-                    expect: "cpld_pdb".to_string(),
-                },
-                Check {
-                    scenario: "HGX BMC",
-                    input: FirmwareComponentType::HGXBmc,
-                    expect: "hgx_bmc".to_string(),
-                },
-                Check {
-                    scenario: "combined BMC+UEFI",
-                    input: FirmwareComponentType::CombinedBmcUefi,
-                    expect: "combined_bmc_uefi".to_string(),
-                },
-                Check {
-                    scenario: "GPU",
-                    input: FirmwareComponentType::Gpu,
-                    expect: "gpu".to_string(),
-                },
-                Check {
-                    scenario: "CX7",
-                    input: FirmwareComponentType::Cx7,
-                    expect: "cx7".to_string(),
-                },
-                Check {
-                    scenario: "unknown",
-                    input: FirmwareComponentType::Unknown,
-                    expect: "unknown".to_string(),
-                },
-            ],
-            |component| FirmwareComponentLabel(component).label_value().to_string(),
+        value_scenarios!(
+            run = |component: FirmwareComponentType| {
+                FirmwareComponentLabel(component).label_value().to_string()
+            };
+            "every component type" {
+                FirmwareComponentType::Bmc => "bmc".to_string(),
+                FirmwareComponentType::Cec => "cec".to_string(),
+                FirmwareComponentType::Uefi => "uefi".to_string(),
+                FirmwareComponentType::Nic => "nic".to_string(),
+                FirmwareComponentType::CpldMb => "cpld_mb".to_string(),
+                FirmwareComponentType::CpldPdb => "cpld_pdb".to_string(),
+                FirmwareComponentType::HGXBmc => "hgx_bmc".to_string(),
+                FirmwareComponentType::CombinedBmcUefi => "combined_bmc_uefi".to_string(),
+                FirmwareComponentType::Gpu => "gpu".to_string(),
+                FirmwareComponentType::Cx7 => "cx7".to_string(),
+                FirmwareComponentType::Unknown => "unknown".to_string(),
+            }
         );
     }
 


### PR DESCRIPTION
`carbide-test-support` gives us two ways to write a table test -- the explicit `Case{}`/`Check{}` array and the `scenarios!`/`value_scenarios!` macros -- and the macro form is roughly a third of the lines per row. Where the row's input reads as well as its hand-written label, the explicit form is just ceremony, and three of the label-mapping tables here were exactly that: a `FirmwareComponentType` or a `MethodLabel` on one side, its snake_case string on the other.

The narrowness is the point, though. `scenarios!` builds its label as `concat!(group, " / ", stringify!(input))`, so a row whose input is a multi-field struct comes back with the whole literal as its label -- worse than the prose it replaced. Of the 1,839 explicit rows in the tree, **658 are that case** and another **756 have a label saying something the input never will** (`"punctuation is normalized"` is not derivable from `"a,b"`). Only about **360** are safe to move, and past the handful converted here they thin out to two or three per file. I left the rest alone rather than churn 70-odd files for the tail.

- **Three label tables collapse**: `power_operation_label_covers_every_system_power_control` (52 lines to 19), `firmware_component_label_renders_snake_case` (62 to 20), and `label_values_render_as_snake_case` in `bmc-proxy` (77 to 27). Same rows, same assertions, same order -- and `stringify!` gives a *better* label here than the prose did, since `PowerOperation::from(SystemPowerControl::GracefulShutdown)` says more than `"graceful shutdown"`.
- **The three `dpf/sdk.rs` tests left over from #4190 now assert something.** All three drive the branch where an existing, non-terminating resource is deliberately left alone, and all three checked only that no error came back -- so a call that quietly created a duplicate would have passed. They now assert the mock still holds exactly one device, node, or flavor. `create_dpu_flavor` also returns the existing name, which is the whole idempotent-reuse contract and was being discarded.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4224

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Function-level coverage A/B over `preingestion-manager`, `bmc-proxy` and `dpf`, baselined on the same `06495cda5` this branch sits on:

```
production functions -- base 30075, after 22848
covered              -- base 1748, after 1748
RESULT: PASS -- no production function lost its coverage
```

**Exactly flat, which is the result you want from a conversion** -- the rows and their assertions are unchanged, only how they're written is. The `dpf` half tightens assertions on paths already being executed, so it doesn't move the function-level number either. All suites green.

Lint gate green (`format-nightly`, `clippy`, `carbide-lints`), no `Cargo.lock` drift.

## Additional Notes

For anyone converting more of these later: `label_value()` returns `opentelemetry::StringValue`, and the explicit form was inferring that through `check_values`. The macro form needs it spelled out on the `run =` closure, and the import added.

This is the last of the five PRs under #3914. Worth recording that the audit driving that epic was directionally useful and numerically unreliable throughout -- it claimed ~11,000 lines of duplicate tests (3,713 were real), 119 silent tests (44 were real), and ~6,500 lines of collapsible table rows (about 360 rows were genuinely safe). Every PR in the series re-verified its candidates against `main` before touching them, and the coverage A/B was the gate throughout.


Closes #4224
