### PR TITLE
feat(flow): Add event rule manager and bindings

### DIFF
--- a/rest-api/flow/internal/eventrule/action.go
+++ b/rest-api/flow/internal/eventrule/action.go
@@ -18,6 +18,14 @@ type ActionCondition struct {
 	ComponentTypes []flowtypes.ComponentType
 }
 
+// Clone returns an independent copy of the condition.
+func (c ActionCondition) Clone() ActionCondition {
+	cloned := c
+	cloned.Severities = slices.Clone(c.Severities)
+	cloned.ComponentTypes = slices.Clone(c.ComponentTypes)
+	return cloned
+}
+
 func (c ActionCondition) validate() error {
 	if err := validateOptionalSlice("severities", c.Severities); err != nil {
 		return err
@@ -102,6 +110,13 @@ type Action struct {
 	Spec      ActionSpec
 }
 
+// Clone returns an independent copy of the action's mutable data.
+func (a Action) Clone() Action {
+	cloned := a
+	cloned.Condition = a.Condition.Clone()
+	return cloned
+}
+
 // NewAction returns an action containing the supplied typed specification.
 func NewAction(id string, condition ActionCondition, spec ActionSpec) Action {
 	return Action{ID: id, Condition: condition, Spec: spec}
@@ -122,6 +137,41 @@ func (a Action) Validate() error {
 	}
 
 	return a.Spec.validate()
+}
+
+// ValidateActions checks an action collection and its identity constraints.
+func ValidateActions(actions []Action) error {
+	if len(actions) == 0 {
+		return fmt.Errorf("actions are required")
+	}
+
+	actionIDs := make(map[string]struct{}, len(actions))
+	for i, action := range actions {
+		if err := action.Validate(); err != nil {
+			return fmt.Errorf("actions[%d]: %w", i, err)
+		}
+
+		if _, ok := actionIDs[action.ID]; ok {
+			return fmt.Errorf("actions[%d]: duplicate action id %q", i, action.ID)
+		}
+
+		actionIDs[action.ID] = struct{}{}
+	}
+
+	return nil
+}
+
+// CloneActions returns an independent copy of an action collection.
+func CloneActions(actions []Action) []Action {
+	if actions == nil {
+		return nil
+	}
+
+	cloned := make([]Action, len(actions))
+	for i := range actions {
+		cloned[i] = actions[i].Clone()
+	}
+	return cloned
 }
 
 // TargetStrategy identifies how a target-bearing action resolves concrete

--- a/rest-api/flow/internal/eventrule/binding.go
+++ b/rest-api/flow/internal/eventrule/binding.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ScopeType identifies an event-rule binding scope.
+type ScopeType string
+
+const (
+	ScopeTypeSite ScopeType = "site"
+	ScopeTypeRack ScopeType = "rack"
+)
+
+// Scope identifies either the site-wide scope or one rack.
+type Scope struct {
+	Type ScopeType
+	ID   uuid.UUID
+}
+
+// Validate checks the scope type and identifier contract.
+func (s Scope) Validate() error {
+	switch s.Type {
+	case ScopeTypeSite:
+		if s.ID != uuid.Nil {
+			return fmt.Errorf("site scope must not have an id")
+		}
+	case ScopeTypeRack:
+		if s.ID == uuid.Nil {
+			return fmt.Errorf("rack scope requires an id")
+		}
+	default:
+		return fmt.Errorf("unknown event rule scope type %q", s.Type)
+	}
+	return nil
+}
+
+// Binding associates a persisted rule with an event-rule scope.
+type Binding struct {
+	ID        uuid.UUID
+	RuleID    uuid.UUID
+	EventType Type
+	Scope     Scope
+}
+
+// Validate checks binding identity, event type, and scope.
+func (b Binding) Validate() error {
+	if b.ID == uuid.Nil {
+		return fmt.Errorf("event rule binding id is required")
+	}
+	if b.RuleID == uuid.Nil {
+		return fmt.Errorf("event rule binding rule id is required")
+	}
+	if err := b.EventType.Validate(); err != nil {
+		return fmt.Errorf("event rule binding event type: %w", err)
+	}
+	return b.Scope.Validate()
+}

--- a/rest-api/flow/internal/eventrule/binding_test.go
+++ b/rest-api/flow/internal/eventrule/binding_test.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBindingValidateRequiresEventType(t *testing.T) {
+	binding := Binding{
+		ID:     uuid.New(),
+		RuleID: uuid.New(),
+		Scope:  Scope{Type: ScopeTypeSite},
+	}
+
+	require.ErrorContains(t, binding.Validate(), "event rule binding event type")
+
+	binding.EventType = "test.event"
+	require.NoError(t, binding.Validate())
+}

--- a/rest-api/flow/internal/eventrule/doc.go
+++ b/rest-api/flow/internal/eventrule/doc.go
@@ -3,8 +3,9 @@
 
 // Package eventrule defines the in-memory domain contracts for policy-driven
 // event handling. It deliberately contains no event transport, database
-// representation, inventory lookup, rule repository, or action executor.
-// Those boundaries convert their own representations into these types.
+// representation, inventory lookup, store implementation, or action executor.
+// Those boundaries convert their own representations into these types and
+// implement the store capabilities declared by this package.
 //
 // # Events
 //
@@ -24,23 +25,55 @@
 // # Rules and policies
 //
 // Rule represents either a configurable persisted rule associated with scopes
-// such as global or rack, or an immutable code-defined fallback. Rule.Origin
+// such as site or rack, or an immutable code-defined fallback. Rule.Origin
 // distinguishes those sources; both use stable UUID identities and the same
 // Policy, so processing executes them identically.
 //
 // EventType belongs to Rule because it controls rule selection. Policy contains
 // only response behavior: optional deduplication and the actions considered for
-// an accepted event. A resolver is
-// expected to select one effective rule before its policy is evaluated, for
-// example rack override, then global rule, then built-in fallback.
+// an accepted event. A resolver is expected to select one effective rule before
+// its policy is evaluated, for example rack override, then site rule, then
+// built-in fallback.
+//
+// Persisted rule creation accepts RuleCreate, containing caller-owned metadata,
+// event type, and policy. The manager generates the rule identity, fixes its
+// origin to persisted, and creates it disabled. Disabled-by-default creation
+// prevents a partially configured rule from becoming effective while callers
+// establish its bindings; activation requires an explicit SetEnabled
+// operation. Persistence supplies timestamps and returns the canonical stored
+// rule.
+//
+// # Bindings and stores
+//
+// Binding associates a persisted rule and its immutable event type with a
+// Scope. A site scope has no ID; a rack scope carries the rack UUID. Bindings
+// are separate from rules so one persisted policy can be managed independently
+// of where it applies.
+//
+// A persisted rule without bindings is inactive. A rule may have multiple rack
+// bindings, but a site-bound rule cannot have any other bindings. At most one
+// binding applies to an event type at a resolved site or rack scope. Disabled
+// persisted rules are ignored during resolution while their bindings remain in
+// place. Built-in rules have no persisted bindings and act as implicit
+// site-wide fallbacks. Effective resolution proceeds from rack to site to
+// built-in.
+//
+// The store interfaces are divided by capability. RuleReader provides common
+// reads. BuiltInRuleReader adds unique built-in lookup by event type.
+// RuleStore adds persisted-rule lifecycle operations. Rule identity and event
+// type remain stable; metadata, deduplication, actions, and enabled state are
+// updated independently. BindingStore separately manages bindings and scope
+// lookup. A resolver composes the rule and binding stores to select rack, site,
+// and built-in precedence. Implementations own persistence,
+// concurrency, and transaction semantics.
 //
 // # Actions
 //
 // Each Action has a stable ID within its policy, an optional Condition, and a
-// concrete ActionSpec. Conditions intentionally support only
-// demonstrated event properties: severity and component type. Values within
-// one condition field use OR semantics, while different fields use AND
-// semantics. An empty condition applies to every event.
+// concrete ActionSpec. Conditions intentionally support only demonstrated event
+// properties: severity and component type. Values within one condition field
+// use OR semantics, while different fields use AND semantics. An empty
+// condition applies to every event.
 //
 // Task actions use a named TargetStrategy rather than an arbitrary inventory
 // query. Target resolution and side effects occur outside this package. If a
@@ -49,9 +82,9 @@
 //
 // # Validation boundaries
 //
-// Collectors validate Envelope before handing it to processing. Repositories
-// and APIs validate Rule when converting from their persistence or transport
-// representations. Event-family code strictly validates any typed payload,
-// and executors validate runtime requirements that depend on inventory or
-// external services.
+// Collectors validate Envelope before handing it to processing. Store
+// implementations and APIs validate Rule and Binding when converting from
+// their persistence or transport representations. Event-family code strictly
+// validates any typed payload, and executors validate runtime requirements that
+// depend on inventory or external services.
 package eventrule

--- a/rest-api/flow/internal/eventrule/manager/manager.go
+++ b/rest-api/flow/internal/eventrule/manager/manager.go
@@ -1,0 +1,339 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package manager unifies immutable built-in and persisted event rules.
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// Manager routes reads and mutations to stores with the appropriate capability.
+type Manager struct {
+	builtIns  eventrule.BuiltInRuleReader
+	persisted eventrule.RuleStore
+	bindings  eventrule.BindingStore
+}
+
+// New constructs an event-rule manager.
+func New(
+	builtIns eventrule.BuiltInRuleReader,
+	persisted eventrule.RuleStore,
+	bindings eventrule.BindingStore,
+) (*Manager, error) {
+	if builtIns == nil {
+		return nil, fmt.Errorf("built-in event rule store is required")
+	}
+
+	if persisted == nil {
+		return nil, fmt.Errorf("persisted event rule store is required")
+	}
+
+	if bindings == nil {
+		return nil, fmt.Errorf("event rule binding store is required")
+	}
+
+	return &Manager{
+		builtIns:  builtIns,
+		persisted: persisted,
+		bindings:  bindings,
+	}, nil
+}
+
+// GetByID looks in persisted rules and then built-ins.
+func (m *Manager) GetByID(ctx context.Context, id uuid.UUID) (*eventrule.Rule, error) {
+	if err := validateRuleID(id); err != nil {
+		return nil, err
+	}
+
+	rule, err := m.persisted.GetByID(ctx, id)
+	if err == nil {
+		return rule, nil
+	}
+
+	if !errors.Is(err, eventrule.ErrRuleNotFound) {
+		return nil, err
+	}
+
+	return m.builtIns.GetByID(ctx, id)
+}
+
+// List returns persisted and built-in rules through one read API.
+func (m *Manager) List(ctx context.Context, filter eventrule.RuleFilter) ([]*eventrule.Rule, error) {
+	persisted, err := m.persisted.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	builtIns, err := m.builtIns.List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	return slices.Concat(persisted, builtIns), nil
+}
+
+// Create constructs and stores a disabled persisted rule. New rules remain
+// disabled so callers can finish configuring and binding them before an
+// explicit SetEnabled call makes them effective.
+func (m *Manager) Create(
+	ctx context.Context,
+	input eventrule.RuleCreate,
+) (*eventrule.Rule, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+
+	rule := eventrule.Rule{
+		ID:          uuid.New(),
+		Origin:      eventrule.RuleOriginPersisted,
+		Name:        input.Metadata.Name,
+		Description: input.Metadata.Description,
+		EventType:   input.EventType,
+		Policy:      input.Policy.Clone(),
+	}
+
+	if err := m.rejectBuiltInID(ctx, rule.ID); err != nil {
+		return nil, err
+	}
+
+	return m.persisted.Create(ctx, &rule)
+}
+
+// UpdateMetadata updates a persisted rule's descriptive fields.
+func (m *Manager) UpdateMetadata(
+	ctx context.Context,
+	id uuid.UUID,
+	metadata eventrule.RuleMetadata,
+) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+
+	if err := metadata.Validate(); err != nil {
+		return err
+	}
+
+	if err := m.rejectBuiltInID(ctx, id); err != nil {
+		return err
+	}
+
+	return m.persisted.UpdateMetadata(ctx, id, metadata)
+}
+
+// SetDedupe replaces or clears a persisted rule's deduplication policy.
+func (m *Manager) SetDedupe(
+	ctx context.Context,
+	id uuid.UUID,
+	dedupe *eventrule.Dedupe,
+) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+
+	if dedupe != nil {
+		if err := dedupe.Validate(); err != nil {
+			return fmt.Errorf("dedupe: %w", err)
+		}
+	}
+
+	if err := m.rejectBuiltInID(ctx, id); err != nil {
+		return err
+	}
+
+	if dedupe == nil {
+		return m.persisted.SetDedupe(ctx, id, nil)
+	}
+
+	cloned := *dedupe
+	return m.persisted.SetDedupe(ctx, id, &cloned)
+}
+
+// ReplaceActions replaces all actions belonging to a persisted rule.
+func (m *Manager) ReplaceActions(
+	ctx context.Context,
+	id uuid.UUID,
+	actions []eventrule.Action,
+) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+
+	if err := eventrule.ValidateActions(actions); err != nil {
+		return err
+	}
+
+	if err := m.rejectBuiltInID(ctx, id); err != nil {
+		return err
+	}
+
+	return m.persisted.ReplaceActions(ctx, id, eventrule.CloneActions(actions))
+}
+
+// Delete delegates deletion to the persisted store, which atomically deletes
+// the rule and all of its bindings in one transaction.
+func (m *Manager) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+
+	if err := m.rejectBuiltInID(ctx, id); err != nil {
+		return err
+	}
+
+	return m.persisted.Delete(ctx, id)
+}
+
+// SetEnabled changes whether a persisted rule is enabled.
+func (m *Manager) SetEnabled(ctx context.Context, id uuid.UUID, enabled bool) error {
+	if err := validateRuleID(id); err != nil {
+		return err
+	}
+
+	if err := m.rejectBuiltInID(ctx, id); err != nil {
+		return err
+	}
+
+	return m.persisted.SetEnabled(ctx, id, enabled)
+}
+
+// Bind associates a persisted rule with a scope and returns the new binding.
+func (m *Manager) Bind(
+	ctx context.Context,
+	ruleID uuid.UUID,
+	scope eventrule.Scope,
+) (*eventrule.Binding, error) {
+	if err := validateRuleID(ruleID); err != nil {
+		return nil, err
+	}
+
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := m.rejectBuiltInID(ctx, ruleID); err != nil {
+		return nil, err
+	}
+
+	rule, err := m.persisted.GetByID(ctx, ruleID)
+	if err != nil {
+		return nil, err
+	}
+
+	binding := eventrule.Binding{
+		ID:        uuid.New(),
+		RuleID:    rule.ID,
+		EventType: rule.EventType,
+		Scope:     scope,
+	}
+
+	if err := binding.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := m.bindings.Bind(ctx, binding); err != nil {
+		return nil, err
+	}
+
+	return &binding, nil
+}
+
+// Unbind removes a persisted rule binding.
+func (m *Manager) Unbind(ctx context.Context, bindingID uuid.UUID) error {
+	if bindingID == uuid.Nil {
+		return fmt.Errorf("event rule binding id is required")
+	}
+
+	return m.bindings.Unbind(ctx, bindingID)
+}
+
+// GetEffective resolves rack, site, then built-in precedence.
+func (m *Manager) GetEffective(
+	ctx context.Context,
+	eventType eventrule.Type,
+	rackID uuid.UUID,
+) (*eventrule.Rule, error) {
+	// Prefer an enabled persisted rule bound to the event's rack.
+	if rackID != uuid.Nil {
+		scope := eventrule.Scope{
+			Type: eventrule.ScopeTypeRack,
+			ID:   rackID,
+		}
+
+		rule, err := m.getForScope(ctx, eventType, scope)
+		if err != nil {
+			return nil, err
+		}
+
+		if rule != nil {
+			return rule, nil
+		}
+	}
+
+	// Fall back to an enabled persisted rule bound to the site.
+	scope := eventrule.Scope{
+		Type: eventrule.ScopeTypeSite,
+		ID:   uuid.Nil,
+	}
+
+	rule, err := m.getForScope(ctx, eventType, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	if rule != nil {
+		return rule, nil
+	}
+
+	// Use the immutable built-in when no persisted scope supplies a rule.
+	return m.builtIns.GetByEventType(ctx, eventType)
+}
+
+func (m *Manager) getForScope(
+	ctx context.Context,
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+) (*eventrule.Rule, error) {
+	binding, err := m.bindings.GetForScope(ctx, eventType, scope)
+	if err != nil || binding == nil {
+		return nil, err
+	}
+
+	rule, err := m.persisted.GetByID(ctx, binding.RuleID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !rule.Enabled {
+		return nil, nil
+	}
+
+	return rule, nil
+}
+
+func (m *Manager) rejectBuiltInID(ctx context.Context, id uuid.UUID) error {
+	_, err := m.builtIns.GetByID(ctx, id)
+	if err == nil {
+		return fmt.Errorf("event rule %s is a built-in and cannot be mutated", id)
+	}
+
+	if !errors.Is(err, eventrule.ErrRuleNotFound) {
+		return err
+	}
+
+	return nil
+}
+
+func validateRuleID(id uuid.UUID) error {
+	if id == uuid.Nil {
+		return fmt.Errorf("event rule id is required")
+	}
+
+	return nil
+}

--- a/rest-api/flow/internal/eventrule/manager/manager_test.go
+++ b/rest-api/flow/internal/eventrule/manager/manager_test.go
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/registry"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerUnifiedReadsAndMutationRouting(t *testing.T) {
+	builtIn := testRule(uuid.New(), eventrule.RuleOriginBuiltIn, "test.event")
+	persisted := testRule(uuid.New(), eventrule.RuleOriginPersisted, "other.event")
+	builtIns, err := registry.New(builtIn)
+	require.NoError(t, err)
+	store := newTestStore(persisted)
+	bindings := newTestBindingStore()
+	manager, err := New(builtIns, store, bindings)
+	require.NoError(t, err)
+
+	for _, id := range []uuid.UUID{persisted.ID, builtIn.ID} {
+		rule, err := manager.GetByID(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, id, rule.ID)
+	}
+	rules, err := manager.List(context.Background(), eventrule.RuleFilter{})
+	require.NoError(t, err)
+	assert.Len(t, rules, 2)
+
+	input := eventrule.RuleCreate{
+		Metadata:  eventrule.RuleMetadata{Name: "new rule"},
+		EventType: "new.event",
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+	}
+	created, err := manager.Create(context.Background(), input)
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, created.ID)
+	assert.Equal(t, eventrule.RuleOriginPersisted, created.Origin)
+	assert.False(t, created.Enabled)
+	assert.Equal(t, 1, store.creates)
+	input.Policy.Actions[0].ID = "changed"
+	assert.Equal(t, "noop", created.Actions[0].ID)
+
+	_, err = manager.Create(context.Background(), eventrule.RuleCreate{})
+	require.Error(t, err)
+	assert.Equal(t, 1, store.creates)
+
+	require.Error(t, manager.UpdateMetadata(
+		context.Background(),
+		persisted.ID,
+		eventrule.RuleMetadata{},
+	))
+	assert.Equal(t, "test", persisted.Name)
+
+	require.Error(t, manager.SetDedupe(
+		context.Background(),
+		persisted.ID,
+		&eventrule.Dedupe{},
+	))
+	assert.Nil(t, persisted.Dedupe)
+
+	require.Error(t, manager.ReplaceActions(context.Background(), persisted.ID, nil))
+	assert.Len(t, persisted.Actions, 1)
+
+	metadata := eventrule.RuleMetadata{Name: "updated", Description: "updated description"}
+	require.NoError(t, manager.UpdateMetadata(context.Background(), persisted.ID, metadata))
+	assert.Equal(t, metadata.Name, persisted.Name)
+	assert.Equal(t, metadata.Description, persisted.Description)
+
+	dedupe := &eventrule.Dedupe{Window: time.Minute}
+	require.NoError(t, manager.SetDedupe(context.Background(), persisted.ID, dedupe))
+	assert.Equal(t, dedupe, persisted.Dedupe)
+	dedupe.Window = 2 * time.Minute
+	assert.Equal(t, time.Minute, persisted.Dedupe.Window)
+
+	actions := []eventrule.Action{
+		eventrule.NewAction("replacement", eventrule.ActionCondition{}, eventrule.Noop{}),
+	}
+	require.NoError(t, manager.ReplaceActions(context.Background(), persisted.ID, actions))
+	assert.Equal(t, actions, persisted.Actions)
+	actions[0].ID = "changed"
+	assert.Equal(t, "replacement", persisted.Actions[0].ID)
+
+	require.NoError(t, manager.SetEnabled(context.Background(), persisted.ID, false))
+	assert.False(t, persisted.Enabled)
+
+	scope := eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: uuid.New()}
+	binding, err := manager.Bind(context.Background(), persisted.ID, scope)
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, binding.ID)
+	assert.Equal(t, persisted.ID, binding.RuleID)
+	assert.Equal(t, persisted.EventType, binding.EventType)
+	assert.Equal(t, scope, binding.Scope)
+	require.Len(t, bindings.bound, 1)
+	assert.Equal(t, persisted.EventType, bindings.bound[0].EventType)
+}
+
+func TestManagerEffectiveRulePrecedence(t *testing.T) {
+	eventType := eventrule.Type("test.event")
+	rackID := uuid.New()
+	builtIn := testRule(uuid.New(), eventrule.RuleOriginBuiltIn, eventType)
+	site := testRule(uuid.New(), eventrule.RuleOriginPersisted, eventType)
+	rack := testRule(uuid.New(), eventrule.RuleOriginPersisted, eventType)
+	builtIns, err := registry.New(builtIn)
+	require.NoError(t, err)
+	store := newTestStore()
+	bindings := newTestBindingStore()
+	manager, err := New(builtIns, store, bindings)
+	require.NoError(t, err)
+
+	rule, err := manager.GetEffective(context.Background(), eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, builtIn.ID, rule.ID)
+
+	store.byID[site.ID] = site
+	bindings.add(eventType, eventrule.Scope{Type: eventrule.ScopeTypeSite}, site.ID)
+	rule, err = manager.GetEffective(context.Background(), eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, site.ID, rule.ID)
+
+	site.Enabled = false
+	rule, err = manager.GetEffective(context.Background(), eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, builtIn.ID, rule.ID)
+	site.Enabled = true
+
+	store.byID[rack.ID] = rack
+	bindings.add(eventType, eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: rackID}, rack.ID)
+	rule, err = manager.GetEffective(context.Background(), eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, rack.ID, rule.ID)
+
+	rack.Enabled = false
+	rule, err = manager.GetEffective(context.Background(), eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, site.ID, rule.ID)
+
+	_, err = manager.GetEffective(context.Background(), "unknown.event", rackID)
+	require.ErrorIs(t, err, eventrule.ErrRuleNotFound)
+}
+
+func TestManagerRejectsMissingIDs(t *testing.T) {
+	builtIns, err := registry.New()
+	require.NoError(t, err)
+	manager, err := New(builtIns, newTestStore(), newTestBindingStore())
+	require.NoError(t, err)
+
+	_, err = manager.GetByID(context.Background(), uuid.Nil)
+	require.ErrorContains(t, err, "event rule id is required")
+
+	require.ErrorContains(t, manager.UpdateMetadata(
+		context.Background(),
+		uuid.Nil,
+		eventrule.RuleMetadata{Name: "test"},
+	), "event rule id is required")
+	require.ErrorContains(t, manager.SetDedupe(
+		context.Background(),
+		uuid.Nil,
+		&eventrule.Dedupe{Window: time.Minute},
+	), "event rule id is required")
+	require.ErrorContains(t, manager.ReplaceActions(
+		context.Background(),
+		uuid.Nil,
+		[]eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		},
+	), "event rule id is required")
+	require.ErrorContains(t, manager.Delete(context.Background(), uuid.Nil), "event rule id is required")
+	require.ErrorContains(
+		t,
+		manager.SetEnabled(context.Background(), uuid.Nil, true),
+		"event rule id is required",
+	)
+	_, err = manager.Bind(
+		context.Background(),
+		uuid.Nil,
+		eventrule.Scope{Type: eventrule.ScopeTypeSite},
+	)
+	require.ErrorContains(t, err, "event rule id is required")
+	require.ErrorContains(
+		t,
+		manager.Unbind(context.Background(), uuid.Nil),
+		"event rule binding id is required",
+	)
+}
+
+type scopeKey struct {
+	eventType eventrule.Type
+	scope     eventrule.Scope
+}
+
+type testStore struct {
+	byID    map[uuid.UUID]*eventrule.Rule
+	creates int
+}
+
+func newTestStore(rules ...*eventrule.Rule) *testStore {
+	store := &testStore{
+		byID: make(map[uuid.UUID]*eventrule.Rule, len(rules)),
+	}
+	for _, rule := range rules {
+		store.byID[rule.ID] = rule
+	}
+	return store
+}
+
+func (s *testStore) GetByID(_ context.Context, id uuid.UUID) (*eventrule.Rule, error) {
+	if rule, ok := s.byID[id]; ok {
+		return rule, nil
+	}
+	return nil, fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+}
+
+func (s *testStore) List(context.Context, eventrule.RuleFilter) ([]*eventrule.Rule, error) {
+	rules := make([]*eventrule.Rule, 0, len(s.byID))
+	for _, rule := range s.byID {
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+func (s *testStore) Create(_ context.Context, rule *eventrule.Rule) (*eventrule.Rule, error) {
+	s.creates++
+	s.byID[rule.ID] = rule
+	return rule, nil
+}
+
+func (s *testStore) UpdateMetadata(
+	_ context.Context,
+	id uuid.UUID,
+	metadata eventrule.RuleMetadata,
+) error {
+	s.byID[id].Name = metadata.Name
+	s.byID[id].Description = metadata.Description
+	return nil
+}
+
+func (s *testStore) SetDedupe(_ context.Context, id uuid.UUID, dedupe *eventrule.Dedupe) error {
+	s.byID[id].Dedupe = dedupe
+	return nil
+}
+
+func (s *testStore) ReplaceActions(
+	_ context.Context,
+	id uuid.UUID,
+	actions []eventrule.Action,
+) error {
+	s.byID[id].Actions = actions
+	return nil
+}
+
+func (s *testStore) Delete(_ context.Context, id uuid.UUID) error {
+	delete(s.byID, id)
+	return nil
+}
+
+func (s *testStore) SetEnabled(_ context.Context, id uuid.UUID, enabled bool) error {
+	s.byID[id].Enabled = enabled
+	return nil
+}
+
+type testBindingStore struct {
+	byScope map[scopeKey]*eventrule.Binding
+	bound   []eventrule.Binding
+}
+
+func newTestBindingStore() *testBindingStore {
+	return &testBindingStore{byScope: make(map[scopeKey]*eventrule.Binding)}
+}
+
+func (s *testBindingStore) add(
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+	ruleID uuid.UUID,
+) {
+	s.byScope[scopeKey{eventType: eventType, scope: scope}] = &eventrule.Binding{
+		ID:        uuid.New(),
+		RuleID:    ruleID,
+		EventType: eventType,
+		Scope:     scope,
+	}
+}
+
+func (s *testBindingStore) Bind(_ context.Context, binding eventrule.Binding) error {
+	s.bound = append(s.bound, binding)
+	return nil
+}
+
+func (s *testBindingStore) Unbind(context.Context, uuid.UUID) error { return nil }
+
+func (s *testBindingStore) GetForScope(
+	_ context.Context,
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+) (*eventrule.Binding, error) {
+	if binding, ok := s.byScope[scopeKey{eventType: eventType, scope: scope}]; ok {
+		return binding, nil
+	}
+	return nil, nil
+}
+
+func testRule(id uuid.UUID, origin eventrule.RuleOrigin, eventType eventrule.Type) *eventrule.Rule {
+	return &eventrule.Rule{
+		ID:        id,
+		Origin:    origin,
+		Name:      "test",
+		Enabled:   true,
+		EventType: eventType,
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+	}
+}

--- a/rest-api/flow/internal/eventrule/policy.go
+++ b/rest-api/flow/internal/eventrule/policy.go
@@ -20,7 +20,19 @@ type Dedupe struct {
 	Window time.Duration
 }
 
-func (d Dedupe) validate() error {
+// Clone returns an independent copy of the policy and its mutable data.
+func (p Policy) Clone() Policy {
+	cloned := p
+	if p.Dedupe != nil {
+		dedupe := *p.Dedupe
+		cloned.Dedupe = &dedupe
+	}
+	cloned.Actions = CloneActions(p.Actions)
+	return cloned
+}
+
+// Validate checks the deduplication policy.
+func (d Dedupe) Validate() error {
 	if d.Window <= 0 {
 		return fmt.Errorf("dedupe window must be positive")
 	}
@@ -31,28 +43,10 @@ func (d Dedupe) validate() error {
 // Validate checks deduplication configuration, actions, and action identity.
 func (p Policy) Validate() error {
 	if p.Dedupe != nil {
-		if err := p.Dedupe.validate(); err != nil {
+		if err := p.Dedupe.Validate(); err != nil {
 			return fmt.Errorf("dedupe: %w", err)
 		}
 	}
 
-	if len(p.Actions) == 0 {
-		return fmt.Errorf("actions are required")
-	}
-
-	actionIDs := make(map[string]struct{}, len(p.Actions))
-	for i := range p.Actions {
-		action := &p.Actions[i]
-		if err := action.Validate(); err != nil {
-			return fmt.Errorf("actions[%d]: %w", i, err)
-		}
-
-		if _, ok := actionIDs[action.ID]; ok {
-			return fmt.Errorf("actions[%d]: duplicate action id %q", i, action.ID)
-		}
-
-		actionIDs[action.ID] = struct{}{}
-	}
-
-	return nil
+	return ValidateActions(p.Actions)
 }

--- a/rest-api/flow/internal/eventrule/registry/registry.go
+++ b/rest-api/flow/internal/eventrule/registry/registry.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package registry provides immutable storage for code-defined event rules.
+package registry
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// Registry stores validated built-in rules. Its read methods accept a context
+// to implement the shared store interfaces, although this in-memory
+// implementation does not use it; persisted stores need it for their I/O.
+type Registry struct {
+	byID        map[uuid.UUID]eventrule.Rule
+	byEventType map[eventrule.Type]uuid.UUID
+}
+
+// New validates and registers immutable built-in rules.
+func New(rules ...*eventrule.Rule) (*Registry, error) {
+	r := &Registry{
+		byID:        make(map[uuid.UUID]eventrule.Rule, len(rules)),
+		byEventType: make(map[eventrule.Type]uuid.UUID, len(rules)),
+	}
+	for _, rule := range rules {
+		if err := r.addRule(rule); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+func (r *Registry) addRule(rule *eventrule.Rule) error {
+	if rule == nil {
+		return fmt.Errorf("register built-in rule: event rule is nil")
+	}
+
+	if rule.Origin != eventrule.RuleOriginBuiltIn {
+		return fmt.Errorf("register built-in rule %s: origin must be %q", rule.ID, eventrule.RuleOriginBuiltIn)
+	}
+
+	if err := rule.Validate(); err != nil {
+		return fmt.Errorf("register built-in rule %s: %w", rule.ID, err)
+	}
+
+	if _, ok := r.byID[rule.ID]; ok {
+		return fmt.Errorf("register built-in rule: duplicate id %s", rule.ID)
+	}
+
+	if _, ok := r.byEventType[rule.EventType]; ok {
+		return fmt.Errorf("register built-in rule: duplicate event type %q", rule.EventType)
+	}
+
+	r.byID[rule.ID] = rule.Clone()
+	r.byEventType[rule.EventType] = rule.ID
+
+	return nil
+}
+
+// GetByID returns a built-in rule by stable UUID.
+func (r *Registry) GetByID(_ context.Context, id uuid.UUID) (*eventrule.Rule, error) {
+	rule, ok := r.byID[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	cloned := rule.Clone()
+	return &cloned, nil
+}
+
+// GetByEventType returns the built-in fallback for an event type.
+func (r *Registry) GetByEventType(_ context.Context, eventType eventrule.Type) (*eventrule.Rule, error) {
+	id, ok := r.byEventType[eventType]
+	if !ok {
+		return nil, fmt.Errorf("%w: event type %q", eventrule.ErrRuleNotFound, eventType)
+	}
+
+	storedRule, ok := r.byID[id]
+	if !ok {
+		return nil, fmt.Errorf(
+			"built-in event rule registry is inconsistent: event type %q references missing rule %s",
+			eventType,
+			id,
+		)
+	}
+
+	rule := storedRule.Clone()
+	return &rule, nil
+}
+
+// List returns built-in rules matching the filter.
+func (r *Registry) List(_ context.Context, filter eventrule.RuleFilter) ([]*eventrule.Rule, error) {
+	rules := make([]*eventrule.Rule, 0, len(r.byID))
+	for _, stored := range r.byID {
+		if !filter.Matches(&stored) {
+			continue
+		}
+		rule := stored.Clone()
+		rules = append(rules, &rule)
+	}
+
+	return rules, nil
+}
+
+var _ eventrule.BuiltInRuleReader = (*Registry)(nil)

--- a/rest-api/flow/internal/eventrule/registry/registry_test.go
+++ b/rest-api/flow/internal/eventrule/registry/registry_test.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRejectsInvalidAndDuplicateRules(t *testing.T) {
+	valid := testRule(uuid.New(), "test.event")
+	duplicateID := testRule(valid.ID, "other.event")
+	duplicateType := testRule(uuid.New(), valid.EventType)
+	persisted := testRule(uuid.New(), "persisted.event")
+	persisted.Origin = eventrule.RuleOriginPersisted
+	invalid := testRule(uuid.New(), "invalid.event")
+	invalid.Actions = nil
+
+	tests := map[string]struct {
+		rules   []*eventrule.Rule
+		wantErr string
+	}{
+		"invalid origin":       {rules: []*eventrule.Rule{persisted}, wantErr: "origin must be"},
+		"invalid policy":       {rules: []*eventrule.Rule{invalid}, wantErr: "actions are required"},
+		"duplicate id":         {rules: []*eventrule.Rule{valid, duplicateID}, wantErr: "duplicate id"},
+		"duplicate event type": {rules: []*eventrule.Rule{valid, duplicateType}, wantErr: "duplicate event type"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(test.rules...)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestRegistryLookup(t *testing.T) {
+	rule := testRule(uuid.New(), "test.event")
+	registry, err := New(rule)
+	require.NoError(t, err)
+
+	rule.Actions[0].ID = "changed-after-registration"
+
+	byID, err := registry.GetByID(context.Background(), rule.ID)
+	require.NoError(t, err)
+	require.Equal(t, rule.ID, byID.ID)
+	require.Equal(t, "noop", byID.Actions[0].ID)
+	byID.Actions[0].ID = "changed"
+
+	byType, err := registry.GetByEventType(context.Background(), rule.EventType)
+	require.NoError(t, err)
+	require.Equal(t, rule.ID, byType.ID)
+	require.Equal(t, "noop", byType.Actions[0].ID)
+}
+
+func TestGetByEventTypeDetectsInconsistentRegistry(t *testing.T) {
+	eventType := eventrule.Type("test.event")
+	registry := &Registry{
+		byID:        make(map[uuid.UUID]eventrule.Rule),
+		byEventType: map[eventrule.Type]uuid.UUID{eventType: uuid.New()},
+	}
+
+	_, err := registry.GetByEventType(context.Background(), eventType)
+	require.ErrorContains(t, err, "registry is inconsistent")
+	require.False(t, errors.Is(err, eventrule.ErrRuleNotFound))
+}
+
+func testRule(id uuid.UUID, eventType eventrule.Type) *eventrule.Rule {
+	return &eventrule.Rule{
+		ID:        id,
+		Origin:    eventrule.RuleOriginBuiltIn,
+		Name:      "test",
+		Enabled:   true,
+		EventType: eventType,
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+	}
+}

--- a/rest-api/flow/internal/eventrule/rule.go
+++ b/rest-api/flow/internal/eventrule/rule.go
@@ -43,6 +43,50 @@ type Rule struct {
 	UpdatedAt time.Time
 }
 
+// RuleMetadata contains the independently mutable descriptive fields of a rule.
+type RuleMetadata struct {
+	Name        string
+	Description string
+}
+
+// RuleCreate contains the caller-provided fields for a persisted rule.
+type RuleCreate struct {
+	Metadata  RuleMetadata
+	EventType Type
+	Policy    Policy
+}
+
+// Validate checks fields supplied when creating a persisted rule.
+func (c RuleCreate) Validate() error {
+	if err := c.Metadata.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.EventType.Validate(); err != nil {
+		return err
+	}
+
+	return c.Policy.Validate()
+}
+
+// Validate checks mutable rule metadata.
+func (m RuleMetadata) Validate() error {
+	if err := validateRequiredString("event rule name", m.Name); err != nil {
+		return err
+	}
+	if len(m.Name) > maxRuleNameLength {
+		return fmt.Errorf("event rule name exceeds %d characters", maxRuleNameLength)
+	}
+	return validateOptionalString("event rule description", m.Description)
+}
+
+// Clone returns an independent copy of the rule and its mutable policy data.
+func (r Rule) Clone() Rule {
+	cloned := r
+	cloned.Policy = r.Policy.Clone()
+	return cloned
+}
+
 // Validate checks rule metadata and policy.
 func (r *Rule) Validate() error {
 	if r == nil {
@@ -57,13 +101,7 @@ func (r *Rule) Validate() error {
 	if r.Origin == RuleOriginBuiltIn && !r.Enabled {
 		return fmt.Errorf("built-in event rule must be enabled")
 	}
-	if err := validateRequiredString("event rule name", r.Name); err != nil {
-		return err
-	}
-	if len(r.Name) > maxRuleNameLength {
-		return fmt.Errorf("event rule name exceeds %d characters", maxRuleNameLength)
-	}
-	if err := validateOptionalString("event rule description", r.Description); err != nil {
+	if err := (RuleMetadata{Name: r.Name, Description: r.Description}).Validate(); err != nil {
 		return err
 	}
 	if err := r.EventType.Validate(); err != nil {

--- a/rest-api/flow/internal/eventrule/store.go
+++ b/rest-api/flow/internal/eventrule/store.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+// ErrRuleNotFound identifies an unsuccessful rule lookup.
+var ErrRuleNotFound = errors.New("event rule not found")
+
+// RuleFilter limits rules returned by a store.
+type RuleFilter struct {
+	EventType *Type
+	Origin    *RuleOrigin
+	Enabled   *bool
+}
+
+// Matches reports whether a rule satisfies every configured filter field.
+func (f RuleFilter) Matches(rule *Rule) bool {
+	if rule == nil {
+		return false
+	}
+	if f.EventType != nil && rule.EventType != *f.EventType {
+		return false
+	}
+	if f.Origin != nil && rule.Origin != *f.Origin {
+		return false
+	}
+	if f.Enabled != nil && rule.Enabled != *f.Enabled {
+		return false
+	}
+	return true
+}
+
+// RuleReader is the common read capability for built-in and persisted rules.
+type RuleReader interface {
+	GetByID(context.Context, uuid.UUID) (*Rule, error)
+	List(context.Context, RuleFilter) ([]*Rule, error)
+}
+
+// BuiltInRuleReader adds unique event-type lookup for built-in rules.
+type BuiltInRuleReader interface {
+	RuleReader
+	GetByEventType(context.Context, Type) (*Rule, error)
+}
+
+// RuleStore manages persisted rule lifecycle operations.
+type RuleStore interface {
+	RuleReader
+	// Create persists a manager-constructed rule and returns the stored rule,
+	// including any persistence-generated timestamps.
+	Create(context.Context, *Rule) (*Rule, error)
+	UpdateMetadata(context.Context, uuid.UUID, RuleMetadata) error
+	SetDedupe(context.Context, uuid.UUID, *Dedupe) error
+	ReplaceActions(context.Context, uuid.UUID, []Action) error
+	// Delete atomically deletes a persisted rule and all of its bindings.
+	// Implementations own the transaction that enforces this invariant.
+	Delete(context.Context, uuid.UUID) error
+	SetEnabled(context.Context, uuid.UUID, bool) error
+}
+
+// BindingStore manages persisted rule bindings and scope lookup.
+type BindingStore interface {
+	Bind(context.Context, Binding) error
+	Unbind(context.Context, uuid.UUID) error
+	// GetForScope returns the binding for an event type and scope. When no
+	// binding exists, implementations must return (nil, nil).
+	GetForScope(context.Context, Type, Scope) (*Binding, error)
+}

--- a/rest-api/flow/internal/eventrule/store_test.go
+++ b/rest-api/flow/internal/eventrule/store_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package eventrule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuleFilterMatches(t *testing.T) {
+	eventType := Type("test.event")
+	otherEventType := Type("other.event")
+	origin := RuleOriginPersisted
+	otherOrigin := RuleOriginBuiltIn
+	enabled := true
+	disabled := false
+	rule := &Rule{
+		EventType: eventType,
+		Origin:    origin,
+		Enabled:   enabled,
+	}
+
+	tests := map[string]struct {
+		filter RuleFilter
+		rule   *Rule
+		want   bool
+	}{
+		"empty filter": {
+			rule: rule,
+			want: true,
+		},
+		"all fields match": {
+			filter: RuleFilter{EventType: &eventType, Origin: &origin, Enabled: &enabled},
+			rule:   rule,
+			want:   true,
+		},
+		"event type differs": {
+			filter: RuleFilter{EventType: &otherEventType},
+			rule:   rule,
+			want:   false,
+		},
+		"origin differs": {
+			filter: RuleFilter{Origin: &otherOrigin},
+			rule:   rule,
+			want:   false,
+		},
+		"enabled differs": {
+			filter: RuleFilter{Enabled: &disabled},
+			rule:   rule,
+			want:   false,
+		},
+		"nil rule": {
+			rule: nil,
+			want: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, test.filter.Matches(test.rule))
+		})
+	}
+}


### PR DESCRIPTION
Leakage detection currently polls NICo Core for leaking information and immediately
submits a force power-off task for each affected component. That is safe as an initial
behavior, but it hard-codes both detection and response in the leak detection job.

We need a pre-defined response at startup, while leaving room for users to define
their own rules later. And the mode should be reusable for other event families such as
thermal alarms, inventory drift, firmware health events, attestation failures, etc.

We plan to create event rules which decide what to do in response to an event.

This PR establishes the event-rule management phase by adding binding and store
contracts, the immutable built-in registry, manager-driven rule lifecycle, and rack/site
scopes and built-in fallback resolution.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

