### PR TITLE
fix: prevent extension services from blocking instances under dpf

### DIFF
--- a/crates/agent/src/extension_services/manager.rs
+++ b/crates/agent/src/extension_services/manager.rs
@@ -116,19 +116,28 @@ impl ExtensionServiceManager {
             let status = match self.get_handler_mut(&service.service_type) {
                 Ok(handler) => handler.get_service_status(&service).await?,
                 Err(err) => {
-                    tracing::error!(
-                        service_id = %service.id,
-                        error = %err,
-                        "Error getting extension service status"
-                    );
+                    let state = if service.removed.is_some() {
+                        tracing::info!(
+                            service_id = %service.id,
+                            error = %err,
+                            "Treating removed unsupported extension service as terminated"
+                        );
+                        rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceTerminated
+                    } else {
+                        tracing::error!(
+                            service_id = %service.id,
+                            error = %err,
+                            "Error getting extension service status"
+                        );
+                        rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceError
+                    };
                     rpc::DpuExtensionServiceStatusObservation {
                         service_id: service.id.to_string(),
                         service_type: service.service_type.into(),
                         service_name: service.name,
                         version: service.version.to_string(),
                         removed: service.removed,
-                        state: rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceError
-                            .into(),
+                        state: state.into(),
                         components: vec![],
                         message: err.to_string(),
                     }
@@ -138,5 +147,46 @@ impl ExtensionServiceManager {
         }
 
         Ok(service_statuses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn service_config(removed: Option<String>) -> rpc::ManagedHostDpuExtensionServiceConfig {
+        rpc::ManagedHostDpuExtensionServiceConfig {
+            service_id: uuid::Uuid::nil().to_string(),
+            name: "test-service".to_string(),
+            version: config_version::ConfigVersion::initial().version_string(),
+            service_type: DpuExtensionServiceType::KubernetesPod.into(),
+            removed,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn containerized_platform_reports_status_for_unsupported_services() {
+        let mut manager =
+            ExtensionServiceManager::platform_defaults(&AgentPlatformType::Containerized);
+
+        let statuses = manager
+            .get_service_statuses(vec![
+                service_config(None),
+                service_config(Some(chrono::Utc::now().to_rfc3339())),
+            ])
+            .await
+            .expect("unsupported services should produce status observations");
+
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(
+            statuses[0].state,
+            rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceError as i32
+        );
+        assert_eq!(
+            statuses[1].state,
+            rpc::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceTerminated as i32
+        );
+        assert!(statuses[1].removed.is_some());
     }
 }

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -1685,6 +1685,18 @@ async fn update_instance_extension_services_config(
         return Err(ConfigValidationError::InstanceDeletionIsRequested.into());
     }
 
+    if mh_snapshot.host_snapshot.config.dpf.used_for_ingestion
+        && instance
+            .config
+            .extension_services
+            .has_new_active_services(extension_services)
+    {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "DPU extension services are not supported on DPF-managed host {}",
+            mh_snapshot.host_snapshot.id
+        )));
+    }
+
     // Calculate the new extension services config.
     let new_extension_services_config = instance
         .config

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -1538,6 +1538,14 @@ pub async fn batch_allocate_instances(
                 NotAllocatableReason::HealthAlert(_) => CarbideError::UnhealthyHost,
             });
         }
+
+        if mh_snapshot.host_snapshot.config.dpf.used_for_ingestion
+            && !request.config.extension_services.service_configs.is_empty()
+        {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "DPU extension services are not supported on DPF-managed host {machine_id}"
+            )));
+        }
     }
 
     // ==== Phase 5: Validate shared resources ====

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -7362,6 +7362,64 @@ async fn test_allocate_instance_with_extension_services(
     Ok(())
 }
 
+#[crate::sqlx_test]
+async fn test_allocate_instance_with_extension_services_rejected_on_dpf_host(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+    let (service, _, _) = create_dpu_extension_services(&env).await?;
+
+    let mut txn = env.pool.begin().await?;
+    db::machine::mark_machine_ingestion_done_with_dpf(&mut txn, &mh.id).await?;
+    txn.commit().await?;
+
+    let result = env
+        .api
+        .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
+            machine_id: Some(mh.id),
+            config: Some(rpc::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(default_os_config()),
+                network: Some(single_interface_network_config(segment_id)),
+                infiniband: None,
+                network_security_group_id: None,
+                nvlink: None,
+                spxconfig: None,
+                dpu_extension_services: Some(rpc::forge::InstanceDpuExtensionServicesConfig {
+                    service_configs: vec![rpc::forge::InstanceDpuExtensionServiceConfig {
+                        service_id: service.service_id,
+                        version: service.latest_version_info.unwrap().version,
+                    }],
+                }),
+            }),
+            instance_id: None,
+            instance_type_id: None,
+            metadata: Some(rpc::Metadata {
+                name: "dpf-extension-service".to_string(),
+                description: String::new(),
+                labels: vec![],
+            }),
+            allow_unhealthy_machine: false,
+        }))
+        .await
+        .expect_err("extension services must be rejected on a DPF-managed host");
+
+    assert_eq!(result.code(), tonic::Code::FailedPrecondition);
+    assert_eq!(
+        result.message(),
+        format!(
+            "DPU extension services are not supported on DPF-managed host {}",
+            mh.id
+        )
+    );
+
+    Ok(())
+}
+
 async fn create_dpu_extension_services(
     env: &TestEnv,
 ) -> Result<
