### PR TITLE
feat(rest-api): Enable NICo MCP Agent Gateway deployment

### DIFF
--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -298,6 +298,31 @@ jobs:
       NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
       NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
 
+  build-nico-mcp:
+    name: Build nico-mcp
+    uses: ./.github/workflows/rest-build-push-service.yml
+    with:
+      ngc_path: ${{ inputs.ngc_path }}
+      runner: ${{ inputs.runner }}
+      service_name: nico-mcp
+      binary_name: nico-mcp
+      binary_path: /app/nico-mcp
+      dockerfile: ./rest-api/docker/production/Dockerfile.nico-mcp
+      semantic_version: ${{ inputs.semantic_version }}
+      short_sha: ${{ inputs.short_sha }}
+      branch_sha_tag: ${{ inputs.branch_sha_tag }}
+      target_registry: ${{ inputs.target_registry }}
+      push_enabled: ${{ inputs.push_enabled }}
+      is_main_branch: ${{ inputs.is_main_branch }}
+      release_tag: ${{ inputs.release_tag }}
+      helm_version: ${{ inputs.helm_version }}
+    secrets:
+      NVCR_USERNAME: ${{ secrets.NVCR_USERNAME }}
+      NVCR_TOKEN: ${{ secrets.NVCR_TOKEN }}
+      NICO_TARGET_REGISTRY_USERNAME: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME }}
+      NICO_TARGET_REGISTRY_TOKEN: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN }}
+      NICO_NGC_TOKEN: ${{ secrets.NICO_NGC_TOKEN }}
+
   build-summary:
     name: Build Summary
     runs-on: ${{ inputs.runner }}
@@ -311,6 +336,7 @@ jobs:
       - build-nico-flow
       - build-nico-psm
       - build-nico-nsm
+      - build-nico-mcp
     if: always()
     outputs:
       build_artifacts: ${{ steps.aggregate.outputs.artifacts }}
@@ -359,6 +385,7 @@ jobs:
           echo "7. \`nico-flow:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
           echo "8. \`nico-psm:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
           echo "9. \`nico-nsm:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
+          echo "10. \`nico-mcp:${{ inputs.branch_sha_tag }}\` (amd64 + arm64)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.push_enabled }}" = "true" ]; then
             echo "## Binary Artifacts Uploaded" >> $GITHUB_STEP_SUMMARY
@@ -375,6 +402,7 @@ jobs:
           echo "- nico-flow: \`${{ needs.build-nico-flow.result }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- nico-psm: \`${{ needs.build-nico-psm.result }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- nico-nsm: \`${{ needs.build-nico-nsm.result }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- nico-mcp: \`${{ needs.build-nico-mcp.result }}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Aggregate outputs
         id: aggregate
@@ -434,6 +462,12 @@ jobs:
               "image_ref": "${{ needs.build-nico-nsm.outputs.image_ref }}",
               "binary_resource": "${{ needs.build-nico-nsm.outputs.ngc_binary_resource }}",
               "image_resource": "${{ needs.build-nico-nsm.outputs.ngc_image_resource }}"
+            },
+            {
+              "service": "nico-mcp",
+              "image_ref": "${{ needs.build-nico-mcp.outputs.image_ref }}",
+              "binary_resource": "${{ needs.build-nico-mcp.outputs.ngc_binary_resource }}",
+              "image_resource": "${{ needs.build-nico-mcp.outputs.ngc_image_resource }}"
             }
           ]
           EOF

--- a/.github/workflows/rest-helm-workflows.yml
+++ b/.github/workflows/rest-helm-workflows.yml
@@ -36,6 +36,8 @@ jobs:
             valueOverrides: '["nico-rest-api.config.keycloak.enabled=true","nico-rest-api.config.keycloak.baseURL=http://keycloak:8082","nico-rest-api.config.keycloak.realm=test","nico-rest-api.config.keycloak.clientID=test"]'
           - chart: helm/rest/nico-rest-site-agent
             valueOverrides: '[]'
+          - chart: helm/rest/nico-mcp
+            valueOverrides: '[]'
           - chart: helm/charts/nico-flow
             valueOverrides: '[]'
     steps:
@@ -63,6 +65,7 @@ jobs:
         chart:
           - helm/rest/nico-rest
           - helm/rest/nico-rest-site-agent
+          - helm/rest/nico-mcp
           - helm/charts/nico-flow
     steps:
       - name: Checkout code

--- a/helm/rest/nico-mcp/templates/service.yaml
+++ b/helm/rest/nico-mcp/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
-      name: http
+      name: mcp
+      appProtocol: agentgateway.dev/mcp
   selector:
     {{- include "nico-mcp.selectorLabels" . | nindent 4 }}

--- a/helm/rest/nico-mcp/tests/service_test.yaml
+++ b/helm/rest/nico-mcp/tests/service_test.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: Agent Gateway discovery metadata
+templates:
+  - service.yaml
+tests:
+  - it: marks the MCP service port for Agent Gateway discovery
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: nico-mcp
+      - equal:
+          path: spec.ports[0].name
+          value: mcp
+      - equal:
+          path: spec.ports[0].appProtocol
+          value: agentgateway.dev/mcp

--- a/rest-api/docker/production/Dockerfile.nico-mcp
+++ b/rest-api/docker/production/Dockerfile.nico-mcp
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
 
 # Docker automatically provides these args during multi-platform builds
 ARG TARGETOS=linux
@@ -43,7 +43,7 @@ RUN go build \
         ./cmd/nico-mcp
 
 # Final stage
-FROM nvcr.io/nvidia/distroless/go:v4.0.8 AS final
+FROM nvcr.io/nvidia/distroless/go:v4.0.8@sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178 AS final
 
 WORKDIR /app
 

--- a/rest-api/docker/production/Dockerfile.nico-mcp
+++ b/rest-api/docker/production/Dockerfile.nico-mcp
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 
 # Docker automatically provides these args during multi-platform builds
 ARG TARGETOS=linux
@@ -43,7 +43,7 @@ RUN go build \
         ./cmd/nico-mcp
 
 # Final stage
-FROM nvcr.io/nvidia/distroless/go:v4.0.8@sha256:938bd28ce4ddb800118a951774203e7563c2067a72b20ae6b85d2c7da165a178 AS final
+FROM nvcr.io/nvidia/distroless/go:v4.0.8 AS final
 
 WORKDIR /app
 


### PR DESCRIPTION
NICo MCP is not published by the normal REST release workflows, and its Service lacks the port metadata Agent Gateway uses for discovery. This publishes the image and chart through the existing REST workflows and marks the MCP Service port for Agent Gateway discovery.

## Related issues

Related to #2006.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`make rest-helm-lint` and `helm unittest --strict helm/rest/nico-mcp` pass. A rendered Service contains the `nico-mcp` label, `mcp` port name, and `agentgateway.dev/mcp` app protocol.

## Additional Notes

None.
