### PR TITLE
fix(bmc-mock): remove duplicate dev-dependencies table

### DIFF
--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -67,6 +67,3 @@ tokio = { features = ["test-util"], workspace = true }
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
PR #3912 and #4138 each added a valid dependency table. Combined during squash merge, they produced duplicate `[dev-dependencies]` tables and broke Cargo commands on `main`.

Remove the duplicate table to restore workspace manifest loading.

## Related issues
Fixes #4268

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

- `cargo metadata --locked --no-deps --format-version 1`

## Additional Notes
A separate follow-up PR will add the merge-result Cargo metadata CI gate.

`cargo make --no-workspace clippy-flow` is blocked locally on macOS by Linux-only `libudev`; Linux CI validation is required.