### PR TITLE
refactor(secrets): stop reserving a pool connection for re-wrap

### DIFF
--- a/crates/api-core/src/handlers/secrets.rs
+++ b/crates/api-core/src/handlers/secrets.rs
@@ -52,6 +52,7 @@ pub(crate) async fn re_wrap_secrets(
 
     let result = crate::secrets::re_wrap_stale(
         &api.database_connection,
+        &api.work_lock_manager_handle,
         ctx.kms.as_ref(),
         &ctx.routing,
         batch_size,

--- a/crates/api-core/src/secrets/mod.rs
+++ b/crates/api-core/src/secrets/mod.rs
@@ -125,6 +125,9 @@ pub enum PgSecretsError {
     #[error("a re-wrap is already running")]
     ReWrapInProgress,
 
+    #[error("work lock error: {0}")]
+    AcquireLock(#[from] db::work_lock_manager::AcquireLockError),
+
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 

--- a/crates/api-core/src/secrets/re_wrap.rs
+++ b/crates/api-core/src/secrets/re_wrap.rs
@@ -17,16 +17,15 @@
 
 use carbide_kms_provider::{EncryptedDek, KmsBackend};
 use carbide_uuid::secret::SecretId;
+use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use sqlx::PgPool;
 
 use super::PgSecretsError;
 use super::routing::SecretRouting;
 
-/// The internal path whose advisory lock makes re-wrap single-flight. Like
-/// the import marker, it starts with a slash so it can never collide with
-/// a credential path -- but unlike the marker, no row is ever written for
-/// it; only its lock is used.
-const RE_WRAP_LOCK_PATH: &str = "/_re_wrap";
+// Replicas only contend when they name the same work, so keep this key stable
+// across releases.
+pub(super) const RE_WRAP_WORK_KEY: &str = "secrets::re_wrap_stale";
 
 /// What a re-wrap pass did, in journal rows.
 pub struct ReWrapStaleResult {
@@ -60,30 +59,26 @@ struct PendingReWrap {
 /// Historical journal entries are re-wrapped too: they must stay
 /// decryptable, and re-wrapping them is what lets an old KEK be retired
 /// completely.
-/// TODO(@chet): Migrate this to using WorkLockManager to do scoped locks of
-/// work without holding open a database connection or transaction.
-#[allow(txn_held_across_await)]
 pub async fn re_wrap_stale(
     pool: &PgPool,
+    work_lock_manager: &WorkLockManagerHandle,
     kms: &dyn KmsBackend,
     routing: &SecretRouting,
     batch_size: i64,
 ) -> Result<ReWrapStaleResult, PgSecretsError> {
-    // One re-wrap at a time: a second concurrent run would double every
-    // KMS round-trip for no benefit. The guard is a session advisory lock
-    // held on a dedicated connection, not a transaction -- the walk awaits
-    // Vault/KMS and opens a transaction per batch, and a lock transaction
-    // held across all of that would trip `txn_held_across_await` and could
-    // starve the pool. Detaching the connection guarantees the lock
-    // releases when it drops, including on an early error return.
-    let mut lock_conn = pool
-        .acquire()
+    // Keep the full walk single-flight without reserving another pool
+    // connection across KMS calls. A crashed owner can leave the key busy
+    // until the manager's lease expires.
+    let _work_lock = match work_lock_manager
+        .try_acquire_lock(RE_WRAP_WORK_KEY.into())
         .await
-        .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?
-        .detach();
-    if !db::secrets::try_lock_path_session(&mut lock_conn, RE_WRAP_LOCK_PATH).await? {
-        return Err(PgSecretsError::ReWrapInProgress);
-    }
+    {
+        Ok(lock) => lock,
+        Err(AcquireLockError::WorkAlreadyLocked(_)) => {
+            return Err(PgSecretsError::ReWrapInProgress);
+        }
+        Err(error) => return Err(error.into()),
+    };
 
     let mut result = ReWrapStaleResult {
         re_wrapped: 0,

--- a/crates/api-core/src/secrets/tests.rs
+++ b/crates/api-core/src/secrets/tests.rs
@@ -26,10 +26,12 @@ use carbide_kms_provider::{IntegratedKmsProvider, KmsBackend};
 use carbide_secrets::credentials::{
     CredentialKey, CredentialReader, CredentialWriter, Credentials,
 };
+use db::work_lock_manager::{self, WorkLockManagerHandle};
+use tokio::task::JoinSet;
 
-use super::PostgresCredentialManager;
-use super::re_wrap::re_wrap_stale;
+use super::re_wrap::{RE_WRAP_WORK_KEY, re_wrap_stale};
 use super::routing::SecretRouting;
+use super::{PgSecretsError, PostgresCredentialManager};
 
 fn test_key(seed: u8) -> [u8; 32] {
     let mut key = [0u8; 32];
@@ -58,6 +60,14 @@ fn manager(
     kms: Arc<dyn KmsBackend>,
 ) -> PostgresCredentialManager {
     PostgresCredentialManager::new(pool.clone(), routing, kms)
+}
+
+async fn start_test_work_lock_manager(pool: &sqlx::PgPool) -> (WorkLockManagerHandle, JoinSet<()>) {
+    let mut tasks = JoinSet::new();
+    let handle = work_lock_manager::start(&mut tasks, pool.clone(), Default::default())
+        .await
+        .expect("start work lock manager");
+    (handle, tasks)
 }
 
 fn ufm_key(fabric: &str) -> CredentialKey {
@@ -280,6 +290,7 @@ async fn ciphertext_copied_to_another_path_does_not_decrypt(pool: sqlx::PgPool) 
 #[crate::sqlx_test]
 async fn re_wrap_stale_moves_rows_and_is_idempotent(pool: sqlx::PgPool) {
     let kms = kms_with_keys(&[("old-key", 1), ("new-key", 2)]);
+    let (work_lock_manager, _work_lock_tasks) = start_test_work_lock_manager(&pool).await;
 
     // Write under old-key: two credentials, one with two journal entries.
     let mgr_old = manager(&pool, catch_all_routing("old-key"), kms.clone());
@@ -298,7 +309,7 @@ async fn re_wrap_stale_moves_rows_and_is_idempotent(pool: sqlx::PgPool) {
 
     // Rotate: routing now assigns new-key to everything.
     let routing = catch_all_routing("new-key");
-    let result = re_wrap_stale(&pool, kms.as_ref(), &routing, 2)
+    let result = re_wrap_stale(&pool, &work_lock_manager, kms.as_ref(), &routing, 2)
         .await
         .expect("re-wrap");
     assert_eq!(result.re_wrapped, 3);
@@ -334,7 +345,7 @@ async fn re_wrap_stale_moves_rows_and_is_idempotent(pool: sqlx::PgPool) {
     );
 
     // A second run reports everything current and changes nothing.
-    let again = re_wrap_stale(&pool, kms.as_ref(), &routing, 2)
+    let again = re_wrap_stale(&pool, &work_lock_manager, kms.as_ref(), &routing, 2)
         .await
         .expect("re-wrap again");
     assert_eq!(again.re_wrapped, 0);
@@ -347,6 +358,7 @@ async fn re_wrap_stale_moves_rows_and_is_idempotent(pool: sqlx::PgPool) {
 #[crate::sqlx_test]
 async fn re_wrap_stale_counts_each_row_once_across_routed_keks(pool: sqlx::PgPool) {
     let kms = kms_with_keys(&[("k1", 1), ("k2", 2)]);
+    let (work_lock_manager, _work_lock_tasks) = start_test_work_lock_manager(&pool).await;
 
     // Both paths start under k1.
     let routing_old = catch_all_routing("k1");
@@ -366,16 +378,47 @@ async fn re_wrap_stale_counts_each_row_once_across_routed_keks(pool: sqlx::PgPoo
         ("beta".to_string(), "k2".to_string()),
     ]);
 
-    let result = re_wrap_stale(&pool, kms.as_ref(), &routing_new, 1)
+    let result = re_wrap_stale(&pool, &work_lock_manager, kms.as_ref(), &routing_new, 1)
         .await
         .expect("re-wrap");
     assert_eq!(result.re_wrapped, 1, "only beta/two moved");
     assert_eq!(result.already_current, 1, "alpha/one was already routed");
     assert_eq!(result.stale_remaining, 0);
 
-    let again = re_wrap_stale(&pool, kms.as_ref(), &routing_new, 1)
+    let again = re_wrap_stale(&pool, &work_lock_manager, kms.as_ref(), &routing_new, 1)
         .await
         .expect("re-wrap again");
     assert_eq!(again.re_wrapped, 0);
     assert_eq!(again.already_current, 2);
+}
+
+// A second re-wrap reports contention while the shared work key is held. Once
+// the guard drops, the manager processes its release before this caller's
+// acquire and the next pass can start immediately.
+#[crate::sqlx_test]
+async fn re_wrap_stale_rejects_overlapping_run_and_releases_lock(pool: sqlx::PgPool) {
+    let kms = kms_with_keys(&[("k1", 1)]);
+    let routing = catch_all_routing("k1");
+    let (work_lock_manager, _work_lock_tasks) = start_test_work_lock_manager(&pool).await;
+
+    let lock = work_lock_manager
+        .try_acquire_lock(RE_WRAP_WORK_KEY.into())
+        .await
+        .expect("acquire re-wrap lock");
+    let error = re_wrap_stale(&pool, &work_lock_manager, kms.as_ref(), &routing, 1)
+        .await
+        .err()
+        .expect("an overlapping re-wrap must be rejected");
+    assert!(
+        matches!(&error, PgSecretsError::ReWrapInProgress),
+        "unexpected error: {error}"
+    );
+
+    drop(lock);
+    let result = re_wrap_stale(&pool, &work_lock_manager, kms.as_ref(), &routing, 1)
+        .await
+        .expect("re-wrap after lock release");
+    assert_eq!(result.re_wrapped, 0);
+    assert_eq!(result.already_current, 0);
+    assert_eq!(result.stale_remaining, 0);
 }

--- a/crates/api-db/src/secrets.rs
+++ b/crates/api-db/src/secrets.rs
@@ -116,24 +116,8 @@ pub async fn lock_path(txn: &mut PgTransaction<'_>, path: &str) -> DatabaseResul
 }
 
 /// Take the session-scoped advisory lock for a path on this connection,
-/// without waiting. Returns false when another session already holds it.
-///
-/// Unlike [`lock_path`], the lock outlives any single transaction and is
-/// held for as long as the connection stays open -- so a caller can guard
-/// a long operation without keeping a transaction open across its awaits.
-/// Release it with [`unlock_path_session`], or by dropping the connection.
-pub async fn try_lock_path_session(conn: &mut PgConnection, path: &str) -> DatabaseResult<bool> {
-    let sql = "SELECT pg_try_advisory_lock(hashtextextended('secrets:' || $1, 0))";
-    sqlx::query_scalar(sql)
-        .bind(path)
-        .fetch_one(conn)
-        .await
-        .map_err(|e| DatabaseError::query(sql, e))
-}
-
-/// Take the session-scoped advisory lock for a path on this connection,
-/// waiting until it is free. The same release rules as
-/// [`try_lock_path_session`] apply.
+/// waiting until it is free. The lock is held until
+/// [`unlock_path_session`] runs or the connection drops.
 pub async fn lock_path_session(conn: &mut PgConnection, path: &str) -> DatabaseResult<()> {
     let sql = "SELECT pg_advisory_lock(hashtextextended('secrets:' || $1, 0))";
     sqlx::query(sql)
@@ -144,9 +128,9 @@ pub async fn lock_path_session(conn: &mut PgConnection, path: &str) -> DatabaseR
     Ok(())
 }
 
-/// Release a session-scoped advisory lock taken by [`lock_path_session`] or
-/// [`try_lock_path_session`]. Dropping the connection releases it too, so
-/// this is only needed when the connection is kept for further work.
+/// Release a session-scoped advisory lock taken by [`lock_path_session`].
+/// Dropping the connection releases it too, so this is only needed when the
+/// connection is kept for further work.
 pub async fn unlock_path_session(conn: &mut PgConnection, path: &str) -> DatabaseResult<()> {
     let sql = "SELECT pg_advisory_unlock(hashtextextended('secrets:' || $1, 0))";
     sqlx::query(sql)


### PR DESCRIPTION
`re_wrap_stale` used a detached PostgreSQL connection to keep a session advisory lock alive for the full KEK walk. That reserved one pool slot through every KMS call even though each batch already finishes its KMS work before opening its short write transaction.

Now the existing `WorkLockManager` owns the single-flight guard, so re-wrap keeps its `ReWrapInProgress` behavior without checking out another connection.

Primary callouts are:

- Add the stable `secrets::re_wrap_stale` key and hold its `WorkLock` through the final stale-row count.
- Preserve `PgSecretsError::ReWrapInProgress` for contention while passing manager failures through the handler's internal-error path.
- Remove the now-unused nonblocking session advisory-lock helper; Vault import keeps its blocking session lock for the separate startup refactor.
- Exercise contention, queued release, immediate reacquisition, and the existing KEK-routing behavior against a real `WorkLockManager`.

A crashed owner can leave the work key busy until its lease expires. During the first mixed-version rollout, operators should also avoid invoking re-wrap because old replicas use the advisory lock while new replicas use `work_locks`.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4368

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `cargo test -p carbide-api-core secrets::tests::re_wrap_stale --lib -- --test-threads=1`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

The documentation that names the re-wrap advisory lock directly is intentionally split into a separate docs-only issue and PR.
