### PR TITLE
Upgrade postgres operator crd version

### DIFF
--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -65,7 +65,7 @@ releases:
     namespace: postgres
     createNamespace: true
     chart: postgres-operator/postgres-operator
-    version: "1.10.1"
+    version: "1.11.0"
     wait: true
     timeout: 600
     values:


### PR DESCRIPTION
Version 1.10.1 is removed from source and hence we need to upgrade to newer version

## Related issues

## Type of Change
<!-- Check one that best describes this PR -->
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

