### PR TITLE
fix(api-core): return already exists error for duplicate sku creation

### DIFF
--- a/crates/api-core/src/handlers/sku.rs
+++ b/crates/api-core/src/handlers/sku.rs
@@ -38,7 +38,9 @@ pub(crate) async fn create(
 
     for sku in sku_list.skus {
         let sku: Sku = sku.into();
-        db::sku::create(&mut txn, &sku).await?;
+        db::sku::create(&mut txn, &sku)
+            .await
+            .map_err(CarbideError::from)?;
         sku_ids.ids.push(sku.id);
     }
 

--- a/crates/api-core/src/tests/sku.rs
+++ b/crates/api-core/src/tests/sku.rs
@@ -437,6 +437,37 @@ pub mod tests {
     }
 
     #[crate::sqlx_test]
+    pub async fn test_sku_create_duplicate_id_returns_already_exists(
+        pool: sqlx::PgPool,
+    ) -> Result<(), eyre::Error> {
+        use rpc::forge::SkuList;
+        use rpc::forge::forge_server::Forge;
+
+        let env = create_test_env(pool).await;
+        let sku: rpc::forge::Sku = serde_json::de::from_str(FULL_SKU_DATA)?;
+        let sku_id = sku.id.clone();
+        let mut conflicting_sku = sku.clone();
+        conflicting_sku.components.as_mut().unwrap().cpus[0].thread_count *= 2;
+
+        env.api
+            .create_sku(tonic::Request::new(SkuList { skus: vec![sku] }))
+            .await?;
+
+        let error = env
+            .api
+            .create_sku(tonic::Request::new(SkuList {
+                skus: vec![conflicting_sku],
+            }))
+            .await
+            .expect_err("Creating a SKU with a duplicate ID should fail");
+
+        assert_eq!(error.code(), tonic::Code::AlreadyExists);
+        assert_eq!(error.message(), format!("SKU already exists: {sku_id}"));
+
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
     pub async fn test_sku_create_rejects_empty_id(pool: sqlx::PgPool) -> Result<(), eyre::Error> {
         let mut txn = pool.begin().await?;
         let rpc_sku: rpc::forge::Sku = serde_json::de::from_str(FULL_SKU_DATA)?;

--- a/crates/api-db/src/sku.rs
+++ b/crates/api-db/src/sku.rs
@@ -164,7 +164,18 @@ pub async fn create(txn: &mut PgConnection, sku: &Sku) -> Result<(), DatabaseErr
         .bind(&sku.device_type)
         .fetch_one(inner_txn.as_pgconn())
         .await
-        .map_err(|e| DatabaseError::new("create sku", e))?;
+        .map_err(|e| {
+            if e.as_database_error()
+                .is_some_and(|e| e.is_unique_violation())
+            {
+                DatabaseError::AlreadyFoundError {
+                    kind: "SKU",
+                    id: sku.id.clone(),
+                }
+            } else {
+                DatabaseError::new("create sku", e)
+            }
+        })?;
 
     inner_txn.commit().await?;
 


### PR DESCRIPTION
## Summary

- map duplicate SKU ID database violations to the Core `AlreadyExists` error

## Why

Duplicate SKU IDs were previously surfaced as generic database errors. Returning `AlreadyExists` lets API clients distinguish the conflict from an internal failure.
