### PR TITLE
fix: dpf: Use product name to identify the BF4 instead of part number.

### DIFF
--- a/crates/machine-controller/Cargo.toml
+++ b/crates/machine-controller/Cargo.toml
@@ -77,6 +77,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 version-compare = { workspace = true }
 
 [dev-dependencies]
+carbide-api-model = { path = "../api-model", default-features = false, features = ["test-support"] }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-redfish = { path = "../redfish", features = ["test-support"] }
 carbide-secrets = { path = "../secrets", features = ["test-support"] }

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -29,11 +29,11 @@ use carbide_dpf::{
 use carbide_uuid::machine::MachineId;
 use model::dpu_machine_update::OutdatedDpfDpu;
 use model::machine::{Machine, ManagedHostStateSnapshot};
-use model::site_explorer::{is_bf3_dpu_part_number, is_bf4_dpu_part_number};
 use sqlx::PgPool;
 use state_controller::controller::Enqueuer;
 use tokio::task::JoinSet;
 
+use crate::handler::is_bf4_dmi_product;
 use crate::io::MachineStateControllerIO;
 
 /// Label key used by [`CarbideDPFLabeler`] to stamp the carbide `MachineId` of
@@ -546,30 +546,34 @@ impl DpfOperations for DpfSdkOps {
     }
 
     fn deployment_type_for_dpu(&self, dpu: &Machine) -> Result<DpuDeploymentType, DpfError> {
-        let part_number = dpu
+        let product_name = dpu
             .status
             .hardware_info
             .as_ref()
-            .and_then(|hw| hw.dpu_info.as_ref())
-            .map(|d| d.part_number.as_str())
-            .unwrap_or_default();
+            .and_then(|hw| hw.dmi_data.as_ref())
+            .map(|d| d.product_name.trim())
+            .filter(|s| !s.is_empty());
 
-        if part_number.is_empty() {
+        let Some(product_name) = product_name else {
             return Err(DpfError::InvalidState(format!(
-                "cannot determine DPU deployment type for machine {}: part number is absent",
+                "cannot determine DPU deployment type for machine {}: product name is absent",
                 dpu.id,
             )));
-        }
-        if is_bf3_dpu_part_number(part_number) {
-            Ok(DpuDeploymentType::Bf3)
-        } else if is_bf4_dpu_part_number(part_number) {
-            Ok(DpuDeploymentType::Bf4Generic)
+        };
+
+        // Only a BF3 or BF4 DPU can reach here.
+        let deployment_type = if is_bf4_dmi_product(product_name) {
+            DpuDeploymentType::Bf4Generic
         } else {
-            Err(DpfError::InvalidState(format!(
-                "cannot determine DPU deployment type for machine {}: unrecognized part number {part_number:?}",
-                dpu.id,
-            )))
-        }
+            DpuDeploymentType::Bf3
+        };
+
+        tracing::info!(
+            "selected deployment type {deployment_type:?} for {product_name}, machine_id: {}",
+            dpu.id
+        );
+
+        Ok(deployment_type)
     }
 
     async fn verify_node_labels(

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3844,6 +3844,38 @@ pub struct DpuMachineStateHandler {
     pub dpf_sdk: Option<Arc<dyn DpfOperations>>,
 }
 
+pub fn is_bf4_dmi_product(product: &str) -> bool {
+    let product = product.to_uppercase();
+    product.contains("B4") || product.contains("BLUEFIELD-4")
+}
+
+/// Whether DPF owns platform configuration for this BF4 DPU.
+///
+/// The persisted ingestion marker prevents an enabled-but-unused DPF
+/// configuration from changing the legacy provisioning path.
+pub fn is_dpf_managed_bf4(
+    state: &ManagedHostStateSnapshot,
+    dpu_snapshot: &Machine,
+) -> Result<bool, StateHandlerError> {
+    if !state.host_snapshot.config.dpf.used_for_ingestion {
+        return Ok(false);
+    }
+
+    let product = dpu_snapshot
+        .status
+        .hardware_info
+        .as_ref()
+        .and_then(|x| x.dmi_data.as_ref())
+        .map(|x| x.product_name.trim())
+        .filter(|x| !x.is_empty())
+        .ok_or_else(|| StateHandlerError::MissingData {
+            object_id: dpu_snapshot.id.to_string(),
+            missing: "product_name in topology",
+        })?;
+
+    Ok(is_bf4_dmi_product(product))
+}
+
 impl DpuMachineStateHandler {
     pub fn new(
         dpu_nic_firmware_initial_update_enabled: bool,
@@ -3859,33 +3891,6 @@ impl DpuMachineStateHandler {
             enable_secure_boot,
             dpf_sdk,
         }
-    }
-
-    /// Whether DPF owns platform configuration for this BF4 DPU.
-    ///
-    /// The persisted ingestion marker prevents an enabled-but-unused DPF
-    /// configuration from changing the legacy provisioning path.
-    fn is_dpf_managed_bf4(
-        &self,
-        state: &ManagedHostStateSnapshot,
-        dpu_snapshot: &Machine,
-    ) -> Result<bool, StateHandlerError> {
-        if !state.host_snapshot.config.dpf.used_for_ingestion {
-            return Ok(false);
-        }
-
-        let product = dpu_snapshot
-            .status
-            .hardware_info
-            .as_ref()
-            .and_then(|x| x.dmi_data.as_ref())
-            .map(|x| x.product_name.to_uppercase())
-            .ok_or_else(|| StateHandlerError::MissingData {
-                object_id: dpu_snapshot.id.to_string(),
-                missing: "product_name in topology",
-            })?;
-
-        Ok(product.contains("B4") || product.contains("BLUEFIELD-4"))
     }
 
     async fn is_secure_boot_disabled(
@@ -4232,7 +4237,7 @@ impl DpuMachineStateHandler {
                     }
                 })?;
 
-                let dpf_managed_bf4 = self.is_dpf_managed_bf4(state, dpu_snapshot)?;
+                let dpf_managed_bf4 = is_dpf_managed_bf4(state, dpu_snapshot)?;
 
                 let dpu_redfish_client = match ctx
                     .services
@@ -4413,7 +4418,7 @@ impl DpuMachineStateHandler {
 
                 // Handle BF4 machines already persisted in this state when the
                 // controller is upgraded: do not issue even one more BIOS query.
-                if self.is_dpf_managed_bf4(state, dpu_snapshot)? {
+                if is_dpf_managed_bf4(state, dpu_snapshot)? {
                     tracing::info!(
                         dpu_machine_id = %dpu_snapshot.id,
                         "Skipping BIOS setup verification for DPF-managed BF4"
@@ -12274,5 +12279,106 @@ mod tests {
             },
             &host_id,
         ));
+    }
+
+    mod is_bf4_dmi_product_tests {
+        use super::*;
+
+        #[test]
+        fn bf4_product_name_is_detected() {
+            assert!(is_bf4_dmi_product("BlueField-4 SmartNIC Main Card"));
+        }
+
+        #[test]
+        fn bf4_detection_is_case_insensitive() {
+            assert!(is_bf4_dmi_product("bluefield-4 smartnic main card"));
+        }
+
+        #[test]
+        fn bf3_product_name_is_not_bf4() {
+            assert!(!is_bf4_dmi_product("BlueField SoC"));
+        }
+
+        #[test]
+        fn empty_product_name_is_not_bf4() {
+            assert!(!is_bf4_dmi_product(""));
+        }
+    }
+
+    mod is_dpf_managed_bf4_tests {
+        use model::hardware_info::{DmiData, HardwareInfo};
+        use model::test_support::machine_snapshot::{dpu_machine, managed_host_state_snapshot};
+
+        use super::*;
+
+        fn dpu_with_product_name(product_name: &str) -> Machine {
+            let mut dpu = dpu_machine(0);
+            dpu.status.hardware_info = Some(HardwareInfo {
+                dmi_data: Some(DmiData {
+                    product_name: product_name.to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
+            dpu
+        }
+
+        fn state_with_ingestion(used_for_ingestion: bool) -> ManagedHostStateSnapshot {
+            let mut state = managed_host_state_snapshot();
+            state.host_snapshot.config.dpf.used_for_ingestion = used_for_ingestion;
+            state
+        }
+
+        #[test]
+        fn returns_false_when_dpf_not_used_for_ingestion() {
+            let state = state_with_ingestion(false);
+            let dpu = dpu_with_product_name("BlueField-4 SmartNIC Main Card");
+            assert!(!is_dpf_managed_bf4(&state, &dpu).unwrap());
+        }
+
+        #[test]
+        fn returns_true_for_bf4_product_name() {
+            let state = state_with_ingestion(true);
+            let dpu = dpu_with_product_name("BlueField-4 SmartNIC Main Card");
+            assert!(is_dpf_managed_bf4(&state, &dpu).unwrap());
+        }
+
+        #[test]
+        fn returns_false_for_bf3_product_name() {
+            let state = state_with_ingestion(true);
+            let dpu = dpu_with_product_name("BlueField-3 Dpu");
+            assert!(!is_dpf_managed_bf4(&state, &dpu).unwrap());
+        }
+
+        #[test]
+        fn errors_when_dmi_data_absent() {
+            let state = state_with_ingestion(true);
+            let mut dpu = dpu_machine(0);
+            dpu.status.hardware_info = Some(HardwareInfo::default());
+            assert!(matches!(
+                is_dpf_managed_bf4(&state, &dpu),
+                Err(StateHandlerError::MissingData { .. })
+            ));
+        }
+
+        #[test]
+        fn errors_when_product_name_empty() {
+            let state = state_with_ingestion(true);
+            let dpu = dpu_with_product_name("");
+            assert!(matches!(
+                is_dpf_managed_bf4(&state, &dpu),
+                Err(StateHandlerError::MissingData { .. })
+            ));
+        }
+
+        #[test]
+        fn errors_when_product_name_whitespace_only() {
+            let state = state_with_ingestion(true);
+            let dpu = dpu_with_product_name("   ");
+            assert!(matches!(
+                is_dpf_managed_bf4(&state, &dpu),
+                Err(StateHandlerError::MissingData { .. })
+            ));
+        }
     }
 }


### PR DESCRIPTION
Use product name to identify the BF4 instead of part number.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

