### PR TITLE
Fix DPU firmware update health alert never clearing on DPF hosts

### DIFF
--- a/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
@@ -174,11 +174,19 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
             "found updated machines",
         );
         for updated_machine in updated_machines {
-            if self
-                .config
-                .dpu_config
-                .dpu_nic_firmware_update_versions
-                .contains(&updated_machine.firmware_version)
+            // DPF picks update targets by the DPUDeployment's expected BFB, not
+            // by `dpu_nic_firmware_update_versions` — `find_outdated_dpus` skips
+            // DPF hosts outright. Holding a DPF host's reported NIC firmware
+            // against that list therefore never matches, which used to leave the
+            // HostUpdateInProgress marker (and its prevent_allocations alert)
+            // pinned forever after a successful reprovision. The reprovision
+            // completing is the completion signal for DPF hosts.
+            if updated_machine.dpf_managed
+                || self
+                    .config
+                    .dpu_config
+                    .dpu_nic_firmware_update_versions
+                    .contains(&updated_machine.firmware_version)
             {
                 if let Err(e) =
                     MachineUpdateManager::remove_machine_update_markers(txn, &updated_machine).await

--- a/crates/api-core/src/tests/dpu_machine_update.rs
+++ b/crates/api-core/src/tests/dpu_machine_update.rs
@@ -324,6 +324,7 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
             host_machine_id: mh.host().id,
             dpu_machine_id: mh.dpu_n(0).id,
             firmware_version: "test_version".to_string(),
+            dpf_managed: false,
         }],
     )
     .await
@@ -382,11 +383,13 @@ async fn test_find_available_outdated_dpus_multidpu_both_under_reprov(
                 host_machine_id: mh.host().id,
                 dpu_machine_id: all_dpus[1].id,
                 firmware_version: "test_version".to_string(),
+                dpf_managed: false,
             },
             DpuMachineUpdate {
                 host_machine_id: mh.host().id,
                 dpu_machine_id: all_dpus[0].id,
                 firmware_version: "test_version".to_string(),
+                dpf_managed: false,
             },
         ],
     )

--- a/crates/api-core/src/tests/dpu_nic_firmware.rs
+++ b/crates/api-core/src/tests/dpu_nic_firmware.rs
@@ -463,6 +463,86 @@ async fn test_wrong_version_failures_count_once_per_outcome(
     Ok(())
 }
 
+/// DPF picks update targets by the DPUDeployment's expected BFB, so a
+/// DPF-managed DPU's reported NIC firmware has no reason to appear in
+/// `dpu_nic_firmware_update_versions`. The completion path must not hold it
+/// against that list, or the HostUpdateInProgress alert stays pinned after the
+/// reprovision finishes and the host never becomes allocatable again.
+#[crate::sqlx_test]
+async fn test_clear_completed_updates_dpf_host_off_list_version(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    // Mark the host as DPF-ingested and pretend a DPF-driven reprovision just
+    // finished: the DPU is back with a firmware version outside the configured
+    // set, its reprovisioning flag is cleared, and the in-update marker is still
+    // on the host.
+    let mut txn = env.pool.begin().await?;
+    db::machine::mark_machine_ingestion_done_with_dpf(&mut txn, &mh.id).await?;
+    update_nic_firmware_version(&mut txn, &mh.dpu().id, "0.0.0-from-bfb").await?;
+    let query = r#"UPDATE machines set reprovisioning_requested = NULL where id = $1"#;
+    sqlx::query(query)
+        .bind(mh.dpu().id.to_string())
+        .execute(&mut *txn)
+        .await?;
+    db::machine::insert_health_report(
+        &mut txn,
+        &mh.id,
+        health_report::HealthReportApplyMode::Merge,
+        &create_host_update_health_report_dpufw(),
+        false,
+    )
+    .await?;
+    txn.commit().await?;
+
+    assert!(
+        !env.config
+            .dpu_config
+            .dpu_nic_firmware_update_versions
+            .contains(&"0.0.0-from-bfb".to_string()),
+        "the version the BFB landed must be off the NIC firmware allowlist",
+    );
+
+    let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
+        reported_wrong_versions: std::sync::Mutex::new(std::collections::HashSet::new()),
+        metrics: None,
+        config: env.config.clone(),
+        dpf: None,
+    };
+
+    let metrics = MetricsCapture::start();
+    let mut txn = env.pool.begin().await?;
+    dpu_nic_firmware_update
+        .clear_completed_updates(&mut txn)
+        .await?;
+
+    let managed_host = mh.snapshot(&mut txn).await;
+    assert!(
+        !managed_host
+            .host_snapshot
+            .health_reports
+            .merges
+            .contains_key(HOST_UPDATE_HEALTH_REPORT_SOURCE),
+        "DPF host must have its update marker removed once the reprovision completes",
+    );
+    assert!(managed_host.aggregate_health.alerts.is_empty());
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_firmware_update_failures_total",
+            &[
+                ("target", "dpu_nic"),
+                ("cause", "wrong_version_after_update"),
+            ],
+        ),
+        0.0,
+        "a DPF update landing off the NIC allowlist is not a wrong-version failure",
+    );
+
+    Ok(())
+}
+
 impl TestManagedHost {
     pub async fn update_nic_firmware_version(
         &self,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -7038,6 +7038,7 @@ async fn test_instance_creation_when_reprovision_is_triggered_parallel(
         host_machine_id: mh.host().id,
         dpu_machine_id: mh.dpu_ids[0],
         firmware_version: "test".to_string(),
+        dpf_managed: false,
     };
 
     db::dpu_machine_update::trigger_reprovisioning_for_managed_host(&mut txn, &[machine_update])

--- a/crates/api-core/src/tests/machine_update_manager.rs
+++ b/crates/api-core/src/tests/machine_update_manager.rs
@@ -165,6 +165,7 @@ async fn test_remove_machine_update_markers(
         host_machine_id,
         dpu_machine_id,
         firmware_version: "1".to_owned(),
+        dpf_managed: false,
     };
 
     let reference = &DpuReprovisionInitiator::Automatic(AutomaticFirmwareUpdateReference {
@@ -321,6 +322,7 @@ async fn test_get_updating_machines(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         host_machine_id: host_machine_id1,
         dpu_machine_id: dpu_machine_id1,
         firmware_version: "1".to_owned(),
+        dpf_managed: false,
     };
 
     let reference = &DpuReprovisionInitiator::Automatic(AutomaticFirmwareUpdateReference {

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -154,6 +154,8 @@ pub async fn get_updated_machines(
                 return None;
             }
 
+            let dpf_managed = managed_host.host_snapshot.config.dpf.used_for_ingestion;
+
             // We only signal an update as complete once ALL DPUs are done
             // That prevents removing the updating flags from the Host
             // if just one DPU completes the update
@@ -170,6 +172,7 @@ pub async fn get_updated_machines(
                         .and_then(|info| info.dpu_info.as_ref())
                         .map(|dpu_info| dpu_info.firmware_version.clone())
                         .unwrap_or_default(),
+                    dpf_managed,
                 })
                 .collect();
 

--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -27,6 +27,14 @@ pub struct DpuMachineUpdate {
     pub host_machine_id: MachineId,
     pub dpu_machine_id: MachineId,
     pub firmware_version: String,
+    /// Whether the owning host is ingested through DPF. DPF decides staleness
+    /// from the DPUDeployment's expected BFB, not from
+    /// `dpu_nic_firmware_update_versions`, so `firmware_version` on a
+    /// DPF-managed update is traceability only and must not be compared
+    /// against that config list. Defaults to `false` when the value is loaded
+    /// straight from a query that does not select it.
+    #[sqlx(default)]
+    pub dpf_managed: bool,
 }
 
 /// A DPU identified via DPF whose installed BFB no longer matches the
@@ -140,6 +148,7 @@ impl DpuMachineUpdate {
                             host_machine_id: *machine_id,
                             dpu_machine_id: dpu.id,
                             firmware_version,
+                            dpf_managed: false,
                         })
                     })
                     .collect();
@@ -182,6 +191,7 @@ impl DpuMachineUpdate {
                 host_machine_id: host_id,
                 dpu_machine_id: outdated.dpu_machine_id,
                 firmware_version: outdated.target_bfb.clone(),
+                dpf_managed: true,
             });
         }
 


