### PR TITLE
fix(rest-api): Keep ExpectedMachine BMC MAC immutable

### DIFF
--- a/rest-api/api/pkg/api/handler/expectedmachine.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"net"
 	"net/http"
 	"slices"
 	"strconv"
@@ -572,6 +573,27 @@ type UpdateExpectedMachineHandler struct {
 	tracerSpan *cutil.TracerSpan
 }
 
+// expectedMachineBmcMacUnchanged accepts an omitted MAC or another spelling of
+// the stored MAC. The BMC MAC identifies the ExpectedMachine in Core, so PATCH
+// may reassert that identity but cannot replace it.
+func expectedMachineBmcMacUnchanged(stored string, submitted *string) bool {
+	if submitted == nil {
+		return true
+	}
+
+	storedMAC, storedErr := net.ParseMAC(stored)
+	submittedMAC, submittedErr := net.ParseMAC(*submitted)
+	return storedErr == nil && submittedErr == nil && slices.Equal(storedMAC, submittedMAC)
+}
+
+// expectedMachineBmcMacImmutableValidationError keeps the single and batch
+// PATCH validation responses aligned.
+func expectedMachineBmcMacImmutableValidationError() validation.Errors {
+	return validation.Errors{
+		"bmcMacAddress": errors.New("BMC MAC address cannot be changed after creation"),
+	}
+}
+
 // NewUpdateExpectedMachineHandler initializes and returns a new handler for updating ExpectedMachine
 func NewUpdateExpectedMachineHandler(dbSession *cdb.Session, scp *sc.ClientPool, cfg *config.Config) UpdateExpectedMachineHandler {
 	return UpdateExpectedMachineHandler{
@@ -687,6 +709,11 @@ func (uemh UpdateExpectedMachineHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site of the Expected Machine", nil)
 	}
 
+	if !expectedMachineBmcMacUnchanged(expectedMachine.BmcMacAddress, apiRequest.BmcMacAddress) {
+		validationErrors := expectedMachineBmcMacImmutableValidationError()
+		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Failed to validate Expected Machine update data", validationErrors)
+	}
+
 	bmcIPAddress := apiRequest.BmcIpAddress
 	clearBmcIPAddress := bmcIPAddress != nil && *bmcIPAddress == ""
 	if clearBmcIPAddress {
@@ -700,7 +727,6 @@ func (uemh UpdateExpectedMachineHandler) Handle(c echo.Context) error {
 			tx,
 			cdbm.ExpectedMachineUpdateInput{
 				ExpectedMachineID:        expectedMachine.ID,
-				BmcMacAddress:            apiRequest.BmcMacAddress,
 				BmcIpAddress:             bmcIPAddress,
 				ChassisSerialNumber:      apiRequest.ChassisSerialNumber,
 				SkuID:                    apiRequest.SkuID,
@@ -1297,12 +1323,10 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 
 	// Validate each item, also collect requested sku IDs
 	// - ID is required and must be unique
-	// - BMC address is optional but must be unique
 	// - Serial Number is optional but must be unique
 	// Note: this is early partial validation before we try to call the DB.
 	validationErrors := validation.Errors{} //
 	idMap := make(map[uuid.UUID]int)        // Map Expected Machine ID to its index in the request array
-	bmcMacMap := make(map[string]int)
 	serialMap := make(map[string]int)
 	requestedSkuIDs := make(map[string]bool)
 	for i, req := range apiRequests {
@@ -1332,15 +1356,6 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 			idMap[mid] = i
 		}
 
-		if req.BmcMacAddress != nil {
-			lowerMac := strings.ToLower(*req.BmcMacAddress)
-			if prev, ok := bmcMacMap[lowerMac]; ok {
-				common.AddToValidationErrors(itemErrors, "bmcMacAddress", fmt.Errorf(
-					"duplicate BMC MAC address '%s' found at indices %d and %d", *req.BmcMacAddress, prev, i))
-			}
-			bmcMacMap[lowerMac] = i
-		}
-
 		if req.ChassisSerialNumber != nil {
 			lowerSerial := strings.ToLower(*req.ChassisSerialNumber)
 			if prev, ok := serialMap[lowerSerial]; ok {
@@ -1368,7 +1383,7 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 	// but we also want to retrieve full Expected Machines from Site to check for Serial uniqueness.
 	// We will split into multiple queries:
 	// 1. Retrieve SiteID and Site by loading the requested ExpectedMachine records
-	// 2. Retrieve all Expected Machines for that Site to check for MAC/Serial uniqueness.
+	// 2. Retrieve all Expected Machines for that Site to check for Serial uniqueness.
 	// 3. Retrieve all SKUs for that Site to validate SKU IDs in the request.
 	// All of these are pure validation reads and stay outside the WithTxResult call below.
 	// TODO: now that we have a unique index on (mac,siteID) we should reconsider adding unique indices on (serial,siteID).
@@ -1450,6 +1465,21 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 		return cutil.NewAPIErrorResponse(c, http.StatusForbidden, "Current org is not associated with the Site", nil)
 	}
 
+	// Validate the stored identity only after the caller's Site access is known.
+	// Otherwise the error would reveal whether a submitted MAC matched a machine
+	// the caller cannot access.
+	validationErrors = validation.Errors{}
+	for i, req := range apiRequests {
+		mid, _ := uuid.Parse(*req.ID)
+		em := requestedEmMap[mid]
+		if !expectedMachineBmcMacUnchanged(em.BmcMacAddress, req.BmcMacAddress) {
+			validationErrors[strconv.Itoa(i)] = expectedMachineBmcMacImmutableValidationError()
+		}
+	}
+	if len(validationErrors) > 0 {
+		return cutil.NewAPIErrorResponse(c, http.StatusBadRequest, "Failed to validate Expected Machine update data", validationErrors)
+	}
+
 	// Retrieve all ExpectedMachines on Site from DB to allow unicity checks at
 	// Site level. Pure validation read, kept outside the write transaction.
 	expectedMachinesOnSite, _, err := emDAO.GetAll(ctx, nil, cdbm.ExpectedMachineFilterInput{
@@ -1484,42 +1514,32 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 		uniqueSkuIDsOnSite[sku.ID] = true
 	}
 
-	// Verify unicity of BMC MAC Addresses and Serial Numbers with existing records on Site
-	expectedMachineMacAddressChecker := common.NewUniqueChecker[uuid.UUID]()
+	// Verify Serial Number uniqueness with existing records on Site
 	expectedMachineSerialNumberChecker := common.NewUniqueChecker[uuid.UUID]()
 
 	// Load DB data into checkers
 	for i := range expectedMachinesOnSite { // iterate on ALL Expected Machine on Site
 		em := &expectedMachinesOnSite[i]
-		expectedMachineMacAddressChecker.Update(em.ID, em.BmcMacAddress)
 		if em.ChassisSerialNumber != "" {
 			expectedMachineSerialNumberChecker.Update(em.ID, em.ChassisSerialNumber)
 		}
 	}
 
-	// Apply changes to MAC and Serial to checkers
+	// Apply Serial changes to the checker
 	for _, req := range apiRequests {
 		mid, _ := uuid.Parse(*req.ID)
-		if req.BmcMacAddress != nil {
-			expectedMachineMacAddressChecker.Update(mid, *req.BmcMacAddress)
-		}
 		if req.ChassisSerialNumber != nil {
 			expectedMachineSerialNumberChecker.Update(mid, *req.ChassisSerialNumber)
 		}
 	}
 
-	// Final checks: unicity of MAC, Serial, and existence of SKUs
+	// Final checks: Serial uniqueness and existence of SKUs
 	validationErrors = validation.Errors{}
 	for i, req := range apiRequests {
 		itemErrors := validation.Errors{}
 		strIndex := strconv.Itoa(i) // index/key as string for validation errors map
 		mid, _ := uuid.Parse(*req.ID)
 
-		// Check MAC unicity
-		if req.BmcMacAddress != nil && expectedMachineMacAddressChecker.DoesIDHaveConflict(mid) {
-			common.AddToValidationErrors(itemErrors, "bmcMacAddress", fmt.Errorf(
-				"Expected Machine with BMC MAC Address: %s already exist", *req.BmcMacAddress))
-		}
 		// Check Serial unicity
 		if req.ChassisSerialNumber != nil && expectedMachineSerialNumberChecker.DoesIDHaveConflict(mid) {
 			common.AddToValidationErrors(itemErrors, "chassisSerialNumber", fmt.Errorf(
@@ -1566,7 +1586,6 @@ func (uemh UpdateExpectedMachinesHandler) Handle(c echo.Context) error {
 		}
 		updateInputs = append(updateInputs, cdbm.ExpectedMachineUpdateInput{
 			ExpectedMachineID:        emID,
-			BmcMacAddress:            machineReq.BmcMacAddress,
 			BmcIpAddress:             bmcIPAddress,
 			ChassisSerialNumber:      machineReq.ChassisSerialNumber,
 			SkuID:                    machineReq.SkuID,

--- a/rest-api/api/pkg/api/handler/expectedmachine_test.go
+++ b/rest-api/api/pkg/api/handler/expectedmachine_test.go
@@ -1151,6 +1151,46 @@ func TestGetExpectedMachineHandler_Handle(t *testing.T) {
 	})
 }
 
+func TestExpectedMachineBmcMacUnchanged(t *testing.T) {
+	stored := "00:11:22:33:44:DD"
+	tests := []struct {
+		name      string
+		submitted *string
+		expected  bool
+	}{
+		{
+			name:     "omitted",
+			expected: true,
+		},
+		{
+			name:      "exact",
+			submitted: cutil.GetPtr(stored),
+			expected:  true,
+		},
+		{
+			name:      "case and separator differ",
+			submitted: cutil.GetPtr("00-11-22-33-44-dd"),
+			expected:  true,
+		},
+		{
+			name:      "dotted notation",
+			submitted: cutil.GetPtr("0011.2233.44dd"),
+			expected:  true,
+		},
+		{
+			name:      "physical MAC differs",
+			submitted: cutil.GetPtr("AA:BB:CC:DD:EE:FF"),
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, expectedMachineBmcMacUnchanged(stored, tt.submitted))
+		})
+	}
+}
+
 func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 	// Setup
 	e := echo.New()
@@ -1214,9 +1254,14 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 	// Add mock temporal client for the site
 	mockTemporalClient := &tmocks.Client{}
 	mockWorkflowRun := &tmocks.WorkflowRun{}
+	var capturedRequest *corev1.ExpectedMachine
 	mockWorkflowRun.On("GetID").Return("test-workflow-id")
 	mockWorkflowRun.Mock.On("Get", mock.Anything, mock.Anything).Return(nil)
-	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedMachine", mock.Anything).Return(mockWorkflowRun, nil)
+	mockTemporalClient.Mock.On("ExecuteWorkflow", mock.Anything, mock.Anything, "UpdateExpectedMachine", mock.Anything).
+		Run(func(args mock.Arguments) {
+			capturedRequest, _ = args.Get(3).(*corev1.ExpectedMachine)
+		}).
+		Return(mockWorkflowRun, nil)
 	scp.IDClientMap[site.ID.String()] = mockTemporalClient
 
 	handler := NewUpdateExpectedMachineHandler(dbSession, scp, cfg)
@@ -1260,10 +1305,10 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
-			name: "successful MAC address update",
+			name: "unchanged MAC address spelling is accepted",
 			id:   testEM.ID.String(),
 			requestBody: model.APIExpectedMachineUpdateRequest{
-				BmcMacAddress: cutil.GetPtr("AA:BB:CC:DD:EE:FF"),
+				BmcMacAddress: cutil.GetPtr("00-11-22-33-44-dd"),
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", createMockUser(org))
@@ -1275,7 +1320,24 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 				var response model.APIExpectedMachine
 				err := json.Unmarshal(body, &response)
 				assert.Nil(t, err)
-				assert.Equal(t, "AA:BB:CC:DD:EE:FF", response.BmcMacAddress, "MAC address in response should match the updated value")
+				assert.Equal(t, testEM.BmcMacAddress, response.BmcMacAddress,
+					"an equivalent spelling must preserve the stored MAC")
+			},
+		},
+		{
+			name: "BMC MAC address cannot be changed",
+			id:   testEM.ID.String(),
+			requestBody: model.APIExpectedMachineUpdateRequest{
+				BmcMacAddress: cutil.GetPtr("AA:BB:CC:DD:EE:FF"),
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName", "id")
+				c.SetParamValues(org, testEM.ID.String())
+			},
+			expectedStatus: http.StatusBadRequest,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				assert.Contains(t, string(body), "BMC MAC address cannot be changed after creation")
 			},
 		},
 		{
@@ -1293,11 +1355,10 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			name: "cannot update on unmanaged site",
+			name: "site access is checked before BMC MAC identity",
 			id:   unmanagedEM.ID.String(),
 			requestBody: model.APIExpectedMachineUpdateRequest{
-				ChassisSerialNumber: cutil.GetPtr("SHOULD-NOT-UPDATE"),
-				Labels:              map[string]string{"env": "fail"},
+				BmcMacAddress: cutil.GetPtr("AA:BB:CC:DD:EE:FF"),
 			},
 			setupContext: func(c echo.Context) {
 				c.Set("user", createMockUser(org))
@@ -1305,6 +1366,9 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 				c.SetParamValues(org, unmanagedEM.ID.String())
 			},
 			expectedStatus: http.StatusForbidden,
+			checkResponseContent: func(t *testing.T, body []byte) {
+				assert.NotContains(t, string(body), "BMC MAC address cannot be changed")
+			},
 		},
 		{
 			name: "invalid SKU ID returns 422",
@@ -1361,11 +1425,20 @@ func TestUpdateExpectedMachineHandler_Handle(t *testing.T) {
 			}
 
 			// Check response content if provided
-			if tt.checkResponseContent != nil && rec.Code == http.StatusOK {
+			if tt.checkResponseContent != nil && rec.Code == tt.expectedStatus {
 				tt.checkResponseContent(t, rec.Body.Bytes())
 			}
 		})
 	}
+
+	mockTemporalClient.AssertNumberOfCalls(t, "ExecuteWorkflow", 2)
+	require.NotNil(t, capturedRequest)
+	assert.Equal(t, testEM.BmcMacAddress, capturedRequest.GetBmcMacAddress(),
+		"Core must receive the stored BMC MAC spelling")
+	stored, err := emDAO.Get(ctx, nil, testEM.ID, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, testEM.BmcMacAddress, stored.BmcMacAddress,
+		"PATCH must never change the stored BMC MAC spelling or identity")
 }
 
 func TestUpdateExpectedMachineHandler_BmcIpAddressPatchSemantics(t *testing.T) {
@@ -2528,6 +2601,25 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 	_, err := dbSession.DB.NewInsert().Model(site2).Exec(ctx)
 	assert.Nil(t, err)
 
+	// Create a Site outside the caller's provider relationship so identity
+	// validation cannot reveal data before the access check.
+	unmanagedIP := &cdbm.InfrastructureProvider{
+		ID:   uuid.New(),
+		Name: "unmanaged-batch-provider",
+		Org:  "other-org",
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedIP).Exec(ctx)
+	assert.Nil(t, err)
+	unmanagedSite := &cdbm.Site{
+		ID:                       uuid.New(),
+		Name:                     "unmanaged-batch-site",
+		Org:                      "other-org",
+		InfrastructureProviderID: unmanagedIP.ID,
+		Status:                   cdbm.SiteStatusRegistered,
+	}
+	_, err = dbSession.DB.NewInsert().Model(unmanagedSite).Exec(ctx)
+	assert.Nil(t, err)
+
 	// Create test ExpectedMachines on site 1
 	emDAO := cdbm.NewExpectedMachineDAO(dbSession)
 	testEM1, err := emDAO.Create(ctx, nil, cdbm.ExpectedMachineCreateInput{
@@ -2537,6 +2629,14 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 		ChassisSerialNumber:      "BATCH-UPDATE-001",
 		FallbackDpuSerialNumbers: []string{"DPU010"},
 		Labels:                   map[string]string{"env": "test"},
+	})
+	assert.Nil(t, err)
+
+	unmanagedEM, err := emDAO.Create(ctx, nil, cdbm.ExpectedMachineCreateInput{
+		ExpectedMachineID:   uuid.New(),
+		SiteID:              unmanagedSite.ID,
+		BmcMacAddress:       "00:11:22:33:44:13",
+		ChassisSerialNumber: "BATCH-UPDATE-UNMANAGED",
 	})
 	assert.Nil(t, err)
 
@@ -2672,6 +2772,120 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 			},
 		},
 		{
+			name: "unchanged MAC address spellings are accepted",
+			requestBody: []model.APIExpectedMachineUpdateRequest{
+				{
+					ID:            cutil.GetPtr(testEM1.ID.String()),
+					BmcMacAddress: cutil.GetPtr("00-11-22-33-44-10"),
+				},
+				{
+					ID:            cutil.GetPtr(testEM2.ID.String()),
+					BmcMacAddress: cutil.GetPtr("00:11:22:33:44:11"),
+				},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusOK,
+			validateResp: func(t *testing.T, body []byte) {
+				var response []model.APIExpectedMachine
+				err := json.Unmarshal(body, &response)
+				require.NoError(t, err)
+				require.Len(t, response, 2)
+
+				responseByID := make(map[uuid.UUID]model.APIExpectedMachine, len(response))
+				for _, machine := range response {
+					responseByID[machine.ID] = machine
+				}
+				assert.Equal(t, testEM1.BmcMacAddress, responseByID[testEM1.ID].BmcMacAddress)
+				assert.Equal(t, testEM2.BmcMacAddress, responseByID[testEM2.ID].BmcMacAddress)
+
+				request, ok := capturedRequest.(*corev1.BatchExpectedMachineOperationRequest)
+				require.True(t, ok)
+				workflowMachines := request.GetExpectedMachines().GetExpectedMachines()
+				require.Len(t, workflowMachines, 2)
+
+				workflowByID := make(map[string]*corev1.ExpectedMachine, len(workflowMachines))
+				for _, machine := range workflowMachines {
+					workflowByID[machine.GetId().GetValue()] = machine
+				}
+				require.Contains(t, workflowByID, testEM1.ID.String())
+				require.Contains(t, workflowByID, testEM2.ID.String())
+				assert.Equal(t, testEM1.BmcMacAddress,
+					workflowByID[testEM1.ID.String()].GetBmcMacAddress())
+				assert.Equal(t, testEM2.BmcMacAddress,
+					workflowByID[testEM2.ID.String()].GetBmcMacAddress())
+			},
+		},
+		{
+			name: "BMC MAC address change rejects the whole batch",
+			requestBody: []model.APIExpectedMachineUpdateRequest{
+				{
+					ID:            cutil.GetPtr(testEM1.ID.String()),
+					BmcMacAddress: cutil.GetPtr("AA:BB:CC:DD:EE:FF"),
+				},
+				{
+					ID:                  cutil.GetPtr(testEM2.ID.String()),
+					ChassisSerialNumber: cutil.GetPtr("REJECTED-BATCH-CHANGE"),
+				},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResp: func(t *testing.T, body []byte) {
+				assert.Contains(t, string(body), "BMC MAC address cannot be changed after creation")
+				stored, err := emDAO.Get(ctx, nil, testEM2.ID, nil, false)
+				require.NoError(t, err)
+				assert.NotEqual(t, "REJECTED-BATCH-CHANGE", stored.ChassisSerialNumber,
+					"a rejected batch must not update another machine")
+			},
+		},
+		{
+			name: "BMC MAC address swap is rejected",
+			requestBody: []model.APIExpectedMachineUpdateRequest{
+				{
+					ID:            cutil.GetPtr(testEM1.ID.String()),
+					BmcMacAddress: cutil.GetPtr(testEM2.BmcMacAddress),
+				},
+				{
+					ID:            cutil.GetPtr(testEM2.ID.String()),
+					BmcMacAddress: cutil.GetPtr(testEM1.BmcMacAddress),
+				},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusBadRequest,
+			validateResp: func(t *testing.T, body []byte) {
+				assert.Contains(t, string(body), "BMC MAC address cannot be changed after creation")
+			},
+		},
+		{
+			name: "site access is checked before BMC MAC identity",
+			requestBody: []model.APIExpectedMachineUpdateRequest{
+				{
+					ID:            cutil.GetPtr(unmanagedEM.ID.String()),
+					BmcMacAddress: cutil.GetPtr("AA:BB:CC:DD:EE:FF"),
+				},
+			},
+			setupContext: func(c echo.Context) {
+				c.Set("user", createMockUser(org))
+				c.SetParamNames("orgName")
+				c.SetParamValues(org)
+			},
+			expectedStatus: http.StatusForbidden,
+			validateResp: func(t *testing.T, body []byte) {
+				assert.NotContains(t, string(body), "BMC MAC address cannot be changed")
+			},
+		},
+		{
 			name:        "empty batch should fail",
 			requestBody: []model.APIExpectedMachineUpdateRequest{},
 			setupContext: func(c echo.Context) {
@@ -2788,21 +3002,18 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 			},
 		},
 		{
-			name: "bad siteID with duplicate MAC and duplicate serial should fail with validation errors",
+			name: "duplicate serial should fail before database lookup",
 			requestBody: []model.APIExpectedMachineUpdateRequest{
 				{
 					ID:                  cutil.GetPtr(testEM1.ID.String()),
-					BmcMacAddress:       cutil.GetPtr("ff:ff:ff:ff:ff:ff"),    // lowercase
 					ChassisSerialNumber: cutil.GetPtr("Duplicate-Everything"), // mixed case
 				},
 				{
 					ID:                  cutil.GetPtr(testEM2.ID.String()),
-					BmcMacAddress:       cutil.GetPtr("FF:FF:FF:FF:FF:FF"),    // uppercase (duplicate MAC, different case)
 					ChassisSerialNumber: cutil.GetPtr("DUPLICATE-EVERYTHING"), // uppercase (duplicate serial, different case)
 				},
 				{
 					ID:                  cutil.GetPtr("00000000-0000-0000-0000-000000000099"), // non-existent ID (bad siteID)
-					BmcMacAddress:       cutil.GetPtr("AA:AA:AA:AA:AA:AA"),
 					ChassisSerialNumber: cutil.GetPtr("NONEXISTENT-SERIAL"),
 				},
 			},
@@ -2813,7 +3024,8 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 			},
 			expectedStatus: http.StatusBadRequest,
 			validateResp: func(t *testing.T, body []byte) {
-				// Verify error response contains validation errors for duplicate MAC and serial
+				// Verify the request-level duplicate is reported before the
+				// handler reaches its database lookup for the missing ID.
 				bodyStr := string(body)
 				t.Logf("Response body: %s", bodyStr)
 
@@ -2823,14 +3035,12 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 				assert.Nil(t, err)
 
 				// Should have validation errors in data field
-				assert.Contains(t, bodyStr, "bmcMacAddress")
-				assert.Contains(t, bodyStr, "duplicate BMC MAC address")
 				assert.Contains(t, bodyStr, "chassisSerialNumber")
 				assert.Contains(t, bodyStr, "duplicate chassis serial number")
 
 				// The error should be about validation, not about machines being found
 				// since the duplicate check happens before the DB query for non-existent machines
-				// This test verifies case-insensitive comparison (ff:ff vs FF:FF and Duplicate vs DUPLICATE)
+				// This test verifies case-insensitive serial comparison.
 				assert.Contains(t, bodyStr, "Failed to validate Expected Machine update data")
 			},
 		},
@@ -2869,6 +3079,14 @@ func TestUpdateExpectedMachinesHandler_Handle(t *testing.T) {
 			}
 		})
 	}
+
+	mockTemporalClient.AssertNumberOfCalls(t, "ExecuteWorkflow", 2)
+	storedEM1, err := emDAO.Get(ctx, nil, testEM1.ID, nil, false)
+	require.NoError(t, err)
+	storedEM2, err := emDAO.Get(ctx, nil, testEM2.ID, nil, false)
+	require.NoError(t, err)
+	assert.Equal(t, testEM1.BmcMacAddress, storedEM1.BmcMacAddress)
+	assert.Equal(t, testEM2.BmcMacAddress, storedEM2.BmcMacAddress)
 }
 
 func TestUpdateExpectedMachinesHandler_BmcIpAddressPatchSemantics(t *testing.T) {

--- a/rest-api/api/pkg/api/model/expectedmachine.go
+++ b/rest-api/api/pkg/api/model/expectedmachine.go
@@ -151,7 +151,8 @@ func (emcr *APIExpectedMachineCreateRequest) Validate() error {
 type APIExpectedMachineUpdateRequest struct {
 	// ID is required for batch updates (must be empty or match path value for single update)
 	ID *string `json:"id"`
-	// BmcMacAddress is the MAC address of the expected machine's BMC
+	// BmcMacAddress may reassert the ExpectedMachine's current BMC MAC, but
+	// cannot change it after creation.
 	BmcMacAddress *string `json:"bmcMacAddress"`
 	// BmcUsername is the username of the expected machine's BMC
 	DefaultBmcUsername *string `json:"defaultBmcUsername"`

--- a/rest-api/openapi/spec.yaml
+++ b/rest-api/openapi/spec.yaml
@@ -23190,7 +23190,9 @@ components:
             - string
             - 'null'
           pattern: '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$'
-          description: MAC address of the Expected Machine's BMC (Baseboard Management Controller)
+          deprecated: true
+          description: |-
+            The Expected Machine's BMC MAC address is immutable after creation. Omit this field, or provide another case/separator spelling of the current MAC as a compatibility no-op.
         defaultBmcUsername:
           type:
             - string

--- a/rest-api/sdk/simple/examples/expectedmachine/main.go
+++ b/rest-api/sdk/simple/examples/expectedmachine/main.go
@@ -153,41 +153,28 @@ func main() {
 	fmt.Printf("Updated ExpectedMachine: ID=%s, Chassis SN=%s, DPU count=%d\n",
 		updatedEM.ID, updatedEM.ChassisSerialNumber, len(updatedEM.FallbackDPUSerialNumbers))
 
-	// Example 5: Update BMC MAC address
-	fmt.Println("\nExample 5: Updating BMC MAC address...")
-	newBmcMacAddress := "00:1A:2B:3C:4D:FF"
-	updateMacRequest := simple.ExpectedMachineUpdateRequest{
-		BmcMacAddress: &newBmcMacAddress,
-	}
-	updatedEMWithNewMAC, apiErr := client.UpdateExpectedMachine(ctx, expectedMachineID, updateMacRequest)
-	if apiErr != nil {
-		fmt.Printf("Error updating ExpectedMachine MAC: %s\n", apiErr.Message)
-		os.Exit(1)
-	}
-	fmt.Printf("Updated ExpectedMachine BMC MAC from %s to %s\n",
-		expectedMachine.BmcMacAddress, updatedEMWithNewMAC.BmcMacAddress)
-
-	// Example 6: Delete an ExpectedMachine
-	fmt.Println("\nExample 6: Deleting an ExpectedMachine...")
+	// Example 5: Delete an ExpectedMachine
+	fmt.Println("\nExample 5: Deleting an ExpectedMachine...")
 	apiErr = client.DeleteExpectedMachine(ctx, expectedMachineID)
 	if apiErr != nil {
 		fmt.Printf("Error deleting ExpectedMachine: %s\n", apiErr.Message)
 		os.Exit(1)
 	}
-	fmt.Printf("Deleted ExpectedMachine with ID: %s\n", updatedEMWithNewMAC.ID)
+	fmt.Printf("Deleted ExpectedMachine with ID: %s\n", updatedEM.ID)
 
 	// Verify deletion
 	fmt.Println("\nVerifying deletion...")
 	_, apiErr = client.GetExpectedMachine(ctx, expectedMachineID)
 	if apiErr != nil {
 		if apiErr.Code == http.StatusNotFound {
-			fmt.Printf("ExpectedMachine with ID %s successfully deleted (no longer present)\n", updatedEMWithNewMAC.ID)
+			fmt.Printf("ExpectedMachine with ID %s successfully deleted (no longer present)\n", updatedEM.ID)
 		} else {
 			fmt.Printf("Error verifying ExpectedMachine deletion: %s\n", apiErr.Message)
 			os.Exit(1)
 		}
 	} else {
-		fmt.Println("Warning: ExpectedMachine still exists after deletion")
+		fmt.Println("Error: ExpectedMachine still exists after deletion")
+		os.Exit(1)
 	}
 	fmt.Println("\nAll examples completed successfully!")
 }

--- a/rest-api/sdk/simple/expectedmachine.go
+++ b/rest-api/sdk/simple/expectedmachine.go
@@ -39,7 +39,9 @@ type ExpectedMachineCreateRequest struct {
 
 // ExpectedMachineUpdateRequest represents a request to update an Expected Machine
 type ExpectedMachineUpdateRequest struct {
-	ID                       string            `json:"id,omitempty"` // Required for batch operations
+	ID string `json:"id,omitempty"` // Required for batch operations
+	// Deprecated: BmcMacAddress may reassert the current BMC MAC but cannot
+	// change it.
 	BmcMacAddress            *string           `json:"bmcMacAddress"`
 	BmcUsername              *string           `json:"bmcUsername"`
 	BmcPassword              *string           `json:"bmcPassword"`

--- a/rest-api/sdk/standard/model_expected_machine_update_request.go
+++ b/rest-api/sdk/standard/model_expected_machine_update_request.go
@@ -24,7 +24,8 @@ var _ MappedNullable = &ExpectedMachineUpdateRequest{}
 type ExpectedMachineUpdateRequest struct {
 	// ID of the Expected Machine to update.  Optional for individual Expected Machine update (ignored if provided, ID from URL path is used).  Required for batch update operations.
 	Id NullableString `json:"id,omitempty"`
-	// MAC address of the Expected Machine's BMC (Baseboard Management Controller)
+	// The Expected Machine's BMC MAC address is immutable after creation. Omit this field, or provide another case/separator spelling of the current MAC as a compatibility no-op.
+	// Deprecated
 	BmcMacAddress NullableString `json:"bmcMacAddress,omitempty" validate:"regexp=^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"`
 	// Username for accessing the Expected Machine's BMC
 	DefaultBmcUsername NullableString `json:"defaultBmcUsername,omitempty"`
@@ -123,6 +124,7 @@ func (o *ExpectedMachineUpdateRequest) UnsetId() {
 }
 
 // GetBmcMacAddress returns the BmcMacAddress field value if set, zero value otherwise (both if not set or set to explicit null).
+// Deprecated
 func (o *ExpectedMachineUpdateRequest) GetBmcMacAddress() string {
 	if o == nil || IsNil(o.BmcMacAddress.Get()) {
 		var ret string
@@ -134,6 +136,7 @@ func (o *ExpectedMachineUpdateRequest) GetBmcMacAddress() string {
 // GetBmcMacAddressOk returns a tuple with the BmcMacAddress field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned
+// Deprecated
 func (o *ExpectedMachineUpdateRequest) GetBmcMacAddressOk() (*string, bool) {
 	if o == nil {
 		return nil, false
@@ -151,6 +154,7 @@ func (o *ExpectedMachineUpdateRequest) HasBmcMacAddress() bool {
 }
 
 // SetBmcMacAddress gets a reference to the given NullableString and assigns it to the BmcMacAddress field.
+// Deprecated
 func (o *ExpectedMachineUpdateRequest) SetBmcMacAddress(v string) {
 	o.BmcMacAddress.Set(&v)
 }


### PR DESCRIPTION
ExpectedMachine BMC MAC updates were accepted by REST even though Core treats the original MAC as machine identity. This could leave REST and Core disagreeing after an otherwise successful PATCH.

This rejects physical MAC changes before any write or workflow while allowing omitted or format-equivalent values for compatibility. Internal inventory reconciliation remains intact, Core always receives the stored MAC, and the update field is now marked deprecated across the REST API and SDKs.

## Related issues

- Fixes #4300
- Part of #3491
- Complements #4283, which adds the matching Core-side guard

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

Existing clients can omit `bmcMacAddress` or reassert the same physical MAC with different case or separators. Requests that attempt to replace the ExpectedMachine identity now return HTTP 400 instead of leaving REST and Core with different MACs.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with focused handler and SDK compilation, affected-package and full Go vet, REST lint, OpenAPI validation, nightly formatting, workspace Clippy, custom Carbide lints, and whitespace checks.

## Additional Notes

- No database migration is required.
- The database-backed handler cases compile locally but could not execute because PostgreSQL was unavailable and the local Docker socket was inaccessible; CI will run them.
- The REST update field remains available for source compatibility, while internal DAO-level MAC updates remain available for inventory reconciliation.

Closes #4300
