### PR TITLE
feat(instrument): support Option for context fields

### DIFF
--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -436,6 +436,43 @@ fn context_mode(attr: &syn::Attribute) -> syn::Result<ContextMode> {
     }
 }
 
+/// Whether a context field's type is written as `Option<...>`, which is how an
+/// Event says a field does not apply to every case it covers. The check is
+/// syntactic, so a type alias for an option (`type MaybeWorker = Option<Uuid>`)
+/// is not recognized -- that surfaces as a compile error at the generated call,
+/// never as a silently wrong log line.
+fn is_option(ty: &syn::Type) -> bool {
+    let syn::Type::Path(path) = ty else {
+        return false;
+    };
+    if path.qself.is_some() {
+        return false;
+    }
+    let segments: Vec<String> = path
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect();
+    // `Option<T>`, or the same spelled out in full through `std`/`core`.
+    // Anything else named `Option` -- including a bare `option::Option` from
+    // somebody's own module -- is their type and is left alone.
+    let spelled_as_the_std_option = matches!(
+        segments
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .as_slice(),
+        ["Option"] | ["std" | "core", "option", "Option"]
+    );
+    let takes_one_type_argument = path.path.segments.last().is_some_and(|segment| {
+        matches!(&segment.arguments, syn::PathArguments::AngleBracketed(args)
+            if args.args.len() == 1
+                && matches!(args.args.first(), Some(syn::GenericArgument::Type(_))))
+    });
+    spelled_as_the_std_option && takes_one_type_argument
+}
+
 fn classify_field(field: &Field) -> syn::Result<FieldKind> {
     let mut kinds = Vec::new();
     for attr in &field.attrs {
@@ -709,7 +746,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
     };
 
     let mut labels: Vec<(&Ident, String)> = Vec::new();
-    let mut contexts: Vec<(&Ident, ContextMode)> = Vec::new();
+    let mut contexts: Vec<(&Ident, ContextMode, bool)> = Vec::new();
     let mut observations: Vec<&Ident> = Vec::new();
     for field in fields {
         let ident = field.ident.as_ref().expect("named field");
@@ -741,7 +778,19 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
                 }
                 labels.push((ident, metric_name));
             }
-            FieldKind::Context(mode) => contexts.push((ident, mode)),
+            FieldKind::Context(mode) => {
+                // The native-value mode exists for fields whose tracing type is
+                // part of the structured-log contract; nothing needs an
+                // optional one yet, so say that rather than guess at it.
+                if mode == ContextMode::Value && is_option(&field.ty) {
+                    return Err(syn::Error::new_spanned(
+                        field,
+                        "#[context(value)] does not take an Option; use #[context] for a field \
+                         that does not apply to every case",
+                    ));
+                }
+                contexts.push((ident, mode, is_option(&field.ty)));
+            }
             FieldKind::Observation => observations.push(ident),
         }
     }
@@ -779,7 +828,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
     let label_names: Vec<&str> = labels.iter().map(|(_, name)| name.as_str()).collect();
     let context_names: Vec<String> = contexts
         .iter()
-        .map(|(ident, _)| ident.to_string())
+        .map(|(ident, _, _)| ident.to_string())
         .collect();
 
     // `log = dynamic` keeps the trait's nominal LOG and routes the decision
@@ -944,27 +993,53 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
             #ident = ::carbide_instrument::LabelValue::label_value(&self.#ident).as_str()
         }
     }));
