### PR TITLE
refactor(instrument): group candidate metrics with a MetricFamily

### DIFF
--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -27,7 +27,7 @@ use tower::ServiceBuilder;
 use tracing::Span;
 
 pub mod config;
-use carbide_instrument::Outcome;
+use carbide_instrument::{MetricFamily, Outcome};
 use carbide_uuid::machine::MachineId;
 pub use config::{get_dpu_agent_meter, get_prometheus_registry};
 
@@ -61,15 +61,25 @@ pub(crate) enum OvsRestart {
     },
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_dpu_agent_service_restart_attempts_total",
+    kind = counter,
+    component = "forge-dpu-agent",
+    describe = "Number of DPU-agent service restart attempts, by service and result."
+)]
+struct DpuAgentServiceRestartAttempts {
+    service: RestartedService,
+    result: ServiceRestartResult,
+}
+
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_lldpd_restart_succeeded",
-    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentServiceRestartAttempts,
     log = info,
-    metric = counter,
-    message = "Restarted lldpd service",
-    describe = "Number of DPU-agent service restart attempts, by service and result."
+    message = "Restarted lldpd service"
 )]
 struct LldpdRestartSucceeded {
     #[label]
@@ -83,12 +93,9 @@ struct LldpdRestartSucceeded {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_lldpd_restart_retrying",
-    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentServiceRestartAttempts,
     log = warn,
-    metric = counter,
-    message = "Couldn't restart lldpd service, retrying",
-    describe = "Number of DPU-agent service restart attempts, by service and result."
+    message = "Couldn't restart lldpd service, retrying"
 )]
 struct LldpdRestartRetrying {
     #[label]
@@ -104,12 +111,9 @@ struct LldpdRestartRetrying {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_lldpd_restart_failed",
-    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentServiceRestartAttempts,
     log = error,
-    metric = counter,
-    message = "Couldn't restart lldpd service",
-    describe = "Number of DPU-agent service restart attempts, by service and result."
+    message = "Couldn't restart lldpd service"
 )]
 struct LldpdRestartFailed {
     #[label]
@@ -125,12 +129,9 @@ struct LldpdRestartFailed {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_ovs_restart_succeeded",
-    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentServiceRestartAttempts,
     log = info,
-    metric = counter,
-    message = "Successfully restarted ovs-vswitchd.service",
-    describe = "Number of DPU-agent service restart attempts, by service and result."
+    message = "Successfully restarted ovs-vswitchd.service"
 )]
 struct OvsRestartSucceeded {
     #[label]
@@ -142,12 +143,9 @@ struct OvsRestartSucceeded {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_ovs_restart_retrying",
-    metric_name = "carbide_dpu_agent_service_restart_attempts_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentServiceRestartAttempts,
     log = error,
-    metric = counter,
-    message = "Restarting OVS after admin network change",
-    describe = "Number of DPU-agent service restart attempts, by service and result."
+    message = "Restarting OVS after admin network change"
 )]
 struct OvsRestartRetrying {
     #[label]
@@ -259,18 +257,28 @@ pub(crate) enum NetworkStatus {
     RpcFailed { error: String },
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_dpu_agent_report_total",
+    kind = counter,
+    component = "forge-dpu-agent",
+    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+)]
+struct DpuAgentReport {
+    report_loop: ReportLoop,
+    outcome: Outcome,
+}
+
 /// `InventoryReportSucceeded` records the inventory loop's successful
 /// completion and owns its DEBUG diagnostic. The other successful loops are
 /// metric-only.
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_inventory_report_succeeded",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentReport,
     log = debug,
-    metric = counter,
-    message = "Successfully updated machine inventory",
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    message = "Successfully updated machine inventory"
 )]
 struct InventoryReportSucceeded {
     #[label]
@@ -285,11 +293,8 @@ struct InventoryReportSucceeded {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_inventory_report_failed",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
-    log = off,
-    metric = counter,
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    metric_family = DpuAgentReport,
+    log = off
 )]
 struct InventoryReportFailed {
     #[label]
@@ -301,11 +306,8 @@ struct InventoryReportFailed {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_config_fetch_succeeded",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
-    log = off,
-    metric = counter,
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    metric_family = DpuAgentReport,
+    log = off
 )]
 struct ConfigFetchSucceeded {
     #[label]
@@ -317,12 +319,9 @@ struct ConfigFetchSucceeded {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_config_fetch_failed",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentReport,
     log = error,
-    metric = counter,
-    message = "Failed to fetch the latest configuration. Will retry",
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    message = "Failed to fetch the latest configuration. Will retry"
 )]
 struct ConfigFetchFailed {
     #[label]
@@ -338,12 +337,9 @@ struct ConfigFetchFailed {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_config_not_found",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentReport,
     log = warn,
-    metric = counter,
-    message = "DPU not found",
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    message = "DPU not found"
 )]
 struct ConfigNotFound {
     #[label]
@@ -357,11 +353,8 @@ struct ConfigNotFound {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_fmds_push_succeeded",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
-    log = off,
-    metric = counter,
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    metric_family = DpuAgentReport,
+    log = off
 )]
 struct FmdsPushSucceeded {
     #[label]
@@ -373,12 +366,9 @@ struct FmdsPushSucceeded {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_fmds_push_failed",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentReport,
     log = error,
-    metric = counter,
-    message = "Failed to send config update to external FMDS",
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    message = "Failed to send config update to external FMDS"
 )]
 struct FmdsPushFailed {
     #[label]
@@ -394,11 +384,8 @@ struct FmdsPushFailed {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_network_status_succeeded",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
-    log = off,
-    metric = counter,
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    metric_family = DpuAgentReport,
+    log = off
 )]
 struct NetworkStatusSucceeded {
     #[label]
@@ -410,12 +397,9 @@ struct NetworkStatusSucceeded {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_network_status_connection_failed",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentReport,
     log = error,
-    metric = counter,
-    message = "record_network_status: Could not connect to Forge API server. Will retry.",
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    message = "record_network_status: Could not connect to Forge API server. Will retry."
 )]
 struct NetworkStatusConnectionFailed {
     #[label]
@@ -431,12 +415,9 @@ struct NetworkStatusConnectionFailed {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_network_status_rpc_failed",
-    metric_name = "carbide_dpu_agent_report_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuAgentReport,
     log = error,
-    metric = counter,
-    message = "Error while executing the record_network_status gRPC call",
-    describe = "Number of DPU-agent report-loop iterations, by loop and outcome"
+    message = "Error while executing the record_network_status gRPC call"
 )]
 struct NetworkStatusRpcFailed {
     #[label]

--- a/crates/api-core/src/credentials/bmc_session_manager.rs
+++ b/crates/api-core/src/credentials/bmc_session_manager.rs
@@ -281,15 +281,24 @@ enum BmcSessionLockoutBreakerTransition {
     Cleared,
 }
 
+/// The one metric the Events below record.
+#[derive(carbide_instrument::MetricFamily)]
+#[metric(
+    name = "carbide_bmc_session_lockout_breaker_transitions_total",
+    kind = counter,
+    component = "nico-api",
+    describe = "Number of BMC session lockout-avoidance breaker transitions."
+)]
+struct BmcSessionLockoutBreakerTransitions {
+    transition: BmcSessionLockoutBreakerTransition,
+}
+
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "bmc_session_lockout_breaker_tripped",
-    metric_name = "carbide_bmc_session_lockout_breaker_transitions_total",
-    component = "nico-api",
+    metric_family = BmcSessionLockoutBreakerTransitions,
     log = warn,
