### PR TITLE
fix: keep seeding networks after reverse zone creation

### DIFF
--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -18,13 +18,14 @@
 use std::collections::HashMap;
 
 use carbide_network::virtualization::VpcVirtualizationType;
+use carbide_uuid::domain::DomainId;
 use carbide_uuid::vpc::VpcId;
 use db::dns::domain;
 use db::network_segment::reconcile_network_defs;
 use db::vpc::{self};
 use db::{ObjectColumnFilter, Transaction, dpu_agent_upgrade_policy, network_segment};
 use itertools::Itertools;
-use model::dns::NewDomain;
+use model::dns::{Domain, NewDomain};
 use model::firmware::AgentUpgradePolicyChoice;
 use model::machine::upgrade_policy::AgentUpgradePolicy;
 use model::metadata::Metadata;
@@ -63,30 +64,84 @@ pub async fn create_initial_domain(
         Ok(false)
     }
 }
+
+#[derive(Debug, PartialEq, Eq)]
+enum SeedNetworkDomainSelection {
+    Selected(DomainId),
+    NoForwardDomain,
+    Ambiguous(Vec<String>),
+}
+
+/// Select the forward domain used to parent config-seeded network segments.
+///
+/// Reverse-DNS zones share the domains table and must not make a sole forward
+/// domain appear ambiguous.
+fn select_seed_network_domain(
+    domains: &[Domain],
+    configured_domain_name: Option<&str>,
+) -> SeedNetworkDomainSelection {
+    let forward_domains = domains
+        .iter()
+        .filter(|domain| {
+            let name = domain.name.trim_end_matches('.');
+            !matches!(name, "in-addr.arpa" | "ip6.arpa")
+                && !name.ends_with(".in-addr.arpa")
+                && !name.ends_with(".ip6.arpa")
+        })
+        .collect_vec();
+
+    if let Some(domain_name) = configured_domain_name {
+        let configured_domains = forward_domains
+            .iter()
+            .filter(|domain| domain.name == domain_name)
+            .collect_vec();
+        if let [domain] = configured_domains.as_slice() {
+            return SeedNetworkDomainSelection::Selected(domain.id);
+        }
+    }
+
+    match forward_domains.as_slice() {
+        [] => SeedNetworkDomainSelection::NoForwardDomain,
+        [domain] => SeedNetworkDomainSelection::Selected(domain.id),
+        domains => SeedNetworkDomainSelection::Ambiguous(
+            domains
+                .iter()
+                .map(|domain| domain.name.clone())
+                .sorted()
+                .collect(),
+        ),
+    }
+}
+
 pub async fn create_initial_networks(
     api: &Api,
     db_pool: &Pool<Postgres>,
     networks: &HashMap<String, NetworkDefinition>,
 ) -> Result<(), CarbideError> {
     let mut txn = Transaction::begin(db_pool).await?;
-    let all_domains = db::dns::domain::find_by(
+    let domains = db::dns::domain::find_by(
         &mut txn,
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
-    if all_domains.is_empty() {
-        tracing::warn!("No domain configured, skipping initial network creation");
-        return Ok(());
-    }
-    if all_domains.len() > 1 {
-        // We only create initial networks if we only have a single domain - usually created
-        // as initial_domain_name in config file.
-        // Having multiple domains is fine, it means we probably created the network much
-        // earlier.
-        tracing::info!("Multiple domains, skipping initial network creation");
-        return Ok(());
-    }
-    let domain_id = all_domains[0].id;
+    let domain_id = match select_seed_network_domain(
+        &domains,
+        api.runtime_config.initial_domain_name.as_deref(),
+    ) {
+        SeedNetworkDomainSelection::Selected(domain_id) => domain_id,
+        SeedNetworkDomainSelection::NoForwardDomain => {
+            tracing::warn!("No forward domain configured, skipping initial network creation");
+            return Ok(());
+        }
+        SeedNetworkDomainSelection::Ambiguous(forward_domains) => {
+            tracing::warn!(
+                ?forward_domains,
+                configured_domain_name = ?api.runtime_config.initial_domain_name,
+                "Multiple forward domains, skipping initial network creation",
+            );
+            return Ok(());
+        }
+    };
     reconcile_network_defs(&mut txn, networks).await?;
 
     for (name, def) in networks {
@@ -524,4 +579,137 @@ pub(crate) async fn create_admin_vpc(
     txn.commit().await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+    use chrono::Utc;
+
+    use super::*;
+
+    struct DomainSelectionCase {
+        domains: Vec<Domain>,
+        configured_domain_name: Option<&'static str>,
+    }
+
+    fn domain_id(id: u128) -> DomainId {
+        uuid::Uuid::from_u128(id).into()
+    }
+
+    fn domain(id: u128, name: &str) -> Domain {
+        let timestamp = Utc::now();
+        Domain {
+            id: domain_id(id),
+            name: name.to_string(),
+            created: timestamp,
+            updated: timestamp,
+            deleted: None,
+            soa: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn seed_network_domain_selection_distinguishes_forward_and_reverse_domains() {
+        check_values(
+            [
+                Check {
+                    scenario: "no domains are available",
+                    input: DomainSelectionCase {
+                        domains: vec![],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::NoForwardDomain,
+                },
+                Check {
+                    scenario: "the configured domain wins among multiple forward domains",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "legacy.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                            domain(3, "site.example"),
+                        ],
+                        configured_domain_name: Some("site.example"),
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(3)),
+                },
+                Check {
+                    scenario: "a renamed configured domain falls back to the sole forward domain",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "renamed.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                        ],
+                        configured_domain_name: Some("site.example"),
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                },
+                Check {
+                    scenario: "an API-created domain works without initial_domain_name",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "api-created.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                            domain(3, "0.0.ip6.arpa"),
+                        ],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                },
+                Check {
+                    scenario: "reverse domains alone do not become the forward domain",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "0.20.172.in-addr.arpa"),
+                            domain(2, "0.0.ip6.arpa."),
+                        ],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::NoForwardDomain,
+                },
+                Check {
+                    scenario: "a configured reverse domain does not override the forward domain",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "site.example"),
+                            domain(2, "0.20.172.in-addr.arpa"),
+                        ],
+                        configured_domain_name: Some("0.20.172.in-addr.arpa"),
+                    },
+                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                },
+                Check {
+                    scenario: "multiple forward domains without a configured match are ambiguous",
+                    input: DomainSelectionCase {
+                        domains: vec![
+                            domain(1, "one.example"),
+                            domain(2, "two.example"),
+                            domain(3, "0.20.172.in-addr.arpa"),
+                        ],
+                        configured_domain_name: None,
+                    },
+                    expect: SeedNetworkDomainSelection::Ambiguous(vec![
+                        "one.example".to_string(),
+                        "two.example".to_string(),
+                    ]),
+                },
+                Check {
+                    scenario: "duplicate configured domains are ambiguous",
+                    input: DomainSelectionCase {
+                        domains: vec![domain(1, "site.example"), domain(2, "site.example")],
+                        configured_domain_name: Some("site.example"),
+                    },
+                    expect: SeedNetworkDomainSelection::Ambiguous(vec![
+                        "site.example".to_string(),
+                        "site.example".to_string(),
+                    ]),
+                },
+            ],
+            |DomainSelectionCase {
+                 domains,
+                 configured_domain_name,
+             }| { select_seed_network_domain(&domains, configured_domain_name) },
+        );
+    }
 }

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -565,7 +565,7 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let env =
         create_test_env_with_overrides(db_pool.clone(), TestEnvOverrides::no_network_segments())
             .await;
