### PR TITLE
patch(v2.0): stop pushing expected inventory into Flow

### DIFF
--- a/rest-api/common/pkg/util/labels/rack_labels.go
+++ b/rest-api/common/pkg/util/labels/rack_labels.go
@@ -4,8 +4,8 @@
 package labels
 
 // Well-known label keys for Expected/Managed Rack metadata.
-// These mirror the constants defined in Core's api-model crate so REST callers,
-// the site-workflow, and Core stay aligned on rack chassis and location labels.
+// These mirror the constants defined in Core's api-model crate so REST callers
+// and Core stay aligned on rack chassis and location labels.
 
 const (
 	// Chassis identity labels — physically identifies the rack hardware.

--- a/rest-api/site-agent/pkg/components/managers/expectedmachine/subscriber.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedmachine/subscriber.go
@@ -35,7 +35,7 @@ func (api *API) RegisterSubscriber() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("ExpectedMachine: Successfully registered UpdateExpectedMachines workflow")
 
 	// Register activities
-	expectedMachineManager := swa.NewManageExpectedMachine(ManagerAccess.Data.EB.Managers.CoreGrpc.Client, ManagerAccess.Data.EB.Managers.FlowGrpc.Client)
+	expectedMachineManager := swa.NewManageExpectedMachine(ManagerAccess.Data.EB.Managers.CoreGrpc.Client)
 
 	// Register CreateExpectedMachineOnSite activity
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnSite)

--- a/rest-api/site-agent/pkg/components/managers/expectedpowershelf/subscriber.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedpowershelf/subscriber.go
@@ -27,7 +27,7 @@ func (api *API) RegisterSubscriber() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("ExpectedPowerShelf: Successfully registered DeleteExpectedPowerShelf workflow")
 
 	// Register activities
-	expectedPowerShelfManager := swa.NewManageExpectedPowerShelf(ManagerAccess.Data.EB.Managers.CoreGrpc.Client, ManagerAccess.Data.EB.Managers.FlowGrpc.Client)
+	expectedPowerShelfManager := swa.NewManageExpectedPowerShelf(ManagerAccess.Data.EB.Managers.CoreGrpc.Client)
 
 	// Register CreateExpectedPowerShelfOnSite activity
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite)

--- a/rest-api/site-agent/pkg/components/managers/expectedrack/subscriber.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedrack/subscriber.go
@@ -35,7 +35,7 @@ func (api *API) RegisterSubscriber() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("ExpectedRack: Successfully registered DeleteAllExpectedRacks workflow")
 
 	// Register activities
-	expectedRackManager := swa.NewManageExpectedRack(ManagerAccess.Data.EB.Managers.CoreGrpc.Client, ManagerAccess.Data.EB.Managers.FlowGrpc.Client)
+	expectedRackManager := swa.NewManageExpectedRack(ManagerAccess.Data.EB.Managers.CoreGrpc.Client)
 
 	// Register CreateExpectedRackOnSite activity
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(expectedRackManager.CreateExpectedRackOnSite)

--- a/rest-api/site-agent/pkg/components/managers/expectedswitch/subscriber.go
+++ b/rest-api/site-agent/pkg/components/managers/expectedswitch/subscriber.go
@@ -27,7 +27,7 @@ func (api *API) RegisterSubscriber() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("ExpectedSwitch: Successfully registered DeleteExpectedSwitch workflow")
 
 	// Register activities
-	expectedSwitchManager := swa.NewManageExpectedSwitch(ManagerAccess.Data.EB.Managers.CoreGrpc.Client, ManagerAccess.Data.EB.Managers.FlowGrpc.Client)
+	expectedSwitchManager := swa.NewManageExpectedSwitch(ManagerAccess.Data.EB.Managers.CoreGrpc.Client)
 
 	// Register CreateExpectedSwitchOnSite activity
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnSite)

--- a/rest-api/site-workflow/pkg/activity/expectedmachine.go
+++ b/rest-api/site-workflow/pkg/activity/expectedmachine.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"go.temporal.io/sdk/client"
 	tClient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -19,7 +18,6 @@ import (
 
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 	cclient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
@@ -151,7 +149,7 @@ func (memi *ManageExpectedMachineInventory) DiscoverExpectedMachineInventory(ctx
 			endIndex = totalCount
 		}
 
-		pagedWorkflowOptions := client.StartWorkflowOptions{
+		pagedWorkflowOptions := tClient.StartWorkflowOptions{
 			ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, cloudPage),
 			TaskQueue: workflowOptions.TaskQueue,
 		}
@@ -243,14 +241,12 @@ func NewManageExpectedMachineInventory(siteID uuid.UUID, coreGrpcAtomicClient *c
 // ManageExpectedMachine is an activity wrapper for Expected Machine management
 type ManageExpectedMachine struct {
 	coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient
-	flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient
 }
 
 // NewManageExpectedMachine returns a new ManageExpectedMachine client
-func NewManageExpectedMachine(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient, flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient) ManageExpectedMachine {
+func NewManageExpectedMachine(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient) ManageExpectedMachine {
 	return ManageExpectedMachine{
 		coreGrpcAtomicClient: coreGrpcAtomicClient,
-		flowGrpcAtomicClient: flowGrpcAtomicClient,
 	}
 }
 
@@ -423,135 +419,20 @@ func (mem *ManageExpectedMachine) CreateExpectedMachinesOnSite(ctx context.Conte
 	return response, nil
 }
 
-// CreateExpectedMachineOnFlow creates an Expected Machine as a component in Flow via AddComponent
-func (mem *ManageExpectedMachine) CreateExpectedMachineOnFlow(ctx context.Context, request *cwssaws.ExpectedMachine) error {
-	logger := log.With().Str("Activity", "CreateExpectedMachineOnFlow").Logger()
-
-	logger.Info().Msg("Starting activity")
-
-	// Validate request
-	if request == nil {
-		return temporal.NewNonRetryableApplicationError("received empty create Expected Machine request for Flow", swe.ErrTypeInvalidRequest, errors.New("nil request"))
-	}
-
-	// If Flow client is not configured, skip gracefully
-	if mem.flowGrpcAtomicClient == nil {
-		logger.Warn().Msg("Flow client not configured, skipping Flow component creation")
-		return nil
-	}
-
-	flowClient := mem.flowGrpcAtomicClient.GetClient()
-	if flowClient == nil {
-		logger.Warn().Msg("Flow client not connected, skipping Flow component creation")
-		return nil
-	}
-
-	component := expectedMachineToFlowComponent(request)
-	_, err := flowClient.GrpcServiceClient().AddComponent(ctx, &flowv1.AddComponentRequest{Component: component})
-	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to create Expected Machine component on Flow")
-		return swe.WrapErr(err)
-	}
-
-	logger.Info().Msg("Completed activity")
+// CreateExpectedMachineOnFlow is retained as a no-op for compatibility with
+// workflow histories recorded before direct Flow writes were removed.
+// Remove it after the matching `GetVersion` branch is retired and those
+// histories can no longer be replayed.
+func (*ManageExpectedMachine) CreateExpectedMachineOnFlow(context.Context, *cwssaws.ExpectedMachine) error {
 	return nil
 }
 
-// CreateExpectedMachinesOnFlow creates multiple Expected Machines as components in Flow via AddComponent
-func (mem *ManageExpectedMachine) CreateExpectedMachinesOnFlow(ctx context.Context, request *cwssaws.BatchExpectedMachineOperationRequest) error {
-	logger := log.With().Str("Activity", "CreateExpectedMachinesOnFlow").Logger()
-
-	logger.Info().Msg("Starting activity")
-
-	// If Flow client is not configured, skip gracefully
-	if mem.flowGrpcAtomicClient == nil {
-		logger.Warn().Msg("Flow client not configured, skipping Flow component creation")
-		return nil
-	}
-
-	flowClient := mem.flowGrpcAtomicClient.GetClient()
-	if flowClient == nil {
-		logger.Warn().Msg("Flow client not connected, skipping Flow component creation")
-		return nil
-	}
-
-	grpcServiceClient := flowClient.GrpcServiceClient()
-	machines := request.GetExpectedMachines().GetExpectedMachines()
-	successes := 0
-	failures := 0
-
-	// TODO(chet): Work with Flow team to add batch support so we don't have to loop here.
-	for _, machine := range machines {
-		component := expectedMachineToFlowComponent(machine)
-		_, err := grpcServiceClient.AddComponent(ctx, &flowv1.AddComponentRequest{Component: component})
-		if err != nil {
-			logger.Warn().Err(err).Str("ID", machine.GetId().GetValue()).Msg("Failed to create Expected Machine component on Flow")
-			failures++
-		} else {
-			successes++
-		}
-	}
-
-	logger.Info().
-		Int("Total", len(machines)).
-		Int("Succeeded", successes).
-		Int("Failed", failures).
-		Msg("Completed activity")
-
+// CreateExpectedMachinesOnFlow is retained as a no-op for compatibility with
+// workflow histories recorded before direct Flow writes were removed.
+// Remove it after the matching `GetVersion` branch is retired and those
+// histories can no longer be replayed.
+func (*ManageExpectedMachine) CreateExpectedMachinesOnFlow(context.Context, *cwssaws.BatchExpectedMachineOperationRequest) error {
 	return nil
-}
-
-// expectedMachineToFlowComponent converts a NICo ExpectedMachine proto to an Flow Component proto
-func expectedMachineToFlowComponent(em *cwssaws.ExpectedMachine) *flowv1.Component {
-	component := &flowv1.Component{
-		Type: flowv1.ComponentType_COMPONENT_TYPE_COMPUTE,
-		Info: &flowv1.DeviceInfo{
-			Id:           &flowv1.UUID{Id: em.GetId().GetValue()},
-			SerialNumber: em.GetChassisSerialNumber(),
-		},
-		Bmcs: []*flowv1.BMCInfo{
-			{
-				Type:       flowv1.BMCType_BMC_TYPE_HOST,
-				MacAddress: em.GetBmcMacAddress(),
-			},
-		},
-		ComponentId: em.GetId().GetValue(),
-	}
-
-	// DeviceInfo fields
-	if name := em.GetName(); name != "" {
-		component.Info.Name = name
-	}
-	if manufacturer := em.GetManufacturer(); manufacturer != "" {
-		component.Info.Manufacturer = manufacturer
-	}
-	if em.Model != nil {
-		component.Info.Model = em.Model
-	}
-	if em.Description != nil {
-		component.Info.Description = em.Description
-	}
-
-	// Rack position
-	if em.SlotId != nil || em.TrayIdx != nil || em.HostId != nil {
-		pos := &flowv1.RackPosition{}
-		if em.SlotId != nil {
-			pos.SlotId = *em.SlotId
-		}
-		if em.TrayIdx != nil {
-			pos.TrayIdx = *em.TrayIdx
-		}
-		if em.HostId != nil {
-			pos.HostId = *em.HostId
-		}
-		component.Position = pos
-	}
-
-	if rackID := em.GetRackId().GetId(); rackID != "" {
-		component.RackId = &flowv1.UUID{Id: rackID}
-	}
-
-	return component
 }
 
 // UpdateExpectedMachinesOnSite updates multiple Expected Machines on NICo using the batch endpoint

--- a/rest-api/site-workflow/pkg/activity/expectedmachine_test.go
+++ b/rest-api/site-workflow/pkg/activity/expectedmachine_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -262,7 +261,7 @@ func TestManageExpectedMachine_CreateExpectedMachineOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient)
 			err := mm.CreateExpectedMachineOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -381,7 +380,7 @@ func TestManageExpectedMachine_UpdateExpectedMachineOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient)
 			err := mm.UpdateExpectedMachineOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -467,7 +466,7 @@ func TestManageExpectedMachine_DeleteExpectedMachineOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient)
 			err := mm.DeleteExpectedMachineOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -553,7 +552,7 @@ func TestManageExpectedMachine_CreateExpectedMachinesOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient)
 			response, err := mm.CreateExpectedMachinesOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -650,7 +649,7 @@ func TestManageExpectedMachine_UpdateExpectedMachinesOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedMachine(tt.fields.coreGrpcAtomicClient)
 			response, err := mm.UpdateExpectedMachinesOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -673,121 +672,15 @@ func TestManageExpectedMachine_UpdateExpectedMachinesOnSite(t *testing.T) {
 }
 
 func TestManageExpectedMachine_CreateExpectedMachineOnFlow(t *testing.T) {
-	t.Run("nil Flow client skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedMachine{flowGrpcAtomicClient: nil}
-		err := mm.CreateExpectedMachineOnFlow(context.Background(), &cwssaws.ExpectedMachine{
-			Id: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", ChassisSerialNumber: "SN001",
-		})
-		assert.NoError(t, err)
-	})
+	manager := NewManageExpectedMachine(nil)
 