-    metric = counter,
-    message = "BmcSessionManager: lockout-avoidance breaker tripped",
-    describe = "Number of BMC session lockout-avoidance breaker transitions."
+    message = "BmcSessionManager: lockout-avoidance breaker tripped"
 )]
 struct BmcSessionLockoutBreakerTripped {
     #[label]
@@ -324,12 +333,9 @@ impl BmcSessionLockoutBreakerTripped {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "bmc_session_lockout_breaker_cleared",
-    metric_name = "carbide_bmc_session_lockout_breaker_transitions_total",
-    component = "nico-api",
+    metric_family = BmcSessionLockoutBreakerTransitions,
     log = info,
-    metric = counter,
-    message = "BmcSessionManager: lockout-avoidance breaker cleared",
-    describe = "Number of BMC session lockout-avoidance breaker transitions."
+    message = "BmcSessionManager: lockout-avoidance breaker cleared"
 )]
 struct BmcSessionLockoutBreakerCleared {
     #[label]

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -222,18 +222,27 @@ enum ConnectionFailReason {
     TlsConnectionFailure,
 }
 
+/// The one metric the Events below record.
+#[derive(carbide_instrument::MetricFamily)]
+#[metric(
+    name = "carbide_api_tls_connection_fail_total",
+    kind = counter,
+    component = "nico-api",
+    describe = "Number of failed inbound TLS connection attempts"
+)]
+struct ApiTlsConnectionFail {
+    reason: ConnectionFailReason,
+}
+
 /// `TcpAcceptFailed` records a listener error before a peer connection exists.
 /// It increments the existing `tcp_connection_failure` series while keeping
 /// the per-attempt error in log-only context.
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "api_tcp_accept_failed",
-    metric_name = "carbide_api_tls_connection_fail_total",
-    component = "nico-api",
+    metric_family = ApiTlsConnectionFail,
     log = error,
-    metric = counter,
-    message = "Error accepting connection",
-    describe = "Number of failed inbound TLS connection attempts"
+    message = "Error accepting connection"
 )]
 struct TcpAcceptFailed {
     #[label]
@@ -248,12 +257,9 @@ struct TcpAcceptFailed {
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "api_tls_connection_failed",
-    metric_name = "carbide_api_tls_connection_fail_total",
-    component = "nico-api",
+    metric_family = ApiTlsConnectionFail,
     log = error,
-    metric = counter,
-    message = "error accepting tls connection",
-    describe = "Number of failed inbound TLS connection attempts"
+    message = "error accepting tls connection"
 )]
 struct TlsConnectionFailed {
     #[label]

--- a/crates/api-core/src/machine_identity/token_exchange.rs
+++ b/crates/api-core/src/machine_identity/token_exchange.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use ::rpc::forge::MachineIdentityResponse;
 use base64::Engine;
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use serde::Deserialize;
 use tonic::Status;
@@ -43,16 +43,25 @@ enum TokenExchangeFailureStage {
     ResponseJson,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_machine_identity_token_exchange_failures_total",
+    kind = counter,
+    component = "nico-api",
+    describe = "Number of machine identity token exchange failures, by failure stage"
+)]
+struct MachineIdentityTokenExchangeFailures {
+    failure_stage: TokenExchangeFailureStage,
+}
+
 /// The HTTP request did not reach a token-exchange response.
 #[derive(Event)]
 #[event(
     event_name = "machine_identity_token_exchange_request_failed",
-    metric_name = "carbide_machine_identity_token_exchange_failures_total",
-    component = "nico-api",
+    metric_family = MachineIdentityTokenExchangeFailures,
     log = error,
