### PR TITLE
feat(api): add HostBmc expected interface configuration

### DIFF
--- a/crates/admin-cli/src/expected_machines/add/args.rs
+++ b/crates/admin-cli/src/expected_machines/add/args.rs
@@ -52,15 +52,15 @@ Add a host whose DPU should be treated as a plain NIC:
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
     --dpu-policy nic
 
-Add a host interface with a fixed IP:
+Add a Host BMC interface that retains its DHCP address:
     $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
-    --host_nics '[{\"mac_address\":\"02:00:00:00:10:01\",\"role\":\"host\",\"ip_allocation\":\"fixed\",\"fixed_ip\":\"192.0.2.21\"}]'
+    --host_nics '[{\"mac_address\":\"00:11:22:33:44:55\",\"role\":\"host_bmc\",\"ip_allocation\":\"retained\"}]'
 
-Add a DPU OS interface that retains its DHCP address:
+Add a DPU OS interface with a fixed IP:
     $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
     --bmc-username admin --bmc-password mypassword --chassis-serial-number sample_serial-1 \
-    --host_nics '[{\"mac_address\":\"02:00:00:00:20:01\",\"role\":\"dpu_os\",\"ip_allocation\":\"retained\"}]'
+    --host_nics '[{\"mac_address\":\"02:00:00:00:20:01\",\"role\":\"dpu_os\",\"ip_allocation\":\"fixed\",\"fixed_ip\":\"192.0.2.10\"}]'
 
 Retain the BMC's auto-allocated DHCP address as a static one (never expires):
     $ nico-admin-cli expected-machine add --bmc-mac-address 00:11:22:33:44:55 \
@@ -133,7 +133,7 @@ pub struct Args {
     #[clap(
         long = "host_nics",
         value_name = "HOST_NICS",
-        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc and ip_allocation=dynamic|fixed|retained. An omitted role defaults to host. When ip_allocation is omitted, fixed_ip implies fixed; otherwise it defaults to dynamic. Explicit fixed policies and DPU fixed addresses must fall within a configured managed prefix; legacy host entries with an omitted policy keep the static-assignments fallback.",
+        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc|host_bmc and ip_allocation=dynamic|fixed|retained. An omitted role defaults to host. When ip_allocation is omitted, fixed_ip implies fixed; without fixed_ip, host_bmc defaults to retained and every other role defaults to dynamic. Explicit fixed policies, DPU fixed addresses, and inferred host_bmc fixed addresses with a segment guard must fall within a configured managed prefix. Legacy host entries with an omitted policy and unguarded inferred host_bmc fixed addresses keep the static-assignments fallback.",
         action = clap::ArgAction::Append
     )]
     pub host_nics: Option<String>,
@@ -245,6 +245,7 @@ impl TryFrom<Args> for rpc::forge::ExpectedMachine {
                 .dpu_policy
                 .map(|policy| rpc::forge::DpuMode::from(policy) as i32),
             bmc_ip_allocation: value.bmc_ip_allocation.map(|m| m as i32),
+            replace_host_nics: false,
             host_lifecycle_profile: value.disable_lockdown.map(|dl| {
                 rpc::forge::HostLifecycleProfile {
                     disable_lockdown: Some(dl),

--- a/crates/admin-cli/src/expected_machines/common.rs
+++ b/crates/admin-cli/src/expected_machines/common.rs
@@ -136,8 +136,12 @@ pub struct ExpectedMachineJson {
     #[serde(default)]
     pub metadata: Option<rpc::forge::Metadata>,
     pub sku_id: Option<String>,
+    /// An omitted field or explicit `null` preserves the stored list for
+    /// file-based updates, while an empty array clears it. `replace-all` has no
+    /// stored row to preserve, so it resolves either form of `None` to an empty
+    /// list.
     #[serde(default)]
-    pub host_nics: Vec<rpc::forge::ExpectedHostNic>,
+    pub host_nics: Option<Vec<rpc::forge::ExpectedHostNic>>,
     pub rack_id: Option<RackId>,
     pub default_pause_ingestion_and_poweron: Option<bool>,
     pub dpf_enabled: Option<bool>,
@@ -269,6 +273,44 @@ mod tests {
 
             "unknown numeric value" {
                 r#", "dpu_mode": 99"# => Fails,
+            }
+        );
+    }
+
+    /// File updates distinguish an omitted interface list from an explicit
+    /// replacement, including an empty replacement.
+    #[test]
+    fn expected_machine_json_preserves_host_nic_presence() {
+        scenarios!(
+            run = |host_nics_json| {
+                let json = format!(
+                    r#"{{
+                        "bmc_mac_address": "AA:BB:CC:DD:EE:FF",
+                        "bmc_username": "root",
+                        "bmc_password": "pass",
+                        "chassis_serial_number": "SN-1"
+                        {host_nics_json}
+                    }}"#,
+                );
+                serde_json::from_str::<ExpectedMachineJson>(&json)
+                    .map(|machine| machine.host_nics.map(|host_nics| host_nics.len()))
+                    .map_err(drop)
+            };
+            "host_nics omitted" {
+                "" => Yields(None),
+            }
+
+            "host_nics explicitly null" {
+                r#", "host_nics": null"# => Yields(None),
+            }
+
+            "host_nics explicitly empty" {
+                r#", "host_nics": []"# => Yields(Some(0)),
+            }
+
+            "host_nics explicitly populated" {
+                r#", "host_nics": [{"mac_address": "00:11:22:33:44:55"}]"# =>
+                    Yields(Some(1)),
             }
         );
     }

--- a/crates/admin-cli/src/expected_machines/patch/args.rs
+++ b/crates/admin-cli/src/expected_machines/patch/args.rs
@@ -76,6 +76,15 @@ Retain the BMC's auto-allocated DHCP address as a static one (never expires):
     $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
     --bmc-ip-allocation retained
 
+Replace the interface list for a matching stored interface that already has a
+fixed IP. The omitted role and allocation policy keep their stored values:
+    $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --host_nics '[{\"mac_address\":\"02:00:00:00:20:01\",\"fixed_ip\":\"192.0.2.10\"}]'
+
+Reset that role to Host and infer Fixed allocation from fixed_ip:
+    $ nico-admin-cli expected-machine patch --bmc-mac-address 00:11:22:33:44:55 \
+    --host_nics '[{\"mac_address\":\"02:00:00:00:20:01\",\"role\":\"unspecified\",\"ip_allocation\":\"unspecified\",\"fixed_ip\":\"192.0.2.10\"}]'
+
 ")]
 pub struct Args {
     #[clap(short = 'a', long, help = "BMC MAC Address of the expected machine")]
@@ -208,7 +217,7 @@ pub struct Args {
         long = "host_nics",
         value_name = "HOST_NICS",
         group = "group",
-        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc|unspecified and ip_allocation=dynamic|fixed|retained|unspecified. Replaces the machine's full host NIC list. For a matching stored MAC, omitting role preserves the stored role; role=unspecified resets it to host. Omitting ip_allocation preserves the stored policy when the presence of fixed_ip is unchanged; ip_allocation=unspecified resets it to fixed_ip inference."
+        help = "Host NICs as a JSON array of ExpectedHostNic objects (fields: mac_address, role, ip_allocation, network_segment_type, fixed_ip, fixed_mask, fixed_gateway, primary; legacy: nic_type). Accepted values: role=host|dpu_os|dpu_bmc|host_bmc|unspecified and ip_allocation=dynamic|fixed|retained|unspecified. Replaces the machine's full host NIC list. For a matching stored MAC, omitting role preserves the stored role; role=unspecified resets it to host. Omitting ip_allocation preserves the stored policy when the presence of fixed_ip is unchanged; ip_allocation=unspecified resets it to fixed_ip inference."
     )]
     pub host_nics: Option<String>,
 

--- a/crates/admin-cli/src/expected_machines/update/mod.rs
+++ b/crates/admin-cli/src/expected_machines/update/mod.rs
@@ -27,9 +27,9 @@ use crate::cfg::runtime::RuntimeContext;
 use crate::errors::CarbideCliResult;
 use crate::expected_machines::common::ExpectedMachineJson;
 
-/// `expected-machine update <file>`: deserializes `ExpectedMachineJson` and calls
-/// `patch_expected_machine` with every field from the file (full replacement style), including
-/// optional `bmc_ip_address` when present in JSON.
+/// `expected-machine update <file>` deserializes `ExpectedMachineJson` and
+/// calls `patch_expected_machine`. An omitted or `null` `host_nics` field
+/// preserves the stored list, while a non-null array replaces it.
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
         let json_file_path = Path::new(&self.filename);
@@ -38,8 +38,13 @@ impl Run for Args {
 
         let dpu_policy = expected_machine.dpu_policy();
         let metadata = expected_machine.metadata.unwrap_or_default();
+        let host_nics = expected_machine
+            .host_nics
+            .map(|host_nics| serde_json::to_string(&host_nics))
+            .transpose()?;
 
-        // Patch merges with the server record; we pass all fields from JSON so the result matches the file.
+        // Values present in the file replace the stored values. The patch
+        // helper preserves optional fields that the file omitted.
         ctx.api_client
             .patch_expected_machine(
                 Some(expected_machine.bmc_mac_address),
@@ -76,9 +81,7 @@ impl Run for Args {
                         disable_lockdown: hlp.disable_lockdown,
                     }
                 }),
-                // TODO: file-based update preserves existing host_nics; wire in
-                // expected_machine.host_nics to honor the file's list
-                None,
+                host_nics,
             )
             .await?;
         Ok(())

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -86,6 +86,104 @@ fn cap_chunk_size(page_size: usize, cap: usize) -> usize {
     }
 }
 
+/// Legacy BMC fields sent with a full `ExpectedMachine` update.
+///
+/// `patch_expected_machine` still fetches the current record so it can merge
+/// ordinary patch fields. These two fields need their own rules because the API
+/// uses their presence to distinguish a legacy `--bmc-*` override from the
+/// canonical `HostBmc` entry in `host_nics`.
+#[derive(Clone, Debug, PartialEq)]
+struct LegacyBmcPatchFields {
+    bmc_ip_address: Option<String>,
+    bmc_ip_allocation: Option<i32>,
+}
+
+/// `replacement_has_effective_host_bmc` resolves an omitted role the same way
+/// the update API does before deciding whether top-level BMC fields are legacy
+/// overrides. Otherwise a matching stored `HostBmc` is hidden at this point,
+/// and replaying the compatibility fields would overwrite its nested changes.
+fn replacement_has_effective_host_bmc(
+    existing: &rpc::ExpectedMachine,
+    replacement_host_nics: &[rpc::ExpectedHostNic],
+) -> bool {
+    let existing_bmc_mac = existing.bmc_mac_address.parse::<MacAddress>().ok();
+
+    replacement_host_nics
+        .iter()
+        .enumerate()
+        .any(|(index, replacement)| {
+            if let Some(role) = replacement.role {
+                return rpc::ExpectedInterfaceRole::try_from(role).ok()
+                    == Some(rpc::ExpectedInterfaceRole::HostBmc);
+            }
+
+            let Ok(mac_address) = replacement.mac_address.parse::<MacAddress>() else {
+                return false;
+            };
+            let existing_interface = existing
+                .host_nics
+                .get(index)
+                .filter(|candidate| {
+                    candidate.mac_address.parse::<MacAddress>().ok() == Some(mac_address)
+                })
+                .or_else(|| {
+                    existing.host_nics.iter().find(|candidate| {
+                        candidate.mac_address.parse::<MacAddress>().ok() == Some(mac_address)
+                    })
+                });
+
+            match existing_interface {
+                Some(existing_interface) => {
+                    existing_interface
+                        .role
+                        .and_then(|role| rpc::ExpectedInterfaceRole::try_from(role).ok())
+                        == Some(rpc::ExpectedInterfaceRole::HostBmc)
+                }
+                None => existing_bmc_mac == Some(mac_address),
+            }
+        })
+}
+
+/// `legacy_bmc_patch_fields` keeps old patch behavior unless the caller
+/// supplies a `HostBmc` replacement or an explicit legacy override.
+///
+/// `Dynamic` and `Retained` use an empty address as an explicit clear. A
+/// missing protobuf string cannot express that on a full update because it also
+/// means the legacy flag was omitted.
+fn legacy_bmc_patch_fields(
+    existing: &rpc::ExpectedMachine,
+    bmc_ip_address_override: Option<String>,
+    bmc_ip_allocation_override: Option<rpc::BmcIpAllocationType>,
+    replacement_host_nics: Option<&[rpc::ExpectedHostNic]>,
+) -> LegacyBmcPatchFields {
+    let replaces_host_bmc = replacement_host_nics
+        .is_some_and(|host_nics| replacement_has_effective_host_bmc(existing, host_nics));
+
+    let clears_fixed_ip = bmc_ip_allocation_override.is_some_and(|allocation| {
+        matches!(
+            allocation,
+            rpc::BmcIpAllocationType::Dynamic | rpc::BmcIpAllocationType::Retained
+        )
+    });
+
+    let bmc_ip_address = match bmc_ip_address_override {
+        Some(bmc_ip_address) => Some(bmc_ip_address),
+        None if clears_fixed_ip => Some(String::new()),
+        None if replaces_host_bmc => None,
+        None => existing.bmc_ip_address.clone(),
+    };
+    let bmc_ip_allocation = match bmc_ip_allocation_override {
+        Some(allocation) => Some(allocation as i32),
+        None if replaces_host_bmc => None,
+        None => existing.bmc_ip_allocation,
+    };
+
+    LegacyBmcPatchFields {
+        bmc_ip_address,
+        bmc_ip_allocation,
+    }
+}
+
 // Benchmarks showed 4 had better overall performance while still overlapping page fetch latency.
 const PAGED_LIST_FETCH_CONCURRENCY: usize = 4;
 
@@ -858,6 +956,16 @@ impl ApiClient {
         let mac_str = bmc_mac_address
             .map(|m| m.to_string())
             .unwrap_or(expected_machine.bmc_mac_address.clone());
+        let parsed_host_nics = host_nics
+            .map(|s| serde_json::from_str::<Vec<rpc::ExpectedHostNic>>(&s))
+            .transpose()?;
+        let replace_host_nics = parsed_host_nics.is_some();
+        let legacy_bmc_fields = legacy_bmc_patch_fields(
+            &expected_machine,
+            bmc_ip_address,
+            bmc_ip_allocation,
+            parsed_host_nics.as_deref(),
+        );
 
         // Merge metadata fields individually
         let merged_metadata =
@@ -905,26 +1013,21 @@ impl ApiClient {
             metadata: merged_metadata,
             sku_id: sku_id.or(expected_machine.sku_id),
             id: expected_machine.id,
-            host_nics: host_nics
-                .map(|s| serde_json::from_str::<Vec<rpc::ExpectedHostNic>>(&s))
-                .transpose()?
-                .unwrap_or(expected_machine.host_nics),
+            host_nics: parsed_host_nics.unwrap_or(expected_machine.host_nics),
             rack_id: rack_id.or(expected_machine.rack_id),
-            default_pause_ingestion_and_poweron,
+            default_pause_ingestion_and_poweron: default_pause_ingestion_and_poweron
+                .or(expected_machine.default_pause_ingestion_and_poweron),
             #[allow(deprecated)]
             dpf_enabled: dpf_enabled.unwrap_or(true),
             is_dpf_enabled: dpf_enabled,
-            bmc_ip_address: bmc_ip_address.or(expected_machine.bmc_ip_address),
+            bmc_ip_address: legacy_bmc_fields.bmc_ip_address,
             bmc_retain_credentials: bmc_retain_credentials
                 .or(expected_machine.bmc_retain_credentials),
             dpu_mode: dpu_policy
                 .map(|policy| ::rpc::forge::DpuMode::from(policy) as i32)
                 .or(expected_machine.dpu_mode),
-            // Use the flag value if given, else preserve the stored per-host
-            // value (patch semantics).
-            bmc_ip_allocation: bmc_ip_allocation
-                .map(|m| m as i32)
-                .or(expected_machine.bmc_ip_allocation),
+            bmc_ip_allocation: legacy_bmc_fields.bmc_ip_allocation,
+            replace_host_nics,
             host_lifecycle_profile: host_lifecycle_profile
                 .or(expected_machine.host_lifecycle_profile),
         };
@@ -954,7 +1057,7 @@ impl ApiClient {
                         .unwrap_or_default(),
                     metadata: machine.metadata,
                     sku_id: machine.sku_id,
-                    host_nics: machine.host_nics,
+                    host_nics: machine.host_nics.unwrap_or_default(),
                     rack_id: machine.rack_id,
                     default_pause_ingestion_and_poweron: machine
                         .default_pause_ingestion_and_poweron,
@@ -964,6 +1067,9 @@ impl ApiClient {
                     bmc_ip_address: machine.bmc_ip_address,
                     bmc_retain_credentials: machine.bmc_retain_credentials,
                     bmc_ip_allocation: machine.bmc_ip_allocation.map(|m| m as i32),
+                    // replace-all is authoritative even when the JSON field is
+                    // omitted and therefore resolves to an empty list.
+                    replace_host_nics: true,
                     host_lifecycle_profile: machine.host_lifecycle_profile.map(|hlp| {
                         ::rpc::forge::HostLifecycleProfile {
                             disable_lockdown: hlp.disable_lockdown,
@@ -2695,7 +2801,29 @@ impl ApiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{cap_chunk_size, maybe_unimplemented};
+    use carbide_test_support::{Check, check_values};
+
+    use super::{
+        LegacyBmcPatchFields, cap_chunk_size, legacy_bmc_patch_fields, maybe_unimplemented, rpc,
+    };
+
+    /// Inputs that differ across the `legacy_bmc_patch_fields` table.
+    #[derive(Debug)]
+    struct LegacyBmcPatchCase {
+        bmc_ip_address_override: Option<String>,
+        bmc_ip_allocation_override: Option<rpc::BmcIpAllocationType>,
+        replacement_host_nics: Option<Vec<rpc::ExpectedHostNic>>,
+    }
+
+    /// Builds the smallest protobuf interface needed by the patch-field table.
+    fn expected_interface(role: rpc::ExpectedInterfaceRole) -> rpc::ExpectedHostNic {
+        rpc::ExpectedHostNic {
+            mac_address: "00:11:22:33:44:55".to_string(),
+            role: Some(role as i32),
+            ip_allocation: Some(rpc::ExpectedInterfaceIpAllocation::Dynamic as i32),
+            ..Default::default()
+        }
+    }
 
     /// `PermissionDenied` must trigger the deprecated-alias fallback: servers
     /// that predate a renamed RPC reject its unknown method name with a bare
@@ -2735,5 +2863,138 @@ mod tests {
         assert_eq!(cap_chunk_size(100, 500), 100);
         // Equal is a no-op.
         assert_eq!(cap_chunk_size(100, 100), 100);
+    }
+
+    /// Patch inputs retain omission, override, and explicit-clear semantics
+    /// before the CLI sends its full-update request.
+    #[test]
+    fn legacy_bmc_patch_fields_preserve_presence_and_clear_semantics() {
+        use rpc::{BmcIpAllocationType as LegacyAllocation, ExpectedInterfaceRole as Role};
+
+        let existing = rpc::ExpectedMachine {
+            bmc_mac_address: "00:11:22:33:44:55".to_string(),
+            bmc_ip_address: Some("192.0.2.20".to_string()),
+            bmc_ip_allocation: Some(LegacyAllocation::Fixed as i32),
+            host_nics: vec![rpc::ExpectedHostNic {
+                fixed_ip: Some("192.0.2.20".to_string()),
+                ip_allocation: None,
+                ..expected_interface(Role::HostBmc)
+            }],
+            ..Default::default()
+        };
+        let expected_existing = LegacyBmcPatchFields {
+            bmc_ip_address: existing.bmc_ip_address.clone(),
+            bmc_ip_allocation: existing.bmc_ip_allocation,
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "an unrelated patch preserves both compatibility fields",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: None,
+                        bmc_ip_allocation_override: None,
+                        replacement_host_nics: None,
+                    },
+                    expect: expected_existing.clone(),
+                },
+                Check {
+                    scenario: "a replacement without HostBmc preserves both compatibility fields",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: None,
+                        bmc_ip_allocation_override: None,
+                        replacement_host_nics: Some(vec![expected_interface(Role::Host)]),
+                    },
+                    expect: expected_existing,
+                },
+                Check {
+                    scenario: "a HostBmc replacement omits both compatibility fields",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: None,
+                        bmc_ip_allocation_override: None,
+                        replacement_host_nics: Some(vec![expected_interface(Role::HostBmc)]),
+                    },
+                    expect: LegacyBmcPatchFields {
+                        bmc_ip_address: None,
+                        bmc_ip_allocation: None,
+                    },
+                },
+                Check {
+                    scenario: "an omitted HostBmc role can reset to inferred allocation",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: None,
+                        bmc_ip_allocation_override: None,
+                        replacement_host_nics: Some(vec![rpc::ExpectedHostNic {
+                            role: None,
+                            fixed_ip: None,
+                            ip_allocation: Some(
+                                rpc::ExpectedInterfaceIpAllocation::Unspecified as i32,
+                            ),
+                            ..expected_interface(Role::HostBmc)
+                        }]),
+                    },
+                    expect: LegacyBmcPatchFields {
+                        bmc_ip_address: None,
+                        bmc_ip_allocation: None,
+                    },
+                },
+                Check {
+                    scenario: "explicit compatibility fields override HostBmc",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: Some("192.0.2.40".to_string()),
+                        bmc_ip_allocation_override: Some(LegacyAllocation::Fixed),
+                        replacement_host_nics: Some(vec![expected_interface(Role::HostBmc)]),
+                    },
+                    expect: LegacyBmcPatchFields {
+                        bmc_ip_address: Some("192.0.2.40".to_string()),
+                        bmc_ip_allocation: Some(LegacyAllocation::Fixed as i32),
+                    },
+                },
+                Check {
+                    scenario: "an explicit dynamic policy clears the compatibility address",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: None,
+                        bmc_ip_allocation_override: Some(LegacyAllocation::Dynamic),
+                        replacement_host_nics: None,
+                    },
+                    expect: LegacyBmcPatchFields {
+                        bmc_ip_address: Some(String::new()),
+                        bmc_ip_allocation: Some(LegacyAllocation::Dynamic as i32),
+                    },
+                },
+                Check {
+                    scenario: "an explicit retained policy clears the compatibility address",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: None,
+                        bmc_ip_allocation_override: Some(LegacyAllocation::Retained),
+                        replacement_host_nics: None,
+                    },
+                    expect: LegacyBmcPatchFields {
+                        bmc_ip_address: Some(String::new()),
+                        bmc_ip_allocation: Some(LegacyAllocation::Retained as i32),
+                    },
+                },
+                Check {
+                    scenario: "an explicit address keeps the stored compatibility policy",
+                    input: LegacyBmcPatchCase {
+                        bmc_ip_address_override: Some("192.0.2.40".to_string()),
+                        bmc_ip_allocation_override: None,
+                        replacement_host_nics: None,
+                    },
+                    expect: LegacyBmcPatchFields {
+                        bmc_ip_address: Some("192.0.2.40".to_string()),
+                        bmc_ip_allocation: Some(LegacyAllocation::Fixed as i32),
+                    },
+                },
+            ],
+            |case| {
+                legacy_bmc_patch_fields(
+                    &existing,
+                    case.bmc_ip_address_override,
+                    case.bmc_ip_allocation_override,
+                    case.replacement_host_nics.as_deref(),
+                )
+            },
+        );
     }
 }

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -482,8 +482,8 @@ pub async fn discover_dhcp(
         && message_kind == Some(DhcpMessageKind::V6InfoRequest);
     let mut expected_interface: Option<ExpectedHostNic> = None;
     // `host_primary_declaration` is intentionally Host-only. A DPU OS
-    // interface is always primary and a DPU BMC interface is never primary;
-    // api-db derives those values from the matched interface role.
+    // interface is always primary, while DPU and Host BMC interfaces are never
+    // primary; api-db derives those values from the matched interface role.
     let mut host_primary_declaration: Option<bool> = None;
 
     let parsed_mac: MacAddress = mac_address.parse()?;
@@ -546,7 +546,28 @@ pub async fn discover_dhcp(
                     // next DHCP request is then the first point where we see that
                     // MAC again, so the idempotent preallocation rebuilds the
                     // reservation before the common find-or-create path runs.
-                    if let Some(m) =
+                    // The top-level BMC MAC is the ExpectedMachine alternate
+                    // key, so resolve it before searching the nested JSON
+                    // list. Otherwise another declaration using the same MAC
+                    // could make DHCP treat a host BMC as a data interface.
+                    if let Some(m) = expected_machine::find_by_bmc_mac_address(&mut txn, parsed_mac)
+                        .await
+                        .map_err(CarbideError::from)?
+                    {
+                        let interface = m.effective_host_bmc();
+                        if interface
+                            .fixed_ip
+                            .is_some_and(|fixed_ip| fixed_ip.is_address_family(address_family))
+                        {
+                            db::machine_interface::preallocate_expected_machine_interface(
+                                &mut txn,
+                                &interface,
+                                api.runtime_config.retained_boot_interface_window,
+                            )
+                            .await?;
+                        }
+                        expected_interface = Some(interface);
+                    } else if let Some(m) =
                         expected_machine::find_by_host_mac_address(&mut txn, parsed_mac)
                             .await
                             .map_err(CarbideError::from)?
@@ -579,26 +600,6 @@ pub async fn discover_dhcp(
                                 .await?;
                             }
                         }
-                    } else if let Some(m) =
-                        expected_machine::find_by_bmc_mac_address(&mut txn, parsed_mac)
-                            .await
-                            .map_err(CarbideError::from)?
-                        && let Some(bmc_ip) = m.data.bmc_ip_address
-                        && bmc_ip.is_address_family(address_family)
-                    {
-                        // In this case it looks like our parsed MAC address is for the BMC
-                        // of an expected machine, and it has a static DHCP reservation per
-                        // its bmc_ip_address, so again, ensure the machine interface is
-                        // allocated before continuing. BMC variant so the row carries
-                        // InterfaceType::Bmc (and primary=false). Races against
-                        // site-explorer's reconciliation pass are handled inside preallocate.
-                        db::machine_interface::preallocate_bmc_machine_interface(
-                            &mut txn,
-                            parsed_mac,
-                            bmc_ip,
-                            api.runtime_config.retained_boot_interface_window,
-                        )
-                        .await?;
                     } else if let Some(s) =
                         db::expected_switch::find_by_nvos_mac_address(&mut txn, parsed_mac)
                             .await

--- a/crates/api-core/src/handlers/expected_machine.rs
+++ b/crates/api-core/src/handlers/expected_machine.rs
@@ -20,16 +20,15 @@ use ::rpc::forge as rpc;
 use lazy_static::lazy_static;
 use mac_address::MacAddress;
 use model::expected_machine::{
-    ExpectedHostNic, ExpectedMachine, ExpectedMachineData, ExpectedMachineRequest,
+    BmcIpAllocationType, ExpectedHostNic, ExpectedMachine, ExpectedMachineData,
+    ExpectedMachineRequest, LegacyHostBmcOverrides,
 };
 use regex::Regex;
 use uuid::Uuid;
 
 use crate::CarbideError;
 use crate::api::{Api, log_request_data};
