### PR TITLE
fix: use initial_domain_name as reference for seeding network segments

### DIFF
--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -69,24 +69,9 @@ pub async fn create_initial_networks(
     networks: &HashMap<String, NetworkDefinition>,
 ) -> Result<(), CarbideError> {
     let mut txn = Transaction::begin(db_pool).await?;
-    let all_domains = db::dns::domain::find_by(
-        &mut txn,
-        ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
-    )
-    .await?;
-    if all_domains.is_empty() {
-        tracing::warn!("No domain configured, skipping initial network creation");
+    let Some(domain_id) = resolve_seed_domain(api, &mut txn).await? else {
         return Ok(());
-    }
-    if all_domains.len() > 1 {
-        // We only create initial networks if we only have a single domain - usually created
-        // as initial_domain_name in config file.
-        // Having multiple domains is fine, it means we probably created the network much
-        // earlier.
-        tracing::info!("Multiple domains, skipping initial network creation");
-        return Ok(());
-    }
-    let domain_id = all_domains[0].id;
+    };
     reconcile_network_defs(&mut txn, networks).await?;
 
     for (name, def) in networks {
@@ -152,6 +137,51 @@ pub async fn create_initial_networks(
 
     txn.commit().await?;
     Ok(())
+}
+
+/// Resolve the parent domain for config-seeded segments by name, ignoring every
+/// other domain.
+///
+/// Not by counting `domains`: that table also holds reverse-DNS zones derived
+/// from segment prefixes, so it grows as segments are created. Counting it made
+/// this seed path disable itself after its first successful run.
+///
+/// `None` (logged) means seed nothing.
+async fn resolve_seed_domain(
+    api: &Api,
+    txn: &mut Transaction<'_>,
+) -> Result<Option<carbide_uuid::domain::DomainId>, CarbideError> {
+    let Some(domain_name) = api.runtime_config.initial_domain_name.as_deref() else {
+        tracing::warn!("No initial_domain_name configured, skipping initial network creation");
+        return Ok(None);
+    };
+
+    match domain::find_by_name(&mut *txn, domain_name)
+        .await?
+        .as_slice()
+    {
+        [domain] => Ok(Some(domain.id)),
+        [] => {
+            tracing::warn!(
+                domain_name,
+                "Configured initial_domain_name matches no domain, \
+                 skipping initial network creation",
+            );
+            Ok(None)
+        }
+        matches => {
+            // `domains.name` carries no UNIQUE constraint, so duplicates are
+            // possible; parenting segments to an arbitrary one of them would be
+            // worse than seeding nothing.
+            tracing::warn!(
+                domain_name,
+                matching_domain_count = matches.len(),
+                "Multiple domains share the configured initial_domain_name, \
+                 skipping initial network creation",
+            );
+            Ok(None)
+        }
+    }
 }
 
 pub async fn create_initial_vpcs(

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1785,7 +1785,7 @@ pub async fn create_test_env_with_overrides(
     // Create domain
     let domain: carbide_uuid::domain::DomainId = api
         .create_domain(Request::new(rpc::protos::dns::CreateDomainRequest {
-            name: "dwrt1.com".to_string(),
+            name: config.initial_domain_name.as_ref().unwrap().clone(),
         }))
         .await
         .unwrap()

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -660,6 +660,95 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     Ok(())
 }
 
+/// A network added to the config after bootstrap is still seeded on the next
+/// startup.
+#[crate::sqlx_test]
+pub async fn test_create_initial_networks_seeds_networks_added_after_first_run(
+    db_pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env =
+        create_test_env_with_overrides(db_pool.clone(), TestEnvOverrides::no_network_segments())
+            .await;
+
+    async fn domain_names(pool: &sqlx::PgPool) -> Result<Vec<String>, eyre::Report> {
+        let domains =
+            db::dns::domain::find_by(pool, ObjectColumnFilter::<db::dns::domain::IdColumn>::All)
+                .await?;
+        Ok(domains.into_iter().map(|d| d.name).collect())
+    }
+
+    let before = domain_names(&db_pool).await?;
+    assert_eq!(
+        before.len(),
+        1,
+        "fixture should start with a single forward domain, got {before:?}"
+    );
+
+    let admin = |prefix: &str, gateway: &str| NetworkDefinition {
+        segment_type: NetworkDefinitionSegmentType::Admin,
+        prefix: prefix.parse().unwrap(),
+        prefix_v6: None,
+        gateway: gateway.parse().unwrap(),
+        dhcpv6_link_address: None,
+        mtu: 9000,
+        reserve_first: 5,
+        allocation_strategy: Default::default(),
+        vpc_name: None,
+    };
+
+    // Run #1: bootstrap, declaring a single network.
+    let mut networks = HashMap::from([("admin".to_string(), admin("172.20.0.0/24", "172.20.0.1"))]);
+    db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
+
+    let mut txn = db_pool.begin().await?;
+    db::network_segment::find_by_name(&mut txn, "admin")
+        .await
+        .expect("the first run must seed the declared network");
+    txn.commit().await?;
+
+    // Seeding grows `domains`: a reverse zone per octet-aligned prefix, plus the
+    // static-assignments segment's two.
+    let after_first = domain_names(&db_pool).await?;
+    assert!(
+        after_first.len() > 1,
+        "the first run should have added reverse-DNS zones, got {after_first:?}"
+    );
+    for zone in ["254.254.254.169.in-addr.arpa", "0.20.172.in-addr.arpa"] {
+        assert!(
+            after_first.iter().any(|name| name == zone),
+            "expected reverse zone {zone} among {after_first:?}"
+        );
+    }
+
+    // The operator adds a network to the site config and restarts the API.
+    networks.insert(
+        "DEV1-C09-IPMI-01".to_string(),
+        NetworkDefinition {
+            segment_type: NetworkDefinitionSegmentType::Underlay,
+            prefix: "172.99.0.0/26".parse().unwrap(),
+            prefix_v6: None,
+            gateway: "172.99.0.1".parse().unwrap(),
+            dhcpv6_link_address: None,
+            mtu: 1500,
+            reserve_first: 5,
+            allocation_strategy: Default::default(),
+            vpc_name: None,
+        },
+    );
+
+    db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
+
+    let mut txn = db_pool.begin().await?;
+    let added = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-01").await;
+    txn.commit().await?;
+    assert!(
+        added.is_ok(),
+        "a network declared after the first run must still be seeded"
+    );
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 pub async fn test_create_initial_vpc_and_attached_network(
     db_pool: sqlx::PgPool,


### PR DESCRIPTION
Use initial_domain_name as reference for seeding network segments so that we don't need to rely on the number of existing domains to make the decision of creating new network segments.


## Related issues
#4286

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This does not change the current behaviour. NICo will fail to start in case the initial_domain_name changes between different process runs.

