### PR TITLE
feat(machine-a-tron): simulate NVOS switch boot

### DIFF
--- a/crates/machine-a-tron/src/api_client.rs
+++ b/crates/machine-a-tron/src/api_client.rs
@@ -59,6 +59,8 @@ pub struct MockDiscoveryData {
 
 static SUBNET_COUNTER: AtomicU32 = AtomicU32::new(0);
 static VPC_COUNTER: AtomicU32 = AtomicU32::new(0);
+const DUMMY_NVOS_USERNAME: &str = "admin";
+const DUMMY_NVOS_PASSWORD: &str = "factory_password";
 
 #[derive(Debug, Clone)]
 pub struct ApiClient(pub ForgeApiClient);
@@ -633,8 +635,8 @@ impl ApiClient {
                 bmc_username: DUMMY_FACTORY_USERNAME.to_string(),
                 bmc_password: DUMMY_FACTORY_PASSWORD.to_string(),
                 switch_serial_number,
-                nvos_username: None,
-                nvos_password: None,
+                nvos_username: Some(DUMMY_NVOS_USERNAME.to_string()),
+                nvos_password: Some(DUMMY_NVOS_PASSWORD.to_string()),
                 bmc_ip_address: String::new(),
                 nvos_ip_address: None,
                 metadata: None,

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -479,6 +479,7 @@ impl DpuMachineHandle {
             api_state: live_state.api_state.clone(),
             power_state: live_state.power_state.to_string(),
             machine_ip: live_state.machine_ip.map(|ip| ip.to_string()),
+            nvos_ip: None,
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -673,6 +673,7 @@ impl MachineHandle {
             api_state: live_state.api_state.clone(),
             power_state: live_state.power_state.to_string(),
             machine_ip: live_state.machine_ip.map(|ip| ip.to_string()),
+            nvos_ip: None,
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -506,6 +506,7 @@ impl PowerShelfHandle {
             api_state: "Unknown".to_string(),
             power_state: state.power_state.to_string(),
             machine_ip: None,
+            nvos_ip: None,
             bmc: BmcStatus {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -84,6 +84,8 @@ pub struct DeviceStatus {
     pub power_state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub machine_ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvos_ip: Option<String>,
     pub bmc: BmcStatus,
     pub dpus: Vec<DeviceStatus>,
 }

--- a/crates/machine-a-tron/src/switch_fsm.rs
+++ b/crates/machine-a-tron/src/switch_fsm.rs
@@ -25,6 +25,9 @@ pub enum SwitchFsm {
         power_cycle_pending: bool,
         paused: bool,
     },
+    NvosInit {
+        paused: bool,
+    },
     DeviceUp {
         paused: bool,
     },
@@ -42,7 +45,7 @@ impl SwitchFsm {
                 power_cycle_pending: false,
                 paused: true,
             },
-            vec![Action::Dhcp],
+            vec![Action::Dhcp(DhcpEndpoint::Bmc)],
         )
     }
 
@@ -59,6 +62,7 @@ impl SwitchFsm {
                 power_cycle_pending,
                 paused,
             } => self.fsm_bmc_init(event, power_on, power_cycle_pending, paused),
+            Self::NvosInit { paused } => self.fsm_nvos_init(event, paused),
             Self::DeviceUp { paused } => self.fsm_device_up(event, paused),
             Self::DeviceDown {
                 power_cycle_pending,
@@ -70,6 +74,7 @@ impl SwitchFsm {
     pub fn is_paused(&self) -> bool {
         match self {
             Self::BmcInit { paused, .. }
+            | Self::NvosInit { paused }
             | Self::DeviceUp { paused }
             | Self::DeviceDown { paused, .. } => *paused,
         }
@@ -77,7 +82,9 @@ impl SwitchFsm {
 
     pub fn power_state(&self) -> MockPowerState {
         match self {
-            Self::BmcInit { power_on: true, .. } | Self::DeviceUp { .. } => MockPowerState::On,
+            Self::BmcInit { power_on: true, .. }
+            | Self::NvosInit { .. }
+            | Self::DeviceUp { .. } => MockPowerState::On,
             Self::BmcInit {
                 power_on: false, ..
             }
@@ -88,8 +95,9 @@ impl SwitchFsm {
     pub fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
-            Self::DeviceUp { .. } => "BmcOnly/DeviceUp",
-            Self::DeviceDown { .. } => "BmcOnly/DeviceDown",
+            Self::NvosInit { .. } => "NvosInit",
+            Self::DeviceUp { .. } => "DeviceUp",
+            Self::DeviceDown { .. } => "DeviceDown",
         }
     }
 
@@ -104,6 +112,7 @@ impl SwitchFsm {
                 power_cycle_pending,
                 paused,
             },
+            Self::NvosInit { .. } => Self::NvosInit { paused },
             Self::DeviceUp { .. } => Self::DeviceUp { paused },
             Self::DeviceDown {
                 power_cycle_pending,
@@ -123,16 +132,20 @@ impl SwitchFsm {
         paused: bool,
     ) -> FsmReturn {
         match event {
-            Event::DhcpComplete => (
+            Event::DhcpComplete(DhcpEndpoint::Bmc) => (
                 if power_on {
-                    Self::DeviceUp { paused }
+                    Self::NvosInit { paused }
                 } else {
                     Self::DeviceDown {
                         power_cycle_pending,
                         paused,
                     }
                 },
-                vec![Action::SetupBmc],
+                if power_on {
+                    vec![Action::SetupBmc, Action::Dhcp(DhcpEndpoint::Nvos)]
+                } else {
+                    vec![Action::SetupBmc]
+                },
             ),
             Event::PowerOn => (
                 Self::BmcInit {
@@ -167,7 +180,29 @@ impl SwitchFsm {
                 vec![],
             ),
             Event::TimerAlert(Timer::PowerCycle) => (self, vec![]),
+            Event::DhcpComplete(DhcpEndpoint::Nvos) => (self, vec![]),
             Event::Pause | Event::Resume => unreachable!("handled before state dispatch"),
+        }
+    }
+
+    fn fsm_nvos_init(self, event: Event, paused: bool) -> FsmReturn {
+        match event {
+            Event::DhcpComplete(DhcpEndpoint::Nvos) => (Self::DeviceUp { paused }, vec![]),
+            Event::PowerOff => (
+                Self::DeviceDown {
+                    power_cycle_pending: false,
+                    paused,
+                },
+                vec![Action::StopNvos],
+            ),
+            Event::PowerCycle => (
+                Self::DeviceDown {
+                    power_cycle_pending: true,
+                    paused,
+                },
+                vec![Action::StopNvos, Action::SetTimer(Timer::PowerCycle)],
+            ),
+            _ => (self, vec![]),
         }
     }
 
@@ -178,14 +213,14 @@ impl SwitchFsm {
                     power_cycle_pending: false,
                     paused,
                 },
-                vec![],
+                vec![Action::StopNvos],
             ),
             Event::PowerCycle => (
                 Self::DeviceDown {
                     power_cycle_pending: true,
                     paused,
                 },
-                vec![Action::SetTimer(Timer::PowerCycle)],
+                vec![Action::StopNvos, Action::SetTimer(Timer::PowerCycle)],
             ),
             _ => (self, vec![]),
         }
@@ -194,8 +229,11 @@ impl SwitchFsm {
     fn fsm_device_down(self, event: Event, power_cycle_pending: bool, paused: bool) -> FsmReturn {
         match event {
             Event::PowerOn => (
-                Self::DeviceUp { paused },
-                cancel_timer_action(power_cycle_pending),
+                Self::NvosInit { paused },
+                cancel_timer_action(power_cycle_pending)
+                    .into_iter()
+                    .chain([Action::Dhcp(DhcpEndpoint::Nvos)])
+                    .collect(),
             ),
             Event::PowerOff => (
                 Self::DeviceDown {
@@ -204,9 +242,10 @@ impl SwitchFsm {
                 },
                 cancel_timer_action(power_cycle_pending),
             ),
-            Event::TimerAlert(Timer::PowerCycle) if power_cycle_pending => {
-                (Self::DeviceUp { paused }, vec![])
-            }
+            Event::TimerAlert(Timer::PowerCycle) if power_cycle_pending => (
+                Self::NvosInit { paused },
+                vec![Action::Dhcp(DhcpEndpoint::Nvos)],
+            ),
             Event::TimerAlert(Timer::PowerCycle) => (self, vec![]),
             Event::PowerCycle => (
                 Self::DeviceDown {
@@ -230,7 +269,7 @@ fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Event {
-    DhcpComplete,
+    DhcpComplete(DhcpEndpoint),
     PowerOn,
     PowerOff,
     PowerCycle,
@@ -241,8 +280,9 @@ pub enum Event {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Action {
-    Dhcp,
+    Dhcp(DhcpEndpoint),
     SetupBmc,
+    StopNvos,
     SetTimer(Timer),
     CancelTimer(Timer),
 }
@@ -250,6 +290,12 @@ pub enum Action {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Timer {
     PowerCycle,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DhcpEndpoint {
+    Bmc,
+    Nvos,
 }
 
 #[cfg(test)]
@@ -270,7 +316,7 @@ mod tests {
                             power_cycle_pending: false,
                             paused: false,
                         },
-                        Event::DhcpComplete,
+                        Event::DhcpComplete(DhcpEndpoint::Bmc),
                     ),
                     expect: (
                         SwitchFsm::DeviceDown {
@@ -288,12 +334,20 @@ mod tests {
                             power_cycle_pending: false,
                             paused: false,
                         },
-                        Event::DhcpComplete,
+                        Event::DhcpComplete(DhcpEndpoint::Bmc),
                     ),
                     expect: (
-                        SwitchFsm::DeviceUp { paused: false },
-                        vec![Action::SetupBmc],
+                        SwitchFsm::NvosInit { paused: false },
+                        vec![Action::SetupBmc, Action::Dhcp(DhcpEndpoint::Nvos)],
                     ),
+                },
+                Check {
+                    scenario: "NVOS DHCP completes switch startup",
+                    input: (
+                        SwitchFsm::NvosInit { paused: false },
+                        Event::DhcpComplete(DhcpEndpoint::Nvos),
+                    ),
+                    expect: (SwitchFsm::DeviceUp { paused: false }, vec![]),
                 },
                 Check {
                     scenario: "powered switch begins a power cycle",
@@ -303,7 +357,7 @@ mod tests {
                             power_cycle_pending: true,
                             paused: false,
                         },
-                        vec![Action::SetTimer(Timer::PowerCycle)],
+                        vec![Action::StopNvos, Action::SetTimer(Timer::PowerCycle)],
                     ),
                 },
                 Check {
@@ -315,7 +369,10 @@ mod tests {
                         },
                         Event::TimerAlert(Timer::PowerCycle),
                     ),
-                    expect: (SwitchFsm::DeviceUp { paused: false }, vec![]),
+                    expect: (
+                        SwitchFsm::NvosInit { paused: false },
+                        vec![Action::Dhcp(DhcpEndpoint::Nvos)],
+                    ),
                 },
                 Check {
                     scenario: "explicit power-on cancels a pending power cycle",
@@ -327,8 +384,11 @@ mod tests {
                         Event::PowerOn,
                     ),
                     expect: (
-                        SwitchFsm::DeviceUp { paused: false },
-                        vec![Action::CancelTimer(Timer::PowerCycle)],
+                        SwitchFsm::NvosInit { paused: false },
+                        vec![
+                            Action::CancelTimer(Timer::PowerCycle),
+                            Action::Dhcp(DhcpEndpoint::Nvos),
+                        ],
                     ),
                 },
                 Check {
@@ -346,6 +406,17 @@ mod tests {
                             paused: false,
                         },
                         vec![Action::SetTimer(Timer::PowerCycle)],
+                    ),
+                },
+                Check {
+                    scenario: "power off while NVOS starts leaves the switch down",
+                    input: (SwitchFsm::NvosInit { paused: false }, Event::PowerOff),
+                    expect: (
+                        SwitchFsm::DeviceDown {
+                            power_cycle_pending: false,
+                            paused: false,
+                        },
+                        vec![Action::StopNvos],
                     ),
                 },
                 Check {

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -38,13 +38,14 @@ use crate::dhcp_wrapper::{DhcpRequestInfo, DhcpRequester, DhcpResponseInfo, vend
 use crate::machine_state_machine::{MachineStateError, OsImage};
 use crate::saturating_add_duration_to_instant;
 use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus};
-use crate::switch_fsm::{Action, Event, SwitchFsm, Timer};
+use crate::switch_fsm::{Action, DhcpEndpoint, Event, SwitchFsm, Timer};
 use crate::tui::UiUpdate;
 
 #[derive(Debug)]
 struct SwitchLiveState {
     power_state: MockPowerState,
     bmc_ip: Option<Ipv4Addr>,
+    nvos_ip: Option<Ipv4Addr>,
     ipmi_endpoint: Option<IpmiEndpoint>,
     ssh_host_key: Option<String>,
     state: &'static str,
@@ -55,6 +56,7 @@ impl SwitchLiveState {
         Self {
             power_state: fsm.power_state(),
             bmc_ip: None,
+            nvos_ip: None,
             ipmi_endpoint: None,
             ssh_host_key: None,
             state: fsm.state_string(),
@@ -125,7 +127,8 @@ impl SwitchActor {
         mac_pool: &mut MacAddressPool,
         hw_mac_addr_pool: MacAddressPoolConfig,
     ) -> Self {
-        let (fsm, actions) = SwitchFsm::init(false);
+        // Simulated switches start powered so NVOS can boot and expose its management interface.
+        let (fsm, actions) = SwitchFsm::init(true);
         Self {
             mat_id: Uuid::new_v4(),
             machine_config_section,
@@ -225,17 +228,32 @@ impl SwitchActor {
         while let Some(action) = self.actions.front().copied() {
             self.update_live_state();
             match action {
-                Action::Dhcp => match self.bmc_dhcp_discovery().await {
+                Action::Dhcp(DhcpEndpoint::Bmc) => match self.bmc_dhcp_discovery().await {
                     Ok(dhcp_info) => {
                         self.bmc_dhcp_info = Some(dhcp_info);
                         self.actions.pop_front();
-                        self.fsm_event(Event::DhcpComplete);
+                        self.fsm_event(Event::DhcpComplete(DhcpEndpoint::Bmc));
                     }
                     Err(error) => {
                         tracing::warn!(
                             device_id = %self.mat_id,
                             error = %error,
                             "Switch BMC DHCP failed",
+                        );
+                        return Some(self.config.run_interval_working);
+                    }
+                },
+                Action::Dhcp(DhcpEndpoint::Nvos) => match self.nvos_dhcp_discovery().await {
+                    Ok(dhcp_info) => {
+                        self.live_state.write().unwrap().nvos_ip = Some(dhcp_info.ip_address);
+                        self.actions.pop_front();
+                        self.fsm_event(Event::DhcpComplete(DhcpEndpoint::Nvos));
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            device_id = %self.mat_id,
+                            error = %error,
+                            "Switch NVOS DHCP failed",
                         );
                         return Some(self.config.run_interval_working);
                     }
@@ -253,6 +271,10 @@ impl SwitchActor {
                         return Some(self.config.run_interval_working);
                     }
                 },
+                Action::StopNvos => {
+                    self.live_state.write().unwrap().nvos_ip = None;
+                    self.actions.pop_front();
+                }
                 Action::SetTimer(Timer::PowerCycle) => {
                     self.power_cycle_alarm = Some(
                         mailbox
@@ -299,6 +321,26 @@ impl SwitchActor {
                 vendor_class: vendor_class(&machine_info, DhcpRequester::Bmc),
             })
             .await
+    }
+
+    async fn nvos_dhcp_discovery(&self) -> eyre::Result<DhcpResponseInfo> {
+        let [nvos_mac_address] = self.host_info.nvos_mac_addresses.as_slice() else {
+            eyre::bail!(
+                "switch must have exactly one NVOS MAC address, found {}",
+                self.host_info.nvos_mac_addresses.len(),
+            );
+        };
+
+        Ok(self
+            .app_context
+            .dhcp_client
+            .request_ip(DhcpRequestInfo {
+                mac_address: *nvos_mac_address,
+                relay_address: self.config.admin_dhcp_relay_address,
+                // No DHCP option 60 value has been verified for NVOS.
+                vendor_class: None,
+            })
+            .await?)
     }
 
     async fn setup_bmc(
@@ -500,6 +542,7 @@ impl SwitchHandle {
             api_state: "Unknown".to_string(),
             power_state: state.power_state.to_string(),
             machine_ip: None,
+            nvos_ip: state.nvos_ip.map(|ip| ip.to_string()),
             bmc: BmcStatus {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),


### PR DESCRIPTION
Machine-a-tron previously simulated only the BMC side of NVOS switches. Without an NVOS DHCP request, no management interface was created and the switch controller remained in `WaitForOsMachineInterface`.

This adds a power-aware NVOS lifecycle to the switch actor. NVOS now performs DHCP when the switch powers on, registers mock bootstrap credentials, and exposes its assigned address through machine-a-tron status.

This enables hardware-free switch lifecycle testing and allows simulated NVOS switches to reach `ready`.

## Related issues

Fixes #3430

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

It simulates NVOS DHCP and bootstrap credentials, but does not provide a real NVOS/NVUE protocol endpoint.
