### PR TITLE
fix(helm): Restrict Site Agent Secret permissions

### DIFF
--- a/helm/rest/nico-rest-site-agent/templates/rbac.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/rbac.yaml
@@ -26,7 +26,7 @@ rules:
     resources: ["secrets"]
     resourceNames:
       - "bootstrap-info"
-      - {{ .Values.envConfig.TEMPORAL_CERT | quote }}
+      - {{ .Values.secrets.temporalClientCerts | quote }}
     verbs: ["get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/rest/nico-rest-site-agent/templates/rbac.yaml
+++ b/helm/rest/nico-rest-site-agent/templates/rbac.yaml
@@ -19,9 +19,15 @@ metadata:
   labels:
     {{- include "nico-rest-site-agent.labels" . | nindent 4 }}
 rules:
+  # Secret volumes are mounted by the kubelet without pod RBAC. The Site Agent
+  # API client only gets and updates bootstrap-info and the configured
+  # Temporal Secret.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    resourceNames:
+      - "bootstrap-info"
+      - {{ .Values.envConfig.TEMPORAL_CERT | quote }}
+    verbs: ["get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/rest/nico-rest-site-agent/tests/rbac_test.yaml
+++ b/helm/rest/nico-rest-site-agent/tests/rbac_test.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: Site Agent runtime RBAC least privilege
+templates:
+  - rbac.yaml
+release:
+  namespace: nico-rest
+tests:
+  - it: grants only get and update access to runtime-mutated Secrets
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              resourceNames:
+                - bootstrap-info
+                - temporal-client-site-agent-certs
+              verbs:
+                - get
+                - update
+
+  - it: follows the configured Temporal Secret name
+    set:
+      envConfig:
+        TEMPORAL_CERT: custom-temporal-client-certs
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: rules[0].resourceNames
+          value:
+            - bootstrap-info
+            - custom-temporal-client-certs
+
+  - it: omits all runtime RBAC resources when RBAC creation is disabled
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/rest/nico-rest-site-agent/tests/rbac_test.yaml
+++ b/helm/rest/nico-rest-site-agent/tests/rbac_test.yaml
@@ -4,10 +4,12 @@
 suite: Site Agent runtime RBAC least privilege
 templates:
   - rbac.yaml
+  - temporal-certs-secret.yaml
 release:
   namespace: nico-rest
 tests:
   - it: grants only get and update access to runtime-mutated Secrets
+    template: rbac.yaml
     documentIndex: 1
     asserts:
       - isKind:
@@ -26,10 +28,13 @@ tests:
                 - get
                 - update
 
-  - it: follows the configured Temporal Secret name
+  - it: follows the configured Temporal Secret name instead of a generic environment value
+    template: rbac.yaml
     set:
+      secrets:
+        temporalClientCerts: custom-temporal-client-certs
       envConfig:
-        TEMPORAL_CERT: custom-temporal-client-certs
+        TEMPORAL_CERT: unrelated-secret
     documentIndex: 1
     asserts:
       - equal:
@@ -38,7 +43,20 @@ tests:
             - bootstrap-info
             - custom-temporal-client-certs
 
+  - it: renders the configured Temporal Secret name
+    template: temporal-certs-secret.yaml
+    set:
+      secrets:
+        temporalClientCerts: custom-temporal-client-certs
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: custom-temporal-client-certs
+
   - it: omits all runtime RBAC resources when RBAC creation is disabled
+    template: rbac.yaml
     set:
       rbac:
         create: false


### PR DESCRIPTION
The Site Agent Role grants namespace-wide Secret permissions that the running workload does not use. This change limits it to `get` and `update` only the configured Temporal credential Secret and `bootstrap-info` used by certificate rotation.

## Related issues
Internal

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

Helm lint, chart unit tests, and default/overridden RBAC rendering pass.

## Additional Notes
The existing rotation code hardcodes `bootstrap-info`; this change preserves that access without changing the chart's separate `siteRegistration` setting.