-    metric = counter,
-    message = "token exchange HTTP request failed",
-    describe = "Number of machine identity token exchange failures, by failure stage"
+    message = "token exchange HTTP request failed"
 )]
 struct TokenExchangeRequestFailed {
     #[label]
@@ -67,12 +76,9 @@ struct TokenExchangeRequestFailed {
 #[derive(Event)]
 #[event(
     event_name = "machine_identity_token_exchange_response_read_failed",
-    metric_name = "carbide_machine_identity_token_exchange_failures_total",
-    component = "nico-api",
+    metric_family = MachineIdentityTokenExchangeFailures,
     log = error,
-    metric = counter,
-    message = "token exchange response body read failed",
-    describe = "Number of machine identity token exchange failures, by failure stage"
+    message = "token exchange response body read failed"
 )]
 struct TokenExchangeResponseReadFailed {
     #[label]
@@ -89,12 +95,9 @@ struct TokenExchangeResponseReadFailed {
 #[derive(Event)]
 #[event(
     event_name = "machine_identity_token_exchange_endpoint_rejected",
-    metric_name = "carbide_machine_identity_token_exchange_failures_total",
-    component = "nico-api",
+    metric_family = MachineIdentityTokenExchangeFailures,
     log = warn,
-    metric = counter,
-    message = "token exchange endpoint returned error",
-    describe = "Number of machine identity token exchange failures, by failure stage"
+    message = "token exchange endpoint returned error"
 )]
 struct TokenExchangeEndpointRejected {
     #[label]
@@ -113,12 +116,9 @@ struct TokenExchangeEndpointRejected {
 #[derive(Event)]
 #[event(
     event_name = "machine_identity_token_exchange_response_invalid",
-    metric_name = "carbide_machine_identity_token_exchange_failures_total",
-    component = "nico-api",
+    metric_family = MachineIdentityTokenExchangeFailures,
     log = warn,
-    metric = counter,
-    message = "token exchange JSON parse failed",
-    describe = "Number of machine identity token exchange failures, by failure stage"
+    message = "token exchange JSON parse failed"
 )]
 struct TokenExchangeResponseInvalid {
     #[label]

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -19,7 +19,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use config_version::ConfigVersion;
 use ipnetwork::Ipv6Network;
 use model::resource_pool;
@@ -85,18 +85,31 @@ impl From<ValueType> for ResourcePoolValueType {
     }
 }
 
-// These Events share one counter. Keep its kind, description, and label keys
-// identical. Existing allocation diagnostics retain their messages and
-// context; `release` gains its first diagnostic at this database boundary.
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_resource_pool_lifecycle_failures_total",
+    kind = counter,
+    component = "nico-api",
+    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+)]
+struct ResourcePoolLifecycleFailures {
+    operation: ResourcePoolOperation,
+    failure: ResourcePoolFailure,
+    failure_policy: ResourcePoolFailurePolicy,
+    allocation_mode: ResourcePoolAllocationMode,
+    value_type: ResourcePoolValueType,
+}
+
+// These Events record the counter the family above declares. Existing
+// allocation diagnostics retain their messages and context; `release` gains
+// its first diagnostic at this database boundary.
 #[derive(Event)]
 #[event(
     event_name = "resource_pool_exhausted",
-    metric_name = "carbide_resource_pool_lifecycle_failures_total",
-    component = "nico-api",
+    metric_family = ResourcePoolLifecycleFailures,
     log = error,
-    metric = counter,
-    message = "Pool exhausted, cannot allocate",
-    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+    message = "Pool exhausted, cannot allocate"
 )]
 struct ResourcePoolExhausted {
     #[label]
@@ -118,12 +131,9 @@ struct ResourcePoolExhausted {
 #[derive(Event)]
 #[event(
     event_name = "resource_pool_requested_vni_unavailable",
-    metric_name = "carbide_resource_pool_lifecycle_failures_total",
-    component = "nico-api",
+    metric_family = ResourcePoolLifecycleFailures,
     log = error,
-    metric = counter,
-    message = "invalid pool value requested, cannot allocate",
-    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+    message = "invalid pool value requested, cannot allocate"
 )]
 struct ResourcePoolRequestedVniUnavailable {
     #[label]
@@ -147,12 +157,9 @@ struct ResourcePoolRequestedVniUnavailable {
 #[derive(Event)]
 #[event(
     event_name = "resource_pool_allocation_failed",
-    metric_name = "carbide_resource_pool_lifecycle_failures_total",
-    component = "nico-api",
+    metric_family = ResourcePoolLifecycleFailures,
     log = error,
-    metric = counter,
-    message = "Error allocating from resource pool",
-    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+    message = "Error allocating from resource pool"
 )]
 struct ResourcePoolAllocationFailed {
     #[label]
@@ -176,12 +183,9 @@ struct ResourcePoolAllocationFailed {
 #[derive(Event)]
 #[event(
     event_name = "resource_pool_release_failed",
-    metric_name = "carbide_resource_pool_lifecycle_failures_total",
-    component = "nico-api",
+    metric_family = ResourcePoolLifecycleFailures,
     log = error,
-    metric = counter,
-    message = "Error releasing value to resource pool",
-    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+    message = "Error releasing value to resource pool"
 )]
 struct ResourcePoolReleaseFailed {
     #[label]
@@ -205,12 +209,9 @@ struct ResourcePoolReleaseFailed {
 #[derive(Event)]
 #[event(
     event_name = "dpu_asn_allocation_failed",
-    metric_name = "carbide_resource_pool_lifecycle_failures_total",
-    component = "nico-api",
+    metric_family = ResourcePoolLifecycleFailures,
     log = info,
-    metric = counter,
-    message = "Failed to allocate asn for dpu",
-    describe = "Number of resource pool lifecycle failures, by operation, failure, failure policy, allocation mode, and value type."
+    message = "Failed to allocate asn for dpu"
 )]
 struct DpuAsnAllocationFailed {
     #[label]

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -32,7 +32,7 @@ use carbide_authn::SpiffeContext;
 use carbide_authn::middleware::{
     AuthContext, Authorization, CertDescriptionMiddleware, ConnectionAttributes, Principal,
 };
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use carbide_utils::HostPortPair;
 use forge_tls::client_config::ClientCert;
 use http::{HeaderMap, Method, Request, Response, StatusCode, Uri};
@@ -261,18 +261,27 @@ enum ConnectionFailReason {
     TlsConnectionFailure,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_bmc_proxy_tls_connection_fail_total",
+    kind = counter,
+    component = "nico-bmc-proxy",
+    describe = "Number of failed inbound connections, by failure reason"
+)]
+struct BmcProxyTlsConnectionFail {
+    reason: ConnectionFailReason,
+}
+
 /// `TcpAcceptFailed` records a listener error before a peer connection exists.
 /// It increments the existing `tcp_connection_failure` series while keeping
 /// the per-attempt error in log-only context.
 #[derive(Event)]
 #[event(
     event_name = "bmc_proxy_tcp_accept_failed",
-    metric_name = "carbide_bmc_proxy_tls_connection_fail_total",
-    component = "nico-bmc-proxy",
+    metric_family = BmcProxyTlsConnectionFail,
     log = error,
