### PR TITLE
fix(helm-prereqs): bump postgres-operator chart to 1.11.0

### DIFF
--- a/helm-prereqs/helmfile.yaml
+++ b/helm-prereqs/helmfile.yaml
@@ -65,7 +65,10 @@ releases:
     namespace: postgres
     createNamespace: true
     chart: postgres-operator/postgres-operator
-    version: "1.10.1"
+    # NOTE: chart versions below 1.11.0 are no longer published in Zalando's chart
+    # repository. The CRD API (acid.zalan.do/v1) is unchanged across this bump, and
+    # nico-pg-cluster pins postgresql.version explicitly, so the database is unaffected.
+    version: "1.11.0"
     wait: true
     timeout: 600
     values:

--- a/helm-prereqs/operators/values/postgres-operator.yaml
+++ b/helm-prereqs/operators/values/postgres-operator.yaml
@@ -1,4 +1,4 @@
-## Zalando postgres-operator 1.10.1
+## Zalando postgres-operator (see helmfile.yaml for the version pin)
 ## Reference: nico-external/manifests/nico-pg-operator-app/values.yaml
 
 configTarget: ConfigMap


### PR DESCRIPTION
Chart versions below 1.11.0 are no longer available from Zalando's chart repository, which causes fresh `helm-prereqs/setup.sh` installs to fail at phase [1b] (`no chart version found for postgres-operator-1.10.1`). The acid.zalan.do/v1 CRD API is unchanged across the bump and nico-pg-cluster pins its PostgreSQL version explicitly, so deployed databases are unaffected.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Verified end to end on a fresh 3-node cluster (dev7): full `setup.sh` install succeeds with the 1.11.0 pin; `nico-pg-cluster` reaches Running with the pinned PostgreSQL version.
