### PR TITLE
fix(rest-api): Simplify generated NICo CLI command paths

### DIFF
--- a/rest-api/cli/pkg/commands.go
+++ b/rest-api/cli/pkg/commands.go
@@ -87,10 +87,9 @@ var reservedBodyFlagNames = map[string]bool{
 	"data-file": true,
 }
 
-// commandPathOverrides is the final naming pass for generated commands. Each
-// value replaces the complete generated path for one OpenAPI operation ID.
-// Keep overrides here instead of adding more operation-name heuristics.
-var commandPathOverrides = map[string][]string{
+// commandPathAliases adds concise aliases for generated commands. The original
+// generated paths remain available for compatibility.
+var commandPathAliases = map[string][]string{
 	"bringup-rack":                                      {"rack", "bringup"},
 	"bringup-racks":                                     {"rack", "bringup-all"},
 	"cancel-task":                                       {"task", "cancel"},
@@ -147,7 +146,25 @@ OPTIONS:
 
 // BuildCommands converts parsed OpenAPI operations into a cli.Command tree grouped by tag.
 func BuildCommands(spec *Spec) []*cli.Command {
-	ops := applyCommandPathOverrides(collectOperations(spec))
+	commands := buildGeneratedCommands(spec)
+	operationIndex := newOperationIndex(spec)
+	for operationID, path := range commandPathAliases {
+		if len(path) < 2 {
+			panic(fmt.Sprintf("command path alias for %q must have at least two components", operationID))
+		}
+		operation, ok := operationIndex[operationID]
+		if !ok {
+			continue
+		}
+		operation.commandPath = path
+		commands = addCommandAtPath(commands, path, buildActionCommand(spec, operation, ""))
+	}
+	sortCommandTree(commands)
+	return commands
+}
+
+func buildGeneratedCommands(spec *Spec) []*cli.Command {
+	ops := collectOperations(spec)
 	grouped := groupByTag(ops)
 
 	tagDescriptions := make(map[string]string)
@@ -214,22 +231,6 @@ func collectOperations(spec *Spec) []resolvedOp {
 	return ops
 }
 
-func applyCommandPathOverrides(operations []resolvedOp) []resolvedOp {
-	for i := range operations {
-		path, ok := commandPathOverrides[operations[i].op.OperationID]
-		if !ok {
-			continue
-		}
-		if len(path) < 2 {
-			panic(fmt.Sprintf("command path override for %q must have at least two components", operations[i].op.OperationID))
-		}
-		operations[i].tag = path[0]
-		operations[i].action = path[len(path)-1]
-		operations[i].commandPath = path
-	}
-	return operations
-}
-
 func groupByTag(ops []resolvedOp) map[string][]resolvedOp {
 	grouped := make(map[string][]resolvedOp)
 	for _, op := range ops {
@@ -246,13 +247,8 @@ func buildTagSubcommands(spec *Spec, ops []resolvedOp) []*cli.Command {
 
 	var primaryOps []resolvedOp
 	subResourceOps := make(map[string][]resolvedOp)
-	var overriddenOps []resolvedOp
 
 	for _, op := range ops {
-		if len(op.commandPath) > 0 {
-			overriddenOps = append(overriddenOps, op)
-			continue
-		}
 		suffix := extractResourceSuffix(op.op.OperationID)
 		subRes := subResourceName(suffix, primary)
 		if subRes == "" {
@@ -317,10 +313,6 @@ func buildTagSubcommands(spec *Spec, ops []resolvedOp) []*cli.Command {
 		})
 	}
 
-	for _, op := range overriddenOps {
-		command := buildActionCommand(spec, op, "")
-		cmds = addCommandAtPath(cmds, op.commandPath[1:], command)
-	}
 	sortCommandTree(cmds)
 
 	return cmds
@@ -330,7 +322,21 @@ func addCommandAtPath(commands []*cli.Command, path []string, command *cli.Comma
 	if len(path) == 1 {
 		for _, existing := range commands {
 			if existing.Name == path[0] {
-				panic(fmt.Sprintf("command path override collides at %q", strings.Join(path, " ")))
+				if existing.Action == nil && len(existing.Subcommands) > 0 {
+					existing.Category = ""
+					existing.Usage = command.Usage
+					existing.UsageText = command.UsageText
+					existing.Flags = command.Flags
+					existing.Action = command.Action
+					return commands
+				}
+				if existing.Usage == command.Usage && existing.UsageText == command.UsageText {
+					return commands
+				}
+				panic(fmt.Sprintf(
+					"command path alias collides at %q: existing usage %q, alias usage %q",
+					strings.Join(path, " "), existing.UsageText, command.UsageText,
+				))
 			}
 		}
 		command.Name = path[0]
@@ -342,7 +348,7 @@ func addCommandAtPath(commands []*cli.Command, path []string, command *cli.Comma
 			continue
 		}
 		if existing.Action != nil {
-			panic(fmt.Sprintf("command path override cannot place a subcommand under action %q", existing.Name))
+			panic(fmt.Sprintf("command path alias cannot place a subcommand under action %q", existing.Name))
 		}
 		existing.Subcommands = addCommandAtPath(existing.Subcommands, path[1:], command)
 		return commands

--- a/rest-api/cli/pkg/commands.go
+++ b/rest-api/cli/pkg/commands.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,12 +24,13 @@ var (
 )
 
 type resolvedOp struct {
-	tag        string
-	action     string
-	method     string
-	path       string
-	op         *Operation
-	pathParams []Parameter
+	tag         string
+	action      string
+	commandPath []string
+	method      string
+	path        string
+	op          *Operation
+	pathParams  []Parameter
 }
 
 type operationIndex map[string]resolvedOp
@@ -85,6 +87,46 @@ var reservedBodyFlagNames = map[string]bool{
 	"data-file": true,
 }
 
+// commandPathOverrides is the final naming pass for generated commands. Each
+// value replaces the complete generated path for one OpenAPI operation ID.
+// Keep overrides here instead of adding more operation-name heuristics.
+var commandPathOverrides = map[string][]string{
+	"bringup-rack":                                      {"rack", "bringup"},
+	"bringup-racks":                                     {"rack", "bringup-all"},
+	"cancel-task":                                       {"task", "cancel"},
+	"create-or-update-host-firmware-config":             {"host-firmware-config", "update"},
+	"create-or-update-machine-health-report":            {"health-report", "update"},
+	"create-or-update-tenant-identity-config":           {"tenant-identity", "update"},
+	"create-or-update-tenant-identity-token-delegation": {"tenant-identity", "token-delegation", "update"},
+	"delete-all-expected-rack":                          {"expected-rack", "delete-all"},
+	"delete-tenant-identity-token-delegation":           {"tenant-identity", "token-delegation", "delete"},
+	"firmware-update-rack":                              {"rack", "firmware"},
+	"firmware-update-racks":                             {"rack", "firmware-all"},
+	"firmware-update-tray":                              {"tray", "firmware"},
+	"firmware-update-trays":                             {"tray", "firmware-all"},
+	"get-dpu-machines":                                  {"machine", "dpu", "get"},
+	"get-machine-gpu-stats":                             {"machine", "gpu-stats"},
+	"get-machine-instance-type-stats":                   {"machine", "instance-type-stats"},
+	"get-machine-instance-type-stats-summary":           {"machine", "instance-type-stats-summary"},
+	"get-rack-tasks":                                    {"rack", "task", "get"},
+	"get-tenant-identity-token-delegation":              {"tenant-identity", "token-delegation", "get"},
+	"get-tenant-instance-type-stats":                    {"tenant", "instance-type-stats"},
+	"get-tray-tasks":                                    {"tray", "task", "get"},
+	"list-rules":                                        {"rule", "list"},
+	"machine-power-control-machine":                     {"machine", "power"},
+	"power-control-rack":                                {"rack", "power"},
+	"power-control-racks":                               {"rack", "power-all"},
+	"power-control-tray":                                {"tray", "power"},
+	"power-control-trays":                               {"tray", "power-all"},
+	"replace-all-expected-rack":                         {"expected-rack", "replace-all"},
+	"reprovision-machine-dpu":                           {"machine", "dpu", "reprovision"},
+	"reset-machine-bmc":                                 {"machine", "bmc", "reset"},
+	"validate-rack":                                     {"rack", "validate"},
+	"validate-racks":                                    {"rack", "validate-all"},
+	"validate-tray":                                     {"tray", "validate"},
+	"validate-trays":                                    {"tray", "validate-all"},
+}
+
 // subResourceHelpTemplate renders actions and sub-resources as separate sections.
 var subResourceHelpTemplate = `NAME:
    {{.HelpName}} - {{.Usage}}
@@ -105,7 +147,7 @@ OPTIONS:
 
 // BuildCommands converts parsed OpenAPI operations into a cli.Command tree grouped by tag.
 func BuildCommands(spec *Spec) []*cli.Command {
-	ops := collectOperations(spec)
+	ops := applyCommandPathOverrides(collectOperations(spec))
 	grouped := groupByTag(ops)
 
 	tagDescriptions := make(map[string]string)
@@ -172,6 +214,22 @@ func collectOperations(spec *Spec) []resolvedOp {
 	return ops
 }
 
+func applyCommandPathOverrides(operations []resolvedOp) []resolvedOp {
+	for i := range operations {
+		path, ok := commandPathOverrides[operations[i].op.OperationID]
+		if !ok {
+			continue
+		}
+		if len(path) < 2 {
+			panic(fmt.Sprintf("command path override for %q must have at least two components", operations[i].op.OperationID))
+		}
+		operations[i].tag = path[0]
+		operations[i].action = path[len(path)-1]
+		operations[i].commandPath = path
+	}
+	return operations
+}
+
 func groupByTag(ops []resolvedOp) map[string][]resolvedOp {
 	grouped := make(map[string][]resolvedOp)
 	for _, op := range ops {
@@ -188,8 +246,13 @@ func buildTagSubcommands(spec *Spec, ops []resolvedOp) []*cli.Command {
 
 	var primaryOps []resolvedOp
 	subResourceOps := make(map[string][]resolvedOp)
+	var overriddenOps []resolvedOp
 
 	for _, op := range ops {
+		if len(op.commandPath) > 0 {
+			overriddenOps = append(overriddenOps, op)
+			continue
+		}
 		suffix := extractResourceSuffix(op.op.OperationID)
 		subRes := subResourceName(suffix, primary)
 		if subRes == "" {
@@ -254,7 +317,56 @@ func buildTagSubcommands(spec *Spec, ops []resolvedOp) []*cli.Command {
 		})
 	}
 
+	for _, op := range overriddenOps {
+		command := buildActionCommand(spec, op, "")
+		cmds = addCommandAtPath(cmds, op.commandPath[1:], command)
+	}
+	sortCommandTree(cmds)
+
 	return cmds
+}
+
+func addCommandAtPath(commands []*cli.Command, path []string, command *cli.Command) []*cli.Command {
+	if len(path) == 1 {
+		for _, existing := range commands {
+			if existing.Name == path[0] {
+				panic(fmt.Sprintf("command path override collides at %q", strings.Join(path, " ")))
+			}
+		}
+		command.Name = path[0]
+		return append(commands, command)
+	}
+
+	for _, existing := range commands {
+		if existing.Name != path[0] {
+			continue
+		}
+		if existing.Action != nil {
+			panic(fmt.Sprintf("command path override cannot place a subcommand under action %q", existing.Name))
+		}
+		existing.Subcommands = addCommandAtPath(existing.Subcommands, path[1:], command)
+		return commands
+	}
+
+	group := &cli.Command{
+		Name:     path[0],
+		Category: "Sub-resources",
+		Usage:    path[0] + " operations",
+	}
+	group.Subcommands = addCommandAtPath(group.Subcommands, path[1:], command)
+	return append(commands, group)
+}
+
+func sortCommandTree(commands []*cli.Command) {
+	sort.Slice(commands, func(i, j int) bool { return commands[i].Name < commands[j].Name })
+	for _, command := range commands {
+		sortCommandTree(command.Subcommands)
+		if slices.ContainsFunc(command.Subcommands, func(child *cli.Command) bool {
+			return child.Category != ""
+		}) {
+			command.CustomHelpTemplate = subResourceHelpTemplate
+		}
+	}
 }
 
 func detectPrimaryResource(ops []resolvedOp) string {
@@ -408,11 +520,17 @@ func buildActionCommand(spec *Spec, ro resolvedOp, subResource string) *cli.Comm
 		return flags[i].Names()[0] < flags[j].Names()[0]
 	})
 
-	usageText := binaryName + " " + tagToCommand(ro.tag)
-	if subResource != "" {
-		usageText += " " + subResource
+	usageText := binaryName
+	if len(ro.commandPath) > 0 {
+		usageText += " " + strings.Join(ro.commandPath, " ")
+	} else {
+		usageText += " " + tagToCommand(ro.tag)
+		if subResource != "" {
+			usageText += " " + subResource
+		}
+		usageText += " " + ro.action
 	}
-	usageText += " " + ro.action + " [command options]"
+	usageText += " [command options]"
 	for _, ap := range argParams {
 		usageText += " <" + ap + ">"
 	}

--- a/rest-api/cli/pkg/commands_test.go
+++ b/rest-api/cli/pkg/commands_test.go
@@ -419,57 +419,70 @@ func TestNewApp_MachinePowerUsesConciseCommand(t *testing.T) {
 	assert.Contains(t, output.String(), "nicocli machine power [command options] <machineId>")
 	assert.NotContains(t, output.String(), "power-control-machine")
 
-	spec, err := ParseSpec(openapi.Spec)
-	require.NoError(t, err)
-	assert.Nil(t, commandAtPath(BuildCommands(spec), []string{
-		"machine", "power-control-machine", "machine-power-control-machine",
-	}))
-}
-
-func TestNewApp_MachinePowerExecutesOriginalOperation(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		assert.Equal(t, http.MethodPatch, request.Method)
-		assert.Equal(t, "/v2/org/test-org/nico/machine/machine-1/power", request.URL.Path)
-		assert.Equal(t, "Bearer test-token", request.Header.Get("Authorization"))
-
-		body, err := io.ReadAll(request.Body)
-		require.NoError(t, err)
-		assert.JSONEq(t, `{"action":"ForceRestart"}`, string(body))
-
-		response.Header().Set("Content-Type", "application/json")
-		_, err = response.Write([]byte(`{"status":"accepted"}`))
-		require.NoError(t, err)
-	}))
-	defer server.Close()
-
-	app, err := NewApp(openapi.Spec)
-	require.NoError(t, err)
-	app.Writer = io.Discard
-
+	output.Reset()
 	require.NoError(t, app.Run([]string{
-		"nicocli",
-		"--base-url", server.URL,
-		"--org", "test-org",
-		"--api-name", "nico",
-		"--token", "test-token",
-		"machine", "power",
-		"--action", "ForceRestart",
-		"machine-1",
+		"nicocli", "machine", "power-control-machine", "machine-power-control-machine", "--help",
 	}))
+	assert.Contains(t, output.String(),
+		"nicocli machine power-control-machine machine-power-control-machine [command options] <machineId>")
 }
 
-func TestBuildCommands_AppliesEveryCommandPathOverride(t *testing.T) {
+func TestNewApp_MachinePowerAliasesExecuteSameOperation(t *testing.T) {
+	tests := map[string][]string{
+		"concise alias": {"machine", "power"},
+		"generated path": {
+			"machine", "power-control-machine", "machine-power-control-machine",
+		},
+	}
+
+	for name, commandPath := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				assert.Equal(t, http.MethodPatch, request.Method)
+				assert.Equal(t, "/v2/org/test-org/nico/machine/machine-1/power", request.URL.Path)
+				assert.Equal(t, "Bearer test-token", request.Header.Get("Authorization"))
+
+				body, err := io.ReadAll(request.Body)
+				require.NoError(t, err)
+				assert.JSONEq(t, `{"action":"ForceRestart"}`, string(body))
+
+				response.Header().Set("Content-Type", "application/json")
+				_, err = response.Write([]byte(`{"status":"accepted"}`))
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			app, err := NewApp(openapi.Spec)
+			require.NoError(t, err)
+			app.Writer = io.Discard
+
+			args := []string{
+				"nicocli",
+				"--base-url", server.URL,
+				"--org", "test-org",
+				"--api-name", "nico",
+				"--token", "test-token",
+			}
+			args = append(args, commandPath...)
+			args = append(args, "--action", "ForceRestart", "machine-1")
+			require.NoError(t, app.Run(args))
+		})
+	}
+}
+
+func TestBuildCommands_AddsEveryCommandPathAlias(t *testing.T) {
 	spec, err := ParseSpec(openapi.Spec)
 	require.NoError(t, err)
 
 	commands := BuildCommands(spec)
+	generatedCommands := buildGeneratedCommands(spec)
 	operations := newOperationIndex(spec)
 	seenPaths := make(map[string]string)
 
-	for operationID, path := range commandPathOverrides {
+	for operationID, path := range commandPathAliases {
 		pathText := strings.Join(path, " ")
 		if previousOperationID, exists := seenPaths[pathText]; exists {
-			t.Errorf("operations %q and %q both override to %q", previousOperationID, operationID, pathText)
+			t.Errorf("operations %q and %q both alias to %q", previousOperationID, operationID, pathText)
 		}
 		seenPaths[pathText] = operationID
 
@@ -477,10 +490,18 @@ func TestBuildCommands_AppliesEveryCommandPathOverride(t *testing.T) {
 		require.NoError(t, err)
 
 		command := commandAtPath(commands, path)
-		require.NotNilf(t, command, "override for %q did not create command path %q", operationID, pathText)
+		require.NotNilf(t, command, "alias for %q did not create command path %q", operationID, pathText)
+		assert.NotNilf(t, command.Action, "alias for %q is not executable at path %q", operationID, pathText)
 		assert.Equal(t, operation.op.Summary, command.Usage)
 		assert.Truef(t, strings.HasPrefix(command.UsageText, binaryName+" "+pathText+" [command options]"),
-			"override for %q produced UsageText %q", operationID, command.UsageText)
+			"alias for %q produced UsageText %q", operationID, command.UsageText)
+
+		if generatedCommand := commandAtPath(generatedCommands, path); generatedCommand != nil {
+			if generatedCommand.Action != nil {
+				assert.Equal(t, command.Usage, generatedCommand.Usage)
+				assert.Equal(t, command.UsageText, generatedCommand.UsageText)
+			}
+		}
 	}
 }
 
@@ -501,9 +522,20 @@ func TestBuildCommands_ContainsEveryOperationAtUniquePath(t *testing.T) {
 			paths[path] = true
 		}
 	}
-	visit("", BuildCommands(spec))
+	generatedCommands := buildGeneratedCommands(spec)
+	visit("", generatedCommands)
+	require.Len(t, paths, len(collectOperations(spec)))
 
-	assert.Len(t, paths, len(collectOperations(spec)))
+	expectedPathCount := len(paths)
+	for _, path := range commandPathAliases {
+		if commandAtPath(generatedCommands, path) == nil {
+			expectedPathCount++
+		}
+	}
+
+	paths = make(map[string]bool)
+	visit("", BuildCommands(spec))
+	assert.Len(t, paths, expectedPathCount)
 }
 
 func TestAddCommandAtPathSupportsArbitraryDepth(t *testing.T) {

--- a/rest-api/cli/pkg/commands_test.go
+++ b/rest-api/cli/pkg/commands_test.go
@@ -6,6 +6,9 @@ package cli
 import (
 	"bytes"
 	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -403,6 +406,127 @@ func TestBuildCommands_NoDuplicateFlags(t *testing.T) {
 		}
 	}
 	visit("nicocli", cmds)
+}
+
+func TestNewApp_MachinePowerUsesConciseCommand(t *testing.T) {
+	app, err := NewApp(openapi.Spec)
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	app.Writer = &output
+	require.NoError(t, app.Run([]string{"nicocli", "machine", "power", "--help"}))
+
+	assert.Contains(t, output.String(), "nicocli machine power [command options] <machineId>")
+	assert.NotContains(t, output.String(), "power-control-machine")
+
+	spec, err := ParseSpec(openapi.Spec)
+	require.NoError(t, err)
+	assert.Nil(t, commandAtPath(BuildCommands(spec), []string{
+		"machine", "power-control-machine", "machine-power-control-machine",
+	}))
+}
+
+func TestNewApp_MachinePowerExecutesOriginalOperation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, http.MethodPatch, request.Method)
+		assert.Equal(t, "/v2/org/test-org/nico/machine/machine-1/power", request.URL.Path)
+		assert.Equal(t, "Bearer test-token", request.Header.Get("Authorization"))
+
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"action":"ForceRestart"}`, string(body))
+
+		response.Header().Set("Content-Type", "application/json")
+		_, err = response.Write([]byte(`{"status":"accepted"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	app, err := NewApp(openapi.Spec)
+	require.NoError(t, err)
+	app.Writer = io.Discard
+
+	require.NoError(t, app.Run([]string{
+		"nicocli",
+		"--base-url", server.URL,
+		"--org", "test-org",
+		"--api-name", "nico",
+		"--token", "test-token",
+		"machine", "power",
+		"--action", "ForceRestart",
+		"machine-1",
+	}))
+}
+
+func TestBuildCommands_AppliesEveryCommandPathOverride(t *testing.T) {
+	spec, err := ParseSpec(openapi.Spec)
+	require.NoError(t, err)
+
+	commands := BuildCommands(spec)
+	operations := newOperationIndex(spec)
+	seenPaths := make(map[string]string)
+
+	for operationID, path := range commandPathOverrides {
+		pathText := strings.Join(path, " ")
+		if previousOperationID, exists := seenPaths[pathText]; exists {
+			t.Errorf("operations %q and %q both override to %q", previousOperationID, operationID, pathText)
+		}
+		seenPaths[pathText] = operationID
+
+		operation, err := operations.require(operationID)
+		require.NoError(t, err)
+
+		command := commandAtPath(commands, path)
+		require.NotNilf(t, command, "override for %q did not create command path %q", operationID, pathText)
+		assert.Equal(t, operation.op.Summary, command.Usage)
+		assert.Truef(t, strings.HasPrefix(command.UsageText, binaryName+" "+pathText+" [command options]"),
+			"override for %q produced UsageText %q", operationID, command.UsageText)
+	}
+}
+
+func TestBuildCommands_ContainsEveryOperationAtUniquePath(t *testing.T) {
+	spec, err := ParseSpec(openapi.Spec)
+	require.NoError(t, err)
+
+	paths := make(map[string]bool)
+	var visit func(prefix string, commands []*cli.Command)
+	visit = func(prefix string, commands []*cli.Command) {
+		for _, command := range commands {
+			path := strings.TrimSpace(prefix + " " + command.Name)
+			if len(command.Subcommands) > 0 {
+				visit(path, command.Subcommands)
+				continue
+			}
+			assert.Falsef(t, paths[path], "duplicate generated command path %q", path)
+			paths[path] = true
+		}
+	}
+	visit("", BuildCommands(spec))
+
+	assert.Len(t, paths, len(collectOperations(spec)))
+}
+
+func TestAddCommandAtPathSupportsArbitraryDepth(t *testing.T) {
+	command := &cli.Command{Name: "generated-name"}
+	path := []string{"group", "nested", "run"}
+
+	commands := addCommandAtPath(nil, path, command)
+
+	assert.Same(t, command, commandAtPath(commands, path))
+	assert.Equal(t, "run", command.Name)
+}
+
+func commandAtPath(commands []*cli.Command, path []string) *cli.Command {
+	for _, command := range commands {
+		if command.Name != path[0] {
+			continue
+		}
+		if len(path) == 1 {
+			return command
+		}
+		return commandAtPath(command.Subcommands, path[1:])
+	}
+	return nil
 }
 
 // TestBuildActionCommand_ReservedBodyPropertyPrefixed verifies that when a


### PR DESCRIPTION
Generated `nicocli` commands currently repeat OpenAPI operation IDs in paths such as `machine power-control-machine machine-power-control-machine`. This change applies a centralized operation-ID alias map after generic command generation so affected operations also have concise paths while their generated paths remain available.

## Related issues
None.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
`go test ./cli/...` excluding the existing site-bootstrap test, `go vet ./cli/...`, and the CLI build passed. `TestSiteBootstrapCommandWritesReplayableManifest` still returns the same 404 on the base commit.