-use crate::handlers::machine_interface_address::{
-    update_preallocated_expected_machine_interface, update_preallocated_machine_interface,
-};
+use crate::handlers::machine_interface_address::update_preallocated_expected_machine_interface;
 
 lazy_static! {
     // Verify what serial is alphanumeric string with, allows dashes '-' and underscores '_'
@@ -73,7 +72,7 @@ pub(crate) async fn add(
 ) -> Result<tonic::Response<()>, tonic::Status> {
     log_request_data(&request);
 
-    let machine = parse_expected_machine_for_insert(request.into_inner())?;
+    let machine = parse_expected_machine_for_insert(request.into_inner(), None)?;
 
     let mut txn = api.txn_begin().await?;
     db::expected_machine::create(&mut txn, machine).await?;
@@ -90,6 +89,7 @@ pub(crate) async fn add(
 /// replacement before it clears the current inventory.
 fn parse_expected_machine_for_insert(
     request: rpc::ExpectedMachine,
+    previous: Option<&ExpectedMachine>,
 ) -> Result<ExpectedMachine, CarbideError> {
     if carbide_utils::has_duplicates(&request.fallback_dpu_serial_numbers) {
         return Err(CarbideError::InvalidArgument(
@@ -118,14 +118,41 @@ fn parse_expected_machine_for_insert(
             })
         })
         .transpose()?;
+    let mut overrides = LegacyHostBmcOverrides::try_from(&request)?;
+    let previous_has_host_bmc = previous.is_some_and(|machine| {
+        machine
+            .data
+            .host_nics
+            .iter()
+            .any(|interface| interface.role.is_host_bmc())
+    });
+    let request_has_host_bmc = request
+        .host_nics
+        .iter()
+        .any(|interface| interface.role == Some(rpc::ExpectedInterfaceRole::HostBmc as i32));
+    if previous.is_some()
+        && !request_has_host_bmc
+        && (request.replace_host_nics || !previous_has_host_bmc)
+    {
+        // This helper's only update caller is replace-all, where omitted
+        // compatibility fields historically meant replacement with their
+        // defaults. An authoritative list without HostBmc follows that same
+        // rule; an older client's omitted list still preserves nested data it
+        // cannot represent.
+        overrides.ip_address.get_or_insert(None);
+        overrides
+            .ip_allocation
+            .get_or_insert(BmcIpAllocationType::Auto);
+    }
     let db_data: ExpectedMachineData = request.try_into()?;
 
-    let machine = ExpectedMachine {
+    let mut machine = ExpectedMachine {
         id,
         bmc_mac_address: parsed_mac,
         data: db_data,
     };
 
+    normalize_host_bmc_configuration(&mut machine, previous, overrides)?;
     validate_expected_machine_for_insert(&machine)?;
     Ok(machine)
 }
@@ -136,6 +163,7 @@ pub(crate) fn validate_expected_machine_for_insert(
     machine: &ExpectedMachine,
 ) -> Result<(), CarbideError> {
     validate_expected_interfaces(&machine.data.host_nics)?;
+    validate_host_bmc_declaration(machine)?;
     machine
         .data
         .bmc_ip_allocation
@@ -168,8 +196,26 @@ pub(crate) async fn create_missing_from(
             );
             continue;
         }
-        validate_expected_machine_for_insert(expected_machine)?;
-        db::expected_machine::create(&mut *txn, expected_machine.clone()).await?;
+        let mut expected_machine = expected_machine.clone();
+        let overrides = if expected_machine
+            .data
+            .host_nics
+            .iter()
+            .any(|interface| interface.role.is_host_bmc())
+        {
+            LegacyHostBmcOverrides {
+                ip_address: expected_machine.data.bmc_ip_address.map(Some),
+                ip_allocation: (expected_machine.data.bmc_ip_allocation
+                    != model::expected_machine::BmcIpAllocationType::Auto)
+                    .then_some(expected_machine.data.bmc_ip_allocation),
+                ..Default::default()
+            }
+        } else {
+            LegacyHostBmcOverrides::default()
+        };
+        normalize_host_bmc_configuration(&mut expected_machine, None, overrides)?;
+        validate_expected_machine_for_insert(&expected_machine)?;
+        db::expected_machine::create(&mut *txn, expected_machine).await?;
     }
 
     Ok(())
@@ -236,14 +282,17 @@ pub(crate) async fn update(
         },
     )
     .await?;
+    ensure_bmc_mac_unchanged(existing.as_ref(), parsed_mac)?;
     preserve_omitted_rpc_role_and_allocation(&mut request, existing.as_ref());
+    let overrides = LegacyHostBmcOverrides::try_from(&request)?;
     let data: ExpectedMachineData = request.try_into()?;
 
-    let machine = ExpectedMachine {
+    let mut machine = ExpectedMachine {
         id,
         bmc_mac_address: parsed_mac,
         data,
     };
+    normalize_host_bmc_configuration(&mut machine, existing.as_ref(), overrides)?;
     validate_expected_machine_for_insert(&machine)?;
 
     update_preallocated_interfaces(
@@ -286,7 +335,8 @@ pub(crate) async fn replace_all(
     let mut seen_ids = HashSet::with_capacity(replacements.len());
     let mut parsed_replacements = Vec::with_capacity(replacements.len());
     for replacement in replacements {
-        let parsed = parse_expected_machine_for_insert(replacement)?;
+        let existing = find_previous_expected_machine(&previous, &replacement);
+        let parsed = parse_expected_machine_for_insert(replacement, existing)?;
         if !seen_bmc_macs.insert(parsed.bmc_mac_address) {
             return Err(CarbideError::InvalidArgument(format!(
                 "duplicate expected machine BMC MAC address {} in replacement list",
@@ -402,7 +452,10 @@ fn validate_expected_interface_role_and_allocation(
                 interface.mac_address,
             ))
         })?;
-        if interface.primary.is_some() && !interface.role.is_host() {
+        let host_bmc_compatibility_false =
+            interface.role.is_host_bmc() && interface.primary == Some(false);
+        if interface.primary.is_some() && !interface.role.is_host() && !host_bmc_compatibility_false
+        {
             return Err(CarbideError::InvalidArgument(format!(
                 "only a role=host interface may set primary; {} has role {}",
                 interface.mac_address, interface.role,
@@ -423,6 +476,130 @@ fn validate_expected_interface_role_and_allocation(
         }
     }
 
+    Ok(())
+}
+
+/// Validate the Host BMC declaration before normalization can correct its
+/// identity fields.
+///
+/// The top-level MAC remains the ExpectedMachine alternate key, so a nested
+/// Host BMC must use that same address. An explicit `primary=false` remains
+/// accepted for clients that serialize false for every interface; the
+/// normalized declaration omits it.
+fn validate_host_bmc_declaration(machine: &ExpectedMachine) -> Result<(), CarbideError> {
+    let host_bmcs = machine
+        .data
+        .host_nics
+        .iter()
+        .filter(|interface| interface.role.is_host_bmc())
+        .collect::<Vec<_>>();
+    if host_bmcs.len() > 1 {
+        return Err(CarbideError::InvalidArgument(format!(
+            "at most one role=host_bmc interface may be configured, got {}",
+            host_bmcs.len(),
+        )));
+    }
+
+    if let Some(host_bmc) = host_bmcs.first() {
+        if host_bmc.mac_address != machine.bmc_mac_address {
+            return Err(CarbideError::InvalidArgument(format!(
+                "role=host_bmc interface MAC {} must match expected machine BMC MAC {}",
+                host_bmc.mac_address, machine.bmc_mac_address,
+            )));
+        }
+        if host_bmc.primary == Some(true) {
+            return Err(CarbideError::InvalidArgument(format!(
+                "role=host_bmc interface {} cannot set primary=true",
+                host_bmc.mac_address,
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Reject a new interface role that conflicts with the machine's BMC identity.
+///
+/// Existing rows may predate the HostBmc role, so an update may carry an
+/// unchanged conflicting declaration forward. Runtime lookup still gives the
+/// top-level BMC identity precedence for those rows.
+fn validate_bmc_identity_role(
+    machine: &ExpectedMachine,
+    previous: Option<&ExpectedMachine>,
+) -> Result<(), CarbideError> {
+    let conflicts = machine
+        .data
+        .host_nics
+        .iter()
+        .filter(|interface| {
+            interface.mac_address == machine.bmc_mac_address && !interface.role.is_host_bmc()
+        })
+        .collect::<Vec<_>>();
+    if conflicts.is_empty() {
+        return Ok(());
+    }
+
+    let unchanged_legacy_conflicts = previous.is_some_and(|previous| {
+        let mut previous_conflicts = previous
+            .data
+            .host_nics
+            .iter()
+            .filter(|interface| {
+                interface.mac_address == previous.bmc_mac_address && !interface.role.is_host_bmc()
+            })
+            .collect::<Vec<_>>();
+        conflicts.len() == previous_conflicts.len()
+            && conflicts.iter().all(|interface| {
+                previous_conflicts
+                    .iter()
+                    .position(|previous| *previous == *interface)
+                    .map(|index| previous_conflicts.swap_remove(index))
+                    .is_some()
+            })
+    });
+    if unchanged_legacy_conflicts {
+        return Ok(());
+    }
+
+    let interface = conflicts[0];
+    Err(CarbideError::InvalidArgument(format!(
+        "expected machine BMC MAC {} may only be configured with role=host_bmc, got role={}",
+        machine.bmc_mac_address, interface.role,
+    )))
+}
+
+/// Apply Host BMC compatibility fields and normalize a configured nested
+/// declaration without adding one to legacy-only rows.
+fn normalize_host_bmc_configuration(
+    machine: &mut ExpectedMachine,
+    previous: Option<&ExpectedMachine>,
+    overrides: LegacyHostBmcOverrides,
+) -> Result<(), CarbideError> {
+    validate_host_bmc_declaration(machine)?;
+    validate_bmc_identity_role(machine, previous)?;
+    machine
+        .normalize_host_bmc(previous, overrides)
+        .map_err(|message| CarbideError::InvalidArgument(format!("host BMC: {message}")))
+}
+
+/// ExpectedMachine updates cannot change the BMC MAC stored as the alternate
+/// key.
+///
+/// The database update selects by ID when one is present but intentionally
+/// leaves `bmc_mac_address` unchanged. Reject a different submitted value
+/// before it can be normalized into `host_nics`.
+fn ensure_bmc_mac_unchanged(
+    existing: Option<&ExpectedMachine>,
+    submitted_bmc_mac_address: MacAddress,
+) -> Result<(), CarbideError> {
+    if let Some(existing) = existing
+        && existing.bmc_mac_address != submitted_bmc_mac_address
+    {
+        return Err(CarbideError::InvalidArgument(format!(
+            "expected machine update cannot change BMC MAC address from {} to {}",
+            existing.bmc_mac_address, submitted_bmc_mac_address,
+        )));
+    }
     Ok(())
 }
 
@@ -491,6 +668,7 @@ fn preserve_omitted_rpc_role_and_allocation(
         return;
     };
 
+    let effective_host_bmc = existing.effective_host_bmc();
     for (index, interface) in replacement.host_nics.iter_mut().enumerate() {
         let Ok(mac_address) = interface.mac_address.parse::<MacAddress>() else {
             continue;
@@ -507,6 +685,7 @@ fn preserve_omitted_rpc_role_and_allocation(
                     .iter()
                     .find(|candidate| candidate.mac_address == mac_address)
             })
+            .or_else(|| (mac_address == existing.bmc_mac_address).then_some(&effective_host_bmc))
         else {
             // A new interface has no stored value to preserve. Missing fields
             // retain their normal inference/default behavior.
@@ -549,23 +728,25 @@ fn preserve_omitted_rpc_role_and_allocation(
 /// row, but leave existing addresses alone. An associated row may receive its
 /// configured fixed address, but its role-derived type and primary setting
 /// remain managed state. Operators still use the machine-interface address APIs
-/// to replace a live address.
+/// to replace a live address. The effective Host BMC is applied separately so
+/// legacy-only rows use the same path without storing a nested declaration.
 async fn update_preallocated_interfaces(
     txn: &mut sqlx::PgConnection,
     machine: &ExpectedMachine,
     retained_window: Option<chrono::Duration>,
 ) -> Result<(), CarbideError> {
-    if let Some(bmc_ip) = machine.data.bmc_ip_address {
-        update_preallocated_machine_interface(
-            &mut *txn,
-            machine.bmc_mac_address,
-            bmc_ip,
-            retained_window,
-        )
-        .await?;
+    let host_bmc = machine.effective_host_bmc();
+    if host_bmc.fixed_ip.is_some() {
+        update_preallocated_expected_machine_interface(&mut *txn, &host_bmc, retained_window)
+            .await?;
     }
 
-    for interface in &machine.data.host_nics {
+    for interface in machine
+        .data
+        .host_nics
+        .iter()
+        .filter(|interface| interface.mac_address != machine.bmc_mac_address)
+    {
         if interface.fixed_ip.is_some() {
             update_preallocated_expected_machine_interface(&mut *txn, interface, retained_window)
                 .await?;
@@ -641,14 +822,16 @@ async fn create_expected_machine(
     parsed_mac: MacAddress,
 ) -> Result<rpc::ExpectedMachine, CarbideError> {
     let result_machine = batch_result_with_id(machine.clone(), id);
+    let overrides = LegacyHostBmcOverrides::try_from(&machine)?;
     let db_data: ExpectedMachineData = machine.try_into()?;
 
-    let expected_machine = ExpectedMachine {
+    let mut expected_machine = ExpectedMachine {
         id: Some(id),
         bmc_mac_address: parsed_mac,
         data: db_data,
     };
 
+    normalize_host_bmc_configuration(&mut expected_machine, None, overrides)?;
     validate_expected_machine_for_insert(&expected_machine)?;
     db::expected_machine::create(txn, expected_machine).await?;
 
@@ -675,15 +858,18 @@ async fn update_expected_machine(
         },
     )
     .await?;
+    ensure_bmc_mac_unchanged(existing.as_ref(), parsed_mac)?;
     preserve_omitted_rpc_role_and_allocation(&mut machine, existing.as_ref());
+    let overrides = LegacyHostBmcOverrides::try_from(&machine)?;
     let data: ExpectedMachineData = machine.try_into()?;
 
-    let expected_machine = ExpectedMachine {
+    let mut expected_machine = ExpectedMachine {
         id: Some(id),
         bmc_mac_address: parsed_mac,
         data,
     };
-    validate_expected_interface_role_and_allocation(&expected_machine.data.host_nics)?;
+    normalize_host_bmc_configuration(&mut expected_machine, existing.as_ref(), overrides)?;
+    validate_expected_machine_for_insert(&expected_machine)?;
     update_preallocated_interfaces(txn, &expected_machine, retained_window).await?;
 
     db::expected_machine::update(txn, &expected_machine).await?;

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -81,7 +81,7 @@ pub async fn update_preallocated_expected_machine_interface(
             interface_type: expected_interface.role.interface_type(),
             primary_interface: expected_interface.role.primary_interface_override(),
             segment_type_guard: expected_interface.segment_type_guard(),
-            require_managed_prefix: !expected_interface.uses_legacy_host_allocation(),
+            require_managed_prefix: !expected_interface.allows_static_assignments_fallback(),
         }),
         retained_window,
     )
@@ -111,8 +111,8 @@ struct ExpectedInterfaceSettings {
 ///
 /// Existing addressed rows remain unchanged. Addressless rows receive the
 /// fixed address, but ExpectedInterface settings are applied only while the row
-/// is unassociated. Passing no settings preserves the existing Host BMC update
-/// behavior.
+/// is unassociated. Passing no settings preserves the existing generic
+/// reservation update behavior.
 async fn update_preallocated_machine_interface_with_settings(
     txn: &mut sqlx::PgConnection,
     mac_address: MacAddress,

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -22,7 +22,8 @@ use common::api_fixtures::{
 use db::{self};
 use mac_address::MacAddress;
 use model::expected_machine::{
-    ExpectedInterfaceIpAllocation, ExpectedInterfaceRole, ExpectedMachine, ExpectedMachineData,
+    BmcIpAllocationType, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole, ExpectedMachine,
+    ExpectedMachineData,
 };
 use rpc::forge::forge_server::Forge;
 use rpc::forge::{ExpectedMachineList, ExpectedMachineRequest};
@@ -68,6 +69,7 @@ async fn create_fixture_expected_machines(pool: &sqlx::PgPool) {
     }
     txn.commit().await.unwrap();
 }
+
 // Test API functionality
 /*
   // Expected Machine Management
@@ -490,7 +492,6 @@ async fn test_replace_all_expected_machines(pool: sqlx::PgPool) {
     // None will become Some(false), so we have to make the adjustment
     let mut expected_machine_3_clone = expected_machine_3.clone();
     expected_machine_3_clone.default_pause_ingestion_and_poweron = Some(false);
-
     assert_eq!(expected_machine_1, resulting_machine_1);
     assert_eq!(expected_machine_2, resulting_machine_2);
     assert_eq!(expected_machine_3_clone, resulting_machine_3);
@@ -733,6 +734,7 @@ async fn test_add_expected_machine_dpu_serials(pool: sqlx::PgPool) {
         bmc_retain_credentials: None,
         dpu_mode: None,
         bmc_ip_allocation: None,
+        replace_host_nics: false,
         host_lifecycle_profile: None,
         #[allow(deprecated)]
         dpf_enabled: true,
@@ -2305,6 +2307,322 @@ async fn test_replace_all_preserves_interface_fields_omitted_by_older_client(
     Ok(())
 }
 
+/// Replace-all retains its legacy full-replacement behavior for top-level BMC
+/// fields, while preserving a nested HostBmc that an older client cannot send.
+#[crate::sqlx_test]
+async fn test_replace_all_distinguishes_legacy_and_nested_host_bmc_omission(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        previous_nested: bool,
+        replacement_nested: bool,
+        initial_allocation: rpc::forge::BmcIpAllocationType,
+        expected_address: Option<&'static str>,
+        expected_nested: bool,
+        expected_allocation: Option<rpc::forge::ExpectedInterfaceIpAllocation>,
+    }
+
+    for case in [
+        Case {
+            name: "legacy omission clears the top-level address",
+            suffix: 0x82,
+            previous_nested: false,
+            replacement_nested: false,
+            initial_allocation: rpc::forge::BmcIpAllocationType::Fixed,
+            expected_address: None,
+            expected_nested: false,
+            expected_allocation: None,
+        },
+        Case {
+            name: "older client omission preserves nested HostBmc",
+            suffix: 0x84,
+            previous_nested: true,
+            replacement_nested: false,
+            initial_allocation: rpc::forge::BmcIpAllocationType::Fixed,
+            expected_address: Some("192.0.2.251"),
+            expected_nested: true,
+            expected_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed),
+        },
+        Case {
+            name: "legacy row can be replaced with nested HostBmc",
+            suffix: 0x86,
+            previous_nested: false,
+            replacement_nested: true,
+            initial_allocation: rpc::forge::BmcIpAllocationType::Dynamic,
+            expected_address: None,
+            expected_nested: true,
+            expected_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic),
+        },
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac = format!("7A:7B:7C:7D:82:{:02X}", case.suffix);
+        let serial = format!("EM-REPLACE-HOST-BMC-{:02X}", case.suffix);
+        let address = "192.0.2.251";
+        let host_nics = case
+            .previous_nested
+            .then(|| rpc::forge::ExpectedHostNic {
+                mac_address: bmc_mac.clone(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+                fixed_ip: Some(address.into()),
+                ..Default::default()
+            })
+            .into_iter()
+            .collect();
+
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                bmc_ip_address: (!case.previous_nested
+                    && case.initial_allocation == rpc::forge::BmcIpAllocationType::Fixed)
+                    .then(|| address.into()),
+                bmc_ip_allocation: (!case.previous_nested)
+                    .then_some(case.initial_allocation as i32),
+                host_nics,
+                ..Default::default()
+            }))
+            .await?;
+
+        env.api
+            .replace_all_expected_machines(tonic::Request::new(ExpectedMachineList {
+                expected_machines: vec![rpc::forge::ExpectedMachine {
+                    id: Some(::rpc::common::Uuid {
+                        value: id.to_string(),
+                    }),
+                    bmc_mac_address: bmc_mac.clone(),
+                    bmc_username: "UPDATED".into(),
+                    bmc_password: "PASS".into(),
+                    chassis_serial_number: serial,
+                    host_nics: case
+                        .replacement_nested
+                        .then(|| rpc::forge::ExpectedHostNic {
+                            mac_address: bmc_mac.clone(),
+                            role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                            ip_allocation: Some(
+                                rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32,
+                            ),
+                            ..Default::default()
+                        })
+                        .into_iter()
+                        .collect(),
+                    ..Default::default()
+                }],
+            }))
+            .await?;
+
+        let stored = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: String::new(),
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(
+            stored.bmc_ip_address.as_deref(),
+            case.expected_address,
+            "case: {}",
+            case.name,
+        );
+        let stored_host_bmc = stored.host_nics.iter().find(|interface| {
+            interface.role == Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32)
+        });
+        assert_eq!(
+            stored_host_bmc.is_some(),
+            case.expected_nested,
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            stored_host_bmc
+                .and_then(|interface| interface.ip_allocation)
+                .and_then(|allocation| {
+                    rpc::forge::ExpectedInterfaceIpAllocation::try_from(allocation).ok()
+                }),
+            case.expected_allocation,
+            "case: {}",
+            case.name,
+        );
+    }
+
+    Ok(())
+}
+
+/// New clients can mark `host_nics` as a complete replacement so an empty
+/// list, or a list without HostBmc, removes nested-only BMC settings. Older
+/// writers leave the marker false and retain the compatibility behavior
+/// covered by `test_replace_all_distinguishes_legacy_and_nested_host_bmc_omission`.
+#[crate::sqlx_test]
+async fn test_authoritative_host_nics_replacement_removes_nested_host_bmc(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    enum Operation {
+        SingleUpdate,
+        BatchUpdate,
+        ReplaceAll,
+    }
+
+    for (scenario, suffix, operation, keep_host_interface) in [
+        (
+            "single update with an empty list",
+            0x88,
+            Operation::SingleUpdate,
+            false,
+        ),
+        (
+            "single update with a Host-only list",
+            0x8a,
+            Operation::SingleUpdate,
+            true,
+        ),
+        (
+            "batch update with an empty list",
+            0x8c,
+            Operation::BatchUpdate,
+            false,
+        ),
+        (
+            "batch update with a Host-only list",
+            0x8e,
+            Operation::BatchUpdate,
+            true,
+        ),
+        (
+            "replace-all with an empty list",
+            0x90,
+            Operation::ReplaceAll,
+            false,
+        ),
+        (
+            "replace-all with a Host-only list",
+            0x92,
+            Operation::ReplaceAll,
+            true,
+        ),
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac = format!("7A:7B:7C:7D:82:{suffix:02X}");
+        let host_mac = format!("7A:7B:7C:7D:82:{:02X}", suffix + 1);
+        let serial = format!("EM-AUTHORITATIVE-HOST-NICS-{suffix:02X}");
+
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    mac_address: bmc_mac.clone(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    network_segment_type: Some(rpc::forge::NetworkSegmentType::Underlay as i32),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .await?;
+
+        let host_nics = keep_host_interface
+            .then(|| rpc::forge::ExpectedHostNic {
+                mac_address: host_mac.clone(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::Host as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                ..Default::default()
+            })
+            .into_iter()
+            .collect();
+        let replacement = rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.clone(),
+            bmc_username: "UPDATED".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial,
+            host_nics,
+            bmc_ip_allocation: Some(rpc::forge::BmcIpAllocationType::Retained as i32),
+            replace_host_nics: true,
+            ..Default::default()
+        };
+
+        match operation {
+            Operation::SingleUpdate => {
+                env.api
+                    .update_expected_machine(tonic::Request::new(replacement))
+                    .await?;
+            }
+            Operation::BatchUpdate => {
+                let response = env
+                    .api
+                    .update_expected_machines(tonic::Request::new(
+                        rpc::forge::BatchExpectedMachineOperationRequest {
+                            expected_machines: Some(ExpectedMachineList {
+                                expected_machines: vec![replacement],
+                            }),
+                            accept_partial_results: false,
+                        },
+                    ))
+                    .await?
+                    .into_inner();
+                assert!(response.results[0].success, "case: {scenario}");
+            }
+            Operation::ReplaceAll => {
+                env.api
+                    .replace_all_expected_machines(tonic::Request::new(ExpectedMachineList {
+                        expected_machines: vec![replacement],
+                    }))
+                    .await?;
+            }
+        }
+
+        let stored = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: String::new(),
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+            }))
+            .await?
+            .into_inner();
+        assert!(
+            stored.host_nics.iter().all(|interface| {
+                interface.role != Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32)
+            }),
+            "case {scenario}: the nested HostBmc should be removed",
+        );
+        assert_eq!(
+            stored.host_nics.len(),
+            usize::from(keep_host_interface),
+            "case: {scenario}",
+        );
+        assert_eq!(
+            stored.bmc_ip_allocation,
+            Some(rpc::forge::BmcIpAllocationType::Retained as i32),
+            "case {scenario}: compatibility allocation should remain available",
+        );
+    }
+
+    Ok(())
+}
+
 // test_patch_dpf_enabled_none_to_true verifies that when an expected machine is
 // added with is_dpf_enabled: None, the value defaults to true on insert, and a
 // subsequent update with is_dpf_enabled: None preserves that value.
@@ -3522,6 +3840,64 @@ async fn test_add_rejects_multiple_primary_host_nics(
     Ok(())
 }
 
+/// Batch updates use the same primary-interface validation as single writes.
+#[crate::sqlx_test]
+async fn test_batch_update_rejects_multiple_primary_host_nics(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let id = Uuid::new_v4();
+    let bmc_mac = "9A:9B:9C:9D:9E:30";
+
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.into(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-BATCH-DUPLICATE-PRIMARY-001".into(),
+            ..Default::default()
+        }))
+        .await?;
+
+    let update = rpc::forge::ExpectedMachine {
+        id: Some(::rpc::common::Uuid {
+            value: id.to_string(),
+        }),
+        bmc_mac_address: bmc_mac.into(),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        chassis_serial_number: "EM-BATCH-DUPLICATE-PRIMARY-001".into(),
+        host_nics: ["9A:9B:9C:9D:9E:31", "9A:9B:9C:9D:9E:32"]
+            .into_iter()
+            .map(|mac_address| rpc::forge::ExpectedHostNic {
+                mac_address: mac_address.into(),
+                primary: Some(true),
+                ..Default::default()
+            })
+            .collect(),
+        ..Default::default()
+    };
+    let result = env
+        .api
+        .update_expected_machines(tonic::Request::new(
+            rpc::forge::BatchExpectedMachineOperationRequest {
+                expected_machines: Some(rpc::forge::ExpectedMachineList {
+                    expected_machines: vec![update],
+                }),
+                accept_partial_results: false,
+            },
+        ))
+        .await;
+
+    let err = result.expect_err("batch update with multiple primary interfaces should fail");
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+
+    Ok(())
+}
+
 /// The declared primary survives whichever order its NICs DHCP in: leasing the
 /// non-primary NIC first, then the declared primary, still lands the declared
 /// primary as `primary_interface` and the other as non-primary.
@@ -3740,22 +4116,21 @@ async fn test_update_changes_dpu_mode(
     Ok(())
 }
 
-/// `ExpectedMachine.bmc_ip_allocation` round-trips through the API: a non-default
-/// value (`Dynamic`, `Retained`) set on the wire persists to the DB and reads back
-/// unchanged (the default/unset case is covered separately below). `Dynamic`/`Retained`
-/// are used here because they're valid with no `bmc_ip_address` (which these requests
-/// omit); `Fixed` requires an address and is exercised by the validation tests.
+/// Every non-default `ExpectedMachine.bmc_ip_allocation` value persists and
+/// reads back unchanged. Fixed includes its required compatibility address;
+/// the default/unset case is covered separately below.
 #[crate::sqlx_test]
 async fn test_bmc_ip_allocation_round_trip_for_non_default_values(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
 
-    for (idx, mode) in [
-        rpc::forge::BmcIpAllocationType::Dynamic,
-        rpc::forge::BmcIpAllocationType::Retained,
+    for (idx, (mode, bmc_ip_address)) in [
+        (rpc::forge::BmcIpAllocationType::Dynamic, None),
+        (rpc::forge::BmcIpAllocationType::Retained, None),
+        (rpc::forge::BmcIpAllocationType::Fixed, Some("192.0.2.25")),
     ]
-    .iter()
+    .into_iter()
     .enumerate()
     {
         let mac = format!("5A:5B:5C:5D:5F:{idx:02X}");
@@ -3764,7 +4139,8 @@ async fn test_bmc_ip_allocation_round_trip_for_non_default_values(
             bmc_username: "ADMIN".into(),
             bmc_password: "PASS".into(),
             chassis_serial_number: format!("EM-BMC-ALLOC-{idx}"),
-            bmc_ip_allocation: Some(*mode as i32),
+            bmc_ip_allocation: Some(mode as i32),
+            bmc_ip_address: bmc_ip_address.map(str::to_string),
             ..Default::default()
         };
 
@@ -3783,8 +4159,13 @@ async fn test_bmc_ip_allocation_round_trip_for_non_default_values(
 
         assert_eq!(
             retrieved.bmc_ip_allocation,
-            Some(*mode as i32),
+            Some(mode as i32),
             "bmc_ip_allocation {mode:?} should survive DB round-trip unchanged"
+        );
+        assert_eq!(
+            retrieved.bmc_ip_address.as_deref(),
+            bmc_ip_address,
+            "bmc_ip_address for {mode:?} should survive DB round-trip unchanged"
         );
     }
 
@@ -4071,6 +4452,784 @@ async fn test_bmc_ip_allocation_combinations_enforced_at_the_api_boundary(
     Ok(())
 }
 
+/// Host BMC declarations keep the top-level BMC MAC as the machine identity.
+///
+/// Clients that serialize `primary=false` for every interface remain accepted,
+/// while ambiguous declarations are rejected before normalization or storage.
+#[crate::sqlx_test]
+async fn test_host_bmc_declaration_validation(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    /// One Host BMC declaration accepted or rejected by the API boundary.
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        interfaces: Vec<rpc::forge::ExpectedHostNic>,
+        expected_error: Option<&'static str>,
+    }
+
+    for case in [
+        Case {
+            name: "one declaration with compatibility primary false",
+            suffix: 0x20,
+            interfaces: vec![rpc::forge::ExpectedHostNic {
+                mac_address: "5A:5B:5C:5D:62:20".into(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                primary: Some(false),
+                ..Default::default()
+            }],
+            expected_error: None,
+        },
+        Case {
+            name: "two Host BMC declarations",
+            suffix: 0x21,
+            interfaces: vec![
+                rpc::forge::ExpectedHostNic {
+                    mac_address: "5A:5B:5C:5D:62:21".into(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: "5A:5B:5C:5D:62:21".into(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                    ..Default::default()
+                },
+            ],
+            expected_error: Some("at most one role=host_bmc interface"),
+        },
+        Case {
+            name: "Host BMC MAC differs from the machine key",
+            suffix: 0x22,
+            interfaces: vec![rpc::forge::ExpectedHostNic {
+                mac_address: "5A:5B:5C:5D:62:FF".into(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                ..Default::default()
+            }],
+            expected_error: Some("must match expected machine BMC MAC"),
+        },
+        Case {
+            name: "Host BMC declares itself primary",
+            suffix: 0x23,
+            interfaces: vec![rpc::forge::ExpectedHostNic {
+                mac_address: "5A:5B:5C:5D:62:23".into(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                primary: Some(true),
+                ..Default::default()
+            }],
+            expected_error: Some("cannot set primary=true"),
+        },
+        Case {
+            name: "one MAC has conflicting roles",
+            suffix: 0x24,
+            interfaces: vec![
+                rpc::forge::ExpectedHostNic {
+                    mac_address: "5A:5B:5C:5D:62:A4".into(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuOs as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: "5A:5B:5C:5D:62:A4".into(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                },
+            ],
+            expected_error: Some("must use the same role"),
+        },
+        Case {
+            name: "machine BMC MAC uses a non-HostBmc role",
+            suffix: 0x25,
+            interfaces: vec![rpc::forge::ExpectedHostNic {
+                mac_address: "5A:5B:5C:5D:62:25".into(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                ..Default::default()
+            }],
+            expected_error: Some("may only be configured with role=host_bmc"),
+        },
+    ] {
+        let bmc_mac = format!("5A:5B:5C:5D:62:{:02X}", case.suffix);
+        let result = env
+            .api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                bmc_mac_address: bmc_mac.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: format!("HOST-BMC-VALIDATION-{:02X}", case.suffix),
+                host_nics: case.interfaces,
+                ..Default::default()
+            }))
+            .await;
+
+        match case.expected_error {
+            Some(expected_error) => {
+                let error = result.expect_err("invalid Host BMC declaration should be rejected");
+                assert_eq!(
+                    error.code(),
+                    tonic::Code::InvalidArgument,
+                    "case: {}",
+                    case.name,
+                );
+                assert!(
+                    error.message().contains(expected_error),
+                    "case {}: unexpected rejection reason: {}",
+                    case.name,
+                    error.message(),
+                );
+            }
+            None => {
+                result?;
+                let stored = env
+                    .api
+                    .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                        bmc_mac_address: bmc_mac,
+                        id: None,
+                    }))
+                    .await?
+                    .into_inner();
+                let host_bmcs = stored
+                    .host_nics
+                    .iter()
+                    .filter(|interface| {
+                        interface.role == Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32)
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(host_bmcs.len(), 1, "case: {}", case.name);
+                assert_eq!(
+                    host_bmcs[0].primary, None,
+                    "case {}: primary=false should normalize to omission",
+                    case.name,
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Legacy-only input keeps its earlier storage shape, while nested and mixed
+/// input store one Host BMC and matching compatibility columns.
+#[crate::sqlx_test]
+async fn test_host_bmc_normalizes_legacy_nested_and_mixed_configuration(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    /// One source combination and its normalized allocation.
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        bmc_ip_address: Option<&'static str>,
+        bmc_ip_allocation: Option<rpc::forge::BmcIpAllocationType>,
+        nested: Option<rpc::forge::ExpectedHostNic>,
+        expected_address: Option<&'static str>,
+        expected_allocation: ExpectedInterfaceIpAllocation,
+        expected_nested: bool,
+    }
+
+    for case in [
+        Case {
+            name: "legacy fields only",
+            suffix: 0x30,
+            bmc_ip_address: None,
+            bmc_ip_allocation: Some(rpc::forge::BmcIpAllocationType::Dynamic),
+            nested: None,
+            expected_address: None,
+            expected_allocation: ExpectedInterfaceIpAllocation::Dynamic,
+            expected_nested: false,
+        },
+        Case {
+            name: "nested declaration only",
+            suffix: 0x31,
+            bmc_ip_address: None,
+            bmc_ip_allocation: None,
+            nested: Some(rpc::forge::ExpectedHostNic {
+                mac_address: "5A:5B:5C:5D:63:31".into(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                network_segment_type: Some(rpc::forge::NetworkSegmentType::Admin as i32),
+                ..Default::default()
+            }),
+            expected_address: None,
+            expected_allocation: ExpectedInterfaceIpAllocation::Retained,
+            expected_nested: true,
+        },
+        Case {
+            name: "legacy fields override the nested baseline",
+            suffix: 0x32,
+            bmc_ip_address: Some("192.0.2.232"),
+            bmc_ip_allocation: Some(rpc::forge::BmcIpAllocationType::Fixed),
+            nested: Some(rpc::forge::ExpectedHostNic {
+                mac_address: "5A:5B:5C:5D:63:32".into(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                ..Default::default()
+            }),
+            expected_address: Some("192.0.2.232"),
+            expected_allocation: ExpectedInterfaceIpAllocation::Fixed,
+            expected_nested: true,
+        },
+    ] {
+        let bmc_mac: MacAddress = format!("5A:5B:5C:5D:63:{:02X}", case.suffix).parse()?;
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                bmc_mac_address: bmc_mac.to_string(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: format!("HOST-BMC-NORMALIZE-{:02X}", case.suffix),
+                bmc_ip_address: case.bmc_ip_address.map(Into::into),
+                bmc_ip_allocation: case.bmc_ip_allocation.map(|allocation| allocation as i32),
+                host_nics: case.nested.into_iter().collect(),
+                ..Default::default()
+            }))
+            .await?;
+
+        let mut txn = env.pool.begin().await?;
+        let stored = db::expected_machine::find_by_bmc_mac_address(&mut *txn, bmc_mac)
+            .await?
+            .expect("expected machine should exist");
+        let host_bmcs = stored
+            .data
+            .host_nics
+            .iter()
+            .filter(|interface| interface.role.is_host_bmc())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            host_bmcs.len(),
+            usize::from(case.expected_nested),
+            "case: {}",
+            case.name,
+        );
+        let effective_host_bmc = stored.effective_host_bmc();
+        assert_eq!(
+            effective_host_bmc.resolved_ip_allocation(),
+            case.expected_allocation,
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            effective_host_bmc.fixed_ip.map(|ip| ip.to_string()),
+            case.expected_address.map(str::to_string),
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            stored
+                .data
+                .bmc_ip_allocation
+                .resolved(stored.data.bmc_ip_address.is_some()),
+            case.expected_allocation,
+            "case {}: compatibility allocation should match the nested declaration",
+            case.name,
+        );
+        assert_eq!(
+            stored.data.bmc_ip_address.map(|ip| ip.to_string()),
+            case.expected_address.map(str::to_string),
+            "case {}: compatibility address should match the nested declaration",
+            case.name,
+        );
+    }
+
+    Ok(())
+}
+
+/// Single and batch create/update paths store the same canonical Host BMC
+/// declaration and compatibility fields.
+#[crate::sqlx_test]
+async fn test_host_bmc_normalization_has_single_and_batch_parity(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        is_update: bool,
+        use_batch: bool,
+    }
+
+    for case in [
+        Case {
+            name: "single create",
+            suffix: 0x40,
+            is_update: false,
+            use_batch: false,
+        },
+        Case {
+            name: "batch create",
+            suffix: 0x41,
+            is_update: false,
+            use_batch: true,
+        },
+        Case {
+            name: "single update",
+            suffix: 0x42,
+            is_update: true,
+            use_batch: false,
+        },
+        Case {
+            name: "batch update",
+            suffix: 0x43,
+            is_update: true,
+            use_batch: true,
+        },
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac: MacAddress = format!("5A:5B:5C:5D:64:{:02X}", case.suffix).parse()?;
+        let serial = format!("HOST-BMC-PARITY-{:02X}", case.suffix);
+        let base = rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial,
+            ..Default::default()
+        };
+        if case.is_update {
+            env.api
+                .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                    bmc_ip_allocation: Some(rpc::forge::BmcIpAllocationType::Dynamic as i32),
+                    ..base.clone()
+                }))
+                .await?;
+        }
+
+        let request = rpc::forge::ExpectedMachine {
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: bmc_mac.to_string(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                network_segment_type: Some(rpc::forge::NetworkSegmentType::Admin as i32),
+                ..Default::default()
+            }],
+            ..base
+        };
+        if case.use_batch {
+            let operation = rpc::forge::BatchExpectedMachineOperationRequest {
+                expected_machines: Some(ExpectedMachineList {
+                    expected_machines: vec![request],
+                }),
+                accept_partial_results: false,
+            };
+            let response = if case.is_update {
+                env.api
+                    .update_expected_machines(tonic::Request::new(operation))
+                    .await?
+            } else {
+                env.api
+                    .create_expected_machines(tonic::Request::new(operation))
+                    .await?
+            };
+            assert!(
+                response.into_inner().results[0].success,
+                "case: {}",
+                case.name,
+            );
+        } else if case.is_update {
+            env.api
+                .update_expected_machine(tonic::Request::new(request))
+                .await?;
+        } else {
+            env.api
+                .add_expected_machine(tonic::Request::new(request))
+                .await?;
+        }
+
+        let mut txn = env.pool.begin().await?;
+        let stored = db::expected_machine::find_by_id(&mut *txn, id)
+            .await?
+            .expect("expected machine should exist");
+        let host_bmcs = stored
+            .data
+            .host_nics
+            .iter()
+            .filter(|interface| interface.role.is_host_bmc())
+            .collect::<Vec<_>>();
+        assert_eq!(host_bmcs.len(), 1, "case: {}", case.name);
+        assert_eq!(
+            host_bmcs[0].ip_allocation,
+            Some(ExpectedInterfaceIpAllocation::Retained),
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            host_bmcs[0].network_segment_type,
+            Some(model::network_segment::NetworkSegmentType::Admin),
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            stored.data.bmc_ip_allocation,
+            BmcIpAllocationType::Retained,
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(stored.data.bmc_ip_address, None, "case: {}", case.name,);
+    }
+
+    Ok(())
+}
+
+/// Compatibility columns remain authoritative for rows changed by an older
+/// writer. Reads expose their value without losing nested-only settings, and
+/// the next ordinary update repairs the stored nested declaration.
+#[crate::sqlx_test]
+async fn test_host_bmc_compatibility_drift_is_read_and_healed(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let id = Uuid::new_v4();
+    let bmc_mac: MacAddress = "5A:5B:5C:5D:65:50".parse()?;
+    let base = rpc::forge::ExpectedMachine {
+        id: Some(::rpc::common::Uuid {
+            value: id.to_string(),
+        }),
+        bmc_mac_address: bmc_mac.to_string(),
+        bmc_username: "ADMIN".into(),
+        bmc_password: "PASS".into(),
+        chassis_serial_number: "HOST-BMC-DRIFT".into(),
+        ..Default::default()
+    };
+    env.api
+        .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: bmc_mac.to_string(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                network_segment_type: Some(rpc::forge::NetworkSegmentType::Admin as i32),
+                ..Default::default()
+            }],
+            ..base.clone()
+        }))
+        .await?;
+
+    // Simulate an older writer that knows only the compatibility columns.
+    let mut txn = env.pool.begin().await?;
+    let mut drifted = db::expected_machine::find_by_id(&mut *txn, id)
+        .await?
+        .expect("expected machine should exist");
+    drifted.data.bmc_ip_allocation = BmcIpAllocationType::Dynamic;
+    drifted.data.bmc_ip_address = None;
+    db::expected_machine::update(&mut txn, &drifted).await?;
+    txn.commit().await?;
+
+    let read = env
+        .api
+        .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+            bmc_mac_address: String::new(),
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+        }))
+        .await?
+        .into_inner();
+    let effective = read
+        .host_nics
+        .iter()
+        .find(|interface| interface.role == Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32))
+        .expect("read should synthesize the effective Host BMC");
+    assert_eq!(
+        effective.ip_allocation,
+        Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+    );
+    assert_eq!(
+        effective.network_segment_type,
+        Some(rpc::forge::NetworkSegmentType::Admin as i32),
+        "nested-only settings should survive compatibility drift",
+    );
+
+    // An old client can omit the nested Host BMC during an unrelated update.
+    env.api
+        .update_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_username: "UPDATED_ADMIN".into(),
+            ..base
+        }))
+        .await?;
+
+    let mut txn = env.pool.begin().await?;
+    let healed = db::expected_machine::find_by_id(&mut *txn, id)
+        .await?
+        .expect("expected machine should exist");
+    let nested = healed
+        .data
+        .host_nics
+        .iter()
+        .find(|interface| interface.role.is_host_bmc())
+        .expect("ordinary update should retain and heal the Host BMC");
+    assert_eq!(
+        nested.ip_allocation,
+        Some(ExpectedInterfaceIpAllocation::Dynamic),
+    );
+    assert_eq!(
+        nested.network_segment_type,
+        Some(model::network_segment::NetworkSegmentType::Admin),
+    );
+    assert_eq!(healed.data.bmc_ip_allocation, BmcIpAllocationType::Dynamic,);
+    assert_eq!(healed.data.bmc_username, "UPDATED_ADMIN");
+
+    Ok(())
+}
+
+/// Single and batch updates preserve an omitted legacy Fixed policy while
+/// allowing nested-only settings to change. Explicit Unspecified still resets
+/// that compatibility policy even when the stored HostBmc role is omitted.
+#[crate::sqlx_test]
+async fn test_host_bmc_updates_preserve_and_reset_compatibility_fixed(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        use_batch: bool,
+    }
+
+    for case in [
+        Case {
+            name: "single update",
+            suffix: 0x54,
+            use_batch: false,
+        },
+        Case {
+            name: "batch update",
+            suffix: 0x56,
+            use_batch: true,
+        },
+    ] {
+        let id = Uuid::new_v4();
+        let bmc_mac = format!("5A:5B:5C:5D:65:{:02X}", case.suffix);
+        let serial = format!("HOST-BMC-FIXED-PRESENCE-{:02X}", case.suffix);
+        let address = format!("192.0.2.{}", case.suffix);
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: bmc_mac.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                bmc_ip_address: Some(address.clone()),
+                bmc_ip_allocation: Some(rpc::forge::BmcIpAllocationType::Fixed as i32),
+                host_nics: vec![rpc::forge::ExpectedHostNic {
+                    mac_address: bmc_mac.clone(),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                    fixed_ip: Some(address.clone()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+            .await?;
+
+        let update = |ip_allocation| rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: bmc_mac.clone(),
+            bmc_username: "UPDATED_ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial.clone(),
+            bmc_ip_address: Some(address.clone()),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: bmc_mac.clone(),
+                // Omitted role and policy model clients that do not know the
+                // stored HostBmc details.
+                role: None,
+                ip_allocation,
+                fixed_ip: Some(address.clone()),
+                network_segment_type: Some(rpc::forge::NetworkSegmentType::Admin as i32),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let apply_update = |machine: rpc::forge::ExpectedMachine| async {
+            if case.use_batch {
+                env.api
+                    .update_expected_machines(tonic::Request::new(
+                        rpc::forge::BatchExpectedMachineOperationRequest {
+                            expected_machines: Some(ExpectedMachineList {
+                                expected_machines: vec![machine],
+                            }),
+                            accept_partial_results: false,
+                        },
+                    ))
+                    .await
+                    .map(|_| ())
+            } else {
+                env.api
+                    .update_expected_machine(tonic::Request::new(machine))
+                    .await
+                    .map(|_| ())
+            }
+        };
+
+        apply_update(update(None)).await?;
+
+        let mut txn = env.pool.begin().await?;
+        let preserved = db::expected_machine::find_by_id(&mut *txn, id)
+            .await?
+            .expect("expected machine should exist");
+        txn.rollback().await?;
+        let preserved_host_bmc = preserved
+            .data
+            .host_nics
+            .iter()
+            .find(|interface| interface.role.is_host_bmc())
+            .expect("nested HostBmc should remain present");
+        assert_eq!(
+            preserved.data.bmc_ip_allocation,
+            BmcIpAllocationType::Fixed,
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            preserved_host_bmc.ip_allocation, None,
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            preserved_host_bmc.network_segment_type,
+            Some(model::network_segment::NetworkSegmentType::Admin),
+            "case: {}",
+            case.name,
+        );
+
+        apply_update(update(Some(
+            rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32,
+        )))
+        .await?;
+
+        let mut txn = env.pool.begin().await?;
+        let reset = db::expected_machine::find_by_id(&mut *txn, id)
+            .await?
+            .expect("expected machine should exist");
+        txn.rollback().await?;
+        assert_eq!(
+            reset.data.bmc_ip_allocation,
+            BmcIpAllocationType::Auto,
+            "case: {}",
+            case.name,
+        );
+        assert_eq!(
+            reset.data.bmc_ip_address.map(|ip| ip.to_string()),
+            Some(address.clone()),
+            "case: {}",
+            case.name,
+        );
+    }
+
+    Ok(())
+}
+
+/// Both update APIs reject changing the BMC MAC selected by an ExpectedMachine
+/// ID, leaving the original alternate key intact.
+#[crate::sqlx_test]
+async fn test_expected_machine_update_rejects_bmc_mac_change(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+
+    struct Case {
+        name: &'static str,
+        suffix: u8,
+        use_batch: bool,
+    }
+
+    for case in [
+        Case {
+            name: "single update",
+            suffix: 0x60,
+            use_batch: false,
+        },
+        Case {
+            name: "batch update",
+            suffix: 0x62,
+            use_batch: true,
+        },
+    ] {
+        let id = Uuid::new_v4();
+        let original_mac = format!("5A:5B:5C:5D:66:{:02X}", case.suffix);
+        let changed_mac = format!("5A:5B:5C:5D:66:{:02X}", case.suffix + 1);
+        let serial = format!("HOST-BMC-KEY-{:02X}", case.suffix);
+        env.api
+            .add_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+                id: Some(::rpc::common::Uuid {
+                    value: id.to_string(),
+                }),
+                bmc_mac_address: original_mac.clone(),
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                chassis_serial_number: serial.clone(),
+                ..Default::default()
+            }))
+            .await?;
+
+        let update = rpc::forge::ExpectedMachine {
+            id: Some(::rpc::common::Uuid {
+                value: id.to_string(),
+            }),
+            bmc_mac_address: changed_mac,
+            bmc_username: "UPDATED_ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: serial,
+            ..Default::default()
+        };
+        let error = if case.use_batch {
+            env.api
+                .update_expected_machines(tonic::Request::new(
+                    rpc::forge::BatchExpectedMachineOperationRequest {
+                        expected_machines: Some(ExpectedMachineList {
+                            expected_machines: vec![update],
+                        }),
+                        accept_partial_results: false,
+                    },
+                ))
+                .await
+                .expect_err("batch BMC MAC change should be rejected")
+        } else {
+            env.api
+                .update_expected_machine(tonic::Request::new(update))
+                .await
+                .expect_err("BMC MAC change should be rejected")
+        };
+        assert_eq!(
+            error.code(),
+            tonic::Code::InvalidArgument,
+            "case: {}",
+            case.name,
+        );
+        assert!(
+            error.message().contains("cannot change BMC MAC address"),
+            "case {}: unexpected rejection reason: {}",
+            case.name,
+            error.message(),
+        );
+
+        let stored = env
+            .api
+            .get_expected_machine(tonic::Request::new(ExpectedMachineRequest {
+                bmc_mac_address: original_mac,
+                id: None,
+            }))
+            .await?
+            .into_inner();
+        assert_eq!(stored.bmc_username, "ADMIN", "case: {}", case.name);
+    }
+
+    Ok(())
+}
+
 /// Make sure expected_machines.json, which uses create_missing_from,
 /// follows the shared codepath for handling interface allocation.
 #[crate::sqlx_test]
@@ -4080,7 +5239,7 @@ async fn test_create_missing_from_preallocates_interfaces(
     let env = create_test_env(pool).await;
     let bmc_mac: MacAddress = "AA:BB:CC:DD:EE:01".parse().unwrap();
     let nic_mac: MacAddress = "AA:BB:CC:DD:EE:02".parse().unwrap();
-    let bmc_ip: std::net::IpAddr = "192.0.2.240".parse().unwrap();
+    let bmc_ip: std::net::IpAddr = "203.0.113.240".parse().unwrap();
     let host_ip: std::net::IpAddr = "192.0.2.241".parse().unwrap();
 
     let machine = ExpectedMachine {
@@ -4113,22 +5272,28 @@ async fn test_create_missing_from_preallocates_interfaces(
     .await?;
     txn.commit().await?;
 
-    // Run the same per-row materialization helpers as Site Explorer.
-    carbide_site_explorer::try_preallocate_one(
-        &env.pool,
-        bmc_mac,
-        bmc_ip,
-        model::machine_interface::InterfaceType::Bmc,
-        "expected_machine BMC",
-        None,
-    )
-    .await;
+    // Run the same effective-interface path as Site Explorer. The legacy BMC
+    // address is intentionally outside every managed prefix, so its inferred
+    // HostBmc declaration must retain the static-assignments fallback.
+    let mut txn = env.pool.begin().await?;
+    let stored = db::expected_machine::find_by_bmc_mac_address(&mut *txn, bmc_mac)
+        .await?
+        .expect("expected machine should exist");
+    txn.rollback().await?;
     carbide_site_explorer::try_apply_expected_interface(
         &env.pool,
-        &machine.data.host_nics[0],
+        &stored.effective_host_bmc(),
         None,
     )
     .await;
+    for interface in stored
+        .data
+        .host_nics
+        .iter()
+        .filter(|interface| interface.mac_address != stored.bmc_mac_address)
+    {
+        carbide_site_explorer::try_apply_expected_interface(&env.pool, interface, None).await;
+    }
 
     let mut txn = env.pool.begin().await?;
     for (mac, expected_ip) in [(bmc_mac, bmc_ip), (nic_mac, host_ip)] {
@@ -4143,6 +5308,15 @@ async fn test_create_missing_from_preallocates_interfaces(
             "machine_interface for MAC {mac} should carry static IP {expected_ip}, got {:?}",
             interfaces[0].addresses,
         );
+        if mac == bmc_mac {
+            assert_eq!(
+                interfaces[0].interface_type,
+                model::machine_interface::InterfaceType::Bmc,
+            );
+            assert!(!interfaces[0].primary_interface);
+            let static_assignments = db::network_segment::static_assignments(txn.as_mut()).await?;
+            assert_eq!(interfaces[0].segment_id, static_assignments.id);
+        }
     }
 
     // Re-running create_missing_from with the same input must be a no-op (idempotent).

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -38,7 +38,8 @@ use itertools::Itertools;
 use mac_address::MacAddress;
 use model::allocation_type::AllocationType;
 use model::expected_machine::{
-    ExpectedHostNic, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole,
+    BmcIpAllocationType, ExpectedHostNic, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole,
+    ExpectedMachine, ExpectedMachineData,
 };
 use model::machine_interface::InterfaceType;
 use model::network_segment::NetworkSegmentType;
@@ -672,14 +673,21 @@ async fn test_expected_interface_roles_and_policies_flow_through_dhcp_and_site_e
                     ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
                     ..Default::default()
                 },
+                rpc::forge::ExpectedHostNic {
+                    mac_address: expected_bmc_mac.to_string(),
+                    network_segment_type: Some(rpc::forge::NetworkSegmentType::Underlay as i32),
+                    role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                    ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Retained as i32),
+                    ..Default::default()
+                },
             ],
             ..Default::default()
         }))
         .await?;
 
-    // The machine-wide primary declaration belongs only to the Host role. DPU
-    // OS and DPU BMC still derive their primary settings from their roles even
-    // when the same ExpectedMachine also declares a primary Host interface.
+    // The machine-wide primary declaration belongs only to the Host role.
+    // DPU OS and BMC interfaces still derive their primary settings from their
+    // roles when the same ExpectedMachine declares a primary Host interface.
     struct Case {
         name: &'static str,
         mac_address: MacAddress,
@@ -717,6 +725,14 @@ async fn test_expected_interface_roles_and_policies_flow_through_dhcp_and_site_e
             name: "DPU BMC retained",
             mac_address: dpu_bmc_mac,
             role: ExpectedInterfaceRole::DpuBmc,
+            policy: ExpectedInterfaceIpAllocation::Retained,
+            interface_type: InterfaceType::Bmc,
+            primary: false,
+        },
+        Case {
+            name: "Host BMC retained",
+            mac_address: expected_bmc_mac,
+            role: ExpectedInterfaceRole::HostBmc,
             policy: ExpectedInterfaceIpAllocation::Retained,
             interface_type: InterfaceType::Bmc,
             primary: false,
@@ -777,6 +793,94 @@ async fn test_expected_interface_roles_and_policies_flow_through_dhcp_and_site_e
             "case: {name}",
         );
     }
+
+    Ok(())
+}
+
+/// The top-level BMC alternate key wins over a stale nested declaration that
+/// happens to reuse the same MAC.
+#[crate::sqlx_test]
+async fn test_host_bmc_identity_wins_expected_interface_mac_lookup(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let bmc_mac: MacAddress = "7A:7B:7C:7D:7E:35".parse()?;
+
+    // Write the conflicting legacy shape directly. Current API validation
+    // rejects this input, but an existing row may predate the HostBmc role.
+    let mut txn = pool.begin().await?;
+    db::expected_machine::create(
+        &mut txn,
+        ExpectedMachine {
+            id: None,
+            bmc_mac_address: bmc_mac,
+            data: ExpectedMachineData {
+                bmc_username: "ADMIN".into(),
+                bmc_password: "PASS".into(),
+                serial_number: "EM-HOST-BMC-LOOKUP-001".into(),
+                bmc_ip_allocation: BmcIpAllocationType::Dynamic,
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: bmc_mac,
+                    role: ExpectedInterfaceRole::Host,
+                    ip_allocation: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                    network_segment_type: Some(NetworkSegmentType::Underlay),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Existing conflicting rows remain updatable so introducing HostBmc does
+    // not turn an unrelated read-modify-write into a breaking change.
+    env.api
+        .update_expected_machine(tonic::Request::new(rpc::forge::ExpectedMachine {
+            bmc_mac_address: bmc_mac.to_string(),
+            bmc_username: "UPDATED_ADMIN".into(),
+            bmc_password: "PASS".into(),
+            chassis_serial_number: "EM-HOST-BMC-LOOKUP-001".into(),
+            bmc_ip_allocation: Some(rpc::forge::BmcIpAllocationType::Dynamic as i32),
+            host_nics: vec![rpc::forge::ExpectedHostNic {
+                mac_address: bmc_mac.to_string(),
+                role: Some(rpc::forge::ExpectedInterfaceRole::Host as i32),
+                ip_allocation: Some(rpc::forge::ExpectedInterfaceIpAllocation::Dynamic as i32),
+                network_segment_type: Some(rpc::forge::NetworkSegmentType::Underlay as i32),
+                ..Default::default()
+            }],
+            ..Default::default()
+        }))
+        .await?;
+
+    let mut txn = pool.begin().await?;
+    let stored = db::expected_machine::find_by_bmc_mac_address(&mut *txn, bmc_mac)
+        .await?
+        .expect("expected machine should exist");
+    txn.rollback().await?;
+    assert!(
+        stored.data.host_nics.iter().any(|interface| {
+            interface.mac_address == bmc_mac && interface.role == ExpectedInterfaceRole::Host
+        }),
+        "the legacy conflicting Host declaration should survive the update",
+    );
+
+    let response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(bmc_mac, FIXTURE_UNDERLAY_NETWORK_SEGMENT_GATEWAY.ip())
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let interface_id = response
+        .machine_interface_id
+        .expect("DHCP response should identify the Host BMC interface");
+
+    let mut txn = pool.begin().await?;
+    let interface = db::machine_interface::find_one(&mut *txn, interface_id).await?;
+    assert_eq!(interface.interface_type, InterfaceType::Bmc);
+    assert!(!interface.primary_interface);
 
     Ok(())
 }

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1237,22 +1237,12 @@ pub async fn preallocate_expected_machine_interface(
             interface_type: expected_interface.role.interface_type(),
             primary_interface: expected_interface.role.primary_interface_override(),
             segment_type_guard: expected_interface.segment_type_guard(),
-            require_managed_prefix: !expected_interface.uses_legacy_host_allocation(),
+            require_managed_prefix: !expected_interface.allows_static_assignments_fallback(),
             allow_associated_interface_settings_update: false,
         },
         retained_window,
     )
     .await
-}
-
-/// Pin a BMC interface's dynamic (DHCP) address as `Static` so lease expiry can't
-/// reap it. Idempotent no-op if the BMC interface has no DHCP address. Honors a
-/// `Retained` bmc_ip_allocation for BMCs with no operator-specified address.
-pub async fn retain_bmc_address_by_mac(
-    txn: &mut PgConnection,
-    bmc_mac: MacAddress,
-) -> DatabaseResult<()> {
-    retain_address_by_mac_and_type(txn, bmc_mac, InterfaceType::Bmc, None).await
 }
 
 /// Pin DHCP addresses for an expected interface whose allocation policy is
@@ -1372,8 +1362,8 @@ struct PreallocationOptions {
     ///
     /// This does not disable fixed-address reconciliation. ExpectedInterface
     /// callers set this to `false` so expected configuration cannot reclassify
-    /// managed state, while legacy generic and Host BMC callers preserve their
-    /// existing setting-update behavior.
+    /// managed state, while legacy generic callers preserve their existing
+    /// setting-update behavior.
     allow_associated_interface_settings_update: bool,
 }
 

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -564,11 +564,10 @@ async fn test_preallocate_machine_interface_promotes_interface_type(
     Ok(())
 }
 
-/// `retain_bmc_address_by_mac` promotes a BMC interface's DHCP address to
-/// `Static` so DHCP lease expiry can't reap it, is a no-op on a second call, and
-/// the promoted address then survives the DHCP-scoped expiry delete path.
+/// A retained Host BMC promotes its DHCP address to `Static`, remains
+/// idempotent, and then survives the DHCP-scoped expiry delete path.
 #[crate::sqlx_test]
-async fn test_retain_bmc_address_pins_dhcp_and_survives_expiry(
+async fn test_retained_host_bmc_address_pins_dhcp_and_survives_expiry(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use model::allocation_type::AllocationType;
@@ -599,9 +598,16 @@ async fn test_retain_bmc_address_pins_dhcp_and_survives_expiry(
     .await?;
     txn.commit().await?;
 
+    let expected_interface = ExpectedHostNic {
+        mac_address: mac,
+        role: ExpectedInterfaceRole::HostBmc,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Retained),
+        ..Default::default()
+    };
+
     // Retain: the DHCP address is promoted to Static.
     let mut txn = db::Transaction::begin(&pool).await?;
-    retain_bmc_address_by_mac(txn.as_pgconn(), mac).await?;
+    retain_expected_machine_interface_address(txn.as_pgconn(), &expected_interface).await?;
     let addrs =
         crate::machine_interface_address::find_for_interface(txn.as_pgconn(), interface_id).await?;
     txn.commit().await?;
@@ -614,7 +620,7 @@ async fn test_retain_bmc_address_pins_dhcp_and_survives_expiry(
 
     // Idempotent: a second retain is a no-op (the row is already Static).
     let mut txn = db::Transaction::begin(&pool).await?;
-    retain_bmc_address_by_mac(txn.as_pgconn(), mac).await?;
+    retain_expected_machine_interface_address(txn.as_pgconn(), &expected_interface).await?;
     let addrs =
         crate::machine_interface_address::find_for_interface(txn.as_pgconn(), interface_id).await?;
     txn.commit().await?;
@@ -847,6 +853,22 @@ async fn test_fixed_preallocation_resolves_managed_prefix_and_segment_type(
         "a legacy Host declaration must not turn its DHCP selector into a fixed-address guard",
     );
 
+    let legacy_host_bmc = ExpectedHostNic {
+        mac_address: "7A:7B:7C:7D:7E:69".parse()?,
+        role: ExpectedInterfaceRole::HostBmc,
+        fixed_ip: Some("203.0.113.69".parse()?),
+        ..Default::default()
+    };
+    preallocate_expected_machine_interface(txn.as_pgconn(), &legacy_host_bmc, None).await?;
+    let legacy_host_bmc_interface =
+        find_by_mac_address(txn.as_pgconn(), legacy_host_bmc.mac_address)
+            .await?
+            .pop()
+            .expect("legacy Host BMC fixed interface should be preallocated");
+    assert_eq!(legacy_host_bmc_interface.segment_id, static_assignments.id);
+    assert_eq!(legacy_host_bmc_interface.interface_type, InterfaceType::Bmc);
+    assert!(!legacy_host_bmc_interface.primary_interface);
+
     // The address alone cannot make an exact row idempotent when an explicit
     // policy resolves it to a different managed segment.
     let misplaced_mac: MacAddress = "7A:7B:7C:7D:7E:68".parse()?;
@@ -889,6 +911,7 @@ async fn test_fixed_preallocation_resolves_managed_prefix_and_segment_type(
         suffix: u8,
         role: ExpectedInterfaceRole,
         ip_allocation: Option<ExpectedInterfaceIpAllocation>,
+        network_segment_type: Option<NetworkSegmentType>,
     }
 
     for case in [
@@ -897,18 +920,35 @@ async fn test_fixed_preallocation_resolves_managed_prefix_and_segment_type(
             suffix: 0x65,
             role: ExpectedInterfaceRole::Host,
             ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+            network_segment_type: None,
         },
         OutsidePrefixCase {
             name: "DPU OS inferred Fixed policy",
             suffix: 0x66,
             role: ExpectedInterfaceRole::DpuOs,
             ip_allocation: None,
+            network_segment_type: None,
         },
         OutsidePrefixCase {
             name: "DPU BMC inferred Fixed policy",
             suffix: 0x67,
             role: ExpectedInterfaceRole::DpuBmc,
             ip_allocation: None,
+            network_segment_type: None,
+        },
+        OutsidePrefixCase {
+            name: "explicit Host BMC Fixed policy",
+            suffix: 0x6a,
+            role: ExpectedInterfaceRole::HostBmc,
+            ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+            network_segment_type: None,
+        },
+        OutsidePrefixCase {
+            name: "inferred Host BMC Fixed policy with a segment guard",
+            suffix: 0x6b,
+            role: ExpectedInterfaceRole::HostBmc,
+            ip_allocation: None,
+            network_segment_type: Some(NetworkSegmentType::Underlay),
         },
     ] {
         let expected_interface = ExpectedHostNic {
@@ -916,6 +956,7 @@ async fn test_fixed_preallocation_resolves_managed_prefix_and_segment_type(
             role: case.role,
             ip_allocation: case.ip_allocation,
             fixed_ip: Some(format!("203.0.113.{}", case.suffix).parse()?),
+            network_segment_type: case.network_segment_type,
             ..Default::default()
         };
 

--- a/crates/api-model/src/expected_machine.rs
+++ b/crates/api-model/src/expected_machine.rs
@@ -137,6 +137,55 @@ impl BmcIpAllocationType {
             BmcIpAllocationType::Dynamic | BmcIpAllocationType::Fixed => false,
         }
     }
+
+    /// Resolve the compatibility BMC policy to the allocation policy used by
+    /// an expected interface.
+    ///
+    /// `Auto` is the only policy whose meaning depends on the address: a
+    /// configured address is Fixed, while an addressless BMC is Retained.
+    pub fn resolved(self, has_address: bool) -> ExpectedInterfaceIpAllocation {
+        match self {
+            Self::Auto if has_address => ExpectedInterfaceIpAllocation::Fixed,
+            Self::Auto => ExpectedInterfaceIpAllocation::Retained,
+            Self::Dynamic => ExpectedInterfaceIpAllocation::Dynamic,
+            Self::Fixed => ExpectedInterfaceIpAllocation::Fixed,
+            Self::Retained => ExpectedInterfaceIpAllocation::Retained,
+        }
+    }
+}
+
+/// Convert an expected-interface policy to its top-level BMC compatibility
+/// equivalent.
+impl From<ExpectedInterfaceIpAllocation> for BmcIpAllocationType {
+    fn from(policy: ExpectedInterfaceIpAllocation) -> Self {
+        match policy {
+            ExpectedInterfaceIpAllocation::Dynamic => Self::Dynamic,
+            ExpectedInterfaceIpAllocation::Fixed => Self::Fixed,
+            ExpectedInterfaceIpAllocation::Retained => Self::Retained,
+        }
+    }
+}
+
+/// Legacy top-level BMC fields explicitly supplied with an ExpectedMachine
+/// write.
+///
+/// The outer `Option` on `ip_address` distinguishes an omitted field from an
+/// explicit clear. This is request state only. Nested Host BMC declarations
+/// store their effective settings in both `host_nics` and the compatibility
+/// columns, while legacy-only declarations remain legacy-shaped for older
+/// clients and are resolved in memory.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LegacyHostBmcOverrides {
+    /// Omitted, explicitly cleared, or configured compatibility address.
+    pub ip_address: Option<Option<IpAddr>>,
+    /// Compatibility policy when the request explicitly supplied it.
+    pub ip_allocation: Option<BmcIpAllocationType>,
+    /// Whether the incoming `host_nics` list is a complete replacement.
+    ///
+    /// Older protobuf writers cannot distinguish an omitted repeated field
+    /// from an empty one. They leave this false so an unknown nested Host BMC
+    /// survives a read-modify-write.
+    pub replace_host_nics: bool,
 }
 
 /// A request to identify an ExpectedMachine by either ID or MAC address.
@@ -152,9 +201,8 @@ pub struct ExpectedMachineRequest {
 /// interface has a role-defined primary state. It does not choose a network
 /// segment or change the allocation policy available to that interface.
 ///
-/// Host BMC identity remains on [`ExpectedMachine::bmc_mac_address`].
-/// [NVIDIA/infra-controller#4103](https://github.com/NVIDIA/infra-controller/issues/4103)
-/// tracks representing its network settings with the same interface model.
+/// Host BMC identity remains on [`ExpectedMachine::bmc_mac_address`], while a
+/// `HostBmc` entry configures that endpoint's network allocation.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ExpectedInterfaceRole {
@@ -166,6 +214,8 @@ pub enum ExpectedInterfaceRole {
     DpuOs,
     /// The DPU's Redfish/BMC interface.
     DpuBmc,
+    /// The host's Redfish/BMC interface.
+    HostBmc,
 }
 
 impl std::fmt::Display for ExpectedInterfaceRole {
@@ -175,6 +225,7 @@ impl std::fmt::Display for ExpectedInterfaceRole {
             Self::Host => "host",
             Self::DpuOs => "dpu_os",
             Self::DpuBmc => "dpu_bmc",
+            Self::HostBmc => "host_bmc",
         })
     }
 }
@@ -189,15 +240,20 @@ impl ExpectedInterfaceRole {
         matches!(self, Self::Host)
     }
 
+    /// Return whether this role configures the ExpectedMachine's host BMC.
+    pub fn is_host_bmc(&self) -> bool {
+        matches!(self, Self::HostBmc)
+    }
+
     /// Return the database interface type produced by this endpoint role.
     ///
-    /// Host and DPU OS endpoints both exchange operating-system data. A DPU
-    /// BMC endpoint uses the BMC interface type so the existing BMC-specific
-    /// routing and address behavior still applies.
+    /// Host and DPU OS endpoints both exchange operating-system data. DPU and
+    /// host BMC endpoints use the BMC interface type so the existing
+    /// BMC-specific routing and address behavior still applies.
     pub fn interface_type(self) -> InterfaceType {
         match self {
             Self::Host | Self::DpuOs => InterfaceType::Data,
-            Self::DpuBmc => InterfaceType::Bmc,
+            Self::DpuBmc | Self::HostBmc => InterfaceType::Bmc,
         }
     }
 
@@ -206,12 +262,12 @@ impl ExpectedInterfaceRole {
     /// Host primary selection needs all Host declarations on the
     /// `ExpectedMachine`, so `None` tells the caller to use that machine-wide
     /// result. A DPU OS interface is always its DPU's primary data interface,
-    /// while a DPU BMC interface is never primary.
+    /// while DPU and host BMC interfaces are never primary.
     pub fn primary_interface_override(self) -> Option<bool> {
         match self {
             Self::Host => None,
             Self::DpuOs => Some(true),
-            Self::DpuBmc => Some(false),
+            Self::DpuBmc | Self::HostBmc => Some(false),
         }
     }
 }
@@ -219,10 +275,10 @@ impl ExpectedInterfaceRole {
 /// Controls how an expected interface receives and retains its IP address.
 ///
 /// When the policy is omitted, [`ExpectedHostNic::resolved_ip_allocation`]
-/// preserves the legacy configuration contract: an interface with
-/// [`ExpectedHostNic::fixed_ip`] is fixed, and one without it is dynamic.
-/// Explicit `Dynamic` differs from omission because it rejects a simultaneous
-/// `fixed_ip` instead of inferring `Fixed`.
+/// preserves the legacy configuration contracts. An interface with
+/// [`ExpectedHostNic::fixed_ip`] is fixed. Without one, Host BMC is retained
+/// and every other role is dynamic. Explicit `Dynamic` differs from omission
+/// because it rejects a simultaneous `fixed_ip` instead of inferring `Fixed`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ExpectedInterfaceIpAllocation {
@@ -230,9 +286,10 @@ pub enum ExpectedInterfaceIpAllocation {
     /// segment-type guard must match the segment selected by the DHCP relay.
     Dynamic,
     /// Reserve the operator-specified [`ExpectedHostNic::fixed_ip`]. An
-    /// explicit Fixed policy or DPU role requires a configured managed prefix
-    /// to contain the address. That prefix selects the segment, and a
-    /// configured segment-type guard must match it.
+    /// explicit Fixed policy, either DPU role, or HostBmc with a segment guard
+    /// requires a configured managed prefix to contain the address. That
+    /// prefix selects the segment, and a configured segment-type guard must
+    /// match it.
     Fixed,
     /// Allocate through DHCP, then change that address row to Static for the
     /// lifetime of this interface row. The address is not saved in
@@ -278,7 +335,8 @@ pub struct ExpectedHostNic {
     #[serde(default, skip_serializing_if = "ExpectedInterfaceRole::is_host")]
     pub role: ExpectedInterfaceRole,
     /// Optional IP allocation policy. Missing declarations infer `Fixed` when
-    /// [`Self::fixed_ip`] is configured and `Dynamic` otherwise.
+    /// [`Self::fixed_ip`] is configured. Without one, Host BMC uses the legacy
+    /// Retained behavior and every other role uses Dynamic.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ip_allocation: Option<ExpectedInterfaceIpAllocation>,
     /// Optional guard for the interface's network segment type.
@@ -291,8 +349,9 @@ pub struct ExpectedHostNic {
     /// behavior where this field only narrows initial DHCP segment selection.
     /// This compatibility rule is exposed by [`Self::segment_type_guard`].
     /// `None` (with no legacy [`Self::nic_type`]) leaves DHCP selection
-    /// unconstrained. Fixed uses the managed prefix containing the address;
-    /// only a legacy Host declaration with an omitted policy may fall back to
+    /// unconstrained. Fixed uses the managed prefix containing the address.
+    /// A legacy Host declaration with an omitted policy, or an inferred Host
+    /// BMC Fixed policy without a segment guard, may fall back to
     /// `static-assignments` when no configured prefix contains it. Updates
     /// retain the existing full-replacement behavior, so omission clears this
     /// field.
@@ -309,7 +368,7 @@ pub struct ExpectedHostNic {
     /// interface. When one Host interface is declared primary, the other Host
     /// interfaces become non-primary. An explicit `false` remains accepted for
     /// compatibility but does not replace that machine-wide selection. DPU OS
-    /// interfaces are primary data interfaces and DPU BMC interfaces are
+    /// interfaces are primary data interfaces and BMC interfaces are
     /// non-primary; those roles must omit this field.
     #[serde(default)]
     pub primary: Option<bool>,
@@ -317,17 +376,20 @@ pub struct ExpectedHostNic {
 
 impl ExpectedHostNic {
     /// Return the configured allocation policy or infer the legacy policy from
-    /// whether this interface has a fixed IP.
+    /// the role and whether this interface has a fixed IP.
     ///
     /// Omission must remain distinguishable from explicit `Dynamic`: old
     /// declarations supplied only `fixed_ip`, while explicit `Dynamic` rejects
-    /// that same combination during validation. Inferring `Fixed` here does not
+    /// that same combination during validation. An addressless Host BMC uses
+    /// the top-level BMC default of Retained. Inferring `Fixed` here does not
     /// opt a legacy Host declaration into the newer segment-type guard; see
     /// [`Self::segment_type_guard`].
     pub fn resolved_ip_allocation(&self) -> ExpectedInterfaceIpAllocation {
         self.ip_allocation.unwrap_or_else(|| {
             if self.fixed_ip.is_some() {
                 ExpectedInterfaceIpAllocation::Fixed
+            } else if self.role.is_host_bmc() {
+                ExpectedInterfaceIpAllocation::Retained
             } else {
                 ExpectedInterfaceIpAllocation::Dynamic
             }
@@ -387,6 +449,18 @@ impl ExpectedHostNic {
         self.role.is_host() && self.ip_allocation.is_none()
     }
 
+    /// Return whether an inferred Fixed policy keeps the legacy
+    /// `static-assignments` fallback.
+    ///
+    /// Host declarations had this behavior before allocation policies existed.
+    /// Host BMC uses the same omission as the compatibility `Auto` policy, but
+    /// a typed segment guard still requires a containing managed prefix.
+    pub fn allows_static_assignments_fallback(&self) -> bool {
+        self.ip_allocation.is_none()
+            && (self.role.is_host()
+                || (self.role.is_host_bmc() && self.network_segment_type.is_none()))
+    }
+
     /// Return the typed segment guard for declarations using the generalized
     /// ExpectedInterface policy contract.
     ///
@@ -438,6 +512,250 @@ pub struct ExpectedMachine {
     pub bmc_mac_address: MacAddress,
     #[serde(flatten)]
     pub data: ExpectedMachineData,
+}
+
+impl ExpectedMachine {
+    /// Build the Host BMC declaration represented by the compatibility
+    /// columns.
+    ///
+    /// An omitted nested policy is intentional here. It preserves the legacy
+    /// external-address fallback for Fixed and resolves an addressless BMC to
+    /// Retained.
+    fn compatibility_host_bmc(&self) -> ExpectedHostNic {
+        let resolved = self
+            .data
+            .bmc_ip_allocation
+            .resolved(self.data.bmc_ip_address.is_some());
+        let fixed_ip = (resolved == ExpectedInterfaceIpAllocation::Fixed)
+            .then_some(self.data.bmc_ip_address)
+            .flatten();
+        let ip_allocation = match self.data.bmc_ip_allocation {
+            BmcIpAllocationType::Auto => None,
+            BmcIpAllocationType::Fixed if fixed_ip.is_some() => None,
+            BmcIpAllocationType::Dynamic => Some(ExpectedInterfaceIpAllocation::Dynamic),
+            BmcIpAllocationType::Fixed => Some(ExpectedInterfaceIpAllocation::Fixed),
+            BmcIpAllocationType::Retained => Some(ExpectedInterfaceIpAllocation::Retained),
+        };
+
+        ExpectedHostNic {
+            mac_address: self.bmc_mac_address,
+            role: ExpectedInterfaceRole::HostBmc,
+            ip_allocation,
+            fixed_ip,
+            ..Default::default()
+        }
+    }
+
+    /// Return the Host BMC configuration used by readers and runtime paths.
+    ///
+    /// New writers keep the nested declaration and compatibility columns in
+    /// sync. Older writers may update only the columns, so they win when the
+    /// two representations disagree. Nested-only fields such as
+    /// `network_segment_type` remain in place.
+    pub fn effective_host_bmc(&self) -> ExpectedHostNic {
+        let compatibility = self.compatibility_host_bmc();
+        let mut host_bmc = self
+            .data
+            .host_nics
+            .iter()
+            .find(|interface| interface.role.is_host_bmc())
+            .cloned()
+            .unwrap_or_else(|| compatibility.clone());
+
+        let allocation_agrees_with_compatibility = match host_bmc.ip_allocation {
+            Some(policy) => self.data.bmc_ip_allocation == policy.into(),
+            None => compatibility.ip_allocation.is_none(),
+        };
+        let agrees_with_compatibility = host_bmc.mac_address == self.bmc_mac_address
+            && allocation_agrees_with_compatibility
+            && host_bmc.resolved_ip_allocation() == compatibility.resolved_ip_allocation()
+            && host_bmc.fixed_ip == compatibility.fixed_ip;
+        if !agrees_with_compatibility {
+            host_bmc.ip_allocation = compatibility.ip_allocation;
+            host_bmc.fixed_ip = compatibility.fixed_ip;
+        }
+
+        host_bmc.mac_address = self.bmc_mac_address;
+        host_bmc.role = ExpectedInterfaceRole::HostBmc;
+        host_bmc.primary = None;
+        host_bmc
+    }
+
+    /// Return the top-level BMC policy that compatibility readers should see.
+    ///
+    /// Inferred policies remain absent/Auto. Explicit nested policies and
+    /// explicit legacy policies retain their concrete wire value.
+    pub fn compatibility_bmc_ip_allocation(&self) -> Option<BmcIpAllocationType> {
+        self.effective_host_bmc()
+            .ip_allocation
+            .map(Into::into)
+            .or_else(|| {
+                (self.data.bmc_ip_allocation != BmcIpAllocationType::Auto)
+                    .then_some(self.data.bmc_ip_allocation)
+            })
+    }
+
+    /// Normalize one Host BMC declaration and its compatibility columns.
+    ///
+    /// An incoming nested declaration is the baseline. Older clients may omit
+    /// it, so updates fall back to the previous effective declaration before
+    /// using the incoming compatibility fields. Explicit legacy fields are
+    /// applied last as overrides.
+    pub fn normalize_host_bmc(
+        &mut self,
+        previous: Option<&ExpectedMachine>,
+        mut overrides: LegacyHostBmcOverrides,
+    ) -> Result<(), &'static str> {
+        let mut host_bmc_indexes = self
+            .data
+            .host_nics
+            .iter()
+            .enumerate()
+            .filter(|(_, interface)| interface.role.is_host_bmc())
+            .map(|(index, _)| index);
+        let host_bmc_index = host_bmc_indexes.next();
+        if host_bmc_indexes.next().is_some() {
+            return Err("at most one role=host_bmc interface may be configured");
+        }
+
+        let incoming_host_bmc = host_bmc_index.map(|index| self.data.host_nics[index].clone());
+        let store_host_bmc = incoming_host_bmc.is_some()
+            || (!overrides.replace_host_nics
+                && previous.is_some_and(|machine| {
+                    machine
+                        .data
+                        .host_nics
+                        .iter()
+                        .any(|interface| interface.role.is_host_bmc())
+                }));
+        let previous_host_bmc = previous.map(ExpectedMachine::effective_host_bmc);
+        let previous_compatibility_allocation =
+            previous.and_then(ExpectedMachine::compatibility_bmc_ip_allocation);
+        let mut host_bmc = incoming_host_bmc
+            .clone()
+            .or_else(|| {
+                previous.map(|machine| {
+                    if overrides.replace_host_nics {
+                        machine.compatibility_host_bmc()
+                    } else {
+                        machine.effective_host_bmc()
+                    }
+                })
+            })
+            .unwrap_or_else(|| self.compatibility_host_bmc());
+
+        if let Some(previous_host_bmc) = previous_host_bmc.as_ref() {
+            // Full-update clients commonly echo the compatibility fields from
+            // a read. Some also drop interface roles they do not understand.
+            // Matching values are projections, not new overrides; ignoring
+            // them preserves details such as an explicit Fixed policy's
+            // managed-prefix requirement.
+            let matching_address_projection = overrides.ip_address
+                == Some(previous_host_bmc.fixed_ip)
+                && (overrides.ip_allocation.is_none()
+                    || overrides.ip_allocation == previous_compatibility_allocation);
+            if matching_address_projection {
+                overrides.ip_address = None;
+            }
+            // A different address makes the compatibility fields a new
+            // override pair, so keep its allocation even when that one value
+            // happens to match the previous policy.
+            let matching_allocation_projection = overrides.ip_address.is_none()
+                && overrides.ip_allocation.is_some()
+                && overrides.ip_allocation == previous_compatibility_allocation;
+            if matching_allocation_projection {
+                overrides.ip_allocation = None;
+            }
+        }
+
+        // Preserve the compatibility representation as well as its resolved
+        // policy. In particular, Auto-with-an-address and explicit legacy
+        // Fixed both resolve to Fixed, but only the latter should remain
+        // present on the compatibility wire field.
+        let mut compatibility_allocation =
+            if let Some(incoming_host_bmc) = incoming_host_bmc.as_ref() {
+                if let Some(ip_allocation) = incoming_host_bmc.ip_allocation {
+                    ip_allocation.into()
+                } else if previous_host_bmc
+                    .as_ref()
+                    .is_some_and(|previous_host_bmc| previous_host_bmc.ip_allocation.is_none())
+                {
+                    // An omitted nested policy preserves its compatibility
+                    // value even when another nested-only field changes.
+                    previous
+                        .map(|machine| machine.data.bmc_ip_allocation)
+                        .unwrap_or(BmcIpAllocationType::Auto)
+                } else if previous_host_bmc.as_ref().is_some_and(|previous_host_bmc| {
+                    let mut normalized_incoming = incoming_host_bmc.clone();
+                    normalized_incoming.mac_address = self.bmc_mac_address;
+                    normalized_incoming.role = ExpectedInterfaceRole::HostBmc;
+                    normalized_incoming.primary = None;
+                    normalized_incoming == *previous_host_bmc
+                }) {
+                    previous
+                        .map(|machine| machine.data.bmc_ip_allocation)
+                        .unwrap_or(BmcIpAllocationType::Auto)
+                } else {
+                    BmcIpAllocationType::Auto
+                }
+            } else if let Some(previous) = previous {
+                previous.data.bmc_ip_allocation
+            } else {
+                self.data.bmc_ip_allocation
+            };
+
+        if let Some(ip_address) = overrides.ip_address {
+            host_bmc.fixed_ip = ip_address;
+            if overrides.ip_allocation.is_none() {
+                host_bmc.ip_allocation = None;
+                compatibility_allocation = BmcIpAllocationType::Auto;
+            }
+        }
+
+        if let Some(ip_allocation) = overrides.ip_allocation {
+            compatibility_allocation = ip_allocation;
+            host_bmc.ip_allocation = match ip_allocation {
+                BmcIpAllocationType::Auto => None,
+                BmcIpAllocationType::Dynamic => {
+                    if !matches!(overrides.ip_address, Some(Some(_))) {
+                        host_bmc.fixed_ip = None;
+                    }
+                    Some(ExpectedInterfaceIpAllocation::Dynamic)
+                }
+                BmcIpAllocationType::Fixed if host_bmc.fixed_ip.is_some() => None,
+                BmcIpAllocationType::Fixed => Some(ExpectedInterfaceIpAllocation::Fixed),
+                BmcIpAllocationType::Retained => {
+                    if !matches!(overrides.ip_address, Some(Some(_))) {
+                        host_bmc.fixed_ip = None;
+                    }
+                    Some(ExpectedInterfaceIpAllocation::Retained)
+                }
+            };
+        }
+
+        host_bmc.mac_address = self.bmc_mac_address;
+        host_bmc.role = ExpectedInterfaceRole::HostBmc;
+        host_bmc.primary = None;
+        if let Err(message) = host_bmc.validate_ip_allocation() {
+            if overrides.ip_address.is_some() || overrides.ip_allocation.is_some() {
+                let legacy_allocation: BmcIpAllocationType =
+                    host_bmc.resolved_ip_allocation().into();
+                return legacy_allocation.validate(host_bmc.fixed_ip.is_some());
+            }
+            return Err(message);
+        }
+
+        self.data.bmc_ip_allocation = compatibility_allocation;
+        self.data.bmc_ip_address = host_bmc.fixed_ip;
+
+        if let Some(index) = host_bmc_index {
+            self.data.host_nics[index] = host_bmc;
+        } else if store_host_bmc {
+            self.data.host_nics.push(host_bmc);
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Default, Deserialize)] // Do not add Debug here, it contains password
@@ -974,6 +1292,11 @@ mod tests {
                     input: ExpectedInterfaceRole::DpuBmc,
                     expect: ("dpu_bmc".to_string(), Some(serde_json::json!("dpu_bmc"))),
                 },
+                Check {
+                    scenario: "Host BMC uses its canonical name",
+                    input: ExpectedInterfaceRole::HostBmc,
+                    expect: ("host_bmc".to_string(), Some(serde_json::json!("host_bmc"))),
+                },
             ],
             |role| {
                 let serialized = serde_json::to_value(ExpectedHostNic {
@@ -1005,6 +1328,11 @@ mod tests {
                     input: ExpectedInterfaceRole::DpuBmc,
                     expect: (false, InterfaceType::Bmc),
                 },
+                Check {
+                    scenario: "Host BMC",
+                    input: ExpectedInterfaceRole::HostBmc,
+                    expect: (false, InterfaceType::Bmc),
+                },
             ],
             |role| (role.is_host(), role.interface_type()),
         );
@@ -1027,6 +1355,11 @@ mod tests {
                 Check {
                     scenario: "DPU BMC is never primary",
                     input: ExpectedInterfaceRole::DpuBmc,
+                    expect: Some(false),
+                },
+                Check {
+                    scenario: "Host BMC is never primary",
+                    input: ExpectedInterfaceRole::HostBmc,
                     expect: Some(false),
                 },
             ],
@@ -1130,6 +1463,15 @@ mod tests {
                     interface.validate_ip_allocation().err(),
                 )
             },
+        );
+
+        let host_bmc = ExpectedHostNic {
+            role: ExpectedInterfaceRole::HostBmc,
+            ..Default::default()
+        };
+        assert_eq!(
+            host_bmc.resolved_ip_allocation(),
+            ExpectedInterfaceIpAllocation::Retained,
         );
     }
 
@@ -1370,6 +1712,507 @@ mod tests {
         assert_eq!(BmcIpAllocationType::default(), BmcIpAllocationType::Auto);
     }
 
+    /// Compatibility columns remain the read authority without removing a
+    /// nested-only segment guard.
+    #[test]
+    fn effective_host_bmc_uses_compatibility_columns_without_losing_nested_guards() {
+        /// One stored nested/compatibility combination and its effective
+        /// Host BMC settings.
+        struct Case {
+            name: &'static str,
+            nested_policy: Option<Option<ExpectedInterfaceIpAllocation>>,
+            nested_ip: Option<IpAddr>,
+            compatibility_policy: BmcIpAllocationType,
+            compatibility_ip: Option<IpAddr>,
+            expected_policy: Option<ExpectedInterfaceIpAllocation>,
+            expected_resolved: ExpectedInterfaceIpAllocation,
+            expected_ip: Option<IpAddr>,
+            expected_compatibility_output: Option<BmcIpAllocationType>,
+        }
+
+        let bmc_mac_address = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+        let first_ip = "192.0.2.10".parse().unwrap();
+        let second_ip = "192.0.2.20".parse().unwrap();
+        for case in [
+            Case {
+                name: "legacy Auto without an address is Retained",
+                nested_policy: None,
+                nested_ip: None,
+                compatibility_policy: BmcIpAllocationType::Auto,
+                compatibility_ip: None,
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Retained,
+                expected_ip: None,
+                expected_compatibility_output: None,
+            },
+            Case {
+                name: "legacy Auto with an address is Fixed",
+                nested_policy: None,
+                nested_ip: None,
+                compatibility_policy: BmcIpAllocationType::Auto,
+                compatibility_ip: Some(first_ip),
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(first_ip),
+                expected_compatibility_output: None,
+            },
+            Case {
+                name: "matching explicit Fixed remains strict",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Fixed)),
+                nested_ip: Some(first_ip),
+                compatibility_policy: BmcIpAllocationType::Fixed,
+                compatibility_ip: Some(first_ip),
+                expected_policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(first_ip),
+                expected_compatibility_output: Some(BmcIpAllocationType::Fixed),
+            },
+            Case {
+                name: "compatibility columns override a stale nested address",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Fixed)),
+                nested_ip: Some(first_ip),
+                compatibility_policy: BmcIpAllocationType::Dynamic,
+                compatibility_ip: Some(second_ip),
+                expected_policy: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                expected_resolved: ExpectedInterfaceIpAllocation::Dynamic,
+                expected_ip: None,
+                expected_compatibility_output: Some(BmcIpAllocationType::Dynamic),
+            },
+            Case {
+                name: "compatibility Auto overrides explicit Fixed at the same address",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Fixed)),
+                nested_ip: Some(first_ip),
+                compatibility_policy: BmcIpAllocationType::Auto,
+                compatibility_ip: Some(first_ip),
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(first_ip),
+                expected_compatibility_output: None,
+            },
+            Case {
+                name: "compatibility Auto overrides explicit Retained",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Retained)),
+                nested_ip: None,
+                compatibility_policy: BmcIpAllocationType::Auto,
+                compatibility_ip: None,
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Retained,
+                expected_ip: None,
+                expected_compatibility_output: None,
+            },
+        ] {
+            let host_nics = case
+                .nested_policy
+                .map(|ip_allocation| {
+                    vec![ExpectedHostNic {
+                        mac_address: bmc_mac_address,
+                        role: ExpectedInterfaceRole::HostBmc,
+                        ip_allocation,
+                        fixed_ip: case.nested_ip,
+                        network_segment_type: Some(NetworkSegmentType::Underlay),
+                        ..Default::default()
+                    }]
+                })
+                .unwrap_or_default();
+            let machine = ExpectedMachine {
+                id: None,
+                bmc_mac_address,
+                data: ExpectedMachineData {
+                    host_nics,
+                    bmc_ip_address: case.compatibility_ip,
+                    bmc_ip_allocation: case.compatibility_policy,
+                    ..Default::default()
+                },
+            };
+
+            let effective = machine.effective_host_bmc();
+            assert_eq!(
+                effective.role,
+                ExpectedInterfaceRole::HostBmc,
+                "{}",
+                case.name
+            );
+            assert_eq!(effective.mac_address, bmc_mac_address, "{}", case.name);
+            assert_eq!(effective.primary, None, "{}", case.name);
+            assert_eq!(
+                effective.ip_allocation, case.expected_policy,
+                "{}",
+                case.name,
+            );
+            assert_eq!(
+                effective.resolved_ip_allocation(),
+                case.expected_resolved,
+                "{}",
+                case.name,
+            );
+            assert_eq!(effective.fixed_ip, case.expected_ip, "{}", case.name);
+            assert_eq!(
+                machine.compatibility_bmc_ip_allocation(),
+                case.expected_compatibility_output,
+                "{}",
+                case.name,
+            );
+            if case.nested_policy.is_some() {
+                assert_eq!(
+                    effective.network_segment_type,
+                    Some(NetworkSegmentType::Underlay),
+                    "{}",
+                    case.name,
+                );
+            }
+        }
+    }
+
+    /// Normalization applies the nested baseline, compatibility overrides, and
+    /// old-client preservation rules in that order. Legacy-only input remains
+    /// legacy-shaped so older clients never receive an unknown HostBmc role.
+    #[test]
+    fn normalize_host_bmc_applies_nested_baseline_then_legacy_overrides() {
+        /// One normalization source combination and its stored settings.
+        struct Case {
+            name: &'static str,
+            nested_policy: Option<Option<ExpectedInterfaceIpAllocation>>,
+            nested_ip: Option<IpAddr>,
+            previous_policy: Option<ExpectedInterfaceIpAllocation>,
+            previous_ip: Option<IpAddr>,
+            overrides: LegacyHostBmcOverrides,
+            expected_policy: Option<ExpectedInterfaceIpAllocation>,
+            expected_resolved: ExpectedInterfaceIpAllocation,
+            expected_ip: Option<IpAddr>,
+            expected_compatibility: BmcIpAllocationType,
+        }
+
+        let bmc_mac_address = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+        let fixed_ip = "192.0.2.20".parse().unwrap();
+        let replacement_ip = "192.0.2.21".parse().unwrap();
+        for case in [
+            Case {
+                name: "nested Dynamic is the baseline",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Dynamic)),
+                nested_ip: None,
+                previous_policy: None,
+                previous_ip: None,
+                overrides: LegacyHostBmcOverrides::default(),
+                expected_policy: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                expected_resolved: ExpectedInterfaceIpAllocation::Dynamic,
+                expected_ip: None,
+                expected_compatibility: BmcIpAllocationType::Dynamic,
+            },
+            Case {
+                name: "same-valued legacy inputs still override on create",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Fixed)),
+                nested_ip: Some(fixed_ip),
+                previous_policy: None,
+                previous_ip: None,
+                overrides: LegacyHostBmcOverrides {
+                    ip_address: Some(Some(fixed_ip)),
+                    ip_allocation: Some(BmcIpAllocationType::Fixed),
+                    ..Default::default()
+                },
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(fixed_ip),
+                expected_compatibility: BmcIpAllocationType::Fixed,
+            },
+            Case {
+                name: "legacy Auto without an address becomes Retained",
+                nested_policy: None,
+                nested_ip: None,
+                previous_policy: None,
+                previous_ip: None,
+                overrides: LegacyHostBmcOverrides::default(),
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Retained,
+                expected_ip: None,
+                expected_compatibility: BmcIpAllocationType::Auto,
+            },
+            Case {
+                name: "legacy address override changes nested Dynamic to Fixed",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Dynamic)),
+                nested_ip: None,
+                previous_policy: None,
+                previous_ip: None,
+                overrides: LegacyHostBmcOverrides {
+                    ip_address: Some(Some(fixed_ip)),
+                    ip_allocation: None,
+                    ..Default::default()
+                },
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(fixed_ip),
+                expected_compatibility: BmcIpAllocationType::Auto,
+            },
+            Case {
+                name: "legacy Dynamic clears a nested fixed address",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Fixed)),
+                nested_ip: Some(fixed_ip),
+                previous_policy: None,
+                previous_ip: None,
+                overrides: LegacyHostBmcOverrides {
+                    ip_address: None,
+                    ip_allocation: Some(BmcIpAllocationType::Dynamic),
+                    ..Default::default()
+                },
+                expected_policy: Some(ExpectedInterfaceIpAllocation::Dynamic),
+                expected_resolved: ExpectedInterfaceIpAllocation::Dynamic,
+                expected_ip: None,
+                expected_compatibility: BmcIpAllocationType::Dynamic,
+            },
+            Case {
+                name: "explicit address clear restores Auto Retained",
+                nested_policy: Some(Some(ExpectedInterfaceIpAllocation::Fixed)),
+                nested_ip: Some(fixed_ip),
+                previous_policy: None,
+                previous_ip: None,
+                overrides: LegacyHostBmcOverrides {
+                    ip_address: Some(None),
+                    ip_allocation: None,
+                    ..Default::default()
+                },
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Retained,
+                expected_ip: None,
+                expected_compatibility: BmcIpAllocationType::Auto,
+            },
+            Case {
+                name: "an old client preserves the previous nested policy",
+                nested_policy: None,
+                nested_ip: None,
+                previous_policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                previous_ip: Some(fixed_ip),
+                overrides: LegacyHostBmcOverrides::default(),
+                expected_policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(fixed_ip),
+                expected_compatibility: BmcIpAllocationType::Fixed,
+            },
+            Case {
+                name: "an old client may echo the projected compatibility fields",
+                nested_policy: None,
+                nested_ip: None,
+                previous_policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                previous_ip: Some(fixed_ip),
+                overrides: LegacyHostBmcOverrides {
+                    ip_address: Some(Some(fixed_ip)),
+                    ip_allocation: Some(BmcIpAllocationType::Fixed),
+                    ..Default::default()
+                },
+                expected_policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(fixed_ip),
+                expected_compatibility: BmcIpAllocationType::Fixed,
+            },
+            Case {
+                name: "a changed address keeps its explicit compatibility policy",
+                nested_policy: None,
+                nested_ip: None,
+                previous_policy: Some(ExpectedInterfaceIpAllocation::Fixed),
+                previous_ip: Some(fixed_ip),
+                overrides: LegacyHostBmcOverrides {
+                    ip_address: Some(Some(replacement_ip)),
+                    ip_allocation: Some(BmcIpAllocationType::Fixed),
+                    ..Default::default()
+                },
+                expected_policy: None,
+                expected_resolved: ExpectedInterfaceIpAllocation::Fixed,
+                expected_ip: Some(replacement_ip),
+                expected_compatibility: BmcIpAllocationType::Fixed,
+            },
+        ] {
+            let expected_stored_count =
+                usize::from(case.nested_policy.is_some() || case.previous_policy.is_some());
+            let nested = case.nested_policy.map(|ip_allocation| ExpectedHostNic {
+                mac_address: bmc_mac_address,
+                role: ExpectedInterfaceRole::HostBmc,
+                ip_allocation,
+                fixed_ip: case.nested_ip,
+                ..Default::default()
+            });
+            let previous = case.previous_policy.map(|ip_allocation| ExpectedMachine {
+                id: None,
+                bmc_mac_address,
+                data: ExpectedMachineData {
+                    host_nics: vec![ExpectedHostNic {
+                        mac_address: bmc_mac_address,
+                        role: ExpectedInterfaceRole::HostBmc,
+                        ip_allocation: Some(ip_allocation),
+                        fixed_ip: case.previous_ip,
+                        ..Default::default()
+                    }],
+                    bmc_ip_address: case.previous_ip,
+                    bmc_ip_allocation: ip_allocation.into(),
+                    ..Default::default()
+                },
+            });
+            let mut machine = ExpectedMachine {
+                id: None,
+                bmc_mac_address,
+                data: ExpectedMachineData {
+                    host_nics: nested.into_iter().collect(),
+                    ..Default::default()
+                },
+            };
+
+            machine
+                .normalize_host_bmc(previous.as_ref(), case.overrides)
+                .unwrap();
+            let stored = machine
+                .data
+                .host_nics
+                .iter()
+                .filter(|interface| interface.role.is_host_bmc())
+                .collect::<Vec<_>>();
+            assert_eq!(stored.len(), expected_stored_count, "{}", case.name);
+            let effective = machine.effective_host_bmc();
+            assert_eq!(
+                effective.ip_allocation, case.expected_policy,
+                "{}",
+                case.name,
+            );
+            assert_eq!(
+                effective.resolved_ip_allocation(),
+                case.expected_resolved,
+                "{}",
+                case.name,
+            );
+            assert_eq!(effective.fixed_ip, case.expected_ip, "{}", case.name);
+            assert_eq!(
+                machine.data.bmc_ip_address, case.expected_ip,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                machine.data.bmc_ip_allocation, case.expected_compatibility,
+                "{}",
+                case.name,
+            );
+        }
+
+        let previous_fixed = ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: bmc_mac_address,
+                    role: ExpectedInterfaceRole::HostBmc,
+                    ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+                    fixed_ip: Some(fixed_ip),
+                    ..Default::default()
+                }],
+                bmc_ip_address: Some(fixed_ip),
+                bmc_ip_allocation: BmcIpAllocationType::Fixed,
+                ..Default::default()
+            },
+        };
+        let mut conflicting_update = ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData::default(),
+        };
+        let error = conflicting_update
+            .normalize_host_bmc(
+                Some(&previous_fixed),
+                LegacyHostBmcOverrides {
+                    ip_address: Some(Some(fixed_ip)),
+                    ip_allocation: Some(BmcIpAllocationType::Dynamic),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+        assert_eq!(
+            error,
+            "bmc_ip_allocation=dynamic cannot be combined with bmc_ip_address",
+        );
+
+        let mut legacy_fixed_update = ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData::default(),
+        };
+        let previous_legacy_fixed = ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: bmc_mac_address,
+                    role: ExpectedInterfaceRole::HostBmc,
+                    fixed_ip: Some(fixed_ip),
+                    ..Default::default()
+                }],
+                bmc_ip_address: Some(fixed_ip),
+                bmc_ip_allocation: BmcIpAllocationType::Fixed,
+                ..Default::default()
+            },
+        };
+        legacy_fixed_update
+            .normalize_host_bmc(
+                Some(&previous_legacy_fixed),
+                LegacyHostBmcOverrides {
+                    ip_address: None,
+                    ip_allocation: Some(BmcIpAllocationType::Auto),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            legacy_fixed_update.data.bmc_ip_allocation,
+            BmcIpAllocationType::Auto,
+        );
+        assert_eq!(legacy_fixed_update.compatibility_bmc_ip_allocation(), None,);
+    }
+
+    /// An authoritative interface replacement removes nested-only Host BMC
+    /// settings while keeping the compatibility fields as the legacy baseline.
+    #[test]
+    fn normalize_host_bmc_honors_authoritative_interface_replacement() {
+        let bmc_mac_address = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+        let fixed_ip = "192.0.2.20".parse().unwrap();
+        let previous = ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: bmc_mac_address,
+                    role: ExpectedInterfaceRole::HostBmc,
+                    fixed_ip: Some(fixed_ip),
+                    network_segment_type: Some(NetworkSegmentType::Underlay),
+                    ..Default::default()
+                }],
+                bmc_ip_address: Some(fixed_ip),
+                ..Default::default()
+            },
+        };
+        let mut replacement = ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                bmc_ip_address: Some(fixed_ip),
+                ..Default::default()
+            },
+        };
+
+        replacement
+            .normalize_host_bmc(
+                Some(&previous),
+                LegacyHostBmcOverrides {
+                    replace_host_nics: true,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert!(
+            replacement
+                .data
+                .host_nics
+                .iter()
+                .all(|interface| !interface.role.is_host_bmc()),
+        );
+        let effective = replacement.effective_host_bmc();
+        assert_eq!(effective.fixed_ip, Some(fixed_ip));
+        assert_eq!(effective.network_segment_type, None);
+    }
+
     /// `declared_primary_mac` returns the MAC of the one NIC flagged
     /// `primary: Some(true)`, and `None` when nothing is declared. `primary:
     /// Some(false)` is an explicit non-primary, not a declaration.
@@ -1597,6 +2440,15 @@ mod tests {
                 uses_legacy_host_allocation: false,
             },
             Case {
+                name: "Host BMC role",
+                role: ExpectedInterfaceRole::HostBmc,
+                ip_allocation: None,
+                fixed_ip: Some("192.0.2.10".parse().unwrap()),
+                network_segment_type: Some(NetworkSegmentType::Underlay),
+                expected_guard: Some(NetworkSegmentType::Underlay),
+                uses_legacy_host_allocation: false,
+            },
+            Case {
                 name: "no typed segment",
                 role: ExpectedInterfaceRole::DpuOs,
                 ip_allocation: Some(ExpectedInterfaceIpAllocation::Dynamic),
@@ -1622,6 +2474,86 @@ mod tests {
             assert_eq!(
                 interface.uses_legacy_host_allocation(),
                 case.uses_legacy_host_allocation,
+                "{}",
+                case.name,
+            );
+        }
+    }
+
+    /// Only compatibility declarations without a Host BMC segment guard retain
+    /// the external-address fallback.
+    #[test]
+    fn static_assignments_fallback_is_limited_to_legacy_fixed_policies() {
+        /// One role/policy pair and whether it keeps the fallback.
+        struct Case {
+            name: &'static str,
+            role: ExpectedInterfaceRole,
+            ip_allocation: Option<ExpectedInterfaceIpAllocation>,
+            network_segment_type: Option<NetworkSegmentType>,
+            expected: bool,
+        }
+
+        for case in [
+            Case {
+                name: "inferred Host Fixed",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: None,
+                network_segment_type: None,
+                expected: true,
+            },
+            Case {
+                name: "explicit Host Fixed",
+                role: ExpectedInterfaceRole::Host,
+                ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+                network_segment_type: None,
+                expected: false,
+            },
+            Case {
+                name: "inferred Host BMC Fixed",
+                role: ExpectedInterfaceRole::HostBmc,
+                ip_allocation: None,
+                network_segment_type: None,
+                expected: true,
+            },
+            Case {
+                name: "inferred Host BMC Fixed with a segment guard",
+                role: ExpectedInterfaceRole::HostBmc,
+                ip_allocation: None,
+                network_segment_type: Some(NetworkSegmentType::Underlay),
+                expected: false,
+            },
+            Case {
+                name: "explicit Host BMC Fixed",
+                role: ExpectedInterfaceRole::HostBmc,
+                ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+                network_segment_type: None,
+                expected: false,
+            },
+            Case {
+                name: "inferred DPU OS Fixed",
+                role: ExpectedInterfaceRole::DpuOs,
+                ip_allocation: None,
+                network_segment_type: None,
+                expected: false,
+            },
+            Case {
+                name: "inferred DPU BMC Fixed",
+                role: ExpectedInterfaceRole::DpuBmc,
+                ip_allocation: None,
+                network_segment_type: None,
+                expected: false,
+            },
+        ] {
+            let interface = ExpectedHostNic {
+                role: case.role,
+                ip_allocation: case.ip_allocation,
+                fixed_ip: Some("192.0.2.10".parse().unwrap()),
+                network_segment_type: case.network_segment_type,
+                ..Default::default()
+            };
+            assert_eq!(
+                interface.allows_static_assignments_fallback(),
+                case.expected,
                 "{}",
                 case.name,
             );

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -515,6 +515,7 @@ impl ApiClient {
                 sku_id: None,
                 id: None,
                 host_nics,
+                replace_host_nics: false,
                 rack_id,
                 default_pause_ingestion_and_poweron: None,
                 #[allow(deprecated)]

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -631,6 +631,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute("HostLifecycleProfile", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute("ExpectedMachine", "#[derive(serde::Serialize)]")
+        .field_attribute(
+            "ExpectedMachine.replace_host_nics",
+            "#[serde(skip_serializing)]",
+        )
         .type_attribute("ExpectedPowerShelf", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedSwitch", "#[derive(serde::Serialize)]")
         .type_attribute("ExpectedRack", "#[derive(serde::Serialize)]")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -6177,8 +6177,8 @@ message ExpectedHostNic {
   // At most one Host interface per `ExpectedMachine` may set it to true; the
   // other Host interfaces then become non-primary. False remains accepted for
   // compatibility but does not replace that machine-wide selection. DPU OS
-  // interfaces are primary data interfaces and DPU BMC interfaces are
-  // non-primary; those roles must omit this field.
+  // interfaces are primary data interfaces, while DPU BMC and Host BMC
+  // interfaces are non-primary.
   optional bool primary = 6;
   // Optional guard for this interface's network segment type. An explicit
   // allocation policy or DPU role applies the guard to DHCP-selected segments
@@ -6188,19 +6188,22 @@ message ExpectedHostNic {
   // On update, omission clears this guard.
   optional NetworkSegmentType network_segment_type = 7;
   // Machine endpoint that owns this interface. The role selects interface type
-  // and primary behavior only; Host, DPU OS, and DPU BMC all accept the same
-  // allocation policies and optional segment guard. On create, missing and
-  // Unspecified mean Host. On update, omission preserves the stored role while
-  // explicit Unspecified resets it to Host.
+  // and primary behavior only; every role accepts the same allocation policies
+  // and optional segment guard. On create, missing and Unspecified mean Host.
+  // On update, omission preserves the stored role while explicit Unspecified
+  // resets it to Host.
   optional ExpectedInterfaceRole role = 8;
-  // Optional allocation policy. On create, missing and Unspecified infer Fixed
-  // from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
-  // stored policy while explicit Unspecified resets to that inference.
+  // Optional allocation policy. On create, omission and explicit Unspecified
+  // infer Fixed from `fixed_ip`. Without one, Host BMC infers Retained and every
+  // other role infers Dynamic. On single and batch update, omission preserves a
+  // matching stored policy while `fixed_ip` presence is unchanged; explicit
+  // Unspecified resets to inference. New interfaces use create behavior.
   // Explicit Dynamic rejects `fixed_ip`. Explicit Fixed, or a DPU role that
   // infers Fixed, requires `fixed_ip` inside a configured managed prefix. A
-  // legacy Host declaration with an omitted policy may instead fall back to
-  // `static-assignments` and does not turn `network_segment_type` into a
-  // fixed-address guard.
+  // legacy Host declaration, or an inferred Host BMC Fixed policy that omits
+  // `network_segment_type`, may instead fall back to `static-assignments`; only
+  // the legacy Host case leaves `network_segment_type` as a first-DHCP
+  // selection hint.
   optional ExpectedInterfaceIpAllocation ip_allocation = 9;
 }
 
@@ -6236,8 +6239,11 @@ enum DpuMode {
 // - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated address pinned as Static
 //   (never expires).
 //
-// Unset and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` both mean "use the default"
-// (AUTO), which preserves behavior for old clients that don't send the field.
+// On create, omission and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On
+// single and batch update, omission preserves the effective Host BMC policy,
+// while explicit `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` resets it to AUTO. On
+// replace-all, omission resets a legacy-only row to AUTO but preserves an
+// existing nested HostBmc policy that an older client cannot send.
 enum BmcIpAllocationType {
   BMC_IP_ALLOCATION_TYPE_UNSPECIFIED = 0;
   BMC_IP_ALLOCATION_TYPE_AUTO = 1;
@@ -6266,6 +6272,9 @@ message ExpectedMachine {
   optional string sku_id =  7;
   // Unique identifier for the expected machine. When omitted, server generates one.
   optional common.UUID id = 8;
+  // Expected interfaces. Top-level BMC fields preserve legacy-only storage
+  // and remain overrides for the effective Host BMC; a Host BMC entry appears
+  // here once it is configured through the nested interface model.
   repeated ExpectedHostNic host_nics = 9;
   optional common.RackId rack_id = 10;
   optional bool default_pause_ingestion_and_poweron = 11;
@@ -6273,7 +6282,10 @@ message ExpectedMachine {
   bool dpf_enabled = 12 [deprecated = true];
   optional bool is_dpf_enabled = 13;
   // Static BMC IP (optional). Pre-allocates a machine_interface like expected
-  // switches and power shelves; external IPs use the static-assignments segment.
+  // switches and power shelves; external IPs use the static-assignments
+  // segment. Single and batch update omission preserves the effective Host BMC
+  // setting; an explicit empty string clears it. Replace-all keeps its earlier
+  // replacement semantics for legacy-only rows.
   optional string bmc_ip_address = 14;
   // When true, site-explorer skips BMC password rotation and stores the
   // factory-default credentials in Vault as-is.
@@ -6286,8 +6298,18 @@ message ExpectedMachine {
   // existing DB value is preserved via COALESCE.
   optional HostLifecycleProfile host_lifecycle_profile = 17;
   // Per-host control over how this BMC's IP is assigned and retained. See
-  // `BmcIpAllocationType` above. Unset means "use the default" (AUTO).
+  // `BmcIpAllocationType` above. On create, omission and explicit
+  // `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On single and batch update,
+  // omission preserves the effective Host BMC policy, while explicit
+  // Unspecified resets it to AUTO. On replace-all, omission resets a
+  // legacy-only row to AUTO but preserves an existing nested HostBmc policy.
   optional BmcIpAllocationType bmc_ip_allocation = 18;
+  // Marks host_nics as a complete replacement. This is needed because a
+  // repeated protobuf field cannot distinguish an omitted list from an empty
+  // list. New update clients set this when they intentionally supply
+  // host_nics, including `[]`; older clients leave it false so an unknown
+  // nested HostBmc is not removed by a read-modify-write.
+  bool replace_host_nics = 19;
 }
 
 message ExpectedMachineRequest {
@@ -9153,9 +9175,9 @@ enum OperatingSystemType {
 //
 // On create, missing and `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` mean Host. On
 // update, omission preserves the stored role, while explicit
-// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. Host BMC identity
-// remains on `ExpectedMachine.bmc_mac_address`. NVIDIA/infra-controller#4103
-// tracks adding its network settings to this same interface model.
+// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. A Host BMC entry
+// configures network allocation, while its identity remains on
+// `ExpectedMachine.bmc_mac_address`.
 enum ExpectedInterfaceRole {
   // Preserve the legacy Host role when the optional field is absent.
   EXPECTED_INTERFACE_ROLE_UNSPECIFIED = 0;
@@ -9165,21 +9187,29 @@ enum ExpectedInterfaceRole {
   EXPECTED_INTERFACE_ROLE_DPU_OS = 2;
   // DPU Redfish/BMC interface. Never primary.
   EXPECTED_INTERFACE_ROLE_DPU_BMC = 3;
+  // Host Redfish/BMC interface. Never primary.
+  EXPECTED_INTERFACE_ROLE_HOST_BMC = 4;
 }
 
 // Controls how an expected interface receives and retains its IP address.
-// Missing and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` preserve legacy
-// behavior: `fixed_ip` implies `FIXED`, while its absence implies `DYNAMIC`.
+// On create, omission and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` use
+// legacy inference: `fixed_ip` implies `FIXED`; without one, Host BMC implies
+// `RETAINED` and every other role implies `DYNAMIC`. On single and batch update,
+// omission preserves a matching stored policy while `fixed_ip` presence is
+// unchanged; explicit `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` resets to
+// inference. New interfaces use create behavior.
 enum ExpectedInterfaceIpAllocation {
-  // Infer Fixed or Dynamic from whether `fixed_ip` is configured. For a legacy
-  // Host declaration, this does not opt into the fixed-address segment guard.
+  // Infer Fixed from `fixed_ip`. Without one, infer Retained for Host BMC and
+  // Dynamic for every other role. For a legacy Host declaration, this does not
+  // opt into the fixed-address segment guard.
   EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED = 0;
   // Use an expiring DHCP lease. The segment guard must match the relay's
   // selected segment when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC = 1;
-  // Reserve `fixed_ip`. Explicit Fixed, or a DPU role that infers Fixed,
-  // requires a configured managed prefix to contain the address. That prefix
-  // selects the segment, and the segment guard must match when configured.
+  // Reserve `fixed_ip`. Explicit Fixed, a DPU role that infers Fixed, or an
+  // inferred Host BMC policy with a segment guard requires a configured
+  // managed prefix to contain the address. That prefix selects the segment,
+  // and the segment guard must match when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_FIXED = 2;
   // Allocate through DHCP, then make the address Static for this interface
   // row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -613,6 +613,7 @@ impl forge::ExpectedInterfaceRole {
                     "host" | "expected_interface_role_host" => Self::Host,
                     "dpu_os" | "dpuos" | "expected_interface_role_dpu_os" => Self::DpuOs,
                     "dpu_bmc" | "dpubmc" | "expected_interface_role_dpu_bmc" => Self::DpuBmc,
+                    "host_bmc" | "hostbmc" | "expected_interface_role_host_bmc" => Self::HostBmc,
                     _ => {
                         return Err(serde::de::Error::custom(format!(
                             "unknown expected interface role {name:?}"
@@ -641,6 +642,7 @@ impl forge::ExpectedInterfaceRole {
             Self::Host => "host",
             Self::DpuOs => "dpu_os",
             Self::DpuBmc => "dpu_bmc",
+            Self::HostBmc => "host_bmc",
         })
     }
 }

--- a/crates/rpc/src/model/expected_machine.rs
+++ b/crates/rpc/src/model/expected_machine.rs
@@ -20,7 +20,7 @@ use mac_address::MacAddress;
 use model::expected_machine::{
     BmcIpAllocationType, ExpectedHostNic, ExpectedInterfaceIpAllocation, ExpectedInterfaceRole,
     ExpectedMachine, ExpectedMachineData, ExpectedMachineRequest, HostDpuPolicy,
-    HostLifecycleProfile, LinkedExpectedMachine, UnexpectedMachine,
+    HostLifecycleProfile, LegacyHostBmcOverrides, LinkedExpectedMachine, UnexpectedMachine,
 };
 use model::metadata::Metadata;
 use model::network_segment::NetworkSegmentType;
@@ -77,6 +77,7 @@ impl From<ExpectedInterfaceRole> for rpc::forge::ExpectedInterfaceRole {
             ExpectedInterfaceRole::Host => Self::Host,
             ExpectedInterfaceRole::DpuOs => Self::DpuOs,
             ExpectedInterfaceRole::DpuBmc => Self::DpuBmc,
+            ExpectedInterfaceRole::HostBmc => Self::HostBmc,
         }
     }
 }
@@ -91,6 +92,7 @@ impl From<rpc::forge::ExpectedInterfaceRole> for ExpectedInterfaceRole {
             | rpc::forge::ExpectedInterfaceRole::Host => Self::Host,
             rpc::forge::ExpectedInterfaceRole::DpuOs => Self::DpuOs,
             rpc::forge::ExpectedInterfaceRole::DpuBmc => Self::DpuBmc,
+            rpc::forge::ExpectedInterfaceRole::HostBmc => Self::HostBmc,
         }
     }
 }
@@ -116,7 +118,7 @@ fn expected_interface_role_from_rpc(
 
 /// Encode a role without adding the default Host field to legacy responses.
 ///
-/// DPU roles must remain explicit because they select different endpoint
+/// Non-Host roles must remain explicit because they select different endpoint
 /// behavior.
 fn expected_interface_role_to_rpc(role: ExpectedInterfaceRole) -> Option<i32> {
     match role {
@@ -138,8 +140,8 @@ impl From<ExpectedInterfaceIpAllocation> for rpc::forge::ExpectedInterfaceIpAllo
 
 /// Convert a concrete protobuf allocation policy to its resolved model value.
 ///
-/// `Unspecified` has no resolved value on its own: the containing interface
-/// needs `fixed_ip` to infer whether the legacy policy is Fixed or Dynamic.
+/// `Unspecified` has no resolved value on its own. The containing interface
+/// uses its role and `fixed_ip` to infer the compatibility policy.
 impl TryFrom<rpc::forge::ExpectedInterfaceIpAllocation> for ExpectedInterfaceIpAllocation {
     type Error = RpcDataConversionError;
 
@@ -159,9 +161,9 @@ impl TryFrom<rpc::forge::ExpectedInterfaceIpAllocation> for ExpectedInterfaceIpA
 
 /// Decode the optional allocation field without resolving an omitted policy.
 ///
-/// Missing and `Unspecified` both remain `None`. That distinction matters
-/// because omission plus `fixed_ip` means Fixed, while explicit Dynamic rejects
-/// `fixed_ip`.
+/// Missing and `Unspecified` both remain `None`. Resolution then uses the
+/// interface role and `fixed_ip`; an explicit Dynamic policy still rejects a
+/// configured address.
 fn expected_interface_ip_allocation_from_rpc(
     policy: Option<i32>,
 ) -> Result<Option<ExpectedInterfaceIpAllocation>, RpcDataConversionError> {
@@ -299,12 +301,25 @@ impl TryFrom<rpc::forge::ExpectedHostNic> for ExpectedHostNic {
 
 impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
     fn from(expected_machine: ExpectedMachine) -> Self {
-        let host_nics = expected_machine
+        let has_stored_host_bmc = expected_machine
             .data
             .host_nics
             .iter()
+            .any(|interface| interface.role.is_host_bmc());
+        let bmc_ip_allocation = expected_machine
+            .compatibility_bmc_ip_allocation()
+            .map(rpc::forge::BmcIpAllocationType::from)
+            .map(|allocation| allocation as i32);
+        let mut host_nics = expected_machine
+            .data
+            .host_nics
+            .iter()
+            .filter(|interface| !interface.role.is_host_bmc())
             .map(|x| x.clone().into())
-            .collect();
+            .collect::<Vec<_>>();
+        if has_stored_host_bmc {
+            host_nics.push(expected_machine.effective_host_bmc().into());
+        }
         rpc::forge::ExpectedMachine {
             id: expected_machine.id.map(|u| crate::common::Uuid {
                 value: u.to_string(),
@@ -334,12 +349,12 @@ impl From<ExpectedMachine> for rpc::forge::ExpectedMachine {
             // Forge retains `dpu_mode` as its stable compatibility field. The
             // default policy remains represented by absence on the wire.
             dpu_mode: host_dpu_policy_to_rpc(expected_machine.data.dpu_policy),
-            // Only emit `bmc_ip_allocation` when it's non-default (Auto), so an
-            // unset field round-trips and older clients keep falling back to Auto.
-            bmc_ip_allocation: match expected_machine.data.bmc_ip_allocation {
-                BmcIpAllocationType::Auto => None,
-                other => Some(rpc::forge::BmcIpAllocationType::from(other) as i32),
-            },
+            // An inferred Host BMC policy remains Auto on the compatibility
+            // wire field, while an explicitly supplied legacy policy retains
+            // its presence. This keeps both older read-modify-write clients
+            // and explicit legacy inputs stable.
+            bmc_ip_allocation,
+            replace_host_nics: false,
             host_lifecycle_profile: (!expected_machine.data.host_lifecycle_profile.is_empty())
                 .then_some(rpc::forge::HostLifecycleProfile {
                     disable_lockdown: expected_machine
@@ -373,6 +388,59 @@ impl From<UnexpectedMachine> for rpc::forge::UnexpectedMachine {
             bmc_mac_address: m.bmc_mac_address.to_string(),
             machine_id: m.machine_id,
         }
+    }
+}
+
+/// Capture which top-level BMC compatibility fields were present on an RPC
+/// request before model conversion applies their defaults.
+///
+/// A present empty address is an explicit clear. Missing fields remain absent
+/// so a nested Host BMC or the previous stored configuration can supply the
+/// baseline. An explicit Unspecified nested policy becomes an Auto override so
+/// it remains distinguishable from a policy omitted by an older client.
+impl TryFrom<&rpc::forge::ExpectedMachine> for LegacyHostBmcOverrides {
+    type Error = RpcDataConversionError;
+
+    fn try_from(machine: &rpc::forge::ExpectedMachine) -> Result<Self, Self::Error> {
+        let ip_address = machine
+            .bmc_ip_address
+            .as_deref()
+            .map(|address| {
+                if address.is_empty() {
+                    Ok(None)
+                } else {
+                    address.parse::<IpAddr>().map(Some).map_err(|_| {
+                        RpcDataConversionError::InvalidArgument(format!(
+                            "Invalid BMC IP address: {address}"
+                        ))
+                    })
+                }
+            })
+            .transpose()?;
+        let nested_allocation_reset = machine.host_nics.iter().any(|interface| {
+            interface.role == Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32)
+                && interface.ip_allocation
+                    == Some(rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32)
+        });
+        let ip_allocation = machine
+            .bmc_ip_allocation
+            .map(|value| {
+                rpc::forge::BmcIpAllocationType::try_from(value)
+                    .map(BmcIpAllocationType::from)
+                    .map_err(|_| {
+                        RpcDataConversionError::InvalidArgument(format!(
+                            "Invalid bmc_ip_allocation: {value}"
+                        ))
+                    })
+            })
+            .transpose()?
+            .or_else(|| nested_allocation_reset.then_some(BmcIpAllocationType::Auto));
+
+        Ok(Self {
+            ip_address,
+            ip_allocation,
+            replace_host_nics: machine.replace_host_nics,
+        })
     }
 }
 
@@ -565,9 +633,10 @@ mod tests {
             None
         );
         assert!(
-            expected_machine.field.iter().all(
-                |field| field.name.as_deref() != Some("dpu_policy") && field.number != Some(19)
-            )
+            expected_machine
+                .field
+                .iter()
+                .all(|field| field.name.as_deref() != Some("dpu_policy"))
         );
 
         let policy_enum = forge
@@ -1022,6 +1091,12 @@ mod tests {
                     Some(rpc::forge::ExpectedInterfaceRole::DpuBmc as i32),
                 )),
             }
+            "host BMC round trips" {
+                Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32) => Yields((
+                    ExpectedInterfaceRole::HostBmc,
+                    Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                )),
+            }
         );
     }
 
@@ -1049,6 +1124,8 @@ mod tests {
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuOs)),
                 serde_json::json!("dpu_bmc") =>
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuBmc)),
+                serde_json::json!("host_bmc") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::HostBmc)),
             }
             "fully-qualified aliases" {
                 serde_json::json!("expected_interface_role_unspecified") =>
@@ -1059,14 +1136,22 @@ mod tests {
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuOs)),
                 serde_json::json!("expected_interface_role_dpu_bmc") =>
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuBmc)),
+                serde_json::json!("expected_interface_role_host_bmc") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::HostBmc)),
             }
             "normalized and numeric values" {
                 serde_json::json!(" DPU-OS ") =>
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuOs)),
                 serde_json::json!("dpubmc") =>
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::DpuBmc)),
+                serde_json::json!("hostbmc") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::HostBmc)),
+                serde_json::json!(" EXPECTED-INTERFACE-ROLE-HOST-BMC ") =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::HostBmc)),
                 serde_json::json!(1) =>
                     Yields(Some(rpc::forge::ExpectedInterfaceRole::Host)),
+                serde_json::json!(4) =>
+                    Yields(Some(rpc::forge::ExpectedInterfaceRole::HostBmc)),
             }
             "optional and invalid values" {
                 serde_json::Value::Null => Yields(None),
@@ -1082,6 +1167,17 @@ mod tests {
         };
         let json = serde_json::to_string(&interface).unwrap();
         assert!(json.contains(r#""role":"dpu_bmc""#), "{json}");
+
+        let host_bmc_interface = rpc::forge::ExpectedHostNic {
+            mac_address: "AA:BB:CC:DD:EE:FF".into(),
+            role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+            ..Default::default()
+        };
+        let host_bmc_json = serde_json::to_string(&host_bmc_interface).unwrap();
+        assert!(
+            host_bmc_json.contains(r#""role":"host_bmc""#),
+            "{host_bmc_json}"
+        );
 
         let legacy_interface = rpc::forge::ExpectedHostNic {
             mac_address: "AA:BB:CC:DD:EE:FF".into(),
@@ -1159,6 +1255,18 @@ mod tests {
             Some(".forge.ExpectedInterfaceIpAllocation")
         );
 
+        let role_enum = forge
+            .enum_type
+            .iter()
+            .find(|enumeration| enumeration.name.as_deref() == Some("ExpectedInterfaceRole"))
+            .unwrap();
+        let host_bmc = role_enum
+            .value
+            .iter()
+            .find(|value| value.name.as_deref() == Some("EXPECTED_INTERFACE_ROLE_HOST_BMC"))
+            .unwrap();
+        assert_eq!(host_bmc.number, Some(4));
+
         let expected_machine = forge
             .message_type
             .iter()
@@ -1170,6 +1278,12 @@ mod tests {
             .find(|field| field.name.as_deref() == Some("host_nics"))
             .unwrap();
         assert_eq!(host_nics.number, Some(9));
+        let replace_host_nics = expected_machine
+            .field
+            .iter()
+            .find(|field| field.name.as_deref() == Some("replace_host_nics"))
+            .unwrap();
+        assert_eq!(replace_host_nics.number, Some(19));
     }
 
     #[test]
@@ -1187,6 +1301,189 @@ mod tests {
         assert!(
             matches!(err, RpcDataConversionError::InvalidMacAddress(mac) if mac == "not-a-mac")
         );
+    }
+
+    /// RPC conversion retains presence for both legacy compatibility fields.
+    #[test]
+    fn legacy_host_bmc_overrides_preserve_rpc_field_presence() {
+        let fixed_address: IpAddr = "192.0.2.44".parse().unwrap();
+        scenarios!(
+            run = |machine: rpc::forge::ExpectedMachine| {
+                LegacyHostBmcOverrides::try_from(&machine).map_err(|error| error.to_string())
+            };
+            "omitted compatibility fields remain absent" {
+                rpc::forge::ExpectedMachine::default() =>
+                    Yields(LegacyHostBmcOverrides::default()),
+            }
+            "an empty address is an explicit clear" {
+                rpc::forge::ExpectedMachine {
+                    bmc_ip_address: Some(String::new()),
+                    ..Default::default()
+                } => Yields(LegacyHostBmcOverrides {
+                    ip_address: Some(None),
+                    ip_allocation: None,
+                    ..Default::default()
+                }),
+            }
+            "a configured address retains its value" {
+                rpc::forge::ExpectedMachine {
+                    bmc_ip_address: Some(fixed_address.to_string()),
+                    ..Default::default()
+                } => Yields(LegacyHostBmcOverrides {
+                    ip_address: Some(Some(fixed_address)),
+                    ip_allocation: None,
+                    ..Default::default()
+                }),
+            }
+            "a configured policy retains its presence" {
+                rpc::forge::ExpectedMachine {
+                    bmc_ip_allocation: Some(
+                        rpc::forge::BmcIpAllocationType::Retained as i32
+                    ),
+                    ..Default::default()
+                } => Yields(LegacyHostBmcOverrides {
+                    ip_address: None,
+                    ip_allocation: Some(BmcIpAllocationType::Retained),
+                    ..Default::default()
+                }),
+            }
+            "explicit unspecified retains the compatibility default" {
+                rpc::forge::ExpectedMachine {
+                    bmc_ip_allocation: Some(
+                        rpc::forge::BmcIpAllocationType::Unspecified as i32
+                    ),
+                    ..Default::default()
+                } => Yields(LegacyHostBmcOverrides {
+                    ip_address: None,
+                    ip_allocation: Some(BmcIpAllocationType::Auto),
+                    ..Default::default()
+                }),
+            }
+            "nested unspecified resets compatibility allocation" {
+                rpc::forge::ExpectedMachine {
+                    host_nics: vec![rpc::forge::ExpectedHostNic {
+                        role: Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32),
+                        ip_allocation: Some(
+                            rpc::forge::ExpectedInterfaceIpAllocation::Unspecified as i32
+                        ),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                } => Yields(LegacyHostBmcOverrides {
+                    ip_address: None,
+                    ip_allocation: Some(BmcIpAllocationType::Auto),
+                    ..Default::default()
+                }),
+            }
+            "an authoritative interface replacement retains its signal" {
+                rpc::forge::ExpectedMachine {
+                    replace_host_nics: true,
+                    ..Default::default()
+                } => Yields(LegacyHostBmcOverrides {
+                    replace_host_nics: true,
+                    ..Default::default()
+                }),
+            }
+        );
+    }
+
+    /// Legacy rows keep their earlier wire shape so clients whose role enum
+    /// predates HostBmc can still serialize the response.
+    #[test]
+    fn expected_machine_output_keeps_legacy_host_bmc_fields_top_level() {
+        let bmc_mac_address = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+        let fixed_ip = "192.0.2.44".parse().unwrap();
+        let rpc_machine = rpc::forge::ExpectedMachine::from(ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                bmc_ip_address: Some(fixed_ip),
+                bmc_ip_allocation: BmcIpAllocationType::Auto,
+                ..Default::default()
+            },
+        });
+
+        assert!(rpc_machine.host_nics.is_empty());
+        assert_eq!(rpc_machine.bmc_mac_address, bmc_mac_address.to_string());
+        assert_eq!(rpc_machine.bmc_ip_address.as_deref(), Some("192.0.2.44"));
+        assert_eq!(rpc_machine.bmc_ip_allocation, None);
+    }
+
+    /// An explicit nested policy is mirrored on the compatibility wire field.
+    #[test]
+    fn expected_machine_output_projects_explicit_host_bmc_policy() {
+        let bmc_mac_address = "AA:BB:CC:DD:EE:FE".parse().unwrap();
+        let fixed_ip = "192.0.2.45".parse().unwrap();
+        let rpc_machine = rpc::forge::ExpectedMachine::from(ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: bmc_mac_address,
+                    role: ExpectedInterfaceRole::HostBmc,
+                    ip_allocation: Some(ExpectedInterfaceIpAllocation::Fixed),
+                    fixed_ip: Some(fixed_ip),
+                    ..Default::default()
+                }],
+                bmc_ip_address: Some(fixed_ip),
+                bmc_ip_allocation: BmcIpAllocationType::Fixed,
+                ..Default::default()
+            },
+        });
+
+        let host_bmc = rpc_machine
+            .host_nics
+            .iter()
+            .find(|interface| {
+                interface.role == Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32)
+            })
+            .expect("output should contain one HostBmc");
+        assert_eq!(
+            host_bmc.ip_allocation,
+            Some(rpc::forge::ExpectedInterfaceIpAllocation::Fixed as i32),
+        );
+        assert_eq!(
+            rpc_machine.bmc_ip_allocation,
+            Some(rpc::forge::BmcIpAllocationType::Fixed as i32),
+        );
+        assert_eq!(rpc_machine.bmc_ip_address.as_deref(), Some("192.0.2.45"));
+    }
+
+    /// An explicit legacy Fixed policy remains present even though its nested
+    /// representation omits the policy to retain external-address fallback.
+    #[test]
+    fn expected_machine_output_preserves_explicit_legacy_fixed_policy() {
+        let bmc_mac_address = "AA:BB:CC:DD:EE:FD".parse().unwrap();
+        let fixed_ip = "192.0.2.46".parse().unwrap();
+        let rpc_machine = rpc::forge::ExpectedMachine::from(ExpectedMachine {
+            id: None,
+            bmc_mac_address,
+            data: ExpectedMachineData {
+                host_nics: vec![ExpectedHostNic {
+                    mac_address: bmc_mac_address,
+                    role: ExpectedInterfaceRole::HostBmc,
+                    fixed_ip: Some(fixed_ip),
+                    ..Default::default()
+                }],
+                bmc_ip_address: Some(fixed_ip),
+                bmc_ip_allocation: BmcIpAllocationType::Fixed,
+                ..Default::default()
+            },
+        });
+
+        let host_bmc = rpc_machine
+            .host_nics
+            .iter()
+            .find(|interface| {
+                interface.role == Some(rpc::forge::ExpectedInterfaceRole::HostBmc as i32)
+            })
+            .expect("output should contain one HostBmc");
+        assert_eq!(host_bmc.ip_allocation, None);
+        assert_eq!(
+            rpc_machine.bmc_ip_allocation,
+            Some(rpc::forge::BmcIpAllocationType::Fixed as i32),
+        );
+        assert_eq!(rpc_machine.bmc_ip_address.as_deref(), Some("192.0.2.46"));
     }
 
     fn make_rpc_expected_machine(disable_lockdown: Option<bool>) -> rpc::forge::ExpectedMachine {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -117,9 +117,30 @@ use crate::explored_endpoint_index::ExploredEndpointIndex;
 ///
 /// Host is the compatibility default for existing `host_nics` entries, so
 /// those entries remain scannable even when they look like data interfaces.
-/// DPU BMC interfaces remain scannable too.
-fn should_skip_expected_interface_redfish_scan(interface: &ExpectedHostNic) -> bool {
-    interface.role == model::expected_machine::ExpectedInterfaceRole::DpuOs
+/// DPU BMC interfaces remain scannable too. A top-level BMC MAC is an
+/// ExpectedMachine identity, so it wins over a historical DPU OS declaration
+/// that reused the same address on any row.
+fn should_skip_expected_interface_redfish_scan(
+    interface: &ExpectedHostNic,
+    expected_host_bmc_macs: &HashSet<MacAddress>,
+) -> bool {
+    !expected_host_bmc_macs.contains(&interface.mac_address)
+        && interface.role == model::expected_machine::ExpectedInterfaceRole::DpuOs
+}
+
+/// Return whether a HostInband row can be treated as a Redfish endpoint.
+///
+/// Host data interfaces also DHCP on HostInband, so only BMC rows are normally
+/// eligible. The ExpectedMachine BMC identity is the compatibility exception:
+/// a historical DPU OS declaration may have left its anonymous row typed
+/// `Data`, and successful exploration will reconcile that row back to `Bmc`.
+fn should_scan_host_inband_interface_for_redfish(
+    interface: &MachineInterfaceSnapshot,
+    expected_host_bmc_macs: &HashSet<MacAddress>,
+) -> bool {
+    interface.interface_type == InterfaceType::Bmc
+        || (interface.machine_id.is_none()
+            && expected_host_bmc_macs.contains(&interface.mac_address))
 }
 
 pub fn new_bmc_explorer(
@@ -2006,12 +2027,11 @@ impl SiteExplorer {
             .collect();
 
         // Record Expected Machine metrics and apply configured address
-        // policies. Host, DPU OS, and DPU BMC declarations all use
-        // `try_apply_expected_interface`; their roles only determine the row's
-        // interface type and primary setting. Fixed addresses create rows when
-        // needed, while Retained changes a matching DHCP address to `Static`.
-        // The database helpers are idempotent, so steady-state passes do not
-        // change rows.
+        // policies. Every role uses `try_apply_expected_interface`; its role
+        // only determines the row's interface type and primary setting. Fixed
+        // addresses create rows when needed, while Retained changes a matching
+        // DHCP address to `Static`. The database helpers are idempotent, so
+        // steady-state passes do not change rows.
         let preallocate_start = Instant::now();
         for expected_machine in &expected_machines {
             let device_type = expected_machine
@@ -2025,27 +2045,23 @@ impl SiteExplorer {
                 device_type,
             );
 
-            if let Some(bmc_ip) = expected_machine.data.bmc_ip_address {
-                try_preallocate_one(
-                    &self.database_connection,
-                    expected_machine.bmc_mac_address,
-                    bmc_ip,
-                    InterfaceType::Bmc,
-                    "expected_machine BMC",
-                    self.config.retained_boot_interface_window,
-                )
-                .await;
-            } else if expected_machine
+            // Compatibility columns may be the only Host BMC configuration on
+            // rows created before the nested role existed. Resolve that one
+            // declaration in memory, then skip any stored entry at the BMC
+            // identity so Site Explorer applies its policy exactly once.
+            let host_bmc = expected_machine.effective_host_bmc();
+            try_apply_expected_interface(
+                &self.database_connection,
+                &host_bmc,
+                self.config.retained_boot_interface_window,
+            )
+            .await;
+            for nic in expected_machine
                 .data
-                .bmc_ip_allocation
-                .retains_dynamic_ip(false)
+                .host_nics
+                .iter()
+                .filter(|interface| interface.mac_address != expected_machine.bmc_mac_address)
             {
-                // No operator-specified BMC IP, but the host's bmc_ip_allocation
-                // retains its auto-allocated address: pin the BMC interface's
-                // DHCP lease as Static so it survives lease expiry.
-                try_retain_bmc(&self.database_connection, expected_machine.bmc_mac_address).await;
-            }
-            for nic in &expected_machine.data.host_nics {
                 try_apply_expected_interface(
                     &self.database_connection,
                     nic,
@@ -2115,17 +2131,24 @@ impl SiteExplorer {
         );
 
         let expected_count = expected_machines.len();
+        let expected_host_bmc_macs = expected_machines
+            .iter()
+            .map(|machine| machine.bmc_mac_address)
+            .collect::<HashSet<_>>();
         let expected_non_redfish_interface_macs = expected_machines
             .iter()
             .flat_map(|machine| &machine.data.host_nics)
-            .filter(|interface| should_skip_expected_interface_redfish_scan(interface))
+            .filter(|interface| {
+                should_skip_expected_interface_redfish_scan(interface, &expected_host_bmc_macs)
+            })
             .map(|interface| interface.mac_address)
             .collect::<HashSet<_>>();
 
         // Tenant and Admin segments are never Redfish discovery networks. The
-        // Underlay may contain DPU OS data interfaces, so keep only explicitly
-        // declared DPU OS MACs out of the scan. Host remains the compatibility
-        // default for legacy entries, and DPU BMC interfaces remain eligible.
+        // Underlay may contain DPU OS data interfaces, so keep explicit DPU OS
+        // MACs out of the scan unless that MAC is an ExpectedMachine BMC
+        // identity. Host remains the compatibility default for legacy entries,
+        // and DPU BMC interfaces remain eligible.
         //
         // Load interfaces after allocation reconciliation so this iteration
         // also sees newly-created fixed reservations.
@@ -2149,9 +2172,14 @@ impl SiteExplorer {
                     && (is_bmc
                         || (iface.machine_id.is_none()
                             && !expected_non_redfish_interface_macs.contains(&iface.mac_address)));
-                // On HostInband only scan BMCs. The host in-band NIC also DHCPs here with no
-                // machine_id and is not a Redfish endpoint.
-                let host_inband = host_inband_segments.contains(&iface.segment_id) && is_bmc;
+                // Host data interfaces also DHCP on HostInband. Only scan BMC
+                // rows plus an anonymous row at an ExpectedMachine BMC identity,
+                // which covers historical rows that were left typed as Data.
+                let host_inband = host_inband_segments.contains(&iface.segment_id)
+                    && should_scan_host_inband_interface_for_redfish(
+                        iface,
+                        &expected_host_bmc_macs,
+                    );
                 underlay || host_inband
             })
             .collect();
@@ -3584,8 +3612,8 @@ impl SiteExplorer {
 /// `try_preallocate_one` reconciles one generic fixed-address reservation in
 /// its own transaction.
 ///
-/// Site Explorer uses this for flat BMC, switch NVOS, and power-shelf
-/// configuration. Nested expected interfaces use
+/// Site Explorer uses this for switch NVOS and switch/power-shelf BMC
+/// configuration. ExpectedMachine interfaces use
 /// [`try_apply_expected_interface`] because their role and segment guard also
 /// need to be applied. Database operations are idempotent, and a failure is
 /// logged without stopping the wider reconciliation pass.
@@ -3657,46 +3685,8 @@ pub async fn try_preallocate_one(
     }
 }
 
-/// Pin a BMC's auto-allocated (DHCP) address as `Static` so DHCP lease expiry
-/// can't reap it, for BMCs whose `bmc_ip_allocation` retains a dynamic IP and
-/// that have no operator-specified `bmc_ip_address`. Mirrors
-/// [`try_preallocate_one`]: own txn from the pool, warn-and-continue on error so
-/// a single failure never fails the whole reconcile pass. Idempotent on the
-/// api-db side -- a no-op once the address is already `Static`.
-pub async fn try_retain_bmc(pool: &PgPool, mac: MacAddress) {
-    let mut txn = match db::Transaction::begin(pool).await {
-        Ok(t) => t,
-        Err(error) => {
-            tracing::warn!(
-                %error,
-                bmc_mac_address = %mac,
-                "Site-explorer BMC retain: txn_begin failed"
-            );
-            return;
-        }
-    };
-    match db::machine_interface::retain_bmc_address_by_mac(txn.as_pgconn(), mac).await {
-        Ok(()) => {
-            if let Err(error) = txn.commit().await {
-                tracing::warn!(
-                    %error,
-                    bmc_mac_address = %mac,
-                    "Site-explorer BMC retain: commit failed"
-                );
-            }
-        }
-        Err(error) => {
-            tracing::warn!(
-                %error,
-                bmc_mac_address = %mac,
-                "Site-explorer BMC retain skipped"
-            );
-        }
-    }
-}
-
-/// `try_apply_expected_interface` applies the allocation policy for one nested
-/// expected interface.
+/// `try_apply_expected_interface` applies the allocation policy for one
+/// configured or compatibility-derived expected interface.
 ///
 /// Every role follows this same policy path. Fixed reservations are
 /// materialized while expected configuration is reconciled. Retained follows
@@ -4285,32 +4275,97 @@ mod tests {
     /// Only an explicit DPU OS role suppresses Redfish scanning.
     ///
     /// Host remains eligible because it is the default for legacy entries
-    /// that did not declare an interface role.
+    /// that did not declare an interface role. The ExpectedMachine BMC key
+    /// takes precedence over a historical conflicting DPU OS declaration.
     #[test]
     fn expected_interface_role_controls_redfish_scan_classification() {
+        let host_bmc_mac_address = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+        let other_mac_address = "AA:BB:CC:DD:EE:FE".parse().unwrap();
+        let expected_host_bmc_macs = HashSet::from([host_bmc_mac_address]);
         check_values(
             [
                 Check {
                     scenario: "legacy host entry",
-                    input: ExpectedInterfaceRole::Host,
+                    input: (ExpectedInterfaceRole::Host, other_mac_address),
                     expect: false,
                 },
                 Check {
                     scenario: "DPU OS interface",
-                    input: ExpectedInterfaceRole::DpuOs,
+                    input: (ExpectedInterfaceRole::DpuOs, other_mac_address),
                     expect: true,
                 },
                 Check {
                     scenario: "DPU BMC interface",
-                    input: ExpectedInterfaceRole::DpuBmc,
+                    input: (ExpectedInterfaceRole::DpuBmc, other_mac_address),
+                    expect: false,
+                },
+                Check {
+                    scenario: "Host BMC interface",
+                    input: (ExpectedInterfaceRole::HostBmc, host_bmc_mac_address),
+                    expect: false,
+                },
+                Check {
+                    scenario: "historical DPU OS declaration at any ExpectedMachine BMC identity",
+                    input: (ExpectedInterfaceRole::DpuOs, host_bmc_mac_address),
                     expect: false,
                 },
             ],
-            |role| {
-                should_skip_expected_interface_redfish_scan(&ExpectedHostNic {
-                    role,
-                    ..Default::default()
-                })
+            |(role, mac_address)| {
+                should_skip_expected_interface_redfish_scan(
+                    &ExpectedHostNic {
+                        mac_address,
+                        role,
+                        ..Default::default()
+                    },
+                    &expected_host_bmc_macs,
+                )
+            },
+        );
+    }
+
+    /// HostInband only scans BMC rows, except for the anonymous compatibility
+    /// row at an ExpectedMachine's top-level BMC identity.
+    #[test]
+    fn host_inband_redfish_scan_allows_historical_bmc_identity() {
+        let host_bmc_mac_address = "AA:BB:CC:DD:EE:FF".parse().unwrap();
+        let other_mac_address = "AA:BB:CC:DD:EE:FE".parse().unwrap();
+        let expected_host_bmc_macs = HashSet::from([host_bmc_mac_address]);
+
+        check_values(
+            [
+                Check {
+                    scenario: "BMC row",
+                    input: (InterfaceType::Bmc, other_mac_address, false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "anonymous historical Data row at the Host BMC identity",
+                    input: (InterfaceType::Data, host_bmc_mac_address, false),
+                    expect: true,
+                },
+                Check {
+                    scenario: "anonymous host Data row",
+                    input: (InterfaceType::Data, other_mac_address, false),
+                    expect: false,
+                },
+                Check {
+                    scenario: "associated Data row at the Host BMC identity",
+                    input: (InterfaceType::Data, host_bmc_mac_address, true),
+                    expect: false,
+                },
+            ],
+            |(interface_type, mac_address, associated)| {
+                let mut interface = MachineInterfaceSnapshot::mock_with_mac(mac_address);
+                interface.interface_type = interface_type;
+                interface.machine_id = associated.then(|| {
+                    carbide_uuid::machine::MachineId::new(
+                        carbide_uuid::machine::MachineIdSource::Tpm,
+                        [0; 32],
+                        MachineType::Host,
+                    )
+                });
+
+                should_scan_host_inband_interface_for_redfish(&interface, &expected_host_bmc_macs)
             },
         );
     }

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -1185,7 +1185,8 @@ mod tests {
         let host_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
         let dpu_os_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x02]);
         let dpu_bmc_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x03]);
-        let redfish_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x04]);
+        let host_bmc_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x04]);
+        let redfish_mac = MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, 0x05]);
         let interface = |mac_address, role| ExpectedHostNic {
             mac_address,
             role,
@@ -1200,6 +1201,7 @@ mod tests {
                 interface(host_mac, ExpectedInterfaceRole::Host),
                 interface(dpu_os_mac, ExpectedInterfaceRole::DpuOs),
                 interface(dpu_bmc_mac, ExpectedInterfaceRole::DpuBmc),
+                interface(host_bmc_mac, ExpectedInterfaceRole::HostBmc),
             ])
         };
         let excluded_report = |chassis_id: &str| EndpointExplorationReport {
@@ -1241,6 +1243,7 @@ mod tests {
                         Some(machine_data(vec![
                             interface(dpu_os_mac, ExpectedInterfaceRole::DpuOs),
                             interface(dpu_bmc_mac, ExpectedInterfaceRole::DpuBmc),
+                            interface(host_bmc_mac, ExpectedInterfaceRole::HostBmc),
                         ])),
                     ),
                     expect: vec![],

--- a/rest-api/api/pkg/api/handler/expectedmachine.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine.go
@@ -738,6 +738,10 @@ func (uemh UpdateExpectedMachineHandler) Handle(c echo.Context) error {
 			Username: apiRequest.DefaultBmcUsername,
 			Password: apiRequest.DefaultBmcPassword,
 		})
+		// REST storage keeps its current value when this PATCH omits the
+		// address. Core needs the request value instead: nil preserves its
+		// current HostBmc configuration, while an empty string clears it.
+		updateExpectedMachineRequest.BmcIpAddress = apiRequest.BmcIpAddress
 
 		logger.Info().Msg("triggering ExpectedMachine update workflow")
 
@@ -1545,8 +1549,9 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 	// by the DB record's ID rather than by slice index, so correlation
 	// doesn't depend on the DAO preserving input order.
 	credsByID := make(map[uuid.UUID]cdbm.ExpectedMachineCredentials, len(apiRequests))
+	bmcIPRequestsByID := make(map[uuid.UUID]*string, len(apiRequests))
 	updateInputs := make([]cdbm.ExpectedMachineUpdateInput, 0, len(apiRequests))
-	bmcIPClearIDs := make([]uuid.UUID, 0)
+	bmcIPClearIDs := make(map[uuid.UUID]struct{})
 	for _, machineReq := range apiRequests {
 		// APIExpectedMachineUpdateRequest must allow nil ID for single update use case. If present here, it has already been validated.
 		if machineReq.ID == nil {
@@ -1559,9 +1564,10 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 			Username: machineReq.DefaultBmcUsername,
 			Password: machineReq.DefaultBmcPassword,
 		}
+		bmcIPRequestsByID[emID] = machineReq.BmcIpAddress
 		bmcIPAddress := machineReq.BmcIpAddress
 		if bmcIPAddress != nil && *bmcIPAddress == "" {
-			bmcIPClearIDs = append(bmcIPClearIDs, emID)
+			bmcIPClearIDs[emID] = struct{}{}
 			bmcIPAddress = nil
 		}
 		updateInputs = append(updateInputs, cdbm.ExpectedMachineUpdateInput{
@@ -1584,12 +1590,29 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 			HostLifecycleProfile:     machineReq.HostLifecycleProfile.ToDBModelPtr(),
 		})
 	}
-
 	// Update provided ExpectedMachines in DB
 	updatedExpectedMachines, err := cdb.WithTxResult(ctx, uemh.dbSession, func(tx *cdb.Tx) ([]cdbm.ExpectedMachine, error) {
-		// Clear first so UpdateMultiple's final SELECT and the workflow payload
-		// both see nil. Its scoped BMC IP update cannot restore cleared rows.
-		for _, expectedMachineID := range bmcIPClearIDs {
+		// Lock the full target set before clearing any one row. Clear touches
+		// only a subset, while UpdateMultiple writes every target; without this
+		// canonical lock pass, overlapping batches can each hold a different
+		// cleared row and deadlock during the bulk update.
+		derr := emDAO.LockForUpdate(ctx, tx, slices.Collect(maps.Keys(idMap)))
+		if derr != nil {
+			if errors.Is(derr, cdb.ErrDoesNotExist) {
+				return nil, cutil.NewAPIError(http.StatusConflict, "One or more Expected Machines were removed before the batch update completed", nil)
+			}
+			logger.Error().Err(derr).Msg("error locking ExpectedMachine records for batch update")
+			return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to update Expected Machine due to DB error", nil)
+		}
+
+		// Clear first so UpdateMultiple's final SELECT sees nil. Its scoped
+		// BMC IP update cannot restore cleared rows. Every target row is already
+		// locked above, so the subset clear cannot introduce a second order.
+		for _, input := range updateInputs {
+			expectedMachineID := input.ExpectedMachineID
+			if _, ok := bmcIPClearIDs[expectedMachineID]; !ok {
+				continue
+			}
 			_, derr := emDAO.Clear(ctx, tx, cdbm.ExpectedMachineClearInput{
 				ExpectedMachineID: expectedMachineID,
 				BmcIpAddress:      true,
@@ -1617,7 +1640,11 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 				logger.Error().Str("ExpectedMachineID", em.ID.String()).Msg("UpdateMultiple returned a machine with an unrecognized ID")
 				return nil, cutil.NewAPIError(http.StatusInternalServerError, "Failed to correlate updated Expected Machine to request", nil)
 			}
-			workflowMachines = append(workflowMachines, em.ToProto(creds))
+			workflowMachine := em.ToProto(creds)
+			// Use the PATCH value at the workflow boundary instead of the REST
+			// row, which may contain an address this request did not touch.
+			workflowMachine.BmcIpAddress = bmcIPRequestsByID[em.ID]
+			workflowMachines = append(workflowMachines, workflowMachine)
 		}
 
 		logger.Info().Int("Count", len(workflowMachines)).Msg("triggering Expected Machine update workflow")

--- a/rest-api/api/pkg/api/handler/expectedmachine_test.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine_test.go
@@ -1420,12 +1420,14 @@ func TestUpdateExpectedMachineHandler_BmcIpAddressPatchSemantics(t *testing.T) {
 		},
 	}
 	updatedIP := "192.0.2.31"
+	emptyIP := ""
 	tests := []struct {
-		name       string
-		body       string
-		wantStatus int
-		wantIP     *string
-		requests   int
+		name           string
+		body           string
+		wantStatus     int
+		wantIP         *string
+		wantWorkflowIP *string
+		requests       int
 	}{
 		{
 			name:       "omission preserves address",
@@ -1434,15 +1436,17 @@ func TestUpdateExpectedMachineHandler_BmcIpAddressPatchSemantics(t *testing.T) {
 			wantIP:     &originalIP,
 		},
 		{
-			name:       "address sets value",
-			body:       `{"bmcIpAddress":"192.0.2.31"}`,
-			wantStatus: http.StatusOK,
-			wantIP:     &updatedIP,
+			name:           "address sets value",
+			body:           `{"bmcIpAddress":"192.0.2.31"}`,
+			wantStatus:     http.StatusOK,
+			wantIP:         &updatedIP,
+			wantWorkflowIP: &updatedIP,
 		},
 		{
-			name:       "empty string clears address",
-			body:       `{"bmcIpAddress":""}`,
-			wantStatus: http.StatusOK,
+			name:           "empty string clears address",
+			body:           `{"bmcIpAddress":""}`,
+			wantStatus:     http.StatusOK,
+			wantWorkflowIP: &emptyIP,
 		},
 		{
 			name:       "explicit null preserves address",
@@ -1451,10 +1455,11 @@ func TestUpdateExpectedMachineHandler_BmcIpAddressPatchSemantics(t *testing.T) {
 			wantIP:     &originalIP,
 		},
 		{
-			name:       "repeated empty string remains cleared",
-			body:       `{"bmcIpAddress":""}`,
-			wantStatus: http.StatusOK,
-			requests:   2,
+			name:           "repeated empty string remains cleared",
+			body:           `{"bmcIpAddress":""}`,
+			wantStatus:     http.StatusOK,
+			wantWorkflowIP: &emptyIP,
+			requests:       2,
 		},
 	}
 
@@ -1497,7 +1502,7 @@ func TestUpdateExpectedMachineHandler_BmcIpAddressPatchSemantics(t *testing.T) {
 				assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 				assert.Equal(t, tc.wantIP, response.BmcIpAddress)
 				if assert.Len(t, capturedRequests, workflowCount+1) {
-					assert.Equal(t, tc.wantIP, capturedRequests[workflowCount].BmcIpAddress)
+					assert.Equal(t, tc.wantWorkflowIP, capturedRequests[workflowCount].BmcIpAddress)
 				}
 			}
 		})
@@ -2910,6 +2915,45 @@ func TestUpdateExpectedMachinesHandler_BmcIpAddressPatchSemantics(t *testing.T) 
 	emUpdated := createExpectedMachine("00:11:22:33:44:D3", "BMC-IP-BATCH-003", nil, &updatedName)
 	emPreserved := createExpectedMachine("00:11:22:33:44:D4", "BMC-IP-BATCH-004", &preservedIP, &preservedName)
 	emNullPreserved := createExpectedMachine("00:11:22:33:44:D5", "BMC-IP-BATCH-005", &nullPreservedIP, &nullPreservedName)
+	emptyIP := ""
+	tests := []struct {
+		name           string
+		machine        *cdbm.ExpectedMachine
+		request        map[string]interface{}
+		wantIP         *string
+		wantWorkflowIP *string
+		wantName       *string
+	}{
+		{
+			name:           "empty string clears address",
+			machine:        emCleared,
+			request:        map[string]interface{}{"bmcIpAddress": ""},
+			wantWorkflowIP: &emptyIP,
+			wantName:       &clearedName,
+		},
+		{
+			name:           "address sets value",
+			machine:        emUpdated,
+			request:        map[string]interface{}{"bmcIpAddress": updatedIP},
+			wantIP:         &updatedIP,
+			wantWorkflowIP: &updatedIP,
+			wantName:       &updatedName,
+		},
+		{
+			name:     "omission preserves REST address and omits workflow address",
+			machine:  emPreserved,
+			request:  map[string]interface{}{},
+			wantIP:   &preservedIP,
+			wantName: &preservedName,
+		},
+		{
+			name:     "null preserves REST address and omits workflow address",
+			machine:  emNullPreserved,
+			request:  map[string]interface{}{"bmcIpAddress": nil},
+			wantIP:   &nullPreservedIP,
+			wantName: &nullPreservedName,
+		},
+	}
 
 	var capturedRequest *corev1.BatchExpectedMachineOperationRequest
 	mockTemporalClient := &tmocks.Client{}
@@ -2936,23 +2980,21 @@ func TestUpdateExpectedMachinesHandler_BmcIpAddressPatchSemantics(t *testing.T) 
 		Return(nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
-	body, err := json.Marshal([]map[string]interface{}{
-		{
-			"id":           emCleared.ID.String(),
-			"bmcIpAddress": "",
-		},
-		{
-			"id":           emUpdated.ID.String(),
-			"bmcIpAddress": updatedIP,
-		},
-		{
-			"id": emPreserved.ID.String(),
-		},
-		{
-			"id":           emNullPreserved.ID.String(),
-			"bmcIpAddress": nil,
-		},
-	})
+	requestBody := make([]map[string]interface{}, 0, len(tests))
+	wantByID := make(map[uuid.UUID]*string, len(tests))
+	wantWorkflowIPByID := make(map[uuid.UUID]*string, len(tests))
+	wantNameByID := make(map[uuid.UUID]*string, len(tests))
+	scenarioByID := make(map[uuid.UUID]string, len(tests))
+	for _, test := range tests {
+		test.request["id"] = test.machine.ID.String()
+		requestBody = append(requestBody, test.request)
+		wantByID[test.machine.ID] = test.wantIP
+		wantWorkflowIPByID[test.machine.ID] = test.wantWorkflowIP
+		wantNameByID[test.machine.ID] = test.wantName
+		scenarioByID[test.machine.ID] = test.name
+	}
+
+	body, err := json.Marshal(requestBody)
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPatch, "/v2/org/"+org+"/nico/expected-machine/batch", bytes.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
@@ -2978,30 +3020,18 @@ func TestUpdateExpectedMachinesHandler_BmcIpAddressPatchSemantics(t *testing.T) 
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code, "Response: %s", rec.Body.String())
 
-	wantByID := map[uuid.UUID]*string{
-		emCleared.ID:       nil,
-		emUpdated.ID:       &updatedIP,
-		emPreserved.ID:     &preservedIP,
-		emNullPreserved.ID: &nullPreservedIP,
-	}
-	wantNameByID := map[uuid.UUID]*string{
-		emCleared.ID:       &clearedName,
-		emUpdated.ID:       &updatedName,
-		emPreserved.ID:     &preservedName,
-		emNullPreserved.ID: &nullPreservedName,
-	}
 	var response []model.APIExpectedMachine
 	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 	assert.Len(t, response, len(wantByID))
 	for _, machine := range response {
-		assert.Equal(t, wantByID[machine.ID], machine.BmcIpAddress)
-		assert.Equal(t, wantNameByID[machine.ID], machine.Name)
+		assert.Equal(t, wantByID[machine.ID], machine.BmcIpAddress, scenarioByID[machine.ID])
+		assert.Equal(t, wantNameByID[machine.ID], machine.Name, scenarioByID[machine.ID])
 	}
 	for id, wantIP := range wantByID {
 		stored, err := emDAO.Get(ctx, nil, id, nil, false)
-		assert.NoError(t, err)
-		assert.Equal(t, wantIP, stored.BmcIpAddress)
-		assert.Equal(t, wantNameByID[id], stored.Name)
+		assert.NoError(t, err, scenarioByID[id])
+		assert.Equal(t, wantIP, stored.BmcIpAddress, scenarioByID[id])
+		assert.Equal(t, wantNameByID[id], stored.Name, scenarioByID[id])
 	}
 
 	if assert.NotNil(t, capturedRequest) && assert.NotNil(t, capturedRequest.ExpectedMachines) {
@@ -3009,8 +3039,8 @@ func TestUpdateExpectedMachinesHandler_BmcIpAddressPatchSemantics(t *testing.T) 
 		for _, machine := range capturedRequest.ExpectedMachines.ExpectedMachines {
 			id, err := uuid.Parse(machine.Id.Value)
 			assert.NoError(t, err)
-			assert.Equal(t, wantByID[id], machine.BmcIpAddress)
-			assert.Equal(t, wantNameByID[id], machine.Name)
+			assert.Equal(t, wantWorkflowIPByID[id], machine.BmcIpAddress, scenarioByID[id])
+			assert.Equal(t, wantNameByID[id], machine.Name, scenarioByID[id])
 		}
 	}
 }

--- a/rest-api/db/pkg/db/model/expectedmachine.go
+++ b/rest-api/db/pkg/db/model/expectedmachine.go
@@ -6,6 +6,7 @@ package model
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -347,6 +348,8 @@ type ExpectedMachineDAO interface {
 	GetAll(ctx context.Context, tx *db.Tx, filter ExpectedMachineFilterInput, page paginator.PageInput, includeRelations []string) ([]ExpectedMachine, int, error)
 	// Get returns row for specified ID
 	Get(ctx context.Context, tx *db.Tx, expectedMachineID uuid.UUID, includeRelations []string, forUpdate bool) (*ExpectedMachine, error)
+	// LockForUpdate locks rows in canonical ID order for the transaction
+	LockForUpdate(ctx context.Context, tx *db.Tx, expectedMachineIDs []uuid.UUID) error
 }
 
 // ExpectedMachineSQLDAO is an implementation of the ExpectedMachineDAO interface
@@ -491,6 +494,63 @@ func (emsd ExpectedMachineSQLDAO) Get(ctx context.Context, tx *db.Tx, expectedMa
 	}
 
 	return em, nil
+}
+
+// LockForUpdate locks ExpectedMachine rows in canonical ID order until the
+// transaction completes. Batch writers call this before any row-specific
+// writes so later operations cannot acquire overlapping row sets in a
+// conflicting order.
+func (emsd ExpectedMachineSQLDAO) LockForUpdate(ctx context.Context, tx *db.Tx, expectedMachineIDs []uuid.UUID) error {
+	if tx == nil {
+		return errors.New("transaction is required to lock ExpectedMachine rows")
+	}
+	if len(expectedMachineIDs) == 0 {
+		return nil
+	}
+
+	ctx, expectedMachineDAOSpan := emsd.tracerSpan.CreateChildInCurrentContext(ctx, "ExpectedMachineDAO.LockForUpdate")
+	if expectedMachineDAOSpan != nil {
+		defer expectedMachineDAOSpan.End()
+		emsd.tracerSpan.SetAttribute(expectedMachineDAOSpan, "batch_size", len(expectedMachineIDs))
+	}
+
+	uniqueIDs := make([]uuid.UUID, 0, len(expectedMachineIDs))
+	seenIDs := make(map[uuid.UUID]struct{}, len(expectedMachineIDs))
+	for _, expectedMachineID := range expectedMachineIDs {
+		if _, seen := seenIDs[expectedMachineID]; seen {
+			continue
+		}
+		seenIDs[expectedMachineID] = struct{}{}
+		uniqueIDs = append(uniqueIDs, expectedMachineID)
+	}
+
+	var locked []ExpectedMachine
+	err := db.GetIDB(tx, emsd.dbSession).
+		NewSelect().
+		Model(&locked).
+		Column("id").
+		Where("em.id IN (?)", bun.In(uniqueIDs)).
+		OrderExpr("em.id ASC").
+		For("UPDATE").
+		Scan(ctx)
+	if err != nil {
+		return err
+	}
+	if len(locked) != len(uniqueIDs) {
+		lockedIDs := make(map[uuid.UUID]struct{}, len(locked))
+		for _, expectedMachine := range locked {
+			lockedIDs[expectedMachine.ID] = struct{}{}
+		}
+		missingIDs := make([]uuid.UUID, 0, len(uniqueIDs)-len(locked))
+		for _, expectedMachineID := range uniqueIDs {
+			if _, ok := lockedIDs[expectedMachineID]; !ok {
+				missingIDs = append(missingIDs, expectedMachineID)
+			}
+		}
+		return fmt.Errorf("ExpectedMachine rows %v were not found while locking: %w", missingIDs, db.ErrDoesNotExist)
+	}
+
+	return nil
 }
 
 // setQueryWithFilter populates the lookup query based on specified filter

--- a/rest-api/db/pkg/db/model/expectedmachine_test.go
+++ b/rest-api/db/pkg/db/model/expectedmachine_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1573,6 +1574,196 @@ func TestExpectedMachineSQLDAO_UpdateMultiple_MacSwap(t *testing.T) {
 	updatedEM2, err := emsd.Get(ctx, nil, em2.ID, nil, false)
 	assert.NoError(t, err)
 	assert.Equal(t, macAddress1, updatedEM2.BmcMacAddress, "em2 should now have em1's original MAC address")
+}
+
+func TestExpectedMachineSQLDAO_LockForUpdateSerializesOverlappingBatches(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testInitDB(t)
+	defer dbSession.Close()
+	testExpectedMachineSetupSchema(t, dbSession)
+
+	user := TestBuildUser(t, dbSession, "test-user", "test-org", []string{"admin"})
+	ip := TestBuildInfrastructureProvider(t, dbSession, "test-provider", "test-org", user)
+	site := TestBuildSite(t, dbSession, ip, "test-site", user)
+	emsd := NewExpectedMachineDAO(dbSession)
+
+	first, err := emsd.Create(ctx, nil, ExpectedMachineCreateInput{
+		ExpectedMachineID:   uuid.New(),
+		SiteID:              site.ID,
+		BmcMacAddress:       "AA:BB:CC:DD:EE:11",
+		ChassisSerialNumber: "CHASSIS-LOCK-001",
+		BmcIpAddress:        cutil.GetPtr("192.0.2.11"),
+		CreatedBy:           user.ID,
+	})
+	require.NoError(t, err)
+	second, err := emsd.Create(ctx, nil, ExpectedMachineCreateInput{
+		ExpectedMachineID:   uuid.New(),
+		SiteID:              site.ID,
+		BmcMacAddress:       "AA:BB:CC:DD:EE:12",
+		ChassisSerialNumber: "CHASSIS-LOCK-002",
+		BmcIpAddress:        cutil.GetPtr("192.0.2.12"),
+		CreatedBy:           user.ID,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	firstBatchName := "first-batch"
+	secondBatchName := "second-batch"
+	firstLocked := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- db.WithTx(ctx, dbSession, func(tx *db.Tx) error {
+			if err := emsd.LockForUpdate(ctx, tx, []uuid.UUID{second.ID, first.ID}); err != nil {
+				return err
+			}
+			close(firstLocked)
+			select {
+			case <-releaseFirst:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			if _, err := emsd.Clear(ctx, tx, ExpectedMachineClearInput{
+				ExpectedMachineID: second.ID,
+				BmcIpAddress:      true,
+			}); err != nil {
+				return err
+			}
+			_, err := emsd.UpdateMultiple(ctx, tx, []ExpectedMachineUpdateInput{
+				{ExpectedMachineID: second.ID, Name: &firstBatchName},
+				{ExpectedMachineID: first.ID, Name: &firstBatchName},
+			})
+			return err
+		})
+	}()
+
+	select {
+	case <-firstLocked:
+	case err := <-firstDone:
+		t.Fatalf("first transaction completed before acquiring its row locks: %v", err)
+	case <-ctx.Done():
+		firstErr := <-firstDone
+		t.Fatalf("timed out waiting for the first transaction to acquire its row locks: %v (transaction: %v)", ctx.Err(), firstErr)
+	}
+
+	secondStarted := make(chan struct{})
+	secondLockAcquired := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- db.WithTx(ctx, dbSession, func(tx *db.Tx) error {
+			close(secondStarted)
+			if err := emsd.LockForUpdate(ctx, tx, []uuid.UUID{first.ID, second.ID}); err != nil {
+				return err
+			}
+			close(secondLockAcquired)
+			if _, err := emsd.Clear(ctx, tx, ExpectedMachineClearInput{
+				ExpectedMachineID: first.ID,
+				BmcIpAddress:      true,
+			}); err != nil {
+				return err
+			}
+			_, err := emsd.UpdateMultiple(ctx, tx, []ExpectedMachineUpdateInput{
+				{ExpectedMachineID: first.ID, Name: &secondBatchName},
+				{ExpectedMachineID: second.ID, Name: &secondBatchName},
+			})
+			return err
+		})
+	}()
+	select {
+	case <-secondStarted:
+	case err := <-secondDone:
+		close(releaseFirst)
+		firstErr := <-firstDone
+		t.Fatalf("second transaction completed before attempting its canonical lock: %v (first transaction: %v)", err, firstErr)
+	case <-ctx.Done():
+		close(releaseFirst)
+		firstErr := <-firstDone
+		secondErr := <-secondDone
+		t.Fatalf(
+			"timed out waiting for the second transaction to attempt its canonical lock: %v (first transaction: %v, second transaction: %v)",
+			ctx.Err(),
+			firstErr,
+			secondErr,
+		)
+	}
+
+	// The second batch must wait at the full-row lock pass. If that lock returns
+	// before the first transaction completes, the partial-lock deadlock is
+	// possible again.
+	var secondErr error
+	secondFinishedEarly := false
+	secondLockAcquiredEarly := false
+	select {
+	case <-secondLockAcquired:
+		secondLockAcquiredEarly = true
+	case secondErr = <-secondDone:
+		secondFinishedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFirst)
+
+	require.NoError(t, <-firstDone)
+	if !secondFinishedEarly {
+		secondErr = <-secondDone
+	}
+	require.False(t, secondLockAcquiredEarly, "the competing batch should wait at the canonical lock pass")
+	require.False(t, secondFinishedEarly, "the competing batch should wait for the first transaction")
+	require.NoError(t, secondErr)
+
+	for _, expectedMachineID := range []uuid.UUID{first.ID, second.ID} {
+		stored, err := emsd.Get(ctx, nil, expectedMachineID, nil, false)
+		require.NoError(t, err)
+		assert.Nil(t, stored.BmcIpAddress)
+		assert.Equal(t, &secondBatchName, stored.Name)
+	}
+}
+
+func TestExpectedMachineSQLDAO_LockForUpdateErrors(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testInitDB(t)
+	defer dbSession.Close()
+	testExpectedMachineSetupSchema(t, dbSession)
+
+	emsd := NewExpectedMachineDAO(dbSession)
+	missingID := uuid.New()
+	tests := []struct {
+		name            string
+		lock            func() error
+		target          error
+		messageContains string
+	}{
+		{
+			name: "transaction is required",
+			lock: func() error {
+				return emsd.LockForUpdate(ctx, nil, []uuid.UUID{missingID})
+			},
+			messageContains: "transaction is required",
+		},
+		{
+			name: "missing row keeps typed error",
+			lock: func() error {
+				return db.WithTx(ctx, dbSession, func(tx *db.Tx) error {
+					return emsd.LockForUpdate(ctx, tx, []uuid.UUID{missingID})
+				})
+			},
+			target: db.ErrDoesNotExist,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.lock()
+			require.Error(t, err)
+			if test.target != nil {
+				require.ErrorIs(t, err, test.target)
+			}
+			if test.messageContains != "" {
+				require.ErrorContains(t, err, test.messageContains)
+			}
+		})
+	}
 }
 
 func TestExpectedMachineSQLDAO_UpdateMultiple(t *testing.T) {

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -2867,8 +2867,11 @@ func (DpuMode) EnumDescriptor() ([]byte, []int) {
 //   - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated address pinned as Static
 //     (never expires).
 //
-// Unset and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` both mean "use the default"
-// (AUTO), which preserves behavior for old clients that don't send the field.
+// On create, omission and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On
+// single and batch update, omission preserves the effective Host BMC policy,
+// while explicit `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` resets it to AUTO. On
+// replace-all, omission resets a legacy-only row to AUTO but preserves an
+// existing nested HostBmc policy that an older client cannot send.
 type BmcIpAllocationType int32
 
 const (
@@ -4500,9 +4503,9 @@ func (OperatingSystemType) EnumDescriptor() ([]byte, []int) {
 //
 // On create, missing and `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` mean Host. On
 // update, omission preserves the stored role, while explicit
-// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. Host BMC identity
-// remains on `ExpectedMachine.bmc_mac_address`. NVIDIA/infra-controller#4103
-// tracks adding its network settings to this same interface model.
+// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. A Host BMC entry
+// configures network allocation, while its identity remains on
+// `ExpectedMachine.bmc_mac_address`.
 type ExpectedInterfaceRole int32
 
 const (
@@ -4514,6 +4517,8 @@ const (
 	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_DPU_OS ExpectedInterfaceRole = 2
 	// DPU Redfish/BMC interface. Never primary.
 	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_DPU_BMC ExpectedInterfaceRole = 3
+	// Host Redfish/BMC interface. Never primary.
+	ExpectedInterfaceRole_EXPECTED_INTERFACE_ROLE_HOST_BMC ExpectedInterfaceRole = 4
 )
 
 // Enum value maps for ExpectedInterfaceRole.
@@ -4523,12 +4528,14 @@ var (
 		1: "EXPECTED_INTERFACE_ROLE_HOST",
 		2: "EXPECTED_INTERFACE_ROLE_DPU_OS",
 		3: "EXPECTED_INTERFACE_ROLE_DPU_BMC",
+		4: "EXPECTED_INTERFACE_ROLE_HOST_BMC",
 	}
 	ExpectedInterfaceRole_value = map[string]int32{
 		"EXPECTED_INTERFACE_ROLE_UNSPECIFIED": 0,
 		"EXPECTED_INTERFACE_ROLE_HOST":        1,
 		"EXPECTED_INTERFACE_ROLE_DPU_OS":      2,
 		"EXPECTED_INTERFACE_ROLE_DPU_BMC":     3,
+		"EXPECTED_INTERFACE_ROLE_HOST_BMC":    4,
 	}
 )
 
@@ -4560,20 +4567,26 @@ func (ExpectedInterfaceRole) EnumDescriptor() ([]byte, []int) {
 }
 
 // Controls how an expected interface receives and retains its IP address.
-// Missing and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` preserve legacy
-// behavior: `fixed_ip` implies `FIXED`, while its absence implies `DYNAMIC`.
+// On create, omission and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` use
+// legacy inference: `fixed_ip` implies `FIXED`; without one, Host BMC implies
+// `RETAINED` and every other role implies `DYNAMIC`. On single and batch update,
+// omission preserves a matching stored policy while `fixed_ip` presence is
+// unchanged; explicit `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` resets to
+// inference. New interfaces use create behavior.
 type ExpectedInterfaceIpAllocation int32
 
 const (
-	// Infer Fixed or Dynamic from whether `fixed_ip` is configured. For a legacy
-	// Host declaration, this does not opt into the fixed-address segment guard.
+	// Infer Fixed from `fixed_ip`. Without one, infer Retained for Host BMC and
+	// Dynamic for every other role. For a legacy Host declaration, this does not
+	// opt into the fixed-address segment guard.
 	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED ExpectedInterfaceIpAllocation = 0
 	// Use an expiring DHCP lease. The segment guard must match the relay's
 	// selected segment when configured.
 	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC ExpectedInterfaceIpAllocation = 1
-	// Reserve `fixed_ip`. Explicit Fixed, or a DPU role that infers Fixed,
-	// requires a configured managed prefix to contain the address. That prefix
-	// selects the segment, and the segment guard must match when configured.
+	// Reserve `fixed_ip`. Explicit Fixed, a DPU role that infers Fixed, or an
+	// inferred Host BMC policy with a segment guard requires a configured
+	// managed prefix to contain the address. That prefix selects the segment,
+	// and the segment guard must match when configured.
 	ExpectedInterfaceIpAllocation_EXPECTED_INTERFACE_IP_ALLOCATION_FIXED ExpectedInterfaceIpAllocation = 2
 	// Allocate through DHCP, then make the address Static for this interface
 	// row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The
@@ -35432,8 +35445,8 @@ type ExpectedHostNic struct {
 	// At most one Host interface per `ExpectedMachine` may set it to true; the
 	// other Host interfaces then become non-primary. False remains accepted for
 	// compatibility but does not replace that machine-wide selection. DPU OS
-	// interfaces are primary data interfaces and DPU BMC interfaces are
-	// non-primary; those roles must omit this field.
+	// interfaces are primary data interfaces, while DPU BMC and Host BMC
+	// interfaces are non-primary.
 	Primary *bool `protobuf:"varint,6,opt,name=primary,proto3,oneof" json:"primary,omitempty"`
 	// Optional guard for this interface's network segment type. An explicit
 	// allocation policy or DPU role applies the guard to DHCP-selected segments
@@ -35443,19 +35456,22 @@ type ExpectedHostNic struct {
 	// On update, omission clears this guard.
 	NetworkSegmentType *NetworkSegmentType `protobuf:"varint,7,opt,name=network_segment_type,json=networkSegmentType,proto3,enum=forge.NetworkSegmentType,oneof" json:"network_segment_type,omitempty"`
 	// Machine endpoint that owns this interface. The role selects interface type
-	// and primary behavior only; Host, DPU OS, and DPU BMC all accept the same
-	// allocation policies and optional segment guard. On create, missing and
-	// Unspecified mean Host. On update, omission preserves the stored role while
-	// explicit Unspecified resets it to Host.
+	// and primary behavior only; every role accepts the same allocation policies
+	// and optional segment guard. On create, missing and Unspecified mean Host.
+	// On update, omission preserves the stored role while explicit Unspecified
+	// resets it to Host.
 	Role *ExpectedInterfaceRole `protobuf:"varint,8,opt,name=role,proto3,enum=forge.ExpectedInterfaceRole,oneof" json:"role,omitempty"`
-	// Optional allocation policy. On create, missing and Unspecified infer Fixed
-	// from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
-	// stored policy while explicit Unspecified resets to that inference.
+	// Optional allocation policy. On create, omission and explicit Unspecified
+	// infer Fixed from `fixed_ip`. Without one, Host BMC infers Retained and every
+	// other role infers Dynamic. On single and batch update, omission preserves a
+	// matching stored policy while `fixed_ip` presence is unchanged; explicit
+	// Unspecified resets to inference. New interfaces use create behavior.
 	// Explicit Dynamic rejects `fixed_ip`. Explicit Fixed, or a DPU role that
 	// infers Fixed, requires `fixed_ip` inside a configured managed prefix. A
-	// legacy Host declaration with an omitted policy may instead fall back to
-	// `static-assignments` and does not turn `network_segment_type` into a
-	// fixed-address guard.
+	// legacy Host declaration, or an inferred Host BMC Fixed policy that omits
+	// `network_segment_type`, may instead fall back to `static-assignments`; only
+	// the legacy Host case leaves `network_segment_type` as a first-DHCP
+	// selection hint.
 	IpAllocation  *ExpectedInterfaceIpAllocation `protobuf:"varint,9,opt,name=ip_allocation,json=ipAllocation,proto3,enum=forge.ExpectedInterfaceIpAllocation,oneof" json:"ip_allocation,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -35614,7 +35630,10 @@ type ExpectedMachine struct {
 	Metadata *Metadata `protobuf:"bytes,6,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	SkuId    *string   `protobuf:"bytes,7,opt,name=sku_id,json=skuId,proto3,oneof" json:"sku_id,omitempty"`
 	// Unique identifier for the expected machine. When omitted, server generates one.
-	Id                              *UUID              `protobuf:"bytes,8,opt,name=id,proto3,oneof" json:"id,omitempty"`
+	Id *UUID `protobuf:"bytes,8,opt,name=id,proto3,oneof" json:"id,omitempty"`
+	// Expected interfaces. Top-level BMC fields preserve legacy-only storage
+	// and remain overrides for the effective Host BMC; a Host BMC entry appears
+	// here once it is configured through the nested interface model.
 	HostNics                        []*ExpectedHostNic `protobuf:"bytes,9,rep,name=host_nics,json=hostNics,proto3" json:"host_nics,omitempty"`
 	RackId                          *RackId            `protobuf:"bytes,10,opt,name=rack_id,json=rackId,proto3,oneof" json:"rack_id,omitempty"`
 	DefaultPauseIngestionAndPoweron *bool              `protobuf:"varint,11,opt,name=default_pause_ingestion_and_poweron,json=defaultPauseIngestionAndPoweron,proto3,oneof" json:"default_pause_ingestion_and_poweron,omitempty"`
@@ -35624,7 +35643,10 @@ type ExpectedMachine struct {
 	DpfEnabled   bool  `protobuf:"varint,12,opt,name=dpf_enabled,json=dpfEnabled,proto3" json:"dpf_enabled,omitempty"`
 	IsDpfEnabled *bool `protobuf:"varint,13,opt,name=is_dpf_enabled,json=isDpfEnabled,proto3,oneof" json:"is_dpf_enabled,omitempty"`
 	// Static BMC IP (optional). Pre-allocates a machine_interface like expected
-	// switches and power shelves; external IPs use the static-assignments segment.
+	// switches and power shelves; external IPs use the static-assignments
+	// segment. Single and batch update omission preserves the effective Host BMC
+	// setting; an explicit empty string clears it. Replace-all keeps its earlier
+	// replacement semantics for legacy-only rows.
 	BmcIpAddress *string `protobuf:"bytes,14,opt,name=bmc_ip_address,json=bmcIpAddress,proto3,oneof" json:"bmc_ip_address,omitempty"`
 	// When true, site-explorer skips BMC password rotation and stores the
 	// factory-default credentials in Vault as-is.
@@ -35637,8 +35659,18 @@ type ExpectedMachine struct {
 	// existing DB value is preserved via COALESCE.
 	HostLifecycleProfile *HostLifecycleProfile `protobuf:"bytes,17,opt,name=host_lifecycle_profile,json=hostLifecycleProfile,proto3,oneof" json:"host_lifecycle_profile,omitempty"`
 	// Per-host control over how this BMC's IP is assigned and retained. See
-	// `BmcIpAllocationType` above. Unset means "use the default" (AUTO).
+	// `BmcIpAllocationType` above. On create, omission and explicit
+	// `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On single and batch update,
+	// omission preserves the effective Host BMC policy, while explicit
+	// Unspecified resets it to AUTO. On replace-all, omission resets a
+	// legacy-only row to AUTO but preserves an existing nested HostBmc policy.
 	BmcIpAllocation *BmcIpAllocationType `protobuf:"varint,18,opt,name=bmc_ip_allocation,json=bmcIpAllocation,proto3,enum=forge.BmcIpAllocationType,oneof" json:"bmc_ip_allocation,omitempty"`
+	// Marks host_nics as a complete replacement. This is needed because a
+	// repeated protobuf field cannot distinguish an omitted list from an empty
+	// list. New update clients set this when they intentionally supply
+	// host_nics, including `[]`; older clients leave it false so an unknown
+	// nested HostBmc is not removed by a read-modify-write.
+	ReplaceHostNics bool `protobuf:"varint,19,opt,name=replace_host_nics,json=replaceHostNics,proto3" json:"replace_host_nics,omitempty"`
 	// WARNING: Following fields are not present in Core, but added directly in REST snapshot
 	Name            *string `protobuf:"bytes,21,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	Manufacturer    *string `protobuf:"bytes,22,opt,name=manufacturer,proto3,oneof" json:"manufacturer,omitempty"`
@@ -35807,6 +35839,13 @@ func (x *ExpectedMachine) GetBmcIpAllocation() BmcIpAllocationType {
 		return *x.BmcIpAllocation
 	}
 	return BmcIpAllocationType_BMC_IP_ALLOCATION_TYPE_UNSPECIFIED
+}
+
+func (x *ExpectedMachine) GetReplaceHostNics() bool {
+	if x != nil {
+		return x.ReplaceHostNics
+	}
+	return false
 }
 
 func (x *ExpectedMachine) GetName() string {
@@ -65037,7 +65076,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x0e_ip_allocation\"[\n" +
 	"\x14HostLifecycleProfile\x12.\n" +
 	"\x10disable_lockdown\x18\x01 \x01(\bH\x00R\x0fdisableLockdown\x88\x01\x01B\x13\n" +
-	"\x11_disable_lockdown\"\xe2\v\n" +
+	"\x11_disable_lockdown\"\x8e\f\n" +
 	"\x0fExpectedMachine\x12&\n" +
 	"\x0fbmc_mac_address\x18\x01 \x01(\tR\rbmcMacAddress\x12!\n" +
 	"\fbmc_username\x18\x02 \x01(\tR\vbmcUsername\x12!\n" +
@@ -65058,7 +65097,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x16bmc_retain_credentials\x18\x0f \x01(\bH\x06R\x14bmcRetainCredentials\x88\x01\x01\x12.\n" +
 	"\bdpu_mode\x18\x10 \x01(\x0e2\x0e.forge.DpuModeH\aR\adpuMode\x88\x01\x01\x12V\n" +
 	"\x16host_lifecycle_profile\x18\x11 \x01(\v2\x1b.forge.HostLifecycleProfileH\bR\x14hostLifecycleProfile\x88\x01\x01\x12K\n" +
-	"\x11bmc_ip_allocation\x18\x12 \x01(\x0e2\x1a.forge.BmcIpAllocationTypeH\tR\x0fbmcIpAllocation\x88\x01\x01\x12\x17\n" +
+	"\x11bmc_ip_allocation\x18\x12 \x01(\x0e2\x1a.forge.BmcIpAllocationTypeH\tR\x0fbmcIpAllocation\x88\x01\x01\x12*\n" +
+	"\x11replace_host_nics\x18\x13 \x01(\bR\x0freplaceHostNics\x12\x17\n" +
 	"\x04name\x18\x15 \x01(\tH\n" +
 	"R\x04name\x88\x01\x01\x12'\n" +
 	"\fmanufacturer\x18\x16 \x01(\tH\vR\fmanufacturer\x88\x01\x01\x12\x19\n" +
@@ -67680,12 +67720,13 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x13OperatingSystemType\x12\x17\n" +
 	"\x13OS_TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fOS_TYPE_IPXE\x10\x01\x12\x1a\n" +
-	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x02*\xab\x01\n" +
+	"\x16OS_TYPE_TEMPLATED_IPXE\x10\x02*\xd1\x01\n" +
 	"\x15ExpectedInterfaceRole\x12'\n" +
 	"#EXPECTED_INTERFACE_ROLE_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cEXPECTED_INTERFACE_ROLE_HOST\x10\x01\x12\"\n" +
 	"\x1eEXPECTED_INTERFACE_ROLE_DPU_OS\x10\x02\x12#\n" +
-	"\x1fEXPECTED_INTERFACE_ROLE_DPU_BMC\x10\x03*\xda\x01\n" +
+	"\x1fEXPECTED_INTERFACE_ROLE_DPU_BMC\x10\x03\x12$\n" +
+	" EXPECTED_INTERFACE_ROLE_HOST_BMC\x10\x04*\xda\x01\n" +
 	"\x1dExpectedInterfaceIpAllocation\x120\n" +
 	",EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED\x10\x00\x12,\n" +
 	"(EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC\x10\x01\x12*\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -6178,8 +6178,8 @@ message ExpectedHostNic {
   // At most one Host interface per `ExpectedMachine` may set it to true; the
   // other Host interfaces then become non-primary. False remains accepted for
   // compatibility but does not replace that machine-wide selection. DPU OS
-  // interfaces are primary data interfaces and DPU BMC interfaces are
-  // non-primary; those roles must omit this field.
+  // interfaces are primary data interfaces, while DPU BMC and Host BMC
+  // interfaces are non-primary.
   optional bool primary = 6;
   // Optional guard for this interface's network segment type. An explicit
   // allocation policy or DPU role applies the guard to DHCP-selected segments
@@ -6189,19 +6189,22 @@ message ExpectedHostNic {
   // On update, omission clears this guard.
   optional NetworkSegmentType network_segment_type = 7;
   // Machine endpoint that owns this interface. The role selects interface type
-  // and primary behavior only; Host, DPU OS, and DPU BMC all accept the same
-  // allocation policies and optional segment guard. On create, missing and
-  // Unspecified mean Host. On update, omission preserves the stored role while
-  // explicit Unspecified resets it to Host.
+  // and primary behavior only; every role accepts the same allocation policies
+  // and optional segment guard. On create, missing and Unspecified mean Host.
+  // On update, omission preserves the stored role while explicit Unspecified
+  // resets it to Host.
   optional ExpectedInterfaceRole role = 8;
-  // Optional allocation policy. On create, missing and Unspecified infer Fixed
-  // from `fixed_ip` and Dynamic otherwise. On update, omission preserves the
-  // stored policy while explicit Unspecified resets to that inference.
+  // Optional allocation policy. On create, omission and explicit Unspecified
+  // infer Fixed from `fixed_ip`. Without one, Host BMC infers Retained and every
+  // other role infers Dynamic. On single and batch update, omission preserves a
+  // matching stored policy while `fixed_ip` presence is unchanged; explicit
+  // Unspecified resets to inference. New interfaces use create behavior.
   // Explicit Dynamic rejects `fixed_ip`. Explicit Fixed, or a DPU role that
   // infers Fixed, requires `fixed_ip` inside a configured managed prefix. A
-  // legacy Host declaration with an omitted policy may instead fall back to
-  // `static-assignments` and does not turn `network_segment_type` into a
-  // fixed-address guard.
+  // legacy Host declaration, or an inferred Host BMC Fixed policy that omits
+  // `network_segment_type`, may instead fall back to `static-assignments`; only
+  // the legacy Host case leaves `network_segment_type` as a first-DHCP
+  // selection hint.
   optional ExpectedInterfaceIpAllocation ip_allocation = 9;
 }
 
@@ -6237,8 +6240,11 @@ enum DpuMode {
 // - BMC_IP_ALLOCATION_TYPE_RETAINED: an auto-allocated address pinned as Static
 //   (never expires).
 //
-// Unset and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` both mean "use the default"
-// (AUTO), which preserves behavior for old clients that don't send the field.
+// On create, omission and `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On
+// single and batch update, omission preserves the effective Host BMC policy,
+// while explicit `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` resets it to AUTO. On
+// replace-all, omission resets a legacy-only row to AUTO but preserves an
+// existing nested HostBmc policy that an older client cannot send.
 enum BmcIpAllocationType {
   BMC_IP_ALLOCATION_TYPE_UNSPECIFIED = 0;
   BMC_IP_ALLOCATION_TYPE_AUTO = 1;
@@ -6267,6 +6273,9 @@ message ExpectedMachine {
   optional string sku_id =  7;
   // Unique identifier for the expected machine. When omitted, server generates one.
   optional common.UUID id = 8;
+  // Expected interfaces. Top-level BMC fields preserve legacy-only storage
+  // and remain overrides for the effective Host BMC; a Host BMC entry appears
+  // here once it is configured through the nested interface model.
   repeated ExpectedHostNic host_nics = 9;
   optional common.RackId rack_id = 10;
   optional bool default_pause_ingestion_and_poweron = 11;
@@ -6274,7 +6283,10 @@ message ExpectedMachine {
   bool dpf_enabled = 12 [deprecated = true];
   optional bool is_dpf_enabled = 13;
   // Static BMC IP (optional). Pre-allocates a machine_interface like expected
-  // switches and power shelves; external IPs use the static-assignments segment.
+  // switches and power shelves; external IPs use the static-assignments
+  // segment. Single and batch update omission preserves the effective Host BMC
+  // setting; an explicit empty string clears it. Replace-all keeps its earlier
+  // replacement semantics for legacy-only rows.
   optional string bmc_ip_address = 14;
   // When true, site-explorer skips BMC password rotation and stores the
   // factory-default credentials in Vault as-is.
@@ -6287,8 +6299,18 @@ message ExpectedMachine {
   // existing DB value is preserved via COALESCE.
   optional HostLifecycleProfile host_lifecycle_profile = 17;
   // Per-host control over how this BMC's IP is assigned and retained. See
-  // `BmcIpAllocationType` above. Unset means "use the default" (AUTO).
+  // `BmcIpAllocationType` above. On create, omission and explicit
+  // `BMC_IP_ALLOCATION_TYPE_UNSPECIFIED` mean AUTO. On single and batch update,
+  // omission preserves the effective Host BMC policy, while explicit
+  // Unspecified resets it to AUTO. On replace-all, omission resets a
+  // legacy-only row to AUTO but preserves an existing nested HostBmc policy.
   optional BmcIpAllocationType bmc_ip_allocation = 18;
+  // Marks host_nics as a complete replacement. This is needed because a
+  // repeated protobuf field cannot distinguish an omitted list from an empty
+  // list. New update clients set this when they intentionally supply
+  // host_nics, including `[]`; older clients leave it false so an unknown
+  // nested HostBmc is not removed by a read-modify-write.
+  bool replace_host_nics = 19;
 
   // WARNING: Following fields are not present in Core, but added directly in REST snapshot
   optional string name = 21;
@@ -9171,9 +9193,9 @@ enum OperatingSystemType {
 //
 // On create, missing and `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` mean Host. On
 // update, omission preserves the stored role, while explicit
-// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. Host BMC identity
-// remains on `ExpectedMachine.bmc_mac_address`. NVIDIA/infra-controller#4103
-// tracks adding its network settings to this same interface model.
+// `EXPECTED_INTERFACE_ROLE_UNSPECIFIED` resets it to Host. A Host BMC entry
+// configures network allocation, while its identity remains on
+// `ExpectedMachine.bmc_mac_address`.
 enum ExpectedInterfaceRole {
   // Preserve the legacy Host role when the optional field is absent.
   EXPECTED_INTERFACE_ROLE_UNSPECIFIED = 0;
@@ -9183,21 +9205,29 @@ enum ExpectedInterfaceRole {
   EXPECTED_INTERFACE_ROLE_DPU_OS = 2;
   // DPU Redfish/BMC interface. Never primary.
   EXPECTED_INTERFACE_ROLE_DPU_BMC = 3;
+  // Host Redfish/BMC interface. Never primary.
+  EXPECTED_INTERFACE_ROLE_HOST_BMC = 4;
 }
 
 // Controls how an expected interface receives and retains its IP address.
-// Missing and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` preserve legacy
-// behavior: `fixed_ip` implies `FIXED`, while its absence implies `DYNAMIC`.
+// On create, omission and `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` use
+// legacy inference: `fixed_ip` implies `FIXED`; without one, Host BMC implies
+// `RETAINED` and every other role implies `DYNAMIC`. On single and batch update,
+// omission preserves a matching stored policy while `fixed_ip` presence is
+// unchanged; explicit `EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED` resets to
+// inference. New interfaces use create behavior.
 enum ExpectedInterfaceIpAllocation {
-  // Infer Fixed or Dynamic from whether `fixed_ip` is configured. For a legacy
-  // Host declaration, this does not opt into the fixed-address segment guard.
+  // Infer Fixed from `fixed_ip`. Without one, infer Retained for Host BMC and
+  // Dynamic for every other role. For a legacy Host declaration, this does not
+  // opt into the fixed-address segment guard.
   EXPECTED_INTERFACE_IP_ALLOCATION_UNSPECIFIED = 0;
   // Use an expiring DHCP lease. The segment guard must match the relay's
   // selected segment when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_DYNAMIC = 1;
-  // Reserve `fixed_ip`. Explicit Fixed, or a DPU role that infers Fixed,
-  // requires a configured managed prefix to contain the address. That prefix
-  // selects the segment, and the segment guard must match when configured.
+  // Reserve `fixed_ip`. Explicit Fixed, a DPU role that infers Fixed, or an
+  // inferred Host BMC policy with a segment guard requires a configured
+  // managed prefix to contain the address. That prefix selects the segment,
+  // and the segment guard must match when configured.
   EXPECTED_INTERFACE_IP_ALLOCATION_FIXED = 2;
   // Allocate through DHCP, then make the address Static for this interface
   // row's lifetime. It is not saved in ExpectedMachine for re-ingestion. The


### PR DESCRIPTION
This is a continuation of the work from https://github.com/NVIDIA/infra-controller/pull/3991. Host BMC address policy has historically lived in the top-level `bmc_*` fields, while `Host`, `DpuOs`, and `DpuBmc` now use the shared expected-interface path. This adds `HostBmc` to that path without making existing configurations or older clients understand the new role.

- `HostBmc` supports `Dynamic`, `Fixed`, and `Retained` allocation with the same optional `network_segment_type` guard.
- Nested and mixed requests write the normalized HostBmc settings to `host_nics` and mirror the IP/allocation into the existing BMC columns.
- Legacy-only rows stay in their old storage and wire form, while DHCP and Site Explorer derive the matching interface in memory.
- Top-level BMC IP/allocation fields remain overrides, including clear/reset and replace-all behavior.
- CLI updates distinguish an omitted `host_nics` field from an explicit empty list. Older writers still preserve nested data they do not understand; an explicit `[]` now removes it.
- When historical `DpuOs` configuration reuses the top-level BMC MAC, the BMC identity takes precedence when Site Explorer decides whether to scan the interface.
- The existing `static-assignments` fallback stays in place when HostBmc Fixed is inferred without a segment guard; explicit or guarded Fixed configuration must resolve inside a managed prefix.
- There is no database migration or backfill here, and reservation transition cleanup remains tracked by #4187.

Tests added!

## Configuration examples

Expected Machine manifests are JSON arrays today, so these examples use the current `expected_machines.json` input rather than TOML.

Existing top-level BMC configuration continues to work without a nested `HostBmc`:

```json
[
  {
    "bmc_mac_address": "02:00:00:00:00:01",
    "bmc_username": "root",
    "bmc_password": "default-password",
    "chassis_serial_number": "SERIAL-1",
    "bmc_ip_address": "192.0.2.20",
    "bmc_ip_allocation": "fixed"
  }
]
```

The same BMC can use Retained allocation through `host_nics`. Its MAC must match the top-level `bmc_mac_address`:

```json
[
  {
    "bmc_mac_address": "02:00:00:00:00:01",
    "bmc_username": "root",
    "bmc_password": "default-password",
    "chassis_serial_number": "SERIAL-1",
    "host_nics": [
      {
        "mac_address": "02:00:00:00:00:01",
        "role": "host_bmc",
        "ip_allocation": "retained"
      }
    ]
  }
]
```

Fixed allocation can derive the segment from the configured prefix containing `fixed_ip`. An optional `network_segment_type` acts as an additional guard:

```json
[
  {
    "bmc_mac_address": "02:00:00:00:00:01",
    "bmc_username": "root",
    "bmc_password": "default-password",
    "chassis_serial_number": "SERIAL-1",
    "host_nics": [
      {
        "mac_address": "02:00:00:00:00:01",
        "role": "host_bmc",
        "ip_allocation": "fixed",
        "fixed_ip": "192.0.2.20",
        "network_segment_type": "admin"
      }
    ]
  }
]
```

`Dynamic` and `Retained` omit `fixed_ip`. A nested `HostBmc` cannot set `primary = true`, and credentials remain at the ExpectedMachine level.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4103

Part of #3491.

Reservation transition cleanup remains tracked in #4187. The public `ExpectedInterface` / `interfaces` rename remains tracked in #4104, and the docs-only update remains tracked in #4151.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

Existing top-level fields, legacy-only storage, old-client reads, and allocation inference remain in place. The request marker is additive, stays out of serialized CLI reads, and defaults to legacy preservation for older writers. There is no database migration or required configuration change.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo make format-nightly`
- `cargo make check-format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- 399 API model tests
- 160 RPC model tests
- 401 admin CLI tests
- 52 Site Explorer tests
- Database-backed six-case authoritative replacement matrix plus legacy omission coverage
- Focused DHCP and Site Explorer HostBmc regressions
- REST ExpectedMachine handler compile, deterministic lock-order regression, and DAO error-contract coverage
- `go test ./proto/core/...`
- Two REST protobuf generation passes with identical generated-file hashes
- CodeRabbit CLI, Claude, and independent read-only reviews; all valid findings addressed

The database-backed Go handler tests were not available locally because their PostgreSQL service was not running on `localhost:30432`; the handler test package still compiled successfully.

## Additional Notes

- Legacy-only rows are not rewritten or sent a `HostBmc` enum value on reads, so older clients can continue serializing the response.
- Nested and mixed inputs keep `host_nics` JSONB and the existing BMC compatibility columns synchronized.
- Existing conflicting rows that predate `HostBmc` remain updateable when the conflicting declaration is unchanged. Site Explorer gives the top-level BMC identity scan precedence so those rows can still be ingested.
- This PR intentionally keeps the `ExpectedHostNic` and `host_nics` names. Their compatibility-preserving rename is separate work under #4104.
- No files under `docs/` are included; the docs-only work remains under #4151.

Closes #4103
