### PR TITLE
ci: validate Cargo metadata on pull request merge results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1407,7 +1407,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Build pull request merge result
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          git merge --no-commit --no-ff origin/main
+
+      - name: Validate Cargo metadata
+        run: cargo metadata --locked --no-deps --format-version 1 >/dev/null
 
       # PostgreSQL is required because sqlx proc macros (sqlx::query!) connect to
       # a local database at compile time to validate SQL queries and return types.


### PR DESCRIPTION
CI currently tests pull-request branches without incorporating current `main`. A stale PR can therefore pass CI but produce an invalid Cargo workspace when merged, as happened with #3912 and #4138.

Update `lint-police` to fetch full history, merge current `main` into the PR branch, and run `cargo metadata --locked --no-deps` before Clippy. Merge conflicts or invalid workspace metadata will fail the required gate.

Follow-up to #4270. Related to #4268.

## Type of Change
- [x] **Internal** - CI hardening

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

- `cargo metadata --locked --no-deps --format-version 1`
- `actionlint` v1.7.12
- YAML parse validation
- Reconstructed the #3912 merge and confirmed the metadata gate detects the duplicate table

## Additional Notes
`cargo make --no-workspace clippy-flow` is blocked locally on macOS by Linux-only `libudev`; Linux CI validation is required.