### PR TITLE
fix(ci): make merge-result gate compatible with sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1412,7 +1412,6 @@ jobs:
 
       - name: Build pull request merge result
         run: |
-          set -euo pipefail
           git fetch --no-tags origin main:refs/remotes/origin/main
           git merge --no-commit --no-ff origin/main
 


### PR DESCRIPTION
PR #4295 added Bash-only `set -euo pipefail` to a container step executed with `sh -e`, causing `lint-police` to fail before either Git command runs.

Remove the redundant shell option line. The runner already enables `-e`, and the step contains no pipeline.

## Related issues

Follow-up to #4295.

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Manual testing performed

- Exact merge step succeeds under `sh -e`
- End-to-end simulation on PR #4219 real stale head passed merge, `cargo metadata --locked`, and repository-clean checks
- `actionlint` v1.7.12
- YAML parse validation
- `cargo metadata --locked --no-deps --format-version 1`
- `CARGO_HOME="$HOME/.cargo" cargo make --no-workspace clippy-flow` passed on Linux in 240.66 seconds