### PR TITLE
docs(changelog): add machine-a-tron to the v2.1 release notes

### DIFF
--- a/fern/changelog/2026-08-31.mdx
+++ b/fern/changelog/2026-08-31.mdx
@@ -1,0 +1,15 @@
+---
+tags: ["next"]
+---
+
+## NVIDIA Infra Controller v2.1 <Badge intent="launch">Next</Badge>
+
+This is a placeholder for the v2.1 release notes.
+
+### Feature 1
+
+Placeholder text.
+
+### Feature 2
+
+Placeholder text.

--- a/fern/changelog/2026-08-31.mdx
+++ b/fern/changelog/2026-08-31.mdx
@@ -13,3 +13,7 @@ Placeholder text.
 ### Feature 2
 
 Placeholder text.
+
+### Validation & Testing
+
+- machine-a-tron Redfish BMC emulator for end-to-end NICo flows without physical servers, deployed via the `nico-machine-a-tron` Helm chart and `helm-prereqs/setup-machine-a-tron.sh`


### PR DESCRIPTION
Follow-up to #4223: machine-a-tron (#2764) landed in main after the `release/v2.0` branch cut, so it ships first in v2.1 — not v2.0.

Moves the machine-a-tron bullet from the v2.0 changelog (`fern/changelog/2026-07-31.mdx`) to the new v2.1 file (`fern/changelog/2026-08-31.mdx`).

**Note:** This PR creates `fern/changelog/2026-08-31.mdx` with the same placeholder content as #4417 plus the machine-a-tron entry. #4417 should merge first; after it does, this branch should be rebased so the diff reduces to just adding the one bullet to the already-existing v2.1 file.

## Related issues

Follow-up to #4223. Stacked on #4417.

## Type of Change

- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] No testing required (docs only)