-    metric = counter,
-    message = "Error accepting connection",
-    describe = "Number of failed inbound connections, by failure reason"
+    message = "Error accepting connection"
 )]
 struct TcpAcceptFailed {
     #[label]
@@ -287,12 +296,9 @@ struct TcpAcceptFailed {
 #[derive(Event)]
 #[event(
     event_name = "bmc_proxy_tls_certificate_reload_failed",
-    metric_name = "carbide_bmc_proxy_tls_connection_fail_total",
-    component = "nico-bmc-proxy",
+    metric_family = BmcProxyTlsConnectionFail,
     log = error,
-    metric = counter,
-    message = "Error reloading TLS certificate, will retry",
-    describe = "Number of failed inbound connections, by failure reason"
+    message = "Error reloading TLS certificate, will retry"
 )]
 struct TlsCertificateReloadFailed {
     #[label]
@@ -307,12 +313,9 @@ struct TlsCertificateReloadFailed {
 #[derive(Event)]
 #[event(
     event_name = "bmc_proxy_tls_connection_failed",
-    metric_name = "carbide_bmc_proxy_tls_connection_fail_total",
-    component = "nico-bmc-proxy",
+    metric_family = BmcProxyTlsConnectionFail,
     log = error,
-    metric = counter,
-    message = "error accepting tls connection",
-    describe = "Number of failed inbound connections, by failure reason"
+    message = "error accepting tls connection"
 )]
 struct TlsConnectionFailed {
     #[label]

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -23,7 +23,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use carbide_instrument::{Event, LabelValue};
+use carbide_instrument::{Event, LabelValue, MetricFamily};
 use http::Method;
 use metrics_endpoint::{MetricsEndpointConfig, MetricsSetup};
 use tokio::task::JoinSet;
@@ -99,23 +99,34 @@ enum AuthorizationLayer {
     RequestAcl,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_bmc_proxy_authorization_denied_total",
+    kind = counter,
+    component = "nico-bmc-proxy",
+    describe = "Number of BMC proxy requests denied by authorization layer and HTTP method"
+)]
+pub(crate) struct BmcProxyAuthorizationDenied {
+    authorization_layer: AuthorizationLayer,
+    #[label(name = "method")]
+    method_label: MethodLabel,
+}
+
 /// The request reached the per-principal ACL, but no configured rule allowed
 /// its method and path. `method_label` bounds the metric while `method` keeps
 /// the existing uppercase log field operators already search.
 #[derive(Event)]
 #[event(
     event_name = "bmc_proxy_request_acl_denied",
-    metric_name = "carbide_bmc_proxy_authorization_denied_total",
-    component = "nico-bmc-proxy",
+    metric_family = BmcProxyAuthorizationDenied,
     log = info,
-    metric = counter,
-    message = "Request denied by BMC proxy ACLs",
-    describe = "Number of BMC proxy requests denied by authorization layer and HTTP method"
+    message = "Request denied by BMC proxy ACLs"
 )]
 pub(crate) struct RequestAclDenied {
     #[label]
     authorization_layer: AuthorizationLayer,
-    #[label(name = "method")]
+    #[label]
     method_label: MethodLabel,
     #[context]
     principals: String,
@@ -143,17 +154,14 @@ impl RequestAclDenied {
 #[derive(Event)]
 #[event(
     event_name = "bmc_proxy_principal_allow_list_denied",
-    metric_name = "carbide_bmc_proxy_authorization_denied_total",
-    component = "nico-bmc-proxy",
+    metric_family = BmcProxyAuthorizationDenied,
     log = info,
-    metric = counter,
-    message = "Request denied by BMC proxy principal allow-list",
-    describe = "Number of BMC proxy requests denied by authorization layer and HTTP method"
+    message = "Request denied by BMC proxy principal allow-list"
 )]
 pub(crate) struct PrincipalAllowListDenied {
     #[label]
     authorization_layer: AuthorizationLayer,
-    #[label(name = "method")]
+    #[label]
     method_label: MethodLabel,
     #[context]
     allowed_principals: String,

--- a/crates/credential-rotation/src/lib.rs
+++ b/crates/credential-rotation/src/lib.rs
@@ -81,7 +81,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, Credentials,
@@ -108,15 +108,24 @@ enum BmcCredentialRotationResult {
     Quarantined,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_bmc_credential_rotation_results_total",
+    kind = counter,
+    component = "credential-rotation",
+    describe = "Number of persisted BMC credential rotation results, by result"
+)]
+struct BmcCredentialRotationResults {
+    result: BmcCredentialRotationResult,
+}
+
 #[derive(Event)]
 #[event(
     event_name = "bmc_credential_rotation_converged",
-    metric_name = "carbide_bmc_credential_rotation_results_total",
-    component = "credential-rotation",
+    metric_family = BmcCredentialRotationResults,
     log = info,
-    metric = counter,
-    message = "BMC credential rotated and converged",
-    describe = "Number of persisted BMC credential rotation results, by result"
+    message = "BMC credential rotated and converged"
 )]
 struct BmcCredentialRotationConverged {
     #[label]
@@ -140,12 +149,9 @@ impl BmcCredentialRotationConverged {
 #[derive(Event)]
 #[event(
     event_name = "bmc_credential_rotation_recovered",
-    metric_name = "carbide_bmc_credential_rotation_results_total",
-    component = "credential-rotation",
+    metric_family = BmcCredentialRotationResults,
     log = warn,
-    metric = counter,
-    message = "BMC already at rotate-to credential; recovered from an interrupted prior rotation",
-    describe = "Number of persisted BMC credential rotation results, by result"
+    message = "BMC already at rotate-to credential; recovered from an interrupted prior rotation"
 )]
 struct BmcCredentialRotationRecovered {
     #[label]
@@ -172,12 +178,9 @@ impl BmcCredentialRotationRecovered {
 #[derive(Event)]
 #[event(
     event_name = "bmc_credential_rotation_quarantined",
-    metric_name = "carbide_bmc_credential_rotation_results_total",
-    component = "credential-rotation",
+    metric_family = BmcCredentialRotationResults,
     log = warn,
-    metric = counter,
-    message = "BMC credential rotation attempt failed; quarantining",
-    describe = "Number of persisted BMC credential rotation results, by result"
+    message = "BMC credential rotation attempt failed; quarantining"
 )]
 struct BmcCredentialRotationQuarantined {
     #[label]

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -23,7 +23,7 @@
 //! Timestamp-file failures share a counter by operation while their paths,
 //! host interface, and errors remain log-only diagnostics.
 
-use carbide_instrument::{DynamicMessage, Event, LabelValue};
+use carbide_instrument::{DynamicMessage, Event, LabelValue, MetricFamily};
 use dhcproto::v4::MessageType;
 
 use crate::errors::DhcpError;
@@ -145,15 +145,25 @@ pub(crate) enum SocketSetupNextAction {
     Panic,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_dhcp_socket_setup_failures_total",
+    kind = counter,
+    component = "nico-dhcp",
+    describe = "Number of DHCP socket setup failures, by operation and next action."
+)]
+pub(crate) struct DhcpSocketSetupFailures {
+    operation: SocketSetupOperation,
+    next_action: SocketSetupNextAction,
+}
+
 #[derive(Event)]
 #[event(
     event_name = "dhcp_server_socket_setup_failed",
