### PR TITLE
refactor(instrument): collapse prefix-grouped Events onto their shared label

### DIFF
--- a/crates/api-core/src/auth/middleware.rs
+++ b/crates/api-core/src/auth/middleware.rs
@@ -64,20 +64,22 @@ enum Authorizer {
     InternalRbac,
 }
 
-/// `CasbinAuthContextMissing` means the authentication middleware did not run
-/// before Casbin. The request still fails closed with a 500; the Event keeps
-/// the existing warning and makes the wiring error visible as a counter.
+/// `AuthContextMissing` means the authentication middleware did not run before
+/// the authorization handler. The request still fails closed with a 500; the
+/// Event keeps the existing warning and makes the wiring error visible as a
+/// counter. `authorizer` names the layer that found the gap, and picks the
+/// handler-specific wording operators already see.
 #[derive(carbide_instrument::Event)]
 #[event(
-    event_name = "casbin_auth_context_missing",
+    event_name = "auth_context_missing",
     metric_name = "carbide_auth_context_missing_total",
     component = "nico-api",
     log = warn,
     metric = counter,
-    message = "CasbinHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.",
+    message = dynamic,
     describe = "Number of Forge authorization requests missing authentication context, by authorizer"
 )]
-struct CasbinAuthContextMissing {
+struct AuthContextMissing {
     #[label]
     authorizer: Authorizer,
     #[context]
@@ -86,26 +88,17 @@ struct CasbinAuthContextMissing {
     client_address: String,
 }
 
-/// `InternalRbacAuthContextMissing` records the same wiring failure at the
-/// static rule layer. It shares the counter with Casbin while retaining the
-/// handler-specific warning operators already see.
-#[derive(carbide_instrument::Event)]
-#[event(
-    event_name = "internal_rbac_auth_context_missing",
-    metric_name = "carbide_auth_context_missing_total",
-    component = "nico-api",
-    log = warn,
-    metric = counter,
-    message = "InternalRBACHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.",
-    describe = "Number of Forge authorization requests missing authentication context, by authorizer"
-)]
-struct InternalRbacAuthContextMissing {
-    #[label]
-    authorizer: Authorizer,
-    #[context]
-    method: String,
-    #[context]
-    client_address: String,
+impl carbide_instrument::DynamicMessage for AuthContextMissing {
+    fn message(&self) -> &'static str {
+        match self.authorizer {
+            Authorizer::Casbin => {
+                "CasbinHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order."
+            }
+            Authorizer::InternalRbac => {
+                "InternalRBACHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order."
+            }
+        }
+    }
 }
 
 /// The peer address of the connection a request arrived on, as recorded by