### PR DESCRIPTION
DPF-ingested hosts never had their `HostUpdateInProgress` health alert removed after an automatic DPU firmware update finished. The machine would reprovision successfully, come back `Ready`, and then sit permanently with an `AutomaticDpuFirmwareUpdate` alert pinned to it. Non-DPF hosts were unaffected.

The cause is an asymmetry between how an update is *started* and how it is *completed*. DPF hosts are deliberately excluded from the version-based staleness check — `find_outdated_dpus` returns early for any host with `dpf.used_for_ingestion`, and `find_outdated_dpus_dpf` selects those hosts instead by comparing against the expected BFB from their `DPUDeployment`. The completion path had no such split: it only removed the update markers when the DPU's reported NIC firmware appeared in `dpu_nic_firmware_update_versions`, a config list that only ever contains NIC firmware version strings. Nothing in the DPF path constrains a DPU to land on a version from that list, so for a DPF host the comparison had no reason to ever match, and the marker was never removed.

The consequences went beyond a stale alert. The alert carries `prevent_allocations`, so affected hosts stayed unallocatable indefinitely. The lingering alert also makes `is_available_for_updates` return false, which excluded those hosts from every subsequent firmware update. And each manager pass emitted a spurious `WrongVersionAfterUpdate` failure metric for a host that had in fact updated correctly.

The fix carries the host's DPF-ingestion flag through `DpuMachineUpdate` so the completion path can mirror the split the start path already has, skipping the NIC-version comparison for DPF hosts. The rest of the completion gate is untouched: the host must still be holding the update marker, be in `ManagedHostState::Ready`, and have every one of its DPUs' `reprovisioning_requested` flags cleared before anything is removed.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Added `test_clear_completed_updates_dpf_host_off_list_version`, which marks a host DPF-ingested, lands its DPU on a firmware version asserted to be absent from `dpu_nic_firmware_update_versions`, clears the reprovisioning flag, and leaves the update marker in place. It asserts the health report is removed, aggregate health is clean, and no `wrong_version_after_update` failure is counted. The test fails against the previous behaviour.

Ran the `dpu_nic_firmware` (7 tests), `dpu_machine_update`, and `machine_update_manager` (18 tests) suites — all passing. Not yet exercised against a live DPF-managed cluster.

## Additional Notes

`DpuMachineUpdate::dpf_managed` is marked `#[sqlx(default)]` because the struct is also loaded via `FromRow` in `get_reprovisioning_machines`, whose query does not select the column; that path only consumes `host_machine_id`, so defaulting to `false` there is inert.

Worth a reviewer's opinion: when a DPF host's reprovision completes but the DPU is still mismatched against a `DPUDeployment` that changed mid-update, this clears the marker rather than retaining it. That is deliberate — `run_single_iteration` calls `clear_completed_updates` and then `start_updates` in the same pass, so the host is re-detected by `find_outdated_dpus_dpf` and the update is re-triggered immediately, with the marker re-applied. Retaining the marker instead would make `is_available_for_updates` false forever and recreate exactly the permanent-pin failure this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)