### PR TITLE
fix: validate expected interface roles and fixed addresses

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -133,7 +133,7 @@ pub struct Args {
     #[clap(
         long = "host_nics",
         value_name = "HOST_NICS",
-        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc and ip_allocation=dynamic|fixed|retained. An omitted role defaults to host. When ip_allocation is omitted, fixed_ip implies fixed; otherwise it defaults to dynamic.",
+        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc and ip_allocation=dynamic|fixed|retained. An omitted role defaults to host. When ip_allocation is omitted, fixed_ip implies fixed; otherwise it defaults to dynamic. Explicit fixed policies and DPU fixed addresses must fall within a configured managed prefix; legacy host entries with an omitted policy keep the static-assignments fallback.",
         action = clap::ArgAction::Append
     )]
     pub host_nics: Option<String>,

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use ::rpc::forge as rpc;
 use lazy_static::lazy_static;
@@ -394,6 +394,7 @@ fn validate_expected_interfaces(host_nics: &[ExpectedHostNic]) -> Result<(), Car
 fn validate_expected_interface_role_and_allocation(
     host_nics: &[ExpectedHostNic],
 ) -> Result<(), CarbideError> {
+    let mut roles_by_mac = HashMap::new();
     for interface in host_nics {
         interface.validate_ip_allocation().map_err(|message| {
             CarbideError::InvalidArgument(format!(
@@ -404,6 +405,19 @@ fn validate_expected_interface_role_and_allocation(
         if interface.primary.is_some() && !interface.role.is_host() {
             return Err(CarbideError::InvalidArgument(format!(
                 "only a role=host interface may set primary; {} has role {}",
+                interface.mac_address, interface.role,
+            )));
+        }
+        // One MAC may have separate IPv4 and IPv6 fixed reservations, so
+        // duplicate entries remain valid. Their role still has to agree:
+        // DHCP consumes one matching declaration while Site Explorer consumes
+        // every declaration, and role controls row type, primary behavior, and
+        // Redfish scanning in both paths.
+        if let Some(existing_role) = roles_by_mac.insert(interface.mac_address, interface.role)
+            && existing_role != interface.role
+        {
+            return Err(CarbideError::InvalidArgument(format!(
+                "host_nics entries for MAC {} must use the same role; found {existing_role} and {}",
                 interface.mac_address, interface.role,
             )));
         }
@@ -985,6 +999,92 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_expected_interface_macs_require_matching_roles() {
+        let shared_mac: MacAddress = "7A:7B:7C:7D:7E:81".parse().unwrap();
+        let other_mac: MacAddress = "7A:7B:7C:7D:7E:82".parse().unwrap();
+        let interface = |mac_address, role| ExpectedHostNic {
+            mac_address,
+            role,
+            ..Default::default()
+        };
+        let fixed_host = |fixed_ip| ExpectedHostNic {
+            mac_address: shared_mac,
+            fixed_ip: Some(fixed_ip),
+            ..Default::default()
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "legacy Host dual-stack reservations",
+                    input: vec![
+                        fixed_host("192.0.2.81".parse().unwrap()),
+                        fixed_host("2001:db8::81".parse().unwrap()),
+                    ],
+                    expect: true,
+                },
+                Check {
+                    scenario: "same DPU OS role",
+                    input: vec![
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        ),
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        ),
+                    ],
+                    expect: true,
+                },
+                Check {
+                    scenario: "different MACs may use different roles",
+                    input: vec![
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        ),
+                        interface(
+                            other_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuBmc,
+                        ),
+                    ],
+                    expect: true,
+                },
+                Check {
+                    scenario: "DPU OS then DPU BMC",
+                    input: vec![
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        ),
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuBmc,
+                        ),
+                    ],
+                    expect: false,
+                },
+                Check {
+                    scenario: "DPU BMC then DPU OS",
+                    input: vec![
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuBmc,
+                        ),
+                        interface(
+                            shared_mac,
+                            model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        ),
+                    ],
+                    expect: false,
+                },
+            ],
+            |host_nics| validate_expected_interface_role_and_allocation(&host_nics).is_ok(),
+        );
+    }
+
+    #[test]
     fn omitted_role_and_allocation_are_preserved_per_list_entry() {
         let mac_address: MacAddress = "7A:7B:7C:7D:7E:91".parse().unwrap();
         let existing = ExpectedMachine {
@@ -1005,7 +1105,7 @@ mod tests {
                     },
                     ExpectedHostNic {
                         mac_address,
-                        role: model::expected_machine::ExpectedInterfaceRole::DpuOs,
+                        role: model::expected_machine::ExpectedInterfaceRole::DpuBmc,
                         ip_allocation: Some(
                             model::expected_machine::ExpectedInterfaceIpAllocation::Dynamic,
                         ),
@@ -1044,7 +1144,7 @@ mod tests {
         assert_eq!(replacement.host_nics[0].network_segment_type, None);
         assert_eq!(
             replacement.host_nics[1].role,
-            Some(rpc::ExpectedInterfaceRole::DpuOs as i32),
+            Some(rpc::ExpectedInterfaceRole::DpuBmc as i32),
         );
         assert_eq!(
             replacement.host_nics[1].ip_allocation,

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -81,6 +81,7 @@ pub async fn update_preallocated_expected_machine_interface(
             interface_type: expected_interface.role.interface_type(),
             primary_interface: expected_interface.role.primary_interface_override(),
             segment_type_guard: expected_interface.segment_type_guard(),
+            require_managed_prefix: !expected_interface.uses_legacy_host_allocation(),
         }),
         retained_window,
     )
@@ -101,6 +102,9 @@ struct ExpectedInterfaceSettings {
     primary_interface: Option<bool>,
     /// Segment type that the fixed address must resolve to.
     segment_type_guard: Option<NetworkSegmentType>,
+    /// Require a managed prefix to contain the fixed address instead of
+    /// falling back to `static-assignments`.
+    require_managed_prefix: bool,
 }
 
 /// Create or safely update a fixed-address reservation.
@@ -117,12 +121,12 @@ async fn update_preallocated_machine_interface_with_settings(
     retained_window: Option<chrono::Duration>,
 ) -> Result<(), CarbideError> {
     let segment_type_guard = settings.and_then(|settings| settings.segment_type_guard);
-    // An explicit segment type is a configuration guard, so validate it even
-    // when an addressed interface will otherwise remain unchanged. Legacy
-    // callers resolve lazily to preserve that addressed-row no-op.
-    let guarded_segment = if let Some(segment_type_guard) = segment_type_guard {
+    // Generalized ExpectedInterface declarations require a managed prefix
+    // even when an addressed interface will otherwise remain unchanged.
+    // Legacy callers resolve lazily to preserve that addressed-row no-op.
+    let resolved_segment = if settings.is_some_and(|settings| settings.require_managed_prefix) {
         Some(
-            db::network_segment::for_static_address(txn, ip_address, Some(segment_type_guard))
+            db::network_segment::for_managed_static_address(txn, ip_address, segment_type_guard)
                 .await?,
         )
     } else {
@@ -135,9 +139,9 @@ async fn update_preallocated_machine_interface_with_settings(
             // No addresses -- safe to assign the static IP.
             db::machine_interface_address::assign_static(txn, iface.id, ip_address).await?;
 
-            let segment = match guarded_segment {
+            let segment = match resolved_segment {
                 Some(segment) => segment,
-                None => db::network_segment::for_static_address(txn, ip_address, None).await?,
+                None => db::network_segment::for_static_address(txn, ip_address).await?,
             };
             if iface.segment_id != segment.id {
                 db::machine_interface::update_segment_id(
@@ -187,9 +191,9 @@ async fn update_preallocated_machine_interface_with_settings(
         }
     } else {
         // No interface yet -- create a new one.
-        let segment = match guarded_segment {
+        let segment = match resolved_segment {
             Some(segment) => segment,
-            None => db::network_segment::for_static_address(txn, ip_address, None).await?,
+            None => db::network_segment::for_static_address(txn, ip_address).await?,
         };
         let interface_type = settings
             .map(|settings| settings.interface_type)
@@ -237,7 +241,7 @@ pub async fn assign_static_address(
     // if needed. IPs within a managed prefix go on that prefix's segment.
     // External IPs go on the static-assignments anchor segment.
     let target_segment =
-        db::network_segment::for_static_address(txn.as_pgconn(), ip_address, None).await?;
+        db::network_segment::for_static_address(txn.as_pgconn(), ip_address).await?;
 
     let current_iface = db::machine_interface::find_one(txn.as_pgconn(), interface_id).await?;
     if current_iface.segment_id != target_segment.id {

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -2614,6 +2614,172 @@ async fn test_expected_machine_update_fixed_interface_single_batch_parity(
     Ok(())
 }
 
+/// Explicit fixed policies require a managed prefix in both update APIs, while
+/// legacy Host entries retain their `static-assignments` fallback.
+#[crate::sqlx_test]
+async fn test_expected_machine_update_fixed_interface_requires_managed_prefix(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    /// One update API and allocation-policy combination.
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        fixed_ip: &'static str,
+        use_batch: bool,
+        explicit_policy: bool,
+    }
+
+    for case in [
+        Case {
+            name: "single legacy Host update",
+            suffix: 0x74,
+            fixed_ip: "203.0.113.240",
+            use_batch: false,
+            explicit_policy: false,
+        },
+        Case {
+            name: "batch legacy Host update",
+            suffix: 0x76,
+            fixed_ip: "203.0.113.241",
+            use_batch: true,
+            explicit_policy: false,
+        },
+        Case {
+            name: "single explicit Fixed update",
+            suffix: 0x78,
+            fixed_ip: "203.0.113.242",
+            use_batch: false,
+            explicit_policy: true,
+        },
+        Case {
+            name: "batch explicit Fixed update",
+            suffix: 0x7a,
+            fixed_ip: "203.0.113.243",
+            use_batch: true,
+            explicit_policy: true,
+        },
+    ] {
+        let fixed_ip: std::net::IpAddr = case.fixed_ip.parse()?;
+        let id = Uuid::new_v4();
+        let bmc_mac: MacAddress = format!("5A:5B:5C:5D:61:{:02X}", case.suffix).parse()?;
+        let interface_mac: MacAddress =
+            format!("5A:5B:5C:5D:61:{:02X}", case.suffix + 1).parse()?;
+        let serial = format!("FIXED-PREFIX-{:02X}", case.suffix);
+
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.to_string(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                ..Default::default()
+            }))
+            .await?;
+
+        let update = rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial,
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: interface_mac.to_string(),
+                ip_allocation: case
+                    .explicit_policy
+                    .then_some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+                fixed_ip: Some(fixed_ip.to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let result = if case.use_batch {
+            env.api
+                .update_expected_machines(tonic::Request::new(
+                    rpc::forge::BatchExpectedMachineOperationRequest {
+                        expected_machines: Some(ExpectedMachineList {
+                            expected_machines: vec![update],
+                        }),
+                        accept_partial_results: false,
+                    },
+                ))
+                .await
+                .map(|_| ())
+        } else {
+            env.api
+                .update_expected_machine(tonic::Request::new(update))
+                .await
+                .map(|_| ())
+        };
+
+        if case.explicit_policy {
+            let error = result.expect_err(case.name);
+            assert_eq!(
+                error.code(),
+                tonic::Code::InvalidArgument,
+                "case: {}",
+                case.name,
+            );
+            assert!(
+                error
+                    .message()
+                    .contains("not within a configured network segment"),
+                "case {}: {error}",
+                case.name,
+            );
+        } else {
+            result?;
+        }
+
+        let expected_interface_count = if case.explicit_policy { 0 } else { 1 };
+        let mut txn = env.pool.begin().await?;
+        let interfaces =
+            db::machine_interface::find_by_mac_address(&mut *txn, interface_mac).await?;
+        assert_eq!(
+            interfaces.len(),
+            expected_interface_count,
+            "case: {}",
+            case.name,
+        );
+        if let Some(interface) = interfaces.first() {
+            assert_eq!(interface.addresses, vec![fixed_ip], "case: {}", case.name,);
+            let static_assignments = db::network_segment::static_assignments(txn.as_mut()).await?;
+            assert_eq!(
+                interface.segment_id, static_assignments.id,
+                "case: {}",
+                case.name,
+            );
+        }
+        txn.rollback().await?;
+
+        let stored = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: String::new(),
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(
+            stored.host_nics.len(),
+            expected_interface_count,
+            "case {}: a rejected update must leave expected configuration unchanged",
+            case.name,
+        );
+    }
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 async fn test_legacy_bmc_update_preserves_interface_behavior_and_restores_naming(
     pool: sqlx::PgPool,

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1180,6 +1180,7 @@ pub async fn preallocate_machine_interface(
             interface_type: InterfaceType::Data,
             primary_interface: None,
             segment_type_guard: None,
+            require_managed_prefix: false,
             allow_associated_interface_settings_update: true,
         },
         retained_window,
@@ -1201,6 +1202,7 @@ pub async fn preallocate_bmc_machine_interface(
             interface_type: InterfaceType::Bmc,
             primary_interface: Some(false),
             segment_type_guard: None,
+            require_managed_prefix: false,
             allow_associated_interface_settings_update: true,
         },
         retained_window,
@@ -1235,6 +1237,7 @@ pub async fn preallocate_expected_machine_interface(
             interface_type: expected_interface.role.interface_type(),
             primary_interface: expected_interface.role.primary_interface_override(),
             segment_type_guard: expected_interface.segment_type_guard(),
+            require_managed_prefix: !expected_interface.uses_legacy_host_allocation(),
             allow_associated_interface_settings_update: false,
         },
         retained_window,
@@ -1362,6 +1365,9 @@ struct PreallocationOptions {
     primary_interface: Option<bool>,
     /// Segment type that the fixed address must resolve to.
     segment_type_guard: Option<NetworkSegmentType>,
+    /// Require a managed prefix to contain the fixed address instead of
+    /// falling back to `static-assignments`.
+    require_managed_prefix: bool,
     /// Allow requested interface settings to change an already-associated row.
     ///
     /// This does not disable fixed-address reconciliation. ExpectedInterface
@@ -1400,6 +1406,18 @@ async fn reconcile_existing_preallocation(
     let same_family = addresses
         .iter()
         .find(|address| address.address.is_address_family(family));
+    // An exact address is not enough when the caller has already resolved its
+    // configured segment. Existing rows must agree with both parts of the
+    // reservation before the idempotent path succeeds.
+    let ensure_target_segment = |target_segment: &NetworkSegment| -> DatabaseResult<()> {
+        if iface.segment_id == target_segment.id {
+            return Ok(());
+        }
+        Err(DatabaseError::InvalidArgument(format!(
+            "a machine interface already exists for MAC {mac_address} on segment {}; fixed IP {static_ip} belongs to segment {}; use update to change the segment",
+            iface.segment_id, target_segment.id,
+        )))
+    };
     match same_family {
         // An existing static reservation for this family is authoritative:
         // callers must use update to change it.
@@ -1416,7 +1434,12 @@ async fn reconcile_existing_preallocation(
         // still continues below to align interface type/primary flags.
         Some(address)
             if address.address == static_ip
-                && address.allocation_type == AllocationType::Static => {}
+                && address.allocation_type == AllocationType::Static =>
+        {
+            if let Some(target_segment) = known_target_segment {
+                ensure_target_segment(target_segment)?;
+            }
+        }
         // No same-family static reservation exists. DHCP/SLAAC rows for this
         // family may be replaced, but only after proving the target IP and
         // target segment are safe for this interface.
@@ -1435,18 +1458,13 @@ async fn reconcile_existing_preallocation(
                 Some(segment) => segment,
                 None => {
                     derived_segment =
-                        db_network_segment::for_static_address(&mut *txn, static_ip, None).await?;
+                        db_network_segment::for_static_address(&mut *txn, static_ip).await?;
                     &derived_segment
                 }
             };
             // Do not silently move an existing preallocated interface; changing
             // segment ownership is an explicit update operation.
-            if iface.segment_id != target_segment.id {
-                return Err(DatabaseError::InvalidArgument(format!(
-                    "a machine interface already exists for MAC {mac_address} on segment {}; fixed IP {static_ip} belongs to segment {}; use update to change the segment",
-                    iface.segment_id, target_segment.id,
-                )));
-            }
+            ensure_target_segment(target_segment)?;
             // Safe replacement point: same interface, same segment, and no
             // conflicting owner for the requested IP.
             crate::machine_interface_address::assign_static(&mut *txn, iface.id, static_ip).await?;
@@ -1484,9 +1502,9 @@ async fn reconcile_existing_preallocation(
 
 /// Create a fixed-address reservation or reconcile an existing row.
 ///
-/// `segment_type_guard` validates configured intent before either path runs.
-/// Associated-row policy affects only role-derived interface settings; it
-/// never suppresses safe fixed-address reconciliation.
+/// Managed-prefix and segment-type requirements validate configured intent
+/// before either path runs. Associated-row policy affects only role-derived
+/// interface settings; it never suppresses safe fixed-address reconciliation.
 async fn preallocate_machine_interface_with_options(
     txn: &mut PgConnection,
     mac_address: MacAddress,
@@ -1494,13 +1512,18 @@ async fn preallocate_machine_interface_with_options(
     options: PreallocationOptions,
     retained_window: Option<chrono::Duration>,
 ) -> DatabaseResult<()> {
-    // An explicit segment type is a configuration guard, so validate it even
-    // when the reservation already exists. Legacy callers resolve lazily to
-    // preserve their exact-(MAC, IP) idempotent path.
-    let guarded_segment = if let Some(segment_type_guard) = options.segment_type_guard {
+    // Generalized ExpectedInterface declarations require a managed prefix
+    // even when the reservation already exists. Legacy callers still resolve
+    // lazily so an exact external `(MAC, IP)` row remains idempotent without a
+    // `static-assignments` segment.
+    let resolved_segment = if options.require_managed_prefix {
         Some(
-            db_network_segment::for_static_address(&mut *txn, static_ip, Some(segment_type_guard))
-                .await?,
+            db_network_segment::for_managed_static_address(
+                &mut *txn,
+                static_ip,
+                options.segment_type_guard,
+            )
+            .await?,
         )
     } else {
         None
@@ -1514,7 +1537,7 @@ async fn preallocate_machine_interface_with_options(
         mac_address,
         static_ip,
         options,
-        guarded_segment.as_ref(),
+        resolved_segment.as_ref(),
     )
     .await?
     {
@@ -1530,9 +1553,9 @@ async fn preallocate_machine_interface_with_options(
         )));
     }
 
-    let segment = match guarded_segment {
+    let segment = match resolved_segment {
         Some(segment) => segment,
-        None => db_network_segment::for_static_address(&mut *txn, static_ip, None).await?,
+        None => db_network_segment::for_static_address(&mut *txn, static_ip).await?,
     };
     match create_with_type(
         txn,

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -252,6 +252,27 @@ async fn test_preallocate_machine_interface_is_idempotent_without_static_assignm
     .await?;
 
     preallocate_machine_interface(txn.as_pgconn(), mac, ip, None).await?;
+    let legacy_expected_interface = ExpectedHostNic {
+        mac_address: mac,
+        fixed_ip: Some(ip),
+        ..Default::default()
+    };
+    preallocate_expected_machine_interface(txn.as_pgconn(), &legacy_expected_interface, None)
+        .await?;
+
+    // An explicit policy requires a managed prefix even when the exact
+    // external reservation already exists. Resolve it before the idempotent
+    // `(MAC, IP)` path can return success.
+    let explicit_expected_interface = ExpectedHostNic {
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        ..legacy_expected_interface
+    };
+    let error =
+        preallocate_expected_machine_interface(txn.as_pgconn(), &explicit_expected_interface, None)
+            .await
+            .expect_err("an explicit fixed policy should require a managed prefix");
+    assert!(matches!(error, DatabaseError::InvalidArgument(_)));
+
     let interfaces = find_by_mac_address(txn.as_pgconn(), mac).await?;
     txn.commit().await?;
 
@@ -768,7 +789,7 @@ async fn test_fixed_host_preallocation_does_not_override_machine_wide_primary_se
 }
 
 #[crate::sqlx_test]
-async fn test_fixed_preallocation_derives_segment_before_applying_typed_guard(
+async fn test_fixed_preallocation_resolves_managed_prefix_and_segment_type(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     create_static_assignments_segment(&pool).await?;
@@ -780,6 +801,7 @@ async fn test_fixed_preallocation_derives_segment_before_applying_typed_guard(
         AllocationStrategy::Reserved,
     )
     .await?;
+    let non_target_segment = create_test_segment(&pool, "fixed-address-non-target").await?;
 
     let mut txn = db::Transaction::begin(&pool).await?;
     let legacy_hint = ExpectedHostNic {
@@ -824,6 +846,96 @@ async fn test_fixed_preallocation_derives_segment_before_applying_typed_guard(
         legacy_interface.segment_id, static_assignments.id,
         "a legacy Host declaration must not turn its DHCP selector into a fixed-address guard",
     );
+
+    // The address alone cannot make an exact row idempotent when an explicit
+    // policy resolves it to a different managed segment.
+    let misplaced_mac: MacAddress = "7A:7B:7C:7D:7E:68".parse()?;
+    let misplaced_ip: IpAddr = "198.51.100.68".parse()?;
+    let misplaced_interface_id: MachineInterfaceId = sqlx::query_scalar(
+        "INSERT INTO machine_interfaces
+            (segment_id, mac_address, primary_interface, hostname)
+         VALUES ($1, $2, true, 'fixed-address-non-target')
+         RETURNING id",
+    )
+    .bind(non_target_segment)
+    .bind(misplaced_mac)
+    .fetch_one(txn.as_pgconn())
+    .await?;
+    crate::machine_interface_address::insert(
+        txn.as_pgconn(),
+        misplaced_interface_id,
+        misplaced_ip,
+        AllocationType::Static,
+    )
+    .await?;
+    let misplaced_reservation = ExpectedHostNic {
+        mac_address: misplaced_mac,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        fixed_ip: Some(misplaced_ip),
+        ..Default::default()
+    };
+    let error =
+        preallocate_expected_machine_interface(txn.as_pgconn(), &misplaced_reservation, None)
+            .await
+            .expect_err("an exact reservation on another segment should be rejected");
+    assert!(matches!(error, DatabaseError::InvalidArgument(_)));
+    let misplaced_interface = find_one(txn.as_pgconn(), misplaced_interface_id).await?;
+    assert_eq!(misplaced_interface.segment_id, non_target_segment);
+
+    /// One generalized fixed-address declaration that must reject the
+    /// out-of-prefix address used by this test.
+    struct OutsidePrefixCase {
+        name: &'static str,
+        suffix: u8,
+        role: ExpectedInterfaceRole,
+        ip_allocation: Option<ExpectedInterfaceIpAllocation>,
+    }
+
+    for case in [
+        OutsidePrefixCase {
+            name: "explicit Host Fixed policy",
+            suffix: 0x65,
+            role: ExpectedInterfaceRole::Host,
+            ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+        },
+        OutsidePrefixCase {
+            name: "DPU OS inferred Fixed policy",
+            suffix: 0x66,
+            role: ExpectedInterfaceRole::DpuOs,
+            ip_allocation: None,
+        },
+        OutsidePrefixCase {
+            name: "DPU BMC inferred Fixed policy",
+            suffix: 0x67,
+            role: ExpectedInterfaceRole::DpuBmc,
+            ip_allocation: None,
+        },
+    ] {
+        let expected_interface = ExpectedHostNic {
+            mac_address: MacAddress::new([0x7a, 0x7b, 0x7c, 0x7d, 0x7e, case.suffix]),
+            role: case.role,
+            ip_allocation: case.ip_allocation,
+            fixed_ip: Some(format!("203.0.113.{}", case.suffix).parse()?),
+            ..Default::default()
+        };
+
+        let error =
+            preallocate_expected_machine_interface(txn.as_pgconn(), &expected_interface, None)
+                .await
+                .expect_err(case.name);
+        assert!(
+            matches!(error, DatabaseError::InvalidArgument(_)),
+            "case: {}",
+            case.name,
+        );
+        assert!(
+            find_by_mac_address(txn.as_pgconn(), expected_interface.mac_address)
+                .await?
+                .is_empty(),
+            "case: {}",
+            case.name,
+        );
+    }
 
     let wrong_guard = ExpectedHostNic {
         mac_address: "7A:7B:7C:7D:7E:62".parse()?,

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -256,34 +256,52 @@ pub async fn for_prefix_containing_address(
     }
 }
 
-/// Resolve the segment that owns a configured static address.
+/// Resolve the managed segment whose configured prefix contains a static
+/// address.
 ///
-/// A segment type is a guard: the address must already fall within a managed
-/// prefix of that type. Without a guard, addresses outside managed prefixes
-/// continue to use `static-assignments`.
-pub async fn for_static_address(
+/// Unlike [`for_static_address`], this never falls back to
+/// `static-assignments`. ExpectedInterface declarations using an explicit
+/// allocation policy or a DPU role use this stricter lookup.
+pub async fn for_managed_static_address(
     txn: &mut PgConnection,
     address: IpAddr,
     expected_segment_type: Option<NetworkSegmentType>,
 ) -> DatabaseResult<NetworkSegment> {
+    let segment = for_prefix_containing_address(&mut *txn, address)
+        .await?
+        .ok_or_else(|| {
+            DatabaseError::InvalidArgument(match expected_segment_type {
+                Some(expected_segment_type) => format!(
+                    "fixed IP {address} is not within a configured {expected_segment_type} network segment",
+                ),
+                None => {
+                    format!("fixed IP {address} is not within a configured network segment")
+                }
+            })
+        })?;
+
+    if let Some(expected_segment_type) = expected_segment_type
+        && segment.config.segment_type != expected_segment_type
+    {
+        return Err(DatabaseError::InvalidArgument(format!(
+            "fixed IP {address} belongs to {} network segment {}, not the expected {expected_segment_type} segment type",
+            segment.config.segment_type, segment.config.name,
+        )));
+    }
+
+    Ok(segment)
+}
+
+/// Resolve the segment that owns a configured static address.
+///
+/// Addresses outside managed prefixes use `static-assignments`.
+pub async fn for_static_address(
+    txn: &mut PgConnection,
+    address: IpAddr,
+) -> DatabaseResult<NetworkSegment> {
     match for_prefix_containing_address(&mut *txn, address).await? {
-        Some(segment) => {
-            if let Some(expected_segment_type) = expected_segment_type
-                && segment.config.segment_type != expected_segment_type
-            {
-                return Err(DatabaseError::InvalidArgument(format!(
-                    "fixed IP {address} belongs to {} network segment {}, not the expected {expected_segment_type} segment type",
-                    segment.config.segment_type, segment.config.name,
-                )));
-            }
-            Ok(segment)
-        }
-        None => match expected_segment_type {
-            Some(expected_segment_type) => Err(DatabaseError::InvalidArgument(format!(
-                "fixed IP {address} is not within a configured {expected_segment_type} network segment",
-            ))),
-            None => static_assignments(&mut *txn).await,
-        },
+        Some(segment) => Ok(segment),
+        None => static_assignments(&mut *txn).await,
     }
 }
 

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -229,9 +229,10 @@ pub enum ExpectedInterfaceIpAllocation {
     /// Allocate a normal DHCP lease that may expire and change. A configured
     /// segment-type guard must match the segment selected by the DHCP relay.
     Dynamic,
-    /// Reserve the operator-specified [`ExpectedHostNic::fixed_ip`]. Prefix
-    /// containment finds the segment, and a configured segment-type guard must
-    /// match it.
+    /// Reserve the operator-specified [`ExpectedHostNic::fixed_ip`]. An
+    /// explicit Fixed policy or DPU role requires a configured managed prefix
+    /// to contain the address. That prefix selects the segment, and a
+    /// configured segment-type guard must match it.
     Fixed,
     /// Allocate through DHCP, then change that address row to Static for the
     /// lifetime of this interface row. The address is not saved in
@@ -290,9 +291,11 @@ pub struct ExpectedHostNic {
     /// behavior where this field only narrows initial DHCP segment selection.
     /// This compatibility rule is exposed by [`Self::segment_type_guard`].
     /// `None` (with no legacy [`Self::nic_type`]) leaves DHCP selection
-    /// unconstrained; a fixed IP still derives its segment from the address.
-    /// Updates retain the existing full-replacement behavior, so omission
-    /// clears this field.
+    /// unconstrained. Fixed uses the managed prefix containing the address;
+    /// only a legacy Host declaration with an omitted policy may fall back to
+    /// `static-assignments` when no configured prefix contains it. Updates
+    /// retain the existing full-replacement behavior, so omission clears this
+    /// field.
     #[serde(default)]
     pub network_segment_type: Option<NetworkSegmentType>,
     /// Legacy free-form NIC-type segment hint (`bf3`, `onboard`, `oob`, ...).
@@ -372,6 +375,18 @@ impl ExpectedHostNic {
         self.fixed_ip.ok_or("ip_allocation=fixed requires fixed_ip")
     }
 
+    /// Return whether this declaration keeps the legacy Host allocation
+    /// behavior.
+    ///
+    /// Before roles and allocation policies existed, Host fixed IPs outside
+    /// every managed prefix used `static-assignments`, and
+    /// `network_segment_type` only narrowed the first DHCP segment selection.
+    /// An explicit policy or either DPU role opts into the generalized
+    /// ExpectedInterface contract instead.
+    pub fn uses_legacy_host_allocation(&self) -> bool {
+        self.role.is_host() && self.ip_allocation.is_none()
+    }
+
     /// Return the typed segment guard for declarations using the generalized
     /// ExpectedInterface policy contract.
     ///
@@ -381,7 +396,7 @@ impl ExpectedHostNic {
     /// DPU role opts into the same guard semantics for every allocation path.
     pub fn segment_type_guard(&self) -> Option<NetworkSegmentType> {
         self.network_segment_type
-            .filter(|_| self.ip_allocation.is_some() || !self.role.is_host())
+            .filter(|_| !self.uses_legacy_host_allocation())
     }
 
     /// Return the network segment type that narrows Dynamic or Retained DHCP
@@ -1514,6 +1529,7 @@ mod tests {
             fixed_ip: Option<IpAddr>,
             network_segment_type: Option<NetworkSegmentType>,
             expected_guard: Option<NetworkSegmentType>,
+            uses_legacy_host_allocation: bool,
         }
 
         for case in [
@@ -1524,6 +1540,7 @@ mod tests {
                 fixed_ip: None,
                 network_segment_type: Some(NetworkSegmentType::Admin),
                 expected_guard: None,
+                uses_legacy_host_allocation: true,
             },
             Case {
                 name: "legacy Host fixed IP inference",
@@ -1532,6 +1549,7 @@ mod tests {
                 fixed_ip: Some("192.0.2.10".parse().unwrap()),
                 network_segment_type: Some(NetworkSegmentType::Admin),
                 expected_guard: None,
+                uses_legacy_host_allocation: true,
             },
             Case {
                 name: "explicit Host Dynamic policy",
@@ -1540,6 +1558,7 @@ mod tests {
                 fixed_ip: None,
                 network_segment_type: Some(NetworkSegmentType::Admin),
                 expected_guard: Some(NetworkSegmentType::Admin),
+                uses_legacy_host_allocation: false,
             },
             Case {
                 name: "explicit Host Fixed policy",
@@ -1548,6 +1567,7 @@ mod tests {
                 fixed_ip: Some("192.0.2.10".parse().unwrap()),
                 network_segment_type: Some(NetworkSegmentType::Admin),
                 expected_guard: Some(NetworkSegmentType::Admin),
+                uses_legacy_host_allocation: false,
             },
             Case {
                 name: "explicit Host Retained policy",
@@ -1556,6 +1576,7 @@ mod tests {
                 fixed_ip: None,
                 network_segment_type: Some(NetworkSegmentType::Admin),
                 expected_guard: Some(NetworkSegmentType::Admin),
+                uses_legacy_host_allocation: false,
             },
             Case {
                 name: "DPU OS role",
@@ -1564,6 +1585,7 @@ mod tests {
                 fixed_ip: None,
                 network_segment_type: Some(NetworkSegmentType::Admin),
                 expected_guard: Some(NetworkSegmentType::Admin),
+                uses_legacy_host_allocation: false,
             },
             Case {
                 name: "DPU BMC role",
@@ -1572,6 +1594,7 @@ mod tests {
                 fixed_ip: None,
                 network_segment_type: Some(NetworkSegmentType::Underlay),
                 expected_guard: Some(NetworkSegmentType::Underlay),
+                uses_legacy_host_allocation: false,
             },
             Case {
                 name: "no typed segment",
@@ -1580,6 +1603,7 @@ mod tests {
                 fixed_ip: None,
                 network_segment_type: None,
                 expected_guard: None,
+                uses_legacy_host_allocation: false,
             },
         ] {
             let interface = ExpectedHostNic {
@@ -1592,6 +1616,12 @@ mod tests {
             assert_eq!(
                 interface.segment_type_guard(),
                 case.expected_guard,
+                "{}",
+                case.name,
+            );
+            assert_eq!(
+                interface.uses_legacy_host_allocation(),
+                case.uses_legacy_host_allocation,
                 "{}",
                 case.name,
             );

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6196,10 +6196,11 @@ message ExpectedHostNic {
   // Optional allocation policy. On create, missing and Unspecified infer Fixed
   // from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
   // stored policy while explicit Unspecified resets to that inference.
-  // Explicit Dynamic rejects `fixed_ip`. For a legacy Host declaration,
-  // inferred Fixed still selects the segment by address-prefix containment but
-  // does not turn `network_segment_type` into a fixed-address guard; configure
-  // Fixed explicitly to request that check.
+  // Explicit Dynamic rejects `fixed_ip`. Explicit Fixed, or a DPU role that
+  // infers Fixed, requires `fixed_ip` inside a configured managed prefix. A
+  // legacy Host declaration with an omitted policy may instead fall back to
+  // `static-assignments` and does not turn `network_segment_type` into a
+  // fixed-address guard.
   optional ExpectedInterfaceIpAllocation ip_allocation = 9;
 }
 
@@ -9176,8 +9177,9 @@ enum ExpectedInterfaceIpAllocation {
   // Use an expiring DHCP lease. The segment guard must match the relay's
   // selected segment when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC = 1;
-  // Reserve `fixed_ip`. Its prefix selects the segment, and the segment guard
-  // must match that segment when configured.
+  // Reserve `fixed_ip`. Explicit Fixed, or a DPU role that infers Fixed,
+  // requires a configured managed prefix to contain the address. That prefix
+  // selects the segment, and the segment guard must match when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_FIXED = 2;
   // Allocate through DHCP, then make the address Static for this interface
   // row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -4571,8 +4571,9 @@ const (
 	// Use an expiring DHCP lease. The segment guard must match the relay's
 	// selected segment when configured.
 	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC ExpectedInterfaceIpAllocation = 1
-	// Reserve `fixed_ip`. Its prefix selects the segment, and the segment guard
-	// must match that segment when configured.
+	// Reserve `fixed_ip`. Explicit Fixed, or a DPU role that infers Fixed,
+	// requires a configured managed prefix to contain the address. That prefix
+	// selects the segment, and the segment guard must match when configured.
 	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_FIXED ExpectedInterfaceIpAllocation = 2
 	// Allocate through DHCP, then make the address Static for this interface
 	// row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The
@@ -35450,10 +35451,11 @@ type ExpectedHostNic struct {
 	// Optional allocation policy. On create, missing and Unspecified infer Fixed
 	// from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
 	// stored policy while explicit Unspecified resets to that inference.
-	// Explicit Dynamic rejects `fixed_ip`. For a legacy Host declaration,
-	// inferred Fixed still selects the segment by address-prefix containment but
-	// does not turn `network_segment_type` into a fixed-address guard; configure
-	// Fixed explicitly to request that check.
+	// Explicit Dynamic rejects `fixed_ip`. Explicit Fixed, or a DPU role that
+	// infers Fixed, requires `fixed_ip` inside a configured managed prefix. A
+	// legacy Host declaration with an omitted policy may instead fall back to
+	// `static-assignments` and does not turn `network_segment_type` into a
+	// fixed-address guard.
 	IpAllocation  *ExpectedInterfaceIpAllocation `protobuf:"varint,9,opt,name=ip_allocation,json=ipAllocation,proto3,enum=forge.ExpectedInterfaceIpAllocation,oneof" json:"ip_allocation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -6197,10 +6197,11 @@ message ExpectedHostNic {
   // Optional allocation policy. On create, missing and Unspecified infer Fixed
   // from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
   // stored policy while explicit Unspecified resets to that inference.
-  // Explicit Dynamic rejects `fixed_ip`. For a legacy Host declaration,
-  // inferred Fixed still selects the segment by address-prefix containment but
-  // does not turn `network_segment_type` into a fixed-address guard; configure
-  // Fixed explicitly to request that check.
+  // Explicit Dynamic rejects `fixed_ip`. Explicit Fixed, or a DPU role that
+  // infers Fixed, requires `fixed_ip` inside a configured managed prefix. A
+  // legacy Host declaration with an omitted policy may instead fall back to
+  // `static-assignments` and does not turn `network_segment_type` into a
+  // fixed-address guard.
   optional ExpectedInterfaceIpAllocation ip_allocation = 9;
 }
 
@@ -9194,8 +9195,9 @@ enum ExpectedInterfaceIpAllocation {
   // Use an expiring DHCP lease. The segment guard must match the relay's
   // selected segment when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC = 1;
-  // Reserve `fixed_ip`. Its prefix selects the segment, and the segment guard
-  // must match that segment when configured.
+  // Reserve `fixed_ip`. Explicit Fixed, or a DPU role that infers Fixed,
+  // requires a configured managed prefix to contain the address. That prefix
+  // selects the segment, and the segment guard must match when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_FIXED = 2;
   // Allocate through DHCP, then make the address Static for this interface
   // row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The


### PR DESCRIPTION
Reject duplicate expected interface entries when one MAC names different roles, since DHCP and Site Explorer would otherwise interpret the same interface differently.

Explicit fixed allocation policies and DPU roles now require `fixed_ip` to fall within a configured managed prefix. Existing exact reservations must also belong to that segment, while legacy Host entries that omit the new policy fields keep the `static-assignments` fallback.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3990

Follow-up to #3991.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with focused model, Core, database, and generated Go protobuf tests, plus `cargo make format-nightly`, `cargo make check-format-nightly`, `cargo make clippy`, and `cargo make carbide-lints`.

The uncommitted diff was also reviewed with CodeRabbit CLI and the local Claude review helper. Their actionable findings are included in this commit.

## Additional Notes

This PR has no database migration or protobuf schema change. The generated Go protobuf diff contains comment updates only.

ExpectedMachine declarations may still be stored before their network segments exist. Strict managed-prefix validation happens when the reservation is materialized or updated.