-	t.Run("nil Flow client connection skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedMachine{flowGrpcAtomicClient: cClient.NewFlowGrpcAtomicClient(&cClient.FlowGrpcClientConfig{})}
-		err := mm.CreateExpectedMachineOnFlow(context.Background(), &cwssaws.ExpectedMachine{
-			Id: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", ChassisSerialNumber: "SN001",
-		})
-		assert.NoError(t, err)
-	})
+	assert.NoError(t, manager.CreateExpectedMachineOnFlow(context.Background(), nil))
+	assert.NoError(t, manager.CreateExpectedMachineOnFlow(context.Background(), &cwssaws.ExpectedMachine{}))
 }
 
 func TestManageExpectedMachine_CreateExpectedMachinesOnFlow(t *testing.T) {
-	t.Run("nil Flow client skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedMachine{flowGrpcAtomicClient: nil}
-		err := mm.CreateExpectedMachinesOnFlow(context.Background(), &cwssaws.BatchExpectedMachineOperationRequest{
-			ExpectedMachines: &cwssaws.ExpectedMachineList{
-				ExpectedMachines: []*cwssaws.ExpectedMachine{
-					{Id: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", ChassisSerialNumber: "SN001"},
-				},
-			},
-		})
-		assert.NoError(t, err)
-	})
+	manager := NewManageExpectedMachine(nil)
 
-	t.Run("nil Flow client connection skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedMachine{flowGrpcAtomicClient: cClient.NewFlowGrpcAtomicClient(&cClient.FlowGrpcClientConfig{})}
-		err := mm.CreateExpectedMachinesOnFlow(context.Background(), &cwssaws.BatchExpectedMachineOperationRequest{
-			ExpectedMachines: &cwssaws.ExpectedMachineList{
-				ExpectedMachines: []*cwssaws.ExpectedMachine{
-					{Id: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", ChassisSerialNumber: "SN001"},
-				},
-			},
-		})
-		assert.NoError(t, err)
-	})
-}
-
-func Test_expectedMachineToFlowComponent(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-	int32Ptr := func(i int32) *int32 { return &i }
-
-	t.Run("maps all fields correctly", func(t *testing.T) {
-		em := &cwssaws.ExpectedMachine{
-			Id:                  &cwssaws.UUID{Value: "em-001"},
-			BmcMacAddress:       "AA:BB:CC:DD:EE:FF",
-			ChassisSerialNumber: "CHASSIS-001",
-			RackId:              &cwssaws.RackId{Id: "rack-001"},
-			Name:                strPtr("compute-node-1"),
-			Manufacturer:        strPtr("NVIDIA"),
-			Model:               strPtr("DGX-H100"),
-			Description:         strPtr("GPU compute node"),
-			SlotId:              int32Ptr(1),
-			TrayIdx:             int32Ptr(2),
-			HostId:              int32Ptr(3),
-		}
-		component := expectedMachineToFlowComponent(em)
-		assert.Equal(t, flowv1.ComponentType_COMPONENT_TYPE_COMPUTE, component.Type)
-		assert.Equal(t, "em-001", component.Info.Id.Id)
-		assert.Equal(t, "CHASSIS-001", component.Info.SerialNumber)
-		assert.Equal(t, "compute-node-1", component.Info.Name)
-		assert.Equal(t, "NVIDIA", component.Info.Manufacturer)
-		assert.Equal(t, "DGX-H100", *component.Info.Model)
-		assert.Equal(t, "GPU compute node", *component.Info.Description)
-		assert.Equal(t, "em-001", component.ComponentId)
-		assert.NotNil(t, component.Position)
-		assert.Equal(t, int32(1), component.Position.SlotId)
-		assert.Equal(t, int32(2), component.Position.TrayIdx)
-		assert.Equal(t, int32(3), component.Position.HostId)
-		if assert.Len(t, component.Bmcs, 1) {
-			assert.Equal(t, flowv1.BMCType_BMC_TYPE_HOST, component.Bmcs[0].Type)
-			assert.Equal(t, "AA:BB:CC:DD:EE:FF", component.Bmcs[0].MacAddress)
-		}
-		assert.NotNil(t, component.RackId)
-		assert.Equal(t, "rack-001", component.RackId.Id)
-	})
-
-	t.Run("handles minimal fields (nil optionals)", func(t *testing.T) {
-		em := &cwssaws.ExpectedMachine{
-			Id: &cwssaws.UUID{Value: "em-002"}, BmcMacAddress: "11:22:33:44:55:66", ChassisSerialNumber: "CHASSIS-002",
-		}
-		component := expectedMachineToFlowComponent(em)
-		assert.Equal(t, flowv1.ComponentType_COMPONENT_TYPE_COMPUTE, component.Type)
-		assert.Equal(t, "em-002", component.ComponentId)
-		assert.Empty(t, component.Info.Name)
-		assert.Empty(t, component.Info.Manufacturer)
-		assert.Nil(t, component.Info.Model)
-		assert.Nil(t, component.Info.Description)
-		assert.Nil(t, component.Position)
-		assert.Nil(t, component.RackId)
-	})
-
-	t.Run("ignores empty rack_id wrapper", func(t *testing.T) {
-		em := &cwssaws.ExpectedMachine{
-			Id: &cwssaws.UUID{Value: "em-003"}, BmcMacAddress: "22:33:44:55:66:77",
-			ChassisSerialNumber: "CHASSIS-003", RackId: &cwssaws.RackId{Id: ""},
-		}
-		component := expectedMachineToFlowComponent(em)
-		assert.Nil(t, component.RackId)
-	})
-
-	t.Run("partial position fields", func(t *testing.T) {
-		em := &cwssaws.ExpectedMachine{
-			Id: &cwssaws.UUID{Value: "em-004"}, BmcMacAddress: "33:44:55:66:77:88",
-			ChassisSerialNumber: "CHASSIS-004", SlotId: int32Ptr(5),
-		}
-		component := expectedMachineToFlowComponent(em)
-		assert.NotNil(t, component.Position)
-		assert.Equal(t, int32(5), component.Position.SlotId)
-		assert.Equal(t, int32(0), component.Position.TrayIdx)
-		assert.Equal(t, int32(0), component.Position.HostId)
-	})
+	assert.NoError(t, manager.CreateExpectedMachinesOnFlow(context.Background(), nil))
+	assert.NoError(t, manager.CreateExpectedMachinesOnFlow(context.Background(), &cwssaws.BatchExpectedMachineOperationRequest{}))
 }

--- a/rest-api/site-workflow/pkg/activity/expectedpowershelf.go
+++ b/rest-api/site-workflow/pkg/activity/expectedpowershelf.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"go.temporal.io/sdk/client"
 	tClient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -19,7 +18,6 @@ import (
 
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 	cclient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
@@ -151,7 +149,7 @@ func (mepsi *ManageExpectedPowerShelfInventory) DiscoverExpectedPowerShelfInvent
 			endIndex = totalCount
 		}
 
-		pagedWorkflowOptions := client.StartWorkflowOptions{
+		pagedWorkflowOptions := tClient.StartWorkflowOptions{
 			ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, cloudPage),
 			TaskQueue: workflowOptions.TaskQueue,
 		}
