### PR TITLE
fix(build): pin cargo-deny in build containers

### DIFF
--- a/dev/docker/Dockerfile.build-container-aarch64
+++ b/dev/docker/Dockerfile.build-container-aarch64
@@ -70,7 +70,8 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 RUN update-alternatives --install /usr/bin/ld ld /usr/bin/lld 50
 
 RUN rustup component add rustfmt
-RUN cargo install cargo-cache cargo-make sccache cargo-deny --locked && \
+RUN cargo install cargo-cache cargo-make sccache --locked && \
+	cargo install cargo-deny --version 0.20.2 --locked && \
 	cargo install mdbook@0.4.52 mdbook-plantuml@0.8.0 mdbook-mermaid@0.16.2 && \
 	cargo cache -r registry-index,registry-sources
 

--- a/dev/docker/Dockerfile.build-container-x86_64
+++ b/dev/docker/Dockerfile.build-container-x86_64
@@ -83,7 +83,8 @@ RUN rustup component add --toolchain ${RUST_NIGHTLY} rustfmt rust-src rustc-dev 
 # The mdbook crates need to be installed with matching version numbers
 # in order to be compatible
 # They need to be installed without --locked to avoid build failures
-RUN cargo install cargo-cache cargo-make sccache cargo-watch taplo-cli cargo-deny --locked && \
+RUN cargo install cargo-cache cargo-make sccache cargo-watch taplo-cli --locked && \
+	cargo install cargo-deny --version 0.20.2 --locked && \
 	cargo install mdbook@0.4.52 mdbook-plantuml@0.8.0 mdbook-mermaid@0.16.2 && \
 	cargo cache -r registry-index,registry-sources
 


### PR DESCRIPTION
Build containers currently install `cargo-deny` without an explicit version.
The `--locked` option locks dependencies for whichever top-level release Cargo
selects; it does not pin the `cargo-deny` release itself.

Existing cached containers could retain a pre-0.20.x release that accepted the
singular `license` alias. A fresh build selected `cargo-deny` 0.20.2, which
dropped that alias in favor of `licenses`, breaking the `check-licenses` task.

`main` already carries the command-side fix from #3435
(`license` → `licenses`). This change is the companion container-side
hardening: it pins `cargo-deny` 0.20.2 in both build-container Dockerfiles,
preventing future rebuilds from silently selecting another release.

## Related issues

Fixes #3510

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manual testing:

- Full no-cache `linux/arm64` build of
  `Dockerfile.build-container-aarch64`
- Verified the arm64 image reports `cargo-deny 0.20.2`
- Full no-cache `linux/amd64` build of
  `Dockerfile.build-container-x86_64`
- Verified the amd64 image reports `cargo-deny 0.20.2`

## Additional Notes

- `taplo-cli` remains unpinned. Its separate, non-fatal formatting-check
  behavior is intentionally outside this cargo-deny-specific PR.
- Docker reported pre-existing legacy `ENV key value` style warnings during
  the builds. They are unrelated to this change.
