### PR TITLE
patch(v2.0): Fix DPU firmware alert never clearing (backport #4236)

### DIFF
--- a/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
@@ -150,11 +150,19 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
             dpu_machine_update::get_updated_machines(txn, self.config.host_health).await?;
         tracing::debug!("found {} updated machines", updated_machines.len());
         for updated_machine in updated_machines {
-            if self
-                .config
-                .dpu_config
-                .dpu_nic_firmware_update_versions
-                .contains(&updated_machine.firmware_version)
+            // DPF picks update targets by the DPUDeployment's expected BFB, not
+            // by `dpu_nic_firmware_update_versions` — `find_outdated_dpus` skips
+            // DPF hosts outright. Holding a DPF host's reported NIC firmware
+            // against that list therefore never matches, which used to leave the
+            // HostUpdateInProgress marker (and its prevent_allocations alert)
+            // pinned forever after a successful reprovision. The reprovision
+            // completing is the completion signal for DPF hosts.
+            if updated_machine.dpf_managed
+                || self
+                    .config
+                    .dpu_config
+                    .dpu_nic_firmware_update_versions
+                    .contains(&updated_machine.firmware_version)
             {
                 if let Err(e) =
                     MachineUpdateManager::remove_machine_update_markers(txn, &updated_machine).await

--- a/crates/api-core/src/tests/dpu_machine_update.rs
+++ b/crates/api-core/src/tests/dpu_machine_update.rs
@@ -324,6 +324,7 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
             host_machine_id: mh.host().id,
             dpu_machine_id: mh.dpu_n(0).id,
             firmware_version: "test_version".to_string(),
+            dpf_managed: false,
         }],
     )
     .await
@@ -382,11 +383,13 @@ async fn test_find_available_outdated_dpus_multidpu_both_under_reprov(
                 host_machine_id: mh.host().id,
                 dpu_machine_id: all_dpus[1].id,
                 firmware_version: "test_version".to_string(),
+                dpf_managed: false,
             },
             DpuMachineUpdate {
                 host_machine_id: mh.host().id,
                 dpu_machine_id: all_dpus[0].id,
                 firmware_version: "test_version".to_string(),
+                dpf_managed: false,
             },
         ],
     )

--- a/crates/api-core/src/tests/dpu_nic_firmware.rs
+++ b/crates/api-core/src/tests/dpu_nic_firmware.rs
@@ -325,6 +325,73 @@ async fn test_clear_completed_updates(
     Ok(())
 }
 
+/// DPF picks update targets by the DPUDeployment's expected BFB, so a
+/// DPF-managed DPU's reported NIC firmware has no reason to appear in
+/// `dpu_nic_firmware_update_versions`. The completion path must not hold it
+/// against that list, or the HostUpdateInProgress alert stays pinned after the
+/// reprovision finishes and the host never becomes allocatable again.
+#[crate::sqlx_test]
+async fn test_clear_completed_updates_dpf_host_off_list_version(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+
+    // Mark the host as DPF-ingested and pretend a DPF-driven reprovision just
+    // finished: the DPU is back with a firmware version outside the configured
+    // set, its reprovisioning flag is cleared, and the in-update marker is still
+    // on the host.
+    let mut txn = env.pool.begin().await?;
+    db::machine::mark_machine_ingestion_done_with_dpf(&mut txn, &mh.id).await?;
+    update_nic_firmware_version(&mut txn, &mh.dpu().id, "0.0.0-from-bfb").await?;
+    let query = r#"UPDATE machines set reprovisioning_requested = NULL where id = $1"#;
+    sqlx::query(query)
+        .bind(mh.dpu().id.to_string())
+        .execute(&mut *txn)
+        .await?;
+    db::machine::insert_health_report(
+        &mut txn,
+        &mh.id,
+        health_report::HealthReportApplyMode::Merge,
+        &create_host_update_health_report_dpufw(),
+        false,
+    )
+    .await?;
+    txn.commit().await?;
+
+    assert!(
+        !env.config
+            .dpu_config
+            .dpu_nic_firmware_update_versions
+            .contains(&"0.0.0-from-bfb".to_string()),
+        "the version the BFB landed must be off the NIC firmware allowlist",
+    );
+
+    let dpu_nic_firmware_update = DpuNicFirmwareUpdate {
+        metrics: None,
+        config: env.config.clone(),
+        dpf: None,
+    };
+
+    let mut txn = env.pool.begin().await?;
+    dpu_nic_firmware_update
+        .clear_completed_updates(&mut txn)
+        .await?;
+
+    let managed_host = mh.snapshot(&mut txn).await;
+    assert!(
+        !managed_host
+            .host_snapshot
+            .health_reports
+            .merges
+            .contains_key(HOST_UPDATE_HEALTH_REPORT_SOURCE),
+        "DPF host must have its update marker removed once the reprovision completes",
+    );
+    assert!(managed_host.aggregate_health.alerts.is_empty());
+
+    Ok(())
+}
+
 impl TestManagedHost {
     pub async fn update_nic_firmware_version(
         &self,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -6045,6 +6045,7 @@ async fn test_instance_creation_when_reprovision_is_triggered_parallel(
         host_machine_id: mh.host().id,
         dpu_machine_id: mh.dpu_ids[0],
         firmware_version: "test".to_string(),
+        dpf_managed: false,
     };
 
     db::dpu_machine_update::trigger_reprovisioning_for_managed_host(&mut txn, &[machine_update])

--- a/crates/api-core/src/tests/machine_update_manager.rs
+++ b/crates/api-core/src/tests/machine_update_manager.rs
@@ -165,6 +165,7 @@ async fn test_remove_machine_update_markers(
         host_machine_id,
         dpu_machine_id,
         firmware_version: "1".to_owned(),
+        dpf_managed: false,
     };
 
     let reference = &DpuReprovisionInitiator::Automatic(AutomaticFirmwareUpdateReference {
@@ -279,6 +280,7 @@ async fn test_get_updating_machines(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         host_machine_id: host_machine_id1,
         dpu_machine_id: dpu_machine_id1,
         firmware_version: "1".to_owned(),
+        dpf_managed: false,
     };
 
     let reference = &DpuReprovisionInitiator::Automatic(AutomaticFirmwareUpdateReference {

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -155,6 +155,8 @@ pub async fn get_updated_machines(
                 return None;
             }
 
+            let dpf_managed = managed_host.host_snapshot.dpf.used_for_ingestion;
+
             // We only signal an update as complete once ALL DPUs are done
             // That prevents removing the updating flags from the Host
             // if just one DPU completes the update
@@ -170,6 +172,7 @@ pub async fn get_updated_machines(
                         .and_then(|info| info.dpu_info.as_ref())
                         .map(|dpu_info| dpu_info.firmware_version.clone())
                         .unwrap_or_default(),
+                    dpf_managed,
                 })
                 .collect();
 

--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -27,6 +27,14 @@ pub struct DpuMachineUpdate {
     pub host_machine_id: MachineId,
     pub dpu_machine_id: MachineId,
     pub firmware_version: String,
+    /// Whether the owning host is ingested through DPF. DPF decides staleness
+    /// from the DPUDeployment's expected BFB, not from
+    /// `dpu_nic_firmware_update_versions`, so `firmware_version` on a
+    /// DPF-managed update is traceability only and must not be compared
+    /// against that config list. Defaults to `false` when the value is loaded
+    /// straight from a query that does not select it.
+    #[sqlx(default)]
+    pub dpf_managed: bool,
 }
 
 /// A DPU identified via DPF whose installed BFB no longer matches the
@@ -139,6 +147,7 @@ impl DpuMachineUpdate {
                             host_machine_id: *machine_id,
                             dpu_machine_id: dpu.id,
                             firmware_version,
+                            dpf_managed: false,
                         })
                     })
                     .collect();
@@ -181,6 +190,7 @@ impl DpuMachineUpdate {
                 host_machine_id: host_id,
                 dpu_machine_id: outdated.dpu_machine_id,
                 firmware_version: outdated.target_bfb.clone(),
+                dpf_managed: true,
             });
         }
 