@@ -243,14 +241,12 @@ func NewManageExpectedPowerShelfInventory(siteID uuid.UUID, coreGrpcAtomicClient
 // ManageExpectedPowerShelf is an activity wrapper for Expected Power Shelf management
 type ManageExpectedPowerShelf struct {
 	coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient
-	flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient
 }
 
 // NewManageExpectedPowerShelf returns a new ManageExpectedPowerShelf client
-func NewManageExpectedPowerShelf(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient, flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient) ManageExpectedPowerShelf {
+func NewManageExpectedPowerShelf(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient) ManageExpectedPowerShelf {
 	return ManageExpectedPowerShelf{
 		coreGrpcAtomicClient: coreGrpcAtomicClient,
-		flowGrpcAtomicClient: flowGrpcAtomicClient,
 	}
 }
 
@@ -333,97 +329,12 @@ func (meps *ManageExpectedPowerShelf) UpdateExpectedPowerShelfOnSite(ctx context
 	return nil
 }
 
-// CreateExpectedPowerShelfOnFlow creates an Expected Power Shelf as a component in Flow via AddComponent
-func (meps *ManageExpectedPowerShelf) CreateExpectedPowerShelfOnFlow(ctx context.Context, request *cwssaws.ExpectedPowerShelf) error {
-	logger := log.With().Str("Activity", "CreateExpectedPowerShelfOnFlow").Logger()
-
-	logger.Info().Msg("Starting activity")
-
-	// Validate request
-	if request == nil {
-		return temporal.NewNonRetryableApplicationError("received empty create Expected Power Shelf request for Flow", swe.ErrTypeInvalidRequest, errors.New("nil request"))
-	}
-
-	// If Flow client is not configured, skip gracefully
-	if meps.flowGrpcAtomicClient == nil {
-		logger.Warn().Msg("Flow client not configured, skipping Flow component creation")
-		return nil
-	}
-
-	grpcClient := meps.flowGrpcAtomicClient.GetClient()
-	if grpcClient == nil {
-		logger.Warn().Msg("Flow client not connected, skipping Flow component creation")
-		return nil
-	}
-	grpcServiceClient := grpcClient.GrpcServiceClient()
-
-	component := expectedPowerShelfToFlowComponent(request)
-	_, err := grpcServiceClient.AddComponent(ctx, &flowv1.AddComponentRequest{Component: component})
-	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to create Expected Power Shelf component on Flow")
-		return swe.WrapErr(err)
-	}
-
-	logger.Info().Msg("Completed activity")
+// CreateExpectedPowerShelfOnFlow is retained as a no-op for compatibility with
+// workflow histories recorded before direct Flow writes were removed.
+// Remove it after the matching `GetVersion` branch is retired and those
+// histories can no longer be replayed.
+func (*ManageExpectedPowerShelf) CreateExpectedPowerShelfOnFlow(context.Context, *cwssaws.ExpectedPowerShelf) error {
 	return nil
-}
-
-// expectedPowerShelfToFlowComponent converts a NICo ExpectedPowerShelf proto to an Flow Component proto
-func expectedPowerShelfToFlowComponent(eps *cwssaws.ExpectedPowerShelf) *flowv1.Component {
-	component := &flowv1.Component{
-		Type: flowv1.ComponentType_COMPONENT_TYPE_POWERSHELF,
-		Info: &flowv1.DeviceInfo{
-			Id:           &flowv1.UUID{Id: eps.GetExpectedPowerShelfId().GetValue()},
-			SerialNumber: eps.GetShelfSerialNumber(),
-		},
-		Bmcs: []*flowv1.BMCInfo{
-			{
-				Type:       flowv1.BMCType_BMC_TYPE_HOST,
-				MacAddress: eps.GetBmcMacAddress(),
-			},
-		},
-		ComponentId: eps.GetExpectedPowerShelfId().GetValue(),
-	}
-
-	// DeviceInfo fields
-	if name := eps.GetName(); name != "" {
-		component.Info.Name = name
-	}
-	if manufacturer := eps.GetManufacturer(); manufacturer != "" {
-		component.Info.Manufacturer = manufacturer
-	}
-	if eps.Model != nil {
-		component.Info.Model = eps.Model
-	}
-	if eps.Description != nil {
-		component.Info.Description = eps.Description
-	}
-
-	// Rack position
-	if eps.SlotId != nil || eps.TrayIdx != nil || eps.HostId != nil {
-		pos := &flowv1.RackPosition{}
-		if eps.SlotId != nil {
-			pos.SlotId = *eps.SlotId
-		}
-		if eps.TrayIdx != nil {
-			pos.TrayIdx = *eps.TrayIdx
-		}
-		if eps.HostId != nil {
-			pos.HostId = *eps.HostId
-		}
-		component.Position = pos
-	}
-
-	if eps.GetBmcIpAddress() != "" {
-		ipAddr := eps.GetBmcIpAddress()
-		component.Bmcs[0].IpAddress = &ipAddr
-	}
-
-	if rackID := eps.GetRackId().GetId(); rackID != "" {
-		component.RackId = &flowv1.UUID{Id: rackID}
-	}
-
-	return component
 }
 
 // DeleteExpectedPowerShelfOnSite deletes Expected Power Shelf on NICo

--- a/rest-api/site-workflow/pkg/activity/expectedpowershelf_test.go
+++ b/rest-api/site-workflow/pkg/activity/expectedpowershelf_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -228,7 +227,7 @@ func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedPowerShelf(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedPowerShelf(tt.fields.coreGrpcAtomicClient)
 			err := mm.CreateExpectedPowerShelfOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -347,7 +346,7 @@ func TestManageExpectedPowerShelf_UpdateExpectedPowerShelfOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedPowerShelf(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedPowerShelf(tt.fields.coreGrpcAtomicClient)
 			err := mm.UpdateExpectedPowerShelfOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -433,7 +432,7 @@ func TestManageExpectedPowerShelf_DeleteExpectedPowerShelfOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedPowerShelf(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedPowerShelf(tt.fields.coreGrpcAtomicClient)
 			err := mm.DeleteExpectedPowerShelfOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -445,76 +444,8 @@ func TestManageExpectedPowerShelf_DeleteExpectedPowerShelfOnSite(t *testing.T) {
 }
 
 func TestManageExpectedPowerShelf_CreateExpectedPowerShelfOnFlow(t *testing.T) {
-	t.Run("nil Flow client skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedPowerShelf{flowGrpcAtomicClient: nil}
-		err := mm.CreateExpectedPowerShelfOnFlow(context.Background(), &cwssaws.ExpectedPowerShelf{
-			ExpectedPowerShelfId: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", ShelfSerialNumber: "SHELF001",
-		})
-		assert.NoError(t, err)
-	})
+	manager := NewManageExpectedPowerShelf(nil)
 
-	t.Run("nil Flow client connection skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedPowerShelf{flowGrpcAtomicClient: cClient.NewFlowGrpcAtomicClient(&cClient.FlowGrpcClientConfig{})}
-		err := mm.CreateExpectedPowerShelfOnFlow(context.Background(), &cwssaws.ExpectedPowerShelf{
-			ExpectedPowerShelfId: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", ShelfSerialNumber: "SHELF001",
-		})
-		assert.NoError(t, err)
-	})
-}
-
-func Test_expectedPowerShelfToFlowComponent(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-	int32Ptr := func(i int32) *int32 { return &i }
-
-	t.Run("maps all fields correctly", func(t *testing.T) {
-		eps := &cwssaws.ExpectedPowerShelf{
-			ExpectedPowerShelfId: &cwssaws.UUID{Value: "eps-001"},
-			BmcMacAddress:        "AA:BB:CC:DD:EE:FF",
-			ShelfSerialNumber:    "SHELF-001",
-			BmcIpAddress:         "10.0.0.1",
-			RackId:               &cwssaws.RackId{Id: "rack-001"},
-			Name:                 strPtr("pdu-shelf-1"),
-			Manufacturer:         strPtr("Vertiv"),
-			Model:                strPtr("GXT5-3000"),
-			Description:          strPtr("Power distribution shelf"),
-			SlotId:               int32Ptr(10),
-			TrayIdx:              int32Ptr(0),
-			HostId:               int32Ptr(0),
-		}
-		component := expectedPowerShelfToFlowComponent(eps)
-		assert.Equal(t, flowv1.ComponentType_COMPONENT_TYPE_POWERSHELF, component.Type)
-		assert.Equal(t, "eps-001", component.Info.Id.Id)
-		assert.Equal(t, "SHELF-001", component.Info.SerialNumber)
-		assert.Equal(t, "pdu-shelf-1", component.Info.Name)
-		assert.Equal(t, "Vertiv", component.Info.Manufacturer)
-		assert.Equal(t, "GXT5-3000", *component.Info.Model)
-		assert.Equal(t, "Power distribution shelf", *component.Info.Description)
-		assert.Equal(t, "eps-001", component.ComponentId)
-		assert.NotNil(t, component.Position)
-		assert.Equal(t, int32(10), component.Position.SlotId)
-		if assert.Len(t, component.Bmcs, 1) {
-			assert.Equal(t, "AA:BB:CC:DD:EE:FF", component.Bmcs[0].MacAddress)
-			assert.NotNil(t, component.Bmcs[0].IpAddress)
-			assert.Equal(t, "10.0.0.1", *component.Bmcs[0].IpAddress)
-		}
-		assert.NotNil(t, component.RackId)
-		assert.Equal(t, "rack-001", component.RackId.Id)
-	})
-
-	t.Run("handles minimal fields (nil optionals)", func(t *testing.T) {
-		eps := &cwssaws.ExpectedPowerShelf{
-			ExpectedPowerShelfId: &cwssaws.UUID{Value: "eps-002"}, BmcMacAddress: "11:22:33:44:55:66",
-			ShelfSerialNumber: "SHELF-002",
-		}
-		component := expectedPowerShelfToFlowComponent(eps)
-		assert.Equal(t, flowv1.ComponentType_COMPONENT_TYPE_POWERSHELF, component.Type)
-		assert.Empty(t, component.Info.Name)
-		assert.Empty(t, component.Info.Manufacturer)
-		assert.Nil(t, component.Info.Model)
-		assert.Nil(t, component.Position)
-		assert.Nil(t, component.RackId)
-		if assert.Len(t, component.Bmcs, 1) {
-			assert.Nil(t, component.Bmcs[0].IpAddress)
-		}
-	})
+	assert.NoError(t, manager.CreateExpectedPowerShelfOnFlow(context.Background(), nil))
+	assert.NoError(t, manager.CreateExpectedPowerShelfOnFlow(context.Background(), &cwssaws.ExpectedPowerShelf{}))
 }

--- a/rest-api/site-workflow/pkg/activity/expectedrack.go
+++ b/rest-api/site-workflow/pkg/activity/expectedrack.go
@@ -11,16 +11,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"go.temporal.io/sdk/client"
 	tClient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/util/labels"
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 	cclient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
@@ -114,7 +111,7 @@ func (meri *ManageExpectedRackInventory) DiscoverExpectedRackInventory(ctx conte
 			endIndex = totalCount
 		}
 
-		pagedWorkflowOptions := client.StartWorkflowOptions{
+		pagedWorkflowOptions := tClient.StartWorkflowOptions{
 			ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, cloudPage),
 			TaskQueue: workflowOptions.TaskQueue,
 		}
@@ -192,14 +189,12 @@ func NewManageExpectedRackInventory(siteID uuid.UUID, coreGrpcAtomicClient *ccli
 // ManageExpectedRack is an activity wrapper for Expected Rack management
 type ManageExpectedRack struct {
 	coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient
-	flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient
 }
 
 // NewManageExpectedRack returns a new ManageExpectedRack client
-func NewManageExpectedRack(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient, flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient) ManageExpectedRack {
+func NewManageExpectedRack(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient) ManageExpectedRack {
 	return ManageExpectedRack{
 		coreGrpcAtomicClient: coreGrpcAtomicClient,
-		flowGrpcAtomicClient: flowGrpcAtomicClient,
 	}
 }
 
@@ -386,100 +381,10 @@ func (mer *ManageExpectedRack) DeleteAllExpectedRacksOnSite(ctx context.Context)
 	return nil
 }
 
-// CreateExpectedRackOnFlow creates an Expected Rack in Flow via CreateExpectedRack.
-// Best-effort: if the Flow client is not configured, the activity logs and returns nil
-// so the workflow can continue. RPC failures are surfaced as errors so the workflow
-// can decide how to handle them (typically log and ignore).
-func (mer *ManageExpectedRack) CreateExpectedRackOnFlow(ctx context.Context, request *cwssaws.ExpectedRack) error {
-	logger := log.With().Str("Activity", "CreateExpectedRackOnFlow").Logger()
-
-	logger.Info().Msg("Starting activity")
-
-	// Validate request
-	if request == nil {
-		return temporal.NewNonRetryableApplicationError("received empty create Expected Rack request for Flow", swe.ErrTypeInvalidRequest, errors.New("nil request"))
-	}
-
-	// If Flow client is not configured, skip gracefully
-	if mer.flowGrpcAtomicClient == nil {
-		logger.Warn().Msg("Flow client not configured, skipping Flow expected rack creation")
-		return nil
-	}
-
-	grpcClient := mer.flowGrpcAtomicClient.GetClient()
-	if grpcClient == nil {
-		logger.Warn().Msg("Flow client not connected, skipping Flow expected rack creation")
-		return nil
-	}
-	grpcServiceClient := grpcClient.GrpcServiceClient()
-
-	rack := expectedRackToFlowRack(request)
-	_, err := grpcServiceClient.CreateExpectedRack(ctx, &flowv1.CreateExpectedRackRequest{Rack: rack})
-	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to create Expected Rack on Flow")
-		return swe.WrapErr(err)
-	}
-
-	logger.Info().Msg("Completed activity")
+// CreateExpectedRackOnFlow is retained as a no-op for compatibility with
+// workflow histories recorded before direct Flow writes were removed.
+// Remove it after the matching `GetVersion` branch is retired and those
+// histories can no longer be replayed.
+func (*ManageExpectedRack) CreateExpectedRackOnFlow(context.Context, *cwssaws.ExpectedRack) error {
 	return nil
-}
-
-// labelValue extracts the value for a label key from a metadata label slice. Returns
-// empty string if the key is not present or the value is nil.
-func labelValue(labels []*cwssaws.Label, key string) string {
-	for _, l := range labels {
-		if l == nil {
-			continue
-		}
-		if l.GetKey() == key {
-			// Label.Value is *string; GetValue() handles nil safely.
-			return l.GetValue()
-		}
-	}
-	return ""
-}
-
-// expectedRackToFlowRack converts a NICo ExpectedRack proto to an Flow Rack proto.
-// Chassis identity (manufacturer/serial/model) and physical location (region/datacenter/
-// room/position) are read from well-known label keys defined in
-// common/pkg/util/labels. Missing labels are tolerated and rendered as empty
-// strings on the Flow side.
-func expectedRackToFlowRack(rack *cwssaws.ExpectedRack) *flowv1.Rack {
-	rackLabels := rack.GetMetadata().GetLabels()
-
-	manufacturer := labelValue(rackLabels, labels.RackLabelChassisManufacturer)
-	serialNumber := labelValue(rackLabels, labels.RackLabelChassisSerialNumber)
-	model := labelValue(rackLabels, labels.RackLabelChassisModel)
-
-	region := labelValue(rackLabels, labels.RackLabelLocationRegion)
-	datacenter := labelValue(rackLabels, labels.RackLabelLocationDatacenter)
-	room := labelValue(rackLabels, labels.RackLabelLocationRoom)
-	position := labelValue(rackLabels, labels.RackLabelLocationPosition)
-
-	deviceInfo := &flowv1.DeviceInfo{
-		Id:           &flowv1.UUID{Id: rack.GetRackId().GetId()},
-		Name:         rack.GetMetadata().GetName(),
-		Manufacturer: manufacturer,
-		SerialNumber: serialNumber,
-	}
-
-	if model != "" {
-		deviceInfo.Model = &model
-	}
-
-	if description := rack.GetMetadata().GetDescription(); description != "" {
-		deviceInfo.Description = &description
-	}
-
-	location := &flowv1.Location{
-		Region:     region,
-		Datacenter: datacenter,
-		Room:       room,
-		Position:   position,
-	}
-
-	return &flowv1.Rack{
-		Info:     deviceInfo,
-		Location: location,
-	}
 }

--- a/rest-api/site-workflow/pkg/activity/expectedrack_test.go
+++ b/rest-api/site-workflow/pkg/activity/expectedrack_test.go
@@ -7,11 +7,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/util/labels"
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -90,7 +87,7 @@ func TestManageExpectedRack_CreateExpectedRackOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient, nil)
+			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient)
 			err := mer.CreateExpectedRackOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -176,7 +173,7 @@ func TestManageExpectedRack_UpdateExpectedRackOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient, nil)
+			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient)
 			err := mer.UpdateExpectedRackOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -246,7 +243,7 @@ func TestManageExpectedRack_DeleteExpectedRackOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient, nil)
