### PR TITLE
patch(v2.0): Backport fix for DPU agent crash caused by extension service under DPF

### DIFF
--- a/crates/agent/src/extension_services/manager.rs
+++ b/crates/agent/src/extension_services/manager.rs
@@ -60,7 +60,12 @@ impl ExtensionServiceManager {
         self.service_handlers
             .get_mut(t)
             .map(|handler| handler.as_mut() as &mut dyn ExtensionServiceHandler)
-            .ok_or_else(|| eyre::eyre!("No handler for {:?}", t))
+            .ok_or_else(|| {
+                eyre::eyre!(
+                    "extension service type {:?} is not supported on this DPU",
+                    t
+                )
+            })
     }
 
     pub async fn update_desired_services(
@@ -108,8 +113,27 @@ impl ExtensionServiceManager {
 
         let mut service_statuses = Vec::with_capacity(service_configs.len());
         for service in service_configs {
-            let handler = self.get_handler_mut(&service.service_type).unwrap();
-            let status = handler.get_service_status(&service).await?;
+            let status = match self.get_handler_mut(&service.service_type) {
+                Ok(handler) => handler.get_service_status(&service).await?,
+                Err(err) => {
+                    tracing::error!(
+                        service_id = %service.id,
+                        error = %err,
+                        "Error getting extension service status"
+                    );
+                    rpc::DpuExtensionServiceStatusObservation {
+                        service_id: service.id.to_string(),
+                        service_type: service.service_type.into(),
+                        service_name: service.name,
+                        version: service.version.to_string(),
+                        removed: service.removed,
+                        state: rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceError
+                            .into(),
+                        components: vec![],
+                        message: err.to_string(),
+                    }
+                }
+            };
             service_statuses.push(status);
         }
 


### PR DESCRIPTION
> [!IMPORTANT]
> This MR cherry-picks [#4220](https://github.com/NVIDIA/infra-controller/pull/4220/changes) into `release/v2.0` and resolves confilct.

nvbug: https://nvbugspro.nvidia.com/bug/6522467