### PR TITLE
feat(instrument): let a metric family compute a label from another label

### DIFF
--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -1056,12 +1056,41 @@ fn family_name(path: &syn::Path) -> String {
 /// one label set. Metric names and describe text are validated exactly as they
 /// are for a metric declared inline on an Event, with the same
 /// `metric_name_unchecked` and `describe_unchecked` escape hatches.
-#[proc_macro_derive(MetricFamily, attributes(metric, label))]
+#[proc_macro_derive(MetricFamily, attributes(metric, label, derived))]
 pub fn derive_metric_family(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as DeriveInput);
     match expand_metric_family(input) {
         Ok(ts) => ts,
         Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// One `#[derived(label: Type, from = source)]` on a metric family: a label the
+/// family computes from another label rather than taking from the call site.
+/// The family stays the list of labels an Event supplies, so a derived label is
+/// declared here instead of as a field.
+struct DerivedLabel {
+    label: Ident,
+    ty: syn::Type,
+    from: Ident,
+}
+
+impl syn::parse::Parse for DerivedLabel {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
+        let label: Ident = input.parse()?;
+        input.parse::<syn::Token![:]>()?;
+        let ty: syn::Type = input.parse()?;
+        input.parse::<syn::Token![,]>()?;
+        let from_key: Ident = input.parse()?;
+        if from_key != "from" {
+            return Err(syn::Error::new_spanned(
+                from_key,
+                "a derived label reads #[derived(label: Type, from = other_label)]",
+            ));
+        }
+        input.parse::<syn::Token![=]>()?;
+        let from: Ident = input.parse()?;
+        Ok(DerivedLabel { label, ty, from })
     }
 }
 
@@ -1228,9 +1257,51 @@ fn expand_metric_family(input: DeriveInput) -> syn::Result<TokenStream> {
         labels_fields.push(field);
     }
 
-    let n_labels = labels.len();
+    // Labels the family computes rather than takes: declared on the struct so
+    // the family's fields stay exactly what an Event has to supply.
+    let mut derived: Vec<DerivedLabel> = Vec::new();
+    for attr in input.attrs.iter().filter(|a| a.path().is_ident("derived")) {
+        let label: DerivedLabel = attr.parse_args()?;
+        let key = validate_metric_label_name(label.label.to_string(), label.label.span())?;
+        if labels.iter().any(|(_, name)| name == &key)
+            || derived.iter().any(|other| other.label == label.label)
+        {
+            return Err(syn::Error::new_spanned(
+                &label.label,
+                format!("duplicate metric label name `{key}`"),
+            ));
+        }
+        // The source must be a label the call site actually supplies: deriving
+        // from another derived label would make the order of computation part
+        // of the declaration.
+        if derived.iter().any(|other| other.label == label.from) {
+            return Err(syn::Error::new_spanned(
+                &label.from,
+                format!(
+                    "`{}` is itself derived; a derived label reads from a label the Event supplies",
+                    label.from
+                ),
+            ));
+        }
+        if !labels.iter().any(|(ident, _)| **ident == label.from) {
+            return Err(syn::Error::new_spanned(
+                &label.from,
+                format!("`{}` is not a field of this metric family", label.from),
+            ));
+        }
+        derived.push(label);
+    }
+
+    let n_labels = labels.len() + derived.len();
     let label_idents: Vec<&Ident> = labels.iter().map(|(ident, _)| *ident).collect();
     let label_names: Vec<&str> = labels.iter().map(|(_, name)| name.as_str()).collect();
+    let derived_keys: Vec<String> = derived
+        .iter()
+        .map(|label| label.label.to_string())
+        .collect();
+    let derived_idents: Vec<&Ident> = derived.iter().map(|label| &label.label).collect();
+    let derived_types: Vec<&syn::Type> = derived.iter().map(|label| &label.ty).collect();
+    let derived_sources: Vec<&Ident> = derived.iter().map(|label| &label.from).collect();
     let describe_value = args
         .describe
         .as_ref()
@@ -1263,11 +1334,24 @@ fn expand_metric_family(input: DeriveInput) -> syn::Result<TokenStream> {
             type Labels = [::carbide_instrument::__private::opentelemetry::KeyValue; #n_labels];
 
             fn labels(&self) -> Self::Labels {
+                #(
+                    // A derived label is computed here, once, from the label it
+                    // reads -- so no call site can pair the two contradictorily.
+                    let #derived_idents: #derived_types = ::std::convert::Into::into(
+                        ::std::clone::Clone::clone(&self.#derived_sources),
+                    );
+                )*
                 [
                     #(
                         ::carbide_instrument::__private::opentelemetry::KeyValue::new(
                             #label_names,
                             ::carbide_instrument::LabelValue::label_value(&self.#label_idents),
+                        ),
+                    )*
+                    #(
+                        ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                            #derived_keys,
+                            ::carbide_instrument::LabelValue::label_value(&#derived_idents),
                         ),
                     )*
                 ]
@@ -1738,6 +1822,67 @@ mod tests {
             ],
             |DiagnosticInput { source, expected }| {
                 let error = family_error(source);
+                (!error.contains(expected)).then(|| format!("expected `{expected}` in `{error}`"))
+            },
+        );
+    }
+
+    /// A derived label is declared once on the family and computed there, so
+    /// its diagnostics point at the family's declaration.
+    #[test]
+    fn derived_label_diagnostics_are_specific() {
+        struct DiagnosticInput {
+            derived: &'static str,
+            expected: &'static str,
+        }
+
+        fn family_error(source: &str) -> String {
+            let input: DeriveInput = syn::parse_str(source).expect("valid derive input");
+            super::expand_metric_family(input)
+                .expect_err("input should be rejected")
+                .to_string()
+        }
+
+        const METRIC: &str = r#"#[metric(name = "carbide_f_total", kind = counter, component = "c", describe = "Number of things")]"#;
+
+        check_values(
+            [
+                Check {
+                    scenario: "the source must be a field of the family",
+                    input: DiagnosticInput {
+                        derived: r#"#[derived(kind: Kind, from = nonexistent)]"#,
+                        expected: "`nonexistent` is not a field of this metric family",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "a derived label cannot read another derived label",
+                    input: DiagnosticInput {
+                        derived: r#"#[derived(kind: Kind, from = stage)] #[derived(other: Kind, from = kind)]"#,
+                        expected: "`kind` is itself derived",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "a derived label cannot collide with a supplied one",
+                    input: DiagnosticInput {
+                        derived: r#"#[derived(stage: Kind, from = stage)]"#,
+                        expected: "duplicate metric label name `stage`",
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "the grammar names the source with `from`",
+                    input: DiagnosticInput {
+                        derived: r#"#[derived(kind: Kind, using = stage)]"#,
+                        expected: "reads #[derived(label: Type, from = other_label)]",
+                    },
+                    expect: None,
+                },
+            ],
+            |DiagnosticInput { derived, expected }| {
+                let error =
+                    family_error(&format!("{METRIC} {derived} struct F {{ stage: Stage }}"));
                 (!error.contains(expected)).then(|| format!("expected `{expected}` in `{error}`"))
             },
         );

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -175,6 +175,71 @@
 //! }
 //! ```
 //!
+//! ## A label the family computes
+//!
+//! Sometimes one label is a function of another -- a failure *kind* that
+//! follows from the *stage* it failed at. Declaring both invites a call site to
+//! pair them wrongly, so the family can compute one instead:
+//!
+//! ```
+//! use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
+//!
+//! #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+//! enum Stage {
+//!     Decode,
+//!     Publish,
+//! }
+//!
+//! #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+//! enum Kind {
+//!     InvalidRequest,
+//!     Rpc,
+//! }
+//!
+//! impl From<Stage> for Kind {
+//!     fn from(stage: Stage) -> Self {
+//!         match stage {
+//!             Stage::Decode => Kind::InvalidRequest,
+//!             Stage::Publish => Kind::Rpc,
+//!         }
+//!     }
+//! }
+//!
+//! #[derive(MetricFamily)]
+//! #[metric(
+//!     name = "carbide_ingest_failures_total",
+//!     kind = counter,
+//!     component = "ingest",
+//!     describe = "Number of ingest failures, by stage and kind",
+//! )]
+//! #[derived(kind: Kind, from = stage)] // computed, never supplied
+//! struct IngestFailures {
+//!     stage: Stage,
+//! }
+//!
+//! #[derive(Event)]
+//! #[event(
+//!     event_name = "ingest_failed",
+//!     metric_family = IngestFailures,
+//!     log = warn,
+//!     message = "ingest failed",
+//! )]
+//! struct IngestFailed {
+//!     #[label]
+//!     stage: Stage, // `kind` is the family's to compute; declaring it here is a compile error
+//! }
+//!
+//! emit(IngestFailed {
+//!     stage: Stage::Publish,
+//! }); // records kind="rpc"
+//! ```
+//!
+//! `kind` stays a metric label with the same values; what changes is that the
+//! family computes it through `From`, so a contradictory pair has no series to
+//! land in. A derived label is not a field of any event, so it does not appear
+//! as a log field either -- the label it reads does, and the `From` impl is the
+//! one place the mapping lives.
+//!
 //! Reach for a family only when two or more events move the same metric. A
 //! metric one event owns stays declared inline on that event -- and because
 //! the family owns the metric side, an event that names one must not restate

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -848,3 +848,99 @@ fn a_histogram_family_converts_the_observation() {
         "the family's histogram is exported under its declared name"
     );
 }
+
+/// A derived label is computed by the family from a label the Event supplies,
+/// so it lands on the metric without the Event -- or its call sites -- ever
+/// being able to pair the two contradictorily.
+#[test]
+fn a_derived_label_is_computed_by_the_family() {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+    enum DerivedStage {
+        Decode,
+        Publish,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
+    enum DerivedKind {
+        InvalidRequest,
+        Rpc,
+    }
+
+    impl From<DerivedStage> for DerivedKind {
+        fn from(stage: DerivedStage) -> Self {
+            match stage {
+                DerivedStage::Decode => DerivedKind::InvalidRequest,
+                DerivedStage::Publish => DerivedKind::Rpc,
+            }
+        }
+    }
+
+    #[derive(MetricFamily)]
+    #[metric(
+        name = "carbide_test_matrix_derived_total",
+        kind = counter,
+        component = "matrix-test",
+        describe = "Number of matrix derived-label test failures, by stage and kind."
+    )]
+    #[derived(kind: DerivedKind, from = stage)]
+    struct DerivedFailures {
+        stage: DerivedStage,
+    }
+
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_derived_failed",
+        metric_family = DerivedFailures,
+        log = warn,
+        message = "matrix derived failed"
+    )]
+    struct DerivedFailed {
+        #[label]
+        stage: DerivedStage,
+        #[context]
+        detail: String,
+    }
+
+    let metrics = MetricsCapture::start();
+    let logs = capture_logs(|| {
+        emit(DerivedFailed {
+            stage: DerivedStage::Publish,
+            detail: "upstream refused".to_string(),
+        });
+        emit(DerivedFailed {
+            stage: DerivedStage::Decode,
+            detail: "bad frame".to_string(),
+        });
+    });
+
+    // Each stage reaches the metric paired with the kind its `From` impl gives.
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_derived_total",
+            &[("stage", "publish"), ("kind", "rpc")],
+        ),
+        1.0
+    );
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_derived_total",
+            &[("stage", "decode"), ("kind", "invalid_request")],
+        ),
+        1.0
+    );
+    // ...and the contradictory pairing has no series at all.
+    assert_eq!(
+        metrics.counter_delta(
+            "carbide_test_matrix_derived_total",
+            &[("stage", "publish"), ("kind", "invalid_request")],
+        ),
+        0.0
+    );
+
+    // The Event never declares the derived label, so it is not a log field --
+    // its source is, and the mapping is the family's `From` impl.
+    assert_eq!(logs.len(), 2);
+    assert_eq!(logs[0].field("stage"), Some("publish"));
+    assert_eq!(logs[0].field("kind"), None);
+    assert_eq!(logs[0].field("detail"), Some("upstream refused"));
+}

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -250,16 +250,22 @@ pub(crate) enum ScoutMlxFailureKind {
     Rpc,
 }
 