+			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient)
 			err := mer.DeleteExpectedRackOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -323,7 +320,7 @@ func TestManageExpectedRack_ReplaceAllExpectedRacksOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient, nil)
+			mer := NewManageExpectedRack(tt.fields.coreGrpcAtomicClient)
 			err := mer.ReplaceAllExpectedRacksOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -340,130 +337,14 @@ func TestManageExpectedRack_DeleteAllExpectedRacksOnSite(t *testing.T) {
 	coreGrpcAtomicClient := cClient.NewCoreGrpcAtomicClient(&cClient.CoreGrpcClientConfig{})
 	coreGrpcAtomicClient.SwapClient(mockCoreGrpcClient)
 
-	mer := NewManageExpectedRack(coreGrpcAtomicClient, nil)
+	mer := NewManageExpectedRack(coreGrpcAtomicClient)
 	err := mer.DeleteAllExpectedRacksOnSite(context.Background())
 	assert.NoError(t, err)
 }
 
 func TestManageExpectedRack_CreateExpectedRackOnFlow(t *testing.T) {
-	t.Run("nil Flow client skips gracefully", func(t *testing.T) {
-		mer := ManageExpectedRack{flowGrpcAtomicClient: nil}
-		err := mer.CreateExpectedRackOnFlow(context.Background(), &cwssaws.ExpectedRack{
-			RackId:        &cwssaws.RackId{Id: uuid.NewString()},
-			RackProfileId: &cwssaws.RackProfileId{Id: uuid.NewString()},
-		})
-		assert.NoError(t, err)
-	})
+	manager := NewManageExpectedRack(nil)
 
-	t.Run("nil Flow client connection skips gracefully", func(t *testing.T) {
-		mer := ManageExpectedRack{flowGrpcAtomicClient: cClient.NewFlowGrpcAtomicClient(&cClient.FlowGrpcClientConfig{})}
-		err := mer.CreateExpectedRackOnFlow(context.Background(), &cwssaws.ExpectedRack{
-			RackId:        &cwssaws.RackId{Id: uuid.NewString()},
-			RackProfileId: &cwssaws.RackProfileId{Id: uuid.NewString()},
-		})
-		assert.NoError(t, err)
-	})
-}
-
-func Test_expectedRackToFlowRack(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-
-	t.Run("maps all fields with full labels", func(t *testing.T) {
-		rack := &cwssaws.ExpectedRack{
-			RackId:        &cwssaws.RackId{Id: "rack-001"},
-			RackProfileId: &cwssaws.RackProfileId{Id: "rack-profile-001"},
-			Metadata: &cwssaws.Metadata{
-				Name:        "rack-alpha",
-				Description: "Primary compute rack",
-				Labels: []*cwssaws.Label{
-					{Key: labels.RackLabelChassisManufacturer, Value: strPtr("NVIDIA")},
-					{Key: labels.RackLabelChassisSerialNumber, Value: strPtr("SN-RACK-001")},
-					{Key: labels.RackLabelChassisModel, Value: strPtr("MGX-1000")},
-					{Key: labels.RackLabelLocationRegion, Value: strPtr("us-east-1")},
-					{Key: labels.RackLabelLocationDatacenter, Value: strPtr("dc1")},
-					{Key: labels.RackLabelLocationRoom, Value: strPtr("room-A")},
-					{Key: labels.RackLabelLocationPosition, Value: strPtr("row-3-col-7")},
-				},
-			},
-		}
-		var flowRack *flowv1.Rack = expectedRackToFlowRack(rack)
-
-		if assert.NotNil(t, flowRack.Info) {
-			assert.NotNil(t, flowRack.Info.Id)
-			assert.Equal(t, "rack-001", flowRack.Info.Id.Id)
-			assert.Equal(t, "rack-alpha", flowRack.Info.Name)
-			assert.Equal(t, "NVIDIA", flowRack.Info.Manufacturer)
-			assert.Equal(t, "SN-RACK-001", flowRack.Info.SerialNumber)
-			if assert.NotNil(t, flowRack.Info.Model) {
-				assert.Equal(t, "MGX-1000", *flowRack.Info.Model)
-			}
-			if assert.NotNil(t, flowRack.Info.Description) {
-				assert.Equal(t, "Primary compute rack", *flowRack.Info.Description)
-			}
-		}
-
-		if assert.NotNil(t, flowRack.Location) {
-			assert.Equal(t, "us-east-1", flowRack.Location.Region)
-			assert.Equal(t, "dc1", flowRack.Location.Datacenter)
-			assert.Equal(t, "room-A", flowRack.Location.Room)
-			assert.Equal(t, "row-3-col-7", flowRack.Location.Position)
-		}
-	})
-
-	t.Run("handles minimal fields (no metadata)", func(t *testing.T) {
-		rack := &cwssaws.ExpectedRack{
-			RackId:        &cwssaws.RackId{Id: "rack-002"},
-			RackProfileId: &cwssaws.RackProfileId{Id: "rack-profile-002"},
-		}
-		flowRack := expectedRackToFlowRack(rack)
-
-		if assert.NotNil(t, flowRack.Info) {
-			if assert.NotNil(t, flowRack.Info.Id) {
-				assert.Equal(t, "rack-002", flowRack.Info.Id.Id)
-			}
-			assert.Empty(t, flowRack.Info.Name)
-			assert.Empty(t, flowRack.Info.Manufacturer)
-			assert.Empty(t, flowRack.Info.SerialNumber)
-			assert.Nil(t, flowRack.Info.Model)
-			assert.Nil(t, flowRack.Info.Description)
-		}
-
-		if assert.NotNil(t, flowRack.Location) {
-			assert.Empty(t, flowRack.Location.Region)
-			assert.Empty(t, flowRack.Location.Datacenter)
-			assert.Empty(t, flowRack.Location.Room)
-			assert.Empty(t, flowRack.Location.Position)
-		}
-	})
-
-	t.Run("handles partial labels", func(t *testing.T) {
-		rack := &cwssaws.ExpectedRack{
-			RackId:        &cwssaws.RackId{Id: "rack-003"},
-			RackProfileId: &cwssaws.RackProfileId{Id: "rack-profile-003"},
-			Metadata: &cwssaws.Metadata{
-				Name: "rack-bravo",
-				Labels: []*cwssaws.Label{
-					{Key: labels.RackLabelChassisManufacturer, Value: strPtr("NVIDIA")},
-					{Key: labels.RackLabelLocationRegion, Value: strPtr("us-west-2")},
-				},
-			},
-		}
-		flowRack := expectedRackToFlowRack(rack)
-
-		if assert.NotNil(t, flowRack.Info) {
-			assert.Equal(t, "rack-bravo", flowRack.Info.Name)
-			assert.Equal(t, "NVIDIA", flowRack.Info.Manufacturer)
-			assert.Empty(t, flowRack.Info.SerialNumber)
-			assert.Nil(t, flowRack.Info.Model)
-			assert.Nil(t, flowRack.Info.Description)
-		}
-
-		if assert.NotNil(t, flowRack.Location) {
-			assert.Equal(t, "us-west-2", flowRack.Location.Region)
-			assert.Empty(t, flowRack.Location.Datacenter)
-			assert.Empty(t, flowRack.Location.Room)
-			assert.Empty(t, flowRack.Location.Position)
-		}
-	})
-
+	assert.NoError(t, manager.CreateExpectedRackOnFlow(context.Background(), nil))
+	assert.NoError(t, manager.CreateExpectedRackOnFlow(context.Background(), &cwssaws.ExpectedRack{}))
 }

