### PR TITLE
refactor: accept explicit host boot targets

### DIFF
--- a/crates/machine-controller/src/boot_interface.rs
+++ b/crates/machine-controller/src/boot_interface.rs
@@ -95,6 +95,21 @@ pub enum BootInterfaceResolution {
     Missing,
 }
 
+impl BootInterfaceResolution {
+    /// Convert this resolution for BIOS paths that preserve an untargeted
+    /// Redfish fallback when no interface is usable.
+    ///
+    /// This intentionally erases the distinction between `AwaitingNic` and
+    /// `Missing`. Callers that must wait or fault retain and match the full
+    /// resolution instead.
+    pub(crate) fn into_target(self) -> Option<BootInterfaceTarget> {
+        match self {
+            Self::Ready(target) => Some(target),
+            Self::AwaitingNic | Self::Missing => None,
+        }
+    }
+}
+
 /// Resolve this host's boot interface for a Redfish boot step, classifying a
 /// missing one as either "wait for the NIC" (zero-DPU) or "fault".
 pub fn resolve_boot_interface(
@@ -218,5 +233,17 @@ mod tests {
             classify_boot_interface(Some(target), false),
             BootInterfaceResolution::Ready(_)
         ));
+    }
+
+    #[test]
+    fn only_ready_resolution_exposes_a_target() {
+        let target = BootInterfaceTarget::MacOnly(MacAddress::new([0, 0, 0, 0, 0, 1]));
+        for (resolution, expected) in [
+            (BootInterfaceResolution::Ready(target.clone()), Some(target)),
+            (BootInterfaceResolution::AwaitingNic, None),
+            (BootInterfaceResolution::Missing, None),
+        ] {
+            assert_eq!(resolution.into_target(), expected);
+        }
     }
 }

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1507,7 +1507,7 @@ impl MachineStateHandler {
                                 set_boot_order_info: Some(initial_set_boot_order_info()),
                             },
                         };
