### PR TITLE
feat(machine-a-tron): typed device simulators

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1561,7 +1561,7 @@ where
         mac_address_pool: None,
     };
 
-    let (machine_handles, mat_handle) = api_test_helper::machine_a_tron::run_local(
+    let (provisionable_handles, mat_handle) = api_test_helper::machine_a_tron::run_local(
         mat_config,
         additional_api_urls,
         &test_env.root_dir,
@@ -1571,7 +1571,7 @@ where
     .await
     .unwrap();
 
-    let results = join_all(machine_handles.into_iter().map(run_assertions)).await;
+    let results = join_all(provisionable_handles.into_iter().map(run_assertions)).await;
     let result_count = results.len();
     let assertion_result: eyre::Result<()> = results.into_iter().try_collect();
     let shutdown_result = mat_handle.shutdown().await;

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -31,7 +31,7 @@ use api_test_helper::{
     vpc_prefix,
 };
 use bmc_mock::test_support::TEST_MAC_POOL;
-use bmc_mock::{HostHardwareType, ListenerOrAddress};
+use bmc_mock::{HardwareType, ListenerOrAddress};
 use carbide_uuid::rack::{RackId, RackProfileId};
 use eyre::ContextCompat;
 use futures::FutureExt;
@@ -143,7 +143,7 @@ async fn test_integration() -> eyre::Result<()> {
     // Run several tests in parallel.
     let all_tests = join_all([
         test_machine_a_tron_multidpu(
-            HostHardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
@@ -152,7 +152,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_multidpu(
-            HostHardwareType::NvidiaDgxH100,
+            HardwareType::NvidiaDgxH100,
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
@@ -161,7 +161,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_multidpu(
-            HostHardwareType::WiwynnGB200Nvl,
+            HardwareType::WiwynnGB200Nvl,
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
@@ -170,7 +170,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_multidpu(
-            HostHardwareType::LenovoGB300Nvl,
+            HardwareType::LenovoGB300Nvl,
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
@@ -179,7 +179,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_multidpu(
-            HostHardwareType::NvidiaDgxGb300,
+            HardwareType::NvidiaDgxGb300,
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
@@ -188,7 +188,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_multidpu(
-            HostHardwareType::SupermicroGb300Nvl,
+            HardwareType::SupermicroGb300Nvl,
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
@@ -197,22 +197,14 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_zerodpu(
-            HostHardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
             &flat_vpc,
         )
         .boxed(),
         test_machine_a_tron_nic_mode(
-            HostHardwareType::DellPowerEdgeR750,
-            &test_env,
-            &bmc_address_registry,
-            &flat_vpc,
-            &host_inband_segment_id,
-        )
-        .boxed(),
-        test_machine_a_tron_nic_mode(
-            HostHardwareType::HpeProliantDl380aGen11,
+            HardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
             &flat_vpc,
@@ -220,7 +212,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_nic_mode(
-            HostHardwareType::WiwynnGB200Nvl,
+            HardwareType::HpeProliantDl380aGen11,
             &test_env,
             &bmc_address_registry,
             &flat_vpc,
@@ -228,7 +220,15 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_nic_mode(
-            HostHardwareType::SupermicroGb300Nvl,
+            HardwareType::WiwynnGB200Nvl,
+            &test_env,
+            &bmc_address_registry,
+            &flat_vpc,
+            &host_inband_segment_id,
+        )
+        .boxed(),
+        test_machine_a_tron_nic_mode(
+            HardwareType::SupermicroGb300Nvl,
             &test_env,
             &bmc_address_registry,
             &flat_vpc,
@@ -241,7 +241,7 @@ async fn test_integration() -> eyre::Result<()> {
         // the host-facing DPU MAC is re-created on the Admin segment before the NIC-mode
         // transition completes.
         test_machine_a_tron_dual_stack(
-            HostHardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
             tenant_org_id,
@@ -252,7 +252,7 @@ async fn test_integration() -> eyre::Result<()> {
         )
         .boxed(),
         test_machine_a_tron_dual_stack_l2(
-            HostHardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR750,
             &test_env,
             &bmc_address_registry,
             &dual_stack_l2_segment_id,
@@ -520,7 +520,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
     assert_eq!(0i64, get_dns_record_count(&db_pool).await);
 
     run_machine_a_tron_test(
-        HostHardwareType::DellPowerEdgeR750,
+        HardwareType::DellPowerEdgeR750,
         1,
         1,
         false,
@@ -661,7 +661,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
 }
 
 async fn test_machine_a_tron_multidpu(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     segment_id: &str,
@@ -764,7 +764,7 @@ async fn test_machine_a_tron_rack(
 ) -> eyre::Result<()> {
     let rack_id = RackId::new("machine-a-tron-nvl72");
     run_machine_a_tron_test(
-        HostHardwareType::WiwynnGB200Nvl,
+        HardwareType::WiwynnGB200Nvl,
         18,
         2,
         false,
@@ -817,7 +817,7 @@ async fn test_machine_a_tron_rack(
 }
 
 async fn test_machine_a_tron_zerodpu(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     flat_vpc_id: &str,
@@ -879,7 +879,7 @@ async fn test_machine_a_tron_zerodpu(
 }
 
 async fn test_machine_a_tron_nic_mode(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     flat_vpc_id: &str,
@@ -1061,7 +1061,7 @@ async fn assert_auto_instance_network(
 /// managed DPU -- then drives the re-ingested NIC-mode host all the way to Ready.
 #[expect(dead_code, reason = "temporarily disabled due to a CI race")]
 async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     admin_dhcp_relay_address: Ipv4Addr,
@@ -1288,7 +1288,7 @@ async fn test_machine_a_tron_dpu_to_nic_mode_reregistration(
 }
 
 async fn test_machine_a_tron_dual_stack(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     tenant_organization_id: &str,
@@ -1404,7 +1404,7 @@ async fn test_machine_a_tron_dual_stack(
 /// The segment is pre-created with both IPv4 and IPv6 prefixes, and the
 /// handler allocates SVI IPs for both. Instances get one IP per prefix.
 async fn test_machine_a_tron_dual_stack_l2(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     dual_stack_segment_id: &str,
@@ -1474,7 +1474,7 @@ async fn test_machine_a_tron_dual_stack_l2(
 
 #[allow(clippy::too_many_arguments)]
 async fn run_machine_a_tron_test<F, O>(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
     host_count: u32,
     dpu_per_host_count: u32,
     dpus_in_nic_mode: bool,

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -23,7 +23,7 @@ use std::time::{self, Duration};
 
 use ::carbide_utils::HostPortPair;
 use ::machine_a_tron::{
-    BmcMockRegistry, DhcpType, HostMachineHandle, MachineATronConfig, MachineConfig, RackConfig,
+    BmcMockRegistry, DeviceHandle, DhcpType, MachineATronConfig, MachineConfig, RackConfig,
 };
 use api_test_helper::utils::TestApiServerArgs;
 use api_test_helper::{
@@ -1485,7 +1485,7 @@ async fn run_machine_a_tron_test<F, O>(
     run_assertions: F,
 ) -> eyre::Result<()>
 where
-    F: Fn(HostMachineHandle) -> O,
+    F: Fn(DeviceHandle) -> O,
     O: Future<Output = eyre::Result<()>>,
 {
     let api_addr = test_env

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -101,7 +101,7 @@ pub async fn run_local(
 
     let mat = MachineATron::new(app_context.clone());
     let simulators = mat.make_devices(false).await?;
-    let machine_handles = simulators.machine_handles();
+    let provisionable_handles = simulators.provisionable_handles();
 
     let (stop_tx, stop_rx) = oneshot::channel();
     let device_simulators = simulators.devices().to_vec();
@@ -125,7 +125,7 @@ pub async fn run_local(
     });
 
     Ok((
-        machine_handles,
+        provisionable_handles,
         MachineATronHandle {
             _stop_tx: stop_tx,
             _join_handle: join_handle,

--- a/crates/api-test-helper/src/machine_a_tron.rs
+++ b/crates/api-test-helper/src/machine_a_tron.rs
@@ -22,7 +22,7 @@ use bmc_mock::mac_address_pool::MacAddressPool;
 use forge_tls::client_config::get_root_ca_path;
 use futures::future::try_join_all;
 use machine_a_tron::{
-    BmcMockRegistry, BmcRegistrationMode, DhcpClient, HostMachineHandle, MachineATron,
+    BmcMockRegistry, BmcRegistrationMode, DeviceHandle, DhcpClient, MachineATron,
     MachineATronConfig, MachineATronContext, UdpDhcpService, api_throttler,
 };
 use rpc::forge_api_client::FailOverOn;
@@ -43,7 +43,7 @@ pub async fn run_local(
     repo_root: &Path,
     bmc_address_registry: Option<BmcMockRegistry>,
     mac_address_pool: Arc<Mutex<MacAddressPool>>,
-) -> eyre::Result<(Vec<HostMachineHandle>, MachineATronHandle)> {
+) -> eyre::Result<(Vec<DeviceHandle>, MachineATronHandle)> {
     app_config.validate()?;
 
     let forge_root_ca_path = get_root_ca_path(None, None); // Will get it from the local repo
@@ -100,25 +100,25 @@ pub async fn run_local(
     });
 
     let mat = MachineATron::new(app_context.clone());
-    let machine_handles = mat.make_machines(false).await?;
+    let simulators = mat.make_devices(false).await?;
+    let machine_handles = simulators.machine_handles();
 
     let (stop_tx, stop_rx) = oneshot::channel();
-    let machine_handles_clone = machine_handles.clone();
+    let device_simulators = simulators.devices().to_vec();
     let join_handle = tokio::spawn(async move {
         stop_rx.await.ok(); // this finishes when stop_tx is dropped
 
         try_join_all(
-            machine_handles_clone
+            device_simulators
                 .iter()
-                .map(HostMachineHandle::abort_and_wait),
+                .map(|simulator| simulator.shutdown()),
         )
         .await?;
 
-        try_join_all(
-            machine_handles_clone
-                .into_iter()
-                .map(|m| m.delete_from_api(app_context.api_client())),
-        )
+        try_join_all(device_simulators.into_iter().map(|simulator| {
+            let api_client = app_context.api_client();
+            async move { simulator.delete_from_api(api_client).await }
+        }))
         .await?;
 
         Ok(())

--- a/crates/bmc-explorer/src/test_support.rs
+++ b/crates/bmc-explorer/src/test_support.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use bmc_mock::test_support::TestBmc;
 use bmc_mock::test_support::axum_http_client::Error as TestBmcError;
-use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo, MachineInfo};
+use bmc_mock::{DpuMachineInfo, DpuSettings, HardwareType, HostMachineInfo, MachineInfo};
 use model::site_explorer::EndpointExplorationReport;
 use nv_redfish::{Bmc, Resource, ServiceRoot};
 
@@ -109,7 +109,7 @@ pub async fn generate_report_for_machine(
 }
 
 pub async fn generate_managed_host_reports(
-    hw_type: HostHardwareType,
+    hw_type: HardwareType,
 ) -> Result<GeneratedManagedHostReports, MockExplorerError> {
     generate_managed_host_reports_from_info(host_info_for_hw_type(hw_type)).await
 }
@@ -137,7 +137,7 @@ pub async fn generate_managed_host_reports_from_info(
     })
 }
 
-fn host_info_for_hw_type(hw_type: HostHardwareType) -> HostMachineInfo {
+fn host_info_for_hw_type(hw_type: HardwareType) -> HostMachineInfo {
     let dpu_count = hw_type.fixed_number_of_dpu().unwrap_or(0);
     let mut pool = bmc_mock::test_support::TEST_MAC_POOL.lock().unwrap();
     let hw_mac_addr_pool = pool.allocate_range_config().unwrap();

--- a/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield4_explore.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use bmc_explorer::nv_generate_exploration_report;
-use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType, MachineInfo, test_support};
+use bmc_mock::{DpuMachineInfo, DpuSettings, HardwareType, MachineInfo, test_support};
 use mac_address::MacAddress;
 use model::site_explorer::EndpointType;
 use tokio::test;
@@ -25,7 +25,7 @@ use crate::common;
 #[test]
 async fn explore_bluefield4_and_generate_machine_id_from_bluefield_bmc_chassis_serial() {
     let h = test_support::dell_poweredge_r760_bluefield4_bmc(DpuMachineInfo {
-        hw_type: HostHardwareType::DellPowerEdgeR760Bf4,
+        hw_type: HardwareType::DellPowerEdgeR760Bf4,
         bmc_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x01]),
         host_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x02]),
         oob_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x04, 0x03]),
@@ -100,7 +100,7 @@ async fn explore_bluefield4_and_generate_machine_id_from_bluefield_bmc_chassis_s
 async fn explore_b4240v_and_generate_machine_id() {
     let host_mac_address = MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x14, 0x02]);
     let h = test_support::bmc_for_machine(MachineInfo::Dpu(DpuMachineInfo {
-        hw_type: HostHardwareType::NvidiaDgxVr,
+        hw_type: HardwareType::NvidiaDgxVr,
         bmc_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x14, 0x01]),
         host_mac_address,
         oob_mac_address: MacAddress::new([0x02, 0x00, 0x00, 0xbf, 0x14, 0x03]),

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -17,7 +17,7 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use bmc_mock::HostHardwareType;
+use bmc_mock::HardwareType;
 use clap::{Parser, ValueEnum};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -32,13 +32,13 @@ pub enum StateBackend {
     Libvirt,
 }
 
-fn parse_hardware_profile(value: &str) -> Result<HostHardwareType, String> {
+fn parse_hardware_profile(value: &str) -> Result<HardwareType, String> {
     let hardware_type = serde_json::from_value(serde_json::Value::String(value.to_string()))
         .map_err(|_| format!("unknown hardware profile: {value}"))?;
     match hardware_type {
-        HostHardwareType::LiteOnPowerShelf
-        | HostHardwareType::DeltaPowerShelf
-        | HostHardwareType::NvidiaSwitchNd5200Ld => {
+        HardwareType::LiteOnPowerShelf
+        | HardwareType::DeltaPowerShelf
+        | HardwareType::NvidiaSwitchNd5200Ld => {
             Err(format!("hardware profile is not a host or DPU: {value}"))
         }
         hardware_type => Ok(hardware_type),
@@ -96,7 +96,7 @@ pub struct Args {
         value_parser = parse_hardware_profile,
         help = "Redfish hardware profile for an explicitly configured host or DPU, using its existing snake_case name"
     )]
-    pub hardware_profile: Option<HostHardwareType>,
+    pub hardware_profile: Option<HardwareType>,
 
     #[clap(long, value_enum, help = "Expose a host BMC or one DPU BMC")]
     pub machine_role: Option<MachineRole>,
@@ -149,22 +149,22 @@ mod tests {
     #[test]
     fn parses_supported_hardware_profiles() {
         let cases = [
-            ("dell_poweredge_r750", HostHardwareType::DellPowerEdgeR750),
+            ("dell_poweredge_r750", HardwareType::DellPowerEdgeR750),
             (
                 "dell_poweredge_r760_bf4",
-                HostHardwareType::DellPowerEdgeR760Bf4,
+                HardwareType::DellPowerEdgeR760Bf4,
             ),
-            ("wiwynn_gb200_nvl", HostHardwareType::WiwynnGB200Nvl),
-            ("lenovo_gb300_nvl", HostHardwareType::LenovoGB300Nvl),
-            ("nvidia_dgx_gb300", HostHardwareType::NvidiaDgxGb300),
-            ("supermicro_gb300_nvl", HostHardwareType::SupermicroGb300Nvl),
-            ("nvidia_dgx_vr", HostHardwareType::NvidiaDgxVr),
-            ("nvidia_dgx_h100", HostHardwareType::NvidiaDgxH100),
-            ("generic_ami", HostHardwareType::GenericAmi),
-            ("generic_supermicro", HostHardwareType::GenericSupermicro),
+            ("wiwynn_gb200_nvl", HardwareType::WiwynnGB200Nvl),
+            ("lenovo_gb300_nvl", HardwareType::LenovoGB300Nvl),
+            ("nvidia_dgx_gb300", HardwareType::NvidiaDgxGb300),
+            ("supermicro_gb300_nvl", HardwareType::SupermicroGb300Nvl),
+            ("nvidia_dgx_vr", HardwareType::NvidiaDgxVr),
+            ("nvidia_dgx_h100", HardwareType::NvidiaDgxH100),
+            ("generic_ami", HardwareType::GenericAmi),
+            ("generic_supermicro", HardwareType::GenericSupermicro),
             (
                 "hpe_proliant_dl380a_gen11",
-                HostHardwareType::HpeProliantDl380aGen11,
+                HardwareType::HpeProliantDl380aGen11,
             ),
         ];
 

--- a/crates/bmc-mock/src/hw/delta_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/delta_power_shelf.rs
@@ -23,7 +23,7 @@
 //!
 //! * There is **no `/redfish/v1/Systems` collection** — the service root does
 //!   not advertise `Systems` and the collection endpoint 404s (see
-//!   [`crate::HostHardwareType::DeltaPowerShelf`] wiring in
+//!   [`crate::HardwareType::DeltaPowerShelf`] wiring in
 //!   `machine_info`/`mock_machine_router`). This reproduces the original
 //!   ingestion failure that Delta support fixes.
 //! * Per-PSU power state is carried under `Oem.deltaenergysystems.Power`

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -58,7 +58,7 @@ pub const DUMMY_FACTORY_PASSWORD: &str = "factory_password";
 pub const DUMMY_FACTORY_DPU_PASSWORD: &str = "0penBmc";
 
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
-pub enum HostHardwareType {
+pub enum HardwareType {
     #[serde(rename = "dell_poweredge_r750")]
     #[default]
     DellPowerEdgeR750,
@@ -93,7 +93,7 @@ pub enum HostHardwareType {
     GenericSupermicro,
 }
 
-impl fmt::Display for HostHardwareType {
+impl fmt::Display for HardwareType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::DellPowerEdgeR750 => "Dell PowerEdge R750".fmt(f),
@@ -114,7 +114,7 @@ impl fmt::Display for HostHardwareType {
     }
 }
 
-impl HostHardwareType {
+impl HardwareType {
     // This function returns how many DPUs must be attached to the
     // platform. If None than platform can support variable number of
     // DPUs.

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -553,7 +553,7 @@ mod tests {
 
     use super::*;
     use crate::test_support::host_info;
-    use crate::{HostHardwareType, MachineRouterOptions, VirtualMediaDeviceConfig, machine_router};
+    use crate::{HardwareType, MachineRouterOptions, VirtualMediaDeviceConfig, machine_router};
 
     async fn request(
         router: &Router,
@@ -645,7 +645,7 @@ esac
             virtual_media_targets: BTreeMap::from([("Cd".to_string(), "sdb".to_string())]),
         }));
         let (router, state) = machine_router(
-            &host_info(HostHardwareType::DellPowerEdgeR750),
+            &host_info(HardwareType::DellPowerEdgeR750),
             callbacks.clone(),
             "test-host-id".to_string(),
             false,

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::mac_address_pool::{MacAddressPool, PoolConfig as MacAddressPoolConfig};
 use crate::redfish::update_service::UpdateServiceConfig;
-use crate::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostHardwareType, hw, redfish};
+use crate::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HardwareType, hw, redfish};
 
 /// Represents static information we know ahead of time about a host or DPU (independent of any
 /// state we get from carbide like IP addresses or machine ID's.) Intended to be immutable and
@@ -35,7 +35,7 @@ pub enum MachineInfo {
 
 #[derive(Debug, Clone)]
 pub struct HostMachineInfo {
-    pub hw_type: HostHardwareType,
+    pub hw_type: HardwareType,
     pub bmc_mac_address: MacAddress,
     pub serial: String,
     pub dpus: Vec<DpuMachineInfo>,
@@ -52,7 +52,7 @@ pub struct HostMachineInfo {
 
 #[derive(Debug, Clone)]
 pub struct DpuMachineInfo {
-    pub hw_type: HostHardwareType,
+    pub hw_type: HardwareType,
     pub bmc_mac_address: MacAddress,
     pub host_mac_address: MacAddress,
     pub oob_mac_address: MacAddress,
@@ -96,11 +96,7 @@ impl Default for DpuSettings {
 }
 
 impl DpuMachineInfo {
-    pub fn new(
-        hw_type: HostHardwareType,
-        pool: &mut MacAddressPool,
-        settings: DpuSettings,
-    ) -> Self {
+    pub fn new(hw_type: HardwareType, pool: &mut MacAddressPool, settings: DpuSettings) -> Self {
         let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         let bmc_mac_address = next_mac();
         let host_mac_address = next_mac();
@@ -117,24 +113,24 @@ impl DpuMachineInfo {
 
     fn bluefield3(&self) -> hw::bluefield3::Bluefield3<'_> {
         let mode = match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750
-            | HostHardwareType::NvidiaDgxH100
-            | HostHardwareType::GenericAmi
-            | HostHardwareType::HpeProliantDl380aGen11
-            | HostHardwareType::GenericSupermicro => hw::bluefield3::Mode::SuperNIC {
+            HardwareType::DellPowerEdgeR750
+            | HardwareType::NvidiaDgxH100
+            | HardwareType::GenericAmi
+            | HardwareType::HpeProliantDl380aGen11
+            | HardwareType::GenericSupermicro => hw::bluefield3::Mode::SuperNIC {
                 nic_mode: self.settings.nic_mode,
             },
             // GB-class cold-aisle DPU mode. Confirmed for GB200; for DGX/SMC GB300 the BF3
             // chassis is in the scrape but the mode is not separately confirmed (synthetic).
-            HostHardwareType::WiwynnGB200Nvl
-            | HostHardwareType::LenovoGB300Nvl
-            | HostHardwareType::NvidiaDgxGb300
-            | HostHardwareType::SupermicroGb300Nvl => hw::bluefield3::Mode::B3240ColdAisle,
-            HostHardwareType::LiteOnPowerShelf
-            | HostHardwareType::DeltaPowerShelf
-            | HostHardwareType::NvidiaSwitchNd5200Ld
-            | HostHardwareType::NvidiaDgxVr
-            | HostHardwareType::DellPowerEdgeR760Bf4 => {
+            HardwareType::WiwynnGB200Nvl
+            | HardwareType::LenovoGB300Nvl
+            | HardwareType::NvidiaDgxGb300
+            | HardwareType::SupermicroGb300Nvl => hw::bluefield3::Mode::B3240ColdAisle,
+            HardwareType::LiteOnPowerShelf
+            | HardwareType::DeltaPowerShelf
+            | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::NvidiaDgxVr
+            | HardwareType::DellPowerEdgeR760Bf4 => {
                 panic!("Bluefield3 DPU is defined for {}", self.hw_type)
             }
         };
@@ -156,22 +152,22 @@ impl DpuMachineInfo {
 
     fn bluefield4(&self) -> hw::bluefield4::Bluefield4<'_> {
         let mode = match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750
-            | HostHardwareType::NvidiaDgxH100
-            | HostHardwareType::GenericAmi
-            | HostHardwareType::HpeProliantDl380aGen11
-            | HostHardwareType::GenericSupermicro
-            | HostHardwareType::WiwynnGB200Nvl
-            | HostHardwareType::LenovoGB300Nvl
-            | HostHardwareType::NvidiaDgxGb300
-            | HostHardwareType::SupermicroGb300Nvl
-            | HostHardwareType::LiteOnPowerShelf
-            | HostHardwareType::DeltaPowerShelf
-            | HostHardwareType::NvidiaSwitchNd5200Ld => {
+            HardwareType::DellPowerEdgeR750
+            | HardwareType::NvidiaDgxH100
+            | HardwareType::GenericAmi
+            | HardwareType::HpeProliantDl380aGen11
+            | HardwareType::GenericSupermicro
+            | HardwareType::WiwynnGB200Nvl
+            | HardwareType::LenovoGB300Nvl
+            | HardwareType::NvidiaDgxGb300
+            | HardwareType::SupermicroGb300Nvl
+            | HardwareType::LiteOnPowerShelf
+            | HardwareType::DeltaPowerShelf
+            | HardwareType::NvidiaSwitchNd5200Ld => {
                 panic!("Bluefield4 DPU is defined for {}", self.hw_type)
             }
-            HostHardwareType::NvidiaDgxVr => hw::bluefield4::Mode::B4240V,
-            HostHardwareType::DellPowerEdgeR760Bf4 => hw::bluefield4::Mode::B4240,
+            HardwareType::NvidiaDgxVr => hw::bluefield4::Mode::B4240V,
+            HardwareType::DellPowerEdgeR760Bf4 => hw::bluefield4::Mode::B4240,
         };
         hw::bluefield4::Bluefield4 {
             host_mac_address: self.host_mac_address,
@@ -183,21 +179,19 @@ impl DpuMachineInfo {
 
     fn dpu_type(&self) -> DpuType {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750
-            | HostHardwareType::NvidiaDgxH100
-            | HostHardwareType::GenericAmi
-            | HostHardwareType::HpeProliantDl380aGen11
-            | HostHardwareType::GenericSupermicro
-            | HostHardwareType::WiwynnGB200Nvl
-            | HostHardwareType::LenovoGB300Nvl
-            | HostHardwareType::NvidiaDgxGb300
-            | HostHardwareType::SupermicroGb300Nvl
-            | HostHardwareType::LiteOnPowerShelf
-            | HostHardwareType::DeltaPowerShelf
-            | HostHardwareType::NvidiaSwitchNd5200Ld => DpuType::Bluefield3,
-            HostHardwareType::DellPowerEdgeR760Bf4 | HostHardwareType::NvidiaDgxVr => {
-                DpuType::Bluefield4
-            }
+            HardwareType::DellPowerEdgeR750
+            | HardwareType::NvidiaDgxH100
+            | HardwareType::GenericAmi
+            | HardwareType::HpeProliantDl380aGen11
+            | HardwareType::GenericSupermicro
+            | HardwareType::WiwynnGB200Nvl
+            | HardwareType::LenovoGB300Nvl
+            | HardwareType::NvidiaDgxGb300
+            | HardwareType::SupermicroGb300Nvl
+            | HardwareType::LiteOnPowerShelf
+            | HardwareType::DeltaPowerShelf
+            | HardwareType::NvidiaSwitchNd5200Ld => DpuType::Bluefield3,
+            HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr => DpuType::Bluefield4,
         }
     }
 
@@ -266,14 +260,14 @@ impl DpuMachineInfo {
 
 impl HostMachineInfo {
     pub fn new(
-        hw_type: HostHardwareType,
+        hw_type: HardwareType,
         dpus: Vec<DpuMachineInfo>,
         pool: &mut MacAddressPool,
         hw_mac_addr_pool: MacAddressPoolConfig,
     ) -> Self {
         let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         let bmc_mac_address = next_mac();
-        let nvos_mac_addresses = if matches!(hw_type, HostHardwareType::NvidiaSwitchNd5200Ld) {
+        let nvos_mac_addresses = if matches!(hw_type, HardwareType::NvidiaSwitchNd5200Ld) {
             vec![next_mac()]
         } else {
             vec![]
@@ -288,9 +282,9 @@ impl HostMachineInfo {
             non_dpu_mac_address: if dpus.is_empty()
                 && !matches!(
                     hw_type,
-                    HostHardwareType::LiteOnPowerShelf
-                        | HostHardwareType::DeltaPowerShelf
-                        | HostHardwareType::NvidiaSwitchNd5200Ld
+                    HardwareType::LiteOnPowerShelf
+                        | HardwareType::DeltaPowerShelf
+                        | HardwareType::NvidiaSwitchNd5200Ld
                 ) {
                 Some(next_mac())
             } else {
@@ -325,21 +319,21 @@ impl HostMachineInfo {
 
     pub fn oem_state(&self) -> redfish::oem::State {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4 => {
+            HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => {
                 redfish::oem::State::DellIdrac(redfish::oem::dell::idrac::IdracState::default())
             }
-            HostHardwareType::WiwynnGB200Nvl
-            | HostHardwareType::LenovoGB300Nvl
-            | HostHardwareType::NvidiaDgxGb300
-            | HostHardwareType::NvidiaDgxVr
-            | HostHardwareType::LiteOnPowerShelf
-            | HostHardwareType::DeltaPowerShelf
-            | HostHardwareType::NvidiaDgxH100
-            | HostHardwareType::NvidiaSwitchNd5200Ld
-            | HostHardwareType::GenericAmi
-            | HostHardwareType::HpeProliantDl380aGen11
-            | HostHardwareType::GenericSupermicro => redfish::oem::State::Other,
-            HostHardwareType::SupermicroGb300Nvl => redfish::oem::State::Supermicro(
+            HardwareType::WiwynnGB200Nvl
+            | HardwareType::LenovoGB300Nvl
+            | HardwareType::NvidiaDgxGb300
+            | HardwareType::NvidiaDgxVr
+            | HardwareType::LiteOnPowerShelf
+            | HardwareType::DeltaPowerShelf
+            | HardwareType::NvidiaDgxH100
+            | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::GenericAmi
+            | HardwareType::HpeProliantDl380aGen11
+            | HardwareType::GenericSupermicro => redfish::oem::State::Other,
+            HardwareType::SupermicroGb300Nvl => redfish::oem::State::Supermicro(
                 redfish::oem::supermicro::manager::SupermicroState::default(),
             ),
         }
@@ -347,92 +341,84 @@ impl HostMachineInfo {
 
     pub fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4 => {
+            HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => {
                 redfish::oem::BmcVendor::Dell
             }
-            HostHardwareType::WiwynnGB200Nvl => redfish::oem::BmcVendor::Wiwynn,
-            HostHardwareType::LenovoGB300Nvl => redfish::oem::BmcVendor::Ami,
-            HostHardwareType::NvidiaDgxGb300 => {
+            HardwareType::WiwynnGB200Nvl => redfish::oem::BmcVendor::Wiwynn,
+            HardwareType::LenovoGB300Nvl => redfish::oem::BmcVendor::Ami,
+            HardwareType::NvidiaDgxGb300 => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
-            HostHardwareType::SupermicroGb300Nvl => redfish::oem::BmcVendor::Supermicro,
-            HostHardwareType::NvidiaDgxVr => {
+            HardwareType::SupermicroGb300Nvl => redfish::oem::BmcVendor::Supermicro,
+            HardwareType::NvidiaDgxVr => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
-            HostHardwareType::LiteOnPowerShelf => redfish::oem::BmcVendor::LiteOn,
-            HostHardwareType::DeltaPowerShelf => redfish::oem::BmcVendor::Delta,
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
+            HardwareType::LiteOnPowerShelf => redfish::oem::BmcVendor::LiteOn,
+            HardwareType::DeltaPowerShelf => redfish::oem::BmcVendor::Delta,
+            HardwareType::NvidiaSwitchNd5200Ld => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
-            HostHardwareType::NvidiaDgxH100 => redfish::oem::BmcVendor::Ami,
-            HostHardwareType::GenericAmi => redfish::oem::BmcVendor::Ami,
-            HostHardwareType::HpeProliantDl380aGen11 => redfish::oem::BmcVendor::Hpe,
-            HostHardwareType::GenericSupermicro => redfish::oem::BmcVendor::Supermicro,
+            HardwareType::NvidiaDgxH100 => redfish::oem::BmcVendor::Ami,
+            HardwareType::GenericAmi => redfish::oem::BmcVendor::Ami,
+            HardwareType::HpeProliantDl380aGen11 => redfish::oem::BmcVendor::Hpe,
+            HardwareType::GenericSupermicro => redfish::oem::BmcVendor::Supermicro,
         }
     }
 
     pub fn bmc_product(&self) -> Option<&'static str> {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => None,
-            HostHardwareType::DellPowerEdgeR760Bf4 => {
-                Some("Integrated Dell Remote Access Controller")
-            }
-            HostHardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
-            HostHardwareType::LenovoGB300Nvl => Some("AMI Redfish Server"),
-            HostHardwareType::NvidiaDgxGb300 => Some("GB BMC"),
-            HostHardwareType::SupermicroGb300Nvl => Some("GB NVL"),
-            HostHardwareType::NvidiaDgxVr => Some("VR NVL72"),
-            HostHardwareType::LiteOnPowerShelf => None,
-            HostHardwareType::DeltaPowerShelf => None,
-            HostHardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
-            HostHardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
-            HostHardwareType::GenericAmi => Some("AMI Redfish Server"),
-            HostHardwareType::HpeProliantDl380aGen11 => Some("ProLiant DL380a Gen11"),
-            HostHardwareType::GenericSupermicro => Some("Super Server"),
+            HardwareType::DellPowerEdgeR750 => None,
+            HardwareType::DellPowerEdgeR760Bf4 => Some("Integrated Dell Remote Access Controller"),
+            HardwareType::WiwynnGB200Nvl => Some("GB200 NVL"),
+            HardwareType::LenovoGB300Nvl => Some("AMI Redfish Server"),
+            HardwareType::NvidiaDgxGb300 => Some("GB BMC"),
+            HardwareType::SupermicroGb300Nvl => Some("GB NVL"),
+            HardwareType::NvidiaDgxVr => Some("VR NVL72"),
+            HardwareType::LiteOnPowerShelf => None,
+            HardwareType::DeltaPowerShelf => None,
+            HardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
+            HardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
+            HardwareType::GenericAmi => Some("AMI Redfish Server"),
+            HardwareType::HpeProliantDl380aGen11 => Some("ProLiant DL380a Gen11"),
+            HardwareType::GenericSupermicro => Some("Super Server"),
         }
     }
 
     pub fn bmc_redfish_version(&self) -> &'static str {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4 => {
-                "1.18.0"
-            }
-            HostHardwareType::WiwynnGB200Nvl => "1.17.0",
-            HostHardwareType::LenovoGB300Nvl => "1.21.1",
-            HostHardwareType::NvidiaDgxGb300 => "1.17.0",
-            HostHardwareType::SupermicroGb300Nvl => "1.17.0",
-            HostHardwareType::NvidiaDgxVr => "1.17.0",
-            HostHardwareType::LiteOnPowerShelf => "1.9.0",
-            HostHardwareType::DeltaPowerShelf => "1.9.0",
-            HostHardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
-            HostHardwareType::NvidiaDgxH100 => "1.11.0",
-            HostHardwareType::GenericAmi => "1.17.0",
-            HostHardwareType::HpeProliantDl380aGen11 => "1.13.0",
-            HostHardwareType::GenericSupermicro => "1.17.0",
+            HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => "1.18.0",
+            HardwareType::WiwynnGB200Nvl => "1.17.0",
+            HardwareType::LenovoGB300Nvl => "1.21.1",
+            HardwareType::NvidiaDgxGb300 => "1.17.0",
+            HardwareType::SupermicroGb300Nvl => "1.17.0",
+            HardwareType::NvidiaDgxVr => "1.17.0",
+            HardwareType::LiteOnPowerShelf => "1.9.0",
+            HardwareType::DeltaPowerShelf => "1.9.0",
+            HardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
+            HardwareType::NvidiaDgxH100 => "1.11.0",
+            HardwareType::GenericAmi => "1.17.0",
+            HardwareType::HpeProliantDl380aGen11 => "1.13.0",
+            HardwareType::GenericSupermicro => "1.17.0",
         }
     }
 
     pub fn manager_config(&self) -> redfish::manager::Config {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
-            HostHardwareType::DellPowerEdgeR760Bf4 => {
-                self.dell_poweredge_r760_bf4().manager_config()
-            }
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().manager_config(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().manager_config(),
-            HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().manager_config(),
-            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().manager_config(),
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
-            HostHardwareType::DeltaPowerShelf => self.delta_power_shelf().manager_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().manager_config()
-            }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
-            HostHardwareType::HpeProliantDl380aGen11 => {
+            HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
+            HardwareType::DellPowerEdgeR760Bf4 => self.dell_poweredge_r760_bf4().manager_config(),
+            HardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().manager_config(),
+            HardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().manager_config(),
+            HardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().manager_config(),
+            HardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().manager_config(),
+            HardwareType::NvidiaDgxVr => self.dgx_vr_nvl().manager_config(),
+            HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
+            HardwareType::DeltaPowerShelf => self.delta_power_shelf().manager_config(),
+            HardwareType::NvidiaSwitchNd5200Ld => self.nvidia_switch_nd5200_ld().manager_config(),
+            HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
+            HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().manager_config()
             }
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
+            HardwareType::GenericAmi | HardwareType::GenericSupermicro => {
                 self.generic_server().manager_config()
             }
         }
@@ -443,29 +429,25 @@ impl HostMachineInfo {
         callbacks: Arc<dyn crate::Callbacks>,
     ) -> redfish::computer_system::Config {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => {
-                self.dell_poweredge_r750().system_config(callbacks)
-            }
-            HostHardwareType::DellPowerEdgeR760Bf4 => {
+            HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().system_config(callbacks),
+            HardwareType::DellPowerEdgeR760Bf4 => {
                 self.dell_poweredge_r760_bf4().system_config(callbacks)
             }
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().system_config(callbacks),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().system_config(callbacks),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().system_config(callbacks),
-            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().system_config(callbacks),
-            HostHardwareType::SupermicroGb300Nvl => {
+            HardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().system_config(callbacks),
+            HardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().system_config(callbacks),
+            HardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().system_config(callbacks),
+            HardwareType::NvidiaDgxVr => self.dgx_vr_nvl().system_config(callbacks),
+            HardwareType::SupermicroGb300Nvl => {
                 self.supermicro_gb300_nvl().system_config(callbacks)
             }
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
-            HostHardwareType::DeltaPowerShelf => self.delta_power_shelf().system_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().system_config()
-            }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
-            HostHardwareType::HpeProliantDl380aGen11 => {
+            HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
+            HardwareType::DeltaPowerShelf => self.delta_power_shelf().system_config(),
+            HardwareType::NvidiaSwitchNd5200Ld => self.nvidia_switch_nd5200_ld().system_config(),
+            HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
+            HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().system_config(callbacks)
             }
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
+            HardwareType::GenericAmi | HardwareType::GenericSupermicro => {
                 self.generic_server().system_config(callbacks)
             }
         }
@@ -473,25 +455,21 @@ impl HostMachineInfo {
 
     pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
-            HostHardwareType::DellPowerEdgeR760Bf4 => {
-                self.dell_poweredge_r760_bf4().chassis_config()
-            }
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().chassis_config(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().chassis_config(),
-            HostHardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().chassis_config(),
-            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().chassis_config(),
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
-            HostHardwareType::DeltaPowerShelf => self.delta_power_shelf().chassis_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
-                self.nvidia_switch_nd5200_ld().chassis_config()
-            }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
-            HostHardwareType::HpeProliantDl380aGen11 => {
+            HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
+            HardwareType::DellPowerEdgeR760Bf4 => self.dell_poweredge_r760_bf4().chassis_config(),
+            HardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().chassis_config(),
+            HardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().chassis_config(),
+            HardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().chassis_config(),
+            HardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().chassis_config(),
+            HardwareType::NvidiaDgxVr => self.dgx_vr_nvl().chassis_config(),
+            HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
+            HardwareType::DeltaPowerShelf => self.delta_power_shelf().chassis_config(),
+            HardwareType::NvidiaSwitchNd5200Ld => self.nvidia_switch_nd5200_ld().chassis_config(),
+            HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
+            HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().chassis_config()
             }
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
+            HardwareType::GenericAmi | HardwareType::GenericSupermicro => {
                 self.generic_server().chassis_config()
             }
         }
@@ -499,29 +477,25 @@ impl HostMachineInfo {
 
     pub fn update_service_config(&self) -> UpdateServiceConfig {
         match self.hw_type {
-            HostHardwareType::DellPowerEdgeR750 => {
-                self.dell_poweredge_r750().update_service_config()
-            }
-            HostHardwareType::DellPowerEdgeR760Bf4 => {
+            HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().update_service_config(),
+            HardwareType::DellPowerEdgeR760Bf4 => {
                 self.dell_poweredge_r760_bf4().update_service_config()
             }
-            HostHardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
-            HostHardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().update_service_config(),
-            HostHardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().update_service_config(),
-            HostHardwareType::SupermicroGb300Nvl => {
-                self.supermicro_gb300_nvl().update_service_config()
-            }
-            HostHardwareType::NvidiaDgxVr => self.dgx_vr_nvl().update_service_config(),
-            HostHardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
-            HostHardwareType::DeltaPowerShelf => self.delta_power_shelf().update_service_config(),
-            HostHardwareType::NvidiaSwitchNd5200Ld => {
+            HardwareType::WiwynnGB200Nvl => self.wiwynn_gb200_nvl().update_service_config(),
+            HardwareType::LenovoGB300Nvl => self.lenovo_gb300_nvl().update_service_config(),
+            HardwareType::NvidiaDgxGb300 => self.dgx_gb300_nvl().update_service_config(),
+            HardwareType::SupermicroGb300Nvl => self.supermicro_gb300_nvl().update_service_config(),
+            HardwareType::NvidiaDgxVr => self.dgx_vr_nvl().update_service_config(),
+            HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().update_service_config(),
+            HardwareType::DeltaPowerShelf => self.delta_power_shelf().update_service_config(),
+            HardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().update_service_config()
             }
-            HostHardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
-            HostHardwareType::HpeProliantDl380aGen11 => {
+            HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
+            HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().update_service_config()
             }
-            HostHardwareType::GenericAmi | HostHardwareType::GenericSupermicro => {
+            HardwareType::GenericAmi | HardwareType::GenericSupermicro => {
                 self.generic_server().update_service_config()
             }
         }
@@ -530,7 +504,7 @@ impl HostMachineInfo {
     pub fn factory_default_account(&self) -> redfish::account_service::Account {
         // TODO: need to be updated for each individual system.
         let id = match self.hw_type {
-            HostHardwareType::NvidiaDgxH100 | HostHardwareType::GenericAmi => "2",
+            HardwareType::NvidiaDgxH100 | HardwareType::GenericAmi => "2",
             _ => DUMMY_FACTORY_USERNAME,
         };
         redfish::account_service::Account::administrator(
@@ -810,7 +784,7 @@ impl HostMachineInfo {
     /// Whether this host advertises and serves a `/redfish/v1/Systems`
     /// collection. Delta power shelves do not.
     pub fn exposes_computer_systems(&self) -> bool {
-        !matches!(self.hw_type, HostHardwareType::DeltaPowerShelf)
+        !matches!(self.hw_type, HardwareType::DeltaPowerShelf)
     }
 
     fn nvidia_switch_nd5200_ld(&self) -> hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld<'_> {
@@ -1105,7 +1079,7 @@ mod tests {
     use super::*;
     use crate::mac_address_pool::{Config, PoolConfig};
 
-    fn gb300_host_info(hw_type: HostHardwareType, pool: &mut MacAddressPool) -> HostMachineInfo {
+    fn gb300_host_info(hw_type: HardwareType, pool: &mut MacAddressPool) -> HostMachineInfo {
         let hw_mac_addr_pool = PoolConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16)
             .expect("valid hardware MAC pool");
         let dpu = DpuMachineInfo::new(hw_type, pool, DpuSettings::default());
@@ -1121,8 +1095,8 @@ mod tests {
             pool: Some(pool_config),
         });
 
-        let dgx = gb300_host_info(HostHardwareType::NvidiaDgxGb300, &mut pool);
-        let supermicro = gb300_host_info(HostHardwareType::SupermicroGb300Nvl, &mut pool);
+        let dgx = gb300_host_info(HardwareType::NvidiaDgxGb300, &mut pool);
+        let supermicro = gb300_host_info(HardwareType::SupermicroGb300Nvl, &mut pool);
 
         let dgx_redfish = dgx.dgx_gb300_nvl();
         assert_eq!(dgx_redfish.system_0_serial_number, dgx.serial);

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -30,9 +30,9 @@ use bmc_mock::mac_address_pool::{
     RangesConfig as MacAddressRangesConfig,
 };
 use bmc_mock::{
-    BmcCommand, BmcState, Callbacks, DpuMachineInfo, DpuSettings, HostHardwareType,
-    HostMachineInfo, ListenerOrAddress, MachineInfo, MachineRouterOptions, MockPowerState,
-    SetSystemPowerError, SystemPowerControl, VirtualMediaDeviceConfig,
+    BmcCommand, BmcState, Callbacks, DpuMachineInfo, DpuSettings, HardwareType, HostMachineInfo,
+    ListenerOrAddress, MachineInfo, MachineRouterOptions, MockPowerState, SetSystemPowerError,
+    SystemPowerControl, VirtualMediaDeviceConfig,
 };
 use command_line::{MachineRole, StateBackend};
 use mac_address::MacAddress;
@@ -219,7 +219,7 @@ fn spawn_qemu_reboot_handler() -> mpsc::UnboundedSender<BmcCommand> {
 struct GeneratedMockConfig {
     machine_role: MachineRole,
     state_backend: StateBackend,
-    hardware_type: HostHardwareType,
+    hardware_type: HardwareType,
     dpu_count: u8,
     dpu_index: usize,
     instance_index: u8,
@@ -242,7 +242,7 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         return Ok(GeneratedMockConfig {
             machine_role: MachineRole::Host,
             state_backend: StateBackend::Internal,
-            hardware_type: HostHardwareType::WiwynnGB200Nvl,
+            hardware_type: HardwareType::WiwynnGB200Nvl,
             dpu_count: 2,
             dpu_index: 0,
             instance_index: 0,
@@ -392,7 +392,7 @@ fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
 
 fn generated_machine_info(
     machine_role: MachineRole,
-    hardware_type: HostHardwareType,
+    hardware_type: HardwareType,
     dpu_count: u8,
     dpu_index: usize,
     instance_index: u8,
@@ -476,10 +476,7 @@ mod tests {
         let config = config(&["bmc-mock"]).unwrap();
         assert_eq!(config.machine_role, MachineRole::Host);
         assert_eq!(config.state_backend, StateBackend::Internal);
-        assert!(matches!(
-            config.hardware_type,
-            HostHardwareType::WiwynnGB200Nvl
-        ));
+        assert!(matches!(config.hardware_type, HardwareType::WiwynnGB200Nvl));
         assert!(config.use_channel_callbacks);
     }
 
@@ -536,10 +533,8 @@ mod tests {
 
     #[test]
     fn host_and_dpu_endpoints_share_deterministic_dpu_identity() {
-        let host =
-            generated_machine_info(MachineRole::Host, HostHardwareType::WiwynnGB200Nvl, 2, 0, 3);
-        let dpu =
-            generated_machine_info(MachineRole::Dpu, HostHardwareType::WiwynnGB200Nvl, 2, 1, 3);
+        let host = generated_machine_info(MachineRole::Host, HardwareType::WiwynnGB200Nvl, 2, 0, 3);
+        let dpu = generated_machine_info(MachineRole::Dpu, HardwareType::WiwynnGB200Nvl, 2, 1, 3);
         let MachineInfo::Host(host) = host else {
             panic!("expected host machine info");
         };

--- a/crates/bmc-mock/src/mock_machine_router.rs
+++ b/crates/bmc-mock/src/mock_machine_router.rs
@@ -24,7 +24,7 @@ use crate::bmc_state::BmcState;
 use crate::injection::InjectionStore;
 use crate::redfish::manager::ManagerState;
 use crate::{
-    Callbacks, HostHardwareType, MachineInfo, SystemPowerControl, VirtualMediaDeviceConfig,
+    Callbacks, HardwareType, MachineInfo, SystemPowerControl, VirtualMediaDeviceConfig,
     auth_router, middleware_router, redfish,
 };
 
@@ -175,7 +175,7 @@ fn machine_router_inner(
         &machine_info,
         MachineInfo::Host(h) if matches!(
             h.hw_type,
-            HostHardwareType::LiteOnPowerShelf | HostHardwareType::DeltaPowerShelf
+            HardwareType::LiteOnPowerShelf | HardwareType::DeltaPowerShelf
         )
     );
     let router = ([

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -261,7 +261,7 @@ mod tests {
     fn test_host_mock() -> Router {
         let callbacks = Arc::new(TestCallbacks {});
         let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
-        let hw_type = HostHardwareType::DellPowerEdgeR750;
+        let hw_type = HardwareType::DellPowerEdgeR750;
         let ranges_config = mac_pool.allocate_range_config().unwrap();
         crate::machine_router(
             &MachineInfo::Host(HostMachineInfo::new(

--- a/crates/bmc-mock/src/redfish/telemetry_service.rs
+++ b/crates/bmc-mock/src/redfish/telemetry_service.rs
@@ -150,13 +150,13 @@ mod tests {
     use crate::test_support::axum_http_client::AxumRouterHttpClient;
     use crate::test_support::{NoopCallbacks, TEST_MAC_POOL};
     use crate::{
-        DpuMachineInfo, DpuSettings, HostHardwareType, HostMachineInfo, MachineInfo,
+        DpuMachineInfo, DpuSettings, HardwareType, HostMachineInfo, MachineInfo,
         MachineRouterOptions, machine_router,
     };
 
     fn test_host_mock() -> Router {
         let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
-        let hw_type = HostHardwareType::DellPowerEdgeR750;
+        let hw_type = HardwareType::DellPowerEdgeR750;
         let ranges_config = mac_pool.allocate_range_config().unwrap();
 
         machine_router(

--- a/crates/bmc-mock/src/redfish/virtual_media.rs
+++ b/crates/bmc-mock/src/redfish/virtual_media.rs
@@ -258,7 +258,7 @@ mod tests {
     use super::*;
     use crate::test_support::host_info;
     use crate::{
-        Callbacks, HostHardwareType, MachineRouterOptions, MockPowerState, SetSystemPowerError,
+        Callbacks, HardwareType, MachineRouterOptions, MockPowerState, SetSystemPowerError,
         SystemPowerControl, machine_router,
     };
 
@@ -285,10 +285,10 @@ mod tests {
     }
 
     fn test_router() -> (Router, Arc<RecordingCallbacks>) {
-        test_router_for(HostHardwareType::DellPowerEdgeR750)
+        test_router_for(HardwareType::DellPowerEdgeR750)
     }
 
-    fn test_router_for(hardware_type: HostHardwareType) -> (Router, Arc<RecordingCallbacks>) {
+    fn test_router_for(hardware_type: HardwareType) -> (Router, Arc<RecordingCallbacks>) {
         let callbacks = Arc::new(RecordingCallbacks::default());
         let router = machine_router(
             &host_info(hardware_type),
@@ -316,7 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn attaches_virtual_media_to_the_controlled_system_not_the_first_member() {
-        let (router, _) = test_router_for(HostHardwareType::NvidiaDgxGb300);
+        let (router, _) = test_router_for(HardwareType::NvidiaDgxGb300);
         let hgx = "/redfish/v1/Systems/HGX_Baseboard_0";
         let host = "/redfish/v1/Systems/System_0";
 

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -28,7 +28,7 @@ use crate::mac_address_pool::{
 };
 use crate::machine_info::DpuSettings;
 use crate::{
-    BmcState, Callbacks, DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo,
+    BmcState, Callbacks, DpuMachineInfo, HardwareType, HostMachineInfo, MachineInfo,
     MachineRouterOptions, MockPowerState, SetSystemPowerError, SystemPowerControl, machine_router,
 };
 
@@ -102,7 +102,7 @@ pub async fn bmc_for_machine(machine_info: MachineInfo) -> TestBmcHandle {
     .await
 }
 
-pub(crate) fn host_info(hw_type: HostHardwareType) -> MachineInfo {
+pub(crate) fn host_info(hw_type: HardwareType) -> MachineInfo {
     let ndpu = hw_type.fixed_number_of_dpu().unwrap_or(0);
     let mut pool = TEST_MAC_POOL.lock().unwrap();
     let ranges_config = pool.allocate_range_config().unwrap();
@@ -118,7 +118,7 @@ pub(crate) fn host_info(hw_type: HostHardwareType) -> MachineInfo {
 
 pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::WiwynnGB200Nvl),
+        &host_info(HardwareType::WiwynnGB200Nvl),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -129,7 +129,7 @@ pub async fn wiwynn_gb200_bmc() -> TestBmcHandle {
 
 pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::LenovoGB300Nvl),
+        &host_info(HardwareType::LenovoGB300Nvl),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -140,7 +140,7 @@ pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
 
 pub async fn dgx_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::NvidiaDgxGb300),
+        &host_info(HardwareType::NvidiaDgxGb300),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -156,7 +156,7 @@ pub async fn dgx_gb300_bmc() -> TestBmcHandle {
 /// it as a host tray at all. Added while investigating #3159.
 pub async fn nvidia_dgx_vr_host_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::NvidiaDgxVr),
+        &host_info(HardwareType::NvidiaDgxVr),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -167,7 +167,7 @@ pub async fn nvidia_dgx_vr_host_bmc() -> TestBmcHandle {
 
 pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::SupermicroGb300Nvl),
+        &host_info(HardwareType::SupermicroGb300Nvl),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -178,7 +178,7 @@ pub async fn supermicro_gb300_bmc() -> TestBmcHandle {
 
 pub async fn generic_supermicro_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::GenericSupermicro),
+        &host_info(HardwareType::GenericSupermicro),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -189,7 +189,7 @@ pub async fn generic_supermicro_bmc() -> TestBmcHandle {
 
 pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::LiteOnPowerShelf),
+        &host_info(HardwareType::LiteOnPowerShelf),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -200,7 +200,7 @@ pub async fn liteon_powershelf_bmc() -> TestBmcHandle {
 
 pub async fn delta_powershelf_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::DeltaPowerShelf),
+        &host_info(HardwareType::DeltaPowerShelf),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -213,7 +213,7 @@ pub async fn delta_powershelf_bmc() -> TestBmcHandle {
 /// `Oem.deltaenergysystems.Power`. Lets tests exercise off and mixed shelves
 /// (the default [`delta_powershelf_bmc`] is an all-on six-bay shelf).
 pub async fn delta_powershelf_bmc_with_psu_power(states: Vec<bool>) -> TestBmcHandle {
-    let machine_info = match host_info(HostHardwareType::DeltaPowerShelf) {
+    let machine_info = match host_info(HardwareType::DeltaPowerShelf) {
         MachineInfo::Host(host) => MachineInfo::Host(host.with_delta_psu_power(states)),
         MachineInfo::Dpu(_) => unreachable!("Delta power shelf must be a host"),
     };
@@ -229,7 +229,7 @@ pub async fn delta_powershelf_bmc_with_psu_power(states: Vec<bool>) -> TestBmcHa
 
 pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::NvidiaSwitchNd5200Ld),
+        &host_info(HardwareType::NvidiaSwitchNd5200Ld),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -240,7 +240,7 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
 
 pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::DellPowerEdgeR750),
+        &host_info(HardwareType::DellPowerEdgeR750),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -253,7 +253,7 @@ pub async fn dell_poweredge_r750_bluefield3_bmc(settings: DpuSettings) -> TestBm
     let machine_info = {
         let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
         MachineInfo::Dpu(DpuMachineInfo::new(
-            HostHardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR750,
             &mut mac_pool,
             settings,
         ))
@@ -284,7 +284,7 @@ pub async fn nvidia_dgx_vr_bluefield4_dpu_bmc(settings: DpuSettings) -> TestBmcH
     let machine_info = {
         let mut mac_pool = TEST_MAC_POOL.lock().unwrap();
         MachineInfo::Dpu(DpuMachineInfo::new(
-            HostHardwareType::NvidiaDgxVr,
+            HardwareType::NvidiaDgxVr,
             &mut mac_pool,
             settings,
         ))
@@ -301,7 +301,7 @@ pub async fn nvidia_dgx_vr_bluefield4_dpu_bmc(settings: DpuSettings) -> TestBmcH
 
 pub async fn hpe_proliant_dl380a_gen11_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::HpeProliantDl380aGen11),
+        &host_info(HardwareType::HpeProliantDl380aGen11),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -312,7 +312,7 @@ pub async fn hpe_proliant_dl380a_gen11_bmc() -> TestBmcHandle {
 
 pub async fn generic_ami_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
-        &host_info(HostHardwareType::GenericAmi),
+        &host_info(HardwareType::GenericAmi),
         Arc::new(NoopCallbacks),
         "test-host-id".to_string(),
         false,
@@ -349,7 +349,7 @@ mod test {
             remaining: None,
         });
         let (router, state) = crate::machine_router_with_injection_store(
-            &host_info(HostHardwareType::DellPowerEdgeR750),
+            &host_info(HardwareType::DellPowerEdgeR750),
             Arc::new(NoopCallbacks),
             "test-host-id".to_string(),
             false,
@@ -373,7 +373,7 @@ mod test {
     async fn transport_supports_expand_query_through_mock_expander() {
         let client = AxumRouterHttpClient::new(
             machine_router(
-                &host_info(HostHardwareType::DellPowerEdgeR750),
+                &host_info(HardwareType::DellPowerEdgeR750),
                 Arc::new(NoopCallbacks),
                 "test-host-id".to_string(),
                 false,

--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -21,7 +21,9 @@ use bmc_mock::{DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, MachineInfo};
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::machine_validation::MachineValidationId;
+use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::{RackId, RackProfileId};
+use carbide_uuid::switch::SwitchId;
 use mac_address::MacAddress;
 use model::expected_machine::HostDpuPolicy;
 use rpc::forge::instance_operating_system_config::Variant;
@@ -328,6 +330,68 @@ impl ApiClient {
             })
             .await
             .map_err(ClientApiError::InvocationError)
+    }
+
+    pub async fn force_delete_switch_by_bmc(
+        &self,
+        bmc_mac: String,
+    ) -> ClientApiResult<Option<SwitchId>> {
+        let mut ids = self
+            .0
+            .find_switch_ids(rpc::forge::SwitchSearchFilter {
+                bmc_mac: Some(bmc_mac.clone()),
+                ..Default::default()
+            })
+            .await
+            .map_err(ClientApiError::InvocationError)?
+            .ids;
+        if ids.len() > 1 {
+            return Err(ClientApiError::ConfigError(format!(
+                "multiple switches found for BMC MAC address {bmc_mac}"
+            )));
+        }
+        let Some(switch_id) = ids.pop() else {
+            return Ok(None);
+        };
+        self.0
+            .admin_force_delete_switch(rpc::forge::AdminForceDeleteSwitchRequest {
+                switch_id: Some(switch_id),
+                delete_interfaces: true,
+            })
+            .await
+            .map_err(ClientApiError::InvocationError)?;
+        Ok(Some(switch_id))
+    }
+
+    pub async fn force_delete_power_shelf_by_bmc(
+        &self,
+        bmc_mac: String,
+    ) -> ClientApiResult<Option<PowerShelfId>> {
+        let mut ids = self
+            .0
+            .find_power_shelf_ids(rpc::forge::PowerShelfSearchFilter {
+                bmc_mac: Some(bmc_mac.clone()),
+                ..Default::default()
+            })
+            .await
+            .map_err(ClientApiError::InvocationError)?
+            .ids;
+        if ids.len() > 1 {
+            return Err(ClientApiError::ConfigError(format!(
+                "multiple power shelves found for BMC MAC address {bmc_mac}"
+            )));
+        }
+        let Some(power_shelf_id) = ids.pop() else {
+            return Ok(None);
+        };
+        self.0
+            .admin_force_delete_power_shelf(rpc::forge::AdminForceDeletePowerShelfRequest {
+                power_shelf_id: Some(power_shelf_id),
+                delete_interfaces: true,
+            })
+            .await
+            .map_err(ClientApiError::InvocationError)?;
+        Ok(Some(power_shelf_id))
     }
 
     pub async fn create_network_segment(

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bmc_mock::mac_address_pool::MacAddressPool;
-use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType};
+use bmc_mock::{DpuMachineInfo, DpuSettings, HardwareType};
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use clap::Parser;
@@ -71,8 +71,8 @@ pub struct MachineATronArgs {
 pub struct MachineConfig {
     #[serde(default)]
     pub rack_id: Option<RackId>,
-    #[serde(default = "default_host_hardware_type")]
-    pub hw_type: HostHardwareType,
+    #[serde(default = "default_hardware_type")]
+    pub hw_type: HardwareType,
     pub host_count: u32,
     pub vpc_count: u32,
     pub subnets_per_vpc: u32,
@@ -438,7 +438,7 @@ impl Default for DhcpType {
 pub struct PersistedDevice {
     pub mat_id: Uuid,
     pub machine_config_section: String,
-    pub hw_type: Option<HostHardwareType>,
+    pub hw_type: Option<HardwareType>,
     pub bmc_mac_address: MacAddress,
     pub serial: String,
     pub dpus: Vec<PersistedDpuMachine>,
@@ -466,7 +466,7 @@ impl PersistedDevice {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedDpuMachine {
     pub mat_id: Uuid,
-    pub hw_type: Option<HostHardwareType>,
+    pub hw_type: Option<HardwareType>,
     pub bmc_mac_address: MacAddress,
     pub host_mac_address: MacAddress,
     pub oob_mac_address: MacAddress,
@@ -521,8 +521,8 @@ fn default_network_status_run_interval() -> Duration {
     Duration::from_secs(20)
 }
 
-fn default_host_hardware_type() -> HostHardwareType {
-    HostHardwareType::default()
+fn default_hardware_type() -> HardwareType {
+    HardwareType::default()
 }
 
 fn default_scout_run_interval() -> Duration {

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -348,15 +348,15 @@ impl MachineATronConfig {
         Ok(())
     }
 
-    pub fn read_persisted_machines(
+    pub fn read_persisted_devices(
         &self,
-    ) -> eyre::Result<Option<HashMap<String, Vec<PersistedHostMachine>>>> {
-        let Some(machines_persist_dir) = &self.machines_persist_dir() else {
+    ) -> eyre::Result<Option<HashMap<String, Vec<PersistedDevice>>>> {
+        let Some(devices_persist_dir) = &self.devices_persist_dir() else {
             return Ok(None);
         };
 
-        let machines_by_config_section: HashMap<String, Vec<PersistedHostMachine>> =
-            std::fs::read_dir(machines_persist_dir)?
+        let devices_by_config_section: HashMap<String, Vec<PersistedDevice>> =
+            std::fs::read_dir(devices_persist_dir)?
                 .map(|f| {
                     let f = f?;
                     let filename = f.file_name().to_string_lossy().into_owned();
@@ -375,40 +375,40 @@ impl MachineATronConfig {
                 .flatten()
                 // Build the HashMap
                 .collect();
-        Ok(Some(machines_by_config_section))
+        Ok(Some(devices_by_config_section))
     }
 
-    pub fn write_persisted_machines(&self, machines: &[PersistedHostMachine]) -> eyre::Result<()> {
-        let Some(machines_persist_dir) = &self.machines_persist_dir() else {
+    pub fn write_persisted_devices(&self, devices: &[PersistedDevice]) -> eyre::Result<()> {
+        let Some(devices_persist_dir) = &self.devices_persist_dir() else {
             return Ok(());
         };
 
-        std::fs::create_dir_all(machines_persist_dir)?;
+        std::fs::create_dir_all(devices_persist_dir)?;
 
-        let mut persisted_machines_by_section: HashMap<String, Vec<&PersistedHostMachine>> =
+        let mut persisted_devices_by_section: HashMap<String, Vec<&PersistedDevice>> =
             HashMap::new();
-        for machine in machines {
-            if let Some(machines) =
-                persisted_machines_by_section.get_mut(&machine.machine_config_section)
+        for device in devices {
+            if let Some(devices) =
+                persisted_devices_by_section.get_mut(&device.machine_config_section)
             {
-                machines.push(machine);
+                devices.push(device);
             } else {
-                persisted_machines_by_section
-                    .insert(machine.machine_config_section.clone(), vec![machine]);
+                persisted_devices_by_section
+                    .insert(device.machine_config_section.clone(), vec![device]);
             }
         }
 
-        for (config_section, persisted_machines) in persisted_machines_by_section {
+        for (config_section, persisted_devices) in persisted_devices_by_section {
             std::fs::write(
-                machines_persist_dir.join(format!("{config_section}.json")),
-                serde_json::to_vec(&persisted_machines)?,
+                devices_persist_dir.join(format!("{config_section}.json")),
+                serde_json::to_vec(&persisted_devices)?,
             )?;
         }
 
         Ok(())
     }
 
-    fn machines_persist_dir(&self) -> Option<PathBuf> {
+    fn devices_persist_dir(&self) -> Option<PathBuf> {
         self.persist_dir.as_ref().map(|d| d.join("machines"))
     }
 }
@@ -433,10 +433,9 @@ impl Default for DhcpType {
     }
 }
 
-/// A subset of the information about a HostMachine which is persisted to JSON to be recovered in
-/// subsequent runs of machine-a-tron.
+/// Device information persisted to JSON for recovery by subsequent machine-a-tron runs.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct PersistedHostMachine {
+pub struct PersistedDevice {
     pub mat_id: Uuid,
     pub machine_config_section: String,
     pub hw_type: Option<HostHardwareType>,
@@ -455,7 +454,7 @@ pub struct PersistedHostMachine {
     pub hw_mac_addr_pool: Option<MacAddressPoolConfig>,
 }
 
-impl PersistedHostMachine {
+impl PersistedDevice {
     pub fn mac_addresses(&self) -> impl Iterator<Item = MacAddress> {
         std::iter::once(self.bmc_mac_address)
             .chain(self.dpus.iter().flat_map(|d| d.mac_addresses()))

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -23,11 +23,10 @@ use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{any, get};
 use axum::{Json, Router};
 use bmc_mock::injection::{InjectionStore, Rule, RuleId};
-use carbide_uuid::machine::MachineId;
 use tower::Service;
-use uuid::Uuid;
 
-use crate::host_machine::HostMachineHandle;
+use crate::device_simulator::SimulatorLifecycle;
+use crate::simulator_registry::SimulatorRegistry;
 use crate::status::{MachineStatusConfig, MachinesStatusResponse};
 
 pub fn append(router: Router, control_state: ControlState) -> Router {
@@ -51,17 +50,14 @@ pub fn append(router: Router, control_state: ControlState) -> Router {
 
 #[derive(Clone)]
 pub struct ControlState {
-    machine_handles: Arc<Vec<HostMachineHandle>>,
+    simulators: SimulatorRegistry,
     status_config: MachineStatusConfig,
 }
 
 impl ControlState {
-    pub fn new(
-        machine_handles: Vec<HostMachineHandle>,
-        status_config: MachineStatusConfig,
-    ) -> Self {
+    pub fn new(simulators: SimulatorRegistry, status_config: MachineStatusConfig) -> Self {
         Self {
-            machine_handles: Arc::new(machine_handles),
+            simulators,
             status_config,
         }
     }
@@ -69,36 +65,16 @@ impl ControlState {
     fn machines_status(&self) -> MachinesStatusResponse {
         MachinesStatusResponse {
             machines: self
-                .machine_handles
+                .simulators
+                .devices()
                 .iter()
-                .map(|machine| machine.status(&self.status_config))
+                .map(|simulator| simulator.status(&self.status_config))
                 .collect(),
         }
     }
 
-    fn machine(&self, id: &str) -> Option<Arc<InjectionStore>> {
-        let mat_id = Uuid::parse_str(id).ok();
-        let machine_id = id.parse::<MachineId>().ok();
-        let matches = |candidate_mat_id, candidate_machine_id: Option<MachineId>| {
-            mat_id.is_some_and(|id| candidate_mat_id == id)
-                || machine_id
-                    .as_ref()
-                    .is_some_and(|id| candidate_machine_id.as_ref() == Some(id))
-        };
-
-        for machine in self.machine_handles.iter() {
-            if matches(machine.mat_id(), machine.observed_machine_id()) {
-                return Some(machine.bmc_injection_store());
-            }
-            if let Some(dpu) = machine
-                .dpus()
-                .iter()
-                .find(|dpu| matches(dpu.mat_id(), dpu.observed_machine_id()))
-            {
-                return Some(dpu.bmc_injection_store());
-            }
-        }
-        None
+    fn device(&self, id: &str) -> Option<Arc<InjectionStore>> {
+        self.simulators.find_injection_store(id)
     }
 }
 
@@ -120,10 +96,10 @@ async fn list_bmc_injection_rules(
     State(state): State<ControlRouter>,
     Path(id): Path<String>,
 ) -> Response {
-    let Some(machine) = state.control_state.machine(&id) else {
-        return machine_not_found();
+    let Some(device) = state.control_state.device(&id) else {
+        return device_not_found();
     };
-    Json(list_rules(&machine)).into_response()
+    Json(list_rules(&device)).into_response()
 }
 
 async fn upsert_bmc_injection_rule(
@@ -131,23 +107,23 @@ async fn upsert_bmc_injection_rule(
     Path(id): Path<String>,
     Json(rule): Json<Rule>,
 ) -> Response {
-    let Some(machine) = state.control_state.machine(&id) else {
-        return machine_not_found();
+    let Some(device) = state.control_state.device(&id) else {
+        return device_not_found();
     };
-    machine.upsert(rule);
-    Json(list_rules(&machine)).into_response()
+    device.upsert(rule);
+    Json(list_rules(&device)).into_response()
 }
 
 async fn delete_bmc_injection_rule(
     State(state): State<ControlRouter>,
     Path((id, rule_id)): Path<(String, String)>,
 ) -> Response {
-    let Some(machine) = state.control_state.machine(&id) else {
-        return machine_not_found();
+    let Some(device) = state.control_state.device(&id) else {
+        return device_not_found();
     };
     let rule_id = RuleId::from(rule_id);
-    if machine.delete(&rule_id) {
-        Json(list_rules(&machine)).into_response()
+    if device.delete(&rule_id) {
+        Json(list_rules(&device)).into_response()
     } else {
         (
             StatusCode::NOT_FOUND,
@@ -157,16 +133,16 @@ async fn delete_bmc_injection_rule(
     }
 }
 
-fn list_rules(machine: &InjectionStore) -> Vec<Rule> {
-    machine
+fn list_rules(device: &InjectionStore) -> Vec<Rule> {
+    device
         .list()
         .into_iter()
         .map(|rule| (*rule).clone())
         .collect()
 }
 
-fn machine_not_found() -> Response {
-    (StatusCode::NOT_FOUND, "machine not found").into_response()
+fn device_not_found() -> Response {
+    (StatusCode::NOT_FOUND, "device not found").into_response()
 }
 
 async fn process(State(mut state): State<ControlRouter>, request: Request<Body>) -> Response {
@@ -197,15 +173,20 @@ mod tests {
 
     use super::{ControlState, append};
     use crate::dpu_machine::DpuMachineHandle;
-    use crate::host_machine::HostMachineHandle;
+    use crate::host_machine::DeviceHandle;
+    use crate::simulator_registry::SimulatorRegistry;
     use crate::status::MachineStatusConfig;
+
+    fn control_state(handles: Vec<DeviceHandle>) -> ControlState {
+        ControlState::new(
+            SimulatorRegistry::try_from_handles(handles).unwrap(),
+            MachineStatusConfig::new(1266),
+        )
+    }
 
     #[tokio::test]
     async fn machines_status_does_not_require_bmc_routes() {
-        let router = append(
-            Router::new(),
-            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
-        );
+        let router = append(Router::new(), control_state(Vec::new()));
 
         let response = router
             .oneshot(
@@ -226,7 +207,7 @@ mod tests {
     async fn machines_ui_returns_html() {
         let router = append(
             Router::new().route("/redfish/v1", get(|| async { "bmc" })),
-            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
+            control_state(Vec::new()),
         );
 
         let response = router
@@ -241,27 +222,24 @@ mod tests {
 
     #[tokio::test]
     async fn machines_status_reports_each_bmc_ipmi_endpoint() {
-        let first = HostMachineHandle::for_control_test(
+        let first = DeviceHandle::for_control_test(
             Vec::new(),
             Some(IpmiEndpoint {
                 reachable_port: 623,
                 listen_port: 16_020,
             }),
         );
-        let second = HostMachineHandle::for_control_test(
+        let second = DeviceHandle::for_control_test(
             Vec::new(),
             Some(IpmiEndpoint {
                 reachable_port: 623,
                 listen_port: 16_021,
             }),
         );
-        let without_ipmi = HostMachineHandle::for_control_test(Vec::new(), None);
+        let without_ipmi = DeviceHandle::for_control_test(Vec::new(), None);
         let router = append(
             Router::new(),
-            ControlState::new(
-                vec![first, second, without_ipmi],
-                MachineStatusConfig::new(1266),
-            ),
+            control_state(vec![first, second, without_ipmi]),
         );
 
         let response = router
@@ -285,11 +263,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bmc_injection_rules_require_known_machine() {
-        let router = append(
-            Router::new(),
-            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
-        );
+    async fn bmc_injection_rules_require_known_device() {
+        let router = append(Router::new(), control_state(Vec::new()));
 
         let get_response = router
             .clone()
@@ -306,7 +281,7 @@ mod tests {
         let body = to_bytes(get_response.into_body(), usize::MAX)
             .await
             .unwrap();
-        assert_eq!(&body[..], b"machine not found");
+        assert_eq!(&body[..], b"device not found");
 
         let post_response = router
             .clone()
@@ -344,11 +319,8 @@ mod tests {
             .parse()
             .unwrap();
         let dpu = DpuMachineHandle::for_control_test(dpu_id, Some(observed_dpu_id));
-        let host = HostMachineHandle::for_control_test(vec![dpu], None);
-        let router = append(
-            Router::new(),
-            ControlState::new(vec![host.clone()], MachineStatusConfig::new(1266)),
-        );
+        let host = DeviceHandle::for_control_test(vec![dpu], None);
+        let router = append(Router::new(), control_state(vec![host.clone()]));
 
         let response = router
             .clone()
@@ -389,7 +361,7 @@ mod tests {
     async fn unmatched_paths_forward_to_inner_router() {
         let router = append(
             Router::new().route("/redfish/v1", get(|| async { "bmc" })),
-            ControlState::new(Vec::new(), MachineStatusConfig::new(1266)),
+            control_state(Vec::new()),
         );
 
         let response = router

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -27,7 +27,7 @@ use tower::Service;
 
 use crate::device_simulator::SimulatorLifecycle;
 use crate::simulator_registry::SimulatorRegistry;
-use crate::status::{MachineStatusConfig, MachinesStatusResponse};
+use crate::status::{DeviceStatusConfig, DevicesStatusResponse};
 
 pub fn append(router: Router, control_state: ControlState) -> Router {
     Router::new()
@@ -51,20 +51,20 @@ pub fn append(router: Router, control_state: ControlState) -> Router {
 #[derive(Clone)]
 pub struct ControlState {
     simulators: SimulatorRegistry,
-    status_config: MachineStatusConfig,
+    status_config: DeviceStatusConfig,
 }
 
 impl ControlState {
-    pub fn new(simulators: SimulatorRegistry, status_config: MachineStatusConfig) -> Self {
+    pub fn new(simulators: SimulatorRegistry, status_config: DeviceStatusConfig) -> Self {
         Self {
             simulators,
             status_config,
         }
     }
 
-    fn machines_status(&self) -> MachinesStatusResponse {
-        MachinesStatusResponse {
-            machines: self
+    fn devices_status(&self) -> DevicesStatusResponse {
+        DevicesStatusResponse {
+            devices: self
                 .simulators
                 .devices()
                 .iter()
@@ -84,8 +84,8 @@ struct ControlRouter {
     control_state: ControlState,
 }
 
-async fn get_machines_status(State(state): State<ControlRouter>) -> Json<MachinesStatusResponse> {
-    Json(state.control_state.machines_status())
+async fn get_machines_status(State(state): State<ControlRouter>) -> Json<DevicesStatusResponse> {
+    Json(state.control_state.devices_status())
 }
 
 async fn get_machines_ui() -> Html<&'static str> {
@@ -175,12 +175,12 @@ mod tests {
     use crate::dpu_machine::DpuMachineHandle;
     use crate::host_machine::DeviceHandle;
     use crate::simulator_registry::SimulatorRegistry;
-    use crate::status::MachineStatusConfig;
+    use crate::status::DeviceStatusConfig;
 
     fn control_state(handles: Vec<DeviceHandle>) -> ControlState {
         ControlState::new(
             SimulatorRegistry::try_from_handles(handles).unwrap(),
-            MachineStatusConfig::new(1266),
+            DeviceStatusConfig::new(1266),
         )
     }
 

--- a/crates/machine-a-tron/src/device_simulator.rs
+++ b/crates/machine-a-tron/src/device_simulator.rs
@@ -20,10 +20,10 @@ use bmc_mock::injection::InjectionStore;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::PersistedHostMachine;
+use crate::PersistedDevice;
 use crate::api_client::ApiClient;
 use crate::host_machine::DeviceHandle;
-use crate::status::{DeviceKind, MachineStatus, MachineStatusConfig};
+use crate::status::{DeviceKind, DeviceStatus, DeviceStatusConfig};
 use crate::tui::UiUpdate;
 
 /// The common lifecycle exposed by every simulated physical device.
@@ -47,16 +47,16 @@ pub trait SimulatorLifecycle {
         self.handle().abort();
     }
 
-    fn persisted(&self) -> PersistedHostMachine {
+    fn persisted(&self) -> PersistedDevice {
         self.handle().persisted()
     }
 
-    fn status(&self, config: &MachineStatusConfig) -> MachineStatus {
+    fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
         let status = self.handle().status(config);
         if self.kind() == DeviceKind::Machine {
             status
         } else {
-            MachineStatus {
+            DeviceStatus {
                 device_kind: self.kind(),
                 device_id: self.mat_id().to_string(),
                 machine_id: None,

--- a/crates/machine-a-tron/src/device_simulator.rs
+++ b/crates/machine-a-tron/src/device_simulator.rs
@@ -1,0 +1,211 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::sync::Arc;
+
+use bmc_mock::injection::InjectionStore;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::PersistedHostMachine;
+use crate::api_client::ApiClient;
+use crate::host_machine::DeviceHandle;
+use crate::status::{DeviceKind, MachineStatus, MachineStatusConfig};
+use crate::tui::UiUpdate;
+
+/// The common lifecycle exposed by every simulated physical device.
+pub trait SimulatorLifecycle {
+    fn handle(&self) -> &DeviceHandle;
+    fn kind(&self) -> DeviceKind;
+
+    fn mat_id(&self) -> Uuid {
+        self.handle().mat_id()
+    }
+
+    fn attach_to_tui(&self, tui_event_tx: Option<mpsc::Sender<UiUpdate>>) -> eyre::Result<()> {
+        self.handle().attach_to_tui(tui_event_tx)
+    }
+
+    fn resume(&self) -> eyre::Result<()> {
+        self.handle().resume()
+    }
+
+    fn abort(&self) {
+        self.handle().abort();
+    }
+
+    fn persisted(&self) -> PersistedHostMachine {
+        self.handle().persisted()
+    }
+
+    fn status(&self, config: &MachineStatusConfig) -> MachineStatus {
+        let status = self.handle().status(config);
+        if self.kind() == DeviceKind::Machine {
+            status
+        } else {
+            MachineStatus {
+                device_kind: self.kind(),
+                device_id: self.mat_id().to_string(),
+                machine_id: None,
+                ..status
+            }
+        }
+    }
+
+    fn bmc_injection_store(&self) -> Arc<InjectionStore> {
+        self.handle().bmc_injection_store()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MachineSimulator(DeviceHandle);
+
+impl MachineSimulator {
+    fn new(handle: DeviceHandle) -> Self {
+        Self(handle)
+    }
+}
+
+impl SimulatorLifecycle for MachineSimulator {
+    fn handle(&self) -> &DeviceHandle {
+        &self.0
+    }
+
+    fn kind(&self) -> DeviceKind {
+        DeviceKind::Machine
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SwitchSimulator(DeviceHandle);
+
+impl SwitchSimulator {
+    fn new(handle: DeviceHandle) -> Self {
+        Self(handle)
+    }
+}
+
+impl SimulatorLifecycle for SwitchSimulator {
+    fn handle(&self) -> &DeviceHandle {
+        &self.0
+    }
+
+    fn kind(&self) -> DeviceKind {
+        DeviceKind::Switch
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PowerShelfSimulator(DeviceHandle);
+
+impl PowerShelfSimulator {
+    fn new(handle: DeviceHandle) -> Self {
+        Self(handle)
+    }
+}
+
+impl SimulatorLifecycle for PowerShelfSimulator {
+    fn handle(&self) -> &DeviceHandle {
+        &self.0
+    }
+
+    fn kind(&self) -> DeviceKind {
+        DeviceKind::PowerShelf
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum DeviceSimulator {
+    Machine(MachineSimulator),
+    Switch(SwitchSimulator),
+    PowerShelf(PowerShelfSimulator),
+}
+
+impl DeviceSimulator {
+    pub(crate) fn from_handle(handle: DeviceHandle) -> Self {
+        match DeviceKind::from(handle.host_info().hw_type) {
+            DeviceKind::Machine => Self::Machine(MachineSimulator::new(handle)),
+            DeviceKind::Switch => Self::Switch(SwitchSimulator::new(handle)),
+            DeviceKind::PowerShelf => Self::PowerShelf(PowerShelfSimulator::new(handle)),
+            DeviceKind::Dpu => unreachable!("a host handle cannot represent a DPU"),
+        }
+    }
+
+    pub fn machine(&self) -> Option<&MachineSimulator> {
+        match self {
+            Self::Machine(simulator) => Some(simulator),
+            Self::Switch(_) | Self::PowerShelf(_) => None,
+        }
+    }
+
+    pub async fn delete_from_api(&self, api_client: ApiClient) -> eyre::Result<()> {
+        match self {
+            Self::Machine(simulator) => {
+                simulator.handle().clone().delete_from_api(api_client).await
+            }
+            Self::Switch(simulator) => {
+                let bmc_mac = simulator.handle().host_info().bmc_mac_address.to_string();
+                if api_client
+                    .force_delete_switch_by_bmc(bmc_mac.clone())
+                    .await?
+                    .is_none()
+                {
+                    tracing::info!(
+                        bmc_mac_address = %bmc_mac,
+                        "Not deleting switch because it has not been discovered"
+                    );
+                }
+                Ok(())
+            }
+            Self::PowerShelf(simulator) => {
+                let bmc_mac = simulator.handle().host_info().bmc_mac_address.to_string();
+                if api_client
+                    .force_delete_power_shelf_by_bmc(bmc_mac.clone())
+                    .await?
+                    .is_none()
+                {
+                    tracing::info!(
+                        bmc_mac_address = %bmc_mac,
+                        "Not deleting power shelf because it has not been discovered"
+                    );
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub async fn shutdown(&self) -> eyre::Result<()> {
+        self.handle().abort_and_wait().await
+    }
+}
+
+impl SimulatorLifecycle for DeviceSimulator {
+    fn handle(&self) -> &DeviceHandle {
+        match self {
+            Self::Machine(simulator) => &simulator.0,
+            Self::Switch(simulator) => &simulator.0,
+            Self::PowerShelf(simulator) => &simulator.0,
+        }
+    }
+
+    fn kind(&self) -> DeviceKind {
+        match self {
+            Self::Machine(_) => DeviceKind::Machine,
+            Self::Switch(_) => DeviceKind::Switch,
+            Self::PowerShelf(_) => DeviceKind::PowerShelf,
+        }
+    }
+}

--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 
-use bmc_mock::{HostHardwareType, MachineInfo};
+use bmc_mock::{HardwareType, MachineInfo};
 use carbide_uuid::machine::MachineInterfaceId;
 use dhcproto::v4::MessageType;
 use mac_address::MacAddress;
@@ -48,7 +48,7 @@ pub(crate) enum DhcpRequester {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum DhcpMachine {
     Dpu,
-    Host(HostHardwareType),
+    Host(HardwareType),
 }
 
 impl From<&MachineInfo> for DhcpMachine {
@@ -72,48 +72,46 @@ fn vendor_class_for(machine: DhcpMachine, requester: DhcpRequester) -> Option<&'
         (DhcpMachine::Dpu, DhcpRequester::Bmc) => Some("NVIDIA/BF/BMC"),
         (DhcpMachine::Dpu, DhcpRequester::System) => Some("NVIDIA/BF/OOB"),
         (
-            DhcpMachine::Host(
-                HostHardwareType::DellPowerEdgeR750 | HostHardwareType::DellPowerEdgeR760Bf4,
-            ),
+            DhcpMachine::Host(HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4),
             DhcpRequester::Bmc,
         ) => Some("iDRAC"),
-        (DhcpMachine::Host(HostHardwareType::HpeProliantDl380aGen11), DhcpRequester::Bmc) => {
+        (DhcpMachine::Host(HardwareType::HpeProliantDl380aGen11), DhcpRequester::Bmc) => {
             Some("CPQRIB3")
         }
         // These BMCs have no verified DHCP vendor class, so omit option 60 rather than
         // reporting a value that may cause Carbide to misidentify the requester.
         (
             DhcpMachine::Host(
-                HostHardwareType::WiwynnGB200Nvl
-                | HostHardwareType::LenovoGB300Nvl
-                | HostHardwareType::NvidiaDgxGb300
-                | HostHardwareType::SupermicroGb300Nvl
-                | HostHardwareType::NvidiaDgxVr
-                | HostHardwareType::LiteOnPowerShelf
-                | HostHardwareType::DeltaPowerShelf
-                | HostHardwareType::NvidiaSwitchNd5200Ld
-                | HostHardwareType::NvidiaDgxH100
-                | HostHardwareType::GenericAmi
-                | HostHardwareType::GenericSupermicro,
+                HardwareType::WiwynnGB200Nvl
+                | HardwareType::LenovoGB300Nvl
+                | HardwareType::NvidiaDgxGb300
+                | HardwareType::SupermicroGb300Nvl
+                | HardwareType::NvidiaDgxVr
+                | HardwareType::LiteOnPowerShelf
+                | HardwareType::DeltaPowerShelf
+                | HardwareType::NvidiaSwitchNd5200Ld
+                | HardwareType::NvidiaDgxH100
+                | HardwareType::GenericAmi
+                | HardwareType::GenericSupermicro,
             ),
             DhcpRequester::Bmc,
         ) => None,
         (
             DhcpMachine::Host(
-                HostHardwareType::DellPowerEdgeR750
-                | HostHardwareType::DellPowerEdgeR760Bf4
-                | HostHardwareType::WiwynnGB200Nvl
-                | HostHardwareType::LenovoGB300Nvl
-                | HostHardwareType::NvidiaDgxGb300
-                | HostHardwareType::SupermicroGb300Nvl
-                | HostHardwareType::NvidiaDgxVr
-                | HostHardwareType::LiteOnPowerShelf
-                | HostHardwareType::DeltaPowerShelf
-                | HostHardwareType::NvidiaSwitchNd5200Ld
-                | HostHardwareType::NvidiaDgxH100
-                | HostHardwareType::GenericAmi
-                | HostHardwareType::HpeProliantDl380aGen11
-                | HostHardwareType::GenericSupermicro,
+                HardwareType::DellPowerEdgeR750
+                | HardwareType::DellPowerEdgeR760Bf4
+                | HardwareType::WiwynnGB200Nvl
+                | HardwareType::LenovoGB300Nvl
+                | HardwareType::NvidiaDgxGb300
+                | HardwareType::SupermicroGb300Nvl
+                | HardwareType::NvidiaDgxVr
+                | HardwareType::LiteOnPowerShelf
+                | HardwareType::DeltaPowerShelf
+                | HardwareType::NvidiaSwitchNd5200Ld
+                | HardwareType::NvidiaDgxH100
+                | HardwareType::GenericAmi
+                | HardwareType::HpeProliantDl380aGen11
+                | HardwareType::GenericSupermicro,
             ),
             DhcpRequester::System,
         ) => Some("PXEClient:Arch:00007:UNDI:003000"),
@@ -356,7 +354,7 @@ mod tests {
                 Check {
                     scenario: "Dell R750 BMC",
                     input: (
-                        DhcpMachine::Host(HostHardwareType::DellPowerEdgeR750),
+                        DhcpMachine::Host(HardwareType::DellPowerEdgeR750),
                         DhcpRequester::Bmc,
                     ),
                     expect: Some("iDRAC"),
@@ -364,7 +362,7 @@ mod tests {
                 Check {
                     scenario: "Dell R760 BMC",
                     input: (
-                        DhcpMachine::Host(HostHardwareType::DellPowerEdgeR760Bf4),
+                        DhcpMachine::Host(HardwareType::DellPowerEdgeR760Bf4),
                         DhcpRequester::Bmc,
                     ),
                     expect: Some("iDRAC"),
@@ -372,7 +370,7 @@ mod tests {
                 Check {
                     scenario: "HPE BMC",
                     input: (
-                        DhcpMachine::Host(HostHardwareType::HpeProliantDl380aGen11),
+                        DhcpMachine::Host(HardwareType::HpeProliantDl380aGen11),
                         DhcpRequester::Bmc,
                     ),
                     expect: Some("CPQRIB3"),
@@ -380,7 +378,7 @@ mod tests {
                 Check {
                     scenario: "unrecognized host BMC",
                     input: (
-                        DhcpMachine::Host(HostHardwareType::GenericAmi),
+                        DhcpMachine::Host(HardwareType::GenericAmi),
                         DhcpRequester::Bmc,
                     ),
                     expect: None,
@@ -388,7 +386,7 @@ mod tests {
                 Check {
                     scenario: "host system PXE client",
                     input: (
-                        DhcpMachine::Host(HostHardwareType::GenericAmi),
+                        DhcpMachine::Host(HardwareType::GenericAmi),
                         DhcpRequester::System,
                     ),
                     expect: Some("PXEClient:Arch:00007:UNDI:003000"),

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -16,7 +16,7 @@
  */
 
 use bmc_mock::mac_address_pool::MacAddressPool;
-use bmc_mock::{DpuMachineInfo, HostHardwareType, HostMachineInfo, MachineInfo};
+use bmc_mock::{DpuMachineInfo, HardwareType, HostMachineInfo, MachineInfo};
 use carbide_utils::arch::CpuArchitecture;
 use mac_address::MacAddress;
 use rpc::machine_discovery::{
@@ -34,19 +34,19 @@ pub(crate) fn for_machine(machine: &MachineInfo) -> DiscoveryInfo {
 
 fn for_dpu(dpu: &DpuMachineInfo) -> DiscoveryInfo {
     match dpu.hw_type {
-        HostHardwareType::DellPowerEdgeR760Bf4 | HostHardwareType::NvidiaDgxVr => bluefield4(dpu),
-        HostHardwareType::DellPowerEdgeR750
-        | HostHardwareType::WiwynnGB200Nvl
-        | HostHardwareType::LenovoGB300Nvl
-        | HostHardwareType::NvidiaDgxGb300
-        | HostHardwareType::SupermicroGb300Nvl
-        | HostHardwareType::NvidiaDgxH100
-        | HostHardwareType::GenericAmi
-        | HostHardwareType::HpeProliantDl380aGen11
-        | HostHardwareType::GenericSupermicro => bluefield3(dpu),
-        HostHardwareType::LiteOnPowerShelf
-        | HostHardwareType::DeltaPowerShelf
-        | HostHardwareType::NvidiaSwitchNd5200Ld => {
+        HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr => bluefield4(dpu),
+        HardwareType::DellPowerEdgeR750
+        | HardwareType::WiwynnGB200Nvl
+        | HardwareType::LenovoGB300Nvl
+        | HardwareType::NvidiaDgxGb300
+        | HardwareType::SupermicroGb300Nvl
+        | HardwareType::NvidiaDgxH100
+        | HardwareType::GenericAmi
+        | HardwareType::HpeProliantDl380aGen11
+        | HardwareType::GenericSupermicro => bluefield3(dpu),
+        HardwareType::LiteOnPowerShelf
+        | HardwareType::DeltaPowerShelf
+        | HardwareType::NvidiaSwitchNd5200Ld => {
             panic!("DPU discovery is not defined for {}", dpu.hw_type)
         }
     }
@@ -54,11 +54,11 @@ fn for_dpu(dpu: &DpuMachineInfo) -> DiscoveryInfo {
 
 fn for_host(host: &HostMachineInfo) -> DiscoveryInfo {
     match host.hw_type {
-        HostHardwareType::DellPowerEdgeR750 => dell_poweredge(host, "PowerEdge R750", "1.13.2"),
-        HostHardwareType::DellPowerEdgeR760Bf4 => dell_poweredge(host, "PowerEdge R760", "2.2.7"),
-        HostHardwareType::WiwynnGB200Nvl => wiwynn_gb200(host),
-        HostHardwareType::LenovoGB300Nvl => lenovo_gb300(host),
-        HostHardwareType::NvidiaDgxGb300 => DiscoveryInfo {
+        HardwareType::DellPowerEdgeR750 => dell_poweredge(host, "PowerEdge R750", "1.13.2"),
+        HardwareType::DellPowerEdgeR760Bf4 => dell_poweredge(host, "PowerEdge R760", "2.2.7"),
+        HardwareType::WiwynnGB200Nvl => wiwynn_gb200(host),
+        HardwareType::LenovoGB300Nvl => lenovo_gb300(host),
+        HardwareType::NvidiaDgxGb300 => DiscoveryInfo {
             network_interfaces: vec![generic_nic(
                 required_dpu(host).host_mac_address,
                 0x0603,
@@ -68,15 +68,15 @@ fn for_host(host: &HostMachineInfo) -> DiscoveryInfo {
             )],
             ..Default::default()
         },
-        HostHardwareType::NvidiaDgxH100 => nvidia_dgx_h100(host),
-        HostHardwareType::HpeProliantDl380aGen11 => hpe_proliant(host),
-        HostHardwareType::GenericAmi
-        | HostHardwareType::GenericSupermicro
-        | HostHardwareType::SupermicroGb300Nvl
-        | HostHardwareType::NvidiaDgxVr => DiscoveryInfo::default(),
-        HostHardwareType::LiteOnPowerShelf
-        | HostHardwareType::DeltaPowerShelf
-        | HostHardwareType::NvidiaSwitchNd5200Ld => {
+        HardwareType::NvidiaDgxH100 => nvidia_dgx_h100(host),
+        HardwareType::HpeProliantDl380aGen11 => hpe_proliant(host),
+        HardwareType::GenericAmi
+        | HardwareType::GenericSupermicro
+        | HardwareType::SupermicroGb300Nvl
+        | HardwareType::NvidiaDgxVr => DiscoveryInfo::default(),
+        HardwareType::LiteOnPowerShelf
+        | HardwareType::DeltaPowerShelf
+        | HardwareType::NvidiaSwitchNd5200Ld => {
             panic!("discovery_info requested for {}", host.hw_type)
         }
     }
@@ -91,10 +91,10 @@ fn architecture(architecture: CpuArchitecture) -> (String, Option<i32>) {
 
 fn bluefield3(dpu: &DpuMachineInfo) -> DiscoveryInfo {
     let part_number = match dpu.hw_type {
-        HostHardwareType::WiwynnGB200Nvl
-        | HostHardwareType::LenovoGB300Nvl
-        | HostHardwareType::NvidiaDgxGb300
-        | HostHardwareType::SupermicroGb300Nvl => "900-9D3B6-00CN-PA0",
+        HardwareType::WiwynnGB200Nvl
+        | HardwareType::LenovoGB300Nvl
+        | HardwareType::NvidiaDgxGb300
+        | HardwareType::SupermicroGb300Nvl => "900-9D3B6-00CN-PA0",
         _ if dpu.settings.nic_mode => "900-9D3B4-00CC-EA0",
         _ => "900-9D3B6-00CV-AA0",
     };
@@ -155,8 +155,8 @@ fn bluefield3(dpu: &DpuMachineInfo) -> DiscoveryInfo {
 
 fn bluefield4(dpu: &DpuMachineInfo) -> DiscoveryInfo {
     let part_number = match dpu.hw_type {
-        HostHardwareType::DellPowerEdgeR760Bf4 => "900-9D4B4-CWAA-TSA",
-        HostHardwareType::NvidiaDgxVr => "900-9D4A4-00CB-TS4",
+        HardwareType::DellPowerEdgeR760Bf4 => "900-9D4B4-CWAA-TSA",
+        HardwareType::NvidiaDgxVr => "900-9D4A4-00CB-TS4",
         _ => unreachable!("invalid BF4 platform"),
     };
     let (machine_type, machine_arch) = architecture(CpuArchitecture::Aarch64);
@@ -185,7 +185,7 @@ fn bluefield4(dpu: &DpuMachineInfo) -> DiscoveryInfo {
 
 fn dell_poweredge(host: &HostMachineInfo, product_name: &str, bios_version: &str) -> DiscoveryInfo {
     let (machine_type, machine_arch) = architecture(CpuArchitecture::X86_64);
-    let network_interfaces = if host.hw_type == HostHardwareType::DellPowerEdgeR760Bf4 {
+    let network_interfaces = if host.hw_type == HardwareType::DellPowerEdgeR760Bf4 {
         vec![generic_nic(
             required_dpu(host).host_mac_address,
             2,
@@ -874,12 +874,12 @@ mod tests {
             pool: Some(pool_config),
         });
         let dpu = DpuMachineInfo::new(
-            HostHardwareType::LenovoGB300Nvl,
+            HardwareType::LenovoGB300Nvl,
             &mut pool,
             DpuSettings::default(),
         );
         MachineInfo::Host(HostMachineInfo::new(
-            HostHardwareType::LenovoGB300Nvl,
+            HardwareType::LenovoGB300Nvl,
             vec![dpu],
             &mut pool,
             hardware_pool_config,
@@ -971,17 +971,17 @@ mod tests {
     #[test]
     fn discovery_is_defined_for_machine_platforms() {
         let platforms = [
-            HostHardwareType::DellPowerEdgeR750,
-            HostHardwareType::DellPowerEdgeR760Bf4,
-            HostHardwareType::WiwynnGB200Nvl,
-            HostHardwareType::LenovoGB300Nvl,
-            HostHardwareType::NvidiaDgxGb300,
-            HostHardwareType::SupermicroGb300Nvl,
-            HostHardwareType::NvidiaDgxVr,
-            HostHardwareType::NvidiaDgxH100,
-            HostHardwareType::GenericAmi,
-            HostHardwareType::HpeProliantDl380aGen11,
-            HostHardwareType::GenericSupermicro,
+            HardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR760Bf4,
+            HardwareType::WiwynnGB200Nvl,
+            HardwareType::LenovoGB300Nvl,
+            HardwareType::NvidiaDgxGb300,
+            HardwareType::SupermicroGb300Nvl,
+            HardwareType::NvidiaDgxVr,
+            HardwareType::NvidiaDgxH100,
+            HardwareType::GenericAmi,
+            HardwareType::HpeProliantDl380aGen11,
+            HardwareType::GenericSupermicro,
         ];
 
         for platform in platforms {
@@ -1006,8 +1006,8 @@ mod tests {
     #[test]
     fn discovery_is_defined_for_bf3_and_bf4_dpus() {
         for platform in [
-            HostHardwareType::DellPowerEdgeR750,
-            HostHardwareType::DellPowerEdgeR760Bf4,
+            HardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR760Bf4,
         ] {
             let pool_config =
                 PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid pool");

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -36,7 +36,7 @@ use crate::config::{MachineATronContext, PersistedDpuMachine};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay, DpuDhcpRelayServer};
 use crate::host_machine::HandleMessageResult;
 use crate::machine_state_machine::{LiveState, MachineStateMachine, OsImage, PersistedMachine};
-use crate::status::{BmcStatus, EndpointStatus, MachineStatus, MachineStatusConfig};
+use crate::status::{BmcStatus, DeviceKind, EndpointStatus, MachineStatus, MachineStatusConfig};
 use crate::tui::HostDetails;
 use crate::{MachineConfig, saturating_add_duration_to_instant};
 
@@ -462,6 +462,12 @@ impl DpuMachineHandle {
         let live_state = self.0.live_state.read().unwrap();
         MachineStatus {
             mat_id: self.0.mat_id.to_string(),
+            device_kind: DeviceKind::Dpu,
+            device_id: live_state
+                .observed_machine_id
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| self.0.mat_id.to_string()),
             machine_id: live_state
                 .observed_machine_id
                 .as_ref()

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 use bmc_mock::injection::InjectionStore;
 use bmc_mock::mac_address_pool::MacAddressPool;
 use bmc_mock::{
-    BmcCommand, DpuMachineInfo, DpuSettings, HostHardwareType, MachineInfo, SetSystemPowerResult,
+    BmcCommand, DpuMachineInfo, DpuSettings, HardwareType, MachineInfo, SetSystemPowerResult,
     SystemPowerControl,
 };
 use carbide_uuid::machine::MachineId;
@@ -112,7 +112,7 @@ impl DpuMachine {
     }
 
     pub fn new(
-        hw_type: HostHardwareType,
+        hw_type: HardwareType,
         mat_host: Uuid,
         dpu_index: u8,
         app_context: Arc<MachineATronContext>,
@@ -385,7 +385,7 @@ impl DpuMachineHandle {
             live_state: Arc::new(RwLock::new(live_state)),
             mat_id,
             dpu_info: DpuMachineInfo {
-                hw_type: HostHardwareType::default(),
+                hw_type: HardwareType::default(),
                 bmc_mac_address: mac,
                 host_mac_address: mac,
                 oob_mac_address: mac,

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -36,7 +36,7 @@ use crate::config::{MachineATronContext, PersistedDpuMachine};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay, DpuDhcpRelayServer};
 use crate::host_machine::HandleMessageResult;
 use crate::machine_state_machine::{LiveState, MachineStateMachine, OsImage, PersistedMachine};
-use crate::status::{BmcStatus, DeviceKind, EndpointStatus, MachineStatus, MachineStatusConfig};
+use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus};
 use crate::tui::HostDetails;
 use crate::{MachineConfig, saturating_add_duration_to_instant};
 
@@ -458,9 +458,9 @@ impl DpuMachineHandle {
         }
     }
 
-    pub fn status(&self, config: &MachineStatusConfig) -> MachineStatus {
+    pub fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
         let live_state = self.0.live_state.read().unwrap();
-        MachineStatus {
+        DeviceStatus {
             mat_id: self.0.mat_id.to_string(),
             device_kind: DeviceKind::Dpu,
             device_id: live_state

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -39,7 +39,7 @@ use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
 use crate::machine_state_machine::{LiveState, MachineStateMachine, PersistedMachine};
 use crate::saturating_add_duration_to_instant;
-use crate::status::{BmcStatus, EndpointStatus, MachineStatus, MachineStatusConfig};
+use crate::status::{BmcStatus, DeviceKind, EndpointStatus, MachineStatus, MachineStatusConfig};
 use crate::tui::{HostDetails, UiUpdate};
 
 pub struct HostMachine {
@@ -232,7 +232,7 @@ impl HostMachine {
     }
 
     #[instrument(skip_all, fields(mat_host_id = %self.mat_id))]
-    pub fn start(mut self, paused: bool) -> HostMachineHandle {
+    pub fn start(mut self, paused: bool) -> DeviceHandle {
         self.paused = paused;
         let (message_tx, mut message_rx) = mpsc::unbounded_channel();
         let live_state = self.live_state.clone();
@@ -260,7 +260,7 @@ impl HostMachine {
             })
             .unwrap();
 
-        HostMachineHandle(Arc::new(HostMachineActor {
+        DeviceHandle(Arc::new(HostMachineActor {
             message_tx,
             live_state,
             mat_id,
@@ -295,7 +295,9 @@ impl HostMachine {
             _ = tokio::time::sleep_until(self.sleep_until.into()) => {}
             _ = self.api_refresh_interval.tick() => {
                 // Wake up to refresh the API state and UI
-                if let Some(machine_id) = self.live_state.read().unwrap().observed_machine_id {
+                if DeviceKind::from(self.host_info.hw_type) == DeviceKind::Machine
+                    && let Some(machine_id) = self.live_state.read().unwrap().observed_machine_id
+                {
                     let actor_message_tx = actor_message_tx.clone();
                     self.app_context.api_throttler.get_machine(machine_id, move |machine| {
                         if let Some(machine) = machine {
@@ -542,9 +544,9 @@ struct HostMachineActor {
 }
 
 #[derive(Debug, Clone)]
-pub struct HostMachineHandle(Arc<HostMachineActor>);
+pub struct DeviceHandle(Arc<HostMachineActor>);
 
-impl HostMachineHandle {
+impl DeviceHandle {
     #[cfg(test)]
     pub(crate) fn for_control_test(
         dpus: Vec<DpuMachineHandle>,
@@ -654,6 +656,12 @@ impl HostMachineHandle {
         let live_state = self.0.live_state.read().unwrap();
         MachineStatus {
             mat_id: self.0.mat_id.to_string(),
+            device_kind: DeviceKind::Machine,
+            device_id: live_state
+                .observed_machine_id
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| self.0.mat_id.to_string()),
             machine_id: live_state
                 .observed_machine_id
                 .as_ref()

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -34,12 +34,12 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::api_client::ApiClient;
-use crate::config::{self, MachineATronContext, MachineConfig, PersistedHostMachine};
+use crate::config::{self, MachineATronContext, MachineConfig, PersistedDevice};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
 use crate::machine_state_machine::{LiveState, MachineStateMachine, PersistedMachine};
 use crate::saturating_add_duration_to_instant;
-use crate::status::{BmcStatus, DeviceKind, EndpointStatus, MachineStatus, MachineStatusConfig};
+use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus};
 use crate::tui::{HostDetails, UiUpdate};
 
 pub struct HostMachine {
@@ -64,26 +64,26 @@ pub struct HostMachine {
 
 impl HostMachine {
     pub fn from_persisted(
-        persisted_host_machine: PersistedHostMachine,
+        persisted_device: PersistedDevice,
         machine_config_section: String,
         app_context: Arc<MachineATronContext>,
         config: Arc<MachineConfig>,
         hw_mac_addr_pool: MacAddressPoolConfig,
     ) -> Self {
-        let mat_id = persisted_host_machine.mat_id;
+        let mat_id = persisted_device.mat_id;
         let (bmc_control_tx, bmc_control_rx) = mpsc::unbounded_channel();
         let (dpu_dhcp_tx, dpu_dhcp_rx) =
             mpsc::unbounded_channel::<oneshot::Sender<DhcpRelayResult<DhcpResponseInfo>>>();
         let mut dpu_dhcp_rx = Some(dpu_dhcp_rx);
         let dpus_in_nic_mode = config.dpus_in_nic_mode;
 
-        let dpu_machines = persisted_host_machine
+        let dpu_machines = persisted_device
             .dpus
             .iter()
             .map(|dpu| {
                 DpuMachine::from_persisted(
                     dpu.clone(),
-                    persisted_host_machine.mat_id,
+                    persisted_device.mat_id,
                     app_context.clone(),
                     config.clone(),
                     if dpus_in_nic_mode {
@@ -95,18 +95,18 @@ impl HostMachine {
             })
             .collect::<Vec<_>>();
         let host_info = HostMachineInfo {
-            hw_type: persisted_host_machine.hw_type.unwrap_or_default(),
-            bmc_mac_address: persisted_host_machine.bmc_mac_address,
-            serial: persisted_host_machine.serial.clone(),
-            dpus: persisted_host_machine
+            hw_type: persisted_device.hw_type.unwrap_or_default(),
+            bmc_mac_address: persisted_device.bmc_mac_address,
+            serial: persisted_device.serial.clone(),
+            dpus: persisted_device
                 .dpus
                 .iter()
                 .cloned()
                 .map(Into::into)
                 .collect(),
-            non_dpu_mac_address: persisted_host_machine.non_dpu_mac_address,
-            nvos_mac_addresses: persisted_host_machine.nvos_mac_addresses.clone(),
-            switch_serial_number: persisted_host_machine.switch_serial_number.clone(),
+            non_dpu_mac_address: persisted_device.non_dpu_mac_address,
+            nvos_mac_addresses: persisted_device.nvos_mac_addresses.clone(),
+            switch_serial_number: persisted_device.switch_serial_number.clone(),
             hw_mac_addr_pool,
             delta_psu_power: None,
         };
@@ -116,7 +116,7 @@ impl HostMachine {
             .collect::<Vec<_>>();
 
         let state_machine = MachineStateMachine::from_persisted(
-            PersistedMachine::Host(persisted_host_machine),
+            PersistedMachine::Host(persisted_device),
             MachineInfo::Host(host_info.clone()),
             config,
             app_context.clone(),
@@ -652,9 +652,9 @@ impl DeviceHandle {
         &self.0.machine_config_section
     }
 
-    pub fn status(&self, config: &MachineStatusConfig) -> MachineStatus {
+    pub fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
         let live_state = self.0.live_state.read().unwrap();
-        MachineStatus {
+        DeviceStatus {
             mat_id: self.0.mat_id.to_string(),
             device_kind: DeviceKind::Machine,
             device_id: live_state
@@ -680,9 +680,9 @@ impl DeviceHandle {
         }
     }
 
-    pub fn persisted(&self) -> PersistedHostMachine {
+    pub fn persisted(&self) -> PersistedDevice {
         let live_state = self.0.live_state.read().unwrap();
-        PersistedHostMachine {
+        PersistedDevice {
             hw_type: Some(self.0.host_info.hw_type),
             mat_id: self.0.mat_id,
             machine_config_section: self.0.machine_config_section.clone(),

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -19,6 +19,7 @@ pub mod api_throttler;
 mod bmc_mock_wrapper;
 mod config;
 mod control_router;
+mod device_simulator;
 mod dhcp_wrapper;
 mod dhcp_wrapper_udp;
 mod discovery_info;
@@ -29,6 +30,7 @@ mod machine_fsm;
 mod machine_state_machine;
 mod machine_utils;
 mod mock_ssh_server;
+mod simulator_registry;
 mod status;
 mod subnet;
 mod tabs;
@@ -44,16 +46,20 @@ pub use config::{
     PersistedDpuMachine, PersistedHostMachine, RackConfig,
 };
 pub use control_router::{ControlState, append as append_control_routes};
+pub use device_simulator::{
+    DeviceSimulator, MachineSimulator, PowerShelfSimulator, SimulatorLifecycle, SwitchSimulator,
+};
 pub use dhcp_wrapper::{DhcpClient, UdpDhcpService};
 pub use dpu_machine::DpuMachineHandle;
-pub use host_machine::HostMachineHandle;
+pub use host_machine::DeviceHandle;
 pub use machine_a_tron::{AppEvent, MachineATron};
 pub use machine_state_machine::BmcRegistrationMode;
 pub use mock_ssh_server::{
     Credentials as MockSshCredentials, MockSshServerHandle, PromptBehavior,
     spawn as spawn_mock_ssh_server,
 };
-pub use status::{MachineStatus, MachineStatusConfig, MachinesStatusResponse};
+pub use simulator_registry::SimulatorRegistry;
+pub use status::{DeviceKind, MachineStatus, MachineStatusConfig, MachinesStatusResponse};
 pub use tui::{Tui, UiUpdate};
 pub use tui_host_logs::TuiHostLogs;
 

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -43,7 +43,7 @@ use std::time::{Duration, Instant};
 pub use bmc_mock_wrapper::BmcMockRegistry;
 pub use config::{
     DhcpType, MachineATronArgs, MachineATronConfig, MachineATronContext, MachineConfig,
-    PersistedDpuMachine, PersistedHostMachine, RackConfig,
+    PersistedDevice, PersistedDpuMachine, RackConfig,
 };
 pub use control_router::{ControlState, append as append_control_routes};
 pub use device_simulator::{
@@ -59,7 +59,7 @@ pub use mock_ssh_server::{
     spawn as spawn_mock_ssh_server,
 };
 pub use simulator_registry::SimulatorRegistry;
-pub use status::{DeviceKind, MachineStatus, MachineStatusConfig, MachinesStatusResponse};
+pub use status::{DeviceKind, DeviceStatus, DeviceStatusConfig, DevicesStatusResponse};
 pub use tui::{Tui, UiUpdate};
 pub use tui_host_logs::TuiHostLogs;
 

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -504,7 +504,7 @@ fn parse_network_virtualization_type(s: Option<&str>) -> Option<VpcVirtualizatio
 mod tests {
     use std::str::FromStr;
 
-    use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType};
+    use bmc_mock::{DpuMachineInfo, DpuSettings, HardwareType};
     use carbide_test_support::{Check, check_values};
     use mac_address::MacAddress;
 
@@ -516,14 +516,14 @@ mod tests {
 
     fn host_info(dpu_host_macs: &[MacAddress], non_dpu_mac: Option<MacAddress>) -> HostMachineInfo {
         HostMachineInfo {
-            hw_type: HostHardwareType::WiwynnGB200Nvl,
+            hw_type: HardwareType::WiwynnGB200Nvl,
             bmc_mac_address: mac("02:00:00:00:00:f0"),
             serial: "test-host".to_string(),
             dpus: dpu_host_macs
                 .iter()
                 .enumerate()
                 .map(|(index, host_mac_address)| DpuMachineInfo {
-                    hw_type: HostHardwareType::WiwynnGB200Nvl,
+                    hw_type: HardwareType::WiwynnGB200Nvl,
                     bmc_mac_address: mac(&format!("02:00:00:00:10:{index:02x}")),
                     host_mac_address: *host_mac_address,
                     oob_mac_address: mac(&format!("02:00:00:00:20:{index:02x}")),

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -25,7 +25,7 @@ use rpc::forge::{ExpectedHostNic, NetworkSegmentType, VpcVirtualizationType};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::PersistedHostMachine;
+use crate::PersistedDevice;
 use crate::config::MachineATronContext;
 use crate::device_simulator::{DeviceSimulator, SimulatorLifecycle};
 use crate::host_machine::{DeviceHandle, HostMachine};
@@ -95,10 +95,10 @@ impl MachineATron {
             }
         }
 
-        let mut persisted_machines = self
+        let mut persisted_devices = self
             .app_context
             .app_config
-            .read_persisted_machines()
+            .read_persisted_devices()
             .inspect_err(|e| {
                 tracing::info!(error=?e, "could not read persisted machines, may be the first run")
             })
@@ -110,8 +110,8 @@ impl MachineATron {
         let machines = {
             let mut mac_address_pool = self.app_context.mac_address_pool.lock().unwrap();
 
-            if let Some(persisted_machines) = persisted_machines.as_ref() {
-                for persisted in persisted_machines.values().flatten() {
+            if let Some(persisted_devices) = persisted_devices.as_ref() {
+                for persisted in persisted_devices.values().flatten() {
                     let hw_mac_address_ranges = persisted
                         .hw_mac_addr_pool
                         .as_ref()
@@ -135,7 +135,7 @@ impl MachineATron {
                 .machines
                 .iter()
                 .flat_map(|(config_name, config)| {
-                    if let Some(persisted_machines) = persisted_machines
+                    if let Some(persisted_devices) = persisted_devices
                         .as_mut()
                         .and_then(|m| m.remove(config_name.as_str()))
                     {
@@ -143,7 +143,7 @@ impl MachineATron {
                             config_name = %config_name,
                             "Recovering persisted machines",
                         );
-                        persisted_machines
+                        persisted_devices
                             .into_iter()
                             .map(|persisted| -> eyre::Result<DeviceHandle> {
                                 let hw_mac_address_ranges = persisted
@@ -291,7 +291,7 @@ impl MachineATron {
         tui_event_tx: Option<mpsc::Sender<UiUpdate>>,
         mut app_rx: mpsc::Receiver<AppEvent>,
     ) -> eyre::Result<()> {
-        let machine_handles = simulators.machine_handles();
+        let provisionable_handles = simulators.provisionable_handles();
         let mut vpc_handles: Vec<Vpc> = Vec::new();
         let mut subnet_handles: Vec<Subnet> = Vec::new();
         // Represents the mat_id of machines which are Assigned to a forge Instance
@@ -362,7 +362,7 @@ impl MachineATron {
                 AppEvent::Quit => {
                     tracing::info!("quit");
                     let cleanup_on_quit = self.app_context.app_config.cleanup_on_quit;
-                    let persisted_machines =
+                    let persisted_devices =
                         try_join_all(simulators.devices().iter().cloned().map(|simulator| {
                             let api_client = self.app_context.api_client();
                             let persisted = simulator.persisted();
@@ -371,7 +371,7 @@ impl MachineATron {
                                 if cleanup_on_quit {
                                     simulator.delete_from_api(api_client).await?;
                                 }
-                                Ok::<PersistedHostMachine, eyre::Report>(persisted)
+                                Ok::<PersistedDevice, eyre::Report>(persisted)
                             }
                         }))
                         .await?;
@@ -379,7 +379,7 @@ impl MachineATron {
                     // Persist the current state of the machines before quitting
                     self.app_context
                         .app_config
-                        .write_persisted_machines(&persisted_machines)?;
+                        .write_persisted_devices(&persisted_devices)?;
 
                     break;
                 }
@@ -388,7 +388,7 @@ impl MachineATron {
                     tracing::info!("Allocating an instance.");
 
                     let Some(free_machine) =
-                        get_next_free_machine(&machine_handles, &assigned_mat_ids).await
+                        get_next_free_machine(&provisionable_handles, &assigned_mat_ids).await
                     else {
                         tracing::error!("No available machines.");
                         continue;

--- a/crates/machine-a-tron/src/machine_a_tron.rs
+++ b/crates/machine-a-tron/src/machine_a_tron.rs
@@ -17,8 +17,8 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use bmc_mock::HostMachineInfo;
 use bmc_mock::mac_address_pool::PoolConfig as MacAddressPoolConfig;
-use bmc_mock::{HostHardwareType, HostMachineInfo};
 use futures::future::try_join_all;
 use model::expected_machine::HostDpuPolicy;
 use rpc::forge::{ExpectedHostNic, NetworkSegmentType, VpcVirtualizationType};
@@ -27,8 +27,10 @@ use uuid::Uuid;
 
 use crate::PersistedHostMachine;
 use crate::config::MachineATronContext;
-use crate::host_machine::{HostMachine, HostMachineHandle};
+use crate::device_simulator::{DeviceSimulator, SimulatorLifecycle};
+use crate::host_machine::{DeviceHandle, HostMachine};
 use crate::machine_utils::get_next_free_machine;
+use crate::simulator_registry::SimulatorRegistry;
 use crate::subnet::Subnet;
 use crate::tui::UiUpdate;
 use crate::vpc::Vpc;
@@ -78,7 +80,7 @@ impl MachineATron {
         Self { app_context }
     }
 
-    pub async fn make_machines(&self, paused: bool) -> eyre::Result<Vec<HostMachineHandle>> {
+    pub async fn make_devices(&self, paused: bool) -> eyre::Result<SimulatorRegistry> {
         self.app_context.app_config.validate()?;
 
         for (machine_group, machine) in &self.app_context.app_config.machines {
@@ -143,7 +145,7 @@ impl MachineATron {
                         );
                         persisted_machines
                             .into_iter()
-                            .map(|persisted| -> eyre::Result<HostMachineHandle> {
+                            .map(|persisted| -> eyre::Result<DeviceHandle> {
                                 let hw_mac_address_ranges = persisted
                                     .hw_mac_addr_pool
                                     .as_ref()
@@ -186,6 +188,8 @@ impl MachineATron {
                 .collect::<Result<Vec<_>, _>>()?
         };
 
+        let simulators = SimulatorRegistry::try_from_handles(machines)?;
+
         if self.app_context.app_config.register_expected_machines {
             for (rack_id, rack) in &self.app_context.app_config.racks {
                 self.app_context
@@ -194,7 +198,8 @@ impl MachineATron {
                     .await?;
             }
 
-            for machine in &machines {
+            for device in simulators.devices() {
+                let machine = device.handle();
                 let host_info = machine.host_info();
                 let machine_config = self
                     .app_context
@@ -203,8 +208,8 @@ impl MachineATron {
                     .get(machine.machine_config_section())
                     .expect("machine was constructed from a configured machine group");
                 let rack_id = machine_config.rack_id.clone();
-                let result = match host_info.hw_type {
-                    HostHardwareType::LiteOnPowerShelf | HostHardwareType::DeltaPowerShelf => {
+                let result = match device {
+                    DeviceSimulator::PowerShelf(_) => {
                         self.app_context
                             .api_client()
                             .add_expected_power_shelf(
@@ -214,7 +219,7 @@ impl MachineATron {
                             )
                             .await
                     }
-                    HostHardwareType::NvidiaSwitchNd5200Ld => {
+                    DeviceSimulator::Switch(_) => {
                         self.app_context
                             .api_client()
                             .add_expected_switch(
@@ -232,7 +237,7 @@ impl MachineATron {
                             )
                             .await
                     }
-                    _ => {
+                    DeviceSimulator::Machine(_) => {
                         // Derive the expected `dpu_policy` from the machine's
                         // MachineConfig: zero-DPU hosts declare `Ignore`, hosts
                         // running their DPUs as NICs declare `Nic`, and
@@ -272,20 +277,21 @@ impl MachineATron {
             }
         } else {
             tracing::info!(
-                machine_count = machines.len(),
+                device_count = simulators.devices().len(),
                 "register_expected_machines=false; skipping auto-registration of mock host(s)",
             );
         }
 
-        Ok(machines)
+        Ok(simulators)
     }
 
     pub async fn run(
         &mut self,
-        machine_handles: Vec<HostMachineHandle>,
+        simulators: SimulatorRegistry,
         tui_event_tx: Option<mpsc::Sender<UiUpdate>>,
         mut app_rx: mpsc::Receiver<AppEvent>,
     ) -> eyre::Result<()> {
+        let machine_handles = simulators.machine_handles();
         let mut vpc_handles: Vec<Vpc> = Vec::new();
         let mut subnet_handles: Vec<Subnet> = Vec::new();
         // Represents the mat_id of machines which are Assigned to a forge Instance
@@ -344,9 +350,9 @@ impl MachineATron {
             }
         }
 
-        for machine_handle in &machine_handles {
-            machine_handle.attach_to_tui(tui_event_tx.clone())?;
-            machine_handle.resume()?;
+        for simulator in simulators.devices() {
+            simulator.attach_to_tui(tui_event_tx.clone())?;
+            simulator.resume()?;
         }
 
         tracing::info!("Machine construction complete");
@@ -355,26 +361,20 @@ impl MachineATron {
             match msg {
                 AppEvent::Quit => {
                     tracing::info!("quit");
-                    let persisted_machines = if self.app_context.app_config.cleanup_on_quit {
-                        try_join_all(machine_handles.into_iter().map(|m| {
+                    let cleanup_on_quit = self.app_context.app_config.cleanup_on_quit;
+                    let persisted_machines =
+                        try_join_all(simulators.devices().iter().cloned().map(|simulator| {
                             let api_client = self.app_context.api_client();
-                            let persisted = m.persisted();
-                            m.abort();
+                            let persisted = simulator.persisted();
                             async move {
-                                m.delete_from_api(api_client).await?;
+                                simulator.shutdown().await?;
+                                if cleanup_on_quit {
+                                    simulator.delete_from_api(api_client).await?;
+                                }
                                 Ok::<PersistedHostMachine, eyre::Report>(persisted)
                             }
                         }))
-                        .await?
-                    } else {
-                        machine_handles
-                            .into_iter()
-                            .map(|m| {
-                                m.abort();
-                                m.persisted()
-                            })
-                            .collect()
-                    };
+                        .await?;
 
                     // Persist the current state of the machines before quitting
                     self.app_context
@@ -504,7 +504,7 @@ fn parse_network_virtualization_type(s: Option<&str>) -> Option<VpcVirtualizatio
 mod tests {
     use std::str::FromStr;
 
-    use bmc_mock::{DpuMachineInfo, DpuSettings};
+    use bmc_mock::{DpuMachineInfo, DpuSettings, HostHardwareType};
     use carbide_test_support::{Check, check_values};
     use mac_address::MacAddress;
 

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -24,8 +24,8 @@ use std::time::Duration;
 use bmc_mock::injection::InjectionStore;
 use bmc_mock::ipmi_sim::IpmiEndpoint;
 use bmc_mock::{
-    BmcCommand, BmcState, BootOptionKind, Callbacks, HostHardwareType, HostnameQuerying,
-    MachineInfo, MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
+    BmcCommand, BmcState, BootOptionKind, Callbacks, HardwareType, HostnameQuerying, MachineInfo,
+    MockPowerState, POWER_CYCLE_DELAY, SetSystemPowerError, SetSystemPowerResult,
     SystemPowerControl,
 };
 use carbide_network::virtualization::build_dual_stack_list;
@@ -1085,7 +1085,7 @@ impl MachineStateMachine {
         );
 
         let pw_override = match &self.machine_info {
-            MachineInfo::Host(host) if host.hw_type == HostHardwareType::LiteOnPowerShelf => None,
+            MachineInfo::Host(host) if host.hw_type == HardwareType::LiteOnPowerShelf => None,
             MachineInfo::Host(_) => self.app_context.app_config.host_bmc_password.as_deref(),
             MachineInfo::Dpu(_) => self.app_context.app_config.dpu_bmc_password.as_deref(),
         };
@@ -1140,8 +1140,8 @@ impl MachineStateMachine {
             MachineInfo::Dpu(_) => config.dpus_in_nic_mode,
             MachineInfo::Host(host) => matches!(
                 host.hw_type,
-                bmc_mock::HostHardwareType::LiteOnPowerShelf
-                    | bmc_mock::HostHardwareType::NvidiaSwitchNd5200Ld
+                bmc_mock::HardwareType::LiteOnPowerShelf
+                    | bmc_mock::HardwareType::NvidiaSwitchNd5200Ld
             ),
         }
     }

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -49,7 +49,7 @@ use crate::machine_state_machine::MachineStateError::MissingMachineId;
 use crate::machine_utils::{
     PxeError, PxeResponse, forge_agent_control, get_validation_id, send_pxe_boot_request,
 };
-use crate::{PersistedDpuMachine, PersistedHostMachine};
+use crate::{PersistedDevice, PersistedDpuMachine};
 
 pub type DpuDhcpRelayHandle = oneshot::Sender<()>;
 
@@ -224,7 +224,7 @@ pub enum BmcRegistrationMode {
 }
 
 pub enum PersistedMachine {
-    Host(PersistedHostMachine),
+    Host(PersistedDevice),
     Dpu(PersistedDpuMachine),
 }
 

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 
 use crate::api_client::ClientApiError;
 use crate::config::MachineATronContext;
-use crate::host_machine::HostMachineHandle;
+use crate::host_machine::DeviceHandle;
 use crate::machine_state_machine::AddressConfigError;
 
 lazy_static! {
@@ -136,9 +136,9 @@ pub async fn send_pxe_boot_request(
 }
 
 pub async fn get_next_free_machine(
-    machine_handles: &Vec<HostMachineHandle>,
+    machine_handles: &Vec<DeviceHandle>,
     assigned_mat_ids: &HashSet<Uuid>,
-) -> Option<HostMachineHandle> {
+) -> Option<DeviceHandle> {
     for machine in machine_handles {
         if assigned_mat_ids.contains(&machine.mat_id()) {
             continue;

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -136,10 +136,10 @@ pub async fn send_pxe_boot_request(
 }
 
 pub async fn get_next_free_machine(
-    machine_handles: &Vec<DeviceHandle>,
+    provisionable_handles: &Vec<DeviceHandle>,
     assigned_mat_ids: &HashSet<Uuid>,
 ) -> Option<DeviceHandle> {
-    for machine in machine_handles {
+    for machine in provisionable_handles {
         if assigned_mat_ids.contains(&machine.mat_id()) {
             continue;
         }

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -35,8 +35,8 @@ use mac_address::MacAddress;
 use machine_a_tron::{
     AppEvent, BmcMockRegistry, BmcRegistrationMode, ControlState, DhcpClient, MachineATron,
     MachineATronArgs, MachineATronConfig, MachineATronContext, MachineStatusConfig,
-    MockSshServerHandle, PromptBehavior, Tui, TuiHostLogs, api_throttler, append_control_routes,
-    spawn_mock_ssh_server,
+    MockSshServerHandle, PromptBehavior, SimulatorLifecycle, Tui, TuiHostLogs, api_throttler,
+    append_control_routes, spawn_mock_ssh_server,
 };
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -202,13 +202,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Machines are created paused here. While paused, their actors do not advance the FSM, so
     // BMC DHCP and shared-router registration cannot run before the combined BMC mock listener is
     // started below.
-    let machine_handles = mat.make_machines(true).await?;
+    let simulators = mat.make_devices(true).await?;
 
     // Persist them once in case of unclean shutdown
     app_context.app_config.write_persisted_machines(
-        machine_handles
+        simulators
+            .devices()
             .iter()
-            .map(|m| m.persisted())
+            .map(SimulatorLifecycle::persisted)
             .collect::<Vec<_>>()
             .as_slice(),
     )?;
@@ -216,10 +217,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Launch the control UI after the machines are created so it can report their handles. In
     // combined-BMC mode it shares the combined BMC listener. In per-IP mode it listens on the
     // loopback address at the same port, independently of the per-machine BMC listeners.
-    let control_state = ControlState::new(
-        machine_handles.clone(),
-        MachineStatusConfig::new(bmc_mock_port),
-    );
+    let control_state =
+        ControlState::new(simulators.clone(), MachineStatusConfig::new(bmc_mock_port));
     let certs_dir = app_context
         .bmc_mock_certs_dir
         .as_ref()
@@ -316,7 +315,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         (None, None, None)
     };
 
-    let mat_result = mat.run(machine_handles, tui_event_tx.clone(), app_rx).await;
+    let mat_result = mat.run(simulators, tui_event_tx.clone(), app_rx).await;
 
     if let Some(tui_handle) = tui_handle {
         if let Some(tui_quit_tx) = tui_quit_tx.as_ref() {

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -33,10 +33,10 @@ use forge_tls::client_config::{
 };
 use mac_address::MacAddress;
 use machine_a_tron::{
-    AppEvent, BmcMockRegistry, BmcRegistrationMode, ControlState, DhcpClient, MachineATron,
-    MachineATronArgs, MachineATronConfig, MachineATronContext, MachineStatusConfig,
-    MockSshServerHandle, PromptBehavior, SimulatorLifecycle, Tui, TuiHostLogs, api_throttler,
-    append_control_routes, spawn_mock_ssh_server,
+    AppEvent, BmcMockRegistry, BmcRegistrationMode, ControlState, DeviceStatusConfig, DhcpClient,
+    MachineATron, MachineATronArgs, MachineATronConfig, MachineATronContext, MockSshServerHandle,
+    PromptBehavior, SimulatorLifecycle, Tui, TuiHostLogs, api_throttler, append_control_routes,
+    spawn_mock_ssh_server,
 };
 use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use rpc::protos::forge_api_client::ForgeApiClient;
@@ -205,7 +205,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let simulators = mat.make_devices(true).await?;
 
     // Persist them once in case of unclean shutdown
-    app_context.app_config.write_persisted_machines(
+    app_context.app_config.write_persisted_devices(
         simulators
             .devices()
             .iter()
@@ -218,7 +218,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // combined-BMC mode it shares the combined BMC listener. In per-IP mode it listens on the
     // loopback address at the same port, independently of the per-machine BMC listeners.
     let control_state =
-        ControlState::new(simulators.clone(), MachineStatusConfig::new(bmc_mock_port));
+        ControlState::new(simulators.clone(), DeviceStatusConfig::new(bmc_mock_port));
     let certs_dir = app_context
         .bmc_mock_certs_dir
         .as_ref()

--- a/crates/machine-a-tron/src/simulator_registry.rs
+++ b/crates/machine-a-tron/src/simulator_registry.rs
@@ -68,7 +68,7 @@ impl SimulatorRegistry {
             .map(|index| &self.inner.devices[*index])
     }
 
-    pub fn machine_handles(&self) -> Vec<DeviceHandle> {
+    pub fn provisionable_handles(&self) -> Vec<DeviceHandle> {
         self.inner
             .devices
             .iter()

--- a/crates/machine-a-tron/src/simulator_registry.rs
+++ b/crates/machine-a-tron/src/simulator_registry.rs
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bmc_mock::injection::InjectionStore;
+use carbide_uuid::machine::MachineId;
+use uuid::Uuid;
+
+use crate::device_simulator::{DeviceSimulator, SimulatorLifecycle};
+use crate::host_machine::DeviceHandle;
+
+#[derive(Debug, Clone)]
+pub struct SimulatorRegistry {
+    inner: Arc<SimulatorRegistryInner>,
+}
+
+#[derive(Debug)]
+struct SimulatorRegistryInner {
+    devices: Vec<DeviceSimulator>,
+    by_mat_id: HashMap<Uuid, usize>,
+}
+
+impl SimulatorRegistry {
+    pub fn try_from_handles(handles: Vec<DeviceHandle>) -> eyre::Result<Self> {
+        let devices = handles
+            .into_iter()
+            .map(DeviceSimulator::from_handle)
+            .collect::<Vec<_>>();
+        let mut by_mat_id = HashMap::with_capacity(devices.len());
+
+        for (index, device) in devices.iter().enumerate() {
+            if by_mat_id.insert(device.mat_id(), index).is_some() {
+                for device in &devices {
+                    device.abort();
+                }
+                eyre::bail!("duplicate simulator identity: {}", device.mat_id());
+            }
+        }
+
+        Ok(Self {
+            inner: Arc::new(SimulatorRegistryInner { devices, by_mat_id }),
+        })
+    }
+
+    pub fn devices(&self) -> &[DeviceSimulator] {
+        &self.inner.devices
+    }
+
+    pub fn get(&self, mat_id: Uuid) -> Option<&DeviceSimulator> {
+        self.inner
+            .by_mat_id
+            .get(&mat_id)
+            .map(|index| &self.inner.devices[*index])
+    }
+
+    pub fn machine_handles(&self) -> Vec<DeviceHandle> {
+        self.inner
+            .devices
+            .iter()
+            .filter_map(DeviceSimulator::machine)
+            .map(|simulator| simulator.handle().clone())
+            .collect()
+    }
+
+    pub fn find_injection_store(&self, id: &str) -> Option<Arc<InjectionStore>> {
+        if let Ok(mat_id) = Uuid::parse_str(id) {
+            if let Some(device) = self.get(mat_id) {
+                return Some(device.bmc_injection_store());
+            }
+            for device in self.devices() {
+                let Some(machine) = device.machine() else {
+                    continue;
+                };
+                if let Some(dpu) = machine
+                    .handle()
+                    .dpus()
+                    .iter()
+                    .find(|dpu| dpu.mat_id() == mat_id)
+                {
+                    return Some(dpu.bmc_injection_store());
+                }
+            }
+        }
+
+        let machine_id = id.parse::<MachineId>().ok()?;
+        for device in self.devices() {
+            let Some(machine) = device.machine() else {
+                continue;
+            };
+            if machine.handle().observed_machine_id().as_ref() == Some(&machine_id) {
+                return Some(machine.bmc_injection_store());
+            }
+            if let Some(dpu) = machine
+                .handle()
+                .dpus()
+                .iter()
+                .find(|dpu| dpu.observed_machine_id().as_ref() == Some(&machine_id))
+            {
+                return Some(dpu.bmc_injection_store());
+            }
+        }
+        None
+    }
+}

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -18,6 +18,27 @@ use bmc_mock::HostHardwareType;
 use bmc_mock::ipmi_sim::IpmiEndpoint;
 use serde::Serialize;
 
+#[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceKind {
+    Machine,
+    Dpu,
+    Switch,
+    PowerShelf,
+}
+
+impl From<HostHardwareType> for DeviceKind {
+    fn from(hardware_type: HostHardwareType) -> Self {
+        match hardware_type {
+            HostHardwareType::NvidiaSwitchNd5200Ld => Self::Switch,
+            HostHardwareType::LiteOnPowerShelf | HostHardwareType::DeltaPowerShelf => {
+                Self::PowerShelf
+            }
+            _ => Self::Machine,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct MachineStatusConfig {
     pub redfish_reachable_port: u16,
@@ -41,6 +62,8 @@ pub struct MachinesStatusResponse {
 #[derive(Debug, Clone, Serialize)]
 pub struct MachineStatus {
     pub mat_id: String,
+    pub device_kind: DeviceKind,
+    pub device_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub machine_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use bmc_mock::HostHardwareType;
+use bmc_mock::HardwareType;
 use bmc_mock::ipmi_sim::IpmiEndpoint;
 use serde::Serialize;
 
@@ -27,13 +27,11 @@ pub enum DeviceKind {
     PowerShelf,
 }
 
-impl From<HostHardwareType> for DeviceKind {
-    fn from(hardware_type: HostHardwareType) -> Self {
+impl From<HardwareType> for DeviceKind {
+    fn from(hardware_type: HardwareType) -> Self {
         match hardware_type {
-            HostHardwareType::NvidiaSwitchNd5200Ld => Self::Switch,
-            HostHardwareType::LiteOnPowerShelf | HostHardwareType::DeltaPowerShelf => {
-                Self::PowerShelf
-            }
+            HardwareType::NvidiaSwitchNd5200Ld => Self::Switch,
+            HardwareType::LiteOnPowerShelf | HardwareType::DeltaPowerShelf => Self::PowerShelf,
             _ => Self::Machine,
         }
     }
@@ -68,7 +66,7 @@ pub struct DeviceStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub machine_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hardware_type: Option<HostHardwareType>,
+    pub hardware_type: Option<HardwareType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mat_state: Option<String>,
     pub api_state: String,

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -40,12 +40,12 @@ impl From<HostHardwareType> for DeviceKind {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct MachineStatusConfig {
+pub struct DeviceStatusConfig {
     pub redfish_reachable_port: u16,
     pub redfish_listen_port: u16,
 }
 
-impl MachineStatusConfig {
+impl DeviceStatusConfig {
     pub fn new(redfish_listen_port: u16) -> Self {
         Self {
             redfish_reachable_port: 443,
@@ -55,12 +55,13 @@ impl MachineStatusConfig {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct MachinesStatusResponse {
-    pub machines: Vec<MachineStatus>,
+pub struct DevicesStatusResponse {
+    #[serde(rename = "machines")]
+    pub devices: Vec<DeviceStatus>,
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct MachineStatus {
+pub struct DeviceStatus {
     pub mat_id: String,
     pub device_kind: DeviceKind,
     pub device_id: String,
@@ -75,7 +76,7 @@ pub struct MachineStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub machine_ip: Option<String>,
     pub bmc: BmcStatus,
-    pub dpus: Vec<MachineStatus>,
+    pub dpus: Vec<DeviceStatus>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -94,7 +95,7 @@ pub struct EndpointStatus {
 }
 
 impl EndpointStatus {
-    pub fn redfish(config: &MachineStatusConfig) -> Self {
+    pub fn redfish(config: &DeviceStatusConfig) -> Self {
         Self {
             reachable_port: config.redfish_reachable_port,
             listen_port: config.redfish_listen_port,

--- a/crates/machine-a-tron/src/tui.rs
+++ b/crates/machine-a-tron/src/tui.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
 
-use bmc_mock::{HostHardwareType, MockPowerState};
+use bmc_mock::{HardwareType, MockPowerState};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use crossterm::ExecutableCommand;
@@ -93,7 +93,7 @@ impl SubnetDetails {
 pub struct HostDetails {
     pub mat_id: Uuid,
     pub machine_id: Option<String>,
-    pub hw_type: Option<HostHardwareType>,
+    pub hw_type: Option<HardwareType>,
     pub power_state: MockPowerState,
     pub mat_state: Option<&'static str>,
     pub api_state: String,

--- a/crates/machine-a-tron/web/index.html
+++ b/crates/machine-a-tron/web/index.html
@@ -309,8 +309,8 @@
           <tbody>
             ${rows.map(({ machine, depth }) => `
               <tr class="${depth > 0 ? "dpu" : ""}">
-                <td class="machine"><code>${html(machine.machine_id || machine.mat_id)}</code></td>
-                <td>${depth > 0 ? "DPU" : html(machine.hardware_type)}</td>
+                <td class="machine"><code>${html(machine.device_id || machine.machine_id || machine.mat_id)}</code></td>
+                <td>${html(machine.device_kind || (depth > 0 ? "dpu" : machine.hardware_type))}</td>
                 <td><span class="state ${stateClass(machine.mat_state)}">${html(machine.mat_state)}</span></td>
                 <td><span class="state ${stateClass(machine.api_state)}">${html(machine.api_state)}</span></td>
                 <td><span class="state ${stateClass(machine.power_state)}">${html(machine.power_state)}</span></td>

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bmc_explorer::test_support::generate_managed_host_reports;
-use bmc_mock::HostHardwareType;
+use bmc_mock::HardwareType;
 use carbide_site_explorer::config::{SiteExplorerConfig, SiteExplorerExploreMode};
 use carbide_test_harness::network::segment::TestNetworkSegment;
 use carbide_test_harness::prelude::*;
@@ -3275,7 +3275,7 @@ async fn test_site_explorer_pairs_vr_bf4_from_bluefield_chassis(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = Env::new(pool).await;
 
-    let reports = generate_managed_host_reports(HostHardwareType::NvidiaDgxVr).await?;
+    let reports = generate_managed_host_reports(HardwareType::NvidiaDgxVr).await?;
     let dpu = reports
         .dpus
         .first()

--- a/docs/development/new_hardware_support.md
+++ b/docs/development/new_hardware_support.md
@@ -381,7 +381,7 @@ To add one:
 
 1. Add a platform module under `crates/bmc-mock/src/hw/`, following a close existing platform such as `dell_poweredge_r750.rs` or `supermicro_gb300_nvl.rs`.
 
-1. Register the module in `crates/bmc-mock/src/hw/mod.rs` and add a typed `HostHardwareType` variant in `crates/bmc-mock/src/lib.rs`.
+1. Register the module in `crates/bmc-mock/src/hw/mod.rs` and add a typed `HardwareType` variant in `crates/bmc-mock/src/lib.rs`.
 
 1. Wire the variant through `crates/bmc-mock/src/machine_info.rs`: DPU count and type, vendor and product identity, Redfish version, manager, system, chassis, discovery, firmware inventory, and OEM behavior should match the live BMC responses relevant to the test.
 


### PR DESCRIPTION
Issue #4277 expands machine-a-tron beyond host machines to switches and power shelves. The simulator abstractions and naming should represent any managed device.

Changes:
- Introduce typed device simulators and a shared simulator registry.
- Rename machine-centric types and fields to device-centric equivalents.
- Rename HostHardwareType to HardwareType.

## Related issues

#4277 

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