-    metric_name = "carbide_dhcp_socket_setup_failures_total",
-    component = "nico-dhcp",
+    metric_family = DhcpSocketSetupFailures,
     log = info,
-    metric = counter,
-    message = dynamic,
-    describe = "Number of DHCP socket setup failures, by operation and next action."
+    message = dynamic
 )]
 pub(crate) struct DhcpSocketSetupFailed {
     #[label]
@@ -198,12 +208,9 @@ impl DynamicMessage for DhcpSocketSetupFailed {
 #[derive(Event)]
 #[event(
     event_name = "dhcp_server_interface_bind_failed",
-    metric_name = "carbide_dhcp_socket_setup_failures_total",
-    component = "nico-dhcp",
+    metric_family = DhcpSocketSetupFailures,
     log = info,
-    metric = counter,
-    message = "Interface not ready, retrying",
-    describe = "Number of DHCP socket setup failures, by operation and next action."
+    message = "Interface not ready, retrying"
 )]
 pub(crate) struct DhcpInterfaceBindFailed {
     #[label]

--- a/crates/dpa/src/metrics.rs
+++ b/crates/dpa/src/metrics.rs
@@ -17,7 +17,17 @@
 
 use std::time::Duration;
 
-use carbide_instrument::Event;
+use carbide_instrument::{Event, MetricFamily};
+
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_dpa_monitor_operations_latency_milliseconds",
+    kind = histogram,
+    component = "dpa-monitor",
+    describe = "Time consumed for one operation"
+)]
+pub(crate) struct DpaMonitorOperationsLatency {}
 
 // The accepted and failed paths keep separate records because they carry
 // different context. Both feed the same label-free histogram, so a command
@@ -28,12 +38,9 @@ use carbide_instrument::Event;
 #[derive(Event)]
 #[event(
     event_name = "dpa_command_sent",
-    metric_name = "carbide_dpa_monitor_operations_latency_milliseconds",
-    component = "dpa-monitor",
+    metric_family = DpaMonitorOperationsLatency,
     log = info,
-    metric = histogram,
-    message = "sent DPA command",
-    describe = "Time consumed for one operation"
+    message = "sent DPA command"
 )]
 pub(crate) struct DpaCommandSent {
     #[observation]
@@ -50,12 +57,9 @@ pub(crate) struct DpaCommandSent {
 #[derive(Event)]
 #[event(
     event_name = "dpa_command_send_failed",
-    metric_name = "carbide_dpa_monitor_operations_latency_milliseconds",
-    component = "dpa-monitor",
+    metric_family = DpaMonitorOperationsLatency,
     log = error,
-    metric = histogram,
-    message = "failed to send DPA command",
-    describe = "Time consumed for one operation"
+    message = "failed to send DPA command"
 )]
 pub(crate) struct DpaCommandSendFailed {
     #[observation]

--- a/crates/dpu-remediation/src/metrics.rs
+++ b/crates/dpu-remediation/src/metrics.rs
@@ -21,7 +21,7 @@
 //! pass. Machine and remediation identifiers remain log context so they do not
 //! create unbounded metric series.
 
-use carbide_instrument::{Event, LabelValue};
+use carbide_instrument::{Event, LabelValue, MetricFamily};
 use carbide_uuid::dpu_remediations::RemediationId;
 use carbide_uuid::machine::MachineId;
 
@@ -36,15 +36,24 @@ enum RemediationExecutorFailureStage {
     ClientCreation,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_dpu_remediation_executor_failures_total",
+    kind = counter,
+    component = "forge-dpu-agent",
+    describe = "Number of DPU remediation executor failures, by failure stage."
+)]
+pub(crate) struct DpuRemediationExecutorFailures {
+    failure_stage: RemediationExecutorFailureStage,
+}
+
 #[derive(Event)]
 #[event(
     event_name = "dpu_remediation_status_output_decode_failed",
-    metric_name = "carbide_dpu_remediation_executor_failures_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuRemediationExecutorFailures,
     log = error,
