### PR TITLE
fix(api-core): seed new site-config networks on subsequent API restarts

### DIFF
--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -142,23 +142,9 @@ pub async fn create_initial_networks(
             return Ok(());
         }
     };
-    reconcile_network_defs(&mut txn, networks).await?;
+    let to_create = reconcile_network_defs(&mut txn, networks).await?;
 
-    for (name, def) in networks {
-        if db::network_segment::find_by_name(&mut txn, name)
-            .await
-            .is_ok()
-        {
-            // Network segments are only created the first time we start carbide-api;
-            // `reconcile_network_defs` above has already recorded the snapshot if
-            // it was missing (the backfill path).
-            tracing::debug!(
-                network_segment_name = %name,
-                "Network segment exists",
-            );
-            continue;
-        }
-
+    for (name, def) in &to_create {
         let mut ns = NewNetworkSegment::build_from(name, domain_id, def)?;
         ns.can_stretch = Some(true);
         ns.vpc_id = if let Some(vpc_name) = &def.vpc_name {

--- a/crates/api-db/src/network_segment.rs
+++ b/crates/api-db/src/network_segment.rs
@@ -496,9 +496,9 @@ pub async fn segment_exists(txn: &mut PgConnection, name: &str) -> Result<bool, 
 
 /// Reconcile declared network definitions against what was previously seeded.
 ///
-///   1. **New** (no snapshot, no segment): no-op. The caller's
-///      segment-creation path is responsible for both creating the segment
-///      and writing the snapshot.
+///   1. **New** (no snapshot, no segment): returned to the caller for creation.
+///      The caller is responsible for creating the segment and writing the
+///      snapshot in the same transaction.
 ///   2. **Backfill** (no snapshot, segment present): record the snapshot,
 ///      linking it to the existing segment's id.
 ///   3. **In sync** (snapshot matches declaration): no-op.
@@ -508,18 +508,25 @@ pub async fn segment_exists(txn: &mut PgConnection, name: &str) -> Result<bool, 
 /// Networks that appear in the snapshot table but are no longer declared
 /// ("dropped" from `InitialObjectsConfig.networks`) are warned about, but
 /// not removed.
+///
+/// # Returns
+///
+/// Config-declared networks that have neither a segment row nor a snapshot,
+/// in unspecified order. The caller must create the segment and write the
+/// snapshot in the same transaction.
 pub async fn reconcile_network_defs(
     txn: &mut PgConnection,
     declared: &HashMap<String, NetworkDefinition>,
-) -> Result<(), DatabaseError> {
+) -> Result<Vec<(String, NetworkDefinition)>, DatabaseError> {
     let stored = all_stored_defs(&mut *txn).await?;
+    let mut to_create: Vec<(String, NetworkDefinition)> = Vec::new();
 
     for (name, def) in declared {
         let exists = segment_exists(&mut *txn, name).await?;
         match (stored.get(name), exists) {
-            // Already seeded with the current declaration
+            // Already seeded with the current declaration — nothing to do.
             (Some(stored_def), true) if stored_def == def => {}
-            // Declaration has drifted since seed. Warn don't reapply
+            // Declaration has drifted since seed; warn and leave both in place.
             (Some(stored_def), true) => {
                 tracing::warn!(
                     network_name = name,
@@ -561,10 +568,10 @@ pub async fn reconcile_network_defs(
                     );
                 }
             }
-            // New networks are seeded by the caller (`create_initial_networks`),
-            // which both expands the definition into a `NewNetworkSegment` and
-            // writes the snapshot in the same transaction.
-            (None, false) => {}
+            // No segment and no snapshot: return to the caller for creation.
+            (None, false) => {
+                to_create.push((name.clone(), def.clone()));
+            }
             (Some(_), false) => {
                 unreachable!("network_def.segment_id is FK; snapshot cannot outlive its segment")
             }
@@ -580,7 +587,7 @@ pub async fn reconcile_network_defs(
         }
     }
 
-    Ok(())
+    Ok(to_create)
 }
 pub async fn find_ids(
     txn: impl DbReader<'_>,
@@ -1253,11 +1260,10 @@ mod tests {
     }
 
     // A brand-new network is declared but no segment exists yet and no
-    // snapshot has been recorded.
-    // (`create_initial_networks`) is responsible for inserting both the
-    // segment and the snapshot in the same transaction.
+    // snapshot has been recorded. reconcile_network_defs must return it in
+    // the to-create list and leave all writes to the caller.
     #[crate::sqlx_test]
-    async fn test_reconcile_network_defs_brand_new_is_noop(
+    async fn test_reconcile_network_defs_brand_new_is_returned(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let def = NetworkDefinition {
@@ -1277,20 +1283,27 @@ mod tests {
             .into_iter()
             .collect();
 
-        reconcile_network_defs(&mut txn, &declared).await?;
+        let to_create = reconcile_network_defs(&mut txn, &declared).await?;
 
-        // Reconcile must not have written a snapshot for the brand-new entry.
+        // reconcile must not have written a snapshot for a brand-new network.
         let stored = stored_def(txn.as_mut(), "brand-new").await?;
         assert!(
             stored.is_none(),
-            "reconcile must leave brand-new networks alone; \
-             snapshot insertion is the caller's responsibility"
+            "reconcile must not write a snapshot for a brand-new network; \
+             that is the caller's responsibility"
         );
 
-        // And must not have created a network_segments row either.
+        // reconcile must not have created a network_segments row.
         assert!(
             !segment_exists(&mut txn, "brand-new").await?,
             "reconcile must not create a network_segments row for a brand-new network"
+        );
+
+        // reconcile must return the brand-new network so the caller can create it.
+        assert_eq!(
+            to_create,
+            vec![("brand-new".to_string(), def)],
+            "brand-new network must appear in the returned to-create list"
         );
 
         txn.rollback().await?;
@@ -1328,7 +1341,12 @@ mod tests {
         let mut txn = pool.begin().await?;
         let def = def("192.168.1.0/24", "192.168.1.1");
 
-        reconcile_network_defs(&mut txn, &declared_one("pre-existing", def.clone())).await?;
+        let to_create =
+            reconcile_network_defs(&mut txn, &declared_one("pre-existing", def.clone())).await?;
+        assert!(
+            to_create.is_empty(),
+            "this arm must not add networks to the to-create list"
+        );
 
         let stored = stored_def(txn.as_mut(), "pre-existing").await?;
         assert_eq!(stored.as_ref(), Some(&def), "snapshot must be backfilled");
@@ -1347,7 +1365,12 @@ mod tests {
         let def = def("192.168.1.0/24", "192.168.1.1");
         insert_network_def(&mut txn, "stable", segment_id, &def).await?;
 
-        reconcile_network_defs(&mut txn, &declared_one("stable", def.clone())).await?;
+        let to_create =
+            reconcile_network_defs(&mut txn, &declared_one("stable", def.clone())).await?;
+        assert!(
+            to_create.is_empty(),
+            "this arm must not add networks to the to-create list"
+        );
 
         let stored = stored_def(txn.as_mut(), "stable").await?;
         assert_eq!(
@@ -1373,7 +1396,12 @@ mod tests {
         let drifted = def("10.0.0.0/24", "10.0.0.1");
         insert_network_def(&mut txn, "drifty", segment_id, &original).await?;
 
-        reconcile_network_defs(&mut txn, &declared_one("drifty", drifted.clone())).await?;
+        let to_create =
+            reconcile_network_defs(&mut txn, &declared_one("drifty", drifted.clone())).await?;
+        assert!(
+            to_create.is_empty(),
+            "this arm must not add networks to the to-create list"
+        );
 
         let stored = stored_def(txn.as_mut(), "drifty").await?;
         assert_eq!(
@@ -1399,7 +1427,11 @@ mod tests {
         insert_network_def(&mut txn, "abandoned", segment_id, &def).await?;
 
         let empty: HashMap<String, NetworkDefinition> = HashMap::new();
-        reconcile_network_defs(&mut txn, &empty).await?;
+        let to_create = reconcile_network_defs(&mut txn, &empty).await?;
+        assert!(
+            to_create.is_empty(),
+            "this arm must not add networks to the to-create list"
+        );
 
         let stored = stored_def(txn.as_mut(), "abandoned").await?;
         assert_eq!(
@@ -1461,7 +1493,12 @@ mod tests {
         let mut txn = pool.begin().await?;
         let def = def("192.168.1.0/24", "192.168.1.1");
 
-        reconcile_network_defs(&mut txn, &declared_one("ambiguous", def.clone())).await?;
+        let to_create =
+            reconcile_network_defs(&mut txn, &declared_one("ambiguous", def.clone())).await?;
+        assert!(
+            to_create.is_empty(),
+            "this arm must not add networks to the to-create list"
+        );
 
         assert!(
             stored_def(txn.as_mut(), "ambiguous").await?.is_none(),


### PR DESCRIPTION
When networks are added to `site-config` after a site's initial API startup, they were silently ignored on every restart because `create_initial_networks` re-derived which networks needed creating via a per-segment `find_by_name` check that was never reached after the domain-count guard fired.

Move that decision into `reconcile_network_defs`, which already queries segment existence for drift detection. It now returns entries with no segment row so the caller iterates them directly, with no redundant round-trip. Networks added to the site config are created on the next API restart.

Also update the doc comment on `reconcile_network_defs` to reflect the new contract, and assert `to_create.is_empty()` in the in-sync, drift, and duplicate-name test arms.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4286

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