-impl ScoutMlxFailureStage {
-    fn failure_kind(self) -> ScoutMlxFailureKind {
-        match self {
-            Self::Create | Self::Discover | Self::Initialize | Self::Execute => {
-                ScoutMlxFailureKind::Backend
+/// Every failure stage belongs to exactly one failure kind, so the family
+/// derives the `failure_kind` label from `failure_stage` through this
+/// conversion rather than letting a call site supply the pair.
+impl From<ScoutMlxFailureStage> for ScoutMlxFailureKind {
+    fn from(stage: ScoutMlxFailureStage) -> Self {
+        match stage {
+            ScoutMlxFailureStage::Create
+            | ScoutMlxFailureStage::Discover
+            | ScoutMlxFailureStage::Initialize
+            | ScoutMlxFailureStage::Execute => ScoutMlxFailureKind::Backend,
+            ScoutMlxFailureStage::Publish => ScoutMlxFailureKind::Rpc,
+            ScoutMlxFailureStage::Decode | ScoutMlxFailureStage::Validate => {
+                ScoutMlxFailureKind::InvalidRequest
             }
-            Self::Publish => ScoutMlxFailureKind::Rpc,
-            Self::Decode | Self::Validate => ScoutMlxFailureKind::InvalidRequest,
-            Self::Lookup => ScoutMlxFailureKind::NotFound,
-            Self::Serialize => ScoutMlxFailureKind::Serialization,
+            ScoutMlxFailureStage::Lookup => ScoutMlxFailureKind::NotFound,
+            ScoutMlxFailureStage::Serialize => ScoutMlxFailureKind::Serialization,
         }
     }
 }
@@ -267,7 +273,10 @@ impl ScoutMlxFailureStage {
 /// `ScoutMlxFailures` is the one metric behind every Scout MLX failure below:
 /// which operation failed, where it failed, and what class of failure it was.
 /// The Events that record it keep their own severity, wording, and diagnostic
-/// context, and the derive checks each one against these three labels.
+/// context, and the derive checks each one against the labels they supply.
+///
+/// `failure_kind` is not one of those: it follows from `failure_stage`, so the
+/// family computes it and no call site can pair the two contradictorily.
 #[derive(MetricFamily)]
 #[metric(
     name = "carbide_scout_mlx_failures_total",
@@ -275,10 +284,10 @@ impl ScoutMlxFailureStage {
     component = "nico-scout",
     describe = "Number of Scout MLX observation, read, mutation, and recovery failures, by operation, failure stage, and failure kind."
 )]
+#[derived(failure_kind: ScoutMlxFailureKind, from = failure_stage)]
 pub(crate) struct ScoutMlxFailures {
     operation: ScoutMlxOperation,
     failure_stage: ScoutMlxFailureStage,
-    failure_kind: ScoutMlxFailureKind,
 }
 
 // The operation, request, device, profile, registry, config, firmware, and
@@ -286,12 +295,11 @@ pub(crate) struct ScoutMlxFailures {
 // diagnostics need different context. Keep separate `Event` structs so each log
 // retains its fields without filling unrelated fields with empty values.
 //
-// Named constructors own each valid (`operation`, `failure_stage`) pair and
-// derive `failure_kind` from the stage. That makes contradictory metric
-// series unrepresentable at call sites. The dynamic log and message matches
-// still have generic fallbacks: `emit()` is diagnostic plumbing and must not
-// panic if a future constructor reaches a pair its matching table does not
-// know yet.
+// Named constructors still own each valid (`operation`, `failure_stage`) pair,
+// so a call site names the situation rather than assembling one. The dynamic
+// log and message matches keep generic fallbacks: `emit()` is diagnostic
+// plumbing and must not panic if a future constructor reaches a pair its
+// matching table does not know yet.
 
 /// An MLX failure whose existing diagnostic only carries an error.
 #[derive(Event)]
@@ -306,8 +314,6 @@ pub(crate) struct ScoutMlxOperationFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     error: String,
 }
@@ -321,7 +327,6 @@ impl ScoutMlxOperationFailed {
         Self {
             operation,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             error,
         }
     }
@@ -487,8 +492,6 @@ pub(crate) struct ScoutMlxRequestRejected {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
 }
 
 impl ScoutMlxRequestRejected {
@@ -497,7 +500,6 @@ impl ScoutMlxRequestRejected {
         Self {
             operation,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
         }
     }
 
@@ -548,8 +550,6 @@ pub(crate) struct ScoutMlxDeviceOperationFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device_id: String,
     #[context]
@@ -566,7 +566,6 @@ impl ScoutMlxDeviceOperationFailed {
         Self {
             operation,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device_id,
             error,
         }
@@ -642,8 +641,6 @@ pub(crate) struct ScoutMlxProfileOperationFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device_id: String,
     #[context]
@@ -662,7 +659,6 @@ impl ScoutMlxProfileOperationFailed {
         Self {
             operation: ScoutMlxOperation::ProfileCompare,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device_id,
             profile_name,
             error,
@@ -678,7 +674,6 @@ impl ScoutMlxProfileOperationFailed {
         Self {
             operation: ScoutMlxOperation::ProfileSync,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device_id,
             profile_name,
             error,
@@ -716,8 +711,6 @@ pub(crate) struct ScoutMlxRegistryLookupFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     registry_name: String,
 }
@@ -728,7 +721,6 @@ impl ScoutMlxRegistryLookupFailed {
         Self {
             operation: ScoutMlxOperation::RegistryShow,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             registry_name,
         }
     }
@@ -747,8 +739,6 @@ pub(crate) struct ScoutMlxConfigRegistryLookupFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device_id: String,
     #[context]
@@ -761,7 +751,6 @@ impl ScoutMlxConfigRegistryLookupFailed {
         Self {
             operation,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device_id,
             registry_name,
         }
@@ -797,8 +786,6 @@ pub(crate) struct ScoutMlxConfigOperationFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device_id: String,
     #[context]
@@ -818,7 +805,6 @@ impl ScoutMlxConfigOperationFailed {
         Self {
             operation,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device_id,
             registry_name,
             error,
@@ -966,8 +952,6 @@ pub(crate) struct ScoutMlxProfileResetFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device: String,
     #[context]
@@ -980,7 +964,6 @@ impl ScoutMlxProfileResetFailed {
         Self {
             operation: ScoutMlxOperation::ProfileReset,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device,
             error,
         }
@@ -1000,8 +983,6 @@ pub(crate) struct ScoutMlxProfileApplyFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device: String,
     #[context]
@@ -1016,7 +997,6 @@ impl ScoutMlxProfileApplyFailed {
         Self {
             operation: ScoutMlxOperation::ProfileApply,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device,
             profile,
             error,
@@ -1037,8 +1017,6 @@ pub(crate) struct ScoutMlxFirmwareFlasherInitializationFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device: String,
     #[context]
@@ -1055,7 +1033,6 @@ impl ScoutMlxFirmwareFlasherInitializationFailed {
         Self {
             operation: ScoutMlxOperation::FirmwareFlash,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device,
             part_number,
             psid,
@@ -1077,8 +1054,6 @@ pub(crate) struct ScoutMlxFirmwareFlashFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     device: String,
     #[context]
@@ -1106,7 +1081,6 @@ impl ScoutMlxFirmwareFlashFailed {
         Self {
             operation: ScoutMlxOperation::FirmwareFlash,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             device,
             part_number,
             psid,
@@ -1130,8 +1104,6 @@ pub(crate) struct ScoutMlxReconciliationFailed {
     operation: ScoutMlxOperation,
     #[label]
     failure_stage: ScoutMlxFailureStage,
-    #[label]
-    failure_kind: ScoutMlxFailureKind,
     #[context]
     pci_name: String,
     #[context]
@@ -1148,7 +1120,6 @@ impl ScoutMlxReconciliationFailed {
         Self {
             operation,
             failure_stage,
-            failure_kind: failure_stage.failure_kind(),
             pci_name,
             error,
         }
@@ -1468,7 +1439,7 @@ mod tests {
                     expect: ScoutMlxFailureKind::Serialization,
                 },
             ],
-            ScoutMlxFailureStage::failure_kind,
+            ScoutMlxFailureKind::from,
         );
     }
 

--- a/crates/scout/src/mlx_device.rs
+++ b/crates/scout/src/mlx_device.rs
@@ -1391,7 +1391,6 @@ mod tests {
         event_name: String,
         operation: Option<String>,
         failure_stage: Option<String>,
-        failure_kind: Option<String>,
         device_id: Option<String>,
         registry_name: Option<String>,
     }
@@ -1419,6 +1418,9 @@ mod tests {
                 Self::MissingProfileCompare | Self::MissingProfileSync => "validate",
                 _ => "lookup",
             };
+            // `failure_kind` is derived by `ScoutMlxFailures` from
+            // `failure_stage`, so it is a metric label without being a log
+            // field -- these labels are what the counter is asserted against.
             let failure_kind = match self {
                 Self::MissingProfileCompare | Self::MissingProfileSync => "invalid_request",
                 _ => "not_found",
@@ -1572,7 +1574,6 @@ mod tests {
                             event_name: "scout_mlx_registry_lookup_failed".to_string(),
                             operation: Some("registry_show".to_string()),
                             failure_stage: Some("lookup".to_string()),
-                            failure_kind: Some("not_found".to_string()),
                             device_id: None,
                             registry_name: Some(REGISTRY.to_string()),
                         }],
@@ -1592,7 +1593,6 @@ mod tests {
                             event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
                             operation: Some("config_query".to_string()),
                             failure_stage: Some("lookup".to_string()),
-                            failure_kind: Some("not_found".to_string()),
                             device_id: Some(DEVICE_ID.to_string()),
                             registry_name: Some(REGISTRY.to_string()),
                         }],
@@ -1612,7 +1612,6 @@ mod tests {
                             event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
                             operation: Some("config_compare".to_string()),
                             failure_stage: Some("lookup".to_string()),
-                            failure_kind: Some("not_found".to_string()),
                             device_id: Some(DEVICE_ID.to_string()),
                             registry_name: Some(REGISTRY.to_string()),
                         }],
@@ -1632,7 +1631,6 @@ mod tests {
                             event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
                             operation: Some("config_set".to_string()),
                             failure_stage: Some("lookup".to_string()),
-                            failure_kind: Some("not_found".to_string()),
                             device_id: Some(DEVICE_ID.to_string()),
                             registry_name: Some(REGISTRY.to_string()),
                         }],
@@ -1652,7 +1650,6 @@ mod tests {
                             event_name: "scout_mlx_config_registry_lookup_failed".to_string(),
                             operation: Some("config_sync".to_string()),
                             failure_stage: Some("lookup".to_string()),
-                            failure_kind: Some("not_found".to_string()),
                             device_id: Some(DEVICE_ID.to_string()),
                             registry_name: Some(REGISTRY.to_string()),
                         }],
@@ -1677,7 +1674,6 @@ mod tests {
                             event_name: event_name.to_string(),
                             operation: log.field("operation").map(str::to_string),
                             failure_stage: log.field("failure_stage").map(str::to_string),
-                            failure_kind: log.field("failure_kind").map(str::to_string),
                             device_id: log.field("device_id").map(str::to_string),
                             registry_name: log.field("registry_name").map(str::to_string),
                         })


### PR DESCRIPTION
`ScoutMlxFailures` has three labels -- `operation`, `failure_stage`, and `failure_kind` -- but only two of them are independent. `failure_kind` is a pure function of `failure_stage`: `Publish` is always an `Rpc` failure, `Lookup` is always `NotFound`, `Decode` and `Validate` are always `InvalidRequest`. No call site should get to pick it, and yet every call site could, because the framework had no way to say "this label is computed."

So scout held the invariant by hand: about forty named constructors whose whole job was pinning the valid pairs, and `DynamicMessage` matches with a `_ =>` fallback for pairs the table doesn't know, commented to explain that `emit()` must not panic if a future constructor reaches one. That's a lot of code to prevent a mistake the compiler can prevent for free.

`#[derived(label: Type, from = other_label)]` on a `MetricFamily` declares a label the family computes through `From` rather than takes from a call site. It stays a metric label with the same values; the family fills it in `labels()`, so a contradictory pair has no series to land in. The family struct keeps holding exactly what an Event supplies, which is what preserves the struct-literal checking from #4257 -- an Event that still declares the derived label gets `E0560: struct 'ScoutMlxFailures' has no field named 'failure_kind'`, which is the nudge you want mid-conversion.

`ScoutMlxFailureStage::failure_kind()` becomes `impl From<ScoutMlxFailureStage> for ScoutMlxFailureKind` and stays the single place the mapping lives. Twelve Events drop the label and twenty-six constructor assignments go with it. The grammar rejects what it should: a `from` naming something other than a supplied label, a derived label reading another derived label, and a derived label colliding with a field each get their own diagnostic at the family's declaration.

Scout is the only user of this in the tree -- 76 multi-label Events elsewhere, none of which computes one label from another -- so the feature and its caller land together and there's no fleet conversion behind it.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4258

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

A new `matrix.rs` case emits both stages and asserts each reaches the metric paired with the kind its `From` impl gives -- and that the contradictory pairing has no series at all. New macro cases cover the four rejections, and each was also checked by hand for the message it actually produces rather than just that it fails.

Battery: `cargo make format-nightly` + `clippy` + `carbide-lints` clean, `carbide-instrument` 41, `carbide-instrument-macros` 10, `carbide-scout` 57, `xtask` 50, both `check-metric-docs` (200 documented) and `check-event-names` (215 declarations) green, plus a full `--workspace --all-features` build.

## Additional Notes

**#4263 has merged and this is rebased onto it** -- the branch now holds a single commit against current `main`. It builds on the `MetricFamily` derive from that PR, so it reads best with that one already in mind.

**One reviewer callout.** A derived label is not a field of any Event, so it no longer renders as a log field: `failure_kind=rpc` leaves those twelve log lines while `failure_stage=publish` stays. A proc macro cannot see the family's fields from the Event's declaration site, so this is a real (small) log change rather than something to engineer around. Nothing is lost, since `failure_kind` is a pure function of a field still on the line, but a saved search on the derived value would move to grepping its source. The exported metric is unchanged and scout's counter assertions still check all three labels -- `mlx_device.rs`'s `metric_labels()` is what proves it.



Closes #4258
