### PR TITLE
feat(flow): Add versioned event rule persistence

### DIFF
--- a/rest-api/flow/internal/converter/dao/event_rule.go
+++ b/rest-api/flow/internal/converter/dao/event_rule.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dao
+
+import (
+	"fmt"
+	"time"
+
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/policycodec"
+	"github.com/google/uuid"
+)
+
+// EventRuleTo converts a domain rule to a database model.
+func EventRuleTo(rule *eventrule.Rule) (*dbmodel.EventRule, error) {
+	if err := rule.Validate(); err != nil {
+		return nil, err
+	}
+
+	if rule.Origin != eventrule.RuleOriginPersisted {
+		return nil, fmt.Errorf(
+			"persisted event rule origin must be %q",
+			eventrule.RuleOriginPersisted,
+		)
+	}
+
+	policy, err := policycodec.Marshal(rule.Policy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dbmodel.EventRule{
+		ID:          rule.ID,
+		Name:        rule.Name,
+		Description: rule.Description,
+		Enabled:     rule.Enabled,
+		EventType:   string(rule.EventType),
+		Policy:      policy,
+		CreatedAt:   rule.CreatedAt,
+		UpdatedAt:   rule.UpdatedAt,
+	}, nil
+}
+
+// EventRuleFrom converts a database model to a domain rule.
+func EventRuleFrom(dbRule *dbmodel.EventRule) (*eventrule.Rule, error) {
+	if dbRule == nil {
+		return nil, nil
+	}
+
+	policy, err := policycodec.Unmarshal(dbRule.Policy)
+	if err != nil {
+		return nil, err
+	}
+
+	rule := &eventrule.Rule{
+		ID:          dbRule.ID,
+		Origin:      eventrule.RuleOriginPersisted,
+		Name:        dbRule.Name,
+		Description: dbRule.Description,
+		Enabled:     dbRule.Enabled,
+		EventType:   eventrule.Type(dbRule.EventType),
+		Policy:      policy,
+		CreatedAt:   dbRule.CreatedAt,
+		UpdatedAt:   dbRule.UpdatedAt,
+	}
+
+	if err := rule.Validate(); err != nil {
+		return nil, fmt.Errorf("decode persisted event rule: %w", err)
+	}
+
+	return rule, nil
+}
+
+// EventRuleBindingTo converts a domain binding to a database model.
+func EventRuleBindingTo(
+	binding eventrule.Binding,
+	createdAt time.Time,
+	updatedAt time.Time,
+) (*dbmodel.EventRuleBinding, error) {
+	if err := binding.Validate(); err != nil {
+		return nil, err
+	}
+
+	var scopeID *uuid.UUID
+	if binding.Scope.HasID() {
+		id := binding.Scope.ID
+		scopeID = &id
+	}
+
+	return &dbmodel.EventRuleBinding{
+		ID:        binding.ID,
+		RuleID:    binding.RuleID,
+		EventType: string(binding.EventType),
+		ScopeType: string(binding.Scope.Type),
+		ScopeID:   scopeID,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}, nil
+}
+
+// EventRuleBindingFrom converts a database model to a domain binding.
+func EventRuleBindingFrom(
+	dbBinding *dbmodel.EventRuleBinding,
+) (*eventrule.Binding, error) {
+	if dbBinding == nil {
+		return nil, nil
+	}
+
+	var scopeID uuid.UUID
+	if dbBinding.ScopeID != nil {
+		scopeID = *dbBinding.ScopeID
+	}
+
+	binding := &eventrule.Binding{
+		ID:        dbBinding.ID,
+		RuleID:    dbBinding.RuleID,
+		EventType: eventrule.Type(dbBinding.EventType),
+		Scope: eventrule.Scope{
+			Type: eventrule.ScopeType(dbBinding.ScopeType),
+			ID:   scopeID,
+		},
+	}
+
+	if err := binding.Validate(); err != nil {
+		return nil, fmt.Errorf("decode persisted event rule binding: %w", err)
+	}
+
+	return binding, nil
+}

--- a/rest-api/flow/internal/converter/dao/event_rule_test.go
+++ b/rest-api/flow/internal/converter/dao/event_rule_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dao
+
+import (
+	"testing"
+	"time"
+
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventRuleRoundTrip(t *testing.T) {
+	now := time.Now().UTC()
+	rule := &eventrule.Rule{
+		ID:          uuid.New(),
+		Origin:      eventrule.RuleOriginPersisted,
+		Name:        "test",
+		Description: "description",
+		Enabled:     true,
+		EventType:   "test.event",
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	dbRule, err := EventRuleTo(rule)
+	require.NoError(t, err)
+	roundTripped, err := EventRuleFrom(dbRule)
+	require.NoError(t, err)
+	require.Equal(t, rule, roundTripped)
+}
+
+func TestEventRuleBindingRoundTrip(t *testing.T) {
+	scopes := map[string]eventrule.Scope{
+		"site": {Type: eventrule.ScopeTypeSite},
+		"rack": {Type: eventrule.ScopeTypeRack, ID: uuid.New()},
+	}
+	for name, scope := range scopes {
+		t.Run(name, func(t *testing.T) {
+			binding := eventrule.Binding{
+				ID:        uuid.New(),
+				RuleID:    uuid.New(),
+				EventType: "test.event",
+				Scope:     scope,
+			}
+			now := time.Now().UTC()
+			dbBinding, err := EventRuleBindingTo(binding, now, now)
+			require.NoError(t, err)
+			roundTripped, err := EventRuleBindingFrom(dbBinding)
+			require.NoError(t, err)
+			require.Equal(t, &binding, roundTripped)
+		})
+	}
+}
+
+func TestEventRuleBindingFromRejectsInvalidModel(t *testing.T) {
+	dbBinding := &dbmodel.EventRuleBinding{
+		ID:        uuid.New(),
+		RuleID:    uuid.New(),
+		EventType: "test.event",
+		ScopeType: string(eventrule.ScopeTypeRack),
+	}
+	_, err := EventRuleBindingFrom(dbBinding)
+	require.ErrorContains(t, err, "rack scope requires an id")
+}

--- a/rest-api/flow/internal/db/model/event_rule.go
+++ b/rest-api/flow/internal/db/model/event_rule.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+// EventRule is the bun model for the event_rules table.
+type EventRule struct {
+	bun.BaseModel `bun:"table:event_rules,alias:er"`
+
+	ID          uuid.UUID       `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	Name        string          `bun:"name,notnull"`
+	Description string          `bun:"description,notnull"`
+	Enabled     bool            `bun:"enabled,notnull"`
+	EventType   string          `bun:"event_type,notnull"`
+	Policy      json.RawMessage `bun:"policy,type:jsonb,notnull"`
+	CreatedAt   time.Time       `bun:"created_at,notnull,default:current_timestamp"`
+	UpdatedAt   time.Time       `bun:"updated_at,notnull,default:current_timestamp"`
+}
+
+// EventRuleBinding is the bun model for the event_rule_bindings table.
+type EventRuleBinding struct {
+	bun.BaseModel `bun:"table:event_rule_bindings,alias:erb"`
+
+	ID        uuid.UUID  `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	RuleID    uuid.UUID  `bun:"rule_id,type:uuid,notnull"`
+	EventType string     `bun:"event_type,notnull"`
+	ScopeType string     `bun:"scope_type,notnull"`
+	ScopeID   *uuid.UUID `bun:"scope_id,type:uuid"`
+	CreatedAt time.Time  `bun:"created_at,notnull,default:current_timestamp"`
+	UpdatedAt time.Time  `bun:"updated_at,notnull,default:current_timestamp"`
+}

--- a/rest-api/flow/internal/eventrule/binding.go
+++ b/rest-api/flow/internal/eventrule/binding.go
@@ -23,15 +23,20 @@ type Scope struct {
 	ID   uuid.UUID
 }
 
+// HasID reports whether the scope carries a resource identifier.
+func (s Scope) HasID() bool {
+	return s.ID != uuid.Nil
+}
+
 // Validate checks the scope type and identifier contract.
 func (s Scope) Validate() error {
 	switch s.Type {
 	case ScopeTypeSite:
-		if s.ID != uuid.Nil {
+		if s.HasID() {
 			return fmt.Errorf("site scope must not have an id")
 		}
 	case ScopeTypeRack:
-		if s.ID == uuid.Nil {
+		if !s.HasID() {
 			return fmt.Errorf("rack scope requires an id")
 		}
 	default:

--- a/rest-api/flow/internal/eventrule/binding_test.go
+++ b/rest-api/flow/internal/eventrule/binding_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestScopeHasID(t *testing.T) {
+	require.False(t, Scope{Type: ScopeTypeSite}.HasID())
+	require.True(t, Scope{Type: ScopeTypeRack, ID: uuid.New()}.HasID())
+}
+
 func TestBindingValidateRequiresEventType(t *testing.T) {
 	binding := Binding{
 		ID:     uuid.New(),

--- a/rest-api/flow/internal/eventrule/event.go
+++ b/rest-api/flow/internal/eventrule/event.go
@@ -48,6 +48,16 @@ const (
 	SeverityCritical    Severity = "critical"
 )
 
+// ParseSeverity converts a string into a validated Severity.
+func ParseSeverity(value string) (Severity, error) {
+	severity := Severity(value)
+	if err := severity.Validate(); err != nil {
+		return SeverityUnspecified, err
+	}
+
+	return severity, nil
+}
+
 // IsUnspecified reports whether no severity was supplied for the event.
 func (s Severity) IsUnspecified() bool {
 	return s == SeverityUnspecified

--- a/rest-api/flow/internal/eventrule/event_test.go
+++ b/rest-api/flow/internal/eventrule/event_test.go
@@ -11,6 +11,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseSeverity(t *testing.T) {
+	tests := map[string]struct {
+		value    string
+		expected Severity
+		wantErr  bool
+	}{
+		"unspecified": {expected: SeverityUnspecified},
+		"info":        {value: "info", expected: SeverityInfo},
+		"warning":     {value: "warning", expected: SeverityWarning},
+		"critical":    {value: "critical", expected: SeverityCritical},
+		"invalid":     {value: "urgent", wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := ParseSeverity(test.value)
+			if test.wantErr {
+				require.Error(t, err)
+				require.Equal(t, SeverityUnspecified, actual)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestEnvelopeValidatePayload(t *testing.T) {
 	tests := map[string]struct {
 		payload json.RawMessage

--- a/rest-api/flow/internal/eventrule/manager/manager_test.go
+++ b/rest-api/flow/internal/eventrule/manager/manager_test.go
@@ -194,6 +194,61 @@ func TestManagerRejectsMissingIDs(t *testing.T) {
 	)
 }
 
+func TestManagerRejectsBuiltInRuleMutations(t *testing.T) {
+	builtIn := testRule(uuid.New(), eventrule.RuleOriginBuiltIn, "test.event")
+	builtIns, err := registry.New(builtIn)
+	require.NoError(t, err)
+	manager, err := New(builtIns, newTestStore(), newTestBindingStore())
+	require.NoError(t, err)
+
+	tests := map[string]func(context.Context) error{
+		"update metadata": func(ctx context.Context) error {
+			return manager.UpdateMetadata(
+				ctx,
+				builtIn.ID,
+				eventrule.RuleMetadata{Name: "updated"},
+			)
+		},
+		"set dedupe": func(ctx context.Context) error {
+			return manager.SetDedupe(
+				ctx,
+				builtIn.ID,
+				&eventrule.Dedupe{Window: time.Minute},
+			)
+		},
+		"replace actions": func(ctx context.Context) error {
+			return manager.ReplaceActions(
+				ctx,
+				builtIn.ID,
+				[]eventrule.Action{
+					eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+				},
+			)
+		},
+		"delete": func(ctx context.Context) error {
+			return manager.Delete(ctx, builtIn.ID)
+		},
+		"bind": func(ctx context.Context) error {
+			_, err := manager.Bind(
+				ctx,
+				builtIn.ID,
+				eventrule.Scope{Type: eventrule.ScopeTypeSite},
+			)
+			return err
+		},
+		"set enabled": func(ctx context.Context) error {
+			return manager.SetEnabled(ctx, builtIn.ID, false)
+		},
+	}
+
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := mutate(context.Background())
+			require.ErrorContains(t, err, "is a built-in and cannot be mutated")
+		})
+	}
+}
+
 type scopeKey struct {
 	eventType eventrule.Type
 	scope     eventrule.Scope
@@ -240,13 +295,21 @@ func (s *testStore) UpdateMetadata(
 	id uuid.UUID,
 	metadata eventrule.RuleMetadata,
 ) error {
-	s.byID[id].Name = metadata.Name
-	s.byID[id].Description = metadata.Description
+	rule, err := s.ruleForMutation(id)
+	if err != nil {
+		return err
+	}
+	rule.Name = metadata.Name
+	rule.Description = metadata.Description
 	return nil
 }
 
 func (s *testStore) SetDedupe(_ context.Context, id uuid.UUID, dedupe *eventrule.Dedupe) error {
-	s.byID[id].Dedupe = dedupe
+	rule, err := s.ruleForMutation(id)
+	if err != nil {
+		return err
+	}
+	rule.Dedupe = dedupe
 	return nil
 }
 
@@ -255,18 +318,37 @@ func (s *testStore) ReplaceActions(
 	id uuid.UUID,
 	actions []eventrule.Action,
 ) error {
-	s.byID[id].Actions = actions
+	rule, err := s.ruleForMutation(id)
+	if err != nil {
+		return err
+	}
+	rule.Actions = actions
 	return nil
 }
 
 func (s *testStore) Delete(_ context.Context, id uuid.UUID) error {
+	if _, err := s.ruleForMutation(id); err != nil {
+		return err
+	}
 	delete(s.byID, id)
 	return nil
 }
 
 func (s *testStore) SetEnabled(_ context.Context, id uuid.UUID, enabled bool) error {
-	s.byID[id].Enabled = enabled
+	rule, err := s.ruleForMutation(id)
+	if err != nil {
+		return err
+	}
+	rule.Enabled = enabled
 	return nil
+}
+
+func (s *testStore) ruleForMutation(id uuid.UUID) (*eventrule.Rule, error) {
+	rule, ok := s.byID[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	return rule, nil
 }
 
 type testBindingStore struct {

--- a/rest-api/flow/internal/eventrule/policycodec/action_v1.go
+++ b/rest-api/flow/internal/eventrule/policycodec/action_v1.go
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package policycodec
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
+)
+
+const actionVersionV1 = 1
+
+type actionV1 struct {
+	Version   int               `json:"version"`
+	ID        string            `json:"id"`
+	Type      string            `json:"type"`
+	Condition actionConditionV1 `json:"condition"`
+	Spec      json.RawMessage   `json:"spec"`
+}
+
+type actionConditionV1 struct {
+	Severities     []string `json:"severities,omitempty"`
+	ComponentTypes []string `json:"componentTypes,omitempty"`
+}
+
+type submitTaskSpecV1 struct {
+	OperationType    string `json:"operationType"`
+	OperationCode    string `json:"operationCode"`
+	TargetStrategy   string `json:"targetStrategy"`
+	ConflictStrategy string `json:"conflictStrategy"`
+	Description      string `json:"description,omitempty"`
+}
+
+type sendAlertSpecV1 struct {
+	Severity string `json:"severity"`
+	Message  string `json:"message,omitempty"`
+}
+
+type noopSpecV1 struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+func marshalActionV1(action eventrule.Action) (json.RawMessage, error) {
+	persisted := actionV1{
+		Version: actionVersionV1,
+		ID:      action.ID,
+		Type:    string(action.Spec.Type()),
+	}
+
+	if action.Condition.Severities != nil {
+		severities := make([]string, len(action.Condition.Severities))
+		for i, severity := range action.Condition.Severities {
+			severities[i] = string(severity)
+		}
+
+		persisted.Condition.Severities = severities
+	}
+
+	if action.Condition.ComponentTypes != nil {
+		cts := make([]string, len(action.Condition.ComponentTypes))
+		for i, componentType := range action.Condition.ComponentTypes {
+			cts[i] = string(componentType)
+		}
+
+		persisted.Condition.ComponentTypes = cts
+	}
+
+	spec, err := marshalActionSpecV1(action.Spec)
+	if err != nil {
+		return nil, err
+	}
+	persisted.Spec = spec
+
+	encoded, err := json.Marshal(persisted)
+	if err != nil {
+		return nil, fmt.Errorf("encode event policy action v1: %w", err)
+	}
+
+	return encoded, nil
+}
+
+func unmarshalActionV1(data json.RawMessage) (eventrule.Action, error) {
+	var persisted actionV1
+	if err := decodeStrict(data, &persisted); err != nil {
+		return eventrule.Action{}, fmt.Errorf("decode event policy action v1: %w", err)
+	}
+
+	condition := eventrule.ActionCondition{}
+	if persisted.Condition.Severities != nil {
+		severities := make([]eventrule.Severity, len(persisted.Condition.Severities))
+		for i, severity := range persisted.Condition.Severities {
+			decodedSeverity, err := eventrule.ParseSeverity(severity)
+			if err != nil {
+				return eventrule.Action{}, fmt.Errorf(
+					"condition severities[%d]: %w",
+					i,
+					err,
+				)
+			}
+
+			if decodedSeverity.IsUnspecified() {
+				return eventrule.Action{}, fmt.Errorf(
+					"condition severities[%d] cannot be unspecified",
+					i,
+				)
+			}
+
+			severities[i] = decodedSeverity
+		}
+
+		condition.Severities = severities
+	}
+
+	if persisted.Condition.ComponentTypes != nil {
+		cts := make([]flowtypes.ComponentType, len(persisted.Condition.ComponentTypes))
+		for i, componentType := range persisted.Condition.ComponentTypes {
+			decodedComponentType, err := flowtypes.ParseComponentType(componentType)
+			if err != nil {
+				return eventrule.Action{}, fmt.Errorf(
+					"condition componentTypes[%d]: %w",
+					i,
+					err,
+				)
+			}
+
+			cts[i] = decodedComponentType
+		}
+
+		condition.ComponentTypes = cts
+	}
+
+	spec, err := unmarshalActionSpecV1(eventrule.ActionType(persisted.Type), persisted.Spec)
+	if err != nil {
+		return eventrule.Action{}, err
+	}
+
+	return eventrule.NewAction(persisted.ID, condition, spec), nil
+}
+
+func marshalActionSpecV1(spec eventrule.ActionSpec) (json.RawMessage, error) {
+	switch typed := spec.(type) {
+	case eventrule.SubmitTask:
+		return json.Marshal(submitTaskSpecV1{
+			OperationType:    string(typed.OperationType),
+			OperationCode:    string(typed.OperationCode),
+			TargetStrategy:   string(typed.TargetStrategy),
+			ConflictStrategy: string(typed.ConflictStrategy),
+			Description:      typed.Description,
+		})
+	case eventrule.SendAlert:
+		return json.Marshal(sendAlertSpecV1{
+			Severity: string(typed.Severity),
+			Message:  typed.Message,
+		})
+	case eventrule.Noop:
+		return json.Marshal(noopSpecV1{Reason: typed.Reason})
+	default:
+		return nil, fmt.Errorf("unsupported action spec %T", spec)
+	}
+}
+
+func unmarshalActionSpecV1(
+	actionType eventrule.ActionType,
+	data json.RawMessage,
+) (eventrule.ActionSpec, error) {
+	switch actionType {
+	case eventrule.ActionTypeSubmitTask:
+		var persisted submitTaskSpecV1
+		if err := decodeStrict(data, &persisted); err != nil {
+			return nil, fmt.Errorf("decode submit_task action spec v1: %w", err)
+		}
+
+		return eventrule.SubmitTask{
+			OperationType:    taskcommon.TaskType(persisted.OperationType),
+			OperationCode:    taskcommon.OperationCode(persisted.OperationCode),
+			TargetStrategy:   eventrule.TargetStrategy(persisted.TargetStrategy),
+			ConflictStrategy: eventrule.ConflictStrategy(persisted.ConflictStrategy),
+			Description:      persisted.Description,
+		}, nil
+	case eventrule.ActionTypeSendAlert:
+		var persisted sendAlertSpecV1
+		if err := decodeStrict(data, &persisted); err != nil {
+			return nil, fmt.Errorf("decode send_alert action spec v1: %w", err)
+		}
+
+		severity, err := eventrule.ParseSeverity(persisted.Severity)
+		if err != nil {
+			return nil, fmt.Errorf("decode send_alert action spec v1 severity: %w", err)
+		}
+
+		return eventrule.SendAlert{
+			Severity: severity,
+			Message:  persisted.Message,
+		}, nil
+	case eventrule.ActionTypeNoop:
+		var persisted noopSpecV1
+		if err := decodeStrict(data, &persisted); err != nil {
+			return nil, fmt.Errorf("decode noop action spec v1: %w", err)
+		}
+
+		return eventrule.Noop{Reason: persisted.Reason}, nil
+	default:
+		return nil, fmt.Errorf("unknown action type %q", actionType)
+	}
+}

--- a/rest-api/flow/internal/eventrule/policycodec/codec.go
+++ b/rest-api/flow/internal/eventrule/policycodec/codec.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package policycodec encodes and decodes versioned persisted event policies.
+package policycodec
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+type versionHeader struct {
+	Version int `json:"version"`
+}
+
+// Marshal encodes a current domain policy using the latest persistence format.
+func Marshal(policy eventrule.Policy) (json.RawMessage, error) {
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+
+	return marshalPolicy(policy)
+}
+
+// Unmarshal decodes any supported persisted policy into the current domain.
+func Unmarshal(data json.RawMessage) (eventrule.Policy, error) {
+	policy, err := unmarshalPolicy(data)
+	if err != nil {
+		return eventrule.Policy{}, err
+	}
+
+	if err := policy.Validate(); err != nil {
+		return eventrule.Policy{}, fmt.Errorf("validate event policy: %w", err)
+	}
+
+	return policy, nil
+}
+
+func marshalPolicy(policy eventrule.Policy) (json.RawMessage, error) {
+	return marshalPolicyV1(policy)
+}
+
+func unmarshalPolicy(data json.RawMessage) (eventrule.Policy, error) {
+	version, err := decodeVersion(data, "event policy")
+	if err != nil {
+		return eventrule.Policy{}, err
+	}
+
+	switch version {
+	case policyVersionV1:
+		return unmarshalPolicyV1(data)
+	default:
+		return eventrule.Policy{}, fmt.Errorf("unknown event policy version %d", version)
+	}
+}
+
+func marshalDedupe(dedupe eventrule.Dedupe) (json.RawMessage, error) {
+	return marshalDedupeV1(dedupe)
+}
+
+func unmarshalDedupe(data json.RawMessage) (*eventrule.Dedupe, error) {
+	version, err := decodeVersion(data, "event policy dedupe")
+	if err != nil {
+		return nil, err
+	}
+
+	switch version {
+	case dedupeVersionV1:
+		return unmarshalDedupeV1(data)
+	default:
+		return nil, fmt.Errorf("unknown event policy dedupe version %d", version)
+	}
+}
+
+func marshalAction(action eventrule.Action) (json.RawMessage, error) {
+	return marshalActionV1(action)
+}
+
+func unmarshalAction(data json.RawMessage) (eventrule.Action, error) {
+	version, err := decodeVersion(data, "event policy action")
+	if err != nil {
+		return eventrule.Action{}, err
+	}
+
+	switch version {
+	case actionVersionV1:
+		return unmarshalActionV1(data)
+	default:
+		return eventrule.Action{}, fmt.Errorf("unknown event policy action version %d", version)
+	}
+}
+
+func decodeVersion(data json.RawMessage, name string) (int, error) {
+	var header versionHeader
+	if err := json.Unmarshal(data, &header); err != nil {
+		return 0, fmt.Errorf("decode %s header: %w", name, err)
+	}
+
+	return header.Version, nil
+}
+
+func decodeStrict(data json.RawMessage, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("unexpected trailing JSON value")
+		}
+		return err
+	}
+
+	return nil
+}

--- a/rest-api/flow/internal/eventrule/policycodec/codec_test.go
+++ b/rest-api/flow/internal/eventrule/policycodec/codec_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package policycodec
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
+	flowtypes "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyV1Fixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/policy_v1_all_actions.json")
+	require.NoError(t, err)
+
+	policy, err := Unmarshal(data)
+	require.NoError(t, err)
+	require.Equal(t, fullPolicy(), policy)
+}
+
+func TestPolicyV1WithoutDedupeFixture(t *testing.T) {
+	data, err := os.ReadFile("testdata/policy_v1_without_dedupe.json")
+	require.NoError(t, err)
+
+	policy, err := Unmarshal(data)
+	require.NoError(t, err)
+	require.Nil(t, policy.Dedupe)
+	require.Len(t, policy.Actions, 1)
+	require.Equal(t, "noop", policy.Actions[0].ID)
+}
+
+func TestPolicyRoundTrip(t *testing.T) {
+	policy := fullPolicy()
+	encoded, err := Marshal(policy)
+	require.NoError(t, err)
+	roundTripped, err := Unmarshal(encoded)
+	require.NoError(t, err)
+	require.Equal(t, policy, roundTripped)
+}
+
+func TestPolicyRejectsUnknownVersionsAndFields(t *testing.T) {
+	tests := map[string]string{
+		"policy version": `{"version":2,"actions":[]}`,
+		"dedupe version": `{
+			"version":1,
+			"dedupe":{"version":2,"window":1},
+			"actions":[]
+		}`,
+		"action version": `{
+			"version":1,
+			"actions":[
+				{"version":2,"id":"noop","type":"noop","condition":{},"spec":{}}
+			]
+		}`,
+		"policy field": `{"version":1,"actions":[],"unknown":true}`,
+		"action field": `{
+			"version":1,
+			"actions":[
+				{
+					"version":1,
+					"id":"noop",
+					"type":"noop",
+					"condition":{},
+					"spec":{},
+					"unknown":true
+				}
+			]
+		}`,
+		"invalid action severity": `{
+			"version":1,
+			"actions":[
+				{
+					"version":1,
+					"id":"noop",
+					"type":"noop",
+					"condition":{"severities":["urgent"]},
+					"spec":{}
+				}
+			]
+		}`,
+		"invalid action component type": `{
+			"version":1,
+			"actions":[
+				{
+					"version":1,
+					"id":"noop",
+					"type":"noop",
+					"condition":{"componentTypes":["GPU"]},
+					"spec":{}
+				}
+			]
+		}`,
+		"invalid send alert severity": `{
+			"version":1,
+			"actions":[
+				{
+					"version":1,
+					"id":"alert",
+					"type":"send_alert",
+					"condition":{},
+					"spec":{"severity":"urgent"}
+				}
+			]
+		}`,
+	}
+
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Unmarshal([]byte(data))
+			require.Error(t, err)
+		})
+	}
+}
+
+func fullPolicy() eventrule.Policy {
+	return eventrule.Policy{
+		Dedupe: &eventrule.Dedupe{Window: 5 * time.Minute},
+		Actions: []eventrule.Action{
+			eventrule.NewAction(
+				"submit",
+				eventrule.ActionCondition{
+					Severities:     []eventrule.Severity{eventrule.SeverityCritical},
+					ComponentTypes: []flowtypes.ComponentType{flowtypes.ComponentTypeCompute},
+				},
+				eventrule.SubmitTask{
+					OperationType:    taskcommon.TaskTypePowerControl,
+					OperationCode:    taskcommon.OpCodePowerControlForcePowerOff,
+					TargetStrategy:   eventrule.TargetStrategyComponent,
+					ConflictStrategy: eventrule.ConflictStrategyQueue,
+					Description:      "power off",
+				},
+			),
+			eventrule.NewAction(
+				"alert",
+				eventrule.ActionCondition{},
+				eventrule.SendAlert{
+					Severity: eventrule.SeverityWarning,
+					Message:  "leak detected",
+				},
+			),
+			eventrule.NewAction(
+				"noop",
+				eventrule.ActionCondition{},
+				eventrule.Noop{Reason: "audit only"},
+			),
+		},
+	}
+}

--- a/rest-api/flow/internal/eventrule/policycodec/dedupe_v1.go
+++ b/rest-api/flow/internal/eventrule/policycodec/dedupe_v1.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package policycodec
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+const dedupeVersionV1 = 1
+
+type dedupeV1 struct {
+	Version int           `json:"version"`
+	Window  time.Duration `json:"window"`
+}
+
+func marshalDedupeV1(dedupe eventrule.Dedupe) (json.RawMessage, error) {
+	encoded, err := json.Marshal(dedupeV1{
+		Version: dedupeVersionV1,
+		Window:  dedupe.Window,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode event policy dedupe v1: %w", err)
+	}
+	return encoded, nil
+}
+
+func unmarshalDedupeV1(data json.RawMessage) (*eventrule.Dedupe, error) {
+	var persisted dedupeV1
+	if err := decodeStrict(data, &persisted); err != nil {
+		return nil, fmt.Errorf("decode event policy dedupe v1: %w", err)
+	}
+	return &eventrule.Dedupe{Window: persisted.Window}, nil
+}

--- a/rest-api/flow/internal/eventrule/policycodec/policy_v1.go
+++ b/rest-api/flow/internal/eventrule/policycodec/policy_v1.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package policycodec
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+)
+
+const policyVersionV1 = 1
+
+type policyV1 struct {
+	Version int               `json:"version"`
+	Dedupe  json.RawMessage   `json:"dedupe,omitempty"`
+	Actions []json.RawMessage `json:"actions"`
+}
+
+func marshalPolicyV1(policy eventrule.Policy) (json.RawMessage, error) {
+	persisted := policyV1{
+		Version: policyVersionV1,
+		Actions: make([]json.RawMessage, len(policy.Actions)),
+	}
+
+	if policy.Dedupe != nil {
+		dedupe, err := marshalDedupe(*policy.Dedupe)
+		if err != nil {
+			return nil, err
+		}
+
+		persisted.Dedupe = dedupe
+	}
+
+	for i, action := range policy.Actions {
+		encodedAction, err := marshalAction(action)
+		if err != nil {
+			return nil, fmt.Errorf("actions[%d]: %w", i, err)
+		}
+
+		persisted.Actions[i] = encodedAction
+	}
+
+	encoded, err := json.Marshal(persisted)
+	if err != nil {
+		return nil, fmt.Errorf("encode event policy v1: %w", err)
+	}
+
+	return encoded, nil
+}
+
+func unmarshalPolicyV1(data json.RawMessage) (eventrule.Policy, error) {
+	var persisted policyV1
+	if err := decodeStrict(data, &persisted); err != nil {
+		return eventrule.Policy{}, fmt.Errorf("decode event policy v1: %w", err)
+	}
+
+	if persisted.Version != policyVersionV1 {
+		return eventrule.Policy{}, fmt.Errorf(
+			"unexpected event policy v1 version %d",
+			persisted.Version,
+		)
+	}
+
+	policy := eventrule.Policy{
+		Actions: make([]eventrule.Action, len(persisted.Actions)),
+	}
+
+	if persisted.Dedupe != nil {
+		dedupe, err := unmarshalDedupe(persisted.Dedupe)
+		if err != nil {
+			return eventrule.Policy{}, err
+		}
+
+		policy.Dedupe = dedupe
+	}
+
+	for i, action := range persisted.Actions {
+		decodedAction, err := unmarshalAction(action)
+		if err != nil {
+			return eventrule.Policy{}, fmt.Errorf("actions[%d]: %w", i, err)
+		}
+
+		policy.Actions[i] = decodedAction
+	}
+
+	return policy, nil
+}

--- a/rest-api/flow/internal/eventrule/policycodec/testdata/policy_v1_all_actions.json
+++ b/rest-api/flow/internal/eventrule/policycodec/testdata/policy_v1_all_actions.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "dedupe": {
+    "version": 1,
+    "window": 300000000000
+  },
+  "actions": [
+    {
+      "version": 1,
+      "id": "submit",
+      "type": "submit_task",
+      "condition": {
+        "severities": ["critical"],
+        "componentTypes": ["COMPUTE"]
+      },
+      "spec": {
+        "operationType": "power_control",
+        "operationCode": "force_power_off",
+        "targetStrategy": "component",
+        "conflictStrategy": "queue",
+        "description": "power off"
+      }
+    },
+    {
+      "version": 1,
+      "id": "alert",
+      "type": "send_alert",
+      "condition": {},
+      "spec": {
+        "severity": "warning",
+        "message": "leak detected"
+      }
+    },
+    {
+      "version": 1,
+      "id": "noop",
+      "type": "noop",
+      "condition": {},
+      "spec": {
+        "reason": "audit only"
+      }
+    }
+  ]
+}

--- a/rest-api/flow/internal/eventrule/policycodec/testdata/policy_v1_without_dedupe.json
+++ b/rest-api/flow/internal/eventrule/policycodec/testdata/policy_v1_without_dedupe.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "actions": [
+    {
+      "version": 1,
+      "id": "noop",
+      "type": "noop",
+      "condition": {},
+      "spec": {
+        "reason": "record only"
+      }
+    }
+  ]
+}

--- a/rest-api/flow/internal/eventrule/store.go
+++ b/rest-api/flow/internal/eventrule/store.go
@@ -49,7 +49,10 @@ type BuiltInRuleReader interface {
 	GetByEventType(context.Context, Type) (*Rule, error)
 }
 
-// RuleStore manages persisted rule lifecycle operations.
+// RuleStore manages persisted rule lifecycle operations. Callers must validate
+// domain values before passing them to mutation methods. Implementations remain
+// responsible for enforcing aggregate and persistence invariants before writes.
+// Mutations targeting an unknown rule ID must return ErrRuleNotFound.
 type RuleStore interface {
 	RuleReader
 	// Create persists a manager-constructed rule and returns the stored rule,
@@ -67,6 +70,7 @@ type RuleStore interface {
 // BindingStore manages persisted rule bindings and scope lookup.
 type BindingStore interface {
 	Bind(context.Context, Binding) error
+	// Unbind returns ErrRuleNotFound when the binding ID does not exist.
 	Unbind(context.Context, uuid.UUID) error
 	// GetForScope returns the binding for an event type and scope. When no
 	// binding exists, implementations must return (nil, nil).

--- a/rest-api/flow/internal/eventrule/store/memory/manager_integration_test.go
+++ b/rest-api/flow/internal/eventrule/store/memory/manager_integration_test.go
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/manager"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/registry"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerIntegration(t *testing.T) {
+	ctx := context.Background()
+	eventType := eventrule.Type("test.event")
+	builtIn := integrationRule(uuid.New(), eventrule.RuleOriginBuiltIn, eventType)
+	builtIns, err := registry.New(builtIn)
+	require.NoError(t, err)
+	store := New()
+	ruleManager, err := manager.New(builtIns, store, store)
+	require.NoError(t, err)
+
+	site, err := ruleManager.Create(ctx, integrationCreate(eventType, "site"))
+	require.NoError(t, err)
+	_, err = ruleManager.Bind(ctx, site.ID, eventrule.Scope{Type: eventrule.ScopeTypeSite})
+	require.NoError(t, err)
+
+	effective, err := ruleManager.GetEffective(ctx, eventType, uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, builtIn.ID, effective.ID)
+
+	require.NoError(t, ruleManager.SetEnabled(ctx, site.ID, true))
+	effective, err = ruleManager.GetEffective(ctx, eventType, uuid.New())
+	require.NoError(t, err)
+	assert.Equal(t, site.ID, effective.ID)
+
+	rackID := uuid.New()
+	rack, err := ruleManager.Create(ctx, integrationCreate(eventType, "rack"))
+	require.NoError(t, err)
+	_, err = ruleManager.Bind(ctx, rack.ID, eventrule.Scope{
+		Type: eventrule.ScopeTypeRack,
+		ID:   rackID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, ruleManager.SetEnabled(ctx, rack.ID, true))
+
+	effective, err = ruleManager.GetEffective(ctx, eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, rack.ID, effective.ID)
+
+	require.NoError(t, ruleManager.SetEnabled(ctx, rack.ID, false))
+	effective, err = ruleManager.GetEffective(ctx, eventType, rackID)
+	require.NoError(t, err)
+	assert.Equal(t, site.ID, effective.ID)
+}
+
+func integrationCreate(eventType eventrule.Type, name string) eventrule.RuleCreate {
+	return eventrule.RuleCreate{
+		Metadata:  eventrule.RuleMetadata{Name: name},
+		EventType: eventType,
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+	}
+}
+
+func integrationRule(
+	id uuid.UUID,
+	origin eventrule.RuleOrigin,
+	eventType eventrule.Type,
+) *eventrule.Rule {
+	return &eventrule.Rule{
+		ID:        id,
+		Origin:    origin,
+		Name:      "built-in",
+		Enabled:   true,
+		EventType: eventType,
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+	}
+}

--- a/rest-api/flow/internal/eventrule/store/memory/store.go
+++ b/rest-api/flow/internal/eventrule/store/memory/store.go
@@ -1,0 +1,297 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package memory implements event-rule stores using versioned persistence
+// models held in memory.
+package memory
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+
+	converterdao "github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/dao"
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+)
+
+// Store implements rule and binding persistence over in-memory model records.
+type Store struct {
+	mu       sync.RWMutex
+	rules    map[uuid.UUID]dbmodel.EventRule
+	bindings map[uuid.UUID]dbmodel.EventRuleBinding
+	now      func() time.Time
+}
+
+// New constructs an empty in-memory store.
+func New() *Store {
+	return &Store{
+		rules:    make(map[uuid.UUID]dbmodel.EventRule),
+		bindings: make(map[uuid.UUID]dbmodel.EventRuleBinding),
+		now:      time.Now,
+	}
+}
+
+// GetByID returns one persisted rule.
+func (s *Store) GetByID(_ context.Context, id uuid.UUID) (*eventrule.Rule, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	persisted, ok := s.rules[id]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	return converterdao.EventRuleFrom(&persisted)
+}
+
+// List returns persisted rules matching the filter.
+func (s *Store) List(
+	_ context.Context,
+	filter eventrule.RuleFilter,
+) ([]*eventrule.Rule, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rules := make([]*eventrule.Rule, 0, len(s.rules))
+	for _, persisted := range s.rules {
+		rule, err := converterdao.EventRuleFrom(&persisted)
+		if err != nil {
+			return nil, err
+		}
+		if filter.Matches(rule) {
+			rules = append(rules, rule)
+		}
+	}
+	slices.SortFunc(rules, func(a, b *eventrule.Rule) int {
+		return cmp.Compare(a.ID.String(), b.ID.String())
+	})
+	return rules, nil
+}
+
+// Create stores a new persisted rule.
+func (s *Store) Create(
+	_ context.Context,
+	rule *eventrule.Rule,
+) (*eventrule.Rule, error) {
+	if rule == nil {
+		return nil, errors.New("event rule is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.rules[rule.ID]; ok {
+		return nil, fmt.Errorf("event rule %s already exists", rule.ID)
+	}
+	canonical := rule.Clone()
+	now := s.now().UTC()
+	canonical.CreatedAt = now
+	canonical.UpdatedAt = now
+	persisted, err := converterdao.EventRuleTo(&canonical)
+	if err != nil {
+		return nil, err
+	}
+	s.rules[canonical.ID] = *persisted
+	return &canonical, nil
+}
+
+// UpdateMetadata updates one persisted rule's metadata.
+func (s *Store) UpdateMetadata(
+	_ context.Context,
+	id uuid.UUID,
+	metadata eventrule.RuleMetadata,
+) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		rule.Name = metadata.Name
+		rule.Description = metadata.Description
+	})
+}
+
+// SetDedupe replaces or clears one persisted rule's deduplication policy.
+func (s *Store) SetDedupe(
+	_ context.Context,
+	id uuid.UUID,
+	dedupe *eventrule.Dedupe,
+) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		if dedupe == nil {
+			rule.Dedupe = nil
+			return
+		}
+		cloned := *dedupe
+		rule.Dedupe = &cloned
+	})
+}
+
+// ReplaceActions replaces all actions belonging to one persisted rule.
+func (s *Store) ReplaceActions(
+	_ context.Context,
+	id uuid.UUID,
+	actions []eventrule.Action,
+) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		rule.Actions = eventrule.CloneActions(actions)
+	})
+}
+
+// Delete atomically deletes a persisted rule and all of its bindings.
+func (s *Store) Delete(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.rules[id]; !ok {
+		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	bindingIDs := make([]uuid.UUID, 0)
+	for bindingID, persisted := range s.bindings {
+		if persisted.RuleID == id {
+			bindingIDs = append(bindingIDs, bindingID)
+		}
+	}
+	delete(s.rules, id)
+	for _, bindingID := range bindingIDs {
+		delete(s.bindings, bindingID)
+	}
+	return nil
+}
+
+// SetEnabled changes one persisted rule's enabled state.
+func (s *Store) SetEnabled(_ context.Context, id uuid.UUID, enabled bool) error {
+	return s.updateRule(id, func(rule *eventrule.Rule) {
+		rule.Enabled = enabled
+	})
+}
+
+// Bind stores a rule-to-scope association.
+func (s *Store) Bind(_ context.Context, binding eventrule.Binding) error {
+	if err := binding.Validate(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.bindings[binding.ID]; ok {
+		return fmt.Errorf("event rule binding %s already exists", binding.ID)
+	}
+
+	ruleRecord, ok := s.rules[binding.RuleID]
+	if !ok {
+		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, binding.RuleID)
+	}
+
+	if string(binding.EventType) != ruleRecord.EventType {
+		return fmt.Errorf(
+			"event rule binding event type %q does not match rule event type %q",
+			binding.EventType,
+			ruleRecord.EventType,
+		)
+	}
+
+	for _, persisted := range s.bindings {
+		if persisted.RuleID == binding.RuleID &&
+			persisted.ScopeType != string(binding.Scope.Type) {
+			return fmt.Errorf("event rule %s cannot mix site and rack bindings", binding.RuleID)
+		}
+
+		if bindingRecordMatchesScope(persisted, binding.EventType, binding.Scope) {
+			return fmt.Errorf(
+				"event type %q already has a binding for scope %q",
+				binding.EventType,
+				binding.Scope.Type,
+			)
+		}
+	}
+
+	now := s.now().UTC()
+	persisted, err := converterdao.EventRuleBindingTo(binding, now, now)
+	if err != nil {
+		return err
+	}
+	s.bindings[binding.ID] = *persisted
+	return nil
+}
+
+// Unbind deletes one binding.
+func (s *Store) Unbind(_ context.Context, id uuid.UUID) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.bindings[id]; !ok {
+		return fmt.Errorf("%w: binding %s", eventrule.ErrRuleNotFound, id)
+	}
+	delete(s.bindings, id)
+	return nil
+}
+
+// GetForScope returns the binding for an event type and scope.
+func (s *Store) GetForScope(
+	_ context.Context,
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+) (*eventrule.Binding, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, persisted := range s.bindings {
+		if bindingRecordMatchesScope(persisted, eventType, scope) {
+			return converterdao.EventRuleBindingFrom(&persisted)
+		}
+	}
+	return nil, nil
+}
+
+func bindingRecordMatchesScope(
+	binding dbmodel.EventRuleBinding,
+	eventType eventrule.Type,
+	scope eventrule.Scope,
+) bool {
+	if binding.EventType != string(eventType) ||
+		binding.ScopeType != string(scope.Type) {
+		return false
+	}
+
+	switch scope.Type {
+	case eventrule.ScopeTypeSite:
+		return binding.ScopeID == nil
+	case eventrule.ScopeTypeRack:
+		return binding.ScopeID != nil && *binding.ScopeID == scope.ID
+	default:
+		return false
+	}
+}
+
+func (s *Store) updateRule(id uuid.UUID, mutate func(*eventrule.Rule)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	persisted, ok := s.rules[id]
+	if !ok {
+		return fmt.Errorf("%w: %s", eventrule.ErrRuleNotFound, id)
+	}
+	rule, err := converterdao.EventRuleFrom(&persisted)
+	if err != nil {
+		return err
+	}
+	mutate(rule)
+	rule.UpdatedAt = s.now().UTC()
+	if err := rule.Validate(); err != nil {
+		return err
+	}
+	updated, err := converterdao.EventRuleTo(rule)
+	if err != nil {
+		return err
+	}
+	s.rules[id] = *updated
+	return nil
+}
+
+var (
+	_ eventrule.RuleStore    = (*Store)(nil)
+	_ eventrule.BindingStore = (*Store)(nil)
+)

