### PR TITLE
feat(flow): default compute to nico and expected-inventory sync on

### DIFF
--- a/rest-api/flow/docs/component-manager-config.md
+++ b/rest-api/flow/docs/component-manager-config.md
@@ -46,7 +46,7 @@ Available implementations:
 
 | Component Type | Available Implementations | Description |
 |----------------|---------------------------|-------------|
-| `compute` | `nicolegacy`, `nico`, `mock` | Manages compute nodes. `nicolegacy` (current default) calls NICo Core's machine-centric RPCs (`AdminPowerControl`, `SetFirmwareUpdateTimeWindow`, ...). `nico` routes through Core's Component Manager dispatch (`ComponentPowerControl`, `UpdateComponentFirmware`, ...) like nvswitch and powershelf already do. See [Selecting the compute implementation](#selecting-the-compute-implementation) for the migration knob. |
+| `compute` | `nicolegacy`, `nico`, `mock` | Manages compute nodes. `nico` (current default) routes through Core's Component Manager dispatch (`ComponentPowerControl`, `UpdateComponentFirmware`, ...) like nvswitch and powershelf already do. `nicolegacy` calls NICo Core's machine-centric RPCs (`AdminPowerControl`, `SetFirmwareUpdateTimeWindow`, ...). See [Selecting the compute implementation](#selecting-the-compute-implementation) for the override knob. |
 | `nvswitch` | `nico`, `mock` | Manages NVLink switches |
 | `powershelf` | `nico`, `mock` | Manages power shelves |
 
@@ -100,14 +100,9 @@ Duration strings use Go format: `30s`, `1m`, `2m30s`, etc.
 ```yaml
 # Equivalent to builtin.LoadConfig("")
 component_managers:
-  compute: nicolegacy
+  compute: nico
   nvswitch: nico
   powershelf: nico
-
-manager_configs:
-  compute:
-    nicolegacy:
-      compute_power_delay: "2s"
 
 providers:
   nico:
@@ -183,25 +178,25 @@ Compute currently has two NICo-backed implementations:
 
 | Implementation | RPC path | Notes |
 |----------------|----------|-------|
-| `nicolegacy` (default) | `AdminPowerControl`, `UpdatePowerOption`, `SetMachineAutoUpdate`, `SetFirmwareUpdateTimeWindow` | Existing machine-centric path. Honours `manager_configs.compute.nicolegacy.compute_power_delay` and the legacy `start_time` / `end_time` firmware window. |
-| `nico` | `ComponentPowerControl`, `GetComponentInventory`, `UpdateComponentFirmware`, `GetComponentFirmwareStatus` | New Component Manager dispatch path, identical to `nvswitch/nico` and `powershelf/nico`. Honours `info.SubTargets` (BMC, BIOS, ...) and forwards `target_version` verbatim to Core (the SoT firmware-object identifier). Does **not** consume the firmware time window — Core dispatches immediately. Requires Core to be configured with `compute_tray_use_state_controller=true` (see `crates/component-manager/src/config.rs`). |
+| `nico` (default) | `ComponentPowerControl`, `GetComponentInventory`, `UpdateComponentFirmware`, `GetComponentFirmwareStatus` | Component Manager dispatch path, identical to `nvswitch/nico` and `powershelf/nico`. Honours `info.SubTargets` (BMC, BIOS, ...) and forwards `target_version` verbatim to Core (the SoT firmware-object identifier). Does **not** consume the firmware time window — Core dispatches immediately. Requires Core to be configured with `compute_tray_use_state_controller=true` (see `crates/component-manager/src/config.rs`). |
+| `nicolegacy` | `AdminPowerControl`, `UpdatePowerOption`, `SetMachineAutoUpdate`, `SetFirmwareUpdateTimeWindow` | Legacy machine-centric path. Honours `manager_configs.compute.nicolegacy.compute_power_delay` and the legacy `start_time` / `end_time` firmware window. Opt-in via `COMPONENT_MANAGER_COMPUTE=nicolegacy`. |
 
-To flip a deployment from the legacy path to the Component Manager path
-without shipping a separate component manager YAML, set the
-`COMPONENT_MANAGER_COMPUTE` environment variable on the Flow service:
+To flip a deployment back to the legacy machine-centric path without shipping
+a separate component manager YAML, set the `COMPONENT_MANAGER_COMPUTE`
+environment variable on the Flow service:
 
 ```bash
-# Use the new Component Manager-based path
+# Use the Component Manager-based path (same as the embedded default)
 COMPONENT_MANAGER_COMPUTE=nico
 
-# Use the legacy machine-centric path (same as the embedded default)
+# Use the legacy machine-centric path
 COMPONENT_MANAGER_COMPUTE=nicolegacy
 ```
 
 The override is consumed by `flow serve` after the base config is
 loaded and replaces only the `compute` entry in `component_managers`.
 An invalid value surfaces as a normal startup failure during catalog
-validation. Once every Flow deployment has been flipped to `nico` the
+validation. Once every Flow deployment no longer needs `nicolegacy` the
 override and the `compute/nicolegacy` package will be removed.
 
 ## Timing Parameters

--- a/rest-api/flow/docs/flow-architecture.md
+++ b/rest-api/flow/docs/flow-architecture.md
@@ -357,8 +357,8 @@ type ComponentManager interface {
 
 | Component Type | Implementation | Provider | Notes |
 |----------------|----------------|----------|-------|
-| Compute | `compute/nicolegacy/` | NICo | Current default. Drives compute trays through machine-centric NICo RPCs (`AdminPowerControl`, `SetFirmwareUpdateTimeWindow`). |
-| Compute | `compute/nico/` | NICo | New, opt-in via `COMPONENT_MANAGER_COMPUTE=nico`. Drives compute trays through Core's Component Manager dispatch (`ComponentPowerControl`, `UpdateComponentFirmware`), the same path as nvswitch and powershelf. |
+| Compute | `compute/nico/` | NICo | Current default. Drives compute trays through Core's Component Manager dispatch (`ComponentPowerControl`, `UpdateComponentFirmware`), the same path as nvswitch and powershelf. |
+| Compute | `compute/nicolegacy/` | NICo | Legacy opt-in via `COMPONENT_MANAGER_COMPUTE=nicolegacy`. Drives compute trays through machine-centric NICo RPCs (`AdminPowerControl`, `SetFirmwareUpdateTimeWindow`). |
 | NVSwitch | `nvswitch/nico/` | NICo | |
 | PowerShelf | `powershelf/nico/` | NICo | |
 
@@ -666,14 +666,9 @@ Stores task execution records.
 
 ```yaml
 component_managers:
-  compute: nicolegacy
+  compute: nico
   nvswitch: nico
   powershelf: nico
-
-manager_configs:
-  compute:
-    nicolegacy:
-      compute_power_delay: "2s"
 
 providers:
   nico:

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/job.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/job.go
@@ -21,11 +21,11 @@ import (
 
 // envExpectedSyncEnabled gates the expected-inventory mirror that runs at
 // the start of each inventory cycle (see expected_mirror*.go). Default is
-// "off": Flow keeps using its existing ingestion path until an operator
-// opts in. Accepted truthy values are anything strconv.ParseBool accepts
-// (1, t, T, true, True, TRUE, ...). An unset, empty, or unparseable value
-// resolves to disabled — the conservative default given the mirror writes
-// directly to the rack / component tables.
+// "on": an unset or empty value enables the mirror. Accepted values are
+// anything strconv.ParseBool accepts (1, t, T, true, True, TRUE, 0, false,
+// ...). An unparseable value resolves to disabled with a warning so a
+// typo cannot silently leave the gate in an ambiguous state. Set the
+// variable to false/0/f to opt out.
 const envExpectedSyncEnabled = "FLOW_EXPECTED_INVENTORY_SYNC_ENABLED"
 
 // Job implements scheduler.Job for the inventory sync task.
@@ -39,7 +39,7 @@ type Job struct {
 func readExpectedSyncEnabled() bool {
 	raw := os.Getenv(envExpectedSyncEnabled)
 	if raw == "" {
-		return false
+		return true
 	}
 	enabled, err := strconv.ParseBool(raw)
 	if err != nil {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/job_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/job_test.go
@@ -10,15 +10,14 @@ import (
 )
 
 func TestReadExpectedSyncEnabled(t *testing.T) {
-	// The mirror writes to rack / component tables, so the default has to
-	// be off — an operator should have to opt in explicitly. These cases
-	// pin both the truthy / falsy ParseBool grammar and the
-	// "unparseable / unset is conservatively off" guarantee.
+	// Default is on when the env var is unset/empty. Operators opt out
+	// with an explicit falsey value. Unparseable values stay disabled
+	// so a typo cannot silently enable or leave the gate ambiguous.
 	for _, tc := range []struct {
 		raw  string
 		want bool
 	}{
-		{"", false},    // unset env var
+		{"", true},     // unset / empty env var
 		{"true", true}, // canonical truthy
 		{"True", true}, // ParseBool accepts mixed case
 		{"TRUE", true}, // and upper case

--- a/rest-api/flow/internal/task/componentmanager/builtin/builtin_test.go
+++ b/rest-api/flow/internal/task/componentmanager/builtin/builtin_test.go
@@ -83,14 +83,14 @@ func (c testServiceProviderConfig) NewProvider(context.Context) (providerapi.Pro
 func TestDefaultServiceComponentManagers(t *testing.T) {
 	componentManagers := defaultServiceComponentManagers()
 
-	assert.Equal(t, computenicolegacy.ImplementationName, componentManagers[devicetypes.ComponentTypeCompute])
+	assert.Equal(t, computenico.ImplementationName, componentManagers[devicetypes.ComponentTypeCompute])
 	assert.Equal(t, nvswitchnico.ImplementationName, componentManagers[devicetypes.ComponentTypeNVSwitch])
 	assert.Equal(t, powershelfnico.ImplementationName, componentManagers[devicetypes.ComponentTypePowerShelf])
 
 	componentManagers[devicetypes.ComponentTypeCompute] = "mutated"
 	assert.Equal(
 		t,
-		computenicolegacy.ImplementationName,
+		computenico.ImplementationName,
 		defaultServiceComponentManagers()[devicetypes.ComponentTypeCompute],
 	)
 }
@@ -110,13 +110,10 @@ func TestLoadConfigUsesDefaultsWithoutPath(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, nicoprovider.DefaultTimeout, nicoConfig.Timeout)
 
-	computeConfig, ok := config.ManagerConfigs[computenicolegacy.Descriptor().Identity()].(*computenicolegacy.Config)
-	require.True(t, ok)
-	assert.Equal(
-		t,
-		computenicolegacy.DefaultComputePowerDelay,
-		computeConfig.ComputePowerDelay,
-	)
+	// compute/nico has no manager-specific config decoder; nicolegacy's
+	// manager config is only completed when that implementation is selected.
+	_, hasLegacyComputeConfig := config.ManagerConfigs[computenicolegacy.Descriptor().Identity()]
+	assert.False(t, hasLegacyComputeConfig)
 }
 
 func TestLoadConfigUsesAuthoritativeFile(t *testing.T) {

--- a/rest-api/flow/internal/task/componentmanager/builtin/manifest.go
+++ b/rest-api/flow/internal/task/componentmanager/builtin/manifest.go
@@ -27,7 +27,7 @@ import (
 // file. A configured file is authoritative and does not merge with this map.
 func defaultServiceComponentManagers() map[devicetypes.ComponentType]string {
 	return map[devicetypes.ComponentType]string{
-		devicetypes.ComponentTypeCompute:    computenicolegacy.ImplementationName,
+		devicetypes.ComponentTypeCompute:    computenico.ImplementationName,
 		devicetypes.ComponentTypeNVSwitch:   nvswitchnico.ImplementationName,
 		devicetypes.ComponentTypePowerShelf: powershelfnico.ImplementationName,
 	}

--- a/rest-api/flow/internal/task/componentmanager/compute/nico/nico.go
+++ b/rest-api/flow/internal/task/componentmanager/compute/nico/nico.go
@@ -22,11 +22,11 @@
 // Component Manager equivalents in Core; they continue to call the
 // existing machine-level RPCs that the legacy path used.
 //
-// During the migration the embedded service config keeps compute pointed
-// at compute/nicolegacy by default. Operators flip the
-// COMPONENT_MANAGER_COMPUTE environment variable to "nico" once the
-// matching Core configuration (compute_tray_use_state_controller / SoT
-// firmware objects) is in place.
+// The embedded service config selects this implementation by default.
+// Operators can still opt back into compute/nicolegacy via
+// COMPONENT_MANAGER_COMPUTE=nicolegacy. Core must be configured with
+// compute_tray_use_state_controller=true (and SoT firmware objects) for
+// this path to work.
 package nico
 
 import (


### PR DESCRIPTION
## Description

- Flip Flow's embedded compute component-manager default from `nicolegacy` to `nico`, so the default compute tray path matches nvswitch/powershelf Component Manager dispatch ([#3809](https://github.com/NVIDIA/infra-controller/issues/3809)).
- Default `FLOW_EXPECTED_INVENTORY_SYNC_ENABLED` to on when unset/empty; operators can still opt out with `false`/`0`/`f`. Unparseable values remain disabled with a warning.
 

## Related issues

- Related to #3809
- Related to #4313

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [x] **This PR contains breaking changes**
 
## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 