### PR TITLE
fix(ssh-console): retry ephemeral listener conflicts

### DIFF
--- a/crates/ssh-console/src/lib.rs
+++ b/crates/ssh-console/src/lib.rs
@@ -20,6 +20,7 @@ mod io_util;
 mod metrics;
 mod ssh_cert_parsing;
 mod ssh_server;
+mod tcp_listener;
 
 mod console_logger;
 mod frontend;

--- a/crates/ssh-console/src/metrics.rs
+++ b/crates/ssh-console/src/metrics.rs
@@ -27,22 +27,21 @@ use hyper_util::server::conn::auto;
 use opentelemetry::metrics::{Meter, MeterProvider};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::Encoder;
-use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 use crate::config::Config;
 use crate::shutdown_handle::ShutdownHandle;
+use crate::tcp_listener;
 
 pub async fn spawn(
     config: Arc<Config>,
     metrics_state: Arc<MetricsState>,
 ) -> Result<MetricsHandle, SpawnError> {
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
-    let listener = TcpListener::bind(config.metrics_address)
+    let (listener, metrics_address) = tcp_listener::bind(config.metrics_address)
         .await
         .map_err(SpawnError::Listen)?;
-    let metrics_address = listener.local_addr().map_err(SpawnError::Listen)?;
 
     tracing::info!(
         %metrics_address,

--- a/crates/ssh-console/src/ssh_server.rs
+++ b/crates/ssh-console/src/ssh_server.rs
@@ -33,6 +33,7 @@ use crate::bmc::client_pool::BmcConnectionStore;
 use crate::config::Config;
 use crate::frontend::{Handler, HandlerError};
 use crate::shutdown_handle::ShutdownHandle;
+use crate::tcp_listener;
 
 pub async fn spawn(
     config: Arc<Config>,
@@ -69,16 +70,13 @@ pub async fn spawn(
         metrics,
     };
 
-    let listener = TcpListener::bind(listen_address)
-        .await
-        .map_err(|error| Listening {
-            addr: listen_address,
-            error,
-        })?;
-    let listen_address = listener.local_addr().map_err(|error| Listening {
-        addr: listen_address,
-        error,
-    })?;
+    let (listener, listen_address) =
+        tcp_listener::bind(listen_address)
+            .await
+            .map_err(|error| Listening {
+                addr: listen_address,
+                error,
+            })?;
     tracing::info!(%listen_address, "SSH server listening");
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();

--- a/crates/ssh-console/src/tcp_listener.rs
+++ b/crates/ssh-console/src/tcp_listener.rs
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::io;
+use std::net::SocketAddr;
+
+use tokio::net::TcpListener;
+
+const MAX_EPHEMERAL_BIND_ATTEMPTS: usize = 10;
+
+pub(crate) async fn bind(address: SocketAddr) -> io::Result<(TcpListener, SocketAddr)> {
+    let mut attempt = 1;
+    loop {
+        match TcpListener::bind(address).await {
+            Ok(listener) => {
+                let effective_address = listener.local_addr()?;
+                return Ok((listener, effective_address));
+            }
+            Err(error) if should_retry(address, error.kind(), attempt) => {
+                tracing::warn!(
+                    configured_address = %address,
+                    %error,
+                    attempt,
+                    max_attempts = MAX_EPHEMERAL_BIND_ATTEMPTS,
+                    "ephemeral TCP listener bind conflicted; retrying"
+                );
+                attempt += 1;
+                tokio::task::yield_now().await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn should_retry(address: SocketAddr, error_kind: io::ErrorKind, attempt: usize) -> bool {
+    address.port() == 0
+        && error_kind == io::ErrorKind::AddrInUse
+        && attempt < MAX_EPHEMERAL_BIND_ATTEMPTS
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[derive(Clone, Copy, Debug)]
+    struct RetryInput {
+        port: u16,
+        error_kind: io::ErrorKind,
+        attempt: usize,
+    }
+
+    #[test]
+    fn retries_only_ephemeral_address_conflicts_with_attempts_remaining() {
+        value_scenarios!(run = |input: RetryInput| should_retry(
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), input.port),
+            input.error_kind,
+            input.attempt,
+        );
+            "ephemeral address conflict" {
+                RetryInput {
+                    port: 0,
+                    error_kind: io::ErrorKind::AddrInUse,
+                    attempt: 1,
+                } => true,
+                RetryInput {
+                    port: 0,
+                    error_kind: io::ErrorKind::AddrInUse,
+                    attempt: MAX_EPHEMERAL_BIND_ATTEMPTS - 1,
+                } => true,
+            }
+
+            "non-retryable bind failure" {
+                RetryInput {
+                    port: 22,
+                    error_kind: io::ErrorKind::AddrInUse,
+                    attempt: 1,
+                } => false,
+                RetryInput {
+                    port: 0,
+                    error_kind: io::ErrorKind::PermissionDenied,
+                    attempt: 1,
+                } => false,
+                RetryInput {
+                    port: 0,
+                    error_kind: io::ErrorKind::AddrInUse,
+                    attempt: MAX_EPHEMERAL_BIND_ATTEMPTS,
+                } => false,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn ephemeral_bind_returns_effective_address() {
+        let configured_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+        let (listener, effective_address) = bind(configured_address)
+            .await
+            .expect("ephemeral listener should bind");
+
+        assert_ne!(effective_address.port(), 0);
+        assert_eq!(
+            listener
+                .local_addr()
+                .expect("bound listener should have a local address"),
+            effective_address
+        );
+    }
+
+    #[tokio::test]
+    async fn occupied_explicit_port_returns_address_in_use() {
+        let existing = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("port reservation should bind");
+        let occupied_address = existing
+            .local_addr()
+            .expect("port reservation should have a local address");
+
+        let error = bind(occupied_address)
+            .await
+            .expect_err("occupied explicit port should fail");
+
+        assert_eq!(error.kind(), io::ErrorKind::AddrInUse);
+    }
+}


### PR DESCRIPTION
Binding an ephemeral SSH or metrics listener can transiently return `AddrInUse` under concurrent test load. This causes ssh-console startup and its integration tests to fail even though the listeners are configured with port zero and should receive OS-assigned ports.

This change introduces a shared listener-binding helper that retries `AddrInUse` failures for port-zero addresses up to a bounded limit. Both the SSH and metrics listeners use the helper. Explicitly configured ports and other bind errors continue to fail immediately.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Example of failure:
https://github.com/NVIDIA/infra-controller/actions/runs/30388317585/job/90373510915
