### PR TITLE
feat(agent): check IPv6-unicast BGP health

### DIFF
--- a/crates/agent/src/hbn_bgp_ipv6_unicast_summary_no_failed_peers.json
+++ b/crates/agent/src/hbn_bgp_ipv6_unicast_summary_no_failed_peers.json
@@ -1,0 +1,5 @@
+{
+  "failedPeersCount": 0,
+  "dynamicPeers": 0,
+  "totalPeers": 2
+}

--- a/crates/agent/src/health.rs
+++ b/crates/agent/src/health.rs
@@ -121,6 +121,8 @@ pub struct HealthCheckParams<'a> {
     pub has_changed_configs: bool,
     pub min_healthy_links: u32,
     pub route_servers: &'a [String],
+    /// Whether this check should require the FNN IPv6-unicast underlay.
+    pub should_check_ipv6_unicast: bool,
     pub hbn_device_names: HBNDeviceNames,
     pub include_dhcp_server: bool,
     pub run_restricted_mode_check: bool,
@@ -167,10 +169,13 @@ pub async fn health_check(params: HealthCheckParams<'_>) -> health_report::Healt
     bgp::check_bgp_stats(
         &mut hr,
         &container_id,
-        params.host_routes,
-        params.min_healthy_links,
-        params.route_servers,
-        params.hbn_device_names,
+        bgp::BgpHealthCheckParams {
+            host_routes: params.host_routes,
+            min_healthy_links: params.min_healthy_links,
+            route_servers: params.route_servers,
+            should_check_ipv6_unicast: params.should_check_ipv6_unicast,
+            hbn_device_names: &params.hbn_device_names,
+        },
     )
     .await;
     check_files(&mut hr, params.hbn_root, &EXPECTED_FILES);

--- a/crates/agent/src/health/bgp.rs
+++ b/crates/agent/src/health/bgp.rs
@@ -22,14 +22,21 @@ use serde::Deserialize;
 use super::{failed, make_alert, passed, probe_ids};
 use crate::{HBNDeviceNames, hbn};
 
+/// `BgpHealthCheckParams` contains the configured peers, uplinks, and address
+/// families that the BGP health check should require.
+pub(super) struct BgpHealthCheckParams<'a> {
+    pub(super) host_routes: &'a [&'a str],
+    pub(super) min_healthy_links: u32,
+    pub(super) route_servers: &'a [String],
+    pub(super) should_check_ipv6_unicast: bool,
+    pub(super) hbn_device_names: &'a HBNDeviceNames,
+}
+
 /// Check HBN BGP stats
