### PR TITLE
fix(preingestion): stop counting a declined multipart route as an upload failure

### DIFF
--- a/crates/preingestion-manager/src/lib.rs
+++ b/crates/preingestion-manager/src/lib.rs
@@ -3347,8 +3347,6 @@ impl PreingestionManagerStatic {
                 }
                 Err(RedfishError::NotSupported(err)) => {
                     emit(MultipartFirmwareUploadUnsupported {
-                        method: FirmwareUploadMethod::Multipart,
-                        outcome: Outcome::Error,
                         bmc_ip_address: endpoint_clone.address,
                         error: err,
                     });

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -174,11 +174,10 @@ pub(crate) enum FirmwareUploadMethod {
     HttpPush,
 }
 
-/// A preingestion firmware upload to a BMC finished. Every outcome updates the
-/// counter; failures also own the route-specific log line.
-/// A multipart attempt a BMC rejects as unsupported uses the sibling
-/// [`MultipartFirmwareUploadUnsupported`] Event so that its distinct fallback
-/// message retains the same `multipart,error` metric labels.
+/// A preingestion firmware upload to a BMC finished. Every result updates the
+/// counter; failures also own the route-specific log line. A multipart route a
+/// BMC declines is not an upload result and does not reach this counter -- refer
+/// to [`MultipartFirmwareUploadUnsupported`].
 #[derive(Event)]
 #[event(
     event_name = "preingestion_firmware_upload_finished",
@@ -229,26 +228,20 @@ impl DynamicMessage for FirmwareUploadFinished {
     }
 }
 
-/// A multipart upload was rejected as unsupported and will fall back to
-/// HttpPushUri. It shares the existing upload counter with
-/// [`FirmwareUploadFinished`] while retaining the fallback-specific WARN
-/// message. Its metric description must remain identical to the sibling
-/// Event's because both register the same counter.
+/// A BMC declined the multipart route, so the upload falls back to
+/// `HttpPushUri`. Declining a route is not an upload result: the upload has not
+/// failed and its real result arrives on the following `http_push`
+/// [`FirmwareUploadFinished`]. This Event is therefore the WARN alone, so a
+/// fallback never counts against the multipart failure series.
 #[derive(Event)]
 #[event(
     event_name = "preingestion_firmware_upload_multipart_unsupported",
-    metric_name = "carbide_preingestion_firmware_upload_total",
     component = "preingestion-manager",
     log = warn,
