### PR TITLE
fix(ci): make merge-result gate container-safe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,6 +171,7 @@ jobs:
               - 'Cargo.lock'
               - 'Makefile.toml'
               - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yaml'
       - name: Calculate version
         id: version
         run: |
@@ -1412,8 +1413,11 @@ jobs:
 
       - name: Build pull request merge result
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --no-tags origin main:refs/remotes/origin/main
-          git merge --no-commit --no-ff origin/main
+          git -c user.name="CI merge validation" \
+            -c user.email=ci@example.invalid \
+            merge --no-commit --no-ff origin/main
 
       - name: Validate Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1 >/dev/null


### PR DESCRIPTION
The merge-result gate added in #4295 now reaches Git after #4320, but the `lint-police` container rejects the bind-mounted workspace as having dubious ownership. After trusting the workspace, the isolated environment also requires a committer identity for the no-commit merge.

- Trust only the exact `$GITHUB_WORKSPACE` path.
- Supply a command-scoped identity for merge validation.
- Run `lint-police` when `.github/workflows/ci.yaml` changes so workflow-only PRs self-test the gate.

## Related issues

Fixes #4324.

Follow-up to #4295 and #4320.

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Manual testing performed

- Reproduced the current `dubious ownership` failure on PR #4219 using Git ownership test mode.
- Confirmed the ownership-only fix exposes the missing committer identity.
- Executed the exact run script extracted from the modified YAML on PR #4219 under forced ownership; fetch and no-commit merge against current `main` passed.
- `cargo metadata --locked --no-deps --format-version 1` passed on the merge result.
- Repository-clean validation passed with the intentional staged merge result.
- `actionlint` v1.7.12 and YAML/gate assertions passed.

## Acceptance criterion

Keep this PR in draft until its own `lint-police` job passes in the actual NVIDIA managed runner and build container. Local full clippy is blocked on macOS by Linux-only `libudev`.