### PR DESCRIPTION
Backport of #4236 to `release/v2.0` (upstream commit 7ba222e).

DPF-ingested hosts pick their DPU firmware update targets from the DPUDeployment's expected BFB: `find_outdated_dpus` skips DPF hosts outright, and `find_outdated_dpus_dpf` selects them by BFB hash instead. The completion path, however, only removed the update markers when the DPU's reported NIC firmware appeared in `dpu_nic_firmware_update_versions` — a config list that only ever holds NIC firmware strings. For a DPF host that comparison has no reason to match, so a successful reprovision left the `HostUpdateInProgress` alert pinned on the host forever.

That is not a cosmetic problem. The alert carries `prevent_allocations`, so the host stayed unallocatable indefinitely, and its lingering alert also made `is_available_for_updates` return false, excluding the host from every later firmware update. Each manager pass additionally emitted a bogus `WrongVersionAfterUpdate` outcome.

The fix carries the host's DPF-ingestion flag through `DpuMachineUpdate` so the completion path can skip the NIC-version comparison for DPF hosts. The rest of the completion gate is unchanged: the host must still hold the update marker, be Ready, and have every DPU's reprovisioning flag cleared. A DPF-driven reprovision finishing is itself the completion signal.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated

Adds `test_clear_completed_updates_dpf_host_off_list_version`, which marks a host DPF-ingested, lands its DPU on a firmware version deliberately outside the configured allowlist, and asserts the update marker and its alert are both cleared. The test was confirmed non-vacuous: neutralizing the `dpf_managed` branch makes it fail with the exact production symptom (`Incorrect firmware version after attempted update`, marker still pinned).

Full runs against a local Postgres, all green: `tests::dpu_nic_firmware` (6), `tests::dpu_machine_update` and `tests::machine_update_manager` (13), `tests::instance::test_instance_creation_when_reprovision_is_triggered_parallel`, and the complete `carbide-api-db` and `carbide-api-model` suites (575).

## Additional Notes

Two adaptations were needed relative to the upstream commit; the production logic change itself is identical.

1. `crates/api-db/src/dpu_machine_update.rs` — upstream reads the flag as `host_snapshot.config.dpf.used_for_ingestion`. On v2.0 `Machine` has no `config` field, so this is `host_snapshot.dpf.used_for_ingestion`, matching the existing usage in `crates/api-model/src/dpu_machine_update.rs`.

2. `crates/api-core/src/tests/dpu_nic_firmware.rs` — the new test drops two things absent from v2.0: the `reported_wrong_versions` field on `DpuNicFirmwareUpdate`, and a `MetricsCapture`-based assertion that no `wrong_version_after_update` failure is counted. v2.0 has no wrong-version metric on this path at all. The health-report and alert assertions, which are the actual regression coverage, are unchanged.