--- a/rest-api/site-workflow/pkg/activity/expectedswitch.go
+++ b/rest-api/site-workflow/pkg/activity/expectedswitch.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"go.temporal.io/sdk/client"
 	tClient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -19,7 +18,6 @@ import (
 
 	swe "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/error"
 	cclient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
@@ -151,7 +149,7 @@ func (mesi *ManageExpectedSwitchInventory) DiscoverExpectedSwitchInventory(ctx c
 			endIndex = totalCount
 		}
 
-		pagedWorkflowOptions := client.StartWorkflowOptions{
+		pagedWorkflowOptions := tClient.StartWorkflowOptions{
 			ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, cloudPage),
 			TaskQueue: workflowOptions.TaskQueue,
 		}
@@ -243,14 +241,12 @@ func NewManageExpectedSwitchInventory(siteID uuid.UUID, coreGrpcAtomicClient *cc
 // ManageExpectedSwitch is an activity wrapper for Expected Switch management
 type ManageExpectedSwitch struct {
 	coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient
-	flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient
 }
 
 // NewManageExpectedSwitch returns a new ManageExpectedSwitch client
-func NewManageExpectedSwitch(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient, flowGrpcAtomicClient *cclient.FlowGrpcAtomicClient) ManageExpectedSwitch {
+func NewManageExpectedSwitch(coreGrpcAtomicClient *cclient.CoreGrpcAtomicClient) ManageExpectedSwitch {
 	return ManageExpectedSwitch{
 		coreGrpcAtomicClient: coreGrpcAtomicClient,
-		flowGrpcAtomicClient: flowGrpcAtomicClient,
 	}
 }
 
@@ -333,92 +329,12 @@ func (mes *ManageExpectedSwitch) UpdateExpectedSwitchOnSite(ctx context.Context,
 	return nil
 }
 
-// CreateExpectedSwitchOnFlow creates an Expected Switch as a component in Flow via AddComponent
-func (mes *ManageExpectedSwitch) CreateExpectedSwitchOnFlow(ctx context.Context, request *cwssaws.ExpectedSwitch) error {
-	logger := log.With().Str("Activity", "CreateExpectedSwitchOnFlow").Logger()
-
-	logger.Info().Msg("Starting activity")
-
-	// Validate request
-	if request == nil {
-		return temporal.NewNonRetryableApplicationError("received empty create Expected Switch request for Flow", swe.ErrTypeInvalidRequest, errors.New("nil request"))
-	}
-
-	// If Flow client is not configured, skip gracefully
-	if mes.flowGrpcAtomicClient == nil {
-		logger.Warn().Msg("Flow client not configured, skipping Flow component creation")
-		return nil
-	}
-
-	grpcClient := mes.flowGrpcAtomicClient.GetClient()
-	if grpcClient == nil {
-		logger.Warn().Msg("Flow client not connected, skipping Flow component creation")
-		return nil
-	}
-	grpcServiceClient := grpcClient.GrpcServiceClient()
-
-	component := expectedSwitchToFlowComponent(request)
-	_, err := grpcServiceClient.AddComponent(ctx, &flowv1.AddComponentRequest{Component: component})
-	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to create Expected Switch component on Flow")
-		return swe.WrapErr(err)
-	}
-
-	logger.Info().Msg("Completed activity")
+// CreateExpectedSwitchOnFlow is retained as a no-op for compatibility with
+// workflow histories recorded before direct Flow writes were removed.
+// Remove it after the matching `GetVersion` branch is retired and those
+// histories can no longer be replayed.
+func (*ManageExpectedSwitch) CreateExpectedSwitchOnFlow(context.Context, *cwssaws.ExpectedSwitch) error {
 	return nil
-}
-
-// expectedSwitchToFlowComponent converts a NICo ExpectedSwitch proto to an Flow Component proto
-func expectedSwitchToFlowComponent(es *cwssaws.ExpectedSwitch) *flowv1.Component {
-	component := &flowv1.Component{
-		Type: flowv1.ComponentType_COMPONENT_TYPE_NVSWITCH,
-		Info: &flowv1.DeviceInfo{
-			Id:           &flowv1.UUID{Id: es.GetExpectedSwitchId().GetValue()},
-			SerialNumber: es.GetSwitchSerialNumber(),
-		},
-		Bmcs: []*flowv1.BMCInfo{
-			{
-				Type:       flowv1.BMCType_BMC_TYPE_HOST,
-				MacAddress: es.GetBmcMacAddress(),
-			},
-		},
-		ComponentId: es.GetExpectedSwitchId().GetValue(),
-	}
-
-	// DeviceInfo fields
-	if name := es.GetName(); name != "" {
-		component.Info.Name = name
-	}
-	if manufacturer := es.GetManufacturer(); manufacturer != "" {
-		component.Info.Manufacturer = manufacturer
-	}
-	if es.Model != nil {
-		component.Info.Model = es.Model
-	}
-	if es.Description != nil {
-		component.Info.Description = es.Description
-	}
-
-	// Rack position
-	if es.SlotId != nil || es.TrayIdx != nil || es.HostId != nil {
-		pos := &flowv1.RackPosition{}
-		if es.SlotId != nil {
-			pos.SlotId = *es.SlotId
-		}
-		if es.TrayIdx != nil {
-			pos.TrayIdx = *es.TrayIdx
-		}
-		if es.HostId != nil {
-			pos.HostId = *es.HostId
-		}
-		component.Position = pos
-	}
-
-	if rackID := es.GetRackId().GetId(); rackID != "" {
-		component.RackId = &flowv1.UUID{Id: rackID}
-	}
-
-	return component
 }
 
 // DeleteExpectedSwitchOnSite deletes Expected Switch on NICo

--- a/rest-api/site-workflow/pkg/activity/expectedswitch_test.go
+++ b/rest-api/site-workflow/pkg/activity/expectedswitch_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
-	flowv1 "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/flow/protobuf/v1"
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -228,7 +227,7 @@ func TestManageExpectedSwitch_CreateExpectedSwitchOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedSwitch(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedSwitch(tt.fields.coreGrpcAtomicClient)
 			err := mm.CreateExpectedSwitchOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -347,7 +346,7 @@ func TestManageExpectedSwitch_UpdateExpectedSwitchOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedSwitch(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedSwitch(tt.fields.coreGrpcAtomicClient)
 			err := mm.UpdateExpectedSwitchOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -433,7 +432,7 @@ func TestManageExpectedSwitch_DeleteExpectedSwitchOnSite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mm := NewManageExpectedSwitch(tt.fields.coreGrpcAtomicClient, nil)
+			mm := NewManageExpectedSwitch(tt.fields.coreGrpcAtomicClient)
 			err := mm.DeleteExpectedSwitchOnSite(tt.args.ctx, tt.args.request)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -445,71 +444,8 @@ func TestManageExpectedSwitch_DeleteExpectedSwitchOnSite(t *testing.T) {
 }
 
 func TestManageExpectedSwitch_CreateExpectedSwitchOnFlow(t *testing.T) {
-	t.Run("nil Flow client skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedSwitch{flowGrpcAtomicClient: nil}
-		err := mm.CreateExpectedSwitchOnFlow(context.Background(), &cwssaws.ExpectedSwitch{
-			ExpectedSwitchId: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", SwitchSerialNumber: "SW001",
-		})
-		assert.NoError(t, err)
-	})
+	manager := NewManageExpectedSwitch(nil)
 
-	t.Run("nil Flow client connection skips gracefully", func(t *testing.T) {
-		mm := ManageExpectedSwitch{flowGrpcAtomicClient: cClient.NewFlowGrpcAtomicClient(&cClient.FlowGrpcClientConfig{})}
-		err := mm.CreateExpectedSwitchOnFlow(context.Background(), &cwssaws.ExpectedSwitch{
-			ExpectedSwitchId: &cwssaws.UUID{Value: uuid.NewString()}, BmcMacAddress: "00:11:22:33:44:55", SwitchSerialNumber: "SW001",
-		})
-		assert.NoError(t, err)
-	})
-}
-
-func Test_expectedSwitchToFlowComponent(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-	int32Ptr := func(i int32) *int32 { return &i }
-
-	t.Run("maps all fields correctly", func(t *testing.T) {
-		es := &cwssaws.ExpectedSwitch{
-			ExpectedSwitchId:   &cwssaws.UUID{Value: "es-001"},
-			BmcMacAddress:      "AA:BB:CC:DD:EE:FF",
-			SwitchSerialNumber: "SW-001",
-			RackId:             &cwssaws.RackId{Id: "rack-001"},
-			Name:               strPtr("nvl-switch-1"),
-			Manufacturer:       strPtr("NVIDIA"),
-			Model:              strPtr("NVL-400"),
-			Description:        strPtr("NVLink switch"),
-			SlotId:             int32Ptr(4),
-			TrayIdx:            int32Ptr(1),
-			HostId:             int32Ptr(0),
-		}
-		component := expectedSwitchToFlowComponent(es)
-		assert.Equal(t, flowv1.ComponentType_COMPONENT_TYPE_NVSWITCH, component.Type)
-		assert.Equal(t, "es-001", component.Info.Id.Id)
-		assert.Equal(t, "SW-001", component.Info.SerialNumber)
-		assert.Equal(t, "nvl-switch-1", component.Info.Name)
-		assert.Equal(t, "NVIDIA", component.Info.Manufacturer)
-		assert.Equal(t, "NVL-400", *component.Info.Model)
-		assert.Equal(t, "NVLink switch", *component.Info.Description)
-		assert.Equal(t, "es-001", component.ComponentId)
-		assert.NotNil(t, component.Position)
-		assert.Equal(t, int32(4), component.Position.SlotId)
-		assert.Equal(t, int32(1), component.Position.TrayIdx)
-		if assert.Len(t, component.Bmcs, 1) {
-			assert.Equal(t, "AA:BB:CC:DD:EE:FF", component.Bmcs[0].MacAddress)
-		}
-		assert.NotNil(t, component.RackId)
-		assert.Equal(t, "rack-001", component.RackId.Id)
-	})
-
-	t.Run("handles minimal fields (nil optionals)", func(t *testing.T) {
-		es := &cwssaws.ExpectedSwitch{
-			ExpectedSwitchId: &cwssaws.UUID{Value: "es-002"}, BmcMacAddress: "11:22:33:44:55:66",
-			SwitchSerialNumber: "SW-002",
-		}
-		component := expectedSwitchToFlowComponent(es)
-		assert.Equal(t, flowv1.ComponentType_COMPONENT_TYPE_NVSWITCH, component.Type)
-		assert.Empty(t, component.Info.Name)
-		assert.Empty(t, component.Info.Manufacturer)
-		assert.Nil(t, component.Info.Model)
-		assert.Nil(t, component.Position)
-		assert.Nil(t, component.RackId)
-	})
+	assert.NoError(t, manager.CreateExpectedSwitchOnFlow(context.Background(), nil))
+	assert.NoError(t, manager.CreateExpectedSwitchOnFlow(context.Background(), &cwssaws.ExpectedSwitch{}))
 }

--- a/rest-api/site-workflow/pkg/workflow/expectedmachine.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedmachine.go
@@ -13,6 +13,13 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+const (
+	removeCreateExpectedMachineOnFlowChangeID       = "remove-create-expected-machine-on-flow"
+	removeCreateExpectedMachineOnFlowVersion        = workflow.Version(1)
+	removeBatchCreateExpectedMachinesOnFlowChangeID = "remove-batch-create-expected-machines-on-flow"
+	removeBatchCreateExpectedMachinesOnFlowVersion  = workflow.Version(1)
+)
+
 // DiscoverExpectedMachineInventory is a workflow to fetch Expected Machine inventory on Site and publish to Cloud
 func DiscoverExpectedMachineInventory(ctx workflow.Context) error {
 	logger := log.With().Str("Workflow", "DiscoverExpectedMachineInventory").Logger()
@@ -50,8 +57,7 @@ func DiscoverExpectedMachineInventory(ctx workflow.Context) error {
 	return nil
 }
 
-// CreateExpectedMachine is a workflow to create new Expected Machines using the CreateExpectedMachineOnSite activity,
-// then also creates the component in Flow via CreateExpectedMachineOnFlow.
+// CreateExpectedMachine is a workflow to create a new Expected Machine using the CreateExpectedMachineOnSite activity.
 func CreateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachine) error {
 	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Create").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ChassisSerialNumber).Logger()
 
@@ -82,10 +88,13 @@ func CreateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachin
 		return err
 	}
 
-	// Then write to Flow (best-effort: log warning but don't fail the workflow)
-	err = workflow.ExecuteActivity(ctx, expectedMachineManager.CreateExpectedMachineOnFlow, request).Get(ctx, nil)
-	if err != nil {
-		logger.Warn().Err(err).Str("Activity", "CreateExpectedMachineOnFlow").Msg("Failed to create component on Flow, Core write succeeded")
+	// Preserve the Flow activity command when replaying histories created before
+	// direct Flow writes were removed.
+	if workflow.GetVersion(ctx, removeCreateExpectedMachineOnFlowChangeID, workflow.DefaultVersion, removeCreateExpectedMachineOnFlowVersion) == workflow.DefaultVersion {
+		err = workflow.ExecuteActivity(ctx, expectedMachineManager.CreateExpectedMachineOnFlow, request).Get(ctx, nil)
+		if err != nil {
+			logger.Warn().Err(err).Str("Activity", "CreateExpectedMachineOnFlow").Msg("Failed to create component on Flow, Core write succeeded")
+		}
 	}
 
 	logger.Info().Msg("completing workflow")
@@ -94,7 +103,6 @@ func CreateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachin
 }
 
 // UpdateExpectedMachine is a workflow to update Expected Machines using the UpdateExpectedMachineOnSite activity
-// TODO: Add Flow PatchComponent dual-write when update/delete Flow support is implemented
 func UpdateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachine) error {
 	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Update").Str("ID", request.GetId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ChassisSerialNumber).Logger()
 
@@ -129,8 +137,7 @@ func UpdateExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachin
 	return nil
 }
 
-// CreateExpectedMachines is a workflow to create multiple Expected Machines using the CreateExpectedMachinesOnSite activity,
-// then also creates the components in Flow via CreateExpectedMachinesOnFlow.
+// CreateExpectedMachines is a workflow to create multiple Expected Machines using the CreateExpectedMachinesOnSite activity.
 func CreateExpectedMachines(ctx workflow.Context, request *cwssaws.BatchExpectedMachineOperationRequest) (*cwssaws.BatchExpectedMachineOperationResponse, error) {
 	logger := log.With().Str("Workflow", "ExpectedMachines").Str("Action", "Create").Int("Count", len(request.GetExpectedMachines().GetExpectedMachines())).Logger()
 
@@ -163,10 +170,13 @@ func CreateExpectedMachines(ctx workflow.Context, request *cwssaws.BatchExpected
 		return nil, err
 	}
 
-	// Then write to Flow (best-effort: log warning but don't fail the workflow)
-	err = workflow.ExecuteActivity(ctx, expectedMachineManager.CreateExpectedMachinesOnFlow, request).Get(ctx, nil)
-	if err != nil {
-		logger.Warn().Err(err).Str("Activity", "CreateExpectedMachinesOnFlow").Msg("Failed to create components on Flow, Core write succeeded")
+	// Preserve the Flow activity command when replaying histories created before
+	// direct Flow writes were removed.
+	if workflow.GetVersion(ctx, removeBatchCreateExpectedMachinesOnFlowChangeID, workflow.DefaultVersion, removeBatchCreateExpectedMachinesOnFlowVersion) == workflow.DefaultVersion {
+		err = workflow.ExecuteActivity(ctx, expectedMachineManager.CreateExpectedMachinesOnFlow, request).Get(ctx, nil)
+		if err != nil {
+			logger.Warn().Err(err).Str("Activity", "CreateExpectedMachinesOnFlow").Msg("Failed to create components on Flow, Core write succeeded")
+		}
 	}
 
 	logger.Info().Msg("completing workflow")
@@ -212,7 +222,6 @@ func UpdateExpectedMachines(ctx workflow.Context, request *cwssaws.BatchExpected
 }
 
 // DeleteExpectedMachine is a workflow to Delete Expected Machines using the DeleteExpectedMachineOnSite activity
-// TODO: Add Flow DeleteComponent dual-write when update/delete Flow support is implemented
 func DeleteExpectedMachine(ctx workflow.Context, request *cwssaws.ExpectedMachineRequest) error {
 	logger := log.With().Str("Workflow", "ExpectedMachine").Str("Action", "Delete").Str("ID", request.GetId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
 

--- a/rest-api/site-workflow/pkg/workflow/expectedmachine_test.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedmachine_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 )
 
 type InventoryExpectedMachineTestSuite struct {
@@ -92,14 +93,18 @@ func (cemts *CreateExpectedMachineTestSuite) Test_CreateExpectedMachine_Success(
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnSite)
 	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachineOnSite, mock.Anything, mock.Anything).Return(nil)
 
-	// Mock CreateExpectedMachineOnFlow activity
-	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnFlow)
-	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachineOnFlow, mock.Anything, mock.Anything).Return(nil)
+	cemts.env.OnGetVersion(
+		removeCreateExpectedMachineOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedMachineOnFlowVersion,
+	).Return(removeCreateExpectedMachineOnFlowVersion)
+	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachineOnFlow, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Execute CreateExpectedMachine workflow
 	cemts.env.ExecuteWorkflow(CreateExpectedMachine, request)
 	cemts.True(cemts.env.IsWorkflowCompleted())
 	cemts.NoError(cemts.env.GetWorkflowError())
+	cemts.env.AssertActivityNumberOfCalls(cemts.T(), "CreateExpectedMachineOnFlow", 0)
 }
 
 func (cemts *CreateExpectedMachineTestSuite) Test_CreateExpectedMachine_Failure() {
@@ -116,16 +121,13 @@ func (cemts *CreateExpectedMachineTestSuite) Test_CreateExpectedMachine_Failure(
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnSite)
 	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachineOnSite, mock.Anything, mock.Anything).Return(errors.New(errMsg))
 
-	// Register CreateExpectedMachineOnFlow activity (not called when Core fails)
-	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnFlow)
-
 	// execute CreateExpectedMachine workflow
 	cemts.env.ExecuteWorkflow(CreateExpectedMachine, request)
 	cemts.True(cemts.env.IsWorkflowCompleted())
 	cemts.Error(cemts.env.GetWorkflowError())
 }
 
-func (cemts *CreateExpectedMachineTestSuite) Test_CreateExpectedMachine_CoreSuccess_FlowFailure() {
+func (cemts *CreateExpectedMachineTestSuite) Test_CreateExpectedMachine_LegacyVersion_FlowFailure() {
 	var expectedMachineManager iActivity.ManageExpectedMachine
 
 	request := &cwssaws.ExpectedMachine{
@@ -136,6 +138,12 @@ func (cemts *CreateExpectedMachineTestSuite) Test_CreateExpectedMachine_CoreSucc
 	// Mock CreateExpectedMachineOnSite activity to succeed
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnSite)
 	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachineOnSite, mock.Anything, mock.Anything).Return(nil)
+
+	cemts.env.OnGetVersion(
+		removeCreateExpectedMachineOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedMachineOnFlowVersion,
+	).Return(temporalworkflow.DefaultVersion)
 
 	// Mock CreateExpectedMachineOnFlow activity to fail (best-effort, should not fail the workflow)
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachineOnFlow)
@@ -323,14 +331,18 @@ func (cemts *CreateExpectedMachinesTestSuite) Test_CreateExpectedMachines_Succes
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnSite)
 	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnSite, mock.Anything, mock.Anything).Return(expectedResponse, nil)
 