-    metric = counter,
-    message = "Unable to deserialize json into hashmap from status output file",
-    describe = "Number of DPU remediation executor failures, by failure stage."
+    message = "Unable to deserialize json into hashmap from status output file"
 )]
 pub(crate) struct RemediationStatusOutputDecodeFailed {
     #[label]
@@ -75,12 +84,9 @@ impl RemediationStatusOutputDecodeFailed {
 #[derive(Event)]
 #[event(
     event_name = "dpu_remediation_apply_failed",
-    metric_name = "carbide_dpu_remediation_executor_failures_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuRemediationExecutorFailures,
     log = error,
-    metric = counter,
-    message = "Remediation failed",
-    describe = "Number of DPU remediation executor failures, by failure stage."
+    message = "Remediation failed"
 )]
 pub(crate) struct RemediationApplyFailed {
     #[label]
@@ -111,12 +117,9 @@ impl RemediationApplyFailed {
 #[derive(Event)]
 #[event(
     event_name = "dpu_remediation_response_invalid",
-    metric_name = "carbide_dpu_remediation_executor_failures_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuRemediationExecutorFailures,
     log = error,
-    metric = counter,
-    message = "received a response with one of id or script but not both, skipping, will retry next loop",
-    describe = "Number of DPU remediation executor failures, by failure stage."
+    message = "received a response with one of id or script but not both, skipping, will retry next loop"
 )]
 pub(crate) struct RemediationResponseInvalid {
     #[label]
@@ -147,12 +150,9 @@ impl RemediationResponseInvalid {
 #[derive(Event)]
 #[event(
     event_name = "dpu_remediation_fetch_failed",
-    metric_name = "carbide_dpu_remediation_executor_failures_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuRemediationExecutorFailures,
     log = error,
-    metric = counter,
-    message = "Remediation executor unable to fetch next remediation this loop, will retry next loop",
-    describe = "Number of DPU remediation executor failures, by failure stage."
+    message = "Remediation executor unable to fetch next remediation this loop, will retry next loop"
 )]
 pub(crate) struct RemediationFetchFailed {
     #[label]
@@ -176,12 +176,9 @@ impl RemediationFetchFailed {
 #[derive(Event)]
 #[event(
     event_name = "dpu_remediation_client_creation_failed",
-    metric_name = "carbide_dpu_remediation_executor_failures_total",
-    component = "forge-dpu-agent",
+    metric_family = DpuRemediationExecutorFailures,
     log = error,
-    metric = counter,
-    message = "Remediation executor unable to create forge client this loop, will retry next loop",
-    describe = "Number of DPU remediation executor failures, by failure stage."
+    message = "Remediation executor unable to create forge client this loop, will retry next loop"
 )]
 pub(crate) struct RemediationClientCreationFailed {
     #[label]

--- a/crates/firmware/src/downloader.rs
+++ b/crates/firmware/src/downloader.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt, emit};
+use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt, MetricFamily, emit};
 use eyre::{Report, WrapErr, eyre};
 use futures_util::StreamExt;
 use reqwest_middleware::ClientWithMiddleware as Client;
@@ -37,19 +37,27 @@ pub(crate) enum ArtifactUnavailableReason {
     StaleCacheRemovalFailed,
 }
 
-// Both failures increment the same counter, but their existing log fields
-// differ. Separate Event types keep each record intact instead of adding empty
-// context. Their descriptions must stay identical so OpenTelemetry treats them
-// as one instrument.
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_firmware_artifact_unavailable_total",
+    kind = counter,
+    component = "carbide-firmware",
+    describe = "Number of firmware artifacts unavailable before download, by reason."
+)]
+pub(crate) struct FirmwareArtifactUnavailable {
+    reason: ArtifactUnavailableReason,
+}
+
+// Both failures record the same counter, but their existing log fields differ.
+// Separate Event types keep each record intact instead of adding empty context;
+// the family above holds the one description they share.
 #[derive(Event)]
 #[event(
     event_name = "firmware_artifact_missing_url",
-    metric_name = "carbide_firmware_artifact_unavailable_total",
-    component = "carbide-firmware",
+    metric_family = FirmwareArtifactUnavailable,
     log = error,
-    metric = counter,
-    message = "Firmware artifact is missing and has no URL",
-    describe = "Number of firmware artifacts unavailable before download, by reason."
+    message = "Firmware artifact is missing and has no URL"
 )]
 pub(crate) struct FirmwareArtifactMissingUrl {
     #[label]
@@ -61,12 +69,9 @@ pub(crate) struct FirmwareArtifactMissingUrl {
 #[derive(Event)]
 #[event(
     event_name = "firmware_stale_cached_artifact_removal_failed",
-    metric_name = "carbide_firmware_artifact_unavailable_total",
-    component = "carbide-firmware",
+    metric_family = FirmwareArtifactUnavailable,
     log = error,
-    metric = counter,
-    message = "Failed to remove stale cached firmware artifact",
-    describe = "Number of firmware artifacts unavailable before download, by reason."
+    message = "Failed to remove stale cached firmware artifact"
 )]
 pub(crate) struct FirmwareStaleCachedArtifactRemovalFailed {
     #[label]

--- a/crates/fmds/src/phone_home.rs
+++ b/crates/fmds/src/phone_home.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use eyre::eyre;
 use forge_dpu_agent_utils::utils::create_forge_client;
 use rpc::forge::InstancePhoneHomeLastContactRequest;
@@ -37,6 +37,18 @@ enum PhoneHomeOutcome {
     Error,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_fmds_phone_home_total",
+    kind = counter,
+    component = "fmds",
+    describe = "Number of FMDS tenant phone-home operations, by outcome"
+)]
+struct FmdsPhoneHome {
+    outcome: PhoneHomeOutcome,
+}
+
 /// `PhoneHomeSucceeded` writes the existing success record with the configured
 /// machine ID and the timestamp returned by Forge. `PhoneHomeCompleted` below
 /// retains the existing Event identity for failures, and both increment the