-                        handle_bios_setup_failed_recovery(ctx, mh_snapshot, recovered).await
+                        handle_bios_setup_failed_recovery(ctx, mh_snapshot, None, recovered).await
                     }
                     _ => {
                         // Do nothing.
@@ -3430,6 +3430,7 @@ async fn handle_dpu_reprovision_host_boot_config_check(
         state,
         reachability_params,
         dpu_freshness,
+        None,
         ctx,
     )
     .await?
@@ -3478,6 +3479,7 @@ async fn handle_dpu_reprovision_host_boot_config_stage(
         reachability_params,
         redfish_client.as_ref(),
         state,
+        None,
         stage,
     )
     .await?
@@ -3575,6 +3577,24 @@ async fn load_boot_predictions(
     let predictions =
         db::predicted_machine_interface::find_by_machine_id(&mut conn, machine_id).await?;
     Ok(predictions)
+}
+
+/// Resolve one boot-config step from either its explicit target or current
+/// interface state.
+///
+/// An explicit target is complete input, so resolving it does not require
+/// reading mutable prediction rows.
+async fn resolve_boot_interface_for_step(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    explicit_target: Option<&BootInterfaceTarget>,
+) -> Result<BootInterfaceResolution, StateHandlerError> {
+    if let Some(target) = explicit_target {
+        return Ok(BootInterfaceResolution::Ready(target.clone()));
+    }
+
+    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    Ok(resolve_boot_interface(mh_snapshot, &predictions))
 }
 
 // Returns true if update_manager flagged this managed host as needing its firmware examined
@@ -4927,31 +4947,15 @@ enum RequiredBootInterface<W> {
     Wait(W),
 }
 
-/// Resolve the boot NIC for a Redfish boot step, folding the not-ready cases
-/// every caller handles the same way: a zero-DPU host that has not discovered
-/// its boot NIC yet maps to the caller's wait outcome (`wait` wraps the shared
-/// message; `activity` names the blocked step), and a host with no resolvable
-/// interface is a hard error. Keeps the boot-order substates and host boot
-/// repair resolving the boot NIC identically.
+/// Map a boot-interface resolution for Redfish steps that require a target.
+///
+/// A zero-DPU host that has not discovered its boot NIC maps to the caller's
+/// wait outcome (`wait` wraps the shared message and `activity` names the
+/// blocked step). A host that should already have an interface returns an
+/// error.
 fn require_boot_interface<W>(
-    mh_snapshot: &ManagedHostStateSnapshot,
-    predictions: &[PredictedMachineInterface],
-    activity: &str,
-    wait: impl FnOnce(String) -> W,
-) -> Result<RequiredBootInterface<W>, StateHandlerError> {
-    map_boot_interface_resolution(
-        resolve_boot_interface(mh_snapshot, predictions),
-        &mh_snapshot.host_snapshot.id,
-        activity,
-        wait,
-    )
-}
-
-/// The mapping behind [`require_boot_interface`], split out from the snapshot
-/// lookup so it can be unit-tested directly.
-fn map_boot_interface_resolution<W>(
-    resolution: BootInterfaceResolution,
     host_id: &MachineId,
+    resolution: BootInterfaceResolution,
     activity: &str,
     wait: impl FnOnce(String) -> W,
 ) -> Result<RequiredBootInterface<W>, StateHandlerError> {
@@ -4980,9 +4984,9 @@ mod require_boot_interface_tests {
     #[test]
     fn ready_passes_the_target_through() {
         let target = BootInterfaceTarget::MacOnly("20:00:00:00:00:01".parse().unwrap());
-        let resolved = map_boot_interface_resolution::<String>(
-            BootInterfaceResolution::Ready(target.clone()),
+        let resolved = require_boot_interface::<String>(
             &host_id(),
+            BootInterfaceResolution::Ready(target.clone()),
             "setting boot order",
             |msg| msg,
         )
@@ -4997,9 +5001,9 @@ mod require_boot_interface_tests {
     // message with the caller's activity spliced in.
     #[test]
     fn awaiting_nic_maps_to_the_callers_wait_outcome() {
-        let resolved = map_boot_interface_resolution::<String>(
-            BootInterfaceResolution::AwaitingNic,
+        let resolved = require_boot_interface::<String>(
             &host_id(),
+            BootInterfaceResolution::AwaitingNic,
             "setting boot order",
             |msg| msg,
         )
@@ -5019,9 +5023,9 @@ mod require_boot_interface_tests {
     // Missing is a hard error, not a wait.
     #[test]
     fn missing_is_a_hard_error() {
-        let err = map_boot_interface_resolution::<String>(
-            BootInterfaceResolution::Missing,
+        let err = require_boot_interface::<String>(
             &host_id(),
+            BootInterfaceResolution::Missing,
             "setting boot order",
             |msg| msg,
         )
@@ -5398,8 +5402,15 @@ async fn handle_host_init_boot_config_stage(
     redfish_client: &dyn Redfish,
     stage: HostBootConfigStage,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    match run_host_boot_config_stage(ctx, reachability_params, redfish_client, mh_snapshot, stage)
-        .await?
+    match run_host_boot_config_stage(
+        ctx,
+        reachability_params,
+        redfish_client,
+        mh_snapshot,
+        None,
+        stage,
+    )
+    .await?
     {
         HostBootConfigOutcome::Continue(stage) => {
             let machine_state = match stage {
@@ -7191,7 +7202,7 @@ impl StateHandler for InstanceStateHandler {
                                     },
                             },
                         };
-                        handle_bios_setup_failed_recovery(ctx, mh_snapshot, recovered).await
+                        handle_bios_setup_failed_recovery(ctx, mh_snapshot, None, recovered).await
                     }
                     _ => {
                         // Only way to proceed for other causes is to
@@ -11008,8 +11019,15 @@ async fn handle_instance_host_boot_config_stage(
     redfish_client: &dyn Redfish,
     stage: HostBootConfigStage,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    match run_host_boot_config_stage(ctx, reachability_params, redfish_client, mh_snapshot, stage)
-        .await?
+    match run_host_boot_config_stage(
+        ctx,
+        reachability_params,
+        redfish_client,
+        mh_snapshot,
+        None,
+        stage,
+    )
+    .await?
     {
         HostBootConfigOutcome::Continue(stage) => {
             let platform_config_state = match stage {
@@ -11292,6 +11310,7 @@ async fn handle_instance_host_platform_config(
                 mh_snapshot,
                 reachability_params,
                 HostBootConfigDpuFreshness::CurrentHostState,
+                None,
                 ctx,
             )
             .await?
@@ -11409,9 +11428,11 @@ async fn set_host_boot_order(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    explicit_target: Option<&BootInterfaceTarget>,
     set_boot_order_info: SetBootOrderInfo,
 ) -> Result<SetBootOrderOutcome, StateHandlerError> {
-    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    let boot_interface_resolution =
+        resolve_boot_interface_for_step(ctx, mh_snapshot, explicit_target).await?;
     match set_boot_order_info.set_boot_order_state {
         SetBootOrderState::SetBootOrder => {
             // There used to be a `force_dpu_nic_mode`-gated short-circuit
@@ -11432,8 +11453,8 @@ async fn set_host_boot_order(
             // resolves via its predictions; it waits only when neither a real row
             // nor a usable prediction exists.
             let boot_interface = match require_boot_interface(
-                mh_snapshot,
-                &predictions,
+                &mh_snapshot.host_snapshot.id,
+                boot_interface_resolution,
                 "setting boot order",
                 SetBootOrderOutcome::Wait,
             )? {
@@ -11572,8 +11593,8 @@ async fn set_host_boot_order(
             const MAX_HTTP_BOOT_DEVICE_APPLY_RETRIES: u32 = 3;
 
             let boot_interface = match require_boot_interface(
-                mh_snapshot,
-                &predictions,
+                &mh_snapshot.host_snapshot.id,
+                boot_interface_resolution,
                 "verifying the re-asserted HTTP boot device",
                 SetBootOrderOutcome::Wait,
             )? {
@@ -11882,8 +11903,8 @@ async fn set_host_boot_order(
                 .max_bios_config_retries;
 
             let boot_interface = match require_boot_interface(
-                mh_snapshot,
-                &predictions,
+                &mh_snapshot.host_snapshot.id,
+                boot_interface_resolution,
                 "verifying boot order",
                 SetBootOrderOutcome::Wait,
             )? {

--- a/crates/machine-controller/src/handler/bios_config.rs
+++ b/crates/machine-controller/src/handler/bios_config.rs
@@ -17,6 +17,7 @@
 
 //! BIOS configuration: machine_setup, Dell job wait/recovery, and PollingBiosSetup escalation.
 
+use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_error;
 use chrono::Utc;
 use eyre::eyre;
@@ -24,7 +25,6 @@ use libredfish::{Redfish, SystemPowerControl};
 use model::machine::{
     BiosConfigInfo, BiosConfigState, ManagedHostState, ManagedHostStateSnapshot, PowerState,
 };
-use model::predicted_machine_interface::PredictedMachineInterface;
 use state_controller::state_handler::{
     StateHandlerContext, StateHandlerError, StateHandlerOutcome,
 };
@@ -33,7 +33,6 @@ use super::{
     ReachabilityParams, RebootStatus, call_machine_setup_and_handle_no_dpu_error,
     handler_host_power_control, trigger_reboot_if_needed,
 };
-use crate::boot_interface::boot_interface_target;
 use crate::config::MachineStateControllerConfig;
 use crate::context::MachineStateHandlerContextObjects;
 
@@ -89,14 +88,12 @@ pub(super) async fn configure_host_bios(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    boot_interface: Option<&BootInterfaceTarget>,
     retry_count: u32,
 ) -> Result<BiosConfigOutcome, StateHandlerError> {
-    let predictions = super::load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
-    let boot_interface = boot_interface_target(mh_snapshot, &predictions);
-
     let bios_job_id = match call_machine_setup_and_handle_no_dpu_error(
         redfish_client,
-        boot_interface.as_ref(),
+        boot_interface,
         mh_snapshot.host_snapshot.associated_dpu_machine_ids().len(),
         &ctx.services.site_config,
     )
@@ -397,12 +394,11 @@ pub(super) async fn advance_polling_bios_setup(
     mh_snapshot: &ManagedHostStateSnapshot,
     retry_count: u32,
     machine_controller_config: &MachineStateControllerConfig,
-    predictions: &[PredictedMachineInterface],
+    boot_interface: Option<&BootInterfaceTarget>,
 ) -> Result<PollingBiosSetupOutcome, StateHandlerError> {
-    let boot_interface = boot_interface_target(mh_snapshot, predictions);
     let stuck_for = mh_snapshot.host_snapshot.state.version.since_state_change();
 
-    let is_bios_setup_result = match &boot_interface {
+    let is_bios_setup_result = match boot_interface {
         Some(target) => {
             target
                 .run(|bi| redfish_client.is_bios_setup(Some(bi)))
@@ -474,10 +470,12 @@ fn escalate_stuck_polling_bios_setup(
 pub(super) async fn handle_bios_setup_failed_recovery(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     mh_snapshot: &ManagedHostStateSnapshot,
+    explicit_target: Option<&BootInterfaceTarget>,
     recovered_state: ManagedHostState,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let predictions = super::load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
-    let boot_interface = boot_interface_target(mh_snapshot, &predictions);
+    let boot_interface =
+        super::resolve_boot_interface_for_step(ctx, mh_snapshot, explicit_target).await?;
+    let boot_interface = boot_interface.into_target();
     let redfish_client = ctx
         .services
         .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)

--- a/crates/machine-controller/src/handler/host_boot_config.rs
+++ b/crates/machine-controller/src/handler/host_boot_config.rs
@@ -44,8 +44,9 @@ use super::bios_config::{
 };
 use super::{
     ReachabilityParams, RequiredBootInterface, SetBootOrderOutcome,
-    are_dpus_up_trigger_reboot_if_needed, is_dpu_observed_since, load_boot_predictions,
-    log_host_config, require_boot_interface, set_host_boot_order, trigger_reboot_if_needed,
+    are_dpus_up_trigger_reboot_if_needed, is_dpu_observed_since, log_host_config,
+    require_boot_interface, resolve_boot_interface_for_step, set_host_boot_order,
+    trigger_reboot_if_needed,
 };
 use crate::context::MachineStateHandlerContextObjects;
 
@@ -176,6 +177,7 @@ pub(super) async fn check_host_boot_config(
     mh_snapshot: &ManagedHostStateSnapshot,
     reachability_params: &ReachabilityParams,
     dpu_freshness: HostBootConfigDpuFreshness,
+    explicit_target: Option<&BootInterfaceTarget>,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<HostBootConfigCheckOutcome, StateHandlerError> {
     if should_wait_for_dpus_before_host_boot_config(
@@ -191,10 +193,10 @@ pub(super) async fn check_host_boot_config(
         ));
     }
 
-    let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+    let resolution = resolve_boot_interface_for_step(ctx, mh_snapshot, explicit_target).await?;
     let boot_interface = match require_boot_interface(
-        mh_snapshot,
-        &predictions,
+        &mh_snapshot.host_snapshot.id,
+        resolution,
         "configuring boot",
         HostBootConfigCheckOutcome::Wait,
     )? {
@@ -248,15 +250,20 @@ pub(super) async fn run_host_boot_config_stage(
     reachability_params: &ReachabilityParams,
     redfish_client: &dyn Redfish,
     mh_snapshot: &ManagedHostStateSnapshot,
+    explicit_target: Option<&BootInterfaceTarget>,
     stage: HostBootConfigStage,
 ) -> Result<HostBootConfigOutcome, StateHandlerError> {
     match stage {
         HostBootConfigStage::ConfigureBios { retry_count } => {
+            let boot_interface =
+                resolve_boot_interface_for_step(ctx, mh_snapshot, explicit_target).await?;
+            let boot_interface = boot_interface.into_target();
             match configure_host_bios(
                 ctx,
                 reachability_params,
                 redfish_client,
                 mh_snapshot,
+                boot_interface.as_ref(),
                 retry_count,
             )
             .await?
@@ -301,13 +308,15 @@ pub(super) async fn run_host_boot_config_stage(
             }
         }
         HostBootConfigStage::PollingBiosSetup { retry_count } => {
-            let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+            let boot_interface =
+                resolve_boot_interface_for_step(ctx, mh_snapshot, explicit_target).await?;
+            let boot_interface = boot_interface.into_target();
             match advance_polling_bios_setup(
                 redfish_client,
                 mh_snapshot,
                 retry_count,
                 &ctx.services.site_config.machine_state_controller,
-                &predictions,
+                boot_interface.as_ref(),
             )
             .await?
             {
@@ -342,6 +351,7 @@ pub(super) async fn run_host_boot_config_stage(
                 reachability_params,
                 redfish_client,
                 mh_snapshot,
+                explicit_target,
                 set_boot_order_info,
             )
             .await?
@@ -463,9 +473,193 @@ async fn should_wait_for_dpus_before_host_boot_config(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use carbide_health_metrics::PerObjectMetricsRegistry;
+    use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
+    use carbide_redfish::libredfish::{RedfishAuth, RedfishClientPool};
+    use carbide_secrets::test_support::credentials::TestCredentialManager;
     use carbide_test_support::value_scenarios;
+    use model::machine_boot_interface::MachineBootInterface;
+    use model::test_support::machine_snapshot::managed_host_state_snapshot;
+    use state_controller::db_write_batch::DbWriteBatch;
 
     use super::*;
+    use crate::config::MachineStateHandlerSiteConfig;
+    use crate::context::MachineStateHandlerServices;
+    use crate::metrics::MachineMetrics;
+
+    fn reachability_params() -> ReachabilityParams {
+        ReachabilityParams {
+            dpu_wait_time: chrono::Duration::zero(),
+            power_down_wait: chrono::Duration::zero(),
+            failure_retry_time: chrono::Duration::zero(),
+            scout_reporting_timeout: chrono::Duration::zero(),
+            waiting_for_measurements_timeout: chrono::Duration::zero(),
+            uefi_boot_wait: chrono::Duration::zero(),
+        }
+    }
+
+    fn change_observed_boot_interface(
+        mh_snapshot: &mut ManagedHostStateSnapshot,
+        mac_address: &str,
+    ) {
+        let interface = mh_snapshot
+            .host_snapshot
+            .status
+            .interfaces
+            .iter_mut()
+            .find(|interface| interface.primary_interface)
+            .expect("fixture host has a primary interface");
+        interface.mac_address = mac_address.parse().unwrap();
+        interface.boot_interface_id = Some(format!("mutable-{mac_address}"));
+    }
+
+    #[tokio::test]
+    async fn explicit_target_is_stable_across_boot_config_stages() {
+        const REDFISH_HOST: &str = "boot-config-test";
+        let explicit_boot_interface = MachineBootInterface {
+            mac_address: "10:00:00:00:00:01".parse().unwrap(),
+            interface_id: "NIC.Slot.5-1".to_string(),
+        };
+        let explicit_target = BootInterfaceTarget::Pair(explicit_boot_interface.clone());
+        let expected_redfish_target = RedfishSimBootInterfaceRef::Pair {
+            mac_address: explicit_boot_interface.mac_address,
+            interface_id: explicit_boot_interface.interface_id.clone(),
+        };
+
+        let redfish_sim = Arc::new(RedfishSim::default());
+        let redfish_client = redfish_sim
+            .create_client(REDFISH_HOST, None, RedfishAuth::Anonymous, None)
+            .await
+            .unwrap();
+        redfish_sim.set_machine_setup_bios_job_id(Some("bios-job".to_string()));
+
+        // Explicit-target stages do not need prediction data. A short-timeout
+        // unreachable pool makes an accidental lookup fail promptly.
+        let db_pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(Duration::from_millis(50))
+            .connect_lazy("postgres://unused:unused@127.0.0.1:1/unused")
+            .unwrap();
+        let mut services = MachineStateHandlerServices {
+            db_pool: db_pool.clone(),
+            db_reader: db_pool.into(),
+            redfish_client_pool: redfish_sim.clone(),
+            ipmi_tool: carbide_ipmi::test_support(),
+            site_config: Arc::new(MachineStateHandlerSiteConfig::test_default()),
+            component_manager: None,
+            credential_manager: Arc::new(TestCredentialManager::default()),
+            per_object_metrics_registry: PerObjectMetricsRegistry::new(
+                Vec::new(),
+                Duration::from_secs(60),
+            ),
+            per_object_info: None,
+        };
+        let mut metrics = MachineMetrics::default();
+        let mut pending_db_writes = DbWriteBatch::new();
+        let mut ctx = StateHandlerContext {
+            services: &mut services,
+            metrics: &mut metrics,
+            pending_db_writes: &mut pending_db_writes,
+        };
+        let reachability_params = reachability_params();
+        let mut mh_snapshot = managed_host_state_snapshot();
+
+        change_observed_boot_interface(&mut mh_snapshot, "20:00:00:00:00:01");
+        assert_eq!(
+            check_host_boot_config(
+                redfish_client.as_ref(),
+                &mh_snapshot,
+                &reachability_params,
+                HostBootConfigDpuFreshness::AlreadyValidated,
+                Some(&explicit_target),
+                &mut ctx,
+            )
+            .await
+            .unwrap(),
+            HostBootConfigCheckOutcome::Ready(HostBootConfigDecision::Complete),
+        );
+
+        macro_rules! run_stage {
+            ($stage:expr) => {
+                run_host_boot_config_stage(
+                    &mut ctx,
+                    &reachability_params,
+                    redfish_client.as_ref(),
+                    &mh_snapshot,
+                    Some(&explicit_target),
+                    $stage,
+                )
+                .await
+                .unwrap()
+            };
+        }
+        let set_boot_order_stage = |set_boot_order_state| HostBootConfigStage::SetBootOrder {
+            set_boot_order_info: SetBootOrderInfo {
+                set_boot_order_jid: None,
+                set_boot_order_state,
+                retry_count: 0,
+            },
+        };
+
+        change_observed_boot_interface(&mut mh_snapshot, "30:00:00:00:00:01");
+        assert!(matches!(
+            run_stage!(HostBootConfigStage::ConfigureBios { retry_count: 0 }),
+            HostBootConfigOutcome::Continue(HostBootConfigStage::WaitingForBiosJob { .. }),
+        ));
+
+        change_observed_boot_interface(&mut mh_snapshot, "40:00:00:00:00:01");
+        assert!(matches!(
+            run_stage!(HostBootConfigStage::PollingBiosSetup { retry_count: 0 }),
+            HostBootConfigOutcome::Continue(HostBootConfigStage::SetBootOrder { .. }),
+        ));
+
+        redfish_sim.set_is_boot_order_setup(false);
+        change_observed_boot_interface(&mut mh_snapshot, "50:00:00:00:00:01");
+        assert!(matches!(
+            run_stage!(set_boot_order_stage(SetBootOrderState::SetBootOrder)),
+            HostBootConfigOutcome::Continue(HostBootConfigStage::SetBootOrder {
+                set_boot_order_info: SetBootOrderInfo {
+                    set_boot_order_state: SetBootOrderState::WaitForSetBootOrderJobScheduled,
+                    ..
+                },
+            }),
+        ));
+
+        change_observed_boot_interface(&mut mh_snapshot, "60:00:00:00:00:01");
+        assert!(matches!(
+            run_stage!(set_boot_order_stage(
+                SetBootOrderState::WaitForHttpBootDeviceApplied
+            )),
+            HostBootConfigOutcome::Continue(HostBootConfigStage::SetBootOrder {
+                set_boot_order_info: SetBootOrderInfo {
+                    set_boot_order_state: SetBootOrderState::SetBootOrder,
+                    ..
+                },
+            }),
+        ));
+
+        change_observed_boot_interface(&mut mh_snapshot, "70:00:00:00:00:01");
+        assert_eq!(
+            run_stage!(set_boot_order_stage(SetBootOrderState::CheckBootOrder)),
+            HostBootConfigOutcome::Complete,
+        );
+
+        let observed_targets = redfish_sim.boot_interface_targets(REDFISH_HOST);
+        assert_eq!(
+            observed_targets.len(),
+            10,
+            "each target-consuming call in the exercised stages must be recorded",
+        );
+        for (call_index, observed_target) in observed_targets.into_iter().enumerate() {
+            assert_eq!(
+                observed_target,
+                Some(expected_redfish_target.clone()),
+                "boot-config target drifted at Redfish call {call_index}",
+            );
+        }
+    }
 
     #[test]
     fn boot_config_decision_chooses_the_smallest_remediation() {

--- a/crates/machine-controller/src/handler/machine_validation.rs
+++ b/crates/machine-controller/src/handler/machine_validation.rs
@@ -34,8 +34,8 @@ use crate::handler::host_boot_config::{
     initial_set_boot_order_info, inspect_host_boot_config, run_host_boot_config_stage,
 };
 use crate::handler::{
-    RequiredBootInterface, handler_host_power_control, host_power_control, load_boot_predictions,
-    rebooted, redfish_error, require_boot_interface, trigger_reboot_if_needed, wait,
+    RequiredBootInterface, handler_host_power_control, host_power_control, rebooted, redfish_error,
+    require_boot_interface, resolve_boot_interface_for_step, trigger_reboot_if_needed, wait,
 };
 
 /// The validation flavor of the managed-host state, so the repair arms can
@@ -70,6 +70,7 @@ async fn handle_validation_boot_config_stage(
         &host_handler_params.reachability_params,
         redfish_client.as_ref(),
         mh_snapshot,
+        None,
         stage,
     )
     .await?
@@ -245,10 +246,11 @@ pub(crate) async fn handle_machine_validation_state(
                 // during the reboot's POST -- the host can't boot into the
                 // validation environment, and further reboots can't restore a
                 // setting that is gone. Correct it instead of pacing forever.
-                let predictions = load_boot_predictions(ctx, &mh_snapshot.host_snapshot.id).await?;
+                let boot_interface_resolution =
+                    resolve_boot_interface_for_step(ctx, mh_snapshot, None).await?;
                 if let RequiredBootInterface::Ready(boot_interface) = require_boot_interface(
-                    mh_snapshot,
-                    &predictions,
+                    &mh_snapshot.host_snapshot.id,
+                    boot_interface_resolution,
                     "verifying the boot config during validation",
                     |message| message,
                 )? {
@@ -481,6 +483,7 @@ pub(crate) async fn handle_machine_validation_state(
                 mh_snapshot,
                 &host_handler_params.reachability_params,
                 HostBootConfigDpuFreshness::CurrentHostState,
+                None,
                 ctx,
             )
             .await?

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -129,6 +129,7 @@ struct RedfishSimHostState {
     power: PowerState,
     lockdown: libredfish::EnabledDisabled,
     actions: Vec<RedfishSimAction>,
+    boot_interface_targets: Vec<Option<RedfishSimBootInterfaceRef>>,
     /// Whether this host's `HttpDev1` UEFI HTTP-boot device is enabled in BIOS.
     /// Defaults to `true` (the steady state after `machine_setup`): the boot
     /// device is present, so `set_boot_order_dpu_first` can promote it and
@@ -153,6 +154,7 @@ impl Default for RedfishSimHostState {
             power: PowerState::default(),
             lockdown: libredfish::EnabledDisabled::Disabled,
             actions: Vec::default(),
+            boot_interface_targets: Vec::default(),
             // Enabled by default so existing tests, which never model a
             // de-enumeration, see the boot order configure normally.
             http_dev1_enabled: true,
@@ -199,6 +201,19 @@ impl RedfishSim {
                 })
                 .collect(),
         }
+    }
+
+    /// Return every logical boot-interface selector supplied to
+    /// `machine_setup`, `is_bios_setup`, `is_boot_order_setup`, or
+    /// `set_boot_order_dpu_first` on one endpoint.
+    pub fn boot_interface_targets(&self, host: &str) -> Vec<Option<RedfishSimBootInterfaceRef>> {
+        self.state
+            .lock()
+            .unwrap()
+            .hosts
+            .get(host)
+            .map(|state| state.boot_interface_targets.clone())
+            .unwrap_or_default()
     }
 
     /// Return the simulated lockdown state for each Redfish client target.
@@ -618,6 +633,9 @@ impl Redfish for RedfishSimClient {
             // `set_boot_order_dpu_first` can then promote the device and the
             // boot order sticks. Per-host, so it recovers only this host.
             host_state.http_dev1_enabled = true;
+            host_state
+                .boot_interface_targets
+                .push(boot_interface.map(RedfishSimBootInterfaceRef::from));
             host_state.actions.push(RedfishSimAction::MachineSetup {
                 oem_manager_profiles: oem_manager_profiles.clone(),
                 boot_interface_mac: boot_interface.map(boot_interface_ref_to_string),
@@ -1586,6 +1604,9 @@ impl Redfish for RedfishSimClient {
             // exactly when this host's HTTP boot device is currently enabled.
             host_state.is_boot_order_setup = Some(host_state.http_dev1_enabled);
             host_state
+                .boot_interface_targets
+                .push(Some(RedfishSimBootInterfaceRef::from(boot_interface)));
+            host_state
                 .actions
                 .push(RedfishSimAction::SetBootOrderDpuFirst {
                     boot_interface_mac: boot_interface_ref_to_string(boot_interface),
@@ -1777,6 +1798,9 @@ impl Redfish for RedfishSimClient {
             // updated only by this host's own `set_boot_order_dpu_first` /
             // `set_is_boot_order_setup`, so other hosts can't flip it.
             let is_boot_order_setup = host_state.is_boot_order_setup.unwrap_or(true);
+            host_state
+                .boot_interface_targets
+                .push(Some(RedfishSimBootInterfaceRef::from(boot_interface)));
             host_state.actions.push(RedfishSimAction::IsBootOrderSetup {
                 boot_interface_mac: boot_interface_ref_to_string(boot_interface),
             });
@@ -1786,10 +1810,16 @@ impl Redfish for RedfishSimClient {
 
     fn is_bios_setup<'a>(
         &'a self,
-        _boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
+        boot_interface: Option<libredfish::BootInterfaceRef<'a>>,
     ) -> libredfish::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let mut state = self.state.lock().unwrap();
+            state
+                .hosts
+                .get_mut(&self._host)
+                .unwrap()
+                .boot_interface_targets
+                .push(boot_interface.map(RedfishSimBootInterfaceRef::from));
             state
                 .platform_actions
                 .push(RedfishSimPlatformAction::IsBiosSetup {
@@ -2242,11 +2272,8 @@ impl RedfishClientPool for RedfishSim {
                 .hosts
                 .entry(host.to_string())
                 .or_insert(RedfishSimHostState {
-                    power: PowerState::On,
                     lockdown: default_lockdown,
-                    actions: Default::default(),
-                    http_dev1_enabled: true,
-                    is_boot_order_setup: None,
+                    ..Default::default()
                 });
             if state.fw_version.is_empty() {
                 state.fw_version = Arc::new("24.10-17".to_string());


### PR DESCRIPTION
The shared host boot-config driver resolves its interface from mutable machine rows every time a stage runs. That works for its current lifecycle callers, but it gives a caller with persisted intent no way to select one exact `BootInterfaceTarget` for the whole Redfish workflow.

So this lets the driver accept an optional `BootInterfaceTarget` and plumbs it through BIOS setup, polling, boot-order application, verification, and failed-BIOS recovery. Existing lifecycle callers pass `None`, so their dynamic resolution behavior stays exactly as it is.

Primary callouts are:
- A supplied target bypasses predicted-interface reads, so mutable rows cannot redirect the Redfish operation.
- Target-required paths still distinguish a zero-DPU host waiting for its NIC from a managed-DPU host missing the interface it should already have.
- `RedfishSim` records the exact selector used by each target-aware operation, including both fields of a `Pair`.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4244

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified with:

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-licenses`
- `cargo make check-bans`
- `cargo xtask check-workspace-deps`
- `cargo test -p carbide-machine-controller --lib`
- `cargo test -p carbide-machine-controller --test integration`
- `cargo test -p carbide-redfish --features test-support --lib`
- `cargo test -p carbide-redfish --features test-support --test service_root_cache_poisoning`

## Additional Notes

This PR is intentionally behavior-neutral for existing lifecycle owners: all production adapters pass `None`. Persisting the desired target and activating Ready-state reconciliation are split into #4245 and #4246; periodic Redfish drift detection is #4248.

Closes #4244