--- a/rest-api/flow/internal/eventrule/store/memory/store_test.go
+++ b/rest-api/flow/internal/eventrule/store/memory/store_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	dbmodel "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/storetest"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreContract(t *testing.T) {
+	storetest.RunContract(t, func() (eventrule.RuleStore, eventrule.BindingStore) {
+		store := New()
+		return store, store
+	})
+}
+
+func TestBindingScansIgnoreUnrelatedInvalidRecords(t *testing.T) {
+	ctx := context.Background()
+	store := New()
+	invalidID := uuid.New()
+	store.bindings[invalidID] = dbmodel.EventRuleBinding{
+		ID:        invalidID,
+		RuleID:    uuid.New(),
+		EventType: "invalid",
+		ScopeType: "invalid",
+	}
+
+	rule, err := store.Create(ctx, &eventrule.Rule{
+		ID:        uuid.New(),
+		Origin:    eventrule.RuleOriginPersisted,
+		Name:      "test",
+		EventType: "test.event",
+		Policy: eventrule.Policy{Actions: []eventrule.Action{
+			eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+		}},
+	})
+	require.NoError(t, err)
+
+	scope := eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: uuid.New()}
+	binding := eventrule.Binding{
+		ID:        uuid.New(),
+		RuleID:    rule.ID,
+		EventType: rule.EventType,
+		Scope:     scope,
+	}
+	require.NoError(t, store.Bind(ctx, binding))
+
+	found, err := store.GetForScope(ctx, rule.EventType, scope)
+	require.NoError(t, err)
+	require.Equal(t, &binding, found)
+	require.NoError(t, store.Delete(ctx, rule.ID))
+}