-	// Mock CreateExpectedMachinesOnFlow activity
-	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnFlow)
-	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnFlow, mock.Anything, mock.Anything).Return(nil)
+	cemts.env.OnGetVersion(
+		removeBatchCreateExpectedMachinesOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeBatchCreateExpectedMachinesOnFlowVersion,
+	).Return(removeBatchCreateExpectedMachinesOnFlowVersion)
+	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnFlow, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Execute CreateExpectedMachines workflow
 	cemts.env.ExecuteWorkflow(CreateExpectedMachines, request)
 	cemts.True(cemts.env.IsWorkflowCompleted())
 	cemts.NoError(cemts.env.GetWorkflowError())
+	cemts.env.AssertActivityNumberOfCalls(cemts.T(), "CreateExpectedMachinesOnFlow", 0)
 
 	var response cwssaws.BatchExpectedMachineOperationResponse
 	err := cemts.env.GetWorkflowResult(&response)
@@ -393,14 +405,18 @@ func (cemts *CreateExpectedMachinesTestSuite) Test_CreateExpectedMachines_Partia
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnSite)
 	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnSite, mock.Anything, mock.Anything).Return(expectedResponse, nil)
 
-	// Mock CreateExpectedMachinesOnFlow activity
-	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnFlow)
-	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnFlow, mock.Anything, mock.Anything).Return(nil)
+	cemts.env.OnGetVersion(
+		removeBatchCreateExpectedMachinesOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeBatchCreateExpectedMachinesOnFlowVersion,
+	).Return(removeBatchCreateExpectedMachinesOnFlowVersion)
+	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnFlow, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Execute CreateExpectedMachines workflow
 	cemts.env.ExecuteWorkflow(CreateExpectedMachines, request)
 	cemts.True(cemts.env.IsWorkflowCompleted())
 	cemts.NoError(cemts.env.GetWorkflowError())
+	cemts.env.AssertActivityNumberOfCalls(cemts.T(), "CreateExpectedMachinesOnFlow", 0)
 
 	var response cwssaws.BatchExpectedMachineOperationResponse
 	err := cemts.env.GetWorkflowResult(&response)
@@ -414,6 +430,47 @@ func (cemts *CreateExpectedMachinesTestSuite) Test_CreateExpectedMachines_Partia
 	cemts.Equal("00:11:22:33:44:55", response.Results[0].GetExpectedMachine().GetBmcMacAddress())
 	cemts.Nil(response.Results[1].GetExpectedMachine())
 	cemts.Equal("duplicate MAC address", response.Results[1].GetErrorMessage())
+}
+
+func (cemts *CreateExpectedMachinesTestSuite) Test_CreateExpectedMachines_LegacyVersion_FlowFailure() {
+	var expectedMachineManager iActivity.ManageExpectedMachine
+
+	machine := &cwssaws.ExpectedMachine{
+		Id:                  &cwssaws.UUID{Value: "test-batch-create-001"},
+		BmcMacAddress:       "00:11:22:33:44:55",
+		ChassisSerialNumber: "SN001",
+	}
+	request := &cwssaws.BatchExpectedMachineOperationRequest{
+		ExpectedMachines: &cwssaws.ExpectedMachineList{
+			ExpectedMachines: []*cwssaws.ExpectedMachine{machine},
+		},
+		AcceptPartialResults: true,
+	}
+	expectedResponse := &cwssaws.BatchExpectedMachineOperationResponse{
+		Results: []*cwssaws.ExpectedMachineOperationResult{
+			{
+				Id:              machine.GetId(),
+				Success:         true,
+				ExpectedMachine: machine,
+			},
+		},
+	}
+
+	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnSite)
+	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnSite, mock.Anything, mock.Anything).Return(expectedResponse, nil)
+
+	cemts.env.OnGetVersion(
+		removeBatchCreateExpectedMachinesOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeBatchCreateExpectedMachinesOnFlowVersion,
+	).Return(temporalworkflow.DefaultVersion)
+
+	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnFlow)
+	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnFlow, mock.Anything, mock.Anything).Return(errors.New("Flow communication error"))
+
+	cemts.env.ExecuteWorkflow(CreateExpectedMachines, request)
+	cemts.True(cemts.env.IsWorkflowCompleted())
+	cemts.NoError(cemts.env.GetWorkflowError())
 }
 
 func (cemts *CreateExpectedMachinesTestSuite) Test_CreateExpectedMachines_Failure() {
@@ -437,9 +494,6 @@ func (cemts *CreateExpectedMachinesTestSuite) Test_CreateExpectedMachines_Failur
 	// Mock CreateExpectedMachinesOnSite activity
 	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnSite)
 	cemts.env.OnActivity(expectedMachineManager.CreateExpectedMachinesOnSite, mock.Anything, mock.Anything).Return(nil, errors.New(errMsg))
-
-	// Register CreateExpectedMachinesOnFlow activity (not called when Core fails)
-	cemts.env.RegisterActivity(expectedMachineManager.CreateExpectedMachinesOnFlow)
 
 	// execute CreateExpectedMachines workflow
 	cemts.env.ExecuteWorkflow(CreateExpectedMachines, request)

