### PR TITLE
fix(bmc-mock): update BF4 Redfish paths to match FW BF4-26.04-10

### DIFF
--- a/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
@@ -23,7 +23,7 @@ use tokio::test;
 use crate::common;
 
 #[test]
-async fn explore_bluefield4_and_generate_machine_id_from_bluefield_bmc_chassis_serial() {
+async fn explore_bluefield4_and_generate_machine_id_from_system_serial() {
     let h = test_support::dell_poweredge_r760_bluefield4_bmc(DpuMachineInfo {
         hw_type: HostHardwareType::DellPowerEdgeR760Bf4,
         bmc_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x01]),
@@ -42,10 +42,7 @@ async fn explore_bluefield4_and_generate_machine_id_from_bluefield_bmc_chassis_s
 
     let system = report.systems.first().expect("systems must be present");
     assert_eq!(system.id, "BlueField_0");
-    assert!(
-        system.serial_number.is_none(),
-        "BF4 Redfish reports the usable serial on chassis, not system"
-    );
+    assert_eq!(system.serial_number.as_deref(), Some("MT2610604VN4"));
 
     assert_eq!(
         report.managers.first().map(|manager| manager.id.as_str()),
@@ -115,7 +112,7 @@ async fn explore_b4240v_and_generate_machine_id() {
     assert_eq!(report.endpoint_type, EndpointType::Bmc);
     assert_eq!(report.vendor, Some(bmc_vendor::BMCVendor::Nvidia));
     assert!(report.chassis.iter().any(|chassis| {
-        chassis.id == "BlueField_BMC_0" && chassis.model.as_deref() == Some("B4240V")
+        chassis.id == "BlueField_0" && chassis.model.as_deref() == Some("B4240V")
     }));
     assert_eq!(
         report

--- a/crates/bmc-mock/src/hw/bluefield4.rs
+++ b/crates/bmc-mock/src/hw/bluefield4.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use mac_address::MacAddress;
 use serde_json::json;
 
-use crate::{Callbacks, LogService, LogServices, hw, redfish};
+use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
 
 #[derive(Clone, Copy, Debug)]
 pub enum Mode {
@@ -34,6 +34,7 @@ pub enum Mode {
 pub struct Bluefield4<'a> {
     pub product_serial_number: Cow<'a, str>,
     pub host_mac_address: MacAddress,
+    pub oob_mac_address: MacAddress,
     pub bmc_mac_address: MacAddress,
     pub mode: Mode,
 }
@@ -66,9 +67,9 @@ impl Bluefield4<'_> {
             chassis: vec![
                 redfish::chassis::SingleChassisConfig {
                     id: "BlueField_0".into(),
-                    chassis_type: "Component".into(),
-                    manufacturer: Some("NVIDIA".into()),
-                    model: Some("NA".into()),
+                    chassis_type: "Card".into(),
+                    manufacturer: Some("Nvidia".into()),
+                    model: Some(self.model().into()),
                     part_number: Some(self.part_number().into()),
                     serial_number: Some(self.product_serial_number.to_string().into()),
                     network_adapters: Some(self.network_adapters()),
@@ -83,7 +84,7 @@ impl Bluefield4<'_> {
                     id: Self::BMC_CHASSIS_ID.into(),
                     chassis_type: "Component".into(),
                     manufacturer: Some("Nvidia".into()),
-                    model: Some(self.model().into()),
+                    model: Some("BlueField-4".into()),
                     part_number: Some(self.part_number().into()),
                     pcie_devices: Some(vec![]),
                     sensors: Some(vec![]),
@@ -165,17 +166,215 @@ impl Bluefield4<'_> {
 
     pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
         let system_id = Self::SYSTEM_ID;
+        let boot_opt_builder = |id: &str, kind| {
+            redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
+                .boot_option_reference(id)
+        };
+        let host_mac = self
+            .host_mac_address
+            .to_string()
+            .replace(':', "")
+            .to_ascii_uppercase();
+        let oob_mac = self
+            .oob_mac_address
+            .to_string()
+            .replace(':', "")
+            .to_ascii_uppercase();
+        let nic_base = |function: &str| {
+            format!(
+                "VenHw(1E5A432C-0466-4D31-B009-D4D9239271D3)/\
+                 MemoryMapped(0xB,0x14140000,0x14141FFF)/PciRoot(0x6)/\
+                 Pci(0x0,0x0)/Pci({function})/MAC({host_mac},0x1)"
+            )
+        };
+        let oob_base = format!(
+            "VenHw(1E5A432C-0466-4D31-B009-D4D9239271D3)/\
+             MemoryMapped(0xB,0x14180000,0x14181FFF)/PciRoot(0x8)/\
+             Pci(0x0,0x0)/Pci(0x0,0x0)/Pci(0x6,0x0)/Pci(0x0,0x0)/\
+             MAC({oob_mac},0x1)"
+        );
+        let pxe_v4_display_name = format!("UEFI PXEv4 (MAC:{host_mac})");
+        let pxe_v6_display_name = format!("UEFI PXEv6 (MAC:{host_mac})");
+        let http_v4_display_name = format!("UEFI HTTPv4 (MAC:{host_mac})");
+        let http_v6_display_name = format!("UEFI HTTPv6 (MAC:{host_mac})");
+        let network_boot_options = [
+            (
+                "Boot0004",
+                "NET-OOB-IPV4",
+                format!("{oob_base}/IPv4(0.0.0.0)"),
+            ),
+            (
+                "Boot0005",
+                "NET-OOB-IPV6",
+                format!("{oob_base}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)"),
+            ),
+            (
+                "Boot0006",
+                "NET-OOB.4040-IPV4",
+                format!("{oob_base}/Vlan(4040)/IPv4(0.0.0.0)"),
+            ),
+            (
+                "Boot0007",
+                "NET-OOB.4040-IPV6",
+                format!(
+                    "{oob_base}/Vlan(4040)/\
+                     IPv6(0000:0000:0000:0000:0000:0000:0000:0000)"
+                ),
+            ),
+            (
+                "Boot0008",
+                "NET-NIC_P0-IPV4",
+                format!("{}/IPv4(0.0.0.0)", nic_base("0x0,0x0")),
+            ),
+            (
+                "Boot0009",
+                "NET-NIC_P0-IPV6",
+                format!(
+                    "{}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)",
+                    nic_base("0x0,0x0")
+                ),
+            ),
+            (
+                "Boot000A",
+                "NET-NIC_P0-IPV4-HTTP",
+                format!("{}/IPv4(0.0.0.0)/Uri()", nic_base("0x0,0x0")),
+            ),
+            (
+                "Boot000B",
+                "NET-NIC_P0-IPV6-HTTP",
+                format!(
+                    "{}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()",
+                    nic_base("0x0,0x0")
+                ),
+            ),
+            (
+                "Boot000C",
+                "NET-NIC_P1-IPV4",
+                format!("{}/IPv4(0.0.0.0)", nic_base("0x0,0x1")),
+            ),
+            (
+                "Boot000D",
+                "NET-NIC_P1-IPV6",
+                format!(
+                    "{}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)",
+                    nic_base("0x0,0x1")
+                ),
+            ),
+            (
+                "Boot000E",
+                "NET-NIC_P1-IPV4-HTTP",
+                format!("{}/IPv4(0.0.0.0)/Uri()", nic_base("0x0,0x1")),
+            ),
+            (
+                "Boot000F",
+                "NET-NIC_P1-IPV6-HTTP",
+                format!(
+                    "{}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()",
+                    nic_base("0x0,0x1")
+                ),
+            ),
+            (
+                "Boot0010",
+                pxe_v4_display_name.as_str(),
+                format!("{}/IPv4(0.0.0.0)", nic_base("0x0,0x2")),
+            ),
+            (
+                "Boot0011",
+                pxe_v6_display_name.as_str(),
+                format!(
+                    "{}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)",
+                    nic_base("0x0,0x2")
+                ),
+            ),
+            (
+                "Boot0012",
+                http_v4_display_name.as_str(),
+                format!("{}/IPv4(0.0.0.0)/Uri()", nic_base("0x0,0x2")),
+            ),
+            (
+                "Boot0013",
+                http_v6_display_name.as_str(),
+                format!(
+                    "{}/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()",
+                    nic_base("0x0,0x2")
+                ),
+            ),
+            (
+                "Boot0014",
+                "NET-OOB-IPV4-HTTP",
+                format!("{oob_base}/IPv4(0.0.0.0)/Uri()"),
+            ),
+            (
+                "Boot0015",
+                "NET-OOB-IPV6-HTTP",
+                format!(
+                    "{oob_base}/\
+                     IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()"
+                ),
+            ),
+            (
+                "Boot0016",
+                "NET-OOB.4040-IPV4-HTTP",
+                format!("{oob_base}/Vlan(4040)/IPv4(0.0.0.0)/Uri()"),
+            ),
+            (
+                "Boot0017",
+                "NET-OOB.4040-IPV6-HTTP",
+                format!(
+                    "{oob_base}/Vlan(4040)/\
+                     IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()"
+                ),
+            ),
+        ]
+        .into_iter()
+        .map(|(id, display_name, uefi_device_path)| {
+            boot_opt_builder(id, BootOptionKind::Network)
+                .display_name(display_name)
+                .uefi_device_path(&uefi_device_path)
+                .build()
+        });
+        let boot_options = [
+            boot_opt_builder("Boot0000", BootOptionKind::Disk)
+                .display_name("ubuntu0")
+                .uefi_device_path(
+                    "HD(1,GPT,3FECD8EB-847F-49EB-A0E5-A59B9D4C0B47,0x800,0x19000)/\
+                     \\EFI\\ubuntu\\shimaa64.efi",
+                )
+                .build(),
+            boot_opt_builder("Boot0003", BootOptionKind::Disk)
+                .display_name("UEFI HFS480GEJ8X176N 4425ADEAQ5394I080947 1")
+                .uefi_device_path(
+                    "VenHw(1E5A432C-0466-4D31-B009-D4D9239271D3)/\
+                     MemoryMapped(0xB,0x141A0000,0x141A1FFF)/PciRoot(0x9)/\
+                     Pci(0x0,0x0)/Pci(0x0,0x0)/\
+                     NVMe(0x1,00-55-CF-55-00-2E-E4-AC)",
+                )
+                .build(),
+        ]
+        .into_iter()
+        .chain(network_boot_options)
+        .chain(std::iter::once(
+            boot_opt_builder("Boot0019", BootOptionKind::Disk)
+                .display_name("UEFI Shell")
+                .uefi_device_path(
+                    "Fv(9AEF2E52-DEAD-4F63-B895-3A504A3E63C4)/\
+                     FvFile(7C04A583-9E3E-4F1C-AD65-E05268D0B4D1)",
+                )
+                .build(),
+        ))
+        .collect();
         redfish::computer_system::Config {
             systems: vec![redfish::computer_system::SingleSystemConfig {
                 id: Cow::Borrowed(system_id),
-                manufacturer: None,
-                model: None,
+                manufacturer: Some("Nvidia".into()),
+                model: Some("BlueField-4".into()),
+                // BF4-26.04-10 exposes this collection with no members.
                 eth_interfaces: Some(vec![]),
                 chassis: vec![Self::BMC_CHASSIS_ID.into()],
-                serial_number: None,
+                serial_number: Some(self.product_serial_number.to_string().into()),
                 boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                 callbacks: Some(callbacks),
-                boot_options: Some(vec![]),
+                boot_options: Some(boot_options),
                 bios_mode: redfish::computer_system::BiosMode::Generic,
                 oem: redfish::computer_system::Oem::NvidiaBluefield,
                 base_bios: Some(
@@ -210,7 +409,7 @@ impl Bluefield4<'_> {
                 ]),
                 host_interfaces: None,
                 serial_interfaces: None,
-                firmware_version: Some("BF4-26.04-4"),
+                firmware_version: Some("BF4-26.04-10"),
                 oem: None,
             }],
         }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -175,6 +175,7 @@ impl DpuMachineInfo {
         };
         hw::bluefield4::Bluefield4 {
             host_mac_address: self.host_mac_address,
+            oob_mac_address: self.oob_mac_address,
             bmc_mac_address: self.bmc_mac_address,
             product_serial_number: Cow::Borrowed(&self.serial),
             mode,
@@ -214,7 +215,7 @@ impl DpuMachineInfo {
     pub fn bmc_product(&self) -> Option<&'static str> {
         match self.dpu_type() {
             DpuType::Bluefield3 => Some("BlueField-3 DPU"),
-            DpuType::Bluefield4 => Some(self.bluefield4().model()),
+            DpuType::Bluefield4 => Some("BlueField-4"),
         }
     }
 

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -64,6 +64,7 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
     const ETH_ID: &str = "{eth_id}";
     const BOOT_OPTION_ID: &str = "{boot_option_id}";
     const LOG_SERVICE_ID: &str = "{log_service_id}";
+    const LOG_ENTRY_ID: &str = "{log_entry_id}";
     const PROCESSOR_ID: &str = "{processor_id}";
     let bios = redfish::bios::resource(SYSTEM_ID);
     r.route(&collection().odata_id, get(get_system_collection))
@@ -108,6 +109,14 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
         .route(
             &redfish::log_service::system_entries_collection(SYSTEM_ID, LOG_SERVICE_ID).odata_id,
             get(get_log_service_entries),
+        )
+        .route(
+            &format!(
+                "{}/{}",
+                redfish::log_service::system_entries_collection(SYSTEM_ID, LOG_SERVICE_ID).odata_id,
+                LOG_ENTRY_ID
+            ),
+            get(get_log_service_entry),
         )
         .route(
             &redfish::storage::system_collection(SYSTEM_ID).odata_id,
@@ -738,6 +747,29 @@ async fn get_log_service_entries(
                 .patch(json!({"Description": "Log services collection"})) // Required by libredfish
                 .into_ok_response()
         })
+        .unwrap_or_else(http::not_found)
+}
+
+async fn get_log_service_entry(
+    State(state): State<BmcState>,
+    Path((system_id, log_service_id, entry_id)): Path<(String, String, String)>,
+) -> Response {
+    state
+        .system_state
+        .find(&system_id)
+        .and_then(|system_state| system_state.config.log_services.as_ref())
+        .and_then(|log_services| log_services.find(&log_service_id))
+        .and_then(|log_service| {
+            let collection =
+                redfish::log_service::system_entries_collection(&system_id, &log_service_id);
+            log_service.entries(&collection).into_iter().find(|entry| {
+                entry
+                    .get("Id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|id| id == entry_id)
+            })
+        })
+        .map(|entry| entry.into_ok_response())
         .unwrap_or_else(http::not_found)
 }
 


### PR DESCRIPTION
New firmware changed BF4 paths a little bit. This PR updates these paths.

## Related issues

Closes: #3287 

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
