### PR TITLE
feat(agent): render DPU IPv6 loopbacks for FNN

### DIFF
--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -135,6 +135,9 @@ pub struct NvueOptions {
 
     #[clap(long)]
     pub loopback_ip: IpAddr,
+
+    #[clap(long)]
+    pub loopback_ip_v6: Option<Ipv6Addr>,
 
     #[clap(long)]
     pub asn: u32,

--- a/crates/agent/src/ethernet_virtualization.rs
+++ b/crates/agent/src/ethernet_virtualization.rs
@@ -308,6 +308,31 @@ impl From<&rpc::FlatInterfaceRoutingProfile> for nvue::InterfaceRoutingProfile {
     }
 }
 
+/// `parse_managed_host_loopback_ips` types the string-valued RPC fields before
+/// NVUE rendering. In particular, parsing `loopback_ip_v6` as `Ipv6Addr` keeps
+/// an IPv4 value from slipping through just because protobuf stores it as a
+/// string.
+fn parse_managed_host_loopback_ips(
+    config: &rpc::ManagedHostNetworkConfig,
+) -> eyre::Result<(IpAddr, Option<Ipv6Addr>)> {
+    if config.loopback_ip.is_empty() {
+        return Err(eyre::eyre!("missing loopback IP"));
+    }
+
+    let loopback_ip = config
+        .loopback_ip
+        .parse()
+        .wrap_err_with(|| format!("invalid primary loopback IP: {}", config.loopback_ip))?;
+    let loopback_ip_v6 = config
+        .loopback_ip_v6
+        .as_deref()
+        .map(str::parse)
+        .transpose()
+        .wrap_err("invalid IPv6 loopback IP")?;
+
+    Ok((loopback_ip, loopback_ip_v6))
+}
+
 /// Update the NVUE network config. Returns Ok(true) if the configuration changed, and
 /// Ok(false) if not.
 pub async fn update_nvue(
@@ -326,18 +351,11 @@ pub async fn update_nvue(
             .and_then(|build_value| hbn::parse_nvue_build_as_hbn_version(&build_value))?,
     };
 
-    let l_ip_str = match &nc.managed_host_config {
-        None => {
-            return Err(eyre::eyre!("missing managed_host_config in response"));
-        }
-        Some(cfg) => {
-            if cfg.loopback_ip.is_empty() {
-                return Err(eyre::eyre!("missing loopback IP"));
-            }
-            &cfg.loopback_ip
-        }
-    };
-    let loopback_ip = l_ip_str.parse().wrap_err_with(|| l_ip_str.clone())?;
+    let managed_host_config = nc
+        .managed_host_config
+        .as_ref()
+        .ok_or_else(|| eyre::eyre!("missing managed_host_config in response"))?;
+    let (loopback_ip, loopback_ip_v6) = parse_managed_host_loopback_ips(managed_host_config)?;
 
     let access_vlans = if nc.use_admin_network {
         let admin_interface = nc
@@ -588,6 +606,7 @@ pub async fn update_nvue(
         use_admin_network: nc.use_admin_network,
         tenancy_enabled,
         loopback_ip,
+        loopback_ip_v6,
         vf_intercept_bridge_port_name: nc.traffic_intercept_config.as_ref().and_then(|vc| {
             vc.bridging
                 .as_ref()
@@ -1985,6 +2004,58 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_managed_host_loopback_ips() {
+        use carbide_test_support::Outcome::*;
+        use carbide_test_support::scenarios;
+
+        scenarios!(run = |config: rpc::ManagedHostNetworkConfig| {
+            parse_managed_host_loopback_ips(&config).map_err(drop)
+        };
+            "valid wire values" {
+                rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.1".to_string(),
+                    loopback_ip_v6: None,
+                    quarantine_state: None,
+                } => Yields(("10.0.0.1".parse().unwrap(), None)),
+                rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.1".to_string(),
+                    loopback_ip_v6: Some("2001:db8::1".to_string()),
+                    quarantine_state: None,
+                } => Yields((
+                    "10.0.0.1".parse().unwrap(),
+                    Some("2001:db8::1".parse().unwrap()),
+                )),
+            }
+
+            "invalid IPv6 wire value" {
+                rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.1".to_string(),
+                    loopback_ip_v6: Some("not-an-ipv6-address".to_string()),
+                    quarantine_state: None,
+                } => Fails,
+                rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.1".to_string(),
+                    loopback_ip_v6: Some("192.0.2.1".to_string()),
+                    quarantine_state: None,
+                } => Fails,
+            }
+
+            "invalid primary loopback" {
+                rpc::ManagedHostNetworkConfig {
+                    loopback_ip: String::new(),
+                    loopback_ip_v6: None,
+                    quarantine_state: None,
+                } => Fails,
+                rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "not-an-ip-address".to_string(),
+                    loopback_ip_v6: None,
+                    quarantine_state: None,
+                } => Fails,
+            }
+        );
+    }
+
+    #[test]
     fn test_build_dhcp_ntp_servers() {
         let service_addrs = ServiceAddresses {
             pxe_ips: vec![],
@@ -2950,6 +3021,7 @@ mod tests {
 
         let netconf = rpc::ManagedHostNetworkConfig {
             loopback_ip: "10.217.5.39".to_string(),
+            loopback_ip_v6: None,
             quarantine_state: None,
         };
         rpc::ManagedHostNetworkConfigResponse {
@@ -3209,6 +3281,7 @@ mod tests {
             tenancy_enabled: true,
             site_global_vpc_vni: None,
             loopback_ip: "10.217.5.39".parse().unwrap(),
+            loopback_ip_v6: None,
             secondary_overlay_vtep_ip: Some("10.255.254.253".parse().unwrap()),
             internal_bridge_routing_prefix: Some("10.255.255.0/29".parse().unwrap()),
             vf_intercept_bridge_port_name: Some("pfdpu0".to_string()),
@@ -3482,6 +3555,7 @@ mod tests {
 
         let netconf = rpc::ManagedHostNetworkConfig {
             loopback_ip: "10.217.5.39".to_string(),
+            loopback_ip_v6: None,
             quarantine_state: None,
         };
 
@@ -3723,6 +3797,7 @@ mod tests {
     fn test_dhcp_server_config_errors_without_ipv4_pxe() -> Result<(), Box<dyn std::error::Error>> {
         let netconf = rpc::ManagedHostNetworkConfig {
             loopback_ip: "10.217.5.39".to_string(),
+            loopback_ip_v6: None,
             quarantine_state: None,
         };
         let network_config = rpc::ManagedHostNetworkConfigResponse {

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -556,6 +556,7 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                     use_admin_network: true,
                     tenancy_enabled: true,
                     loopback_ip: opts.loopback_ip,
+                    loopback_ip_v6: opts.loopback_ip_v6,
                     secondary_overlay_vtep_ip: opts.secondary_overlay_vtep_ip,
                     internal_bridge_routing_prefix: opts.internal_bridge_routing_prefix,
                     vf_intercept_bridge_port_name: opts.vf_intercept_bridge_port_name,

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -556,6 +556,10 @@ impl CurrentNetworkVersion {
         conf.deprecated_deny_prefixes.hash(h);
         conf.dhcp_servers.hash(h);
         conf.internet_l3_vni.hash(h);
+        // `managed_host_config_version` normally follows machine-group updates,
+        // but that relies on the DPU already being attached to its host. Hash
+        // the nested config so a missed fan-out cannot hide a DPU-specific change.
+        conf.managed_host_config.hash(h);
         conf.network_security_policy_overrides.hash(h);
         conf.ntp_servers.hash(h);
         conf.remote_id.hash(h);
@@ -1637,6 +1641,42 @@ ATF: v2.2(release):4.9.3-")
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_current_network_version_hashes_nested_managed_host_config() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |managed_host_config| {
+            let mut conf = Arc::new(ManagedHostNetworkConfigResponse {
+                managed_host_config: Some(rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.1".to_string(),
+                    loopback_ip_v6: None,
+                    quarantine_state: None,
+                }),
+                managed_host_config_version: "managed-v1".to_string(),
+                instance_network_config_version: "instance-v1".to_string(),
+                ..Default::default()
+            });
+            let mut current = CurrentNetworkVersion::default();
+            current.update_from(&conf);
+            Arc::get_mut(&mut conf).unwrap().managed_host_config = managed_host_config;
+            current.matches_versions_from(&conf)
+        };
+            "nested config changes invalidate the cache" {
+                Some(rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.2".to_string(),
+                    loopback_ip_v6: None,
+                    quarantine_state: None,
+                }) => false,
+                Some(rpc::ManagedHostNetworkConfig {
+                    loopback_ip: "10.0.0.1".to_string(),
+                    loopback_ip_v6: Some("2001:db8::1".to_string()),
+                    quarantine_state: None,
+                }) => false,
+                None => false,
+            }
+        );
+    }
 
     #[cfg(target_os = "linux")]
     #[tokio::test]

--- a/crates/agent/src/nvue.rs
+++ b/crates/agent/src/nvue.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::path::Path;
 
 use ::rpc::forge as rpc;
@@ -594,6 +594,11 @@ pub fn build(conf: NvueConfig) -> eyre::Result<String> {
         BgpLeafSessionPassword: conf.bgp_leaf_session_password.unwrap_or_default(),
         UseAdminNetwork: conf.use_admin_network,
         LoopbackIP: conf.loopback_ip.to_string(),
+        HasLoopbackIpv6: conf.loopback_ip_v6.is_some(),
+        LoopbackIpv6: conf
+            .loopback_ip_v6
+            .map(|ip| ip.to_string())
+            .unwrap_or_default(),
         HasSiteGlobalVpcVni: conf.site_global_vpc_vni.is_some(),
         SiteGlobalVpcVni: conf.site_global_vpc_vni.unwrap_or_default(),
         HasStaticAdvertisements: has_static_advertisements,
@@ -1141,6 +1146,7 @@ pub struct NvueConfig {
     pub use_admin_network: bool,
     pub tenancy_enabled: bool,
     pub loopback_ip: IpAddr,
+    pub loopback_ip_v6: Option<Ipv6Addr>,
     pub asn: u32,
     pub datacenter_asn: u32,
     pub site_global_vpc_vni: Option<u32>,
@@ -1350,6 +1356,8 @@ struct TmplNvue {
     HasSiteGlobalVpcVni: bool,
     SiteGlobalVpcVni: u32,
     LoopbackIP: String,
+    HasLoopbackIpv6: bool,
+    LoopbackIpv6: String,
     HasSecondaryOverlayVTEP: bool,
     HasStaticAdvertisements: bool,
     SecondaryOverlayVtepIP: String,
@@ -1721,6 +1729,8 @@ struct TmplVni {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use carbide_test_support::value_scenarios;
 
     use super::*;
@@ -1847,6 +1857,7 @@ mod tests {
             use_admin_network: false,
             tenancy_enabled: true,
             loopback_ip: "10.0.0.1".parse().unwrap(),
+            loopback_ip_v6: None,
             asn: 65000,
             datacenter_asn: 11414,
             site_global_vpc_vni: None,
@@ -1880,6 +1891,82 @@ mod tests {
             ct_access_vlans: vec![],
             ct_routing_profile: None,
         }
+    }
+
+    struct LoopbackRenderRow {
+        virtualization_type: VpcVirtualizationType,
+        loopback_ip_v6: Option<Ipv6Addr>,
+    }
+
+    fn address_set(addresses: &[&str]) -> BTreeSet<String> {
+        addresses
+            .iter()
+            .map(|address| (*address).to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_build_renders_ipv6_loopback_only_for_fnn() {
+        value_scenarios!(run = |row: LoopbackRenderRow| {
+            let mut conf = minimal_nvue_config();
+            conf.is_fnn = row.virtualization_type == VpcVirtualizationType::Fnn;
+            conf.vpc_virtualization_type = row.virtualization_type;
+            conf.loopback_ip_v6 = row.loopback_ip_v6;
+
+            let rendered = build(conf).unwrap();
+            let rendered_yaml: serde_yaml::Value = serde_yaml::from_str(&rendered).unwrap();
+            let loopback_addresses = rendered_yaml.as_sequence().unwrap()[1]["set"]["interface"]
+                ["lo"]["ip"]["address"]
+                .as_mapping()
+                .unwrap()
+                .keys()
+                .map(|address| address.as_str().unwrap().to_string())
+                .collect();
+            let ipv6_underlay_prefixes = rendered_yaml.as_sequence().unwrap()[1]["set"]["router"]
+                ["policy"]["prefix-list"]["ALLOW_TO_UNDERLAY_PREFIX_LIST_IPV6"]["rule"]["65000"]
+                ["match"]
+                .as_mapping()
+                .into_iter()
+                .flat_map(|mapping| mapping.keys())
+                .map(|address| address.as_str().unwrap().to_string())
+                .collect();
+
+            assert!(
+                rendered.contains("address: 10.0.0.1"),
+                "the IPv4 loopback must remain the VXLAN VTEP"
+            );
+            assert!(
+                rendered.contains("router-id: 10.0.0.1"),
+                "the IPv4 loopback must remain the BGP router ID"
+            );
+
+            (loopback_addresses, ipv6_underlay_prefixes)
+        };
+            "FNN loopback rendering" {
+                LoopbackRenderRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    loopback_ip_v6: Some("2001:db8::1".parse().unwrap()),
+                } => (
+                    address_set(&["10.0.0.1/32", "2001:db8::1/128"]),
+                    address_set(&["2001:db8::1/128"]),
+                ),
+                LoopbackRenderRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    loopback_ip_v6: None,
+                } => (address_set(&["10.0.0.1/32"]), address_set(&[])),
+            }
+
+            "ETV ignores the IPv6 loopback" {
+                LoopbackRenderRow {
+                    virtualization_type: VpcVirtualizationType::EthernetVirtualizer,
+                    loopback_ip_v6: Some("2001:db8::1".parse().unwrap()),
+                } => (address_set(&["10.0.0.1/32"]), address_set(&[])),
+                LoopbackRenderRow {
+                    virtualization_type: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    loopback_ip_v6: Some("2001:db8::1".parse().unwrap()),
+                } => (address_set(&["10.0.0.1/32"]), address_set(&[])),
+            }
+        );
     }
 
     #[test]

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -894,6 +894,7 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
 
         managed_host_config: Some(rpc::forge::ManagedHostNetworkConfig {
             loopback_ip: "127.0.0.1".to_string(),
+            loopback_ip_v6: None,
             quarantine_state: None,
         }),
         managed_host_config_version: config_version.clone(),

--- a/crates/agent/templates/nvue_startup_fnn.conf
+++ b/crates/agent/templates/nvue_startup_fnn.conf
@@ -26,6 +26,9 @@
         ip:
           address:
             {{ .LoopbackIP }}/32: {}
+{{- if .HasLoopbackIpv6 }}
+            {{ .LoopbackIpv6 }}/128: {}
+{{- end }}
         type: loopback
 {{- if $nvueConfig.IsDpuOs }}
 {{- range $portConfig := $tenant.PortConfigs }}
@@ -215,16 +218,20 @@
                   {{- end }}
               {{- end}}
 {{/*
-  We only support HostIP/HostRoute (and not HostIPV6) right now, so there is nothing to leak to the underlay for v6.
-  We also assume either dual-stack or IPv4-only.  Once we support HostIPV6, we need to update this prefix-list
-  to include the IPs if they exist in a rule that exists conditionally based on whether there are any IPv6
-  host IPs.
-  Similarly, when/if we support IPv6-only environments, then the rule for including IPv4 host IPs in the matching
-  v4 prefix list will need to be conditional as well.
+  When `HasLoopbackIpv6` is true, leak `LoopbackIpv6` as a /128 so the underlay can resolve the DPU's IPv6 next hop.
+  `HostIPV6` remains unsupported, so there are no IPv6 tenant host routes to add here. Once `HostIPV6` is supported,
+  add those addresses with a conditional rule like the IPv4 host-IP entries above. If IPv6-only environments
+  become supported, make the IPv4 host-IP rule conditional too.
 */}}
           ALLOW_TO_UNDERLAY_PREFIX_LIST_IPV6:
             type: ipv6
             rule:
+{{- if $nvueConfig.HasLoopbackIpv6 }}
+              '65000':
+                action: permit
+                match:
+                  '{{ $nvueConfig.LoopbackIpv6 }}/128': {}
+{{- end }}
               '65535':
                 action: deny
                 match:

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -16,7 +16,7 @@
  */
 
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
 
 use ::rpc::errors::RpcDataConversionError;
@@ -60,14 +60,20 @@ const HBN_SINGLE_VLAN_DEVICE: &str = "vxlan48";
 /// Consolidates host-level and DPU-level `ManagedHostNetworkConfig` into
 /// the single proto sent to `carbide-dpu-agent`. The host layer
 /// contributes shared fields (e.g. `use_admin_network`); the DPU layer
-/// contributes per-DPU fields (e.g. `loopback_ip`).
+/// contributes per-DPU fields (e.g. `loopback_ip`). The IPv6 loopback is
+/// present only for FNN so other agents keep their IPv4-only wire contract.
 fn build_consolidated_network_config(
     host_network_config: &model::machine::network::ManagedHostNetworkConfig,
     dpu_loopback_ip: IpAddr,
+    dpu_loopback_ip_v6: Option<Ipv6Addr>,
+    network_virtualization_type: VpcVirtualizationType,
 ) -> rpc::ManagedHostNetworkConfig {
     rpc::ManagedHostNetworkConfig {
         loopback_ip: dpu_loopback_ip.to_string(),
         quarantine_state: host_network_config.quarantine_state.clone().map(Into::into),
+        loopback_ip_v6: dpu_loopback_ip_v6
+            .filter(|_| network_virtualization_type == VpcVirtualizationType::Fnn)
+            .map(|ip| ip.to_string()),
     }
 }
 
@@ -510,6 +516,8 @@ pub(crate) async fn get_managed_host_network_config_inner(
     let network_config = build_consolidated_network_config(
         &snapshot.host_snapshot.network_config.value,
         loopback_ip,
+        dpu_snapshot.loopback_ip_v6(),
+        network_virtualization_type,
     );
 
     let asn = if network_virtualization_type == VpcVirtualizationType::Fnn {
@@ -1557,8 +1565,9 @@ mod deny_prefix_tests {
 
 #[cfg(test)]
 mod consolidated_network_config_tests {
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, Ipv6Addr};
 
+    use carbide_test_support::value_scenarios;
     use model::machine::network::{
         ManagedHostNetworkConfig, ManagedHostQuarantineMode, ManagedHostQuarantineState,
     };
@@ -1574,7 +1583,12 @@ mod consolidated_network_config_tests {
     #[test]
     fn dpu_loopback_ip_carries_through_with_empty_host_layer() {
         let host = ManagedHostNetworkConfig::default();
-        let consolidated = build_consolidated_network_config(&host, dpu_ip());
+        let consolidated = build_consolidated_network_config(
+            &host,
+            dpu_ip(),
+            None,
+            VpcVirtualizationType::EthernetVirtualizer,
+        );
         assert_eq!(consolidated.loopback_ip, "10.0.0.1");
         assert!(consolidated.quarantine_state.is_none());
     }
@@ -1590,7 +1604,12 @@ mod consolidated_network_config_tests {
             }),
             ..ManagedHostNetworkConfig::default()
         };
-        let consolidated = build_consolidated_network_config(&host, dpu_ip());
+        let consolidated = build_consolidated_network_config(
+            &host,
+            dpu_ip(),
+            None,
+            VpcVirtualizationType::EthernetVirtualizer,
+        );
         assert_eq!(consolidated.loopback_ip, "10.0.0.1");
         let qs = consolidated.quarantine_state.expect("quarantine_state");
         assert_eq!(qs.reason.as_deref(), Some("test"));
@@ -1616,11 +1635,63 @@ mod consolidated_network_config_tests {
             quarantine_state: None,
             use_admin_network_changed: None,
         };
-        let consolidated = build_consolidated_network_config(&host, dpu_ip());
+        let consolidated = build_consolidated_network_config(
+            &host,
+            dpu_ip(),
+            None,
+            VpcVirtualizationType::EthernetVirtualizer,
+        );
         assert_eq!(
             consolidated.loopback_ip, "10.0.0.1",
             "consolidator must use the dpu_loopback_ip arg, not host.loopback_ip"
         );
         assert!(consolidated.quarantine_state.is_none());
+    }
+
+    #[test]
+    fn dpu_ipv6_loopback_carries_through_independently() {
+        let host_ip = Ipv6Addr::new(0x2001, 0xdb8, 0xffff, 0, 0, 0, 0, 1);
+        let first_dpu_ip = Ipv6Addr::new(0x2001, 0xdb8, 0x2390, 0, 0, 0, 0, 1);
+        let second_dpu_ip = Ipv6Addr::new(0x2001, 0xdb8, 0x2390, 0, 0, 0, 0, 2);
+
+        value_scenarios!(
+            run = |(host_loopback_ip_v6, dpu_loopback_ip_v6, virtualization_type)| {
+                let host = ManagedHostNetworkConfig {
+                    loopback_ip_v6: host_loopback_ip_v6,
+                    ..ManagedHostNetworkConfig::default()
+                };
+                build_consolidated_network_config(
+                    &host,
+                    dpu_ip(),
+                    dpu_loopback_ip_v6,
+                    virtualization_type,
+                )
+                .loopback_ip_v6
+            };
+            "FNN uses the requesting DPU's IPv6 loopback" {
+                (None, None, VpcVirtualizationType::Fnn) => None,
+                (Some(host_ip), None, VpcVirtualizationType::Fnn) => None,
+                (None, Some(first_dpu_ip), VpcVirtualizationType::Fnn) => {
+                    Some(first_dpu_ip.to_string())
+                },
+                (Some(host_ip), Some(second_dpu_ip), VpcVirtualizationType::Fnn) => {
+                    Some(second_dpu_ip.to_string())
+                },
+            }
+
+            "non-FNN agents keep the IPv4-only wire contract" {
+                (
+                    None,
+                    Some(first_dpu_ip),
+                    VpcVirtualizationType::EthernetVirtualizer,
+                ) => None,
+                (
+                    None,
+                    Some(first_dpu_ip),
+                    VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                ) => None,
+                (None, Some(first_dpu_ip), VpcVirtualizationType::Flat) => None,
+            }
+        );
     }
 }

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -157,6 +157,7 @@ async fn test_clear_use_admin_network_changed_keeps_newer_version_flag(pool: sql
 
 #[crate::sqlx_test]
 async fn test_managed_host_network_config(pool: sqlx::PgPool) {
+    // The default fixture omits `lo-ip-v6`, which must preserve the existing IPv4-only response.
     let env = api_fixtures::create_test_env(pool).await;
     let host_config = env.managed_host_config();
     let mh = dpu::create_dpu_machine_in_waiting_for_network_install(&env, &host_config).await;
@@ -168,9 +169,18 @@ async fn test_managed_host_network_config(pool: sqlx::PgPool) {
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
             dpu_machine_id: Some(dpu_machine_id),
         }))
-        .await;
+        .await
+        .unwrap()
+        .into_inner();
 
-    assert!(response.is_ok());
+    assert!(
+        response
+            .managed_host_config
+            .expect("managed host config")
+            .loopback_ip_v6
+            .is_none(),
+        "sites without lo-ip-v6 must remain IPv4-only"
+    );
 }
 
 #[crate::sqlx_test]
@@ -1178,6 +1188,81 @@ async fn test_managed_host_network_config_multi_dpu(pool: sqlx::PgPool) {
     assert_ne!(
         dpu_1_network_config.host_interface_id,
         dpu_2_network_config.host_interface_id,
+    );
+}
+
+#[crate::sqlx_test]
+async fn test_managed_host_network_config_multi_dpu_fnn_ipv6_loopbacks(pool: sqlx::PgPool) {
+    let mut overrides = TestEnvOverrides::default().with_fnn_config(None);
+    overrides.fnn_config.as_mut().unwrap().admin_vpc = Some(AdminFnnConfig {
+        enabled: true,
+        vpc_vni: Some(10000),
+        routing_profile: FnnRoutingProfileConfig::default(),
+    });
+    let env = api_fixtures::create_test_env_with_overrides(pool, overrides).await;
+    crate::db_init::create_admin_vpc(&env.pool, Some(10000))
+        .await
+        .unwrap();
+    crate::db_init::update_network_segments_svi_ip(&env.pool)
+        .await
+        .unwrap();
+    env.api
+        .admin_grow_resource_pool(tonic::Request::new(rpc::forge::GrowResourcePoolRequest {
+            text: r#"
+[lo-ip-v6]
+type = "ipv6"
+prefix = "2001:db8:2390::/126"
+"#
+            .to_string(),
+        }))
+        .await
+        .unwrap();
+
+    let mh = api_fixtures::create_managed_host_multi_dpu(&env, 2).await;
+    let host_machine = mh.host().rpc_machine().await;
+    let dpu_ids = &host_machine
+        .status
+        .as_ref()
+        .expect("host status")
+        .associated_dpu_machine_ids;
+
+    let dpu_1_network_config = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_ids[0]),
+        }))
+        .await
+        .expect("DPU 1 network config")
+        .into_inner();
+    let dpu_2_network_config = env
+        .api
+        .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
+            dpu_machine_id: Some(dpu_ids[1]),
+        }))
+        .await
+        .expect("DPU 2 network config")
+        .into_inner();
+
+    // Each response must use the requesting DPU's allocation even though both
+    // responses share the host-level managed config version.
+    let dpu_1_loopback_ip_v6 = dpu_1_network_config
+        .managed_host_config
+        .as_ref()
+        .expect("DPU 1 managed host config")
+        .loopback_ip_v6
+        .as_deref()
+        .expect("DPU 1 IPv6 loopback");
+    let dpu_2_loopback_ip_v6 = dpu_2_network_config
+        .managed_host_config
+        .as_ref()
+        .expect("DPU 2 managed host config")
+        .loopback_ip_v6
+        .as_deref()
+        .expect("DPU 2 IPv6 loopback");
+    assert_ne!(dpu_1_loopback_ip_v6, dpu_2_loopback_ip_v6);
+    assert_eq!(
+        dpu_1_network_config.managed_host_config_version,
+        dpu_2_network_config.managed_host_config_version,
     );
 }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -4673,6 +4673,8 @@ message ManagedHostNetworkConfig {
   // DPU loopback IP
   string loopback_ip = 1;
   optional ManagedHostQuarantineState quarantine_state = 2;
+  // DPU IPv6 loopback IP; unset for non-FNN agents or when the `lo-ip-v6` pool is not configured.
+  optional string loopback_ip_v6 = 3;
 }
 
 message FlatInterfaceConfig {

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -26045,8 +26045,10 @@ type ManagedHostNetworkConfig struct {
 	// DPU loopback IP
 	LoopbackIp      string                      `protobuf:"bytes,1,opt,name=loopback_ip,json=loopbackIp,proto3" json:"loopback_ip,omitempty"`
 	QuarantineState *ManagedHostQuarantineState `protobuf:"bytes,2,opt,name=quarantine_state,json=quarantineState,proto3,oneof" json:"quarantine_state,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// DPU IPv6 loopback IP; unset for non-FNN agents or when the `lo-ip-v6` pool is not configured.
+	LoopbackIpV6  *string `protobuf:"bytes,3,opt,name=loopback_ip_v6,json=loopbackIpV6,proto3,oneof" json:"loopback_ip_v6,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ManagedHostNetworkConfig) Reset() {
@@ -26091,6 +26093,13 @@ func (x *ManagedHostNetworkConfig) GetQuarantineState() *ManagedHostQuarantineSt
 		return x.QuarantineState
 	}
 	return nil
+}
+
+func (x *ManagedHostNetworkConfig) GetLoopbackIpV6() string {
+	if x != nil && x.LoopbackIpV6 != nil {
+		return *x.LoopbackIpV6
+	}
+	return ""
 }
 
 type FlatInterfaceConfig struct {
@@ -64119,12 +64128,14 @@ const file_nico_nico_proto_rawDesc = "" +
 	"machine_id\x18\x01 \x01(\v2\x11.common.MachineIdR\tmachineId\"\xa2\x01\n" +
 	"'ClearManagedHostQuarantineStateResponse\x12\\\n" +
 	"\x16prior_quarantine_state\x18\x01 \x01(\v2!.forge.ManagedHostQuarantineStateH\x00R\x14priorQuarantineState\x88\x01\x01B\x19\n" +
-	"\x17_prior_quarantine_state\"\xa3\x01\n" +
+	"\x17_prior_quarantine_state\"\xe1\x01\n" +
 	"\x18ManagedHostNetworkConfig\x12\x1f\n" +
 	"\vloopback_ip\x18\x01 \x01(\tR\n" +
 	"loopbackIp\x12Q\n" +
-	"\x10quarantine_state\x18\x02 \x01(\v2!.forge.ManagedHostQuarantineStateH\x00R\x0fquarantineState\x88\x01\x01B\x13\n" +
-	"\x11_quarantine_state\"\xf1\t\n" +
+	"\x10quarantine_state\x18\x02 \x01(\v2!.forge.ManagedHostQuarantineStateH\x00R\x0fquarantineState\x88\x01\x01\x12)\n" +
+	"\x0eloopback_ip_v6\x18\x03 \x01(\tH\x01R\floopbackIpV6\x88\x01\x01B\x13\n" +
+	"\x11_quarantine_stateB\x11\n" +
+	"\x0f_loopback_ip_v6\"\xf1\t\n" +
 	"\x13FlatInterfaceConfig\x12A\n" +
 	"\rfunction_type\x18\x01 \x01(\x0e2\x1c.forge.InterfaceFunctionTypeR\ffunctionType\x12\x17\n" +
 	"\avlan_id\x18\x02 \x01(\rR\x06vlanId\x12\x10\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -4673,6 +4673,8 @@ message ManagedHostNetworkConfig {
   // DPU loopback IP
   string loopback_ip = 1;
   optional ManagedHostQuarantineState quarantine_state = 2;
+  // DPU IPv6 loopback IP; unset for non-FNN agents or when the `lo-ip-v6` pool is not configured.
+  optional string loopback_ip_v6 = 3;
 }
 
 message FlatInterfaceConfig {


### PR DESCRIPTION
With #2389, each DPU can reserve an optional IPv6 loopback, but the managed-host response still stops at the IPv4 address. That leaves FNN's already-enabled `ipv6-unicast` session without an IPv6 address on `lo` to use as its next hop.

So, this plumbs `loopback_ip_v6` through `ManagedHostNetworkConfig`, parses it as `Ipv6Addr` at the agent boundary, renders it as a `/128` on the FNN loopback, and permits that route through the IPv6 underlay export policy.

In practice:

- `get_managed_host_network_config` uses the requesting DPU's reservation, so two DPUs on one host do not collapse onto one address.
- ETV and sites without `lo-ip-v6` stay IPv4-only.
- The existing IPv4 loopback remains the router ID and VXLAN VTEP.
- `CurrentNetworkVersion` hashes the nested managed-host config so a missed machine-group version fan-out cannot leave a DPU-specific loopback hidden behind the agent cache.
- The manual `write nvue` path accepts `--loopback-ip-v6` so operators can reproduce the generated FNN config.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2390

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-agent --lib`
- `cargo test -p carbide-api-core handlers::dpu::consolidated_network_config_tests::dpu_ipv6_loopback_carries_through_independently --lib -- --exact --nocapture`
- `cargo test -p carbide-api-core tests::machine_network::test_managed_host_network_config --lib -- --exact --nocapture`
- `cargo test -p carbide-api-core tests::machine_network::test_managed_host_network_config_multi_dpu --lib -- --exact --nocapture`
- `cargo test -p carbide-api-core tests::machine_network::test_managed_host_network_config_multi_dpu_fnn_ipv6_loopbacks --lib -- --exact --nocapture`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make --no-workspace generate-rest-core-proto`

## Additional Notes

FNN only: ETV intentionally does not receive the optional IPv6 address, and the existing IPv4 loopback remains the router ID and VXLAN VTEP. The optional protobuf field is wire-compatible; older agents ignore it, while newer agents treat its absence as the existing IPv4-only behavior.

The REST Core protobuf snapshot and Go binding are regenerated for repository sync, but the curated public REST/OpenAPI model intentionally remains unchanged.

The per-DPU reservation dependency landed through #3913.

Closes #2390