### PR TITLE
fix(bmc-mock): Remove duplicate dependency table

### DIFF
--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -67,6 +67,3 @@ tokio = { features = ["test-util"], workspace = true }
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
`main` contains two `[dev-dependencies]` tables in `crates/bmc-mock/Cargo.toml`, which prevents Cargo from parsing the workspace and causes Core CI builds to fail. This removes the redundant table while retaining the existing Tokio test dependency.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`cargo metadata --no-deps --format-version 1`, `cargo make check-workspace-deps`, and `cargo fmt --all -- --check` pass. The locally runnable `bmc-mock` tests pass; `ipmi_sim::tests::real_ipmitool_resets_chassis` could not run because the external `ipmi_sim` executable is unavailable locally.

## Additional Notes

None.