@@ -44,12 +56,9 @@ enum PhoneHomeOutcome {
 #[derive(Event)]
 #[event(
     event_name = "fmds_phone_home_succeeded",
-    metric_name = "carbide_fmds_phone_home_total",
-    component = "fmds",
+    metric_family = FmdsPhoneHome,
     log = info,
-    metric = counter,
-    message = "Successfully phoned home",
-    describe = "Number of FMDS tenant phone-home operations, by outcome"
+    message = "Successfully phoned home"
 )]
 struct PhoneHomeSucceeded {
     #[label]
@@ -66,12 +75,9 @@ struct PhoneHomeSucceeded {
 #[derive(Event)]
 #[event(
     event_name = "fmds_phone_home_completed",
-    metric_name = "carbide_fmds_phone_home_total",
-    component = "fmds",
+    metric_family = FmdsPhoneHome,
     log = warn,
-    metric = counter,
-    message = "Phone home failed",
-    describe = "Number of FMDS tenant phone-home operations, by outcome"
+    message = "Phone home failed"
 )]
 struct PhoneHomeCompleted {
     #[label]

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -20,7 +20,9 @@ use std::net::IpAddr;
 use std::time::Duration;
 
 use ::carbide_utils::metrics::SharedMetricsHolder;
-use carbide_instrument::{DynamicLog, DynamicMessage, Event, LabelValue, LogAt, Outcome, emit};
+use carbide_instrument::{
+    DynamicLog, DynamicMessage, Event, LabelValue, LogAt, MetricFamily, Outcome, emit,
+};
 use libredfish::model::task::TaskState;
 use libredfish::{RedfishError, SystemPowerControl};
 use model::firmware::FirmwareComponentType;
@@ -458,6 +460,20 @@ pub(crate) enum PowerControlLog {
     },
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_preingestion_power_control_total",
+    kind = counter,
+    component = "preingestion-manager",
+    describe = "Number of preingestion Redfish power operations (host power control, BMC and \
+    chassis resets), by operation and outcome."
+)]
+pub(crate) struct PreingestionPowerControl {
+    operation: PowerOperation,
+    outcome: Outcome,
+}
+
 /// A preingestion Redfish power operation completed. Every call updates the
 /// existing counter; failures also retain the caller's terminal record. A
 /// successful operation stays silent, while an already-satisfied recovery
@@ -465,13 +481,9 @@ pub(crate) enum PowerControlLog {
 #[derive(Event)]
 #[event(
     event_name = "preingestion_power_control_finished",
-    metric_name = "carbide_preingestion_power_control_total",
-    component = "preingestion-manager",
+    metric_family = PreingestionPowerControl,
     log = dynamic,
-    metric = counter,
-    message = dynamic,
-    describe = "Number of preingestion Redfish power operations (host power control, BMC and \
-                chassis resets), by operation and outcome."
+    message = dynamic
 )]
 pub(crate) struct PowerControlFinished {
     #[label]
@@ -534,13 +546,9 @@ impl DynamicMessage for PowerControlFinished {
 #[derive(Event)]
 #[event(
     event_name = "preingestion_initial_bmc_reset_finished",
-    metric_name = "carbide_preingestion_power_control_total",
-    component = "preingestion-manager",
+    metric_family = PreingestionPowerControl,
     log = dynamic,
-    metric = counter,
-    message = dynamic,
-    describe = "Number of preingestion Redfish power operations (host power control, BMC and \
-                chassis resets), by operation and outcome."
+    message = dynamic
 )]
 struct InitialBmcResetFinished {
     #[label]
@@ -583,13 +591,9 @@ impl DynamicMessage for InitialBmcResetFinished {
 #[derive(Event)]
 #[event(
     event_name = "preingestion_bfb_platform_power_control_finished",
-    metric_name = "carbide_preingestion_power_control_total",
-    component = "preingestion-manager",
+    metric_family = PreingestionPowerControl,
     log = dynamic,
-    metric = counter,
-    message = dynamic,
-    describe = "Number of preingestion Redfish power operations (host power control, BMC and \
-                chassis resets), by operation and outcome."
+    message = dynamic
 )]
 struct BfbPlatformPowerControlFinished {
     #[label]

--- a/crates/pxe/src/metrics.rs
+++ b/crates/pxe/src/metrics.rs
@@ -16,7 +16,7 @@
  */
 use std::time::Duration;
 
-use carbide_instrument::{Event, LabelValue};
+use carbide_instrument::{Event, LabelValue, MetricFamily};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use tokio::time::sleep;
 
@@ -97,6 +97,19 @@ pub(crate) enum OutcomeReason {
     UpstreamApiError,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_pxe_boot_outcomes_total",
+    kind = counter,
+    component = "carbide-pxe",
+    describe = "Number of PXE boot-path outcomes served, by endpoint and reason."
+)]
+pub(crate) struct PxeBootOutcomes {
+    endpoint: BootEndpoint,
+    reason: OutcomeReason,
+}
+
 /// `PxeBootOutcome` records a boot-path result without writing a log. The
 /// quiet success and extractor paths use this type; failures that already
 /// have an `ERROR` record use the sibling Events below so one `emit()` writes
