### PR TITLE
Rack-scale decommissioning with NICo flow

### DIFF
--- a/crates/admin-cli/src/machine/decommission/args.rs
+++ b/crates/admin-cli/src/machine/decommission/args.rs
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use clap::Parser;
+use rpc::forge::{AdminDecommissionMachineRequest, AdminDecommissionSiteRequest};
+
+/// Decommission a single machine (must be in Ready state).
+#[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Decommission a single machine (by UUID, IPv4, MAC, or hostname):
+    $ nico-admin-cli machine decommission machine --machine 12345678-1234-5678-90ab-cdef01234567
+
+")]
+pub struct MachineArgs {
+    #[clap(
+        long,
+        help = "UUID, IPv4, MAC, or hostname of the host or its attached DPU"
+    )]
+    pub machine: String,
+}
+
+impl From<&MachineArgs> for AdminDecommissionMachineRequest {
+    fn from(args: &MachineArgs) -> Self {
+        Self {
+            host_query: args.machine.clone(),
+        }
+    }
+}
+
+/// Decommission all machines at the site.
+#[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Decommission the entire site (disables ingestion and begins decommissioning all Ready machines):
+    $ nico-admin-cli machine decommission site
+
+")]
+pub struct SiteArgs {}
+
+impl From<&SiteArgs> for AdminDecommissionSiteRequest {
+    fn from(_: &SiteArgs) -> Self {
+        Self {}
+    }
+}

--- a/crates/admin-cli/src/machine/decommission/cmd.rs
+++ b/crates/admin-cli/src/machine/decommission/cmd.rs
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::errors::CarbideCliResult;
+use crate::rpc::ApiClient;
+
+use super::args::{MachineArgs, SiteArgs};
+
+pub async fn decommission_machine(args: MachineArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req = rpc::forge::AdminDecommissionMachineRequest::from(&args);
+    let response = api_client.0.admin_decommission_machine(req).await?;
+    println!(
+        "Decommission initiated for machine {}. The machine will progress through BMC reset, \
+         credential deletion, and MAC blocking before being removed.",
+        response.machine_id,
+    );
+    Ok(())
+}
+
+pub async fn decommission_site(args: SiteArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let req = rpc::forge::AdminDecommissionSiteRequest::from(&args);
+    let response = api_client.0.admin_decommission_site(req).await?;
+    println!(
+        "Site decommission initiated.\n  \
+         Machines immediately decommissioned (were Ready): {}\n  \
+         Machines pending decommission (PreventAllocations applied): {}",
+        response.machines_started, response.machines_pending,
+    );
+    Ok(())
+}

--- a/crates/admin-cli/src/machine/decommission/mod.rs
+++ b/crates/admin-cli/src/machine/decommission/mod.rs
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod args;
+pub mod cmd;
+
+use clap::Parser;
+
+use crate::cfg::dispatch::Dispatch;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+#[derive(Parser, Debug, Dispatch)]
+#[command(about = "Decommission a machine or the entire site")]
+pub enum Args {
+    #[clap(about = "Decommission a single machine (must be in Ready state)")]
+    Machine(args::MachineArgs),
+    #[clap(about = "Decommission all machines at the site")]
+    Site(args::SiteArgs),
+}
+
+impl Run for args::MachineArgs {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::decommission_machine(self, &ctx.api_client).await
+    }
+}
+
+impl Run for args::SiteArgs {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        cmd::decommission_site(self, &ctx.api_client).await
+    }
+}

--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod auto_update;
 pub mod common;
+pub mod decommission;
 pub mod force_delete;
 pub mod hardware_info;
 pub mod health_report;