@@ -165,7 +158,7 @@ where
                         .extensions_mut()
                         .get_mut::<AuthContext>()
                         .ok_or_else(|| {
-                            carbide_instrument::emit(CasbinAuthContextMissing {
+                            carbide_instrument::emit(AuthContextMissing {
                                 authorizer: Authorizer::Casbin,
                                 method: method_name.clone(),
                                 client_address: client_address(peer_address),
@@ -301,7 +294,7 @@ where
                     let request_peer_address = peer_address(&request);
                     let req_auth_context =
                         request.extensions().get::<AuthContext>().ok_or_else(|| {
-                            carbide_instrument::emit(InternalRbacAuthContextMissing {
+                            carbide_instrument::emit(AuthContextMissing {
                                 authorizer: Authorizer::InternalRbac,
                                 method: method_name.clone(),
                                 client_address: client_address(request_peer_address),
@@ -486,7 +479,7 @@ mod tests {
                     expect: MissingAuthContextObservation {
                         status: StatusCode::INTERNAL_SERVER_ERROR,
                         level: tracing::Level::WARN,
-                        metadata_name: "casbin_auth_context_missing".to_string(),
+                        metadata_name: "auth_context_missing".to_string(),
                         message: "CasbinHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.".to_string(),
                         authorizer: "casbin".to_string(),
                         method: "PowerControl".to_string(),
@@ -500,7 +493,7 @@ mod tests {
                     expect: MissingAuthContextObservation {
                         status: StatusCode::INTERNAL_SERVER_ERROR,
                         level: tracing::Level::WARN,
-                        metadata_name: "internal_rbac_auth_context_missing".to_string(),
+                        metadata_name: "auth_context_missing".to_string(),
                         message: "InternalRBACHandler::authorize() found a request with no AuthContext in its extensions. This may mean the authentication middleware didn't run successfully, or the middleware layers are nested in the wrong order.".to_string(),
                         authorizer: "internal_rbac".to_string(),
                         method: "PowerControl".to_string(),

--- a/crates/api-core/src/credentials/bmc_session_manager.rs
+++ b/crates/api-core/src/credentials/bmc_session_manager.rs
@@ -182,95 +182,51 @@ enum BmcSessionCleanupOperation {
     DeleteSessionRows,
 }
 
-/// The prior session was still present on the BMC, but its revoke failed.
+/// A BMC session outlived the work that created it and could not be cleaned
+/// up. `operation` names which cleanup failed and picks the wording operators
+/// already receive. `spiffe_service_id` and `session` are absent on the paths
+/// that never had one -- `flush_mac` works from the MAC alone, and a failed
+/// session listing never reached a specific session.
 #[derive(carbide_instrument::Event)]
 #[event(
-    event_name = "bmc_session_prior_revoke_failed",
+    event_name = "bmc_session_cleanup_failed",
     metric_name = "carbide_bmc_session_cleanup_failures_total",
     component = "nico-api",
     log = warn,
     metric = counter,
-    message = "failed to revoke prior BMC session; continuing with new session creation",
+    message = dynamic,
     describe = "Number of BMC session cleanup failures, by operation."
 )]
-struct BmcSessionPriorRevokeFailed {
+struct BmcSessionCleanupFailed {
     #[label]
     operation: BmcSessionCleanupOperation,
     #[context]
     bmc_mac_address: MacAddress,
-    #[context(value)]
-    spiffe_service_id: String,
     #[context]
-    session: ODataId,
+    spiffe_service_id: Option<String>,
+    #[context]
+    session: Option<ODataId>,
     #[context]
     error: String,
 }
 
-/// The BMC session collection could not be listed before the prior revoke.
-#[derive(carbide_instrument::Event)]
-#[event(
-    event_name = "bmc_session_prior_revoke_list_failed",
-    metric_name = "carbide_bmc_session_cleanup_failures_total",
-    component = "nico-api",
-    log = warn,
-    metric = counter,
-    message = "failed to list BMC sessions for prior-session revoke; continuing",
-    describe = "Number of BMC session cleanup failures, by operation."
-)]
-struct BmcSessionPriorRevokeListFailed {
-    #[label]
-    operation: BmcSessionCleanupOperation,
-    #[context]
-    bmc_mac_address: MacAddress,
-    #[context(value)]
-    spiffe_service_id: String,
-    #[context]
-    error: String,
-}
-
-/// Session metadata could not be stored, and rolling back the new BMC session
-/// failed too.
-#[derive(carbide_instrument::Event)]
-#[event(
-    event_name = "bmc_session_unpersisted_revoke_failed",
-    metric_name = "carbide_bmc_session_cleanup_failures_total",
-    component = "nico-api",
-    log = warn,
-    metric = counter,
-    message = "failed to revoke just-created session after store upsert failed; it will leak until BMC idle timeout",
-    describe = "Number of BMC session cleanup failures, by operation."
-)]
-struct BmcSessionUnpersistedRevokeFailed {
-    #[label]
-    operation: BmcSessionCleanupOperation,
-    #[context]
-    bmc_mac_address: MacAddress,
-    #[context(value)]
-    spiffe_service_id: String,
-    #[context]
-    session: ODataId,
-    #[context]
-    error: String,
-}
-
-/// `flush_mac` could not delete the persisted session rows for a BMC.
-#[derive(carbide_instrument::Event)]
-#[event(
-    event_name = "bmc_session_store_flush_failed",
-    metric_name = "carbide_bmc_session_cleanup_failures_total",
-    component = "nico-api",
-    log = warn,
-    metric = counter,
-    message = "failed to delete BMC session rows during flush_mac; continuing",
-    describe = "Number of BMC session cleanup failures, by operation."
-)]
-struct BmcSessionStoreFlushFailed {
-    #[label]
-    operation: BmcSessionCleanupOperation,
-    #[context]
-    bmc_mac_address: MacAddress,
-    #[context]
-    error: String,
+impl carbide_instrument::DynamicMessage for BmcSessionCleanupFailed {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            BmcSessionCleanupOperation::RevokePriorSession => {
+                "failed to revoke prior BMC session; continuing with new session creation"
+            }
+            BmcSessionCleanupOperation::ListSessionsForRevoke => {
+                "failed to list BMC sessions for prior-session revoke; continuing"
+            }
+            BmcSessionCleanupOperation::RevokeUnpersistedSession => {
+                "failed to revoke just-created session after store upsert failed; it will leak until BMC idle timeout"
+            }
+            BmcSessionCleanupOperation::DeleteSessionRows => {
+                "failed to delete BMC session rows during flush_mac; continuing"
+            }
+        }
+    }
 }
 
 /// The actual lockout-avoidance state change, as the bounded `transition`
@@ -527,11 +483,11 @@ impl BmcSessionManager {
                         .find(|m| m.raw().odata_id() == &prior_id)
                     {
                         if let Err(err) = prior_session.delete().await {
-                            carbide_instrument::emit(BmcSessionPriorRevokeFailed {
+                            carbide_instrument::emit(BmcSessionCleanupFailed {
                                 operation: BmcSessionCleanupOperation::RevokePriorSession,
                                 bmc_mac_address: bmc_mac,
-                                spiffe_service_id: spiffe_service_id.to_owned(),
-                                session: prior_id,
+                                spiffe_service_id: Some(spiffe_service_id.to_owned()),
+                                session: Some(prior_id),
                                 error: format!("{err:?}"),
                             });
                         }
@@ -546,10 +502,11 @@ impl BmcSessionManager {
                     }
                 }
                 Err(err) => {
-                    carbide_instrument::emit(BmcSessionPriorRevokeListFailed {
+                    carbide_instrument::emit(BmcSessionCleanupFailed {
                         operation: BmcSessionCleanupOperation::ListSessionsForRevoke,
                         bmc_mac_address: bmc_mac,
-                        spiffe_service_id: spiffe_service_id.to_owned(),
+                        spiffe_service_id: Some(spiffe_service_id.to_owned()),
+                        session: None,
                         error: format!("{err:?}"),
                     });
                 }
@@ -586,11 +543,11 @@ impl BmcSessionManager {
             .await
         {
             if let Err(revoke_err) = created.delete().await {
-                carbide_instrument::emit(BmcSessionUnpersistedRevokeFailed {
+                carbide_instrument::emit(BmcSessionCleanupFailed {
                     operation: BmcSessionCleanupOperation::RevokeUnpersistedSession,
                     bmc_mac_address: bmc_mac,
-                    spiffe_service_id: spiffe_service_id.to_owned(),
-                    session: location,
+                    spiffe_service_id: Some(spiffe_service_id.to_owned()),
+                    session: Some(location),
                     error: format!("{revoke_err:?}"),
                 });
             }
@@ -662,9 +619,11 @@ impl BmcSessionManager {
     /// Drop all session rows for `bmc_mac` and clear any lockout state.
     pub async fn flush_mac(&self, bmc_mac: MacAddress) {
         if let Err(err) = self.store.delete_by_mac(bmc_mac).await {
-            carbide_instrument::emit(BmcSessionStoreFlushFailed {
+            carbide_instrument::emit(BmcSessionCleanupFailed {
                 operation: BmcSessionCleanupOperation::DeleteSessionRows,
                 bmc_mac_address: bmc_mac,
+                spiffe_service_id: None,
+                session: None,
                 error: err.to_string(),
             });
         }
@@ -812,9 +771,8 @@ mod tests {
     use tokio::sync::Mutex;
 
     use super::{
-        BmcSessionCleanupOperation, BmcSessionError, BmcSessionManager,
-        BmcSessionPriorRevokeFailed, BmcSessionPriorRevokeListFailed, BmcSessionStore,
-        BmcSessionStoreFlushFailed, BmcSessionUnpersistedRevokeFailed, StoredSession,
+        BmcSessionCleanupFailed, BmcSessionCleanupOperation, BmcSessionError, BmcSessionManager,
+        BmcSessionStore, StoredSession,
     };
 
     fn mac(byte: u8) -> MacAddress {
@@ -1018,7 +976,7 @@ mod tests {
         let log = cleanup_logs[0];
         let bmc_mac_address = bmc_mac.to_string();
         assert_eq!(log.level, tracing::Level::WARN);
-        assert_eq!(log.metadata_name, "bmc_session_store_flush_failed");
+        assert_eq!(log.metadata_name, "bmc_session_cleanup_failed");
         assert_eq!(
             log.message,
             "failed to delete BMC session rows during flush_mac; continuing"
@@ -1426,35 +1384,38 @@ mod tests {
         let metrics = MetricsCapture::start();
         let logs = capture_logs(|| match case {
             CleanupFailureCase::RevokePriorSession => {
-                carbide_instrument::emit(BmcSessionPriorRevokeFailed {
+                carbide_instrument::emit(BmcSessionCleanupFailed {
                     operation: BmcSessionCleanupOperation::RevokePriorSession,
                     bmc_mac_address: bmc_mac,
-                    spiffe_service_id: TEST_SPIFFE_SERVICE_ID.to_string(),
-                    session: nv_redfish::core::ODataId::from(TEST_SESSION_ID.to_string()),
+                    spiffe_service_id: Some(TEST_SPIFFE_SERVICE_ID.to_string()),
+                    session: Some(nv_redfish::core::ODataId::from(TEST_SESSION_ID.to_string())),
                     error: "DeleteError { status: 500 }".to_string(),
                 });
             }
             CleanupFailureCase::ListSessionsForRevoke => {
-                carbide_instrument::emit(BmcSessionPriorRevokeListFailed {
+                carbide_instrument::emit(BmcSessionCleanupFailed {
                     operation: BmcSessionCleanupOperation::ListSessionsForRevoke,
                     bmc_mac_address: bmc_mac,
-                    spiffe_service_id: TEST_SPIFFE_SERVICE_ID.to_string(),
+                    spiffe_service_id: Some(TEST_SPIFFE_SERVICE_ID.to_string()),
+                    session: None,
                     error: "ListError { status: 503 }".to_string(),
                 });
             }
             CleanupFailureCase::RevokeUnpersistedSession => {
-                carbide_instrument::emit(BmcSessionUnpersistedRevokeFailed {
+                carbide_instrument::emit(BmcSessionCleanupFailed {
                     operation: BmcSessionCleanupOperation::RevokeUnpersistedSession,
                     bmc_mac_address: bmc_mac,
-                    spiffe_service_id: TEST_SPIFFE_SERVICE_ID.to_string(),
-                    session: nv_redfish::core::ODataId::from(TEST_SESSION_ID.to_string()),
+                    spiffe_service_id: Some(TEST_SPIFFE_SERVICE_ID.to_string()),
+                    session: Some(nv_redfish::core::ODataId::from(TEST_SESSION_ID.to_string())),
                     error: "DeleteError { status: 500 }".to_string(),
                 });
             }
             CleanupFailureCase::DeleteSessionRows => {
-                carbide_instrument::emit(BmcSessionStoreFlushFailed {
+                carbide_instrument::emit(BmcSessionCleanupFailed {
                     operation: BmcSessionCleanupOperation::DeleteSessionRows,
                     bmc_mac_address: bmc_mac,
+                    spiffe_service_id: None,
+                    session: None,
                     error: "BMC session store error: database unavailable".to_string(),
                 });
             }
@@ -1511,7 +1472,7 @@ mod tests {
             spiffe_service_id: spiffe_service_id.map(str::to_string),
             session: session.map(str::to_string),
             error: Some(error.to_string()),
-            spiffe_service_id_kind: spiffe_service_id.map(|_| CapturedFieldKind::String),
+            spiffe_service_id_kind: spiffe_service_id.map(|_| CapturedFieldKind::Debug),
             error_kind: Some(CapturedFieldKind::Debug),
             counter_delta: 1.0,
         }
@@ -1523,7 +1484,7 @@ mod tests {
             run = observe_cleanup_failure;
             "prior session revoke fails" {
                 CleanupFailureCase::RevokePriorSession => expected_cleanup_failure(
-                    "bmc_session_prior_revoke_failed",
+                    "bmc_session_cleanup_failed",
                     "failed to revoke prior BMC session; continuing with new session creation",
                     "revoke_prior_session",
                     Some(TEST_SPIFFE_SERVICE_ID),
@@ -1533,7 +1494,7 @@ mod tests {
             }
             "session listing for prior revoke fails" {
                 CleanupFailureCase::ListSessionsForRevoke => expected_cleanup_failure(
-                    "bmc_session_prior_revoke_list_failed",
+                    "bmc_session_cleanup_failed",
                     "failed to list BMC sessions for prior-session revoke; continuing",
                     "list_sessions_for_revoke",
                     Some(TEST_SPIFFE_SERVICE_ID),
@@ -1543,7 +1504,7 @@ mod tests {
             }
             "unpersisted session rollback revoke fails" {
                 CleanupFailureCase::RevokeUnpersistedSession => expected_cleanup_failure(
-                    "bmc_session_unpersisted_revoke_failed",
+                    "bmc_session_cleanup_failed",
                     "failed to revoke just-created session after store upsert failed; it will leak until BMC idle timeout",
                     "revoke_unpersisted_session",
                     Some(TEST_SPIFFE_SERVICE_ID),
@@ -1553,7 +1514,7 @@ mod tests {
             }
             "flush store deletion fails" {
                 CleanupFailureCase::DeleteSessionRows => expected_cleanup_failure(
-                    "bmc_session_store_flush_failed",
+                    "bmc_session_cleanup_failed",
                     "failed to delete BMC session rows during flush_mac; continuing",
                     "delete_session_rows",
                     None,

--- a/crates/api-core/src/handlers/extension_service.rs
+++ b/crates/api-core/src/handlers/extension_service.rs
@@ -16,7 +16,7 @@
  */
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{DynamicMessage, Event, LabelValue, emit};
 use carbide_secrets::credentials::{CredentialKey, Credentials};
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::extension_service::ExtensionServiceId;
@@ -45,48 +45,44 @@ enum ExtensionServiceCredentialCleanupOperation {
     Delete,
 }
 
-/// A create or update stored a credential before its database transaction
-/// failed, and the follow-up cleanup could not delete it.
+/// A stored extension-service credential outlived the record it belonged to,
+/// and the follow-up cleanup could not delete it. `operation` names the API
+/// call that left it behind: a create or update whose transaction failed, or a
+/// delete whose post-commit cleanup failed. `version` is present only for the
+/// delete path, where a specific version was removed.
 #[derive(Event)]
 #[event(
-    event_name = "extension_service_credential_rollback_cleanup_failed",
+    event_name = "extension_service_credential_cleanup_failed",
     metric_name = "carbide_extension_service_credential_cleanup_failures_total",
     component = "nico-api",
     log = warn,
     metric = counter,
-    message = "Failed to delete extension service credential after transaction failure",
+    message = dynamic,
     describe = "Number of extension-service credential cleanup failures, by operation."
 )]
-struct ExtensionServiceCredentialRollbackCleanupFailed {
+struct ExtensionServiceCredentialCleanupFailed {
     #[label]
     operation: ExtensionServiceCredentialCleanupOperation,
     #[context]
     extension_service_id: ExtensionServiceId,
+    #[context]
+    version: Option<ConfigVersion>,
     #[context]
     error: String,
 }
 
-/// A version was deleted in the database, but its post-commit credential
-/// cleanup failed.
-#[derive(Event)]
-#[event(
-    event_name = "extension_service_credential_delete_cleanup_failed",
-    metric_name = "carbide_extension_service_credential_cleanup_failures_total",
-    component = "nico-api",
-    log = warn,
-    metric = counter,
-    message = "Failed to delete extension service credential",
-    describe = "Number of extension-service credential cleanup failures, by operation."
-)]
-struct ExtensionServiceCredentialDeleteCleanupFailed {
-    #[label]
-    operation: ExtensionServiceCredentialCleanupOperation,
-    #[context]
-    extension_service_id: ExtensionServiceId,
-    #[context]
-    version: ConfigVersion,
-    #[context]
-    error: String,
+impl DynamicMessage for ExtensionServiceCredentialCleanupFailed {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            ExtensionServiceCredentialCleanupOperation::Create
+            | ExtensionServiceCredentialCleanupOperation::Update => {
+                "Failed to delete extension service credential after transaction failure"
+            }
+            ExtensionServiceCredentialCleanupOperation::Delete => {
+                "Failed to delete extension service credential"
+            }
+        }
+    }
 }
 
 /// Creates a new extension service with an initial version.
@@ -198,9 +194,10 @@ pub(crate) async fn create(
                     delete_extension_service_credential(&api.credential_manager, credential_key)
                         .await
                 {
-                    emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                    emit(ExtensionServiceCredentialCleanupFailed {
                         operation: ExtensionServiceCredentialCleanupOperation::Create,
                         extension_service_id: service_id,
+                        version: None,
                         error: delete_err.to_string(),
                     });
                 }
@@ -445,9 +442,10 @@ pub(crate) async fn update(
                         delete_extension_service_credential(&api.credential_manager, credential_key)
                             .await
                     {
-                        emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                        emit(ExtensionServiceCredentialCleanupFailed {
                             operation: ExtensionServiceCredentialCleanupOperation::Update,
                             extension_service_id: service_id,
+                            version: None,
                             error: delete_err.to_string(),
                         });
                     }
@@ -580,10 +578,10 @@ pub(crate) async fn delete(
             if let Err(error) =
                 delete_extension_service_credential(&api.credential_manager, credential_key).await
             {
-                emit(ExtensionServiceCredentialDeleteCleanupFailed {
+                emit(ExtensionServiceCredentialCleanupFailed {
                     operation: ExtensionServiceCredentialCleanupOperation::Delete,
                     extension_service_id: service_id,
-                    version: *version,
+                    version: Some(*version),
                     error: error.to_string(),
                 });
             }
@@ -1189,24 +1187,26 @@ mod tests {
                 let metrics = MetricsCapture::start();
                 let logs = capture_logs(|| match case {
                     CleanupFailureCase::Create => {
-                        emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                        emit(ExtensionServiceCredentialCleanupFailed {
                             operation: ExtensionServiceCredentialCleanupOperation::Create,
                             extension_service_id,
+                            version: None,
                             error: "credential delete failed".to_string(),
                         });
                     }
                     CleanupFailureCase::Update => {
-                        emit(ExtensionServiceCredentialRollbackCleanupFailed {
+                        emit(ExtensionServiceCredentialCleanupFailed {
                             operation: ExtensionServiceCredentialCleanupOperation::Update,
                             extension_service_id,
+                            version: None,
                             error: "credential delete failed".to_string(),
                         });
                     }
                     CleanupFailureCase::Delete => {
-                        emit(ExtensionServiceCredentialDeleteCleanupFailed {
+                        emit(ExtensionServiceCredentialCleanupFailed {
                             operation: ExtensionServiceCredentialCleanupOperation::Delete,
                             extension_service_id,
-                            version,
+                            version: Some(version),
                             error: "credential delete failed".to_string(),
                         });
                     }
@@ -1236,9 +1236,9 @@ mod tests {
             "create transaction cleanup fails" {
                 CleanupFailureCase::Create => CleanupFailureObservation {
                     level: tracing::Level::WARN,
-                    metadata_name: "extension_service_credential_rollback_cleanup_failed".to_string(),
+                    metadata_name: "extension_service_credential_cleanup_failed".to_string(),
                     message: "Failed to delete extension service credential after transaction failure".to_string(),
-                    event_name: Some("extension_service_credential_rollback_cleanup_failed".to_string()),
+                    event_name: Some("extension_service_credential_cleanup_failed".to_string()),
                     metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
                     operation: Some("create".to_string()),
                     extension_service_id: Some(EXTENSION_SERVICE_ID.to_string()),
@@ -1250,9 +1250,9 @@ mod tests {
             "update transaction cleanup fails" {
                 CleanupFailureCase::Update => CleanupFailureObservation {
                     level: tracing::Level::WARN,
-                    metadata_name: "extension_service_credential_rollback_cleanup_failed".to_string(),
+                    metadata_name: "extension_service_credential_cleanup_failed".to_string(),
                     message: "Failed to delete extension service credential after transaction failure".to_string(),
-                    event_name: Some("extension_service_credential_rollback_cleanup_failed".to_string()),
+                    event_name: Some("extension_service_credential_cleanup_failed".to_string()),
                     metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
                     operation: Some("update".to_string()),
                     extension_service_id: Some(EXTENSION_SERVICE_ID.to_string()),
@@ -1264,9 +1264,9 @@ mod tests {
             "post-commit delete cleanup fails" {
                 CleanupFailureCase::Delete => CleanupFailureObservation {
                     level: tracing::Level::WARN,
-                    metadata_name: "extension_service_credential_delete_cleanup_failed".to_string(),
+                    metadata_name: "extension_service_credential_cleanup_failed".to_string(),
                     message: "Failed to delete extension service credential".to_string(),
-                    event_name: Some("extension_service_credential_delete_cleanup_failed".to_string()),
+                    event_name: Some("extension_service_credential_cleanup_failed".to_string()),
                     metric_name: Some(CLEANUP_FAILURE_METRIC.to_string()),
                     operation: Some("delete".to_string()),
                     extension_service_id: Some(EXTENSION_SERVICE_ID.to_string()),

--- a/crates/api-core/src/handlers/machine_identity.rs
+++ b/crates/api-core/src/handlers/machine_identity.rs
@@ -35,10 +35,10 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data};
 use crate::auth::AuthContext;
 use crate::machine_identity::{
-    Es256Signer, MachineIdentitySigningKeyDecryptionFailed,
-    MachineIdentityTokenDelegationAuthDecryptionFailed, SignOptions, Signer,
-    decrypt_machine_identity_ciphertext, decrypt_token_delegation_encrypted_blob,
-    token_delegation_credentials, token_exchange_http_client, token_exchange_request,
+    Es256Signer, MachineIdentityStoredSecretDecryptionFailed, SignOptions, Signer,
+    StoredMachineIdentitySecretKind, decrypt_machine_identity_ciphertext,
+    decrypt_token_delegation_encrypted_blob, token_delegation_credentials,
+    token_exchange_http_client, token_exchange_request,
 };
 
 /// Shared gate for APIs that require site `[machine_identity].enabled` (identity admin + discovery).
@@ -194,7 +194,8 @@ pub(crate) async fn sign_machine_identity(
         decrypt_machine_identity_ciphertext(api.credential_manager.as_ref(), enc_key.as_str())
             .await
             .inspect_err(|e| {
-                carbide_instrument::emit(MachineIdentitySigningKeyDecryptionFailed::from_status(
+                carbide_instrument::emit(MachineIdentityStoredSecretDecryptionFailed::from_status(
+                    StoredMachineIdentitySecretKind::SigningKey,
                     identity_row.organization_id.as_str(),
                     e,
                 ));
@@ -243,12 +244,11 @@ pub(crate) async fn sign_machine_identity(
         )
         .await
         .inspect_err(|e| {
-            carbide_instrument::emit(
-                MachineIdentityTokenDelegationAuthDecryptionFailed::from_status(
-                    identity_row.organization_id.as_str(),
-                    e,
-                ),
-            );
+            carbide_instrument::emit(MachineIdentityStoredSecretDecryptionFailed::from_status(
+                StoredMachineIdentitySecretKind::TokenDelegationAuth,
+                identity_row.organization_id.as_str(),
+                e,
+            ));
         })?;
         let delegation_creds =
             token_delegation_credentials(auth_method, delegation_plain.as_deref())?;

--- a/crates/api-core/src/handlers/tenant_identity_config.rs
+++ b/crates/api-core/src/handlers/tenant_identity_config.rs
@@ -49,7 +49,7 @@ use crate::CarbideError;
 use crate::api::{Api, log_request_data, log_request_data_redacted};
 use crate::handlers::machine_identity::require_machine_identity_site_enabled;
 use crate::machine_identity::{
-    MachineIdentityTokenDelegationAuthDecryptionFailed, ReencryptBlobOutcome,
+    MachineIdentityStoredSecretDecryptionFailed, ReencryptBlobOutcome,
     StoredMachineIdentitySecretKind, decrypt_token_delegation_encrypted_blob,
     machine_identity_encryption_secret, reencrypt_ciphertext_if_needed,
 };
@@ -66,12 +66,11 @@ async fn tenant_identity_with_decrypted_token_delegation(
     )
     .await
     .inspect_err(|e| {
-        carbide_instrument::emit(
-            MachineIdentityTokenDelegationAuthDecryptionFailed::from_status(
-                cfg.organization_id.as_str(),
-                e,
-            ),
-        );
+        carbide_instrument::emit(MachineIdentityStoredSecretDecryptionFailed::from_status(
+            StoredMachineIdentitySecretKind::TokenDelegationAuth,
+            cfg.organization_id.as_str(),
+            e,
+        ));
     })?;
     Ok(TenantIdentityConfigDecrypted {
         row: cfg,

--- a/crates/api-core/src/machine_identity/crypto.rs
+++ b/crates/api-core/src/machine_identity/crypto.rs
@@ -22,7 +22,7 @@
 //! Decrypt uses the `key_id` embedded in each ciphertext envelope. Encrypt uses site
 //! `[machine_identity].current_encryption_key_id`.
 
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{DynamicMessage, Event, LabelValue, emit};
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use carbide_secrets::key_encryption;
 use model::tenant::{
@@ -39,18 +39,20 @@ pub(crate) enum StoredMachineIdentitySecretKind {
     TokenDelegationAuth,
 }
 
-/// A tenant's stored signing key could not be decrypted.
+/// A tenant's stored machine-identity secret could not be decrypted.
+/// `secret_kind` names which one, and picks the wording each path already
+/// logged.
 #[derive(Event)]
 #[event(
-    event_name = "machine_identity_signing_key_decryption_failed",
+    event_name = "machine_identity_stored_secret_decryption_failed",
     metric_name = "carbide_machine_identity_stored_secret_decryption_failures_total",
     component = "nico-api",
     log = error,
     metric = counter,
-    message = "tenant signing key decrypt failed",
+    message = dynamic,
     describe = "Number of stored machine identity secret decryption failures, by secret kind."
 )]
-pub(crate) struct MachineIdentitySigningKeyDecryptionFailed {
+pub(crate) struct MachineIdentityStoredSecretDecryptionFailed {
     #[label]
     secret_kind: StoredMachineIdentitySecretKind,
     #[context]
@@ -59,40 +61,25 @@ pub(crate) struct MachineIdentitySigningKeyDecryptionFailed {
     error: String,
 }
 
-impl MachineIdentitySigningKeyDecryptionFailed {
-    pub(crate) fn from_status(organization_id: &str, error: &Status) -> Self {
-        Self {
-            secret_kind: StoredMachineIdentitySecretKind::SigningKey,
-            organization_id: organization_id.to_string(),
-            error: error.message().to_string(),
+impl DynamicMessage for MachineIdentityStoredSecretDecryptionFailed {
+    fn message(&self) -> &'static str {
+        match self.secret_kind {
+            StoredMachineIdentitySecretKind::SigningKey => "tenant signing key decrypt failed",
+            StoredMachineIdentitySecretKind::TokenDelegationAuth => {
+                "token delegation auth config decrypt failed"
+            }
         }
     }
 }
 
-/// A tenant's stored token-delegation authentication could not be decrypted.
-#[derive(Event)]
-#[event(
-    event_name = "machine_identity_token_delegation_auth_decryption_failed",
-    metric_name = "carbide_machine_identity_stored_secret_decryption_failures_total",
-    component = "nico-api",
-    log = error,
-    metric = counter,
-    message = "token delegation auth config decrypt failed",
-    describe = "Number of stored machine identity secret decryption failures, by secret kind."
-)]
-pub(crate) struct MachineIdentityTokenDelegationAuthDecryptionFailed {
-    #[label]
-    secret_kind: StoredMachineIdentitySecretKind,
-    #[context]
-    organization_id: String,
-    #[context]
-    error: String,
-}
-
-impl MachineIdentityTokenDelegationAuthDecryptionFailed {
-    pub(crate) fn from_status(organization_id: &str, error: &Status) -> Self {
+impl MachineIdentityStoredSecretDecryptionFailed {
+    pub(crate) fn from_status(
+        secret_kind: StoredMachineIdentitySecretKind,
+        organization_id: &str,
+        error: &Status,
+    ) -> Self {
         Self {
-            secret_kind: StoredMachineIdentitySecretKind::TokenDelegationAuth,
+            secret_kind,
             organization_id: organization_id.to_string(),
             error: error.message().to_string(),
         }
@@ -104,14 +91,11 @@ fn emit_stored_secret_decryption_failed(
     organization_id: &str,
     error: &Status,
 ) {
-    match secret_kind {
-        StoredMachineIdentitySecretKind::SigningKey => emit(
-            MachineIdentitySigningKeyDecryptionFailed::from_status(organization_id, error),
-        ),
-        StoredMachineIdentitySecretKind::TokenDelegationAuth => emit(
-            MachineIdentityTokenDelegationAuthDecryptionFailed::from_status(organization_id, error),
-        ),
-    }
+    emit(MachineIdentityStoredSecretDecryptionFailed::from_status(
+        secret_kind,
+        organization_id,
+        error,
+    ));
 }
 
 pub(crate) async fn machine_identity_encryption_secret(
@@ -295,10 +279,11 @@ mod tests {
                         counter_deltas: [1.0, 0.0],
                         log_count: 1,
                         level: tracing::Level::ERROR,
-                        metadata_name: "machine_identity_signing_key_decryption_failed".to_string(),
+                        metadata_name: "machine_identity_stored_secret_decryption_failed"
+                            .to_string(),
                         message: "tenant signing key decrypt failed".to_string(),
                         event_name: Some(
-                            "machine_identity_signing_key_decryption_failed".to_string(),
+                            "machine_identity_stored_secret_decryption_failed".to_string(),
                         ),
                         metric_name: Some(STORED_SECRET_DECRYPTION_FAILURE_METRIC.to_string()),
                         secret_kind: Some("signing_key".to_string()),
@@ -314,11 +299,11 @@ mod tests {
                         counter_deltas: [0.0, 1.0],
                         log_count: 1,
                         level: tracing::Level::ERROR,
-                        metadata_name: "machine_identity_token_delegation_auth_decryption_failed"
+                        metadata_name: "machine_identity_stored_secret_decryption_failed"
                             .to_string(),
                         message: "token delegation auth config decrypt failed".to_string(),
                         event_name: Some(
-                            "machine_identity_token_delegation_auth_decryption_failed".to_string(),
+                            "machine_identity_stored_secret_decryption_failed".to_string(),
                         ),
                         metric_name: Some(STORED_SECRET_DECRYPTION_FAILURE_METRIC.to_string()),
                         secret_kind: Some("token_delegation_auth".to_string()),

--- a/crates/api-core/src/machine_identity/mod.rs
+++ b/crates/api-core/src/machine_identity/mod.rs
@@ -30,8 +30,8 @@ use std::fmt;
 
 use base64::Engine;
 pub(crate) use crypto::{
-    MachineIdentitySigningKeyDecryptionFailed, MachineIdentityTokenDelegationAuthDecryptionFailed,
-    ReencryptBlobOutcome, StoredMachineIdentitySecretKind, decrypt_machine_identity_ciphertext,
+    MachineIdentityStoredSecretDecryptionFailed, ReencryptBlobOutcome,
+    StoredMachineIdentitySecretKind, decrypt_machine_identity_ciphertext,
     decrypt_token_delegation_encrypted_blob, machine_identity_encryption_secret,
     reencrypt_ciphertext_if_needed, token_delegation_credentials,
 };

--- a/crates/api-db/src/work_lock_manager.rs
+++ b/crates/api-db/src/work_lock_manager.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{DynamicMessage, Event, LabelValue, emit};
 use sqlx::pool::PoolConnection;
 use sqlx::{PgConnection, PgPool, Postgres};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
@@ -44,55 +44,26 @@ enum WorkLockFailure {
     LockLost,
 }
 
-// These Events share one counter. Keep its kind, description, and label keys
-// identical while each boundary retains its existing diagnostic message and
-// context.
+/// A work lock could not be kept or given back. `operation` says which half of
+/// the lifecycle broke and `failure` says how, and together they pick the
+/// diagnostic that boundary already logged.
+///
+/// One pairing is worth remembering: `(KeepAlive, LockLost)` belongs to the
+/// keepalive loop's `Err(KeepAliveError::LockLost)` arm, which returns before
+/// the general `Err(e)` arm can see it. That arm ordering is what keeps this a
+/// function -- reorder it and `LockLost` would arrive here from two paths that
+/// want different wording.
 #[derive(Event)]
 #[event(
-    event_name = "work_lock_release_failed",
+    event_name = "work_lock_failed",
     metric_name = "carbide_work_lock_failures_total",
     component = "nico-api",
     log = error,
     metric = counter,
-    message = "Could not release work lock",
+    message = dynamic,
     describe = "Number of work-lock lifecycle failures, by operation and failure kind."
 )]
-struct WorkLockReleaseFailed {
-    #[label]
-    operation: WorkLockOperation,
-    #[label]
-    failure: WorkLockFailure,
-    #[context]
-    work_key: WorkKey,
-    #[context]
-    error: String,
-}
-
-impl WorkLockReleaseFailed {
-    fn new(work_key: WorkKey, error: &DatabaseError) -> Self {
-        Self {
-            operation: WorkLockOperation::Release,
-            failure: match error {
-                DatabaseError::FailedPrecondition(_) => WorkLockFailure::LockLost,
-                _ => WorkLockFailure::Database,
-            },
-            work_key,
-            error: error.to_string(),
-        }
-    }
-}
-
-#[derive(Event)]
-#[event(
-    event_name = "work_lock_release_dispatch_failed",
-    metric_name = "carbide_work_lock_failures_total",
-    component = "nico-api",
-    log = error,
-    metric = counter,
-    message = "Could not release work lock: the WorkLockManager has shut down",
-    describe = "Number of work-lock lifecycle failures, by operation and failure kind."
-)]
-struct WorkLockReleaseDispatchFailed {
+struct WorkLockFailed {
     #[label]
     operation: WorkLockOperation,
     #[label]
@@ -105,8 +76,37 @@ struct WorkLockReleaseDispatchFailed {
     error: String,
 }
 
-impl WorkLockReleaseDispatchFailed {
-    fn new(work_key: WorkKey, worker_id: WorkerId, error: String) -> Self {
+impl DynamicMessage for WorkLockFailed {
+    fn message(&self) -> &'static str {
+        match (self.operation, self.failure) {
+            (WorkLockOperation::Release, WorkLockFailure::CommandDispatch) => {
+                "Could not release work lock: the WorkLockManager has shut down"
+            }
+            (WorkLockOperation::Release, _) => "Could not release work lock",
+            (WorkLockOperation::KeepAlive, WorkLockFailure::LockLost) => "worker lost lock",
+            (WorkLockOperation::KeepAlive, _) => "Failed to send work-lock keepalive; retrying",
+        }
+    }
+}
+
+impl WorkLockFailed {
+    /// The release write itself failed. A `FailedPrecondition` means the lock
+    /// had already expired; anything else is a database problem.
+    fn release(work_key: WorkKey, worker_id: WorkerId, error: &DatabaseError) -> Self {
+        Self {
+            operation: WorkLockOperation::Release,
+            failure: match error {
+                DatabaseError::FailedPrecondition(_) => WorkLockFailure::LockLost,
+                _ => WorkLockFailure::Database,
+            },
+            work_key,
+            worker_id,
+            error: error.to_string(),
+        }
+    }
+
+    /// The release command could not be queued because the manager is gone.
+    fn release_dispatch(work_key: WorkKey, worker_id: WorkerId, error: String) -> Self {
         Self {
             operation: WorkLockOperation::Release,
             failure: WorkLockFailure::CommandDispatch,
@@ -115,33 +115,9 @@ impl WorkLockReleaseDispatchFailed {
             error,
         }
     }
-}
 
-#[derive(Event)]
-#[event(
-    event_name = "work_lock_lost",
-    metric_name = "carbide_work_lock_failures_total",
-    component = "nico-api",
-    log = error,
-    metric = counter,
-    message = "worker lost lock",
-    describe = "Number of work-lock lifecycle failures, by operation and failure kind."
-)]
-struct WorkLockLost {
-    #[label]
-    operation: WorkLockOperation,
-    #[label]
-    failure: WorkLockFailure,
-    #[context]
-    work_key: WorkKey,
-    #[context]
-    worker_id: WorkerId,
-    #[context]
-    error: String,
-}
-
-impl WorkLockLost {
-    fn new(work_key: WorkKey, worker_id: WorkerId, error: String) -> Self {
+    /// The keepalive loop learned the lock is no longer ours.
+    fn lock_lost(work_key: WorkKey, worker_id: WorkerId, error: String) -> Self {
         Self {
             operation: WorkLockOperation::KeepAlive,
             failure: WorkLockFailure::LockLost,
@@ -150,33 +126,10 @@ impl WorkLockLost {
             error,
         }
     }
-}
 
-#[derive(Event)]
-#[event(
-    event_name = "work_lock_keepalive_failed",
-    metric_name = "carbide_work_lock_failures_total",
-    component = "nico-api",
-    log = error,
-    metric = counter,
-    message = "Failed to send work-lock keepalive; retrying",
-    describe = "Number of work-lock lifecycle failures, by operation and failure kind."
-)]
-struct WorkLockKeepaliveFailed {
-    #[label]
-    operation: WorkLockOperation,
-    #[label]
-    failure: WorkLockFailure,
-    #[context]
-    work_key: WorkKey,
-    #[context]
-    worker_id: WorkerId,
-    #[context]
-    error: String,
-}
-
-impl WorkLockKeepaliveFailed {
-    fn new(
+    /// A keepalive attempt failed for a reason that leaves the lock held, so
+    /// the loop retries.
+    fn keepalive(
         failure: WorkLockFailure,
         work_key: WorkKey,
         worker_id: WorkerId,
@@ -351,7 +304,7 @@ async fn run_loop(
                 release_lock(db, &work_key, worker_id)
                     .await
                     .inspect_err(|e| {
-                        emit(WorkLockReleaseFailed::new(work_key.clone(), e));
+                        emit(WorkLockFailed::release(work_key.clone(), worker_id, e));
                     })
                     .ok();
                 tracing::debug!(%work_key, "Released work lock");
@@ -470,7 +423,7 @@ impl Drop for WorkLock {
                 worker_id: self.worker_id,
             })
             .inspect_err(|e| {
-                emit(WorkLockReleaseDispatchFailed::new(
+                emit(WorkLockFailed::release_dispatch(
                     self.work_key.clone(),
                     self.worker_id,
                     e.to_string(),
@@ -512,7 +465,7 @@ impl WorkLock {
                                             keepalive_stop_rx.try_recv(),
                                             Err(oneshot::error::TryRecvError::Empty)
                                         ) {
-                                            emit(WorkLockLost::new(
+                                            emit(WorkLockFailed::lock_lost(
                                                 work_key,
                                                 worker_id,
                                                 msg,
@@ -521,7 +474,7 @@ impl WorkLock {
                                         return;
                                     }
                                     Err(e) => {
-                                        emit(WorkLockKeepaliveFailed::new(
+                                        emit(WorkLockFailed::keepalive(
                                             e.failure(),
                                             work_key.clone(),
                                             worker_id,
@@ -841,15 +794,15 @@ mod tests {
                     scenario: "release database failure",
                     input: FailureEvent::ReleaseDatabase,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_release_failed".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "Could not release work lock".to_string(),
-                        event_name: Some("work_lock_release_failed".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("release".to_string()),
                         failure: Some("database".to_string()),
                         work_key: Some("work-key".to_string()),
-                        worker_id: None,
+                        worker_id: Some(worker_id.to_string()),
                         error: Some("internal error: database unavailable".to_string()),
                         counter_delta: 1.0,
                     },
@@ -858,15 +811,15 @@ mod tests {
                     scenario: "release after lock loss",
                     input: FailureEvent::ReleaseLockLost,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_release_failed".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "Could not release work lock".to_string(),
-                        event_name: Some("work_lock_release_failed".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("release".to_string()),
                         failure: Some("lock_lost".to_string()),
                         work_key: Some("work-key".to_string()),
-                        worker_id: None,
+                        worker_id: Some(worker_id.to_string()),
                         error: Some("lock expired".to_string()),
                         counter_delta: 1.0,
                     },
@@ -875,11 +828,11 @@ mod tests {
                     scenario: "release command dispatch failure",
                     input: FailureEvent::ReleaseDispatch,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_release_dispatch_failed".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "Could not release work lock: the WorkLockManager has shut down"
                             .to_string(),
-                        event_name: Some("work_lock_release_dispatch_failed".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("release".to_string()),
                         failure: Some("command_dispatch".to_string()),
@@ -893,10 +846,10 @@ mod tests {
                     scenario: "keepalive lock lost",
                     input: FailureEvent::KeepaliveLockLost,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_lost".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "worker lost lock".to_string(),
-                        event_name: Some("work_lock_lost".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("keep_alive".to_string()),
                         failure: Some("lock_lost".to_string()),
@@ -910,10 +863,10 @@ mod tests {
                     scenario: "keepalive database failure",
                     input: FailureEvent::KeepaliveDatabase,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_keepalive_failed".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "Failed to send work-lock keepalive; retrying".to_string(),
-                        event_name: Some("work_lock_keepalive_failed".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("keep_alive".to_string()),
                         failure: Some("database".to_string()),
@@ -927,10 +880,10 @@ mod tests {
                     scenario: "keepalive command dispatch failure",
                     input: FailureEvent::KeepaliveDispatch,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_keepalive_failed".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "Failed to send work-lock keepalive; retrying".to_string(),
-                        event_name: Some("work_lock_keepalive_failed".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("keep_alive".to_string()),
                         failure: Some("command_dispatch".to_string()),
@@ -944,10 +897,10 @@ mod tests {
                     scenario: "keepalive command reply failure",
                     input: FailureEvent::KeepaliveReply,
                     expect: FailureRecord {
-                        metadata_name: "work_lock_keepalive_failed".to_string(),
+                        metadata_name: "work_lock_failed".to_string(),
                         level: tracing::Level::ERROR,
                         message: "Failed to send work-lock keepalive; retrying".to_string(),
-                        event_name: Some("work_lock_keepalive_failed".to_string()),
+                        event_name: Some("work_lock_failed".to_string()),
                         metric_name: Some(WORK_LOCK_FAILURES_METRIC.to_string()),
                         operation: Some("keep_alive".to_string()),
                         failure: Some("command_reply".to_string()),
@@ -968,7 +921,11 @@ mod tests {
                             message: "database unavailable".to_string(),
                         };
                         let logs = capture_logs(|| {
-                            emit(WorkLockReleaseFailed::new("work-key".to_string(), &error));
+                            emit(WorkLockFailed::release(
+                                "work-key".to_string(),
+                                worker_id,
+                                &error,
+                            ));
                         });
                         (operation, failure, logs)
                     }
@@ -977,7 +934,11 @@ mod tests {
                         let failure = WorkLockFailure::LockLost;
                         let error = DatabaseError::FailedPrecondition("lock expired".to_string());
                         let logs = capture_logs(|| {
-                            emit(WorkLockReleaseFailed::new("work-key".to_string(), &error));
+                            emit(WorkLockFailed::release(
+                                "work-key".to_string(),
+                                worker_id,
+                                &error,
+                            ));
                         });
                         (operation, failure, logs)
                     }
@@ -985,7 +946,7 @@ mod tests {
                         let operation = WorkLockOperation::Release;
                         let failure = WorkLockFailure::CommandDispatch;
                         let logs = capture_logs(|| {
-                            emit(WorkLockReleaseDispatchFailed::new(
+                            emit(WorkLockFailed::release_dispatch(
                                 "work-key".to_string(),
                                 worker_id,
                                 "the WorkLockManager has shut down".to_string(),
@@ -997,7 +958,7 @@ mod tests {
                         let operation = WorkLockOperation::KeepAlive;
                         let failure = WorkLockFailure::LockLost;
                         let logs = capture_logs(|| {
-                            emit(WorkLockLost::new(
+                            emit(WorkLockFailed::lock_lost(
                                 "work-key".to_string(),
                                 worker_id,
                                 "lock expired".to_string(),
@@ -1009,7 +970,7 @@ mod tests {
                         let operation = WorkLockOperation::KeepAlive;
                         let failure = WorkLockFailure::Database;
                         let logs = capture_logs(|| {
-                            emit(WorkLockKeepaliveFailed::new(
+                            emit(WorkLockFailed::keepalive(
                                 failure,
                                 "work-key".to_string(),
                                 worker_id,
@@ -1022,7 +983,7 @@ mod tests {
                         let operation = WorkLockOperation::KeepAlive;
                         let failure = WorkLockFailure::CommandDispatch;
                         let logs = capture_logs(|| {
-                            emit(WorkLockKeepaliveFailed::new(
+                            emit(WorkLockFailed::keepalive(
                                 failure,
                                 "work-key".to_string(),
                                 worker_id,
@@ -1035,7 +996,7 @@ mod tests {
                         let operation = WorkLockOperation::KeepAlive;
                         let failure = WorkLockFailure::CommandReply;
                         let logs = capture_logs(|| {
-                            emit(WorkLockKeepaliveFailed::new(
+                            emit(WorkLockFailed::keepalive(
                                 failure,
                                 "work-key".to_string(),
                                 worker_id,

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -55,8 +55,8 @@ use tower_http::add_extension::AddExtensionLayer;
 
 use crate::config::{AuthConfig, TlsConfig};
 use crate::metrics::{
-    MethodLabel, PrincipalAllowListAuthContextMissing, PrincipalAllowListDenied,
-    RequestAclAuthContextMissing, RequestAclDenied, UpstreamRequestCompleted, UpstreamStatus,
+    AuthContextMissing, MethodLabel, PrincipalAllowListDenied, RequestAclDenied,
+    UpstreamRequestCompleted, UpstreamStatus,
 };
 
 const TLS_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
@@ -113,7 +113,7 @@ enum ForwardedHeaderParseError {
 impl BmcProxyState {
     fn allows(&self, request: &Request<Body>) -> bool {
         let Some(auth_context) = request.extensions().get::<AuthContext<()>>() else {
-            emit(RequestAclAuthContextMissing::new(request.method()));
+            emit(AuthContextMissing::request_acl(request.method()));
             return false;
         };
 
@@ -765,7 +765,7 @@ fn authorize_principal_allow_list(
         .extensions()
         .get::<AuthContext<()>>()
         .ok_or_else(|| {
-            emit(PrincipalAllowListAuthContextMissing::new(request.method()));
+            emit(AuthContextMissing::principal_allow_list(request.method()));
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
@@ -1829,7 +1829,7 @@ mod tests {
                         result: false,
                         denial_delta: 0.0,
                         error_delta: 1.0,
-                        event_names: vec!["bmc_proxy_request_acl_auth_context_missing".to_string()],
+                        event_names: vec!["bmc_proxy_auth_context_missing".to_string()],
                     },
                 },
             ],
@@ -1887,9 +1887,7 @@ mod tests {
                         result: Err(StatusCode::INTERNAL_SERVER_ERROR),
                         denial_delta: 0.0,
                         error_delta: 1.0,
-                        event_names: vec![
-                            "bmc_proxy_principal_allow_list_auth_context_missing".to_string(),
-                        ],
+                        event_names: vec!["bmc_proxy_auth_context_missing".to_string()],
                     },
                 },
             ],

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -23,7 +23,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use carbide_instrument::{Event, LabelValue, MetricFamily};
+use carbide_instrument::{DynamicLog, DynamicMessage, Event, LabelValue, LogAt, MetricFamily};
 use http::Method;
 use metrics_endpoint::{MetricsEndpointConfig, MetricsSetup};
 use tokio::task::JoinSet;
@@ -188,60 +188,65 @@ impl PrincipalAllowListDenied {
     }
 }
 
-/// The per-principal ACL could not run because authentication middleware did
+/// An authorization layer could not run because authentication middleware did
 /// not attach an `AuthContext`. This is a wiring error, not a policy denial,
-/// so it has a separate metric and keeps the existing ERROR diagnostic.
+/// so it is counted separately from a normal 403. `authorization_layer` names
+/// the layer that could not evaluate, and picks the level and diagnostic each
+/// one already had: the request ACL treats it as a bug and logs `ERROR`, while
+/// the outer allow-list keeps its `WARN`. Either way the request is a 500.
 #[derive(Event)]
 #[event(
-    event_name = "bmc_proxy_request_acl_auth_context_missing",
+    event_name = "bmc_proxy_auth_context_missing",
     metric_name = "carbide_bmc_proxy_authorization_errors_total",
     component = "nico-bmc-proxy",
-    log = error,
+    log = dynamic,
     metric = counter,
-    message = "BUG: No AuthContext middleware found, all requests will be denied",
+    message = dynamic,
     describe = "Number of BMC proxy authorization errors caused by missing authentication context, by authorization layer and HTTP method"
 )]
-pub(crate) struct RequestAclAuthContextMissing {
+pub(crate) struct AuthContextMissing {
     #[label]
     authorization_layer: AuthorizationLayer,
     #[label(name = "method")]
     method_label: MethodLabel,
 }
 
-impl RequestAclAuthContextMissing {
-    pub(crate) fn new(method: &Method) -> Self {
+impl AuthContextMissing {
+    /// The per-principal ACL could not evaluate the request.
+    pub(crate) fn request_acl(method: &Method) -> Self {
         Self {
             authorization_layer: AuthorizationLayer::RequestAcl,
             method_label: method.into(),
         }
     }
-}
 
-/// The outer allow-list could not run because authentication middleware did
-/// not attach an `AuthContext`. The request remains a 500 and the diagnostic
-/// remains WARN, but the error is counted separately from a normal 403.
-#[derive(Event)]
-#[event(
-    event_name = "bmc_proxy_principal_allow_list_auth_context_missing",
-    metric_name = "carbide_bmc_proxy_authorization_errors_total",
-    component = "nico-bmc-proxy",
-    log = warn,
-    metric = counter,
-    message = "authorize_proxy_request found a request with no AuthContext in its extensions",
-    describe = "Number of BMC proxy authorization errors caused by missing authentication context, by authorization layer and HTTP method"
-)]
-pub(crate) struct PrincipalAllowListAuthContextMissing {
-    #[label]
-    authorization_layer: AuthorizationLayer,
-    #[label(name = "method")]
-    method_label: MethodLabel,
-}
-
-impl PrincipalAllowListAuthContextMissing {
-    pub(crate) fn new(method: &Method) -> Self {
+    /// The outer principal allow-list could not evaluate the request.
+    pub(crate) fn principal_allow_list(method: &Method) -> Self {
         Self {
             authorization_layer: AuthorizationLayer::PrincipalAllowList,
             method_label: method.into(),
+        }
+    }
+}
+
+impl DynamicLog for AuthContextMissing {
+    fn log_at(&self) -> LogAt {
+        match self.authorization_layer {
+            AuthorizationLayer::RequestAcl => LogAt::Level(tracing::Level::ERROR),
+            AuthorizationLayer::PrincipalAllowList => LogAt::Level(tracing::Level::WARN),
+        }
+    }
+}
+
+impl DynamicMessage for AuthContextMissing {
+    fn message(&self) -> &'static str {
+        match self.authorization_layer {
+            AuthorizationLayer::RequestAcl => {
+                "BUG: No AuthContext middleware found, all requests will be denied"
+            }
+            AuthorizationLayer::PrincipalAllowList => {
+                "authorize_proxy_request found a request with no AuthContext in its extensions"
+            }
         }
     }
 }
@@ -370,11 +375,11 @@ mod tests {
     }
 
     fn emit_request_acl_auth_context_missing() {
-        emit(RequestAclAuthContextMissing::new(&Method::DELETE));
+        emit(AuthContextMissing::request_acl(&Method::DELETE));
     }
 
     fn emit_principal_allow_list_auth_context_missing() {
-        emit(PrincipalAllowListAuthContextMissing::new(&Method::OPTIONS));
+        emit(AuthContextMissing::principal_allow_list(&Method::OPTIONS));
     }
 
     fn observe_authorization_event(
@@ -693,7 +698,7 @@ mod tests {
                     },
                     expect: expected_authorization_event(
                         tracing::Level::ERROR,
-                        "bmc_proxy_request_acl_auth_context_missing",
+                        "bmc_proxy_auth_context_missing",
                         AUTHORIZATION_ERROR_METRIC,
                         "BUG: No AuthContext middleware found, all requests will be denied",
                         "request_acl",
@@ -709,7 +714,7 @@ mod tests {
                     },
                     expect: expected_authorization_event(
                         tracing::Level::WARN,
-                        "bmc_proxy_principal_allow_list_auth_context_missing",
+                        "bmc_proxy_auth_context_missing",
                         AUTHORIZATION_ERROR_METRIC,
                         "authorize_proxy_request found a request with no AuthContext in its extensions",
                         "principal_allow_list",

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -38,7 +38,7 @@ use proto::{
 };
 
 use crate::errors::DhcpError;
-use crate::metrics::DhcpTimestampFileReadFailed;
+use crate::metrics::DhcpTimestampFileFailed;
 
 // ── Public control channel types ─────────────────────────────────────────────
 
@@ -217,7 +217,7 @@ impl DhcpServerControl for DhcpServerControlService {
     ) -> Result<Response<GetDhcpTimestampsResponse>, Status> {
         let mut ts = DhcpTimestamps::new(DhcpTimestampsFilePath::Hbn);
         if let Err(e) = ts.read() {
-            emit(DhcpTimestampFileReadFailed::new(
+            emit(DhcpTimestampFileFailed::read(
                 DhcpTimestampsFilePath::Hbn.path_str().to_string(),
                 e.to_string(),
             ));

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -41,10 +41,7 @@ use forge_tls::client_config::ClientCert;
 use forge_tls::default::{default_client_cert, default_client_key, default_root_ca};
 use grpc_server::{ControlRequest, run_grpc_server};
 use lru::LruCache;
-use metrics::{
-    DhcpPacketDropped, DhcpReplySent, DhcpTimestampFileInitializationFailed,
-    DhcpTimestampFileWriteFailed, DropReason,
-};
+use metrics::{DhcpPacketDropped, DhcpReplySent, DhcpTimestampFileFailed, DropReason};
 use metrics_endpoint::{MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint};
 use modes::DhcpMode;
 use modes::controller::Controller;
@@ -95,7 +92,7 @@ async fn run_dhcp_server(args: Args, cancel_token: CancellationToken) {
         // and pollute the logs. We could have read() skip NotFound errors, but that
         // could be misleading in other scenarios.  Let's just "init" the file.
         if let Err(e) = d.write() {
-            emit(DhcpTimestampFileInitializationFailed::new(
+            emit(DhcpTimestampFileFailed::initialization(
                 dhcp_timestamps_path_context,
                 e.to_string(),
             ));
@@ -741,7 +738,7 @@ async fn process(
         let mut dhcp_timestamps = dhcp_timestamps.lock().await;
         dhcp_timestamps.add_timestamp(host_config.host_interface_id, Utc::now().to_rfc3339());
         if let Err(e) = dhcp_timestamps.write() {
-            emit(DhcpTimestampFileWriteFailed::new(
+            emit(DhcpTimestampFileFailed::write(
                 DhcpTimestampsFilePath::HbnTmp.path_str().to_string(),
                 host_config.host_interface_id.to_string(),
                 e.to_string(),

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -23,7 +23,7 @@
 //! Timestamp-file failures share a counter by operation while their paths,
 //! host interface, and errors remain log-only diagnostics.
 
-use carbide_instrument::{DynamicMessage, Event, LabelValue, MetricFamily};
+use carbide_instrument::{DynamicLog, DynamicMessage, Event, LabelValue, LogAt, MetricFamily};
 use dhcproto::v4::MessageType;
 
 use crate::errors::DhcpError;
@@ -295,62 +295,68 @@ pub struct DhcpReplySent {
     pub message_type: MessageTypeLabel,
 }
 
-/// The startup write could not initialize the timestamp file. This server
-/// generation does not start after the failure.
+/// A DHCP timestamp-file operation failed. `operation` names which one, and
+/// picks the level and diagnostic that path already had: an initialize or
+/// write failure keeps its `ERROR`, while a read failure stays `WARN` because
+/// the control RPC still answers with an empty list. `host_interface_id` is
+/// present only for the write path, which is per-interface.
 #[derive(Event)]
 #[event(
-    event_name = "dhcp_timestamp_file_initialization_failed",
+    event_name = "dhcp_timestamp_file_failed",
     metric_name = "carbide_dhcp_timestamp_file_failures_total",
     component = "nico-dhcp",
-    log = error,
+    log = dynamic,
     metric = counter,
-    message = "Failed to init DHCP timestamps file",
+    message = dynamic,
     describe = "Number of DHCP timestamp file failures, by operation"
 )]
-pub(crate) struct DhcpTimestampFileInitializationFailed {
+pub(crate) struct DhcpTimestampFileFailed {
     #[label]
     operation: TimestampFileOperation,
     #[context]
     dhcp_timestamps_path: String,
     #[context]
+    host_interface_id: Option<String>,
+    #[context]
     error: String,
 }
 
-impl DhcpTimestampFileInitializationFailed {
-    pub(crate) fn new(dhcp_timestamps_path: String, error: String) -> Self {
-        Self {
-            operation: TimestampFileOperation::Initialize,
-            dhcp_timestamps_path,
-            error,
+impl DynamicLog for DhcpTimestampFileFailed {
+    fn log_at(&self) -> LogAt {
+        match self.operation {
+            TimestampFileOperation::Initialize | TimestampFileOperation::Write => {
+                LogAt::Level(tracing::Level::ERROR)
+            }
+            TimestampFileOperation::Read => LogAt::Level(tracing::Level::WARN),
         }
     }
 }
 
-/// Updating the in-memory timestamp succeeded, but persisting the file failed.
-/// Packet processing continues because the timestamp write is best effort.
-#[derive(Event)]
-#[event(
-    event_name = "dhcp_timestamp_file_write_failed",
-    metric_name = "carbide_dhcp_timestamp_file_failures_total",
-    component = "nico-dhcp",
-    log = error,
-    metric = counter,
-    message = "Failed to write DHCP timestamps file",
-    describe = "Number of DHCP timestamp file failures, by operation"
-)]
-pub(crate) struct DhcpTimestampFileWriteFailed {
-    #[label]
-    operation: TimestampFileOperation,
-    #[context]
-    dhcp_timestamps_path: String,
-    #[context]
-    host_interface_id: String,
-    #[context]
-    error: String,
+impl DynamicMessage for DhcpTimestampFileFailed {
+    fn message(&self) -> &'static str {
+        match self.operation {
+            TimestampFileOperation::Initialize => "Failed to init DHCP timestamps file",
+            TimestampFileOperation::Write => "Failed to write DHCP timestamps file",
+            TimestampFileOperation::Read => "Failed to read DHCP timestamps file",
+        }
+    }
 }
 
-impl DhcpTimestampFileWriteFailed {
-    pub(crate) fn new(
+impl DhcpTimestampFileFailed {
+    /// The startup write could not initialize the file, so this server
+    /// generation does not start.
+    pub(crate) fn initialization(dhcp_timestamps_path: String, error: String) -> Self {
+        Self {
+            operation: TimestampFileOperation::Initialize,
+            dhcp_timestamps_path,
+            host_interface_id: None,
+            error,
+        }
+    }
+
+    /// The in-memory timestamp advanced but the file did not. Packet
+    /// processing continues because the write is best effort.
+    pub(crate) fn write(
         dhcp_timestamps_path: String,
         host_interface_id: String,
         error: String,
@@ -358,38 +364,18 @@ impl DhcpTimestampFileWriteFailed {
         Self {
             operation: TimestampFileOperation::Write,
             dhcp_timestamps_path,
-            host_interface_id,
+            host_interface_id: Some(host_interface_id),
             error,
         }
     }
-}
 
-/// The control RPC could not read the timestamp file. It still returns an
-/// empty list so callers keep treating an unreadable file as no requests yet.
-#[derive(Event)]
-#[event(
-    event_name = "dhcp_timestamp_file_read_failed",
-    metric_name = "carbide_dhcp_timestamp_file_failures_total",
-    component = "nico-dhcp",
-    log = warn,
-    metric = counter,
-    message = "Failed to read DHCP timestamps file",
-    describe = "Number of DHCP timestamp file failures, by operation"
-)]
-pub(crate) struct DhcpTimestampFileReadFailed {
-    #[label]
-    operation: TimestampFileOperation,
-    #[context]
-    dhcp_timestamps_path: String,
-    #[context]
-    error: String,
-}
-
-impl DhcpTimestampFileReadFailed {
-    pub(crate) fn new(dhcp_timestamps_path: String, error: String) -> Self {
+    /// The control RPC could not read the file. It still returns an empty list
+    /// so callers keep treating an unreadable file as no requests yet.
+    pub(crate) fn read(dhcp_timestamps_path: String, error: String) -> Self {
         Self {
             operation: TimestampFileOperation::Read,
             dhcp_timestamps_path,
+            host_interface_id: None,
             error,
         }
     }
@@ -462,14 +448,14 @@ mod tests {
     }
 
     fn emit_timestamp_initialization_failure() {
-        emit(DhcpTimestampFileInitializationFailed::new(
+        emit(DhcpTimestampFileFailed::initialization(
             "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp".to_string(),
             "permission denied".to_string(),
         ));
     }
 
     fn emit_timestamp_write_failure() {
-        emit(DhcpTimestampFileWriteFailed::new(
+        emit(DhcpTimestampFileFailed::write(
             "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp".to_string(),
             "60cef902-9779-4666-8362-c9bb4b37185f".to_string(),
             "read-only file system".to_string(),
@@ -477,7 +463,7 @@ mod tests {
     }
 
     fn emit_timestamp_read_failure() {
-        emit(DhcpTimestampFileReadFailed::new(
+        emit(DhcpTimestampFileFailed::read(
             "/var/support/forge-dhcp/logs/dhcp_timestamps.json".to_string(),
             "file not found".to_string(),
         ));
@@ -821,7 +807,7 @@ mod tests {
                     expect: expected_timestamp_file_failure(
                         "initialize",
                         tracing::Level::ERROR,
-                        "dhcp_timestamp_file_initialization_failed",
+                        "dhcp_timestamp_file_failed",
                         "Failed to init DHCP timestamps file",
                         "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp",
                         None,
@@ -836,7 +822,7 @@ mod tests {
                     expect: expected_timestamp_file_failure(
                         "write",
                         tracing::Level::ERROR,
-                        "dhcp_timestamp_file_write_failed",
+                        "dhcp_timestamp_file_failed",
                         "Failed to write DHCP timestamps file",
                         "/var/support/forge-dhcp/logs/dhcp_timestamps.json.tmp",
                         Some("60cef902-9779-4666-8362-c9bb4b37185f"),
@@ -851,7 +837,7 @@ mod tests {
                     expect: expected_timestamp_file_failure(
                         "read",
                         tracing::Level::WARN,
-                        "dhcp_timestamp_file_read_failed",
+                        "dhcp_timestamp_file_failed",
                         "Failed to read DHCP timestamps file",
                         "/var/support/forge-dhcp/logs/dhcp_timestamps.json",
                         None,

--- a/crates/dpu-fmds-shared/src/machine_identity.rs
+++ b/crates/dpu-fmds-shared/src/machine_identity.rs
@@ -29,7 +29,7 @@ use async_trait::async_trait;
 use axum::http::header::{ACCEPT, CONTENT_TYPE, HeaderMap, HeaderValue};
 use axum::http::{StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{DynamicLog, DynamicMessage, Event, LabelValue, LogAt, emit};
 use forge_dpu_agent_utils::machine_identity::defaults::{
     BURST, REQUESTS_PER_SECOND, SIGN_TIMEOUT_SECS, WAIT_TIMEOUT_SECS,
 };
@@ -58,73 +58,58 @@ enum SignProxyFailureStage {
     UpstreamServer,
 }
 
-/// The sign-proxy request failed before an HTTP response was available.
+/// A machine-identity sign-proxy call did not produce a usable response.
+/// `failure_stage` names where it broke and picks both the level and the
+/// diagnostic that stage already had: the local transport and response stages
+/// keep their `WARN`, while an upstream server error stays log-silent because
+/// the status is already forwarded to the caller unchanged. `error` is absent
+/// for that stage, which has no local error text to report.
 #[derive(Event)]
 #[event(
-    event_name = "machine_identity_sign_proxy_request_failed",
+    event_name = "machine_identity_sign_proxy_failed",
     metric_name = "carbide_machine_identity_sign_proxy_failures_total",
     component = "machine-identity",
-    log = warn,
+    log = dynamic,
     metric = counter,
-    message = "machine identity sign proxy request failed",
+    message = dynamic,
     describe = "Number of machine identity sign proxy transport, local response handling, and upstream server failures, by failure stage."
 )]
-struct MachineIdentitySignProxyRequestFailed {
+struct MachineIdentitySignProxyFailed {
     #[label]
     failure_stage: SignProxyFailureStage,
     #[context]
-    error: String,
+    error: Option<String>,
 }
 
-/// The sign proxy answered, but its response body could not be read.
-#[derive(Event)]
-#[event(
-    event_name = "machine_identity_sign_proxy_response_read_failed",
-    metric_name = "carbide_machine_identity_sign_proxy_failures_total",
-    component = "machine-identity",
-    log = warn,
-    metric = counter,
-    message = "machine identity sign proxy response body read failed",
-    describe = "Number of machine identity sign proxy transport, local response handling, and upstream server failures, by failure stage."
-)]
-struct MachineIdentitySignProxyResponseReadFailed {
-    #[label]
-    failure_stage: SignProxyFailureStage,
-    #[context]
-    error: String,
+impl DynamicLog for MachineIdentitySignProxyFailed {
+    fn log_at(&self) -> LogAt {
+        match self.failure_stage {
+            SignProxyFailureStage::RequestTimeout
+            | SignProxyFailureStage::RequestTransport
+            | SignProxyFailureStage::ResponseBody
+            | SignProxyFailureStage::ResponseBuild => LogAt::Level(tracing::Level::WARN),
+            SignProxyFailureStage::UpstreamServer => LogAt::Off,
+        }
+    }
 }
 
-/// The sign-proxy response could not be represented by the local HTTP server.
-#[derive(Event)]
-#[event(
-    event_name = "machine_identity_sign_proxy_response_build_failed",
-    metric_name = "carbide_machine_identity_sign_proxy_failures_total",
-    component = "machine-identity",
-    log = warn,
-    metric = counter,
-    message = "machine identity sign proxy response build failed",
-    describe = "Number of machine identity sign proxy transport, local response handling, and upstream server failures, by failure stage."
-)]
-struct MachineIdentitySignProxyResponseBuildFailed {
-    #[label]
-    failure_stage: SignProxyFailureStage,
-    #[context]
-    error: String,
-}
-
-/// The sign proxy returned a server-error response that was forwarded unchanged.
-#[derive(Event)]
-#[event(
-    event_name = "machine_identity_sign_proxy_upstream_server_failed",
-    metric_name = "carbide_machine_identity_sign_proxy_failures_total",
-    component = "machine-identity",
-    log = off,
-    metric = counter,
-    describe = "Number of machine identity sign proxy transport, local response handling, and upstream server failures, by failure stage."
-)]
-struct MachineIdentitySignProxyUpstreamServerFailed {
-    #[label]
-    failure_stage: SignProxyFailureStage,
+impl DynamicMessage for MachineIdentitySignProxyFailed {
+    fn message(&self) -> &'static str {
+        match self.failure_stage {
+            SignProxyFailureStage::RequestTimeout | SignProxyFailureStage::RequestTransport => {
+                "machine identity sign proxy request failed"
+            }
+            SignProxyFailureStage::ResponseBody => {
+                "machine identity sign proxy response body read failed"
+            }
+            SignProxyFailureStage::ResponseBuild => {
+                "machine identity sign proxy response build failed"
+            }
+            SignProxyFailureStage::UpstreamServer => {
+                "machine identity sign proxy upstream returned a server error"
+            }
+        }
+    }
 }
 
 /// Validated, normalized machine-identity limits.
@@ -567,9 +552,9 @@ pub async fn forward_sign_proxy_http(
                 StatusCode::BAD_GATEWAY
             };
             let error_text = sign_proxy_reqwest_error_text(error);
-            emit(MachineIdentitySignProxyRequestFailed {
+            emit(MachineIdentitySignProxyFailed {
                 failure_stage,
-                error: error_text.log_error,
+                error: Some(error_text.log_error),
             });
             return (code, error_text.response_body).into_response();
         }
@@ -587,9 +572,9 @@ pub async fn forward_sign_proxy_http(
         Ok(b) => b,
         Err(error) => {
             let error_text = sign_proxy_reqwest_error_text(error);
-            emit(MachineIdentitySignProxyResponseReadFailed {
+            emit(MachineIdentitySignProxyFailed {
                 failure_stage: SignProxyFailureStage::ResponseBody,
-                error: error_text.log_error,
+                error: Some(error_text.log_error),
             });
             return (StatusCode::BAD_GATEWAY, error_text.response_body).into_response();
         }
@@ -603,9 +588,9 @@ pub async fn forward_sign_proxy_http(
         Ok(response) => response,
         Err(error) => {
             let error = error.to_string();
-            emit(MachineIdentitySignProxyResponseBuildFailed {
+            emit(MachineIdentitySignProxyFailed {
                 failure_stage: SignProxyFailureStage::ResponseBuild,
-                error: error.clone(),
+                error: Some(error.clone()),
             });
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -615,8 +600,9 @@ pub async fn forward_sign_proxy_http(
         }
     };
     if status.is_server_error() {
-        emit(MachineIdentitySignProxyUpstreamServerFailed {
+        emit(MachineIdentitySignProxyFailed {
             failure_stage: SignProxyFailureStage::UpstreamServer,
+            error: None,
         });
     }
     response
@@ -745,19 +731,7 @@ mod tests {
     #[test]
     fn sign_proxy_failures_share_one_bounded_metric() {
         assert_eq!(
-            <MachineIdentitySignProxyRequestFailed as Event>::COMPONENT,
-            "machine-identity"
-        );
-        assert_eq!(
-            <MachineIdentitySignProxyResponseReadFailed as Event>::COMPONENT,
-            "machine-identity"
-        );
-        assert_eq!(
-            <MachineIdentitySignProxyResponseBuildFailed as Event>::COMPONENT,
-            "machine-identity"
-        );
-        assert_eq!(
-            <MachineIdentitySignProxyUpstreamServerFailed as Event>::COMPONENT,
+            <MachineIdentitySignProxyFailed as Event>::COMPONENT,
             "machine-identity"
         );
         check_values(
@@ -769,11 +743,9 @@ mod tests {
                         counter_deltas: [1.0, 0.0, 0.0, 0.0, 0.0],
                         log_count: 1,
                         level: Some(tracing::Level::WARN),
-                        metadata_name: Some(
-                            "machine_identity_sign_proxy_request_failed".to_string(),
-                        ),
+                        metadata_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         message: Some("machine identity sign proxy request failed".to_string()),
-                        event_name: Some("machine_identity_sign_proxy_request_failed".to_string()),
+                        event_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         metric_name: Some(SIGN_PROXY_FAILURE_METRIC.to_string()),
                         failure_stage: Some("request_timeout".to_string()),
                         error: Some("sanitized proxy error".to_string()),
@@ -787,11 +759,9 @@ mod tests {
                         counter_deltas: [0.0, 1.0, 0.0, 0.0, 0.0],
                         log_count: 1,
                         level: Some(tracing::Level::WARN),
-                        metadata_name: Some(
-                            "machine_identity_sign_proxy_request_failed".to_string(),
-                        ),
+                        metadata_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         message: Some("machine identity sign proxy request failed".to_string()),
-                        event_name: Some("machine_identity_sign_proxy_request_failed".to_string()),
+                        event_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         metric_name: Some(SIGN_PROXY_FAILURE_METRIC.to_string()),
                         failure_stage: Some("request_transport".to_string()),
                         error: Some("sanitized proxy error".to_string()),
@@ -805,15 +775,11 @@ mod tests {
                         counter_deltas: [0.0, 0.0, 1.0, 0.0, 0.0],
                         log_count: 1,
                         level: Some(tracing::Level::WARN),
-                        metadata_name: Some(
-                            "machine_identity_sign_proxy_response_read_failed".to_string(),
-                        ),
+                        metadata_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         message: Some(
                             "machine identity sign proxy response body read failed".to_string(),
                         ),
-                        event_name: Some(
-                            "machine_identity_sign_proxy_response_read_failed".to_string(),
-                        ),
+                        event_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         metric_name: Some(SIGN_PROXY_FAILURE_METRIC.to_string()),
                         failure_stage: Some("response_body".to_string()),
                         error: Some("sanitized proxy error".to_string()),
@@ -827,15 +793,11 @@ mod tests {
                         counter_deltas: [0.0, 0.0, 0.0, 1.0, 0.0],
                         log_count: 1,
                         level: Some(tracing::Level::WARN),
-                        metadata_name: Some(
-                            "machine_identity_sign_proxy_response_build_failed".to_string(),
-                        ),
+                        metadata_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         message: Some(
                             "machine identity sign proxy response build failed".to_string(),
                         ),
-                        event_name: Some(
-                            "machine_identity_sign_proxy_response_build_failed".to_string(),
-                        ),
+                        event_name: Some("machine_identity_sign_proxy_failed".to_string()),
                         metric_name: Some(SIGN_PROXY_FAILURE_METRIC.to_string()),
                         failure_stage: Some("response_build".to_string()),
                         error: Some("sanitized proxy error".to_string()),
@@ -861,29 +823,17 @@ mod tests {
             ],
             |failure_stage| {
                 let metrics = MetricsCapture::start();
-                let logs = capture_logs(|| match failure_stage {
-                    SignProxyFailureStage::RequestTimeout
-                    | SignProxyFailureStage::RequestTransport => {
-                        emit(MachineIdentitySignProxyRequestFailed {
-                            failure_stage,
-                            error: "sanitized proxy error".to_string(),
-                        });
-                    }
-                    SignProxyFailureStage::ResponseBody => {
-                        emit(MachineIdentitySignProxyResponseReadFailed {
-                            failure_stage,
-                            error: "sanitized proxy error".to_string(),
-                        });
-                    }
-                    SignProxyFailureStage::ResponseBuild => {
-                        emit(MachineIdentitySignProxyResponseBuildFailed {
-                            failure_stage,
-                            error: "sanitized proxy error".to_string(),
-                        });
-                    }
-                    SignProxyFailureStage::UpstreamServer => {
-                        emit(MachineIdentitySignProxyUpstreamServerFailed { failure_stage });
-                    }
+                let logs = capture_logs(|| {
+                    // The upstream-server stage forwards the status unchanged and
+                    // has no local error text; every other stage sanitizes one.
+                    let error = match failure_stage {
+                        SignProxyFailureStage::UpstreamServer => None,
+                        _ => Some("sanitized proxy error".to_string()),
+                    };
+                    emit(MachineIdentitySignProxyFailed {
+                        failure_stage,
+                        error,
+                    });
                 });
                 let log = logs.first();
 
@@ -1391,7 +1341,7 @@ mod tests {
         );
         assert_redacted_sign_proxy_event(
             &logs,
-            "machine_identity_sign_proxy_request_failed",
+            "machine_identity_sign_proxy_failed",
             "request_transport",
             "error sending request",
             &[
@@ -1501,7 +1451,7 @@ mod tests {
         );
         assert_redacted_sign_proxy_event(
             &logs,
-            "machine_identity_sign_proxy_response_read_failed",
+            "machine_identity_sign_proxy_failed",
             "response_body",
             "error decoding response body",
             &[

--- a/crates/fmds/src/grpc_server.rs
+++ b/crates/fmds/src/grpc_server.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use carbide_instrument::{Event, Outcome, emit};
+use carbide_instrument::{DynamicLog, DynamicMessage, Event, LogAt, Outcome, emit};
 use rpc::fmds::fmds_config_service_server::FmdsConfigService;
 use rpc::fmds::{UpdateConfigRequest, UpdateConfigResponse};
 use tonic::{Request, Response, Status};
@@ -34,44 +34,46 @@ impl FmdsGrpcServer {
     }
 }
 
-/// `ConfigUpdateIngestSucceeded` keeps the agent address on accepted updates.
-/// Rejections use `ConfigUpdateIngested` below, which retains the existing
-/// Event identity and error-only log fields.
-#[derive(Event)]
-#[event(
-    event_name = "fmds_config_update_ingest_succeeded",
-    metric_name = "carbide_fmds_config_updates_total",
-    component = "fmds",
-    log = info,
-    metric = counter,
-    message = "Received config update from agent",
-    describe = "Number of FMDS gRPC config-update ingests, by outcome"
-)]
-struct ConfigUpdateIngestSucceeded {
-    #[label]
-    outcome: Outcome,
-    #[context(value)]
-    agent_address: String,
-}
-
-/// `ConfigUpdateIngested` retains the existing failure Event identity. Both
-/// Events feed the same `outcome` series, while each log keeps only the fields
-/// operators already receive for that result.
+/// An agent's config update was accepted or rejected. `outcome` is the metric
+/// label and picks the level and wording each result already had: an accepted
+/// update keeps its `INFO` record with the agent address, while a rejection
+/// keeps its `WARN` with the error. Each field is present only for the result
+/// it belongs to, so neither log gains a field operators did not receive.
 #[derive(Event)]
 #[event(
     event_name = "fmds_config_update_ingested",
     metric_name = "carbide_fmds_config_updates_total",
     component = "fmds",
-    log = warn,
+    log = dynamic,
     metric = counter,
-    message = "Failed to ingest config update",
+    message = dynamic,
     describe = "Number of FMDS gRPC config-update ingests, by outcome"
 )]
 struct ConfigUpdateIngested {
     #[label]
     outcome: Outcome,
     #[context]
-    error: String,
+    agent_address: Option<String>,
+    #[context]
+    error: Option<String>,
+}
+
+impl DynamicLog for ConfigUpdateIngested {
+    fn log_at(&self) -> LogAt {
+        match self.outcome {
+            Outcome::Ok => LogAt::Level(tracing::Level::INFO),
+            Outcome::Error => LogAt::Level(tracing::Level::WARN),
+        }
+    }
+}
+
+impl DynamicMessage for ConfigUpdateIngested {
+    fn message(&self) -> &'static str {
+        match self.outcome {
+            Outcome::Ok => "Received config update from agent",
+            Outcome::Error => "Failed to ingest config update",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -88,16 +90,18 @@ impl FmdsConfigService for FmdsGrpcServer {
     ) -> Result<Response<UpdateConfigResponse>, Status> {
         match self.apply_config_update(request) {
             Ok(applied) => {
-                emit(ConfigUpdateIngestSucceeded {
+                emit(ConfigUpdateIngested {
                     outcome: Outcome::Ok,
-                    agent_address: applied.agent_address,
+                    agent_address: Some(applied.agent_address),
+                    error: None,
                 });
                 Ok(applied.response)
             }
             Err(status) => {
                 emit(ConfigUpdateIngested {
                     outcome: Outcome::Error,
-                    error: status.to_string(),
+                    agent_address: None,
+                    error: Some(status.to_string()),
                 });
                 Err(status)
             }
@@ -382,7 +386,7 @@ mod tests {
             metric_name: Some("carbide_fmds_config_updates_total".to_string()),
             outcome: Some(outcome.to_string()),
             agent_address: agent_address.map(str::to_string),
-            agent_address_kind: agent_address.map(|_| CapturedFieldKind::String),
+            agent_address_kind: agent_address.map(|_| CapturedFieldKind::Debug),
             error: error.map(str::to_string),
             error_kind: error.map(|_| CapturedFieldKind::Debug),
         }]
@@ -450,7 +454,7 @@ mod tests {
                         status: None,
                         metric_delta: 1.0,
                         logs: expected_log(
-                            "fmds_config_update_ingest_succeeded",
+                            "fmds_config_update_ingested",
                             tracing::Level::INFO,
                             "Received config update from agent",
                             "ok",

--- a/crates/switch-controller/src/fetch_info.rs
+++ b/crates/switch-controller/src/fetch_info.rs
@@ -17,7 +17,7 @@
 
 //! Handler for SwitchControllerState::FetchInfo.
 
-use carbide_instrument::{Event, LabelValue, emit};
+use carbide_instrument::{DynamicMessage, Event, LabelValue, emit};
 use carbide_uuid::switch::SwitchId;
 use model::switch::{Switch, SwitchControllerState, ValidatingState};
 use state_controller::state_handler::{
@@ -38,63 +38,63 @@ enum SwitchSlotTrayEnrichmentFailureStage {
     DatabaseUpdate,
 }
 
-/// `SwitchSlotTrayEndpointResolutionFailed` records the dependency failure
-/// that prevents `FetchInfo` from reaching the component-manager backend.
+/// `FetchInfo` could not enrich a switch with its RMS slot and tray. These
+/// failures stay best-effort -- the controller still moves to `Validating` --
+/// so `failure_stage` is what tells an operator which dependency left the
+/// location data unset, and picks the diagnostic that step already logged.
+/// `backend` is present only for the stages that actually reached one.
 #[derive(Event)]
 #[event(
-    event_name = "switch_slot_tray_endpoint_resolution_failed",
+    event_name = "switch_slot_tray_enrichment_failed",
     metric_name = "carbide_switch_slot_tray_enrichment_failures_total",
     component = "switch-controller",
     log = warn,
     metric = counter,
-    message = "Failed to resolve switch endpoint for slot and tray lookup",
+    message = dynamic,
     describe = "Number of switch slot and tray enrichment failures, by failure stage."
 )]
-struct SwitchSlotTrayEndpointResolutionFailed {
+struct SwitchSlotTrayEnrichmentFailed {
     #[label]
     failure_stage: SwitchSlotTrayEnrichmentFailureStage,
     #[context]
     error: String,
     #[context]
     switch_id: String,
+    #[context]
+    backend: Option<String>,
 }
 
-impl SwitchSlotTrayEndpointResolutionFailed {
-    fn new(error: String, switch_id: &SwitchId) -> Self {
-        Self {
-            failure_stage: SwitchSlotTrayEnrichmentFailureStage::EndpointResolution,
-            error,
-            switch_id: switch_id.to_string(),
+impl DynamicMessage for SwitchSlotTrayEnrichmentFailed {
+    fn message(&self) -> &'static str {
+        match self.failure_stage {
+            SwitchSlotTrayEnrichmentFailureStage::EndpointResolution => {
+                "Failed to resolve switch endpoint for slot and tray lookup"
+            }
+            SwitchSlotTrayEnrichmentFailureStage::BackendRequest
+            | SwitchSlotTrayEnrichmentFailureStage::BackendResponse => {
+                "Failed to get slot and tray from component manager backend"
+            }
+            SwitchSlotTrayEnrichmentFailureStage::DatabaseUpdate => {
+                "Failed to update slot_number and tray_index for switch"
+            }
         }
     }
 }
 
-/// `SwitchSlotTrayBackendLookupFailed` keeps request failures and per-result
-/// errors under one diagnostic while recording which backend step failed.
-#[derive(Event)]
-#[event(
-    event_name = "switch_slot_tray_backend_lookup_failed",
-    metric_name = "carbide_switch_slot_tray_enrichment_failures_total",
-    component = "switch-controller",
-    log = warn,
-    metric = counter,
-    message = "Failed to get slot and tray from component manager backend",
-    describe = "Number of switch slot and tray enrichment failures, by failure stage."
-)]
-struct SwitchSlotTrayBackendLookupFailed {
-    #[label]
-    failure_stage: SwitchSlotTrayEnrichmentFailureStage,
-    #[context]
-    error: String,
-    #[context]
-    switch_id: String,
-    #[context]
-    backend: String,
-}
+impl SwitchSlotTrayEnrichmentFailed {
+    /// The switch endpoint could not be resolved, so the backend was never
+    /// reached.
+    fn endpoint_resolution(error: String, switch_id: &SwitchId) -> Self {
+        Self::without_backend(
+            SwitchSlotTrayEnrichmentFailureStage::EndpointResolution,
+            error,
+            switch_id,
+        )
+    }
 
-impl SwitchSlotTrayBackendLookupFailed {
-    fn request(error: String, switch_id: &SwitchId, backend: &str) -> Self {
-        Self::new(
+    /// The component-manager request itself failed.
+    fn backend_request(error: String, switch_id: &SwitchId, backend: &str) -> Self {
+        Self::with_backend(
             SwitchSlotTrayEnrichmentFailureStage::BackendRequest,
             error,
             switch_id,
@@ -102,8 +102,9 @@ impl SwitchSlotTrayBackendLookupFailed {
         )
     }
 
-    fn response(error: String, switch_id: &SwitchId, backend: &str) -> Self {
-        Self::new(
+    /// The backend answered, but its result could not be used.
+    fn backend_response(error: String, switch_id: &SwitchId, backend: &str) -> Self {
+        Self::with_backend(
             SwitchSlotTrayEnrichmentFailureStage::BackendResponse,
             error,
             switch_id,
@@ -111,7 +112,16 @@ impl SwitchSlotTrayBackendLookupFailed {
         )
     }
 
-    fn new(
+    /// The location data was fetched but could not be written back.
+    fn persistence(error: String, switch_id: &SwitchId) -> Self {
+        Self::without_backend(
+            SwitchSlotTrayEnrichmentFailureStage::DatabaseUpdate,
+            error,
+            switch_id,
+        )
+    }
+
+    fn with_backend(
         failure_stage: SwitchSlotTrayEnrichmentFailureStage,
         error: String,
         switch_id: &SwitchId,
@@ -121,38 +131,20 @@ impl SwitchSlotTrayBackendLookupFailed {
             failure_stage,
             error,
             switch_id: switch_id.to_string(),
-            backend: backend.to_string(),
+            backend: Some(backend.to_string()),
         }
     }
-}
 
-/// `SwitchSlotTrayPersistenceFailed` records the database failure that leaves
-/// RMS location data unapplied before `FetchInfo` moves on.
-#[derive(Event)]
-#[event(
-    event_name = "switch_slot_tray_persistence_failed",
-    metric_name = "carbide_switch_slot_tray_enrichment_failures_total",
-    component = "switch-controller",
-    log = warn,
-    metric = counter,
-    message = "Failed to update slot_number and tray_index for switch",
-    describe = "Number of switch slot and tray enrichment failures, by failure stage."
-)]
-struct SwitchSlotTrayPersistenceFailed {
-    #[label]
-    failure_stage: SwitchSlotTrayEnrichmentFailureStage,
-    #[context]
-    error: String,
-    #[context]
-    switch_id: String,
-}
-
-impl SwitchSlotTrayPersistenceFailed {
-    fn new(error: String, switch_id: &SwitchId) -> Self {
+    fn without_backend(
+        failure_stage: SwitchSlotTrayEnrichmentFailureStage,
+        error: String,
+        switch_id: &SwitchId,
+    ) -> Self {
         Self {
-            failure_stage: SwitchSlotTrayEnrichmentFailureStage::DatabaseUpdate,
+            failure_stage,
             error,
             switch_id: switch_id.to_string(),
+            backend: None,
         }
     }
 }
@@ -181,7 +173,7 @@ pub async fn handle_fetch_info(
                 Ok(results) => {
                     if let Some(result) = results.into_iter().next() {
                         if let Some(error) = result.error.as_deref() {
-                            emit(SwitchSlotTrayBackendLookupFailed::response(
+                            emit(SwitchSlotTrayEnrichmentFailed::backend_response(
                                 error.to_string(),
                                 switch_id,
                                 component_manager.nv_switch.name(),
@@ -196,7 +188,7 @@ pub async fn handle_fetch_info(
                         )
                         .await
                         {
-                            emit(SwitchSlotTrayPersistenceFailed::new(
+                            emit(SwitchSlotTrayEnrichmentFailed::persistence(
                                 e.to_string(),
                                 switch_id,
                             ));
@@ -207,7 +199,7 @@ pub async fn handle_fetch_info(
                     }
                 }
                 Err(error) => {
-                    emit(SwitchSlotTrayBackendLookupFailed::request(
+                    emit(SwitchSlotTrayEnrichmentFailed::backend_request(
                         error.to_string(),
                         switch_id,
                         component_manager.nv_switch.name(),
@@ -215,7 +207,7 @@ pub async fn handle_fetch_info(
                 }
             },
             Err(error) => {
-                emit(SwitchSlotTrayEndpointResolutionFailed::new(
+                emit(SwitchSlotTrayEnrichmentFailed::endpoint_resolution(
                     error.to_string(),
                     switch_id,
                 ));
@@ -281,7 +273,7 @@ mod tests {
                         level: tracing::Level::WARN,
                         message: "Failed to resolve switch endpoint for slot and tray lookup"
                             .to_string(),
-                        event_name: Some("switch_slot_tray_endpoint_resolution_failed".to_string()),
+                        event_name: Some("switch_slot_tray_enrichment_failed".to_string()),
                         metric_name: Some(METRIC.to_string()),
                         failure_stage: Some("endpoint_resolution".to_string()),
                         error: Some(ERROR.to_string()),
@@ -298,7 +290,7 @@ mod tests {
                         level: tracing::Level::WARN,
                         message: "Failed to get slot and tray from component manager backend"
                             .to_string(),
-                        event_name: Some("switch_slot_tray_backend_lookup_failed".to_string()),
+                        event_name: Some("switch_slot_tray_enrichment_failed".to_string()),
                         metric_name: Some(METRIC.to_string()),
                         failure_stage: Some("backend_request".to_string()),
                         error: Some(ERROR.to_string()),
@@ -315,7 +307,7 @@ mod tests {
                         level: tracing::Level::WARN,
                         message: "Failed to get slot and tray from component manager backend"
                             .to_string(),
-                        event_name: Some("switch_slot_tray_backend_lookup_failed".to_string()),
+                        event_name: Some("switch_slot_tray_enrichment_failed".to_string()),
                         metric_name: Some(METRIC.to_string()),
                         failure_stage: Some("backend_response".to_string()),
                         error: Some(ERROR.to_string()),
@@ -332,7 +324,7 @@ mod tests {
                         level: tracing::Level::WARN,
                         message: "Failed to update slot_number and tray_index for switch"
                             .to_string(),
-                        event_name: Some("switch_slot_tray_persistence_failed".to_string()),
+                        event_name: Some("switch_slot_tray_enrichment_failed".to_string()),
                         metric_name: Some(METRIC.to_string()),
                         failure_stage: Some("database_update".to_string()),
                         error: Some(ERROR.to_string()),
@@ -353,27 +345,27 @@ mod tests {
                 let switch_id = SwitchId::from_str(SWITCH_ID).unwrap();
                 let logs = capture_logs(|| match case {
                     FailureCase::EndpointResolution => {
-                        emit(SwitchSlotTrayEndpointResolutionFailed::new(
+                        emit(SwitchSlotTrayEnrichmentFailed::endpoint_resolution(
                             ERROR.to_string(),
                             &switch_id,
                         ));
                     }
                     FailureCase::BackendRequest => {
-                        emit(SwitchSlotTrayBackendLookupFailed::request(
+                        emit(SwitchSlotTrayEnrichmentFailed::backend_request(
                             ERROR.to_string(),
                             &switch_id,
                             "rms",
                         ));
                     }
                     FailureCase::BackendResponse => {
-                        emit(SwitchSlotTrayBackendLookupFailed::response(
+                        emit(SwitchSlotTrayEnrichmentFailed::backend_response(
                             ERROR.to_string(),
                             &switch_id,
                             "rms",
                         ));
                     }
                     FailureCase::DatabaseUpdate => {
-                        emit(SwitchSlotTrayPersistenceFailed::new(
+                        emit(SwitchSlotTrayEnrichmentFailed::persistence(
                             ERROR.to_string(),
                             &switch_id,
                         ));


### PR DESCRIPTION
Ten of our metrics were moved by a family of Events whose names were the same word with different endings -- `WorkLockReleaseFailed`, `WorkLockLost`, `WorkLockKeepaliveFailed` -- where the variation that actually mattered was already sitting right there as a label. Twenty-eight structs, twenty-eight `event_name` values, ten metrics.

So each group becomes one Event that matches on the label it already had. `log = dynamic` and `message = dynamic` pick the level and the wording per case, and a context field that does not apply to every case is now `Option<T>`, so its key is absent from the line instead of blank -- which is what #4334 made writable honestly.

Primary callouts are:

- Nothing the metrics export moves. Same names, same label keys, same values. `check-metric-docs` goes 151 -> 133 and `check-event-names` 215 -> 197, both exactly twenty-eight declarations becoming ten.
- Four groups needed `log = dynamic` as well, not just `message`: sign-proxy (`warn`/`off`), DHCP timestamps (`error`/`warn`), FMDS config updates (`info`/`warn`), and BMC-proxy authorization errors (`error`/`warn`). Each case keeps the exact level operators already got for it.
- `event_name` is the real cost, paid per group. `casbin_auth_context_missing` and `internal_rbac_auth_context_missing` become `auth_context_missing` plus the `authorizer` label that already told them apart.
- Two `#[context(value)]` fields drop to plain `#[context]`, because they no longer apply to every case and `#[context(value)]` rejects `Option` by design. `spiffe_service_id` and `agent_address` still render the same text, but their structured field kind moves from `String` to `Debug`.

Worth a reviewer's eye: for `carbide_work_lock_failures_total`, `(KeepAlive, LockLost)` resolves to one message only because the keepalive loop matches `Err(KeepAliveError::LockLost)` ahead of the general `Err(e)` arm and returns there. `e.failure()` can produce `LockLost` on its own, so reordering those arms would quietly put two different messages behind one label pair. That reasoning is in the Event's doc comment.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4305

Part of #3169.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Each group's existing tests were updated to the collapsed Event and still assert the per-case level, message, labels, context fields, and counter deltas -- so they pin exactly what this change had to preserve. `cargo xtask check-metric-docs` and `check-event-names` both pass at the counts above.

## Additional Notes


Closes #4305
