### PR TITLE
feat(dhcp-server): no-offer and NAK for ignored BMC MAC addresses

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -866,6 +866,20 @@ impl Forge for Api {
         Ok(crate::dhcp::discover::discover_dhcp(self, request).await?)
     }
 
+    async fn get_suppressed_dhcp_macs(
+        &self,
+        request: Request<rpc::GetSuppressedDhcpMacsRequest>,
+    ) -> Result<Response<rpc::GetSuppressedDhcpMacsResponse>, Status> {
+        crate::dhcp::ignored_macs::get_suppressed_dhcp_macs(self, request).await
+    }
+
+    async fn record_dhcp_discover_suppressed(
+        &self,
+        request: Request<rpc::RecordDhcpDiscoverSuppressedRequest>,
+    ) -> Result<Response<rpc::RecordDhcpDiscoverSuppressedResponse>, Status> {
+        crate::dhcp::ignored_macs::record_dhcp_discover_suppressed(self, request).await
+    }
+
     async fn expire_dhcp_lease(
         &self,
         request: Request<rpc::ExpireDhcpLeaseRequest>,

--- a/crates/api-core/src/dhcp/ignored_macs.rs
+++ b/crates/api-core/src/dhcp/ignored_macs.rs
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use ::rpc::forge as rpc;
+use mac_address::MacAddress;
+use std::str::FromStr;
+use tonic::{Request, Response, Status};
+
+use crate::CarbideError;
+use crate::api::Api;
+
+pub(crate) async fn get_suppressed_dhcp_macs(
+    api: &Api,
+    _request: Request<rpc::GetSuppressedDhcpMacsRequest>,
+) -> Result<Response<rpc::GetSuppressedDhcpMacsResponse>, Status> {
+    let pool = api.pg_pool();
+    let rows = db::ignored_bmc_mac::load_all(pool)
+        .await
+        .map_err(CarbideError::from)?;
+
+    let bmc_mac_addresses = rows
+        .into_iter()
+        .filter(|r| r.suppress_dhcp)
+        .map(|r| r.bmc_mac_address.to_string())
+        .collect();
+
+    Ok(Response::new(rpc::GetSuppressedDhcpMacsResponse {
+        bmc_mac_addresses,
+    }))
+}
+
+pub(crate) async fn record_dhcp_discover_suppressed(
+    api: &Api,
+    request: Request<rpc::RecordDhcpDiscoverSuppressedRequest>,
+) -> Result<Response<rpc::RecordDhcpDiscoverSuppressedResponse>, Status> {
+    let mac_str = request.into_inner().bmc_mac_address;
+    let mac = MacAddress::from_str(&mac_str).map_err(|e| {
+        Status::invalid_argument(format!("invalid bmc_mac_address {mac_str:?}: {e}"))
+    })?;
+
+    let mut txn = api.txn_begin().await?;
+    db::ignored_bmc_mac::record_dhcp_discover_suppressed(&mut txn, &mac)
+        .await
+        .map_err(CarbideError::from)?;
+    txn.commit().await?;
+
+    tracing::info!(bmc_mac_address = %mac, "Recorded DHCP discover suppressed");
+
+    Ok(Response::new(rpc::RecordDhcpDiscoverSuppressedResponse {}))
+}

--- a/crates/api-core/src/dhcp/mod.rs
+++ b/crates/api-core/src/dhcp/mod.rs
@@ -17,4 +17,5 @@
 
 pub mod discover;
 pub mod expire;
+pub mod ignored_macs;
 mod v6;

--- a/crates/dhcp-server/proto/dhcp_server_control.proto
+++ b/crates/dhcp-server/proto/dhcp_server_control.proto
@@ -33,6 +33,12 @@ service DhcpServerControl {
     // The gRPC server remains up to accept future requests.  The DHCP server
     // will be restarted automatically by the next UpdateAndReloadConfig call.
     rpc StopServer(StopServerRequest) returns (StopServerResponse);
+
+    // Invalidate the DHCP record cache and reload the suppressed-MAC set from
+    // the Core API.  This triggers a server restart so that (a) the LRU cache
+    // is cleared and (b) newly suppressed BMC MACs take effect immediately.
+    // Callers should invoke this after updating ignored_bmc_macs.suppress_dhcp.
+    rpc InvalidateDhcpCache(InvalidateDhcpCacheRequest) returns (InvalidateDhcpCacheResponse);
 }
 
 // ── UpdateAndReloadConfig ─────────────────────────────────────────────────────
@@ -107,3 +113,9 @@ message GetDhcpTimestampsResponse {
 message StopServerRequest {}
 
 message StopServerResponse {}
+
+// ── InvalidateDhcpCache ───────────────────────────────────────────────────────
+
+message InvalidateDhcpCacheRequest {}
+
+message InvalidateDhcpCacheResponse {}

--- a/crates/dhcp-server/src/errors.rs
+++ b/crates/dhcp-server/src/errors.rs
@@ -80,4 +80,7 @@ pub enum DhcpError {
 
     #[error("multiple interfaces are provided, but only 1 is supported: {0}")]
     MultipleInterfacesProvidedOneSupported(usize),
+
+    #[error("DHCPDISCOVER from ignored MAC {0}: no offer sent")]
+    SuppressedMacDiscover(String),
 }

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -33,7 +33,8 @@ pub mod proto {
 
 use proto::dhcp_server_control_server::{DhcpServerControl, DhcpServerControlServer};
 use proto::{
-    GetDhcpTimestampsRequest, GetDhcpTimestampsResponse, StopServerRequest, StopServerResponse,
+    GetDhcpTimestampsRequest, GetDhcpTimestampsResponse, InvalidateDhcpCacheRequest,
+    InvalidateDhcpCacheResponse, StopServerRequest, StopServerResponse,
     UpdateAndReloadConfigRequest, UpdateAndReloadConfigResponse,
 };
 
@@ -54,6 +55,10 @@ pub enum ControlRequest {
     /// Stop the DHCP server.  The gRPC control server stays up so that a
     /// subsequent UpdateAndReload can restart the DHCP server.
     Stop,
+    /// Force a server restart to clear the LRU DHCP record cache and reload
+    /// the suppressed-MAC set from the Core API.  Used after
+    /// `ignored_bmc_macs.suppress_dhcp` is updated for a BMC.
+    InvalidateCache,
 }
 
 // ── Proto → model conversions ─────────────────────────────────────────────────
@@ -189,6 +194,21 @@ impl DhcpServerControl for DhcpServerControlService {
 
         tracing::debug!("UpdateAndReloadConfig accepted");
         Ok(Response::new(UpdateAndReloadConfigResponse {}))
+    }
+
+    /// Forces a server restart so that the LRU DHCP record cache is cleared
+    /// and the suppressed-MAC set is reloaded from the Core API.
+    async fn invalidate_dhcp_cache(
+        &self,
+        _request: Request<InvalidateDhcpCacheRequest>,
+    ) -> Result<Response<InvalidateDhcpCacheResponse>, Status> {
+        self.ctrl_tx
+            .send(ControlRequest::InvalidateCache)
+            .await
+            .map_err(|_| Status::internal("control channel closed"))?;
+
+        tracing::info!("InvalidateDhcpCache accepted");
+        Ok(Response::new(InvalidateDhcpCacheResponse {}))
     }
 
     /// Stops the DHCP server without terminating the gRPC control server.

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -486,6 +486,13 @@ async fn run_with_grpc_control(
                             tracing::info!("StopServer: DHCP server was not running");
                         }
                     }
+                    ControlRequest::InvalidateCache => {
+                        tracing::info!("InvalidateCache: restarting DHCP server to clear cache and reload suppressed MACs");
+                        let (ct, h) =
+                            handle_reload(&args, cancel_token, dhcp_handle, true).await?;
+                        cancel_token = ct;
+                        dhcp_handle = h;
+                    }
                 }
             }
         }