--- a/rest-api/flow/internal/eventrule/store/storetest/contract.go
+++ b/rest-api/flow/internal/eventrule/store/storetest/contract.go
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package storetest contains reusable event-rule store contract tests.
+package storetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Factory constructs empty rule and binding stores that share one persistence
+// boundary.
+type Factory func() (eventrule.RuleStore, eventrule.BindingStore)
+
+// RunContract executes the shared rule and binding store contract.
+func RunContract(t *testing.T, factory Factory) {
+	t.Helper()
+	t.Run("rule lifecycle", func(t *testing.T) {
+		testRuleLifecycle(t, factory)
+	})
+	t.Run("binding invariants", func(t *testing.T) {
+		testBindingInvariants(t, factory)
+	})
+	t.Run("concurrent binding conflict", func(t *testing.T) {
+		testConcurrentBindingConflict(t, factory)
+	})
+	t.Run("delete cascades bindings", func(t *testing.T) {
+		testDeleteCascadesBindings(t, factory)
+	})
+}
+
+func testRuleLifecycle(t *testing.T, factory Factory) {
+	t.Helper()
+	ctx := context.Background()
+	rules, _ := factory()
+	rule := newRule("test.event")
+
+	created, err := rules.Create(ctx, rule)
+	require.NoError(t, err)
+	require.NotZero(t, created.CreatedAt)
+	assert.Equal(t, created.CreatedAt, created.UpdatedAt)
+	_, err = rules.Create(ctx, rule)
+	require.Error(t, err)
+
+	invalid := newRule("test.invalid")
+	invalid.Name = ""
+	_, err = rules.Create(ctx, invalid)
+	require.Error(t, err)
+	_, err = rules.GetByID(ctx, invalid.ID)
+	require.ErrorIs(t, err, eventrule.ErrRuleNotFound)
+
+	loaded, err := rules.GetByID(ctx, rule.ID)
+	require.NoError(t, err)
+	require.Equal(t, created, loaded)
+	loaded.Name = "caller mutation"
+	reloaded, err := rules.GetByID(ctx, rule.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "test", reloaded.Name)
+
+	require.NoError(t, rules.UpdateMetadata(ctx, rule.ID, eventrule.RuleMetadata{
+		Name:        "updated",
+		Description: "updated description",
+	}))
+	require.NoError(t, rules.SetDedupe(ctx, rule.ID, &eventrule.Dedupe{Window: time.Minute}))
+	require.NoError(t, rules.ReplaceActions(ctx, rule.ID, []eventrule.Action{
+		eventrule.NewAction("replacement", eventrule.ActionCondition{}, eventrule.Noop{}),
+	}))
+	require.NoError(t, rules.SetEnabled(ctx, rule.ID, true))
+
+	updated, err := rules.GetByID(ctx, rule.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated", updated.Name)
+	assert.Equal(t, "updated description", updated.Description)
+	assert.Equal(t, time.Minute, updated.Dedupe.Window)
+	assert.Equal(t, "replacement", updated.Actions[0].ID)
+	assert.True(t, updated.Enabled)
+	assert.False(t, updated.UpdatedAt.Before(updated.CreatedAt))
+
+	require.NoError(t, rules.SetDedupe(ctx, rule.ID, nil))
+	updated, err = rules.GetByID(ctx, rule.ID)
+	require.NoError(t, err)
+	assert.Nil(t, updated.Dedupe)
+
+	enabled := true
+	listed, err := rules.List(ctx, eventrule.RuleFilter{
+		EventType: &rule.EventType,
+		Enabled:   &enabled,
+	})
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, rule.ID, listed[0].ID)
+
+	require.NoError(t, rules.Delete(ctx, rule.ID))
+	_, err = rules.GetByID(ctx, rule.ID)
+	require.ErrorIs(t, err, eventrule.ErrRuleNotFound)
+
+	unknownID := uuid.New()
+	mutations := map[string]func() error{
+		"update metadata": func() error {
+			return rules.UpdateMetadata(
+				ctx,
+				unknownID,
+				eventrule.RuleMetadata{Name: "updated"},
+			)
+		},
+		"set dedupe": func() error {
+			return rules.SetDedupe(ctx, unknownID, nil)
+		},
+		"replace actions": func() error {
+			return rules.ReplaceActions(ctx, unknownID, []eventrule.Action{
+				eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+			})
+		},
+		"delete": func() error {
+			return rules.Delete(ctx, unknownID)
+		},
+		"set enabled": func() error {
+			return rules.SetEnabled(ctx, unknownID, true)
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run("unknown ID "+name, func(t *testing.T) {
+			require.ErrorIs(t, mutate(), eventrule.ErrRuleNotFound)
+		})
+	}
+}
+
+func testBindingInvariants(t *testing.T, factory Factory) {
+	t.Helper()
+	ctx := context.Background()
+	rules, bindings := factory()
+	first := createRule(t, ctx, rules, "test.event")
+	second := createRule(t, ctx, rules, "test.event")
+	rackID := uuid.New()
+	firstRack := newBinding(first, eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: rackID})
+	require.NoError(t, bindings.Bind(ctx, firstRack))
+
+	found, err := bindings.GetForScope(ctx, first.EventType, firstRack.Scope)
+	require.NoError(t, err)
+	require.Equal(t, &firstRack, found)
+
+	missing, err := bindings.GetForScope(
+		ctx,
+		first.EventType,
+		eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: uuid.New()},
+	)
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+
+	require.Error(t, bindings.Bind(ctx, newBinding(
+		second,
+		eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: rackID},
+	)))
+	require.Error(t, bindings.Bind(ctx, newBinding(
+		first,
+		eventrule.Scope{Type: eventrule.ScopeTypeSite},
+	)))
+
+	secondSite := newBinding(second, eventrule.Scope{Type: eventrule.ScopeTypeSite})
+	require.NoError(t, bindings.Bind(ctx, secondSite))
+	require.ErrorContains(t, bindings.Bind(ctx, newBinding(
+		second,
+		eventrule.Scope{Type: eventrule.ScopeTypeSite},
+	)), "already has a binding for scope")
+	require.ErrorContains(t, bindings.Bind(ctx, newBinding(
+		second,
+		eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: uuid.New()},
+	)), "cannot mix site and rack bindings")
+
+	mismatched := newBinding(first, eventrule.Scope{
+		Type: eventrule.ScopeTypeRack,
+		ID:   uuid.New(),
+	})
+	mismatched.EventType = "other.event"
+	require.Error(t, bindings.Bind(ctx, mismatched))
+
+	require.NoError(t, bindings.Unbind(ctx, firstRack.ID))
+	require.ErrorIs(
+		t,
+		bindings.Unbind(ctx, firstRack.ID),
+		eventrule.ErrRuleNotFound,
+	)
+	found, err = bindings.GetForScope(ctx, first.EventType, firstRack.Scope)
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+func testConcurrentBindingConflict(t *testing.T, factory Factory) {
+	t.Helper()
+	ctx := context.Background()
+	rules, bindings := factory()
+	first := createRule(t, ctx, rules, "test.event")
+	second := createRule(t, ctx, rules, "test.event")
+	scope := eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: uuid.New()}
+	candidates := []eventrule.Binding{
+		newBinding(first, scope),
+		newBinding(second, scope),
+	}
+
+	results := make(chan error, len(candidates))
+	for _, binding := range candidates {
+		go func() {
+			results <- bindings.Bind(ctx, binding)
+		}()
+	}
+
+	successes := 0
+	for range candidates {
+		if err := <-results; err == nil {
+			successes++
+		}
+	}
+	assert.Equal(t, 1, successes)
+}
+
+func testDeleteCascadesBindings(t *testing.T, factory Factory) {
+	t.Helper()
+	ctx := context.Background()
+	rules, bindings := factory()
+	rule := createRule(t, ctx, rules, "test.event")
+	scope := eventrule.Scope{Type: eventrule.ScopeTypeRack, ID: uuid.New()}
+	require.NoError(t, bindings.Bind(ctx, newBinding(rule, scope)))
+
+	require.NoError(t, rules.Delete(ctx, rule.ID))
+	found, err := bindings.GetForScope(ctx, rule.EventType, scope)
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+func createRule(
+	t *testing.T,
+	ctx context.Context,
+	store eventrule.RuleStore,
+	eventType eventrule.Type,
+) *eventrule.Rule {
+	t.Helper()
+	created, err := store.Create(ctx, newRule(eventType))
+	require.NoError(t, err)
+	return created
+}
+
+func newRule(eventType eventrule.Type) *eventrule.Rule {
+	return &eventrule.Rule{
+		ID:        uuid.New(),
+		Origin:    eventrule.RuleOriginPersisted,
+		Name:      "test",
+		EventType: eventType,
+		Policy: eventrule.Policy{
+			Actions: []eventrule.Action{
+				eventrule.NewAction("noop", eventrule.ActionCondition{}, eventrule.Noop{}),
+			},
+		},
+	}
+}
+
+func newBinding(rule *eventrule.Rule, scope eventrule.Scope) eventrule.Binding {
+	return eventrule.Binding{
+		ID:        uuid.New(),
+		RuleID:    rule.ID,
+		EventType: rule.EventType,
+		Scope:     scope,
+	}
+}

--- a/rest-api/flow/pkg/types/enums.go
+++ b/rest-api/flow/pkg/types/enums.go
@@ -22,6 +22,16 @@ const (
 	ComponentTypeCDU        ComponentType = "CDU"
 )
 
+// ParseComponentType converts a string into a validated ComponentType.
+func ParseComponentType(value string) (ComponentType, error) {
+	componentType := ComponentType(value)
+	if err := componentType.Validate(); err != nil {
+		return ComponentTypeUnknown, err
+	}
+
+	return componentType, nil
+}
+
 // Validate checks that the component type identifies a concrete supported type.
 func (ct ComponentType) Validate() error {
 	switch ct {

--- a/rest-api/flow/pkg/types/enums_test.go
+++ b/rest-api/flow/pkg/types/enums_test.go
@@ -9,6 +9,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseComponentType(t *testing.T) {
+	tests := map[string]struct {
+		value    string
+		expected ComponentType
+		wantErr  bool
+	}{
+		"compute": {value: "COMPUTE", expected: ComponentTypeCompute},
+		"cdu":     {value: "CDU", expected: ComponentTypeCDU},
+		"unknown": {value: "UNKNOWN", wantErr: true},
+		"invalid": {value: "GPU", wantErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual, err := ParseComponentType(test.value)
+			if test.wantErr {
+				require.Error(t, err)
+				require.Equal(t, ComponentTypeUnknown, actual)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
 func TestComponentTypeValidate(t *testing.T) {
 	tests := map[string]struct {
 		componentType ComponentType


### PR DESCRIPTION
Leakage detection currently polls NICo Core for leaking information and immediately
submits a force power-off task for each affected component. That is safe as an initial
behavior, but it hard-codes both detection and response in the leak detection job.

We need a pre-defined response at startup, while leaving room for users to define
their own rules later. And the mode should be reusable for other event families such as
thermal alarms, inventory drift, firmware health events, attestation failures, etc.

We plan to create event rules which decide what to do in response to an event.

This is the third PR with the following changes: 
- Add versioned policy codecs and DAO conversions for persisted event rules.
- Implement a concurrency-safe in-memory rule and binding store with reusable contract tests, binding invariants, cascade deletion, and manager integration coverage.

## Related issues

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