-    metric = counter,
-    message = "Multipart firmware update is not supported; trying HttpPushUri",
-    describe = "Number of preingestion firmware uploads to a BMC, by upload method and outcome."
+    metric = none,
+    message = "Multipart firmware update is not supported; trying HttpPushUri"
 )]
 pub(crate) struct MultipartFirmwareUploadUnsupported {
-    #[label]
-    pub method: FirmwareUploadMethod,
-    #[label]
-    pub outcome: Outcome,
     /// The BMC whose multipart route rejected the upload.
     #[context]
     pub bmc_ip_address: IpAddr,
@@ -898,13 +891,7 @@ mod tests {
     }
 
     #[derive(Clone, Copy)]
-    enum FirmwareUploadEventKind {
-        Finished,
-        MultipartUnsupported,
-    }
-
     struct FirmwareUploadInput {
-        kind: FirmwareUploadEventKind,
         method: FirmwareUploadMethod,
         outcome: Outcome,
         error: &'static str,
@@ -934,21 +921,13 @@ mod tests {
         let bmc_ip_address = IpAddr::from([10, 0, 0, 5]);
         let method_label = input.method.label_value();
         let outcome_label = input.outcome.label_value();
-        let logs = capture_logs(|| match input.kind {
-            FirmwareUploadEventKind::Finished => emit(FirmwareUploadFinished {
+        let logs = capture_logs(|| {
+            emit(FirmwareUploadFinished {
                 method: input.method,
                 outcome: input.outcome,
                 bmc_ip_address,
                 error: input.error.to_string(),
-            }),
-            FirmwareUploadEventKind::MultipartUnsupported => {
-                emit(MultipartFirmwareUploadUnsupported {
-                    method: input.method,
-                    outcome: input.outcome,
-                    bmc_ip_address,
-                    error: input.error.to_string(),
-                });
-            }
+            });
         })
         .into_iter()
         .map(|log| {
@@ -1023,7 +1002,6 @@ mod tests {
                 Check {
                     scenario: "SimpleUpdate success",
                     input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::Finished,
                         method: FirmwareUploadMethod::SimpleUpdate,
                         outcome: Outcome::Ok,
                         error: "",
@@ -1038,7 +1016,6 @@ mod tests {
                 Check {
                     scenario: "SimpleUpdate failure",
                     input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::Finished,
                         method: FirmwareUploadMethod::SimpleUpdate,
                         outcome: Outcome::Error,
                         error: "simple update failed",
@@ -1055,62 +1032,8 @@ mod tests {
                     ),
                 },
                 Check {
-                    scenario: "multipart success",
-                    input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::Finished,
-                        method: FirmwareUploadMethod::Multipart,
-                        outcome: Outcome::Ok,
-                        error: "",
-                    },
-                    expect: expected_firmware_upload(
-                        FirmwareUploadMethod::Multipart,
-                        Outcome::Ok,
-                        "",
-                        None,
-                    ),
-                },
-                Check {
-                    scenario: "multipart failure",
-                    input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::Finished,
-                        method: FirmwareUploadMethod::Multipart,
-                        outcome: Outcome::Error,
-                        error: "multipart upload failed",
-                    },
-                    expect: expected_firmware_upload(
-                        FirmwareUploadMethod::Multipart,
-                        Outcome::Error,
-                        "multipart upload failed",
-                        Some((
-                            tracing::Level::WARN,
-                            "preingestion_firmware_upload_finished",
-                            "Failed to upload firmware via multipart update",
-                        )),
-                    ),
-                },
-                Check {
-                    scenario: "multipart unsupported",
-                    input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::MultipartUnsupported,
-                        method: FirmwareUploadMethod::Multipart,
-                        outcome: Outcome::Error,
-                        error: "multipart is unsupported",
-                    },
-                    expect: expected_firmware_upload(
-                        FirmwareUploadMethod::Multipart,
-                        Outcome::Error,
-                        "multipart is unsupported",
-                        Some((
-                            tracing::Level::WARN,
-                            "preingestion_firmware_upload_multipart_unsupported",
-                            "Multipart firmware update is not supported; trying HttpPushUri",
-                        )),
-                    ),
-                },
-                Check {
                     scenario: "HttpPush success",
                     input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::Finished,
                         method: FirmwareUploadMethod::HttpPush,
                         outcome: Outcome::Ok,
                         error: "",
@@ -1125,7 +1048,6 @@ mod tests {
                 Check {
                     scenario: "HttpPush failure",
                     input: FirmwareUploadInput {
-                        kind: FirmwareUploadEventKind::Finished,
                         method: FirmwareUploadMethod::HttpPush,
                         outcome: Outcome::Error,
                         error: "HTTP push failed",
@@ -1146,15 +1068,14 @@ mod tests {
         );
     }
 
-    /// An unsupported multipart attempt counts as its own error before the
-    /// `HttpPush` fallback records a second, independent attempt.
+    /// A declined multipart route writes its WARN and leaves the upload counter
+    /// alone: the fallback that follows records the upload's only result, so the
+    /// multipart failure series stays a count of real multipart failures.
     #[test]
-    fn unsupported_multipart_preserves_the_http_push_fallback_sequence() {
+    fn a_declined_multipart_route_does_not_count_as_an_upload_failure() {
         let metrics = MetricsCapture::start();
         let logs = capture_logs(|| {
             emit(MultipartFirmwareUploadUnsupported {
-                method: FirmwareUploadMethod::Multipart,
-                outcome: Outcome::Error,
                 bmc_ip_address: IpAddr::from([10, 0, 0, 6]),
                 error: "multipart is unsupported".to_string(),
             });
@@ -1166,13 +1087,24 @@ mod tests {
             });
         });
 
-        assert_eq!(logs.len(), 1, "only unsupported multipart logs: {logs:?}");
+        assert_eq!(logs.len(), 1, "only the declined route logs: {logs:?}");
+        assert_eq!(logs[0].level, tracing::Level::WARN);
+        assert_eq!(
+            logs[0].field("event_name"),
+            Some("preingestion_firmware_upload_multipart_unsupported"),
+        );
+        assert_eq!(
+            logs[0].field("metric_name"),
+            None,
+            "a declined route records no metric",
+        );
         assert_eq!(
             metrics.counter_delta(
                 "carbide_preingestion_firmware_upload_total",
                 &[("method", "multipart"), ("outcome", "error")],
             ),
-            1.0,
+            0.0,
+            "the fallback must not count against multipart failures",
         );
         assert_eq!(
             metrics.counter_delta(
@@ -1180,6 +1112,7 @@ mod tests {
                 &[("method", "http_push"), ("outcome", "ok")],
             ),
             1.0,
+            "the upload's real result is the one the counter records",
         );
     }
 


### PR DESCRIPTION
When a BMC refuses a multipart firmware upload, preingestion falls back to `HttpPushUri` and the upload succeeds. The counter said otherwise -- one successful upload recorded both of these:

```
carbide_preingestion_firmware_upload_total{method="multipart", outcome="error"}  +1
carbide_preingestion_firmware_upload_total{method="http_push",  outcome="ok"}    +1
```

Graph multipart failures across a fleet with a lot of BMCs that do not implement multipart and the number is mostly fiction. `outcome` is meant to mean the same thing everywhere, and here it did not.

The root of it is that `(multipart, error)` had to mean two opposite things: a multipart upload that genuinely failed and ended the operation, and a multipart route the BMC declined before the upload succeeded another way. `MultipartFirmwareUploadUnsupported` existed only to give the second case its own WARN wording, which is why the two Events had identical fields and nothing at a call site told you which to reach for.

A refused route is not an upload result, so it comes off the upload counter. `MultipartFirmwareUploadUnsupported` becomes `metric = none` and drops `method` and `outcome` -- labels it only ever declared in order to reach the counter -- while keeping its WARN, its message, and its context unchanged. `FirmwareUploadFinished` becomes the counter's only declaring Event, so `(multipart, error)` now means a real multipart failure and the metric stays an inline declaration with no family needed.

The two Events also stop looking alike, because they stop being alike: `metric = none` says which is which at a glance, and there is now exactly one struct that can produce `(multipart, error)`.

**The metric contract:** same name, same label keys, same description. What changes is that one series stops being incremented for a case that was never a failure. Anyone alerting on `{method="multipart",outcome="error"}` will see that number drop to the real multipart failure rate, which is the point.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4321

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`unsupported_multipart_preserves_the_http_push_fallback_sequence` asserted the old behavior in both its name and its doc comment ("An unsupported multipart attempt counts as its own error"), so it is replaced by `a_declined_multipart_route_does_not_count_as_an_upload_failure`. It pins the WARN, the now-absent `metric_name` on that log line, a **zero** delta on `{method="multipart",outcome="error"}`, and the `{method="http_push",outcome="ok"}` increment that records the upload's real result.

I confirmed it fails without the fix rather than trusting that it would:

```
left: Some("carbide_preingestion_firmware_upload_total")
right: None
```

The table-driven upload test now covers `FirmwareUploadFinished` alone, since the two Events no longer share a log surface.

Battery: `carbide-preingestion-manager` 34 tests (20 unit + 14 integration), `format-nightly` + `check-format-nightly` + `clippy` + `carbide-lints` clean, `lint-error-messages` clean, and both `check-metric-docs` (151 documented, one fewer declaration exactly as expected) and `check-event-names` green.

## Additional Notes

Found while scoping the `MetricFamily` sweep in #4310: this metric looked like a family candidate, and working out why its two Events had identical fields turned up the miscount instead. Two sibling findings from the same sweep are still open for a later PR -- `carbide_dhcp_requests_total` ships two different label dimensionalities, and `carbide_ib_monitor_partial_failures_total` feeds one label from two different enums.


Closes #4321