--- a/rest-api/site-workflow/pkg/workflow/expectedpowershelf.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedpowershelf.go
@@ -13,6 +13,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+const (
+	removeCreateExpectedPowerShelfOnFlowChangeID = "remove-create-expected-power-shelf-on-flow"
+	removeCreateExpectedPowerShelfOnFlowVersion  = workflow.Version(1)
+)
+
 // DiscoverExpectedPowerShelfInventory is a workflow to fetch Expected Power Shelf inventory on Site and publish to Cloud
 func DiscoverExpectedPowerShelfInventory(ctx workflow.Context) error {
 	logger := log.With().Str("Workflow", "DiscoverExpectedPowerShelfInventory").Logger()
@@ -50,8 +55,7 @@ func DiscoverExpectedPowerShelfInventory(ctx workflow.Context) error {
 	return nil
 }
 
-// CreateExpectedPowerShelf is a workflow to create a new Expected Power Shelf using the CreateExpectedPowerShelfOnSite activity,
-// then also creates the component in Flow via CreateExpectedPowerShelfOnFlow.
+// CreateExpectedPowerShelf is a workflow to create a new Expected Power Shelf using the CreateExpectedPowerShelfOnSite activity.
 func CreateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPowerShelf) error {
 	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Create").Str("ID", request.GetExpectedPowerShelfId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ShelfSerialNumber).Logger()
 
@@ -82,10 +86,13 @@ func CreateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPow
 		return err
 	}
 
-	// Then write to Flow (best-effort: log warning but don't fail the workflow)
-	err = workflow.ExecuteActivity(ctx, expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow, request).Get(ctx, nil)
-	if err != nil {
-		logger.Warn().Err(err).Str("Activity", "CreateExpectedPowerShelfOnFlow").Msg("Failed to create component on Flow, Core write succeeded")
+	// Preserve the Flow activity command when replaying histories created before
+	// direct Flow writes were removed.
+	if workflow.GetVersion(ctx, removeCreateExpectedPowerShelfOnFlowChangeID, workflow.DefaultVersion, removeCreateExpectedPowerShelfOnFlowVersion) == workflow.DefaultVersion {
+		err = workflow.ExecuteActivity(ctx, expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow, request).Get(ctx, nil)
+		if err != nil {
+			logger.Warn().Err(err).Str("Activity", "CreateExpectedPowerShelfOnFlow").Msg("Failed to create component on Flow, Core write succeeded")
+		}
 	}
 
 	logger.Info().Msg("completing workflow")
@@ -94,7 +101,6 @@ func CreateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPow
 }
 
 // UpdateExpectedPowerShelf is a workflow to update an Expected Power Shelf using the UpdateExpectedPowerShelfOnSite activity
-// TODO: Add Flow PatchComponent dual-write when update/delete Flow support is implemented
 func UpdateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPowerShelf) error {
 	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Update").Str("ID", request.GetExpectedPowerShelfId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.ShelfSerialNumber).Logger()
 
@@ -130,7 +136,6 @@ func UpdateExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPow
 }
 
 // DeleteExpectedPowerShelf is a workflow to Delete an Expected Power Shelf using the DeleteExpectedPowerShelfOnSite activity
-// TODO: Add Flow DeleteComponent dual-write when update/delete Flow support is implemented
 func DeleteExpectedPowerShelf(ctx workflow.Context, request *cwssaws.ExpectedPowerShelfRequest) error {
 	logger := log.With().Str("Workflow", "ExpectedPowerShelf").Str("Action", "Delete").Str("ID", request.GetExpectedPowerShelfId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
 

--- a/rest-api/site-workflow/pkg/workflow/expectedpowershelf_test.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedpowershelf_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 )
 
 type InventoryExpectedPowerShelfTestSuite struct {
@@ -93,11 +94,41 @@ func (cepsts *CreateExpectedPowerShelfTestSuite) Test_CreateExpectedPowerShelf_S
 	cepsts.env.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite)
 	cepsts.env.OnActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite, mock.Anything, mock.Anything).Return(nil)
 
-	// Mock CreateExpectedPowerShelfOnFlow activity
-	cepsts.env.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow)
-	cepsts.env.OnActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow, mock.Anything, mock.Anything).Return(nil)
+	cepsts.env.OnGetVersion(
+		removeCreateExpectedPowerShelfOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedPowerShelfOnFlowVersion,
+	).Return(removeCreateExpectedPowerShelfOnFlowVersion)
+	cepsts.env.OnActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Execute CreateExpectedPowerShelf workflow
+	cepsts.env.ExecuteWorkflow(CreateExpectedPowerShelf, request)
+	cepsts.True(cepsts.env.IsWorkflowCompleted())
+	cepsts.NoError(cepsts.env.GetWorkflowError())
+	cepsts.env.AssertActivityNumberOfCalls(cepsts.T(), "CreateExpectedPowerShelfOnFlow", 0)
+}
+
+func (cepsts *CreateExpectedPowerShelfTestSuite) Test_CreateExpectedPowerShelf_LegacyVersion_FlowFailure() {
+	var expectedPowerShelfManager iActivity.ManageExpectedPowerShelf
+
+	request := &cwssaws.ExpectedPowerShelf{
+		ExpectedPowerShelfId: &cwssaws.UUID{Value: "test-create-workflow-001"},
+		BmcMacAddress:        "00:11:22:33:44:55",
+		ShelfSerialNumber:    "SHELF-001",
+	}
+
+	cepsts.env.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite)
+	cepsts.env.OnActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite, mock.Anything, mock.Anything).Return(nil)
+
+	cepsts.env.OnGetVersion(
+		removeCreateExpectedPowerShelfOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedPowerShelfOnFlowVersion,
+	).Return(temporalworkflow.DefaultVersion)
+
+	cepsts.env.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow)
+	cepsts.env.OnActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow, mock.Anything, mock.Anything).Return(errors.New("Flow communication error"))
+
 	cepsts.env.ExecuteWorkflow(CreateExpectedPowerShelf, request)
 	cepsts.True(cepsts.env.IsWorkflowCompleted())
 	cepsts.NoError(cepsts.env.GetWorkflowError())
@@ -117,9 +148,6 @@ func (cepsts *CreateExpectedPowerShelfTestSuite) Test_CreateExpectedPowerShelf_F
 	// Mock CreateExpectedPowerShelfOnSite activity
 	cepsts.env.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite)
 	cepsts.env.OnActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnSite, mock.Anything, mock.Anything).Return(errors.New(errMsg))
-
-	// Register CreateExpectedPowerShelfOnFlow activity (not called when Core fails)
-	cepsts.env.RegisterActivity(expectedPowerShelfManager.CreateExpectedPowerShelfOnFlow)
 
 	// execute CreateExpectedPowerShelf workflow
 	cepsts.env.ExecuteWorkflow(CreateExpectedPowerShelf, request)

--- a/rest-api/site-workflow/pkg/workflow/expectedrack.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedrack.go
@@ -14,6 +14,11 @@ import (
 	cwssaws "github.com/NVIDIA/infra-controller/rest-api/workflow-schema/schema/site-agent/workflows/v1"
 )
 