@@ -569,6 +576,9 @@ pub struct Config {
     host_config: Option<HostConfig>, // Valid only for Dpu mode.
     relay_response_port: u16,
     forge_client_config: ForgeClientConfig,
+    /// BMC MAC addresses (formatted "aa:bb:cc:dd:ee:ff") with suppress_dhcp = true.
+    /// Loaded from the Core API on startup and on InvalidateDhcpCache.
+    suppressed_macs: std::collections::HashSet<String>,
 }
 
 async fn init(args: Args) -> Result<Config, DhcpError> {
@@ -583,11 +593,35 @@ async fn init(args: Args) -> Result<Config, DhcpError> {
         host_config = None;
     };
 
+    // Build a partial Config (without suppressed_macs) so we can pass it to
+    // get_suppressed_dhcp_macs, which needs the forge client config and API URL.
+    let partial_config = Config {
+        dhcp_config: dhcp_config.clone(),
+        host_config: host_config.clone(),
+        relay_response_port: args.relay_response_port,
+        forge_client_config: forge_client_config.clone(),
+        suppressed_macs: std::collections::HashSet::new(),
+    };
+
+    let suppressed_macs = match rpc::client::get_suppressed_dhcp_macs(&partial_config).await {
+        Ok(macs) => {
+            if !macs.is_empty() {
+                tracing::info!(count = macs.len(), "Loaded suppressed BMC MAC addresses");
+            }
+            macs
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to load suppressed MACs; starting with empty set");
+            std::collections::HashSet::new()
+        }
+    };
+
     Ok(Config {
         dhcp_config,
         host_config,
         relay_response_port: args.relay_response_port,
         forge_client_config,
+        suppressed_macs,
     })
 }
 

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -90,6 +90,7 @@ pub enum DropReason {
     NotMyPacket,
     VendorClassParseError,
     MultipleInterfaces,
+    SuppressedMac,
 }
 
 impl From<&DhcpError> for DropReason {
@@ -114,6 +115,7 @@ impl From<&DhcpError> for DropReason {
             DhcpError::NotMyPacket(_) => Self::NotMyPacket,
             DhcpError::VendorClassParseError(_) => Self::VendorClassParseError,
             DhcpError::MultipleInterfacesProvidedOneSupported(_) => Self::MultipleInterfaces,
+            DhcpError::SuppressedMacDiscover(_) => Self::SuppressedMac,
         }
     }
 }

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -279,6 +279,15 @@ pub async fn process_packet(
     decoded_packet.is_this_for_us(config)?;
 
     let msg_type = msg_type?;
+
+    // Check whether the client MAC is in the suppressed set before hitting the
+    // cache or the Core API.  The suppressed set is decommission-agnostic: the
+    // DHCP server only cares that suppress_dhcp is set, not why.
+    let mac_str = util::u8_to_mac(decoded_packet.packet.chaddr());
+    if config.suppressed_macs.contains(&mac_str) {
+        return handle_suppressed_mac(&decoded_packet, &mac_str, msg_type, config);
+    }
+
     let dhcp_response = handler
         .discover_dhcp(
             decoded_packet.get_discovery_request(handler, circuit_id),
@@ -514,6 +523,63 @@ fn create_dhcp_reply_packet(
         .insert(DhcpOption::VendorExtensions(vendor_option));
 
     Ok(msg)
+}
+
+/// Handle a packet from a MAC address whose `suppress_dhcp` flag is set.
+///
+/// - `DHCPDISCOVER`: return no-offer and fire-and-forget a call to record
+///   `dhcp_discover_suppressed_at` in the Core API.
+/// - `DHCPREQUEST`: return a NAK so the BMC client returns to INIT state.
+/// - Any other message type: drop silently.
+fn handle_suppressed_mac(
+    src: &DecodedPacket,
+    mac: &str,
+    msg_type: MessageType,
+    config: &Config,
+) -> Result<Packet, DhcpError> {
+    match msg_type {
+        MessageType::Discover => {
+            tracing::info!(mac, "Suppressed DHCPDISCOVER from ignored MAC: sending no-offer");
+            let mac_owned = mac.to_string();
+            let config_clone = config.clone();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    crate::rpc::client::record_dhcp_discover_suppressed(&mac_owned, &config_clone)
+                        .await
+                {
+                    tracing::warn!(
+                        mac = %mac_owned,
+                        error = %e,
+                        "Failed to record DHCP discover suppression in Core API"
+                    );
+                }
+            });
+            Err(DhcpError::SuppressedMacDiscover(mac.to_string()))
+        }
+        MessageType::Request => {
+            tracing::info!(mac, "Suppressed DHCPREQUEST from ignored MAC: sending NAK");
+            let msg = nak_packet(
+                src,
+                config.dhcp_config.carbide_provisioning_server_ipv4,
+                config.dhcp_config.carbide_dhcp_server,
+            )?;
+            let (dst_address, dst_port) =
+                src.decide_dst_ip(msg_type, config.relay_response_port);
+            let mut encoded_packet = Vec::new();
+            let mut e = Encoder::new(&mut encoded_packet);
+            msg.encode(&mut e)?;
+            Ok(Packet {
+                encoded_packet,
+                dst_address,
+                dst_port,
+                message_type: crate::metrics::MessageTypeLabel::Nak,
+            })
+        }
+        _ => {
+            tracing::debug!(mac, ?msg_type, "Dropping packet from ignored MAC");
+            Err(DhcpError::SuppressedMacDiscover(mac.to_string()))
+        }
+    }
 }
 
 fn nak_packet(

--- a/crates/dhcp-server/src/rpc/client.rs
+++ b/crates/dhcp-server/src/rpc/client.rs
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use rpc::forge::{DhcpDiscovery, DhcpRecord};
+use std::collections::HashSet;
+
+use rpc::forge::{DhcpDiscovery, DhcpRecord, GetSuppressedDhcpMacsRequest, RecordDhcpDiscoverSuppressedRequest};
 use rpc::forge_tls_client::{ApiConfig, ForgeTlsClient};
 
 use crate::Config;
@@ -39,4 +41,52 @@ pub async fn discover_dhcp(
     let request = tonic::Request::new(discovery_request);
 
     Ok(client.discover_dhcp(request).await?.into_inner())
+}
+
+/// Load the set of BMC MAC addresses that have `suppress_dhcp = true`.
+/// Called on server startup and on `InvalidateDhcpCache` to rebuild the
+/// in-memory suppression set.
+pub async fn get_suppressed_dhcp_macs(config: &Config) -> Result<HashSet<String>, DhcpError> {
+    let Some(carbide_api_url) = &config.dhcp_config.carbide_api_url else {
+        return Ok(HashSet::new());
+    };
+
+    let api_config = ApiConfig::new(carbide_api_url, &config.forge_client_config);
+    let mut client = ForgeTlsClient::retry_build(&api_config)
+        .await
+        .map_err(|e| DhcpError::GenericError(e.to_string()))?;
+
+    let response = client
+        .get_suppressed_dhcp_macs(tonic::Request::new(GetSuppressedDhcpMacsRequest {}))
+        .await?
+        .into_inner();
+
+    Ok(response.bmc_mac_addresses.into_iter().collect())
+}
+
+/// Notify the Core API that a DHCPDISCOVER from `mac` was suppressed.
+/// The Core API writes `dhcp_discover_suppressed_at` in `ignored_bmc_macs`.
+/// This is fire-and-forget: errors are logged but do not affect packet handling.
+pub async fn record_dhcp_discover_suppressed(
+    mac: &str,
+    config: &Config,
+) -> Result<(), DhcpError> {
+    let Some(carbide_api_url) = &config.dhcp_config.carbide_api_url else {
+        return Ok(());
+    };
+
+    let api_config = ApiConfig::new(carbide_api_url, &config.forge_client_config);
+    let mut client = ForgeTlsClient::retry_build(&api_config)
+        .await
+        .map_err(|e| DhcpError::GenericError(e.to_string()))?;
+
+    client
+        .record_dhcp_discover_suppressed(tonic::Request::new(
+            RecordDhcpDiscoverSuppressedRequest {
+                bmc_mac_address: mac.to_string(),
+            },
+        ))
+        .await?;
+
+    Ok(())
 }

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -221,6 +221,17 @@ service Forge {
   rpc DiscoverDhcp(DhcpDiscovery) returns (DhcpRecord);
   rpc ExpireDhcpLease(ExpireDhcpLeaseRequest) returns (ExpireDhcpLeaseResponse);
 
+  // GetSuppressedDhcpMacs returns the MAC addresses of all BMCs whose DHCP
+  // traffic should be suppressed (suppress_dhcp = true in ignored_bmc_macs).
+  // The DHCP server calls this on startup and after an InvalidateDhcpCache
+  // control request to rebuild its in-memory suppression set.
+  rpc GetSuppressedDhcpMacs(GetSuppressedDhcpMacsRequest) returns (GetSuppressedDhcpMacsResponse);
+
+  // RecordDhcpDiscoverSuppressed is called by the DHCP server when it drops a
+  // DHCPDISCOVER from a suppressed MAC, proving the BMC DHCP client has
+  // returned to the INIT state.  Only the DHCP server should call this RPC.
+  rpc RecordDhcpDiscoverSuppressed(RecordDhcpDiscoverSuppressedRequest) returns (RecordDhcpDiscoverSuppressedResponse);
+
   rpc AssignStaticAddress(AssignStaticAddressRequest) returns (AssignStaticAddressResponse);
   rpc RemoveStaticAddress(RemoveStaticAddressRequest) returns (RemoveStaticAddressResponse);
   rpc FindInterfaceAddresses(FindInterfaceAddressesRequest) returns (FindInterfaceAddressesResponse);
@@ -4232,6 +4243,21 @@ enum MessageKind {
   // DHCPv6 Information-request. Requires ADDRESS_FAMILY_V6 and a non-empty duid.
   MESSAGE_KIND_V6_INFO_REQUEST = 4;
 }
+
+message GetSuppressedDhcpMacsRequest {}
+
+message GetSuppressedDhcpMacsResponse {
+  // MAC addresses (formatted as "aa:bb:cc:dd:ee:ff") of BMCs with
+  // suppress_dhcp = true in ignored_bmc_macs.
+  repeated string bmc_mac_addresses = 1;
+}
+
+message RecordDhcpDiscoverSuppressedRequest {
+  // MAC address of the BMC whose DHCPDISCOVER was suppressed.
+  string bmc_mac_address = 1;
+}
+
+message RecordDhcpDiscoverSuppressedResponse {}
 
 message ExpireDhcpLeaseRequest {
   string ip_address = 1;


### PR DESCRIPTION
When a BMC MAC has suppress_dhcp = true in ignored_bmc_macs, the DHCP server now responds as follows without consulting the cache or Core API:

  DHCPDISCOVER → no-offer; fires RecordDhcpDiscoverSuppressed to write
                 dhcp_discover_suppressed_at in the Core API (the
                 acknowledgement the decommission controller waits for)
  DHCPREQUEST  → DHCPNAK, forcing the BMC client back to INIT state

The suppressed-MAC set is loaded from the Core API on server startup via the new GetSuppressedDhcpMacs RPC and reloaded on InvalidateDhcpCache, a new dhcp_server_control gRPC call that triggers a server restart to clear the LRU record cache and pick up updated suppression state.

The DHCP server is decommission-agnostic: it reads only the suppress_dhcp flag and does not know why a MAC is suppressed.

Closes #3816