### PR TITLE
patch(v2.0): fix: Use UpdateStrategy with maxunavailable 100% (backport #4294)

### DIFF
--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -25,10 +25,7 @@ use carbide_dpf::types::{
     DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME,
     FMDS_SERVICE_NAME, OTEL_COLLECTOR_SERVICE_NAME,
 };
-use carbide_dpf::{
-    ConfigPortsServiceType, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
-    ServiceInterface, ServiceNAD, ServiceNADResourceType,
-};
+use carbide_dpf::{ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType};
 
 use crate::cfg::file::{DEFAULT_DPF_IMAGE_PULL_SECRET, DpfServiceConfig};
 
@@ -265,13 +262,8 @@ pub fn dts_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "exposedPorts": { "ports": { "httpserverport": true } }
         })),
-        config_ports: Some(vec![ServiceConfigPort {
-            name: "httpserverport".to_string(),
-            port: 9189,
-            protocol: ServiceConfigPortProtocol::Tcp,
-            node_port: None,
-        }]),
-        config_ports_service_type: Some(ConfigPortsServiceType::ClusterIp),
+        config_ports: None,
+        config_ports_service_type: None,
         ..ServiceDefinition::new(
             &cfg.name,
             &cfg.helm_repo_url,

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::core::ObjectMeta;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -48,8 +49,10 @@ use crate::crds::dpuserviceconfigurations_generated::{
     DpuServiceConfigurationServiceConfigurationConfigPortsPortsProtocol,
     DpuServiceConfigurationServiceConfigurationConfigPortsServiceType,
     DpuServiceConfigurationServiceConfigurationHelmChart,
-    DpuServiceConfigurationServiceConfigurationServiceDaemonSet, DpuServiceConfigurationSpec,
-    DpuServiceConfigurationUpgradePolicy,
+    DpuServiceConfigurationServiceConfigurationServiceDaemonSet,
+    DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategy,
+    DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategyRollingUpdate,
+    DpuServiceConfigurationSpec, DpuServiceConfigurationUpgradePolicy,
 };
 use crate::crds::dpuserviceinterfaces_generated::{
     DPUServiceInterface, DpuServiceInterfaceSpec, DpuServiceInterfaceTemplate,
@@ -609,7 +612,12 @@ pub fn build_service_configuration(
             annotations: Some(annos.clone()),
             labels: None,
             resources: None,
-            update_strategy: None,
+            update_strategy: Some(
+                DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategy {
+                    rolling_update: Some(DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategyRollingUpdate{ max_surge: None, max_unavailable: Some(IntOrString::String("100%".to_string())) }),
+                    r#type: Some("RollingUpdate".into()),
+                },
+            ),
         }
     });
 


### PR DESCRIPTION
Backport of #4294 to `release/v2.0`.

Use `UpdateStrategy` with `maxUnavailable: 100%` for DPU service daemon sets, and remove the unused `config_ports`/`config_ports_service_type` from `dts_service`.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Backport of #4294. Two conflicts resolved:

- `crates/dpf/src/sdk.rs`: `carbide_utils::none_if_empty::NoneIfEmpty` is not a dependency in `release/v2.0`'s `dpf` crate (it was pre-existing on `main` before #4294). Only the `IntOrString` import needed for `UpdateStrategy` was added.
- `crates/api-core/src/dpf_services.rs`: `dts_service` has a different structure in `release/v2.0` (no `helm_values` variable, inline JSON instead). Kept `release/v2.0`'s `helm_values` expression while taking the PR's `config_ports: None` / `config_ports_service_type: None`.