@@ -7854,6 +7912,67 @@ async fn test_update_instance_with_extension_services(
     assert!(err.message().starts_with(
         "duplicate extension services in configuration. only one version of each service is allowed"
     ));
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_attach_extension_service_rejected_on_dpf_host(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+    let (service, _, _) = create_dpu_extension_services(&env).await?;
+    let tinstance = mh
+        .instance_builer(&env)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+
+    let mut txn = env.pool.begin().await?;
+    db::machine::mark_machine_ingestion_done_with_dpf(&mut txn, &mh.id).await?;
+    txn.commit().await?;
+
+    let result = env
+        .api
+        .update_instance_config(Request::new(rpc::forge::InstanceConfigUpdateRequest {
+            instance_id: Some(tinstance.id),
+            if_version_match: None,
+            config: Some(rpc::InstanceConfig {
+                tenant: Some(default_tenant_config()),
+                os: Some(default_os_config()),
+                network: Some(single_interface_network_config(segment_id)),
+                infiniband: None,
+                network_security_group_id: None,
+                nvlink: None,
+                spxconfig: None,
+                dpu_extension_services: Some(rpc::forge::InstanceDpuExtensionServicesConfig {
+                    service_configs: vec![rpc::forge::InstanceDpuExtensionServiceConfig {
+                        service_id: service.service_id,
+                        version: service.latest_version_info.unwrap().version,
+                    }],
+                }),
+            }),
+            metadata: Some(rpc::Metadata {
+                name: "dpf-extension-service".to_string(),
+                description: String::new(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .expect_err("attaching an extension service must fail on a DPF-managed host");
+
+    assert_eq!(result.code(), tonic::Code::FailedPrecondition);
+    assert_eq!(
+        result.message(),
+        format!(
+            "DPU extension services are not supported on DPF-managed host {}",
+            mh.id
+        )
+    );
 
     Ok(())
 }

--- a/crates/api-model/src/instance/config/extension_services.rs
+++ b/crates/api-model/src/instance/config/extension_services.rs
@@ -78,6 +78,21 @@ impl InstanceExtensionServicesConfig {
         current_active != new_services
     }
 
+    /// Returns whether `new_config` introduces an active service or service version that is not
+    /// already active in the current config.
+    pub fn has_new_active_services(&self, new_config: &Self) -> bool {
+        let current_active: HashSet<_> = self
+            .active_services()
+            .iter()
+            .map(|s| (s.service_id, s.version.to_string()))
+            .collect();
+
+        new_config
+            .active_services()
+            .iter()
+            .any(|s| !current_active.contains(&(s.service_id, s.version.to_string())))
+    }
+
     /// Calculates the new actual extension services config based on the current config and the new config.
     /// For any current active service that is not in the new config, it will be marked as deleted.
     /// For any new service that is not in the current config, it will be added to the new config.
@@ -201,5 +216,47 @@ mod tests {
         assert_eq!(cleaned.service_configs[0].service_id, sid);
         assert_eq!(cleaned.service_configs[0].version, second_version);
         assert!(cleaned.service_configs[0].removed.is_none());
+    }
+
+    #[test]
+    fn extension_service_detects_only_new_active_services() {
+        let existing_id =
+            ExtensionServiceId::from_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let new_id = ExtensionServiceId::from_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let initial_version = ConfigVersion::initial();
+        let current = InstanceExtensionServicesConfig {
+            service_configs: vec![InstanceExtensionServiceConfig {
+                service_id: existing_id,
+                version: initial_version,
+                removed: None,
+            }],
+        };
+
+        let detached = InstanceExtensionServicesConfig::default();
+        assert!(!current.has_new_active_services(&detached));
+
+        let unchanged = current.clone();
+        assert!(!current.has_new_active_services(&unchanged));
+
+        let added = InstanceExtensionServicesConfig {
+            service_configs: vec![
+                unchanged.service_configs[0].clone(),
+                InstanceExtensionServiceConfig {
+                    service_id: new_id,
+                    version: initial_version,
+                    removed: None,
+                },
+            ],
+        };
+        assert!(current.has_new_active_services(&added));
+
+        let upgraded = InstanceExtensionServicesConfig {
+            service_configs: vec![InstanceExtensionServiceConfig {
+                service_id: existing_id,
+                version: initial_version.increment(),
+                removed: None,
+            }],
+        };
+        assert!(current.has_new_active_services(&upgraded));
     }
 }


### PR DESCRIPTION
When DPF is enabled, DPU agent currently does not report any status for the extension services attached to the instance. If any extension service is attached to the instance, the instance may never reach `RUNNING` state and may become stuck during termination while waiting for the service to report `TERMINATED`.

This MR prevents new extension services from being attached to DPF-managed instances. For services that were attached before the host was reprovisioned through DPF, the DPU agent reports TERMINATED after they are marked for removal during instance termination, so that the instance lifecycle can proceed normally to clean up.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