-    log_fields.extend(contexts.iter().map(|(ident, mode)| match mode {
-        ContextMode::Display => quote! { #ident = %self.#ident },
-        ContextMode::Value => quote! { #ident = self.#ident },
-    }));
+    log_fields.extend(
+        contexts
+            .iter()
+            .map(|(ident, mode, optional)| match (mode, optional) {
+                // `tracing` records nothing for a `None`, so the key is absent from the
+                // line rather than blank -- which is the whole point of declaring the
+                // field optional.
+                (ContextMode::Display, true) => quote! {
+                    #ident = self.#ident.as_ref().map(
+                        ::carbide_instrument::__private::tracing::field::display,
+                    )
+                },
+                (ContextMode::Display, false) => quote! { #ident = %self.#ident },
+                (ContextMode::Value, _) => quote! { #ident = self.#ident },
+            }),
+    );
 
-    let context_values =
+    let context_pushes =
         contexts
             .iter()
             .zip(&context_names)
-            .map(|((ident, mode), name)| match mode {
-                ContextMode::Display => quote! {
-                    ::carbide_instrument::__private::opentelemetry::KeyValue::new(
-                        #name,
-                        ::std::string::ToString::to_string(&self.#ident),
-                    )
+            .map(|((ident, mode, optional), name)| match (mode, optional) {
+                (ContextMode::Display, true) => quote! {
+                    if let ::std::option::Option::Some(__value) = &self.#ident {
+                        __context.push(
+                            ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                                #name,
+                                ::std::string::ToString::to_string(__value),
+                            ),
+                        );
+                    }
                 },
-                ContextMode::Value => quote! {
-                    ::carbide_instrument::__private::opentelemetry::KeyValue::new(
-                        #name,
-                        ::std::clone::Clone::clone(&self.#ident),
-                    )
+                (ContextMode::Display, false) => quote! {
+                    __context.push(
+                        ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                            #name,
+                            ::std::string::ToString::to_string(&self.#ident),
+                        ),
+                    );
+                },
+                (ContextMode::Value, _) => quote! {
+                    __context.push(
+                        ::carbide_instrument::__private::opentelemetry::KeyValue::new(
+                            #name,
+                            ::std::clone::Clone::clone(&self.#ident),
+                        ),
+                    );
                 },
             });
     let log_arm = |level: proc_macro2::TokenStream| {
@@ -1027,9 +1102,9 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
             #labels_fn
 
             fn context(&self) -> ::std::vec::Vec<::carbide_instrument::__private::opentelemetry::KeyValue> {
-                ::std::vec![
-                    #(#context_values,)*
-                ]
+                let mut __context = ::std::vec::Vec::new();
+                #(#context_pushes)*
+                __context
             }
 
             #observation_fn
@@ -1967,6 +2042,108 @@ mod tests {
             |DiagnosticInput { source, expected }| {
                 let error = expansion_error(source);
                 (!error.contains(expected)).then(|| format!("expected `{expected}` in `{error}`"))
+            },
+        );
+    }
+
+    /// The native-value mode has its own types and no optional form, so it says
+    /// that rather than letting the field reach a trait error somewhere else.
+    #[test]
+    fn context_value_rejects_an_optional_field() {
+        let error = expansion_error(
+            r#"#[event(event_name = "demo", component = "demo", message = "demo")] struct Demo { #[context(value)] value: Option<String> }"#,
+        );
+        assert!(
+            error.contains("#[context(value)] does not take an Option"),
+            "expected the targeted rejection, got `{error}`"
+        );
+        assert!(
+            error.contains("use #[context]"),
+            "the rejection points at the mode that does take one, got `{error}`"
+        );
+    }
+
+    /// `Option<T>` is recognized only in the spellings the docs promise, so a
+    /// type of somebody else's that happens to be named `Option` keeps rendering
+    /// through `Display` instead of being treated as an absent-able field.
+    #[test]
+    fn only_the_std_option_counts_as_optional() {
+        struct SpellingCase {
+            ty: &'static str,
+            optional: bool,
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "the bare std option",
+                    input: SpellingCase {
+                        ty: "Option<String>",
+                        optional: true,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "spelled out through std",
+                    input: SpellingCase {
+                        ty: "std::option::Option<String>",
+                        optional: true,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "spelled out through core",
+                    input: SpellingCase {
+                        ty: "core::option::Option<String>",
+                        optional: true,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "leading-colon std path",
+                    input: SpellingCase {
+                        ty: "::std::option::Option<String>",
+                        optional: true,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "somebody else's option module",
+                    input: SpellingCase {
+                        ty: "option::Option<String>",
+                        optional: false,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "somebody else's Option type",
+                    input: SpellingCase {
+                        ty: "mine::Option<String>",
+                        optional: false,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "a non-generic type named Option",
+                    input: SpellingCase {
+                        ty: "Option",
+                        optional: false,
+                    },
+                    expect: None,
+                },
+                Check {
+                    scenario: "an option taking more than one argument is not one",
+                    input: SpellingCase {
+                        ty: "Option<String, u8>",
+                        optional: false,
+                    },
+                    expect: None,
+                },
+            ],
+            |SpellingCase { ty, optional }| {
+                let parsed: syn::Type = syn::parse_str(ty).expect("valid type");
+                (super::is_option(&parsed) != optional)
+                    .then(|| format!("`{ty}`: expected optional={optional}"))
             },
         );
     }

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -97,6 +97,36 @@
 //! }
 //! ```
 //!
+//! A context field that does not apply to every case an event covers is
+//! written `Option<T>`. `None` leaves the key off the log line entirely, rather
+//! than writing a blank or a stand-in value -- which is the only honest form
+//! for a typed field, since there is no empty `WorkerId`:
+//!
+//! ```
+//! use std::net::IpAddr;
+//!
+//! #[derive(carbide_instrument::Event)]
+//! #[event(
+//!     event_name = "upload_failed",
+//!     component = "demo",
+//!     log = warn,
+//!     message = "upload failed"
+//! )]
+//! struct UploadFailed {
+//!     #[context]
+//!     peer: Option<IpAddr>, // absent when the upload never reached a peer
+//!     #[context]
+//!     error: String,
+//! }
+//! ```
+//!
+//! The check is syntactic: it recognizes `Option<T>` spelled bare or through
+//! `std`/`core`, and leaves any other type named `Option` alone. A type alias
+//! for an option is therefore not recognized as one, which surfaces as a
+//! compile error at the generated call rather than a silently wrong log line.
+//! `#[context(value)]` keeps its own types and rejects `Option<...>`, pointing
+//! at `#[context]` instead.
+//!
 //! `#[label(name = "component")]` exists for a frozen metric key that cannot
 //! also be the Rust field name because Event logs reserve `component`. For a
 //! field such as `publisher: Publisher`, the metric keeps `component` while

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -944,3 +944,106 @@ fn a_derived_label_is_computed_by_the_family() {
     assert_eq!(logs[0].field("kind"), None);
     assert_eq!(logs[0].field("detail"), Some("upstream refused"));
 }
+
+/// A context field written as `Option<...>` says it does not apply to every
+/// case: `None` leaves the key off the log line entirely rather than writing a
+/// blank or a sentinel, and `Event::context` agrees with the line.
+#[test]
+fn an_absent_optional_context_field_leaves_no_key() {
+    use std::net::IpAddr;
+
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_optional_context",
+        component = "matrix-test",
+        log = warn,
+        message = "optional context"
+    )]
+    struct OptionalContext {
+        #[label]
+        outcome: Outcome,
+        /// A typed field with no blank value: absent is the only honest form.
+        #[context]
+        peer: Option<IpAddr>,
+        #[context]
+        error: Option<String>,
+        #[context]
+        always: String,
+    }
+
+    let logs = capture_logs(|| {
+        emit(OptionalContext {
+            outcome: Outcome::Error,
+            peer: Some(IpAddr::from([10, 0, 0, 5])),
+            error: Some("boom".to_string()),
+            always: "here".to_string(),
+        });
+        emit(OptionalContext {
+            outcome: Outcome::Ok,
+            peer: None,
+            error: None,
+            always: "here".to_string(),
+        });
+    });
+
+    // Present: rendered through Display exactly as a non-optional field is.
+    assert_eq!(logs[0].field("peer"), Some("10.0.0.5"));
+    assert_eq!(logs[0].field("error"), Some("boom"));
+    assert_eq!(logs[0].field("always"), Some("here"));
+
+    // Absent: the key is not on the line at all -- not blank, not a sentinel.
+    assert_eq!(logs[1].field("peer"), None);
+    assert_eq!(logs[1].field("error"), None);
+    assert_eq!(logs[1].field("always"), Some("here"));
+    let keys: Vec<&str> = logs[1].fields.iter().map(|(k, _)| k.as_str()).collect();
+    assert!(
+        !keys.contains(&"peer"),
+        "absent field must not appear: {keys:?}"
+    );
+    assert!(
+        !keys.contains(&"error"),
+        "absent field must not appear: {keys:?}"
+    );
+
+    // Each optional field stands on its own: one being absent says nothing
+    // about the other.
+    let mixed = capture_logs(|| {
+        emit(OptionalContext {
+            outcome: Outcome::Error,
+            peer: Some(IpAddr::from([10, 0, 0, 9])),
+            error: None,
+            always: "here".to_string(),
+        });
+        emit(OptionalContext {
+            outcome: Outcome::Error,
+            peer: None,
+            error: Some("only the error".to_string()),
+            always: "here".to_string(),
+        });
+    });
+    assert_eq!(mixed[0].field("peer"), Some("10.0.0.9"));
+    assert_eq!(mixed[0].field("error"), None);
+    assert_eq!(mixed[1].field("peer"), None);
+    assert_eq!(mixed[1].field("error"), Some("only the error"));
+
+    let peer_only = OptionalContext {
+        outcome: Outcome::Error,
+        peer: Some(IpAddr::from([10, 0, 0, 9])),
+        error: None,
+        always: "here".to_string(),
+    };
+    let peer_only_context = Event::context(&peer_only);
+    let peer_only_keys: Vec<&str> = peer_only_context.iter().map(|kv| kv.key.as_str()).collect();
+    assert_eq!(peer_only_keys, vec!["peer", "always"]);
+
+    // `Event::context` is introspection for tooling, so it agrees with the line.
+    let absent = OptionalContext {
+        outcome: Outcome::Ok,
+        peer: None,
+        error: None,
+        always: "here".to_string(),
+    };
+    let context = Event::context(&absent);
+    let context_keys: Vec<&str> = context.iter().map(|kv| kv.key.as_str()).collect();
+    assert_eq!(context_keys, vec!["always"]);
+}


### PR DESCRIPTION
Some context fields do not apply to every case an Event covers. A work-lock release failure has no worker; a BMC session flush has no session. The framework had one answer for that -- declare a second Event -- and it is why `carbide_work_lock_failures_total` is four structs whose only real difference is which fields they hold.

The other answer people reach for is worse: give the field an empty value and move on. That works for a `String`, at the cost of a log line asserting `error=""` when there is no error, and it does not work at all for a typed field. There is no empty `WorkerId`; the best available is `00000000-0000-0000-0000-000000000000`, which an operator reads as a real worker.

So a context field can now say it does not apply. The entire surface is one word:

```rust
#[context]
worker_id: Option<WorkerId>, // no worker on the release path
```

`None` leaves the key off the line rather than writing a blank or a stand-in:

```logfmt
event_name=work_lock_failed operation=release    failure=database  work_key=... error="..."
event_name=work_lock_failed operation=keep_alive failure=lock_lost work_key=... worker_id=7f3a... error="..."
```

`tracing` already behaves this way (`impl<T: Value> Value for Option<T>` records nothing for `None`), so the derive routes an optional `#[context]` through `self.field.as_ref().map(tracing::field::display)` and lets the library do the rest. `Event::context()` skips absent fields too, so the introspection tooling and tests read agrees with the line an operator would see.

**`#[context(value)]` rejects `Option<...>`** with a diagnostic pointing at `#[context]`. That mode exists for `bool`, `i64`, `f64`, and `String` whose native tracing type is part of the structured-log contract; nothing needs an optional one yet, and saying so beats inventing semantics for it.

**The detection is deliberately narrow.** It recognizes `Option<T>` spelled bare or through `std`/`core` and taking exactly one type argument, so somebody's own type named `Option` is left alone and renders through `Display` as it always did. A type alias for an option is not recognized either, which surfaces as a compile error at the generated call rather than a silently wrong log line. Both are in the crate docs.

**Nothing existing changes.** Every Event in the tree keeps its fields, its log line, and its metric; the catalogue stays at 152.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4334

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

A new `matrix.rs` case covers a typed optional (`Option<IpAddr>`, which has no blank form) alongside an optional `String` and a required field. It asserts the present rendering, the absent key being genuinely missing rather than empty, that `Event::context()` agrees with the line, and -- because one field's optionality must not leak into another's -- the two mixed states where one is `Some` while the other is `None`.

I also checked by hand that a user-defined non-generic type named `Option` still renders through `Display` while `std::option::Option<String>` is treated as optional, and that the `#[context(value)]` rejection produces its intended message rather than a trait error.

Battery: `format-nightly` + `check-format-nightly` + `clippy` + `carbide-lints` clean, full `--workspace --all-features` build, 54 tests across `carbide-instrument` and `carbide-instrument-macros`, `check-metric-docs` unchanged at 152, no `Cargo.lock` drift.

## Additional Notes

This lands before #4305, which merges sets of Events whose context differs case by case. That is exactly where the empty-string pattern would otherwise be stamped into another eleven places, and three of those groups are blocked on it outright because their absent fields are typed (`WorkerId`, `ODataId`, `ConfigVersion`).

It also retires an existing wart: `ScoutActionHandled` carries `error: String` with a doc comment apologizing for it -- "Successful actions use `""` because Event context fields are present on every generated record." That comment becomes deletable.


Closes #4334