-    let networks = HashMap::from([
+    let mut networks = HashMap::from([
         (
             "admin".to_string(),
             NetworkDefinition {
@@ -617,6 +617,10 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
     let admin = db::network_segment::find_by_name(&mut txn, "admin").await?;
     assert_eq!(admin.config.mtu, 9000);
     assert_eq!(admin.config.segment_type, NetworkSegmentType::Admin);
+    let initial_domain_id = admin
+        .config
+        .subdomain_id
+        .expect("config-seeded network should use the forward domain");
 
     let underlay = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-01").await?;
     assert_eq!(underlay.config.mtu, 1500);
@@ -629,6 +633,19 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
         NetworkSegmentType::HostInband
     );
     assert_eq!(host_inband.config.vpc_id, None);
+    // These extra domain rows reproduce the state that previously disabled later seeding.
+    for reverse_domain in [
+        "254.254.254.169.in-addr.arpa",
+        "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.ip6.arpa",
+    ] {
+        assert_eq!(
+            db::dns::domain::find_by_name(txn.as_mut(), reverse_domain)
+                .await?
+                .len(),
+            1,
+            "static assignment reverse domain should exist"
+        );
+    }
     txn.commit().await?;
 
     // Now create them again. It should succeed but not create any more
@@ -657,6 +674,28 @@ pub async fn test_create_initial_networks(db_pool: sqlx::PgPool) -> Result<(), e
         num_before, num_after,
         "second create_initial_networks should not have created any segments"
     );
+
+    networks.insert(
+        "DEV1-C09-IPMI-02".to_string(),
+        NetworkDefinition {
+            segment_type: NetworkDefinitionSegmentType::Underlay,
+            prefix: "172.99.0.64/27".parse().unwrap(),
+            prefix_v6: None,
+            gateway: "172.99.0.65".parse().unwrap(),
+            dhcpv6_link_address: None,
+            mtu: 1500,
+            reserve_first: 5,
+            allocation_strategy: Default::default(),
+            vpc_name: None,
+        },
+    );
+    crate::db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
+
+    let mut txn = db_pool.begin().await?;
+    let added = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-02").await?;
+    assert_eq!(added.config.subdomain_id, Some(initial_domain_id));
+    txn.commit().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Once NICo started creating reverse-DNS zones for aligned network prefixes, the `domains` table stopped meaning "the one domain we can use for seed networks." The static `169.254.254.254/32` and IPv6 assignments create zones of their own on every new site, and `create_initial_networks` was counting those rows as if they were forward domains. So, adding another configured segment later could log that the domain was ambiguous and quietly skip the segment.

This teaches `create_initial_networks` to choose from forward domains only. A unique `initial_domain_name` match wins; otherwise the existing single-forward-domain behavior still works for sites that created or renamed the domain through the API. If more than one forward domain is still possible, NICo yells and leaves the seed config alone instead of guessing.

Tests now create both static-assignment reverse zones, add another seed network, and check that its subdomain still points at the original forward domain. I also kept the resolver cases table-driven so the API-created, renamed, reverse-only, and ambiguous paths are explicit. Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4286

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `cargo test -p carbide-api-core seed_network_domain_selection --lib`
- `cargo test -p carbide-api-core test_create_initial_networks --lib`
- `cargo test -p carbide-api-core test_machine_metadata --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

Raphael's #4331 comes at #4286 from the same `initial_domain_name` direction. This pass keeps the previous single-forward-domain fallback when `initial_domain_name` is unset or no longer matches, while still using an exact configured match when several forward domains exist. Also, thanks @rapphil for catching that the selector names should say `seed network` rather than `initial domain` -- that's a much better description of what the helper returns.

Closes #4286