### PR TITLE
patch(v2.0): fix: Use UpdateStrategy with maxunavailable 100% (backport #4294)

### DIFF
--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -25,10 +25,7 @@ use carbide_dpf::types::{
     DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME,
     FMDS_SERVICE_NAME, OTEL_COLLECTOR_SERVICE_NAME,
 };
-use carbide_dpf::{
-    ConfigPortsServiceType, ServiceConfigPort, ServiceConfigPortProtocol, ServiceDefinition,
-    ServiceInterface, ServiceNAD, ServiceNADResourceType,
-};
+use carbide_dpf::{ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType};
 
 use crate::cfg::file::{DEFAULT_DPF_IMAGE_PULL_SECRET, DpfServiceConfig};
 
@@ -265,13 +262,8 @@ pub fn dts_service(cfg: &DpfServiceConfig) -> ServiceDefinition {
         helm_values: Some(serde_json::json!({
             "exposedPorts": { "ports": { "httpserverport": true } }
         })),
-        config_ports: Some(vec![ServiceConfigPort {
-            name: "httpserverport".to_string(),
-            port: 9189,
-            protocol: ServiceConfigPortProtocol::Tcp,
-            node_port: None,
-        }]),
-        config_ports_service_type: Some(ConfigPortsServiceType::ClusterIp),
+        config_ports: None,
+        config_ports_service_type: None,
         ..ServiceDefinition::new(
             &cfg.name,
             &cfg.helm_repo_url,

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::core::ObjectMeta;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -48,8 +49,10 @@ use crate::crds::dpuserviceconfigurations_generated::{
     DpuServiceConfigurationServiceConfigurationConfigPortsPortsProtocol,
     DpuServiceConfigurationServiceConfigurationConfigPortsServiceType,
     DpuServiceConfigurationServiceConfigurationHelmChart,
-    DpuServiceConfigurationServiceConfigurationServiceDaemonSet, DpuServiceConfigurationSpec,
-    DpuServiceConfigurationUpgradePolicy,
+    DpuServiceConfigurationServiceConfigurationServiceDaemonSet,
+    DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategy,
+    DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategyRollingUpdate,
+    DpuServiceConfigurationSpec, DpuServiceConfigurationUpgradePolicy,
 };
 use crate::crds::dpuserviceinterfaces_generated::{
     DPUServiceInterface, DpuServiceInterfaceSpec, DpuServiceInterfaceTemplate,
@@ -609,7 +612,12 @@ pub fn build_service_configuration(
             annotations: Some(annos.clone()),
             labels: None,
             resources: None,
-            update_strategy: None,
+            update_strategy: Some(
+                DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategy {
+                    rolling_update: Some(DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategyRollingUpdate{ max_surge: None, max_unavailable: Some(IntOrString::String("100%".to_string())) }),
+                    r#type: Some("RollingUpdate".into()),
+                },
+            ),
         }
     });
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -607,33 +607,24 @@ pub fn build_service_configuration(
         })
     });
 
-    let service_daemon_set = svc.service_daemon_set_annotations.as_ref().map(|annos| {
-        DpuServiceConfigurationServiceConfigurationServiceDaemonSet {
-            annotations: Some(annos.clone()),
-            labels: None,
-            resources: None,
-            update_strategy: Some(
-                DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategy {
-                    rolling_update: Some(DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategyRollingUpdate{ max_surge: None, max_unavailable: Some(IntOrString::String("100%".to_string())) }),
-                    r#type: Some("RollingUpdate".into()),
-                },
-            ),
-        }
-    });
-
-    let service_configuration = if config_ports_crd.is_some()
-        || helm_chart_config.is_some()
-        || service_daemon_set.is_some()
-    {
-        Some(DpuServiceConfigurationServiceConfiguration {
-            config_ports: config_ports_crd,
-            deploy_in_cluster: None,
-            helm_chart: helm_chart_config,
-            service_daemon_set,
-        })
-    } else {
-        None
+    let service_daemon_set = DpuServiceConfigurationServiceConfigurationServiceDaemonSet {
+        annotations: svc.service_daemon_set_annotations.clone(),
+        labels: None,
+        resources: None,
+        update_strategy: Some(
+            DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategy {
+                rolling_update: Some(DpuServiceConfigurationServiceConfigurationServiceDaemonSetUpdateStrategyRollingUpdate{ max_surge: None, max_unavailable: Some(IntOrString::String("100%".to_string())) }),
+                r#type: Some("RollingUpdate".into()),
+            },
+        ),
     };
+
+    let service_configuration = Some(DpuServiceConfigurationServiceConfiguration {
+        config_ports: config_ports_crd,
+        deploy_in_cluster: None,
+        helm_chart: helm_chart_config,
+        service_daemon_set: Some(service_daemon_set),
+    });
 
     DPUServiceConfiguration {
         metadata: ObjectMeta {


### PR DESCRIPTION
Backport of #4294 to `release/v2.0`, with one additional bug fix.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Two commits:

**Commit 1** — cherry-pick of #4294 with conflict resolutions:
- `crates/dpf/src/sdk.rs`: added only the `IntOrString` import needed for `UpdateStrategy`; `carbide_utils::none_if_empty::NoneIfEmpty` was already on `main` before #4294 and is not a dep of the `dpf` crate in `release/v2.0`.
- `crates/api-core/src/dpf_services.rs`: `dts_service` has a different structure in `release/v2.0` (inline `helm_values` JSON vs a variable). Kept `release/v2.0`'s `helm_values` while taking `config_ports: None` / `config_ports_service_type: None`.

**Commit 2** — bug fix: `service_daemon_set` was gated on `svc.service_daemon_set_annotations` being `Some`, so `update_strategy` was never applied to services without annotations. Always construct `service_daemon_set` and emit `service_configuration` unconditionally so every service gets the `100%` maxUnavailable rolling update policy.