### PR TITLE
docs(helm): document values required when upgrading from pre-2.0.0 carbide naming

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -274,6 +274,99 @@ helm diff upgrade nico ./helm \
   -f values-production.yaml
 ```
 
+### Upgrading from pre-2.0.0 (carbide/forge naming)
+
+Starting with v2.0.0 the chart defaults changed from the legacy `carbide`/`forge` naming
+to `nico`. A **fresh install** works out of the box with no overrides — all default service
+names, SPIFFE identities, and trust domains are already `nico`-prefixed.
+
+A site **upgrading from a pre-2.0.0 release** needs to preserve the old names so that
+running DPU agents (which have certificates issued under `forge.local` and dial
+`carbide-api.forge-system`) keep working without a coordinated cut-over. Add the following
+block to your site values file (in addition to your normal site-specific overrides):
+
+```yaml
+# Preserves pre-2.0.0 carbide/forge naming across the upgrade.
+# Safe to remove once every DPU agent on the site has been re-issued a certificate
+# under nico.local and updated to the new binary that dials nico-api.
+global:
+  spiffe:
+    trustDomain: forge.local   # existing certs were issued under forge.local
+
+nico-api:
+  nameOverride: carbide-api
+  certificate:
+    identityNamespace: forge-system
+  auth:
+    namespace: forge-system    # accept /forge-system/sa/ and /forge-system/machine/ SPIFFE paths
+    principals:
+      dhcp: carbide-dhcp
+      dns: carbide-dns
+
+nico-bmc-proxy:
+  nameOverride: carbide-bmc-proxy
+  certificate:
+    identityNamespace: forge-system
+  auth:
+    namespace: forge-system
+    apiPrincipal: carbide-api
+
+nico-dhcp:
+  nameOverride: carbide-dhcp
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system
+
+nico-dns:
+  nameOverride: carbide-dns
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system
+
+nico-dsx-exchange-consumer:
+  nameOverride: carbide-dsx-exchange-consumer
+  certificate:
+    identityNamespace: forge-system
+
+nico-hardware-health:
+  nameOverride: carbide-hardware-health
+  certificate:
+    identityNamespace: forge-system
+
+nico-pxe:
+  nameOverride: carbide-pxe
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system
+
+nico-ssh-console-rs:
+  nameOverride: carbide-ssh-console-rs
+  apiServiceName: carbide-api
+  certificate:
+    identityNamespace: forge-system
+```
+
+This is also available as a ready-to-use overlay at
+[`examples/carbide-legacy.yaml`](./examples/carbide-legacy.yaml).
+
+**Why each block matters:**
+
+- `global.spiffe.trustDomain: forge.local` — all existing DPU agent and service certificates
+  were issued under this trust domain. Changing it before reissuing every cert breaks mTLS
+  cluster-wide.
+- `nameOverride: carbide-*` — keeps each Kubernetes Service name stable so existing clients
+  find the service. Without this, `helm upgrade` deletes `carbide-api` and creates `nico-api`,
+  causing an outage window and breaking any client that cached the old DNS name.
+- `certificate.identityNamespace: forge-system` — keeps the SPIFFE URI of each service
+  consistent with what Vault and peer services expect (e.g.
+  `spiffe://forge.local/forge-system/sa/carbide-api`).
+- `auth.namespace: forge-system` — tells `nico-api` to accept SPIFFE IDs whose path contains
+  `/forge-system/`, which is what pre-2.0.0 client certificates present.
+- `apiServiceName: carbide-api` — tells `nico-pxe`, `nico-dhcp`, `nico-dns`, and
+  `nico-ssh-console-rs` to dial `carbide-api` (the name the Service has after `nameOverride`),
+  rather than the new default `nico-api`. Without this, those services build a URL pointing at
+  a Service that does not exist.
+
 ## Uninstalling
 
 ```bash

--- a/helm/README.md
+++ b/helm/README.md
@@ -280,7 +280,21 @@ Starting with v2.0.0 the chart defaults changed from the legacy `carbide`/`forge
 to `nico`. A **fresh install** works out of the box with no overrides — all default service
 names, SPIFFE identities, and trust domains are already `nico`-prefixed.
 
-A site **upgrading from a pre-2.0.0 release** needs to preserve the old names so that
+> **Cutting over to nico naming on an existing site:** if you want to fully migrate an
+> existing site from `carbide`/`forge` naming to `nico` naming rather than preserving the
+> old names in-place, the safe procedure is:
+> 1. Back up the PostgreSQL database (`pg_dump`).
+> 2. Uninstall the current release (`helm uninstall nico -n forge-system`).
+> 3. Re-install from scratch with the new defaults and your target namespace
+>    (`helm upgrade --install nico ./helm -n nico-system --create-namespace -f values-production.yaml`).
+> 4. Restore the database into the new cluster (`pg_restore`).
+>
+> This is necessary because Kubernetes Services, Certificates, and SPIFFE identities cannot
+> be renamed in-place without a coordinated restart of every component and re-issuance of
+> every DPU agent certificate. A backup/restore avoids that coordination.
+
+A site **upgrading from a pre-2.0.0 release** that wants to keep the old names running
+without a full cut-over needs to preserve the old names so that
 running DPU agents (which have certificates issued under `forge.local` and dial
 `carbide-api.forge-system`) keep working without a coordinated cut-over. Add the following
 block to your site values file (in addition to your normal site-specific overrides):


### PR DESCRIPTION
## Summary

The `Upgrading` section in `helm/README.md` previously only showed the `helm upgrade` command with no mention that v2.0.0 changed all chart defaults from `carbide`/`forge` to `nico`. Sites coming from a pre-2.0.0 install need explicit overrides to keep service names, SPIFFE identities, and trust domains stable across the upgrade — otherwise `helm upgrade` renames Services (causing an outage window) and changes the expected SPIFFE trust domain (breaking mTLS with existing DPU agent certs).

This adds a **Upgrading from pre-2.0.0** subsection that:
- Shows the full override block needed to preserve carbide naming
- Points to the existing `examples/carbide-legacy.yaml` as a ready-to-use overlay
- Explains why each entry is needed (nameOverride, apiServiceName, auth.namespace, spiffe.trustDomain, certificate.identityNamespace)

Fresh 2.0.0 installs are unaffected — the defaults are already correct and require no overrides.

## Related issues

Closes #4196 (ytl-dev1-dh1: nico-pxe using carbide-api endpoint)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)