### PR TITLE
patch(v2.0): honor custom namespaces in ServiceMonitors (backport #4306)

### DIFF
--- a/helm/charts/nico-dhcp/templates/service-monitor.yaml
+++ b/helm/charts/nico-dhcp/templates/service-monitor.yaml
@@ -9,5 +9,5 @@ metadata:
     app: {{ include "nico-dhcp.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-dhcp.serviceMonitorSpec" (dict "name" (include "nico-dhcp.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-dhcp.serviceMonitorSpec" (dict "name" (include "nico-dhcp.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-dhcp.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-hardware-health/templates/service-monitor.yaml
+++ b/helm/charts/nico-hardware-health/templates/service-monitor.yaml
@@ -9,5 +9,5 @@ metadata:
     app: {{ include "nico-hardware-health.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-hardware-health.serviceMonitorSpec" (dict "name" (include "nico-hardware-health.name" .) "port" "metrics" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-hardware-health.serviceMonitorSpec" (dict "name" (include "nico-hardware-health.name" .) "port" "metrics" "monitor" .Values.serviceMonitor "namespace" (include "nico-hardware-health.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
+++ b/helm/charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
@@ -9,5 +9,5 @@ metadata:
     app: nico-hardware-health
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-hardware-health.telemetryServiceMonitorSpec" (dict "name" "nico-hardware-health" "port" "metrics" "monitor" .Values.telemetryServiceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-hardware-health.telemetryServiceMonitorSpec" (dict "name" "nico-hardware-health" "port" "metrics" "monitor" .Values.telemetryServiceMonitor "namespace" (include "nico-hardware-health.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-pxe/templates/service-monitor.yaml
+++ b/helm/charts/nico-pxe/templates/service-monitor.yaml
@@ -9,5 +9,5 @@ metadata:
     app: {{ include "nico-pxe.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-pxe.serviceMonitorSpec" (dict "name" (include "nico-pxe.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-pxe.serviceMonitorSpec" (dict "name" (include "nico-pxe.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-pxe.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/charts/nico-ssh-console-rs/templates/service-monitor.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/service-monitor.yaml
@@ -9,5 +9,5 @@ metadata:
     app: {{ include "nico-ssh-console-rs.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-ssh-console-rs.serviceMonitorSpec" (dict "name" (include "nico-ssh-console-rs.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" "nico-system") | nindent 2 }}
+  {{- include "nico-ssh-console-rs.serviceMonitorSpec" (dict "name" (include "nico-ssh-console-rs.name" .) "port" "http" "monitor" .Values.serviceMonitor "namespace" (include "nico-ssh-console-rs.namespace" .)) | nindent 2 }}
 {{- end }}

--- a/helm/tests/service_monitor_namespace_test.yaml
+++ b/helm/tests/service_monitor_namespace_test.yaml
@@ -1,0 +1,74 @@
+suite: ServiceMonitor namespace selectors
+templates:
+  - charts/nico-dhcp/templates/service-monitor.yaml
+  - charts/nico-hardware-health/templates/service-monitor.yaml
+  - charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
+  - charts/nico-pxe/templates/service-monitor.yaml
+  - charts/nico-ssh-console-rs/templates/service-monitor.yaml
+release:
+  namespace: custom-nico
+tests:
+  - it: nico-dhcp selects Services in the release namespace
+    template: charts/nico-dhcp/templates/service-monitor.yaml
+    set:
+      nico-dhcp.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-nico
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - custom-nico
+
+  - it: nico-hardware-health selects Services in the release namespace
+    template: charts/nico-hardware-health/templates/service-monitor.yaml
+    set:
+      nico-hardware-health.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-nico
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - custom-nico
+
+  - it: nico-hardware-health telemetry selects Services in the release namespace
+    template: charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
+    set:
+      nico-hardware-health.telemetryServiceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-nico
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - custom-nico
+
+  - it: nico-pxe selects Services in the release namespace
+    template: charts/nico-pxe/templates/service-monitor.yaml
+    set:
+      nico-pxe.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-nico
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - custom-nico
+
+  - it: nico-ssh-console-rs selects Services in the release namespace
+    template: charts/nico-ssh-console-rs/templates/service-monitor.yaml
+    set:
+      nico-ssh-console-rs.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-nico
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value:
+            - custom-nico


### PR DESCRIPTION
Backport of #4306 to `release/v2.0` (upstream commit `d6ebd1426`).

Fixes #4250 by using each chart resolved namespace in its ServiceMonitor namespace selector. The cherry-pick applied cleanly with no release-specific changes.

## Related issues

Fixes #4250

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated

- 5 focused Helm namespace tests pass
- `helm lint helm` passes
- `cargo metadata --locked --no-deps --format-version 1` passes
- Full Helm suite: 18 failed/65 passed versus 18 failed/60 passed on clean `release/v2.0`
- `CARGO_HOME="$HOME/.cargo" cargo make --no-workspace clippy-flow` passes on Linux