@@ -104,11 +117,8 @@ pub(crate) enum OutcomeReason {
 #[derive(Event)]
 #[event(
     event_name = "pxe_boot_outcome",
-    metric_name = "carbide_pxe_boot_outcomes_total",
-    component = "carbide-pxe",
-    log = off,
-    metric = counter,
-    describe = "Number of PXE boot-path outcomes served, by endpoint and reason."
+    metric_family = PxeBootOutcomes,
+    log = off
 )]
 pub(crate) struct PxeBootOutcome {
     #[label]
@@ -126,12 +136,9 @@ pub(crate) struct PxeBootOutcome {
 #[derive(Event)]
 #[event(
     event_name = "pxe_cloud_init_request_failed",
-    metric_name = "carbide_pxe_boot_outcomes_total",
-    component = "carbide-pxe",
+    metric_family = PxeBootOutcomes,
     log = error,
-    metric = counter,
-    message = "cloud-init request could not be served",
-    describe = "Number of PXE boot-path outcomes served, by endpoint and reason."
+    message = "cloud-init request could not be served"
 )]
 pub(crate) struct PxeCloudInitRequestFailed {
     #[label]
@@ -147,12 +154,9 @@ pub(crate) struct PxeCloudInitRequestFailed {
 #[derive(Event)]
 #[event(
     event_name = "pxe_custom_ipxe_fetch_failed",
-    metric_name = "carbide_pxe_boot_outcomes_total",
-    component = "carbide-pxe",
+    metric_family = PxeBootOutcomes,
     log = error,
-    metric = counter,
-    message = "failed to fetch custom ipxe script",
-    describe = "Number of PXE boot-path outcomes served, by endpoint and reason."
+    message = "failed to fetch custom ipxe script"
 )]
 pub(crate) struct PxeCustomIpxeFetchFailed {
     #[label]

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use eyre::{ContextCompat, WrapErr, eyre};
 use opentelemetry::StringValue;
 use opentelemetry::metrics::{Gauge, Meter};
@@ -174,6 +174,7 @@ enum VaultRequestType {
 /// label value; the hand-written `LabelValue` impl is the reviewed escape hatch
 /// for a bounded-but-not-enum value, and reproduces the previous
 /// `code.to_string()`-or-empty rendering byte for byte.
+#[derive(Clone, Copy)]
 struct VaultFailureStatusCode(Option<u16>);
 
 impl LabelValue for VaultFailureStatusCode {
@@ -213,17 +214,27 @@ struct VaultRequestSucceeded {
     request_type: VaultRequestType,
 }
 
+/// The one metric the Events below record.
+#[derive(MetricFamily)]
+#[metric(
+    name = "carbide_api_vault_requests_failed_total",
+    kind = counter,
+    component = "nico-api",
+    describe = "Number of failed Vault requests"
+)]
+struct ApiVaultRequestsFailed {
+    request_type: VaultRequestType,
+    http_response_status_code: VaultFailureStatusCode,
+}
+
 /// Counts a failed request when this layer does not own a diagnostic record.
 /// Callers either handle the response as an expected absence or propagate the
 /// error to the layer that owns its log.
 #[derive(Event)]
 #[event(
     event_name = "vault_request_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
-    log = off,
-    metric = counter,
-    describe = "Number of failed Vault requests"
+    metric_family = ApiVaultRequestsFailed,
+    log = off
 )]
 struct VaultRequestFailed {
     #[label]
@@ -243,12 +254,9 @@ struct VaultRequestFailed {
 #[derive(Event)]
 #[event(
     event_name = "vault_credentials_not_found",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = debug,
-    metric = counter,
-    message = "Credentials not found",
-    describe = "Number of failed Vault requests"
+    message = "Credentials not found"
 )]
 struct VaultCredentialsNotFound {
     #[label]
@@ -264,12 +272,9 @@ struct VaultCredentialsNotFound {
 #[derive(Event)]
 #[event(
     event_name = "vault_credentials_get_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = error,
-    metric = counter,
-    message = "Error getting credentials",
-    describe = "Number of failed Vault requests"
+    message = "Error getting credentials"
 )]
 struct VaultCredentialsGetFailed {
     #[label]
@@ -285,12 +290,9 @@ struct VaultCredentialsGetFailed {
 #[derive(Event)]
 #[event(
     event_name = "vault_credentials_set_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = error,
-    metric = counter,
-    message = "Error setting credentials",
-    describe = "Number of failed Vault requests"
+    message = "Error setting credentials"
 )]
 struct VaultCredentialsSetFailed {
     #[label]
@@ -304,12 +306,9 @@ struct VaultCredentialsSetFailed {
 #[derive(Event)]
 #[event(
     event_name = "vault_credentials_delete_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = error,
-    metric = counter,
-    message = "Error deleting credentials",
-    describe = "Number of failed Vault requests"
+    message = "Error deleting credentials"
 )]
 struct VaultCredentialsDeleteFailed {
     #[label]
@@ -324,12 +323,9 @@ struct VaultCredentialsDeleteFailed {
 #[derive(Event)]
 #[event(
     event_name = "vault_token_validation_retrying",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = error,
-    metric = counter,
-    message = "Vault token renewal check: error reading kv mount location config, waiting for token to be good",
-    describe = "Number of failed Vault requests"
+    message = "Vault token renewal check: error reading kv mount location config, waiting for token to be good"
 )]
 struct VaultTokenValidationRetrying {
     #[label]
@@ -342,12 +338,9 @@ struct VaultTokenValidationRetrying {
 #[derive(Event)]
 #[event(
     event_name = "vault_token_validation_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = error,
-    metric = counter,
-    message = "Vault token renewal check: error reading kv mount location config, giving up after max attempts",
-    describe = "Number of failed Vault requests"
+    message = "Vault token renewal check: error reading kv mount location config, giving up after max attempts"
 )]
 struct VaultTokenValidationFailed {
     #[label]
@@ -360,12 +353,9 @@ struct VaultTokenValidationFailed {
 #[derive(Event)]
 #[event(
     event_name = "vault_secret_path_list_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = warn,
-    metric = counter,
-    message = "failed to list vault path",
-    describe = "Number of failed Vault requests"
+    message = "failed to list vault path"
 )]
 struct VaultSecretPathListFailed {
     #[label]
@@ -382,12 +372,9 @@ struct VaultSecretPathListFailed {
 #[derive(Event)]
 #[event(
     event_name = "vault_secret_not_found",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = debug,
-    metric = counter,
-    message = "vault secret not found",
-    describe = "Number of failed Vault requests"
+    message = "vault secret not found"
 )]
 struct VaultSecretNotFound {
     #[label]
@@ -402,12 +389,9 @@ struct VaultSecretNotFound {
 #[derive(Event)]
 #[event(
     event_name = "vault_secret_read_failed",
-    metric_name = "carbide_api_vault_requests_failed_total",
-    component = "nico-api",
+    metric_family = ApiVaultRequestsFailed,
     log = warn,
-    metric = counter,
-    message = "failed to read vault secret",
-    describe = "Number of failed Vault requests"
+    message = "failed to read vault secret"
 )]
 struct VaultSecretReadFailed {
     #[label]


### PR DESCRIPTION
`MetricFamily` landed in #4257 (with `scout` as the PoC). The rest were still maintained by hand: each metric declared by two or more Events, every one of them restating the same `metric_name`, `component`, `metric = counter`, and the same `describe` sentence, and every one registering the same instrument again with its own copy of the description.

This converts them. Each metric gets one `#[derive(MetricFamily)]` declaration and its Events point at it with `metric_family = ...`, exactly the move #4257 made for `carbide_scout_mlx_failures_total`.

**Nothing observable moves.** The Events keep their own `#[label]` fields, so every generated log line stays byte-identical, and the metric name, label set, and description are the values that were already there. If it compiles, the label sets match -- that is the whole verification story, and it is why this diff is meant to be skimmed rather than read line by line.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4304

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Companion work in the same epic: #4305 collapses twelve prefix-grouped Event sets into one Event with a label each, which is a disjoint set of metrics and touches only two files in common with this PR.


Closes #4304