@@ -66,6 +67,8 @@ pub enum Cmd {
     Reboot(reboot::Args),
     #[clap(about = "Force delete a machine")]
     ForceDelete(force_delete::Args),
+    #[clap(subcommand, about = "Decommission a machine or the entire site")]
+    Decommission(decommission::Args),
     #[clap(about = "Set individual machine firmware autoupdate (host only)")]
     AutoUpdate(auto_update::Args),
     #[clap(subcommand, about = "Edit Metadata associated with a Machine")]

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -1160,6 +1160,20 @@ impl Forge for Api {
         crate::handlers::machine::admin_force_delete_machine(self, request).await
     }
 
+    async fn admin_decommission_machine(
+        &self,
+        request: Request<rpc::AdminDecommissionMachineRequest>,
+    ) -> Result<Response<rpc::AdminDecommissionMachineResponse>, Status> {
+        crate::handlers::machine::admin_decommission_machine(self, request).await
+    }
+
+    async fn admin_decommission_site(
+        &self,
+        request: Request<rpc::AdminDecommissionSiteRequest>,
+    ) -> Result<Response<rpc::AdminDecommissionSiteResponse>, Status> {
+        crate::handlers::machine::admin_decommission_site(self, request).await
+    }
+
     /// Example TOML data in request.text:
     ///
     /// [lo-ip]

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -16,6 +16,8 @@
  */
 
 use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::atomic::Ordering;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
@@ -23,10 +25,15 @@ use ::rpc::model::machine::ManagedHostStateSnapshotRpc;
 use carbide_redfish::libredfish::RedfishAuth;
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
 use carbide_uuid::machine::MachineId;
+use health_report::{
+    HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthReport, HealthReportApplyMode,
+};
 use libredfish::SystemPowerControl;
 use model::hardware_info::MachineNvLinkInfo;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{LoadSnapshotOptions, Machine, ManagedHostState, ManagedHostStateSnapshot};
+use model::machine::{
+    DecommissionState, LoadSnapshotOptions, Machine, ManagedHostState, ManagedHostStateSnapshot,
+};
 use model::metadata::Metadata;
 use tonic::{Request, Response, Status};
 
@@ -974,4 +981,171 @@ pub(crate) async fn update_machine_nv_link_info(
     txn.commit().await?;
 
     Ok(tonic::Response::new(()))
+}
+
+const DECOMMISSION_HEALTH_SOURCE: &str = "decommission";
+
+/// Transition a single host machine (and all its DPUs) to
+/// `Decommissioning { Init }`.  The machine must be in the `Ready` state.
+pub(crate) async fn admin_decommission_machine(
+    api: &Api,
+    request: Request<rpc::AdminDecommissionMachineRequest>,
+) -> Result<Response<rpc::AdminDecommissionMachineResponse>, Status> {
+    log_request_data(&request);
+    let request = request.into_inner();
+
+    let mut txn = api.txn_begin().await?;
+
+    let machine = match db::machine::find_by_query(&mut txn, &request.host_query).await? {
+        Some(m) => m,
+        None => {
+            return Err(CarbideError::NotFound(format!(
+                "machine not found: {}",
+                request.host_query
+            ))
+            .into());
+        }
+    };
+    log_machine_id(&machine.id);
+
+    let host_machine;
+    let dpu_machines;
+    if machine.is_dpu() {
+        if let Some(host) = db::machine::find_host_by_dpu_machine_id(&mut txn, &machine.id).await?
+        {
+            dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &host.id).await?;
+            host_machine = host;
+        } else {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "DPU {} has no associated host machine",
+                machine.id
+            ))
+            .into());
+        }
+    } else {
+        dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine.id).await?;
+        host_machine = machine;
+    }
+
+    if !matches!(host_machine.state.value, ManagedHostState::Ready) {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "machine {} is in state {} but must be Ready to be decommissioned",
+            host_machine.id, host_machine.state.value
+        ))
+        .into());
+    }
+
+    let decommission_state = ManagedHostState::Decommissioning {
+        decommission_state: DecommissionState::Init,
+    };
+    db::machine::advance(&host_machine, &mut txn, &decommission_state, None).await?;
+    for dpu in &dpu_machines {
+        db::machine::advance(dpu, &mut txn, &decommission_state, None).await?;
+    }
+
+    let machine_id = host_machine.id.to_string();
+    txn.commit().await?;
+
+    tracing::info!(
+        machine_id,
+        dpu_count = dpu_machines.len(),
+        "Decommission initiated for machine",
+    );
+
+    Ok(Response::new(rpc::AdminDecommissionMachineResponse { machine_id }))
+}
+
+/// Disable new machine ingestion and begin decommissioning all host machines
+/// that are currently in the `Ready` state.  Machines in other states receive
+/// a `PreventAllocations` health alert and will be decommissioned automatically
+/// once the state controller drains them to `Ready`.
+pub(crate) async fn admin_decommission_site(
+    api: &Api,
+    request: Request<rpc::AdminDecommissionSiteRequest>,
+) -> Result<Response<rpc::AdminDecommissionSiteResponse>, Status> {
+    log_request_data(&request);
+
+    // Disable new machine ingestion first so re-ingestion can't race decommission.
+    api.dynamic_settings
+        .create_machines
+        .store(false, Ordering::Relaxed);
+    tracing::info!("Decommission site: create_machines disabled");
+
+    let prevent_allocations_report = HealthReport {
+        source: DECOMMISSION_HEALTH_SOURCE.to_string(),
+        triggered_by: None,
+        observed_at: Some(chrono::Utc::now()),
+        alerts: vec![HealthProbeAlert {
+            id: HealthProbeId::from_str("DecommissionInProgress").expect("valid probe id"),
+            target: None,
+            in_alert_since: Some(chrono::Utc::now()),
+            message: "Machine is being decommissioned".to_string(),
+            tenant_message: None,
+            classifications: vec![HealthAlertClassification::prevent_allocations()],
+        }],
+        successes: vec![],
+    };
+
+    // Load host IDs without a transaction (cheap read, no write needed yet).
+    let host_ids = db::managed_host::load_host_ids(api.pg_pool()).await?;
+
+    let decommission_state = ManagedHostState::Decommissioning {
+        decommission_state: DecommissionState::Init,
+    };
+
+    let mut machines_started: u32 = 0;
+    let mut machines_pending: u32 = 0;
+
+    for host_id in &host_ids {
+        let mut txn = api.txn_begin().await?;
+
+        let host = match db::machine::find_one(api.pg_pool(), host_id, MachineSearchConfig::default()).await? {
+            Some(m) => m,
+            None => continue, // race: machine deleted between load_host_ids and now
+        };
+
+        if matches!(host.state.value, ManagedHostState::Ready) {
+            db::machine::advance(&host, &mut txn, &decommission_state, None).await?;
+            machines_started += 1;
+        } else {
+            db::machine::insert_health_report(
+                &mut txn,
+                &host.id,
+                HealthReportApplyMode::Merge,
+                &prevent_allocations_report,
+                false,
+            )
+            .await?;
+            machines_pending += 1;
+        }
+
+        let dpus = db::machine::find_dpus_by_host_machine_id(&mut txn, &host.id).await?;
+        for dpu in &dpus {
+            if matches!(host.state.value, ManagedHostState::Ready) {
+                db::machine::advance(dpu, &mut txn, &decommission_state, None).await?;
+            } else {
+                db::machine::insert_health_report(
+                    &mut txn,
+                    &dpu.id,
+                    HealthReportApplyMode::Merge,
+                    &prevent_allocations_report,
+                    false,
+                )
+                .await?;
+            }
+        }
+
+        txn.commit().await?;
+    }
+
+    tracing::info!(
+        machines_started,
+        machines_pending,
+        "Site decommission initiated",
+    );
+
+    Ok(Response::new(rpc::AdminDecommissionSiteResponse {
+        machines_started,
+        machines_pending,
+    }))
 }

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -428,6 +428,7 @@ impl TestEnv {
             ManagedHostState::WaitingForCleanup { .. } => state.clone(),
             ManagedHostState::Created => state.clone(),
             ManagedHostState::ForceDeletion => state.clone(),
+            ManagedHostState::Decommissioning { .. } => state.clone(),
             ManagedHostState::Failed {
                 details,
                 machine_id,

--- a/crates/api-db/migrations/20260724120000_ignored_macs.sql
+++ b/crates/api-db/migrations/20260724120000_ignored_macs.sql
@@ -1,0 +1,14 @@
+-- MAC addresses that the DHCP server should ignore.
+--
+-- When a BMC is decommissioned its MAC is inserted here so the DHCP server:
+--   * silently drops DHCPDISCOVER packets from the address, and
+--   * responds with DHCPNAK to any outstanding DHCPREQUEST.
+--
+-- machine_id is nullable: a MAC may be marked ignored before or after the
+-- corresponding machine record is removed from the database.
+CREATE TABLE ignored_macs (
+    mac_address  macaddr     NOT NULL PRIMARY KEY,
+    machine_id   uuid,
+    reason       text        NOT NULL DEFAULT '',
+    created_at   timestamptz NOT NULL DEFAULT now()
+);

--- a/crates/api-db/migrations/20260729120000_ignored_bmc_macs.sql
+++ b/crates/api-db/migrations/20260729120000_ignored_bmc_macs.sql
@@ -1,0 +1,20 @@
+-- BMC MAC addresses that NICo is actively suppressing during decommissioning.
+--
+-- suppress_site_explorer: Site Explorer must not start new exploration for this
+--   MAC. Once it has drained all queued/in-flight work it writes
+--   site_explorer_suppressed_at as an acknowledgement.
+--
+-- suppress_dhcp: the DHCP server must return DHCPNAK to DHCPREQUEST and no
+--   offer to DHCPDISCOVER. On the first suppressed DHCPDISCOVER it writes
+--   dhcp_discover_suppressed_at, proving the BMC DHCP client has returned to
+--   the INIT state.
+CREATE TABLE ignored_bmc_macs (
+    bmc_mac_address             macaddr     NOT NULL PRIMARY KEY,
+    reason                      text        NOT NULL,
+    suppress_site_explorer      boolean     NOT NULL DEFAULT FALSE,
+    site_explorer_suppressed_at timestamptz,
+    suppress_dhcp               boolean     NOT NULL DEFAULT FALSE,
+    dhcp_discover_suppressed_at timestamptz,
+    created_at                  timestamptz NOT NULL DEFAULT now(),
+    updated_at                  timestamptz NOT NULL DEFAULT now()
+);

--- a/crates/api-db/src/dhcp_record.rs
+++ b/crates/api-db/src/dhcp_record.rs
@@ -16,10 +16,11 @@
  */
 
 use carbide_network::ip::IpAddressFamily;
+use carbide_uuid::machine::MachineId;
 use carbide_uuid::network::NetworkSegmentId;
 use chrono::{DateTime, Utc};
 use mac_address::MacAddress;
-use model::dhcp_record::DhcpRecord;
+use model::dhcp_record::{DhcpRecord, IgnoredMac};
 use sqlx::PgConnection;
 
 use crate::DatabaseError;
@@ -52,6 +53,78 @@ pub async fn last_invalidation_time(
     let query = "SELECT last_deletion FROM machine_interfaces_deletion WHERE id = 1";
     sqlx::query_scalar(query)
         .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Check whether a MAC address is in the ignored list.
+pub async fn is_mac_ignored(
+    txn: &mut PgConnection,
+    mac_address: &MacAddress,
+) -> Result<bool, DatabaseError> {
+    let query = "SELECT EXISTS(SELECT 1 FROM ignored_macs WHERE mac_address = $1::macaddr)";
+    sqlx::query_scalar(query)
+        .bind(mac_address)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Insert a MAC address into the ignored list.
+///
+/// Silently succeeds if the MAC is already present (ON CONFLICT DO NOTHING).
+pub async fn ignore_mac(
+    txn: &mut PgConnection,
+    mac_address: &MacAddress,
+    machine_id: Option<&MachineId>,
+    reason: &str,
+) -> Result<(), DatabaseError> {
+    let query = "INSERT INTO ignored_macs (mac_address, machine_id, reason) \
+                 VALUES ($1::macaddr, $2, $3) ON CONFLICT DO NOTHING";
+    sqlx::query(query)
+        .bind(mac_address)
+        .bind(machine_id)
+        .bind(reason)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Remove a MAC address from the ignored list, returning whether it existed.
+pub async fn unignore_mac(
+    txn: &mut PgConnection,
+    mac_address: &MacAddress,
+) -> Result<bool, DatabaseError> {
+    let query = "DELETE FROM ignored_macs WHERE mac_address = $1::macaddr";
+    sqlx::query(query)
+        .bind(mac_address)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// List all ignored MACs, optionally filtering by machine ID.
+pub async fn list_ignored_macs(
+    txn: &mut PgConnection,
+    machine_id: Option<&MachineId>,
+) -> Result<Vec<IgnoredMac>, DatabaseError> {
+    let (query, bind_machine_id) = match machine_id {
+        Some(_) => (
+            "SELECT * FROM ignored_macs WHERE machine_id = $1::uuid ORDER BY created_at",
+            true,
+        ),
+        None => (
+            "SELECT * FROM ignored_macs ORDER BY created_at",
+            false,
+        ),
+    };
+    let mut q = sqlx::query_as(query);
+    if bind_machine_id {
+        q = q.bind(machine_id);
+    }
+    q.fetch_all(txn)
         .await
         .map_err(|e| DatabaseError::query(query, e))
 }

--- a/crates/api-db/src/ignored_bmc_mac.rs
+++ b/crates/api-db/src/ignored_bmc_mac.rs
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use mac_address::MacAddress;
+use model::ignored_bmc_mac::IgnoredBmcMac;
+use sqlx::{PgConnection, PgPool};
+
+use crate::DatabaseError;
+
+/// Insert a row for `mac` with `suppress_site_explorer = true`, or update an
+/// existing row to set it.  Clears `site_explorer_suppressed_at` whenever
+/// `suppress_site_explorer` transitions from `false` to `true` so that the
+/// decommissioning workflow can wait for a fresh acknowledgement.
+pub async fn upsert_suppress_site_explorer(
+    txn: &mut PgConnection,
+    mac: &MacAddress,
+    reason: &str,
+) -> Result<(), DatabaseError> {
+    let query = "\
+        INSERT INTO ignored_bmc_macs \
+            (bmc_mac_address, reason, suppress_site_explorer, site_explorer_suppressed_at, updated_at) \
+        VALUES ($1::macaddr, $2, TRUE, NULL, now()) \
+        ON CONFLICT (bmc_mac_address) DO UPDATE \
+            SET suppress_site_explorer      = TRUE, \
+                site_explorer_suppressed_at = CASE \
+                    WHEN ignored_bmc_macs.suppress_site_explorer = FALSE THEN NULL \
+                    ELSE ignored_bmc_macs.site_explorer_suppressed_at \
+                END, \
+                updated_at = now()";
+    sqlx::query(query)
+        .bind(mac)
+        .bind(reason)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Record that Site Explorer has observed suppression and drained all
+/// queued/in-flight work for `mac`.  This is the acknowledgement that the
+/// decommissioning workflow waits on before starting hardware cleanup.
+///
+/// Only Site Explorer should call this function.
+pub async fn record_site_explorer_suppressed(
+    txn: &mut PgConnection,
+    mac: &MacAddress,
+) -> Result<(), DatabaseError> {
+    let query = "\
+        UPDATE ignored_bmc_macs \
+        SET site_explorer_suppressed_at = now(), updated_at = now() \
+        WHERE bmc_mac_address = $1::macaddr \
+          AND suppress_site_explorer = TRUE \
+          AND site_explorer_suppressed_at IS NULL";
+    sqlx::query(query)
+        .bind(mac)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Set `suppress_dhcp = true` for `mac` and clear `dhcp_discover_suppressed_at`
+/// so the decommissioning workflow can wait for a fresh acknowledgement from
+/// the DHCP server.  No-ops if the row does not exist.
+pub async fn set_suppress_dhcp(
+    txn: &mut PgConnection,
+    mac: &MacAddress,
+) -> Result<(), DatabaseError> {
+    let query = "\
+        UPDATE ignored_bmc_macs \
+        SET suppress_dhcp               = TRUE, \
+            dhcp_discover_suppressed_at = CASE \
+                WHEN suppress_dhcp = FALSE THEN NULL \
+                ELSE dhcp_discover_suppressed_at \
+            END, \
+            updated_at = now() \
+        WHERE bmc_mac_address = $1::macaddr";
+    sqlx::query(query)
+        .bind(mac)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Record that the DHCP server observed a DHCPDISCOVER from `mac` and returned
+/// no offer, proving the BMC DHCP client has returned to the INIT state.
+///
+/// Only the DHCP server should call this function.  The update is conditional:
+/// it only writes the timestamp when suppression is enabled and no timestamp
+/// has been recorded yet, so retries are safe.
+pub async fn record_dhcp_discover_suppressed(
+    txn: &mut PgConnection,
+    mac: &MacAddress,
+) -> Result<(), DatabaseError> {
+    let query = "\
+        UPDATE ignored_bmc_macs \
+        SET dhcp_discover_suppressed_at = now(), updated_at = now() \
+        WHERE bmc_mac_address = $1::macaddr \
+          AND suppress_dhcp = TRUE \
+          AND dhcp_discover_suppressed_at IS NULL";
+    sqlx::query(query)
+        .bind(mac)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Remove the ignore entry for `mac`.  Returns `true` if a row was deleted.
+///
+/// Callers are responsible for verifying that no managed resource still
+/// references this MAC before calling this function.
+pub async fn release(
+    txn: &mut PgConnection,
+    mac: &MacAddress,
+) -> Result<bool, DatabaseError> {
+    let query = "DELETE FROM ignored_bmc_macs WHERE bmc_mac_address = $1::macaddr";
+    sqlx::query(query)
+        .bind(mac)
+        .execute(txn)
+        .await
+        .map(|r| r.rows_affected() > 0)
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Load all rows from `ignored_bmc_macs`.  Used by Site Explorer and the DHCP
+/// server to build their suppression sets at the start of each pass.
+pub async fn load_all(pool: &PgPool) -> Result<Vec<IgnoredBmcMac>, DatabaseError> {
+    let query = "SELECT * FROM ignored_bmc_macs ORDER BY created_at";
+    sqlx::query_as(query)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Look up a single entry by MAC address.
+pub async fn find(
+    txn: &mut PgConnection,
+    mac: &MacAddress,
+) -> Result<Option<IgnoredBmcMac>, DatabaseError> {
+    let query = "SELECT * FROM ignored_bmc_macs WHERE bmc_mac_address = $1::macaddr";
+    sqlx::query_as(query)
+        .bind(mac)
+        .fetch_optional(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))
+}

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -29,6 +29,7 @@ pub mod db_read;
 pub mod desired_firmware;
 pub mod dhcp_entry;
 pub mod dhcp_record;
+pub mod ignored_bmc_mac;
 pub mod dns;
 pub mod dpa_interface;
 pub mod dpu_agent_upgrade_policy;

--- a/crates/api-model/src/dhcp_record.rs
+++ b/crates/api-model/src/dhcp_record.rs
@@ -19,6 +19,7 @@ use std::net::IpAddr;
 use carbide_uuid::domain::DomainId;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
 use carbide_uuid::network::NetworkSegmentId;
+use chrono::{DateTime, Utc};
 use ipnetwork::IpNetwork;
 use mac_address::MacAddress;
 use sqlx::FromRow;
@@ -46,4 +47,16 @@ pub struct DhcpRecord {
     pub gateway: Option<IpAddr>,
 
     pub last_invalidation_time: chrono::DateTime<chrono::Utc>,
+}
+
+/// A row from the `ignored_macs` table.
+///
+/// MAC addresses listed here are treated as blocked by the DHCP server:
+/// DISCOVER packets are dropped silently and REQUEST packets receive a NAK.
+#[derive(Debug, Clone, FromRow)]
+pub struct IgnoredMac {
+    pub mac_address: MacAddress,
+    pub machine_id: Option<MachineId>,
+    pub reason: String,
+    pub created_at: DateTime<Utc>,
 }

--- a/crates/api-model/src/ignored_bmc_mac.rs
+++ b/crates/api-model/src/ignored_bmc_mac.rs
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use chrono::{DateTime, Utc};
+use mac_address::MacAddress;
+use sqlx::FromRow;
+
+/// A row from the `ignored_bmc_macs` table.
+///
+/// Tracks per-MAC suppression state for Site Explorer and DHCP during
+/// decommissioning. The two suppressed-at timestamps are written exclusively
+/// by Site Explorer and the DHCP server respectively, and serve as
+/// acknowledgements that the decommissioning workflow waits on before
+/// advancing to hardware cleanup or the `Decommissioned` terminal state.
+#[derive(Debug, Clone, FromRow)]
+pub struct IgnoredBmcMac {
+    pub bmc_mac_address: MacAddress,
+    pub reason: String,
+    pub suppress_site_explorer: bool,
+    pub site_explorer_suppressed_at: Option<DateTime<Utc>>,
+    pub suppress_dhcp: bool,
+    pub dhcp_discover_suppressed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -55,6 +55,7 @@ pub mod expected_switch;
 pub mod extension_service;
 pub mod firmware;
 pub mod hardware_info;
+pub mod ignored_bmc_mac;
 pub mod health;
 pub mod host_machine_update;
 pub mod ib;

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1174,6 +1174,12 @@ pub enum ManagedHostState {
     /// State controller will no longer manage the Machine
     ForceDeletion,
 
+    /// The machine is being decommissioned: BMCs are reset to factory defaults,
+    /// credentials are removed, and MAC addresses are marked as ignored by DHCP.
+    Decommissioning {
+        decommission_state: DecommissionState,
+    },
+
     /// A dummy state used to create DPU in beginning. State will sync to Init when host will be
     /// created.
     Created,
@@ -2013,6 +2019,40 @@ pub enum CleanupContext {
     Deprovision,
     InitialDiscovery,
 }
+/// Sub-states for [`ManagedHostState::Decommissioning`].
+///
+/// Progress is strictly forward: each sub-state completes one action and
+/// advances to the next.  The final step (`MarkMacsIgnored`) causes the state
+/// controller to emit `deleted()` and remove the machine from the database.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum DecommissionState {
+    /// Entry point: attach a `PreventAllocations` health alert so the machine
+    /// cannot be assigned while decommission is in progress.
+    Init,
+    /// Reset the host BMC to factory defaults via Redfish `Manager.ResetToDefaults`.
+    BmcResetToDefaults,
+    /// Reset each attached DPU BMC to factory defaults.
+    DpuBmcResetToDefaults,
+    /// Delete per-machine credentials (SSH keys, BMC accounts) from the secret store.
+    DeleteCredentials,
+    /// Insert BMC MAC addresses into the `ignored_macs` table so the DHCP server
+    /// stops issuing leases and NAKs any outstanding requests.
+    MarkMacsIgnored,
+}
+
+impl std::fmt::Display for DecommissionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecommissionState::Init => write!(f, "Init"),
+            DecommissionState::BmcResetToDefaults => write!(f, "BmcResetToDefaults"),
+            DecommissionState::DpuBmcResetToDefaults => write!(f, "DpuBmcResetToDefaults"),
+            DecommissionState::DeleteCredentials => write!(f, "DeleteCredentials"),
+            DecommissionState::MarkMacsIgnored => write!(f, "MarkMacsIgnored"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, EnumIter)]
 #[serde(rename_all = "lowercase")]
 pub enum LockdownState {
@@ -2350,6 +2390,9 @@ impl Display for ManagedHostState {
                 write!(f, "WaitingForCleanup/{cleanup_state}")
             }
             ManagedHostState::ForceDeletion => write!(f, "ForceDeletion"),
+            ManagedHostState::Decommissioning { decommission_state } => {
+                write!(f, "Decommissioning/{decommission_state}")
+            }
             ManagedHostState::Failed { details, .. } => {
                 write!(f, "Failed/{}", details.cause)
             }
@@ -2444,6 +2487,9 @@ impl ManagedHostState {
                 format!("WaitingForCleanup/{cleanup_state}")
             }
             ManagedHostState::ForceDeletion => "ForceDeletion".to_string(),
+            ManagedHostState::Decommissioning { decommission_state } => {
+                format!("Decommissioning/{decommission_state}")
+            }
             ManagedHostState::Failed { details, .. } => {
                 format!("Failed/{}", details.cause)
             }
@@ -2742,6 +2788,9 @@ pub fn state_sla(
                 }
             },
         },
+        ManagedHostState::Decommissioning { .. } => {
+            StateSla::with_sla(slas::MAINTENANCE, time_in_state)
+        }
     }
 }
 

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -413,11 +413,12 @@ impl ComponentManager {
                         if matches!(
                             machine.state.value,
                             model::machine::ManagedHostState::ForceDeletion
+                                | model::machine::ManagedHostState::Decommissioning { .. }
                         ) {
                             results.push(MachineMaintenanceRequestResult {
                                 machine_id: *machine_id,
                                 error: Some(format!(
-                                    "machine {machine_id} is marked for forced deletion"
+                                    "machine {machine_id} is marked for forced deletion or is being decommissioned"
                                 )),
                             });
                             continue;

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -72,11 +72,12 @@ use model::machine::infiniband::{IbConfigNotSyncedReason, ib_config_synced};
 use model::machine::nvlink::nvlink_config_synced;
 use model::machine::{
     AttestationMode, BomValidating, BomValidatingContext, CleanupContext, CleanupState,
-    CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState, DpuInitNextStateResolver,
-    DpuInitState, FailureCause, FailureDetails, FailureSource, HostPlatformConfigurationState,
-    HostReprovisionState, InitialResetPhase, InstallDpuOsState, InstanceNextStateResolver,
-    InstanceState, LockdownInfo, LockdownState, MAX_FIRMWARE_UPGRADE_RETRIES, Machine,
-    MachineLastRebootRequested, MachineLastRebootRequestedMode, MachineNextStateResolver,
+    CreateBossVolumeContext, CreateBossVolumeState, DecommissionState, DpuDiscoveringState,
+    DpuInitNextStateResolver, DpuInitState, FailureCause, FailureDetails, FailureSource,
+    HostPlatformConfigurationState, HostReprovisionState, InitialResetPhase, InstallDpuOsState,
+    InstanceNextStateResolver, InstanceState, LockdownInfo, LockdownState,
+    MAX_FIRMWARE_UPGRADE_RETRIES, Machine, MachineLastRebootRequested,
+    MachineLastRebootRequestedMode, MachineNextStateResolver,
     MachineState, MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot,
     MeasuringState, NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation,
     PowerDrainState, PowerState, ReprovisionState, RetryInfo, SecureEraseBossContext,
@@ -116,6 +117,7 @@ use crate::{MeasuringOutcome, get_measuring_prerequisites, handle_measuring_stat
 
 pub mod attestation;
 mod bios_config;
+mod decommission;
 mod dpf;
 mod firmware_artifact;
 mod helpers;
@@ -834,6 +836,27 @@ impl MachineStateHandler {
                     return Ok(outcome);
                 }
 
+                // A site decommission may have placed a PreventAllocations health
+                // alert on this machine while it was in a non-Ready state.  Now that
+                // it has drained to Ready, begin the decommission sequence.
+                if mh_snapshot
+                    .host_snapshot
+                    .health_reports
+                    .merges
+                    .contains_key(decommission::DECOMMISSION_HEALTH_SOURCE)
+                {
+                    tracing::info!(
+                        machine_id = %host_machine_id,
+                        "Machine reached Ready with a pending decommission; \
+                         transitioning to Decommissioning",
+                    );
+                    return Ok(StateHandlerOutcome::transition(
+                        ManagedHostState::Decommissioning {
+                            decommission_state: DecommissionState::Init,
+                        },
+                    ));
+                }
+
                 if let Some(outcome) = maintenance::maintenance_transition_if_requested(mh_snapshot)
                 {
                     return Ok(outcome);
@@ -1300,6 +1323,9 @@ impl MachineStateHandler {
                     "Machine is marked for forced deletion. Ignoring.",
                 );
                 Ok(StateHandlerOutcome::deleted())
+            }
+            ManagedHostState::Decommissioning { .. } => {
+                decommission::handle_decommission(host_machine_id, mh_snapshot, ctx).await
             }
             ManagedHostState::Failed {
                 details,

--- a/crates/machine-controller/src/handler/decommission.rs
+++ b/crates/machine-controller/src/handler/decommission.rs
@@ -1,0 +1,335 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Handler for [`ManagedHostState::Decommissioning`].
+
+use std::str::FromStr;
+
+use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, CredentialWriter};
+use carbide_uuid::machine::MachineId;
+use db::dhcp_record as db_dhcp;
+use db::machine as db_machine;
+use health_report::{
+    HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthReport, HealthReportApplyMode,
+};
+use model::machine::{DecommissionState, ManagedHostState, ManagedHostStateSnapshot};
+use state_controller::state_handler::{StateHandlerContext, StateHandlerError, StateHandlerOutcome};
+
+use crate::context::MachineStateHandlerContextObjects;
+
+pub(super) const DECOMMISSION_HEALTH_SOURCE: &str = "decommission";
+const DECOMMISSION_PROBE_ID: &str = "DecommissionInProgress";
+
+/// Top-level dispatcher for the `Decommissioning` state.
+pub async fn handle_decommission(
+    host_machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let decommission_state = match &mh_snapshot.managed_state {
+        ManagedHostState::Decommissioning { decommission_state } => decommission_state.clone(),
+        _ => unreachable!("handle_decommission called with non-Decommissioning state"),
+    };
+
+    match decommission_state {
+        DecommissionState::Init => handle_init(host_machine_id, mh_snapshot, ctx).await,
+        DecommissionState::BmcResetToDefaults => {
+            handle_bmc_reset(host_machine_id, mh_snapshot, ctx).await
+        }
+        DecommissionState::DpuBmcResetToDefaults => {
+            handle_dpu_bmc_reset(host_machine_id, mh_snapshot, ctx).await
+        }
+        DecommissionState::DeleteCredentials => {
+            handle_delete_credentials(host_machine_id, mh_snapshot, ctx).await
+        }
+        DecommissionState::MarkMacsIgnored => {
+            handle_mark_macs_ignored(host_machine_id, mh_snapshot, ctx).await
+        }
+    }
+}
+
+/// `Init`: attach a `PreventAllocations` health alert, then advance to `BmcResetToDefaults`.
+async fn handle_init(
+    host_machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    tracing::info!(
+        machine_id = %host_machine_id,
+        "Decommission Init: attaching PreventAllocations health alert",
+    );
+
+    let health_report = HealthReport {
+        source: DECOMMISSION_HEALTH_SOURCE.to_string(),
+        triggered_by: None,
+        observed_at: Some(chrono::Utc::now()),
+        alerts: vec![HealthProbeAlert {
+            id: HealthProbeId::from_str(DECOMMISSION_PROBE_ID).expect("valid probe id"),
+            target: None,
+            in_alert_since: Some(chrono::Utc::now()),
+            message: "Machine is being decommissioned".to_string(),
+            tenant_message: None,
+            classifications: vec![HealthAlertClassification::prevent_allocations()],
+        }],
+        successes: vec![],
+    };
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    db_machine::insert_health_report(
+        &mut txn,
+        host_machine_id,
+        HealthReportApplyMode::Merge,
+        &health_report,
+        false,
+    )
+    .await?;
+
+    // Also apply the alert to all DPU machines so none can be allocated.
+    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
+        db_machine::insert_health_report(
+            &mut txn,
+            &dpu_snapshot.id,
+            HealthReportApplyMode::Merge,
+            &health_report,
+            false,
+        )
+        .await?;
+    }
+
+    let next_state = ManagedHostState::Decommissioning {
+        decommission_state: DecommissionState::BmcResetToDefaults,
+    };
+    Ok(StateHandlerOutcome::transition(next_state).with_txn(txn))
+}
+
+/// `BmcResetToDefaults`: send `Manager.ResetToDefaults` to the host BMC.
+///
+/// If the BMC is unreachable or already reset, we log and continue rather than
+/// blocking decommission indefinitely.
+async fn handle_bmc_reset(
+    host_machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    tracing::info!(
+        machine_id = %host_machine_id,
+        "Decommission BmcResetToDefaults: resetting host BMC to factory defaults",
+    );
+
+    match ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await
+    {
+        Ok(redfish) => {
+            if let Err(e) = redfish.bmc_reset_to_defaults().await {
+                tracing::warn!(
+                    machine_id = %host_machine_id,
+                    error = %e,
+                    "Host BMC reset to defaults failed; proceeding with decommission",
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                machine_id = %host_machine_id,
+                error = %e,
+                "Could not connect to host BMC for factory reset; proceeding with decommission",
+            );
+        }
+    }
+
+    Ok(StateHandlerOutcome::transition(ManagedHostState::Decommissioning {
+        decommission_state: DecommissionState::DpuBmcResetToDefaults,
+    }))
+}
+
+/// `DpuBmcResetToDefaults`: reset each attached DPU BMC to factory defaults.
+async fn handle_dpu_bmc_reset(
+    host_machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    tracing::info!(
+        machine_id = %host_machine_id,
+        dpu_count = mh_snapshot.dpu_snapshots.len(),
+        "Decommission DpuBmcResetToDefaults: resetting DPU BMCs to factory defaults",
+    );
+
+    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
+        match ctx
+            .services
+            .create_redfish_client_from_machine(dpu_snapshot)
+            .await
+        {
+            Ok(redfish) => {
+                if let Err(e) = redfish.bmc_reset_to_defaults().await {
+                    tracing::warn!(
+                        machine_id = %host_machine_id,
+                        dpu_machine_id = %dpu_snapshot.id,
+                        error = %e,
+                        "DPU BMC reset to defaults failed; proceeding with decommission",
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    machine_id = %host_machine_id,
+                    dpu_machine_id = %dpu_snapshot.id,
+                    error = %e,
+                    "Could not connect to DPU BMC for factory reset; proceeding with decommission",
+                );
+            }
+        }
+    }
+
+    Ok(StateHandlerOutcome::transition(ManagedHostState::Decommissioning {
+        decommission_state: DecommissionState::DeleteCredentials,
+    }))
+}
+
+/// `DeleteCredentials`: remove per-machine secrets from the credential store.
+///
+/// Site-wide credentials (`SiteWideRoot`, `SiteDefault`) are intentionally
+/// left intact — they are shared across all machines.
+async fn handle_delete_credentials(
+    host_machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    tracing::info!(
+        machine_id = %host_machine_id,
+        "Decommission DeleteCredentials: removing per-machine credentials",
+    );
+
+    // Host BMC per-device credentials (keyed by BMC MAC).
+    if let Some(bmc_mac) = mh_snapshot.host_snapshot.status.bmc_info.mac {
+        for key in [
+            CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::BmcRoot { bmc_mac_address: bmc_mac },
+            },
+            CredentialKey::BmcCredentials {
+                credential_type: BmcCredentialType::BmcForgeAdmin { bmc_mac_address: bmc_mac },
+            },
+        ] {
+            if let Err(e) = ctx.services.credential_manager.delete_credentials(&key).await {
+                tracing::warn!(
+                    machine_id = %host_machine_id,
+                    ?key,
+                    error = %e,
+                    "Failed to delete host BMC credential; continuing",
+                );
+            }
+        }
+    } else {
+        tracing::warn!(
+            machine_id = %host_machine_id,
+            "Host BMC MAC not available; skipping BMC credential deletion",
+        );
+    }
+
+    // Per-DPU credentials (keyed by DPU machine ID and DPU BMC MAC).
+    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
+        let dpu_id = dpu_snapshot.id;
+
+        for key in [
+            CredentialKey::DpuSsh { machine_id: dpu_id },
+            CredentialKey::DpuHbn { machine_id: dpu_id },
+        ] {
+            if let Err(e) = ctx.services.credential_manager.delete_credentials(&key).await {
+                tracing::warn!(
+                    machine_id = %host_machine_id,
+                    %dpu_id,
+                    ?key,
+                    error = %e,
+                    "Failed to delete DPU credential; continuing",
+                );
+            }
+        }
+
+        if let Some(dpu_bmc_mac) = dpu_snapshot.status.bmc_info.mac {
+            for key in [
+                CredentialKey::BmcCredentials {
+                    credential_type: BmcCredentialType::BmcRoot {
+                        bmc_mac_address: dpu_bmc_mac,
+                    },
+                },
+                CredentialKey::BmcCredentials {
+                    credential_type: BmcCredentialType::BmcForgeAdmin {
+                        bmc_mac_address: dpu_bmc_mac,
+                    },
+                },
+            ] {
+                if let Err(e) = ctx.services.credential_manager.delete_credentials(&key).await {
+                    tracing::warn!(
+                        machine_id = %host_machine_id,
+                        %dpu_id,
+                        ?key,
+                        error = %e,
+                        "Failed to delete DPU BMC credential; continuing",
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(StateHandlerOutcome::transition(ManagedHostState::Decommissioning {
+        decommission_state: DecommissionState::MarkMacsIgnored,
+    }))
+}
+
+/// `MarkMacsIgnored`: insert all BMC MAC addresses into the `ignored_macs` table so
+/// the DHCP server stops issuing leases and NAKs any outstanding DHCPREQUEST.
+///
+/// This is the final step — after the DB write completes the machine is deleted.
+async fn handle_mark_macs_ignored(
+    host_machine_id: &MachineId,
+    mh_snapshot: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    tracing::info!(
+        machine_id = %host_machine_id,
+        "Decommission MarkMacsIgnored: marking BMC MACs as DHCP-ignored",
+    );
+
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    if let Some(host_bmc_mac) = mh_snapshot.host_snapshot.status.bmc_info.mac {
+        db_dhcp::ignore_mac(
+            &mut txn,
+            &host_bmc_mac,
+            Some(host_machine_id),
+            "decommissioned",
+        )
+        .await?;
+    }
+
+    for dpu_snapshot in &mh_snapshot.dpu_snapshots {
+        if let Some(dpu_bmc_mac) = dpu_snapshot.status.bmc_info.mac {
+            db_dhcp::ignore_mac(
+                &mut txn,
+                &dpu_bmc_mac,
+                Some(&dpu_snapshot.id),
+                "decommissioned",
+            )
+            .await?;
+        }
+    }
+
+    Ok(StateHandlerOutcome::deleted().with_txn(txn))
+}

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -358,6 +358,16 @@ impl StateControllerIO for MachineStateControllerIO {
                 }
                 machine::BomValidating::SkuMissing(_) => ("bomvalidating", "skumissing"),
             },
+            ManagedHostState::Decommissioning { decommission_state } => {
+                let sub = match decommission_state {
+                    machine::DecommissionState::Init => "init",
+                    machine::DecommissionState::BmcResetToDefaults => "bmcresettodefaults",
+                    machine::DecommissionState::DpuBmcResetToDefaults => "dpubmcresettodefaults",
+                    machine::DecommissionState::DeleteCredentials => "deletecredentials",
+                    machine::DecommissionState::MarkMacsIgnored => "markmacsignored",
+                };
+                ("decommissioning", sub)
+            }
             ManagedHostState::Validation { validation_state } => match validation_state {
                 ValidationState::MachineValidation { machine_validation } => (
                     "validation",

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -331,6 +331,18 @@ service Forge {
   // appropriate customer-facing workflow available or where those workflows fail.
   rpc AdminForceDeleteMachine(AdminForceDeleteMachineRequest) returns (AdminForceDeleteMachineResponse);
 
+  // AdminDecommissionMachine begins the decommission sequence for a single machine:
+  // adds a PreventAllocations health alert, resets Host and DPU BMCs to factory
+  // defaults, removes per-machine credentials, and marks BMC MACs as DHCP-ignored.
+  // The machine must be in the Ready state.
+  rpc AdminDecommissionMachine(AdminDecommissionMachineRequest) returns (AdminDecommissionMachineResponse);
+
+  // AdminDecommissionSite begins site-wide decommission: disables new machine
+  // ingestion and starts decommissioning every machine that is currently in the
+  // Ready state.  Machines in other states receive a PreventAllocations alert and
+  // will be decommissioned automatically once they drain to Ready.
+  rpc AdminDecommissionSite(AdminDecommissionSiteRequest) returns (AdminDecommissionSiteResponse);
+
   // List existing resource pools and their stats
   rpc AdminListResourcePools(ListResourcePoolsRequest) returns (ResourcePools);
 
@@ -4903,6 +4915,29 @@ message AdminForceDeleteMachineResponse {
 }
 
 message DisableSecureBootResponse {
+}
+
+// AdminDecommissionMachine — request to decommission a single host machine.
+// The machine must be in the Ready state; machines in other states are rejected.
+message AdminDecommissionMachineRequest {
+  // UUID, IP address, hostname, or MAC address of the host (or its attached DPU).
+  string host_query = 1;
+}
+
+message AdminDecommissionMachineResponse {
+  // The host machine ID that was transitioned to Decommissioning.
+  string machine_id = 1;
+}
+
+// AdminDecommissionSite — request to decommission all machines at the site.
+message AdminDecommissionSiteRequest {}
+
+message AdminDecommissionSiteResponse {
+  // Number of machines immediately transitioned to Decommissioning (were in Ready state).
+  uint32 machines_started = 1;
+  // Number of machines that received a PreventAllocations alert but are not yet
+  // in Ready state and will be decommissioned once they drain.
+  uint32 machines_pending = 2;
 }
 
 message LockdownRequest {

--- a/crates/rpc/src/model/instance/status/tenant.rs
+++ b/crates/rpc/src/model/instance/status/tenant.rs
@@ -128,7 +128,9 @@ pub fn instance_status_tenant_state(
             InstanceState::WaitingForDpaToBeReady => TenantState::Updating,
             InstanceState::Failed { .. } => TenantState::Failed,
         },
-        ManagedHostState::ForceDeletion => TenantState::Terminating,
+        ManagedHostState::ForceDeletion | ManagedHostState::Decommissioning { .. } => {
+            TenantState::Terminating
+        }
         _ => {
             tracing::error!(%machine_state, "Invalid state during state handling");
             TenantState::Invalid


### PR DESCRIPTION
Adds the `ignored_bmc_macs` table and supporting code needed by the
decommissioning workflow to suppress Site Explorer and DHCP for
decommissioned BMC MACs and decommission racks.

- Migration: `ignored_bmc_macs` table with `suppress_site_explorer`,
  `site_explorer_suppressed_at`, `suppress_dhcp`, and
  `dhcp_discover_suppressed_at` columns
- `api-model`: `IgnoredBmcMac` struct
- `api-db`: helpers to upsert suppression state, record acknowledgements
  from Site Explorer and the DHCP server, release entries, and bulk-load
  the table