-pub async fn check_bgp_stats(
+pub(super) async fn check_bgp_stats(
     hr: &mut health_report::HealthReport,
     container_id: &str,
-    host_routes: &[&str],
-    min_healthy_links: u32,
-    route_servers: &[String],
-    hbn_device_names: HBNDeviceNames,
+    params: BgpHealthCheckParams<'_>,
 ) {
     // If BGP daemon is not enabled, we will get a bunch of bogus alerts shown
     // that are not helpful to anyone. Since showing `BgpDaemonEnabled` already
@@ -45,26 +52,43 @@ pub async fn check_bgp_stats(
     let mut health_data = BgpHealthData::default();
 
     // `vtysh` is the Free Range Routing (FRR) shell.
-    match hbn::run_in_container(
+    let bgp_summary_parsed = match hbn::run_in_container(
         container_id,
         &["vtysh", "-c", "show bgp summary json"],
         true,
     )
     .await
     {
-        Ok(bgp_json) => verify_bgp_summary(
-            &mut health_data,
-            &bgp_json,
-            host_routes,
-            min_healthy_links,
-            route_servers,
-            hbn_device_names,
-        ),
+        Ok(bgp_json) => verify_bgp_summary(&mut health_data, &bgp_json, &params),
         Err(err) => {
             tracing::warn!(error = %err, "Failed to fetch BGP summary");
             health_data.other_errors.push(err.to_string());
+            false
         }
     };
+
+    if params.should_check_ipv6_unicast && bgp_summary_parsed {
+        match hbn::run_in_container(
+            container_id,
+            &["vtysh", "-c", "show bgp ipv6 unicast summary failed json"],
+            true,
+        )
+        .await
+        {
+            Ok(failed_peers_json) => verify_failed_ipv6_unicast_peers(
+                &mut health_data,
+                &failed_peers_json,
+                params.min_healthy_links,
+                params.hbn_device_names,
+            ),
+            Err(err) => {
+                tracing::warn!(error = %err, "Failed to fetch failed IPv6-unicast BGP peers");
+                health_data.other_errors.push(format!(
+                    "failed to fetch failed IPv6-unicast BGP peers: {err}"
+                ));
+            }
+        }
+    }
 
     health_data.into_health_report(hr);
 }
@@ -106,21 +130,22 @@ pub fn check_daemon_enabled(hr: &mut health_report::HealthReport, hbn_daemons_fi
     passed(hr, probe_ids::BgpDaemonEnabled.clone(), None);
 }
 
+/// `verify_bgp_summary` records health failures from a parsed FRR summary.
+///
+/// The return value only says whether deserialization succeeded. Individual
+/// BGP failures stay in `health_data` and still return `true`.
 fn verify_bgp_summary(
     health_data: &mut BgpHealthData,
     bgp_json: &str,
-    host_routes: &[&str],
-    min_healthy_links: u32,
-    route_servers: &[String],
-    hbn_device_names: HBNDeviceNames,
-) {
+    params: &BgpHealthCheckParams<'_>,
+) -> bool {
     let networks: BgpNetworks = match serde_json::from_str(bgp_json) {
         Ok(networks) => networks,
-        Err(e) => {
-            health_data.other_errors.push(format!(
-                "failed to deserialize bgp_json: {bgp_json} with error: {e}"
-            ));
-            return;
+        Err(error) => {
+            health_data
+                .other_errors
+                .push(format!("failed to deserialize BGP summary: {error}"));
+            return false;
         }
     };
 
@@ -128,25 +153,40 @@ fn verify_bgp_summary(
         "ipv4_unicast",
         &networks.ipv4_unicast,
         health_data,
-        host_routes,
-        min_healthy_links,
-        hbn_device_names.clone(),
+        params.host_routes,
+        params.min_healthy_links,
+        params.hbn_device_names,
     );
+    if params.should_check_ipv6_unicast {
+        match &networks.ipv6_unicast {
+            Some(ipv6_unicast) => check_bgp_stats_ipv6_unicast(
+                "ipv6_unicast",
+                ipv6_unicast,
+                health_data,
+                params.min_healthy_links,
+                params.hbn_device_names,
+            ),
+            None => health_data
+                .other_errors
+                .push("ipv6_unicast BGP summary was not reported".to_string()),
+        }
+    }
     check_bgp_stats_l2_vpn_evpn(
         "l2_vpn_evpn",
         &networks.l2_vpn_evpn,
         health_data,
-        route_servers,
-        min_healthy_links,
-        hbn_device_names,
+        params.route_servers,
+        params.min_healthy_links,
+        params.hbn_device_names,
     );
+    true
 }
 
 fn check_bgp_tor_routes(
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     min_healthy_links: u32,
-    hbn_device_names: HBNDeviceNames,
+    hbn_device_names: &HBNDeviceNames,
 ) {
     for port_id in 0..min_healthy_links {
         let mut message = None;
@@ -158,11 +198,14 @@ fn check_bgp_tor_routes(
         else {
             // This case should not happen, and will only happen if a configuration error at runtime is applied
             // such as having 7 min_healthy_links but we only have 2 ports
-            health_data.other_errors.push(format!(
+            let error = format!(
                 "The number of min healthy links: {min_healthy_links} \
                 was bigger than the number of uplinks defined by the hbn device names: {}",
                 hbn_device_names.uplinks.len()
-            ));
+            );
+            if !health_data.other_errors.contains(&error) {
+                health_data.other_errors.push(error);
+            }
             return;
         };
 
@@ -189,26 +232,16 @@ fn check_bgp_tor_routes(
     }
 }
 
-fn check_bgp_stats_ipv4_unicast(
+/// Applies the ToR-session and dynamic-peer invariants shared by both underlay
+/// unicast address families.
+fn check_bgp_stats_unicast(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
-    host_routes: &[&str],
     min_healthy_links: u32,
-    hbn_device_names: HBNDeviceNames,
+    hbn_device_names: &HBNDeviceNames,
 ) {
     check_bgp_tor_routes(s, health_data, min_healthy_links, hbn_device_names);
-
-    // We ignore the BPG sessions pointing towards tenant Machines
-    // Tenants can choose to use or not use them.
-    // However no other sessions are expected
-    for (peer_name, _peer) in s.other_peers() {
-        if !host_routes.contains(&peer_name.as_str()) {
-            health_data
-                .unexpected_peers
-                .push((name.to_string(), peer_name.clone()));
-        }
-    }
 
     if s.dynamic_peers != 0 {
         health_data.other_errors.push(format!(
@@ -218,13 +251,93 @@ fn check_bgp_stats_ipv4_unicast(
     }
 }
 
+/// Checks the default-VRF IPv6 underlay, where every non-ToR peer is
+/// unexpected.
+///
+/// Tenant peers live in per-VPC VRFs, and route-server IPv6 is disabled. That
+/// leaves the configured HBN uplinks as the only expected peers here.
+fn check_bgp_stats_ipv6_unicast(
+    name: &str,
+    s: &BgpStats,
+    health_data: &mut BgpHealthData,
+    min_healthy_links: u32,
+    hbn_device_names: &HBNDeviceNames,
+) {
+    check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
+
+    for peer_name in s.peers.keys() {
+        if !hbn_device_names.uplinks.contains(&peer_name.as_str()) {
+            health_data
+                .unexpected_peers
+                .push((name.to_string(), peer_name.clone()));
+        }
+    }
+}
+
+/// Maps FRR's address-family-specific failed-peer view back to the required
+/// physical uplinks.
+///
+/// The regular summary's peer state describes the shared BGP transport. The
+/// filtered view also includes established peers whose remote did not
+/// negotiate IPv6-unicast.
+fn verify_failed_ipv6_unicast_peers(
+    health_data: &mut BgpHealthData,
+    failed_peers_json: &str,
+    min_healthy_links: u32,
+    hbn_device_names: &HBNDeviceNames,
+) {
+    let failed_summary: BgpFailedSummary = match serde_json::from_str(failed_peers_json) {
+        Ok(summary) => summary,
+        Err(error) => {
+            health_data.other_errors.push(format!(
+                "failed to deserialize failed IPv6-unicast BGP summary: {error}"
+            ));
+            return;
+        }
+    };
+
+    for &port_name in hbn_device_names
+        .uplinks
+        .iter()
+        .take(min_healthy_links as usize)
+    {
+        if failed_summary.peers.contains_key(port_name) {
+            health_data
+                .unhealthy_tor_peers
+                .entry(port_name.to_string())
+                .or_insert_with(|| format!("Session {port_name} did not negotiate IPv6-unicast"));
+        }
+    }
+}
+
+fn check_bgp_stats_ipv4_unicast(
+    name: &str,
+    s: &BgpStats,
+    health_data: &mut BgpHealthData,
+    host_routes: &[&str],
+    min_healthy_links: u32,
+    hbn_device_names: &HBNDeviceNames,
+) {
+    check_bgp_stats_unicast(name, s, health_data, min_healthy_links, hbn_device_names);
+
+    // Tenant sessions are optional because tenants choose whether to use them.
+    // No other non-ToR sessions belong in the IPv4-unicast summary.
+    for (peer_name, _peer) in s.other_peers() {
+        if !host_routes.contains(&peer_name.as_str()) {
+            health_data
+                .unexpected_peers
+                .push((name.to_string(), peer_name.clone()));
+        }
+    }
+}
+
 fn check_bgp_stats_l2_vpn_evpn(
     name: &str,
     s: &BgpStats,
     health_data: &mut BgpHealthData,
     route_servers: &[String],
     min_healthy_links: u32,
-    hbn_device_names: HBNDeviceNames,
+    hbn_device_names: &HBNDeviceNames,
 ) {
     // In case Route servers are not specified, the peer list should contain only
     // TORs. Otherwise we expect it to contain the route servers.
@@ -279,10 +392,10 @@ fn check_bgp_stats_l2_vpn_evpn(
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct BgpHealthData {
-    // Note that these are HashMaps because we check TOR connections in 2 places
-    // and dedup the messages using the HashMap
+    // ToR state appears in multiple address-family summaries. Keying by port
+    // emits one alert for each physical link.
     pub unhealthy_tor_peers: HashMap<String, String>,
     pub unhealthy_route_server_peers: Vec<(String, String)>,
     pub unexpected_peers: Vec<(String, String)>,
@@ -336,7 +449,40 @@ impl BgpHealthData {
 #[serde(rename_all = "camelCase")]
 struct BgpNetworks {
     ipv4_unicast: BgpStats,
+    /// FRR can omit or null inactive address families; the configuration gate
+    /// decides when this summary becomes required.
+    ipv6_unicast: Option<BgpStats>,
     l2_vpn_evpn: BgpStats,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(try_from = "BgpFailedSummaryWire")]
+struct BgpFailedSummary {
+    /// FRR omits this map when no peers fail the address-family filter.
+    peers: HashMap<String, serde::de::IgnoredAny>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BgpFailedSummaryWire {
+    #[serde(default)]
+    peers: HashMap<String, serde::de::IgnoredAny>,
+    failed_peers: Option<u32>,
+    failed_peers_count: Option<u32>,
+}
+
+impl TryFrom<BgpFailedSummaryWire> for BgpFailedSummary {
+    type Error = &'static str;
+
+    fn try_from(summary: BgpFailedSummaryWire) -> Result<Self, Self::Error> {
+        if summary.failed_peers.is_none() && summary.failed_peers_count.is_none() {
+            return Err("missing failedPeers or failedPeersCount");
+        }
+
+        Ok(Self {
+            peers: summary.peers,
+        })
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -387,6 +533,8 @@ mod tests {
         include_str!("../hbn_bgp_summary_with_route_server_and_tenant_routes.json");
     const BGP_SUMMARY_JSON_WITH_ROUTE_SERVER_FAILED_ALL_PEERS: &str =
         include_str!("../hbn_bgp_summary_with_route_server_failed_all_peers.json");
+    const BGP_IPV6_UNICAST_SUMMARY_JSON_NO_FAILED_PEERS: &str =
+        include_str!("../hbn_bgp_ipv6_unicast_summary_no_failed_peers.json");
 
     /// One `verify_bgp_summary` scenario: a BGP summary JSON plus the host routes
     /// and route servers that frame what's expected, and the exact alerts the
@@ -547,15 +695,361 @@ mod tests {
                 verify_bgp_summary(
                     &mut health_data,
                     row.json,
-                    row.host_routes,
-                    2,
-                    &route_servers,
-                    HBNDeviceNames::hbn_23(),
+                    &BgpHealthCheckParams {
+                        host_routes: row.host_routes,
+                        min_healthy_links: 2,
+                        route_servers: &route_servers,
+                        should_check_ipv6_unicast: false,
+                        hbn_device_names: &HBNDeviceNames::hbn_23(),
+                    },
                 );
                 health_data.into_health_report(&mut hr);
                 let mut alerts = hr.alerts;
                 sort_alerts(&mut alerts);
                 alerts
+            },
+        );
+    }
+
+    #[test]
+    fn malformed_bgp_summary_is_not_verified() {
+        let mut health_data = BgpHealthData::default();
+
+        let verified = verify_bgp_summary(
+            &mut health_data,
+            r#"{"ipv4Unicast":"#,
+            &BgpHealthCheckParams {
+                host_routes: &[],
+                min_healthy_links: 2,
+                route_servers: &[],
+                should_check_ipv6_unicast: true,
+                hbn_device_names: &HBNDeviceNames::hbn_23(),
+            },
+        );
+
+        assert!(!verified);
+        assert_eq!(health_data.other_errors.len(), 1);
+        assert!(
+            health_data.other_errors[0].starts_with("failed to deserialize BGP summary"),
+            "unexpected error: {}",
+            health_data.other_errors[0]
+        );
+    }
+
+    enum Ipv6UnicastSummary {
+        Missing,
+        Null,
+        Healthy,
+        P0Idle,
+        DynamicPeer,
+        UnexpectedPeer,
+        UnexpectedTorLikePeer,
+        Unhealthy,
+    }
+
+    struct Ipv6UnicastInput {
+        should_check_ipv6_unicast: bool,
+        summary: Ipv6UnicastSummary,
+    }
+
+    #[test]
+    fn ipv6_unicast_summary_checks_enabled_underlay_sessions() {
+        check_values(
+            [
+                Check {
+                    scenario: "disabled health ignores an unhealthy IPv6 summary",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: false,
+                        summary: Ipv6UnicastSummary::Unhealthy,
+                    },
+                    expect: BgpHealthData::default(),
+                },
+                Check {
+                    scenario: "missing enabled address family is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::Missing,
+                    },
+                    expect: BgpHealthData {
+                        other_errors: vec!["ipv6_unicast BGP summary was not reported".to_string()],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "null enabled address family is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::Null,
+                    },
+                    expect: BgpHealthData {
+                        other_errors: vec!["ipv6_unicast BGP summary was not reported".to_string()],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "established underlay sessions are healthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::Healthy,
+                    },
+                    expect: BgpHealthData::default(),
+                },
+                Check {
+                    scenario: "idle underlay session is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::P0Idle,
+                    },
+                    expect: BgpHealthData {
+                        unhealthy_tor_peers: HashMap::from([(
+                            "p0_if".to_string(),
+                            "Session p0_if is not Established, but in state Idle".to_string(),
+                        )]),
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "dynamic peers are unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::DynamicPeer,
+                    },
+                    expect: BgpHealthData {
+                        other_errors: vec![
+                            "ipv6_unicast.dynamic_peers is 1 should be 0".to_string(),
+                        ],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "unexpected default-VRF peer is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::UnexpectedPeer,
+                    },
+                    expect: BgpHealthData {
+                        unexpected_peers: vec![(
+                            "ipv6_unicast".to_string(),
+                            "2001:db8::2".to_string(),
+                        )],
+                        ..Default::default()
+                    },
+                },
+                Check {
+                    scenario: "unconfigured ToR-like peer is unhealthy",
+                    input: Ipv6UnicastInput {
+                        should_check_ipv6_unicast: true,
+                        summary: Ipv6UnicastSummary::UnexpectedTorLikePeer,
+                    },
+                    expect: BgpHealthData {
+                        unexpected_peers: vec![("ipv6_unicast".to_string(), "p2_if".to_string())],
+                        ..Default::default()
+                    },
+                },
+            ],
+            |input: Ipv6UnicastInput| {
+                let mut summary: serde_json::Value =
+                    serde_json::from_str(BGP_SUMMARY_JSON_NO_ROUTE_SERVER_SUCCESS)
+                        .expect("parse known-good BGP summary fixture");
+                match input.summary {
+                    Ipv6UnicastSummary::Missing => {}
+                    Ipv6UnicastSummary::Null => {
+                        summary["ipv6Unicast"] = serde_json::Value::Null;
+                    }
+                    Ipv6UnicastSummary::Healthy => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                    }
+                    Ipv6UnicastSummary::P0Idle => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["p0_if"]["state"] = "Idle".into();
+                    }
+                    Ipv6UnicastSummary::DynamicPeer => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["dynamicPeers"] = 1.into();
+                    }
+                    Ipv6UnicastSummary::UnexpectedPeer => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["2001:db8::2"] =
+                            summary["ipv4Unicast"]["peers"]["p0_if"].clone();
+                    }
+                    Ipv6UnicastSummary::UnexpectedTorLikePeer => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["p2_if"] =
+                            summary["ipv4Unicast"]["peers"]["p0_if"].clone();
+                    }
+                    Ipv6UnicastSummary::Unhealthy => {
+                        summary["ipv6Unicast"] = summary["ipv4Unicast"].clone();
+                        summary["ipv6Unicast"]["peers"]["p0_if"]["state"] = "Idle".into();
+                        summary["ipv6Unicast"]["dynamicPeers"] = 1.into();
+                        summary["ipv6Unicast"]["peers"]["2001:db8::2"] =
+                            summary["ipv4Unicast"]["peers"]["p0_if"].clone();
+                    }
+                }
+
+                let mut health_data = BgpHealthData::default();
+                verify_bgp_summary(
+                    &mut health_data,
+                    &summary.to_string(),
+                    &BgpHealthCheckParams {
+                        host_routes: &[],
+                        min_healthy_links: 2,
+                        route_servers: &[],
+                        should_check_ipv6_unicast: input.should_check_ipv6_unicast,
+                        hbn_device_names: &HBNDeviceNames::hbn_23(),
+                    },
+                );
+                health_data
+            },
+        );
+    }
+
+    struct FailedIpv6SummaryInput {
+        json: &'static str,
+        min_healthy_links: u32,
+        existing_p0_error: Option<&'static str>,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct FailedIpv6SummaryOutcome {
+        unhealthy_tor_peers: HashMap<String, String>,
+        other_error_count: usize,
+        has_deserialization_error: bool,
+    }
+
+    #[test]
+    fn failed_ipv6_unicast_summary_checks_only_required_uplinks() {
+        check_values(
+            [
+                Check {
+                    scenario: "no failed peers is healthy",
+                    input: FailedIpv6SummaryInput {
+                        json: BGP_IPV6_UNICAST_SUMMARY_JSON_NO_FAILED_PEERS,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "required p0 negotiation failure is unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p0_if":{}},"failedPeers":1}"#,
+                        min_healthy_links: 1,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::from([(
+                            "p0_if".to_string(),
+                            "Session p0_if did not negotiate IPv6-unicast".to_string(),
+                        )]),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "optional p1 negotiation failure is healthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p1_if":{}},"failedPeers":1}"#,
+                        min_healthy_links: 1,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "both required negotiation failures are unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p0_if":{},"p1_if":{}},"failedPeers":2}"#,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::from([
+                            (
+                                "p0_if".to_string(),
+                                "Session p0_if did not negotiate IPv6-unicast".to_string(),
+                            ),
+                            (
+                                "p1_if".to_string(),
+                                "Session p1_if did not negotiate IPv6-unicast".to_string(),
+                            ),
+                        ]),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "transport failure remains the primary diagnosis",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":{"p0_if":{}},"failedPeers":1}"#,
+                        min_healthy_links: 1,
+                        existing_p0_error: Some("Session p0_if is in state Idle"),
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::from([(
+                            "p0_if".to_string(),
+                            "Session p0_if is in state Idle".to_string(),
+                        )]),
+                        other_error_count: 0,
+                        has_deserialization_error: false,
+                    },
+                },
+                Check {
+                    scenario: "unrelated JSON payload is unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"error":"BGP instance unavailable"}"#,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 1,
+                        has_deserialization_error: true,
+                    },
+                },
+                Check {
+                    scenario: "malformed failed-peer summary is unhealthy",
+                    input: FailedIpv6SummaryInput {
+                        json: r#"{"peers":"#,
+                        min_healthy_links: 2,
+                        existing_p0_error: None,
+                    },
+                    expect: FailedIpv6SummaryOutcome {
+                        unhealthy_tor_peers: HashMap::new(),
+                        other_error_count: 1,
+                        has_deserialization_error: true,
+                    },
+                },
+            ],
+            |input: FailedIpv6SummaryInput| {
+                let mut health_data = BgpHealthData::default();
+                if let Some(error) = input.existing_p0_error {
+                    health_data
+                        .unhealthy_tor_peers
+                        .insert("p0_if".to_string(), error.to_string());
+                }
+
+                verify_failed_ipv6_unicast_peers(
+                    &mut health_data,
+                    input.json,
+                    input.min_healthy_links,
+                    &HBNDeviceNames::hbn_23(),
+                );
+
+                let has_deserialization_error = health_data.other_errors.iter().any(|error| {
+                    error.starts_with("failed to deserialize failed IPv6-unicast BGP summary")
+                });
+                FailedIpv6SummaryOutcome {
+                    unhealthy_tor_peers: health_data.unhealthy_tor_peers,
+                    other_error_count: health_data.other_errors.len(),
+                    has_deserialization_error,
+                }
             },
         );
     }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -391,6 +391,9 @@ pub async fn start(cmdline: command_line::Options) -> eyre::Result<()> {
                 has_changed_configs: false,
                 min_healthy_links: 2,
                 route_servers: &[],
+                // Standalone checks lack managed-host config to establish that
+                // the FNN IPv6 underlay is active.
+                should_check_ipv6_unicast: false,
                 hbn_device_names: HBNDeviceNames::hbn_23(),
                 include_dhcp_server: false,
                 run_restricted_mode_check: true,

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -844,6 +844,7 @@ impl MainLoop {
                     .collect();
 
                 let tenant_peers = ethernet_virtualization::tenant_peers(&conf);
+                let mut should_check_ipv6_unicast = false;
                 if self.is_hbn_up {
                     // First thing is to read the existing HBN version and properly set the hbn device names
                     // associated with that version.
@@ -896,10 +897,12 @@ impl MainLoop {
                     }
 
                     tracing::trace!(network_config = ?conf, "Desired network config");
-                    // Get the actual virtualization type to use for configuring
-                    // an interface, where we'll default to reading the one provided
-                    // by the Carbide API, with the ability to override via RunOptions.
+                    // Resolve the virtualization type used to generate HBN
+                    // configuration, including any RunOptions override. The IPv6
+                    // health gate follows that same effective value.
                     let virtualization_type = effective_virtualization_type(&conf, &self.options)?;
+                    should_check_ipv6_unicast =
+                        ipv6_unicast_health_enabled(&conf, virtualization_type);
 
                     let dhcp_result = ethernet_virtualization::update_dhcp(
                         &self.agent_config.hbn.root_dir,
@@ -1106,6 +1109,7 @@ impl MainLoop {
                             has_changed_configs,
                             min_healthy_links: conf.min_dpu_functioning_links.unwrap_or(2),
                             route_servers: &conf.route_servers,
+                            should_check_ipv6_unicast,
                             hbn_device_names: self.hbn_device_names.clone(),
                             include_dhcp_server: !conf.use_admin_network || conf.is_primary_dpu,
                             run_restricted_mode_check: false,
@@ -1311,6 +1315,23 @@ impl MainLoop {
             loop_period: Default::default(),
         }
     }
+}
+
+/// Enables IPv6-unicast health only after the effective FNN configuration has
+/// the dedicated IPv6 loopback used by that underlay.
+///
+/// FNN templates activate the address family before the loopback pool is
+/// available, so FRR summary-key presence cannot serve as the activation
+/// signal.
+fn ipv6_unicast_health_enabled(
+    conf: &ManagedHostNetworkConfigResponse,
+    virtualization_type: VpcVirtualizationType,
+) -> bool {
+    virtualization_type == VpcVirtualizationType::Fnn
+        && conf
+            .managed_host_config
+            .as_ref()
+            .is_some_and(|config| config.loopback_ip_v6.is_some())
 }
 
 /// effective_virtualization_type returns the virtualization type
@@ -1749,6 +1770,77 @@ mod test {
                 // Interface identity prevents profiles from being silently
                 // reassociated with a different port.
                 InterfaceChange::Identity => false,
+            }
+        );
+    }
+
+    enum ManagedHostConfigInput {
+        Missing,
+        WithoutIpv6Loopback,
+        WithIpv6Loopback(&'static str),
+    }
+
+    struct Ipv6UnicastHealthRow {
+        virtualization_type: VpcVirtualizationType,
+        managed_host_config: ManagedHostConfigInput,
+    }
+
+    #[test]
+    fn ipv6_unicast_health_requires_fnn_with_an_ipv6_loopback() {
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(run = |row: Ipv6UnicastHealthRow| {
+            let managed_host_config = match row.managed_host_config {
+                ManagedHostConfigInput::Missing => None,
+                ManagedHostConfigInput::WithoutIpv6Loopback => {
+                    Some(rpc::ManagedHostNetworkConfig {
+                        loopback_ip: "10.0.0.1".to_string(),
+                        loopback_ip_v6: None,
+                        quarantine_state: None,
+                    })
+                }
+                ManagedHostConfigInput::WithIpv6Loopback(loopback_ip_v6) => {
+                    Some(rpc::ManagedHostNetworkConfig {
+                        loopback_ip: "10.0.0.1".to_string(),
+                        loopback_ip_v6: Some(loopback_ip_v6.to_string()),
+                        quarantine_state: None,
+                    })
+                }
+            };
+            let conf = ManagedHostNetworkConfigResponse {
+                managed_host_config,
+                ..Default::default()
+            };
+            ipv6_unicast_health_enabled(&conf, row.virtualization_type)
+        };
+            "FNN with a reserved IPv6 loopback" {
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => true,
+            }
+
+            "inactive IPv6 underlay" {
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    managed_host_config: ManagedHostConfigInput::Missing,
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Fnn,
+                    managed_host_config: ManagedHostConfigInput::WithoutIpv6Loopback,
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::EthernetVirtualizer,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::EthernetVirtualizerWithNvue,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => false,
+                Ipv6UnicastHealthRow {
+                    virtualization_type: VpcVirtualizationType::Flat,
+                    managed_host_config: ManagedHostConfigInput::WithIpv6Loopback("2001:db8::1"),
+                } => false,
             }
         );
     }


### PR DESCRIPTION
FNN already renders an `ipv6-unicast` address family, but the agent's BGP health report only checks IPv4-unicast and EVPN. That leaves the IPv6 underlay invisible once a DPU gets its dedicated IPv6 loopback.

This makes `ipv6Unicast` part of the BGP summary model and enables its health checks only for FNN configs with `loopback_ip_v6`. The ordinary summary catches missing sessions, bad transport state, dynamic peers, and unexpected default-VRF peers; FRR's filtered failed-peer summary catches required ToR sessions that never negotiated the IPv6 address family.

IPv4-only sites stay on the existing path, and single-link profiles still check only their required uplink.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2392

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The following checks pass:

- `cargo test -p carbide-agent --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

Alerting remains out of scope because there is no in-repository Prometheus rule to mirror. The check follows the existing `min_dpu_functioning_links` uplink selection.

Closes #2392