+const (
+	removeCreateExpectedRackOnFlowChangeID = "remove-create-expected-rack-on-flow"
+	removeCreateExpectedRackOnFlowVersion  = workflow.Version(1)
+)
+
 // expectedRackActivityOptions returns the common ActivityOptions used by all
 // ExpectedRack workflows.
 func expectedRackActivityOptions() workflow.ActivityOptions {
@@ -67,8 +72,7 @@ func DiscoverExpectedRackInventory(ctx workflow.Context) error {
 }
 
 // CreateExpectedRack is a workflow to create a new Expected Rack using the
-// CreateExpectedRackOnSite activity, then also creates the rack in Flow via
-// CreateExpectedRackOnFlow (best-effort).
+// CreateExpectedRackOnSite activity.
 func CreateExpectedRack(ctx workflow.Context, request *cwssaws.ExpectedRack) error {
 	logger := log.With().Str("Workflow", "ExpectedRack").Str("Action", "Create").Str("ID", request.GetRackId().GetId()).Str("RackProfileID", request.GetRackProfileId().GetId()).Logger()
 
@@ -85,10 +89,13 @@ func CreateExpectedRack(ctx workflow.Context, request *cwssaws.ExpectedRack) err
 		return err
 	}
 
-	// Then write to Flow (best-effort: log warning but don't fail the workflow)
-	err = workflow.ExecuteActivity(ctx, expectedRackManager.CreateExpectedRackOnFlow, request).Get(ctx, nil)
-	if err != nil {
-		logger.Warn().Err(err).Str("Activity", "CreateExpectedRackOnFlow").Msg("Failed to create rack on Flow, Core write succeeded")
+	// Preserve the Flow activity command when replaying histories created before
+	// direct Flow writes were removed.
+	if workflow.GetVersion(ctx, removeCreateExpectedRackOnFlowChangeID, workflow.DefaultVersion, removeCreateExpectedRackOnFlowVersion) == workflow.DefaultVersion {
+		err = workflow.ExecuteActivity(ctx, expectedRackManager.CreateExpectedRackOnFlow, request).Get(ctx, nil)
+		if err != nil {
+			logger.Warn().Err(err).Str("Activity", "CreateExpectedRackOnFlow").Msg("Failed to create rack on Flow, Core write succeeded")
+		}
 	}
 
 	logger.Info().Msg("completing workflow")
@@ -98,7 +105,6 @@ func CreateExpectedRack(ctx workflow.Context, request *cwssaws.ExpectedRack) err
 
 // UpdateExpectedRack is a workflow to update an Expected Rack using the
 // UpdateExpectedRackOnSite activity.
-// TODO: Add Flow PatchComponent dual-write when update/delete Flow support is implemented
 func UpdateExpectedRack(ctx workflow.Context, request *cwssaws.ExpectedRack) error {
 	logger := log.With().Str("Workflow", "ExpectedRack").Str("Action", "Update").Str("ID", request.GetRackId().GetId()).Str("RackProfileID", request.GetRackProfileId().GetId()).Logger()
 
@@ -121,7 +127,6 @@ func UpdateExpectedRack(ctx workflow.Context, request *cwssaws.ExpectedRack) err
 
 // DeleteExpectedRack is a workflow to delete an Expected Rack using the
 // DeleteExpectedRackOnSite activity.
-// TODO: Add Flow PatchComponent dual-write when update/delete Flow support is implemented
 func DeleteExpectedRack(ctx workflow.Context, request *cwssaws.ExpectedRackRequest) error {
 	logger := log.With().Str("Workflow", "ExpectedRack").Str("Action", "Delete").Str("ID", request.GetRackId()).Logger()
 

--- a/rest-api/site-workflow/pkg/workflow/expectedrack_test.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedrack_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 )
 
 type CreateExpectedRackTestSuite struct {
@@ -41,14 +42,18 @@ func (certs *CreateExpectedRackTestSuite) Test_CreateExpectedRack_Success() {
 	certs.env.RegisterActivity(expectedRackManager.CreateExpectedRackOnSite)
 	certs.env.OnActivity(expectedRackManager.CreateExpectedRackOnSite, mock.Anything, mock.Anything).Return(nil)
 
-	// Mock CreateExpectedRackOnFlow activity
-	certs.env.RegisterActivity(expectedRackManager.CreateExpectedRackOnFlow)
-	certs.env.OnActivity(expectedRackManager.CreateExpectedRackOnFlow, mock.Anything, mock.Anything).Return(nil)
+	certs.env.OnGetVersion(
+		removeCreateExpectedRackOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedRackOnFlowVersion,
+	).Return(removeCreateExpectedRackOnFlowVersion)
+	certs.env.OnActivity(expectedRackManager.CreateExpectedRackOnFlow, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Execute CreateExpectedRack workflow
 	certs.env.ExecuteWorkflow(CreateExpectedRack, request)
 	certs.True(certs.env.IsWorkflowCompleted())
 	certs.NoError(certs.env.GetWorkflowError())
+	certs.env.AssertActivityNumberOfCalls(certs.T(), "CreateExpectedRackOnFlow", 0)
 }
 
 func (certs *CreateExpectedRackTestSuite) Test_CreateExpectedRack_Failure() {
@@ -65,16 +70,13 @@ func (certs *CreateExpectedRackTestSuite) Test_CreateExpectedRack_Failure() {
 	certs.env.RegisterActivity(expectedRackManager.CreateExpectedRackOnSite)
 	certs.env.OnActivity(expectedRackManager.CreateExpectedRackOnSite, mock.Anything, mock.Anything).Return(errors.New(errMsg))
 
-	// Register CreateExpectedRackOnFlow activity (not called when Core fails)
-	certs.env.RegisterActivity(expectedRackManager.CreateExpectedRackOnFlow)
-
 	// Execute CreateExpectedRack workflow
 	certs.env.ExecuteWorkflow(CreateExpectedRack, request)
 	certs.True(certs.env.IsWorkflowCompleted())
 	certs.Error(certs.env.GetWorkflowError())
 }
 
-func (certs *CreateExpectedRackTestSuite) Test_CreateExpectedRack_CoreSuccess_FlowFailure() {
+func (certs *CreateExpectedRackTestSuite) Test_CreateExpectedRack_LegacyVersion_FlowFailure() {
 	var expectedRackManager iActivity.ManageExpectedRack
 
 	request := &cwssaws.ExpectedRack{
@@ -85,6 +87,12 @@ func (certs *CreateExpectedRackTestSuite) Test_CreateExpectedRack_CoreSuccess_Fl
 	// Mock CreateExpectedRackOnSite activity (success)
 	certs.env.RegisterActivity(expectedRackManager.CreateExpectedRackOnSite)
 	certs.env.OnActivity(expectedRackManager.CreateExpectedRackOnSite, mock.Anything, mock.Anything).Return(nil)
+
+	certs.env.OnGetVersion(
+		removeCreateExpectedRackOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedRackOnFlowVersion,
+	).Return(temporalworkflow.DefaultVersion)
 
 	// Mock CreateExpectedRackOnFlow activity (failure - workflow should still succeed)
 	certs.env.RegisterActivity(expectedRackManager.CreateExpectedRackOnFlow)

--- a/rest-api/site-workflow/pkg/workflow/expectedswitch.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedswitch.go
@@ -13,6 +13,11 @@ import (
 	"go.temporal.io/sdk/workflow"
 )
 
+const (
+	removeCreateExpectedSwitchOnFlowChangeID = "remove-create-expected-switch-on-flow"
+	removeCreateExpectedSwitchOnFlowVersion  = workflow.Version(1)
+)
+
 // DiscoverExpectedSwitchInventory is a workflow to fetch Expected Switch inventory on Site and publish to Cloud
 func DiscoverExpectedSwitchInventory(ctx workflow.Context) error {
 	logger := log.With().Str("Workflow", "DiscoverExpectedSwitchInventory").Logger()
@@ -50,8 +55,7 @@ func DiscoverExpectedSwitchInventory(ctx workflow.Context) error {
 	return nil
 }
 
-// CreateExpectedSwitch is a workflow to create a new Expected Switch using the CreateExpectedSwitchOnSite activity,
-// then also creates the component in Flow via CreateExpectedSwitchOnFlow.
+// CreateExpectedSwitch is a workflow to create a new Expected Switch using the CreateExpectedSwitchOnSite activity.
 func CreateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch) error {
 	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Create").Str("ID", request.GetExpectedSwitchId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.SwitchSerialNumber).Logger()
 
@@ -82,10 +86,13 @@ func CreateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch)
 		return err
 	}
 
-	// Then write to Flow (best-effort: log warning but don't fail the workflow)
-	err = workflow.ExecuteActivity(ctx, expectedSwitchManager.CreateExpectedSwitchOnFlow, request).Get(ctx, nil)
-	if err != nil {
-		logger.Warn().Err(err).Str("Activity", "CreateExpectedSwitchOnFlow").Msg("Failed to create component on Flow, Core write succeeded")
+	// Preserve the Flow activity command when replaying histories created before
+	// direct Flow writes were removed.
+	if workflow.GetVersion(ctx, removeCreateExpectedSwitchOnFlowChangeID, workflow.DefaultVersion, removeCreateExpectedSwitchOnFlowVersion) == workflow.DefaultVersion {
+		err = workflow.ExecuteActivity(ctx, expectedSwitchManager.CreateExpectedSwitchOnFlow, request).Get(ctx, nil)
+		if err != nil {
+			logger.Warn().Err(err).Str("Activity", "CreateExpectedSwitchOnFlow").Msg("Failed to create component on Flow, Core write succeeded")
+		}
 	}
 
 	logger.Info().Msg("completing workflow")
@@ -94,7 +101,6 @@ func CreateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch)
 }
 
 // UpdateExpectedSwitch is a workflow to update an Expected Switch using the UpdateExpectedSwitchOnSite activity
-// TODO: Add Flow PatchComponent dual-write when update/delete Flow support is implemented
 func UpdateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch) error {
 	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Update").Str("ID", request.GetExpectedSwitchId().GetValue()).Str("Expected MAC address", request.BmcMacAddress).Str("Serial", request.SwitchSerialNumber).Logger()
 
@@ -130,7 +136,6 @@ func UpdateExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitch)
 }
 
 // DeleteExpectedSwitch is a workflow to Delete an Expected Switch using the DeleteExpectedSwitchOnSite activity
-// TODO: Add Flow DeleteComponent dual-write when update/delete Flow support is implemented
 func DeleteExpectedSwitch(ctx workflow.Context, request *cwssaws.ExpectedSwitchRequest) error {
 	logger := log.With().Str("Workflow", "ExpectedSwitch").Str("Action", "Delete").Str("ID", request.GetExpectedSwitchId().GetValue()).Str("optional MAC address", request.BmcMacAddress).Logger()
 

--- a/rest-api/site-workflow/pkg/workflow/expectedswitch_test.go
+++ b/rest-api/site-workflow/pkg/workflow/expectedswitch_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	temporalworkflow "go.temporal.io/sdk/workflow"
 )
 
 type InventoryExpectedSwitchTestSuite struct {
@@ -93,11 +94,41 @@ func (cests *CreateExpectedSwitchTestSuite) Test_CreateExpectedSwitch_Success() 
 	cests.env.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnSite)
 	cests.env.OnActivity(expectedSwitchManager.CreateExpectedSwitchOnSite, mock.Anything, mock.Anything).Return(nil)
 
-	// Mock CreateExpectedSwitchOnFlow activity
-	cests.env.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnFlow)
-	cests.env.OnActivity(expectedSwitchManager.CreateExpectedSwitchOnFlow, mock.Anything, mock.Anything).Return(nil)
+	cests.env.OnGetVersion(
+		removeCreateExpectedSwitchOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedSwitchOnFlowVersion,
+	).Return(removeCreateExpectedSwitchOnFlowVersion)
+	cests.env.OnActivity(expectedSwitchManager.CreateExpectedSwitchOnFlow, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	// Execute CreateExpectedSwitch workflow
+	cests.env.ExecuteWorkflow(CreateExpectedSwitch, request)
+	cests.True(cests.env.IsWorkflowCompleted())
+	cests.NoError(cests.env.GetWorkflowError())
+	cests.env.AssertActivityNumberOfCalls(cests.T(), "CreateExpectedSwitchOnFlow", 0)
+}
+
+func (cests *CreateExpectedSwitchTestSuite) Test_CreateExpectedSwitch_LegacyVersion_FlowFailure() {
+	var expectedSwitchManager iActivity.ManageExpectedSwitch
+
+	request := &cwssaws.ExpectedSwitch{
+		ExpectedSwitchId:   &cwssaws.UUID{Value: "test-create-workflow-001"},
+		BmcMacAddress:      "00:11:22:33:44:55",
+		SwitchSerialNumber: "SWITCH-001",
+	}
+
+	cests.env.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnSite)
+	cests.env.OnActivity(expectedSwitchManager.CreateExpectedSwitchOnSite, mock.Anything, mock.Anything).Return(nil)
+
+	cests.env.OnGetVersion(
+		removeCreateExpectedSwitchOnFlowChangeID,
+		temporalworkflow.DefaultVersion,
+		removeCreateExpectedSwitchOnFlowVersion,
+	).Return(temporalworkflow.DefaultVersion)
+
+	cests.env.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnFlow)
+	cests.env.OnActivity(expectedSwitchManager.CreateExpectedSwitchOnFlow, mock.Anything, mock.Anything).Return(errors.New("Flow communication error"))
+
 	cests.env.ExecuteWorkflow(CreateExpectedSwitch, request)
 	cests.True(cests.env.IsWorkflowCompleted())
 	cests.NoError(cests.env.GetWorkflowError())
@@ -117,9 +148,6 @@ func (cests *CreateExpectedSwitchTestSuite) Test_CreateExpectedSwitch_Failure() 
 	// Mock CreateExpectedSwitchOnSite activity
 	cests.env.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnSite)
 	cests.env.OnActivity(expectedSwitchManager.CreateExpectedSwitchOnSite, mock.Anything, mock.Anything).Return(errors.New(errMsg))
-
-	// Register CreateExpectedSwitchOnFlow activity (not called when Core fails)
-	cests.env.RegisterActivity(expectedSwitchManager.CreateExpectedSwitchOnFlow)
 
 	// execute CreateExpectedSwitch workflow
 	cests.env.ExecuteWorkflow(CreateExpectedSwitch, request)


### PR DESCRIPTION
> [!IMPORTANT]
> This PR cherry-picks commit 5496a5a65ffb9b1bc737b0e6e3370128a8a3ec94 (#4328) into `release/v2.0`.

Expected inventory creates write to Core, then best-effort push the same records into Flow. Flow's Core mirror already defaults on for every inventory cycle on this branch (#4313), so that second write leaves two paths populating the same tables. Site workflows stop scheduling Flow writes and drop their Flow clients and converters; single and batch machine, switch, power-shelf, and rack creates now write to Core once, and Flow sees them on its next inventory cycle.

Old Temporal histories still expect the five `CreateExpected*OnFlow` commands, so each workflow keeps a `workflow.GetVersion` branch at the old command boundary and the activity names stay registered as no-ops -- those histories replay without putting duplicate data back into Flow.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2127

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated

`go build ./...` and `go test ./site-workflow/pkg/activity/... ./site-workflow/pkg/workflow/...` pass on the branch.

## Additional Notes

**Adapted, not a clean pick.** `release/v2.0` does not have #3238 (unified Core protobuf location), so `site-workflow` here still uses the `cwssaws` schema types where `main` uses `corev1`. The picked change is translated onto that baseline: same logic, same `GetVersion` change IDs, same no-op stubs, with `cwssaws` types and imports. Normalizing the alias, the only remaining delta against `main` is the `grpc_duration` latency logging from #2702 -- also not on this branch, and intentionally not pulled in here.

The prerequisite for dropping the Flow write is already on the branch: `FLOW_EXPECTED_INVENTORY_SYNC_ENABLED` defaults on (`inventorysync/job.go` is identical to `main`), so expected inventory still reaches Flow via the mirror.
