### PR TITLE
feat(rack): optional firmware object to support FW update on ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,6 +2828,7 @@ dependencies = [
  "librms",
  "mac_address",
  "opentelemetry 0.32.0",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sqlx",

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -336,12 +336,6 @@ and `failure_retry_time` knobs:
 Defaults are reasonable; touch these only when you have a specific timing
 constraint.
 
-The optional `[rack_profiles.<name>.firmware_object]` block enables firmware
-update during ingestion for that rack profile. Its `url` selects the SOT JSON
-document and `fetch_timeout` defaults to `30s`. Missing blocks skip firmware
-update. Fetch, HTTP status, and JSON validation errors leave the rack at
-`FirmwareUpgrade(Start)` for retry.
-
 ### Host health thresholds
 
 `[host_health]` — `hardware_health_reports = "MonitorOnly"` or `"Enforce"`,
@@ -993,12 +987,12 @@ images plus version constraints). The state controller picks the right
 images when a machine in the model joins. See
 [`crates/api-core/src/cfg/README.md` → host_models](../../../crates/api-core/src/cfg/README.md#hostmodelsfirmware).
 
-### Rack-ingestion firmware object — `[rack_profiles.<name>]`
+### Rack profile firmware object: `[rack_profiles.<name>]`
 
-Each rack profile may define a `firmware_object` block containing one rack-wide
-SOT JSON `url` and a fetch timeout. Core validates the URL during configuration
-parsing. During ingestion, the existing rack firmware request applies that
-document to the profile's discovered compute and switch inventory.
+A rack profile can define a `firmware_object` block for one firmware-object JSON
+document. NICo uses the document as the default firmware input during rack
+ingestion. The block contains a `url` and an optional `fetch_timeout`, which
+defaults to `30s`.
 
 ---
 

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -336,6 +336,12 @@ and `failure_retry_time` knobs:
 Defaults are reasonable; touch these only when you have a specific timing
 constraint.
 
+The optional `[rack_profiles.<name>.firmware_object]` block enables firmware
+update during ingestion for that rack profile. Its `url` selects the SOT JSON
+document and `fetch_timeout` defaults to `30s`. Missing blocks skip firmware
+update. Fetch, HTTP status, and JSON validation errors leave the rack at
+`FirmwareUpgrade(Start)` for retry.
+
 ### Host health thresholds
 
 `[host_health]` — `hardware_health_reports = "MonitorOnly"` or `"Enforce"`,
@@ -986,6 +992,13 @@ Maps a host model identifier to a Firmware definition (BMC, UEFI, NIC
 images plus version constraints). The state controller picks the right
 images when a machine in the model joins. See
 [`crates/api-core/src/cfg/README.md` → host_models](../../../crates/api-core/src/cfg/README.md#hostmodelsfirmware).
+
+### Rack-ingestion firmware object — `[rack_profiles.<name>]`
+
+Each rack profile may define a `firmware_object` block containing one rack-wide
+SOT JSON `url` and a fetch timeout. Core validates the URL during configuration
+parsing. During ingestion, the existing rack firmware request applies that
+document to the profile's discovered compute and switch inventory.
 
 ---
 

--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -992,7 +992,9 @@ images when a machine in the model joins. See
 A rack profile can define a `firmware_object` block for one firmware-object JSON
 document. NICo uses the document as the default firmware input during rack
 ingestion. The block contains a `url` and an optional `fetch_timeout`, which
-defaults to `30s`.
+accepts duration strings such as `30s` and `60s` and defaults to `30s`. Use
+seconds for this request timeout, although the parser accepts other duration
+units such as milliseconds (`ms`), minutes (`m`), and hours (`h`).
 
 ---
 

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -488,7 +488,12 @@ mod tests {
         else {
             panic!("switch command should build a switch target");
         };
-        assert_eq!(target.switch_ids.expect("switch IDs").ids.len(), 1);
+
+        let switch_ids = target.switch_ids.expect("switch IDs");
+
+        assert_eq!(switch_ids.ids.len(), 1);
+        assert_eq!(switch_ids.ids[0].to_string(), SWITCH_ID);
+
         assert_eq!(
             target.components,
             [
@@ -523,10 +528,12 @@ mod tests {
         else {
             panic!("compute-tray command should build a compute-tray target");
         };
-        assert_eq!(
-            target.machine_ids.expect("machine IDs").machine_ids.len(),
-            1
-        );
+
+        let machine_ids = target.machine_ids.expect("machine IDs");
+
+        assert_eq!(machine_ids.machine_ids.len(), 1);
+        assert_eq!(machine_ids.machine_ids[0].to_string(), MACHINE_ID);
+
         assert_eq!(
             target.components,
             [
@@ -561,10 +568,12 @@ mod tests {
         else {
             panic!("power-shelf command should build a power-shelf target");
         };
-        assert_eq!(
-            target.power_shelf_ids.expect("power shelf IDs").ids.len(),
-            1
-        );
+
+        let power_shelf_ids = target.power_shelf_ids.expect("power shelf IDs");
+
+        assert_eq!(power_shelf_ids.ids.len(), 1);
+        assert_eq!(power_shelf_ids.ids[0].to_string(), POWER_SHELF_ID);
+
         assert_eq!(
             target.components,
             [
@@ -598,7 +607,11 @@ mod tests {
         else {
             panic!("rack command should build a rack target");
         };
-        assert_eq!(target.rack_ids.expect("rack IDs").rack_ids.len(), 1);
+
+        let rack_ids = target.rack_ids.expect("rack IDs");
+
+        assert_eq!(rack_ids.rack_ids.len(), 1);
+        assert_eq!(rack_ids.rack_ids[0].to_string(), RACK_ID);
 
         let _ = std::fs::remove_file(sot_json);
     }

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -405,6 +405,30 @@ mod tests {
 
         scenarios!(
             run = |source| resolve_firmware_source(source).map_err(drop);
+            "both firmware sources are rejected" {
+                FirmwareSourceArgs {
+                    target_version: Some("fw-1.0".to_string()),
+                    sot_json_file: Some(invalid_json.clone()),
+                    access_token: None,
+                } => Fails,
+            }
+
+            "a missing firmware source is rejected" {
+                FirmwareSourceArgs {
+                    target_version: None,
+                    sot_json_file: None,
+                    access_token: None,
+                } => Fails,
+            }
+
+            "an empty target version is rejected" {
+                FirmwareSourceArgs {
+                    target_version: Some(" ".to_string()),
+                    sot_json_file: None,
+                    access_token: None,
+                } => Fails,
+            }
+
             "access token without a SOT JSON file" {
                 FirmwareSourceArgs {
                     target_version: Some("fw-1.0".to_string()),
@@ -423,5 +447,159 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(invalid_json);
+    }
+
+    #[test]
+    fn update_firmware_commands_build_requests_for_every_target() {
+        const CONFIG_JSON: &str = r#"{"Id":"fw-object","Version":"1.2.3"}"#;
+        const MACHINE_ID: &str = "fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg";
+        const POWER_SHELF_ID: &str = "ps100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0";
+        const RACK_ID: &str = "rack-test";
+        const SWITCH_ID: &str = "sw100ntjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0";
+
+        let sot_json = temp_sot_file(CONFIG_JSON);
+        let sot_json = sot_json.to_str().expect("temporary path is UTF-8");
+
+        let switch_request = rpc::forge::UpdateComponentFirmwareRequest::try_from(
+            Args::try_parse_from([
+                "update-firmware",
+                "switch",
+                "--switch-id",
+                SWITCH_ID,
+                "--sot-json-file",
+                sot_json,
+                "--access-token",
+                "token",
+                "--component",
+                "bmc,nvos",
+                "--force-update",
+                "--bypass-state-controller",
+            ])
+            .expect("switch command should parse"),
+        )
+        .expect("switch command should build a request");
+
+        assert_eq!(switch_request.target_version, CONFIG_JSON);
+        assert_eq!(switch_request.access_token.as_deref(), Some("token"));
+        assert!(switch_request.force_update);
+        assert!(switch_request.bypass_state_controller);
+        let Some(rpc::forge::update_component_firmware_request::Target::Switches(target)) =
+            switch_request.target
+        else {
+            panic!("switch command should build a switch target");
+        };
+        assert_eq!(target.switch_ids.expect("switch IDs").ids.len(), 1);
+        assert_eq!(
+            target.components,
+            [
+                rpc::forge::NvSwitchComponent::Bmc as i32,
+                rpc::forge::NvSwitchComponent::Nvos as i32,
+            ]
+        );
+
+        let compute_request = rpc::forge::UpdateComponentFirmwareRequest::try_from(
+            Args::try_parse_from([
+                "update-firmware",
+                "compute-tray",
+                "--machine-id",
+                MACHINE_ID,
+                "--target-version",
+                "fw-1.2.3",
+                "--component",
+                "bmc,bios",
+                "--force-update",
+                "--bypass-state-controller",
+            ])
+            .expect("compute-tray command should parse"),
+        )
+        .expect("compute-tray command should build a request");
+
+        assert_eq!(compute_request.target_version, "fw-1.2.3");
+        assert_eq!(compute_request.access_token, None);
+        assert!(compute_request.force_update);
+        assert!(compute_request.bypass_state_controller);
+        let Some(rpc::forge::update_component_firmware_request::Target::ComputeTrays(target)) =
+            compute_request.target
+        else {
+            panic!("compute-tray command should build a compute-tray target");
+        };
+        assert_eq!(
+            target.machine_ids.expect("machine IDs").machine_ids.len(),
+            1
+        );
+        assert_eq!(
+            target.components,
+            [
+                rpc::forge::ComputeTrayComponent::Bmc as i32,
+                rpc::forge::ComputeTrayComponent::Bios as i32,
+            ]
+        );
+
+        let power_shelf_request = rpc::forge::UpdateComponentFirmwareRequest::try_from(
+            Args::try_parse_from([
+                "update-firmware",
+                "power-shelf",
+                "--power-shelf-id",
+                POWER_SHELF_ID,
+                "--target-version",
+                "fw-1.2.3",
+                "--component",
+                "pmc,psu",
+                "--force-update",
+                "--bypass-state-controller",
+            ])
+            .expect("power-shelf command should parse"),
+        )
+        .expect("power-shelf command should build a request");
+
+        assert_eq!(power_shelf_request.target_version, "fw-1.2.3");
+        assert_eq!(power_shelf_request.access_token, None);
+        assert!(power_shelf_request.force_update);
+        assert!(power_shelf_request.bypass_state_controller);
+        let Some(rpc::forge::update_component_firmware_request::Target::PowerShelves(target)) =
+            power_shelf_request.target
+        else {
+            panic!("power-shelf command should build a power-shelf target");
+        };
+        assert_eq!(
+            target.power_shelf_ids.expect("power shelf IDs").ids.len(),
+            1
+        );
+        assert_eq!(
+            target.components,
+            [
+                rpc::forge::PowerShelfComponent::Pmc as i32,
+                rpc::forge::PowerShelfComponent::Psu as i32,
+            ]
+        );
+
+        let rack_request = rpc::forge::UpdateComponentFirmwareRequest::try_from(
+            Args::try_parse_from([
+                "update-firmware",
+                "rack",
+                "--rack-id",
+                RACK_ID,
+                "--sot-json-file",
+                sot_json,
+                "--access-token",
+                "token",
+                "--force-update",
+            ])
+            .expect("rack command should parse"),
+        )
+        .expect("rack command should build a request");
+
+        assert_eq!(rack_request.target_version, CONFIG_JSON);
+        assert_eq!(rack_request.access_token.as_deref(), Some("token"));
+        assert!(rack_request.force_update);
+        assert!(!rack_request.bypass_state_controller);
+        let Some(rpc::forge::update_component_firmware_request::Target::Racks(target)) =
+            rack_request.target
+        else {
+            panic!("rack command should build a rack target");
+        };
+        assert_eq!(target.rack_ids.expect("rack IDs").rack_ids.len(), 1);
+
+        let _ = std::fs::remove_file(sot_json);
     }
 }

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -181,7 +181,7 @@ product_family = "gb200"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
 
 [rack_profiles.NVL72.firmware_object]
-url = "https://firmware.example.com/sot/nvl72.json"
+url = "https://firmware.example.com/objects/nvl72.json"
 fetch_timeout = "30s"
 
 [rack_profiles.NVL72.rack_capabilities.compute]

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -58,11 +58,11 @@ applicable.
 | `vpc_prefix_state_controller` | `VpcPrefixStateControllerConfig` | *(see below)* | `networking` | VPC prefix state controller timing. |
 | `ib_partition_state_controller` | `IbPartitionStateControllerConfig` | *(see below)* | `hardware` | IB partition state controller timing. |
 | `dpa_interface_state_controller` | `DpaInterfaceStateControllerConfig` | *(see below)* | `networking` | DPA interface state controller timing. |
-| `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | `hardware` | Rack state controller timing. |
+| `rack_state_controller` | `RackStateControllerConfig` | *(see below)* | `hardware` | Rack state controller timing and optional firmware update during ingestion. |
 | `power_shelf_state_controller` | `PowerShelfStateControllerConfig` | *(see below)* | `hardware` | Power shelf state controller timing and optional rack firmware reprovisioning. |
 | `switch_state_controller` | `SwitchStateControllerConfig` | *(see below)* | `hardware` | Switch state controller timing. |
 | `spdm_state_controller` | `SpdmStateControllerConfig` | *(see below)* | `security` | SPDM state controller timing. |
-| `host_models` | `HashMap<String, Firmware>` | `{}` | `machines` | Maps host model identifiers to firmware definitions for BMC/UEFI/NIC upgrades. |
+| `host_models` | `HashMap<String, Firmware>` | `{}` | `machines` | Maps host model identifiers to firmware definitions. |
 | `firmware_global` | `FirmwareGlobal` | *(see below)* | `machines` | Global firmware update settings (see [FirmwareGlobal](#firmwareglobal)). |
 | `machine_updater` | `MachineUpdater` | *(see below)* | `machines` | Machine update policies (see [MachineUpdater](#machineupdater)). |
 | `max_find_by_ids` | `u32` | `100` | `server` | Max IDs accepted by `find_*_by_ids` APIs. |
@@ -179,6 +179,10 @@ power_shelf_backend = "rms"
 [rack_profiles.NVL72]
 product_family = "gb200"
 rack_hardware_topology = "gb200_nvl72r1_c2g4_topology"
+
+[rack_profiles.NVL72.firmware_object]
+url = "https://firmware.example.com/sot/nvl72.json"
+fetch_timeout = "30s"
 
 [rack_profiles.NVL72.rack_capabilities.compute]
 vendor = "NVIDIA"

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -4484,6 +4484,27 @@ mod tests {
         for (_, entry) in config.host_models.iter() {
             assert_eq!(entry.vendor, bmc_vendor::BMCVendor::Dell);
         }
+
+        assert_eq!(
+            config
+                .rack_profiles
+                .rack_profiles
+                .get("NVL72")
+                .and_then(|profile| profile.firmware_object.as_ref())
+                .map(|firmware_object| firmware_object.url.as_str()),
+            Some("https://firmware.example.invalid/sot/nvl72.json")
+        );
+
+        assert_eq!(
+            config
+                .rack_profiles
+                .rack_profiles
+                .get("NVL72")
+                .and_then(|profile| profile.firmware_object.as_ref())
+                .map(|firmware_object| firmware_object.fetch_timeout),
+            Some(std::time::Duration::from_secs(45))
+        );
+
         assert_eq!(config.firmware_global.max_uploads, 3);
         assert_eq!(config.firmware_global.run_interval, Duration::seconds(20));
         assert_eq!(config.firmware_global.max_concurrent_bfb_copies, 7);

--- a/crates/api-core/src/cfg/test_data/full_config.toml
+++ b/crates/api-core/src/cfg/test_data/full_config.toml
@@ -218,6 +218,10 @@ OperatingModes_ChooseOperatingMode = "MinimalPower"
 [rack_profiles.NVL72]
 product_family = "gb200"
 
+[rack_profiles.NVL72.firmware_object]
+url = "https://firmware.example.invalid/sot/nvl72.json"
+fetch_timeout = "45s"
+
 [rack_profiles.NVL72.rack_capabilities.compute]
 name = "GB200"
 count = 18

--- a/crates/api-core/src/cfg/test_data/full_config_post_migration.toml
+++ b/crates/api-core/src/cfg/test_data/full_config_post_migration.toml
@@ -171,6 +171,10 @@ OperatingModes_ChooseOperatingMode = "MinimalPower"
 [rack_profiles.NVL72]
 product_family = "gb200"
 
+[rack_profiles.NVL72.firmware_object]
+url = "https://firmware.example.invalid/sot/nvl72.json"
+fetch_timeout = "45s"
+
 [rack_profiles.NVL72.rack_capabilities.compute]
 name = "GB200"
 count = 18

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1530,6 +1530,7 @@ async fn initialize_and_start_controllers<'a>(
                 nmx_cluster_switch_mtls_services: carbide_config
                     .rack_state_controller
                     .effective_nmx_cluster_switch_mtls_services_as_i32(),
+                firmware_object_fetcher: Arc::new(reqwest::Client::new()),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
             }
             .into(),

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1510,6 +1510,21 @@ async fn initialize_and_start_controllers<'a>(
         .build_and_spawn(join_set, cancel_token.clone())
         .expect("Unable to build PowerShelfStateController");
 
+    let default_redirect_policy = reqwest::redirect::Policy::default();
+
+    let firmware_object_fetcher = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            let initial_origin = attempt.previous().first().map(reqwest::Url::origin);
+
+            if initial_origin == Some(attempt.url().origin()) {
+                default_redirect_policy.redirect(attempt)
+            } else {
+                attempt.error("firmware-object redirect changed the configured origin")
+            }
+        }))
+        .build()
+        .wrap_err("failed to build the firmware-object HTTP client")?;
+
     StateController::<RackStateControllerIO>::builder()
         .database(db_pool.clone(), work_lock_manager_handle.clone())
         .meter("carbide_racks", meter.clone())
@@ -1530,7 +1545,7 @@ async fn initialize_and_start_controllers<'a>(
                 nmx_cluster_switch_mtls_services: carbide_config
                     .rack_state_controller
                     .effective_nmx_cluster_switch_mtls_services_as_i32(),
-                firmware_object_fetcher: Arc::new(reqwest::Client::new()),
+                firmware_object_fetcher: Arc::new(firmware_object_fetcher),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
             }
             .into(),
@@ -1730,7 +1745,7 @@ mod tests {
 
     use carbide_network::virtualization::VpcVirtualizationType;
     use carbide_test_support::Outcome::{FailsWith, Yields};
-    use carbide_test_support::{Case, check_cases, scenarios};
+    use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
     use figment::Figment;
     use figment::providers::{Format, Toml};
     use model::expected_machine::HostDpuPolicy;
@@ -1741,6 +1756,42 @@ mod tests {
     use super::*;
     use crate::cfg::file::{CarbideConfig, InitialObjectsConfig};
     use crate::cfg::load::{merged_carbide_config_figment, parse_carbide_config};
+
+    #[test]
+    fn firmware_object_redirects_require_same_origin() {
+        value_scenarios!(run = |(initial, redirect)| {
+            let initial = reqwest::Url::parse(initial).expect("initial test URL must parse");
+            let redirect = reqwest::Url::parse(redirect).expect("redirect test URL must parse");
+
+            initial.origin() == redirect.origin()
+        };
+            "same-origin redirects are allowed" {
+                (
+                    "https://firmware.example.test/object.json",
+                    "https://firmware.example.test/releases/object.json",
+                ) => true,
+                (
+                    "https://firmware.example.test/object.json",
+                    "https://firmware.example.test:443/object.json",
+                ) => true,
+            }
+
+            "origin changes are rejected" {
+                (
+                    "https://firmware.example.test/object.json",
+                    "http://firmware.example.test/object.json",
+                ) => false,
+                (
+                    "https://firmware.example.test/object.json",
+                    "https://mirror.example.test/object.json",
+                ) => false,
+                (
+                    "https://firmware.example.test/object.json",
+                    "https://firmware.example.test:8443/object.json",
+                ) => false,
+            }
+        );
+    }
 
     #[derive(Clone, Copy)]
     struct PolicyLayers {

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -50,6 +50,7 @@ use carbide_power_shelf_controller::io::PowerShelfStateControllerIO;
 use carbide_rack::rms_client::test_support::RmsSim;
 use carbide_rack_controller::config::RackConfig;
 use carbide_rack_controller::context::RackStateHandlerServices;
+use carbide_rack_controller::firmware_object::FirmwareObjectFetcher;
 use carbide_rack_controller::handler::RackStateHandler;
 use carbide_rack_controller::io::RackStateControllerIO;
 use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimTestOverrides};
@@ -183,6 +184,10 @@ pub struct TestEnvOverrides {
     pub compute_allocation_enforcement: Option<ComputeAllocationEnforcement>,
     pub nmxc_simulator: Option<bool>,
     pub redfish_overrides: Option<RedfishOverrides>,
+
+    /// Optional firmware-object fetcher injected into the rack state handler.
+    pub firmware_object_fetcher: Option<Arc<dyn FirmwareObjectFetcher>>,
+
     pub nras_should_fail_parsing: Option<Arc<AtomicBool>>,
     pub vpc_prefixes_drain_period: Option<chrono::Duration>,
     pub dhcp_lease_expiry_handling: Option<bool>,
@@ -306,6 +311,10 @@ pub struct TestEnv {
     pub test_credential_manager: Arc<TestCredentialManager>,
     pub rms_sim: Arc<RmsSim>,
     pub test_component_manager: Option<Arc<component_manager::component_manager::ComponentManager>>,
+
+    /// Firmware-object fetcher used by this environment's rack state handler.
+    pub firmware_object_fetcher: Arc<dyn FirmwareObjectFetcher>,
+
     pub drop_guard: DropGuard,
     // Background tasks are spawned here, hold it so they don't get dropped.
     pub join_set: JoinSet<()>,
@@ -377,6 +386,7 @@ impl TestEnv {
                 component_manager::config::switch_mtls_services_as_i32(
                     &component_manager::config::effective_nmx_cluster_switch_mtls_services(&[]),
                 ),
+            firmware_object_fetcher: self.firmware_object_fetcher.clone(),
             per_object_metrics_registry: self.per_object_metrics_registry(),
         }
     }
@@ -1265,6 +1275,11 @@ pub async fn create_test_env_with_overrides(
     let test_meter = TestMeter::default();
     let credential_manager = Arc::new(TestCredentialManager::default());
 
+    let firmware_object_fetcher = overrides
+        .firmware_object_fetcher
+        .clone()
+        .unwrap_or_else(|| Arc::new(reqwest::Client::new()));
+
     let chained_reader = ChainedCredentialReader::from(vec![
         Box::new(test_static_credential_snapshot()) as Box<dyn CredentialReader>,
         Box::new(credential_manager.clone()),
@@ -1714,6 +1729,7 @@ pub async fn create_test_env_with_overrides(
                     component_manager::config::switch_mtls_services_as_i32(
                         &component_manager::config::effective_nmx_cluster_switch_mtls_services(&[]),
                     ),
+                firmware_object_fetcher: firmware_object_fetcher.clone(),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
             }
             .into(),
@@ -1858,6 +1874,7 @@ pub async fn create_test_env_with_overrides(
         test_credential_manager: credential_manager.clone(),
         rms_sim,
         test_component_manager,
+        firmware_object_fetcher,
         drop_guard: cancel_token.drop_guard(),
         join_set,
     }

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -15,8 +15,12 @@
  * limitations under the License.
  */
 
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
 use carbide_rack_controller::config::ScaleUpFabricManagerApiVersion;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_rack_controller::firmware_object::FirmwareObjectFetcher;
 use carbide_rack_controller::handler::RackStateHandler;
 use carbide_rack_controller::maintenance::apply_nvos_job_status_response;
 use carbide_rack_controller::metrics::RackMetrics;
@@ -41,8 +45,8 @@ use model::rack::{
 };
 use model::rack_type::{
     RackCapabilitiesSet, RackCapabilityCompute, RackCapabilityPowerShelf, RackCapabilitySwitch,
-    RackHardwareClass, RackHardwareTopology, RackHardwareType, RackProductFamily, RackProfile,
-    RackProfileConfig,
+    RackFirmwareObjectConfig, RackHardwareClass, RackHardwareTopology, RackHardwareType,
+    RackProductFamily, RackProfile, RackProfileConfig,
 };
 use model::switch::{
     CONTROL_PLANE_STATE_CONFIGURED, FabricManagerState, FabricManagerStatus, NewSwitch,
@@ -58,6 +62,22 @@ use crate::tests::common::api_fixtures::site_explorer::{create_expected_switches
 use crate::tests::common::api_fixtures::{
     TestEnv, TestEnvOverrides, create_test_env_with_overrides, get_config,
 };
+
+#[derive(Debug)]
+struct StaticFirmwareObjectFetcher {
+    response: Mutex<Result<String, String>>,
+    requested_urls: Mutex<Vec<String>>,
+    requested_timeouts: Mutex<Vec<std::time::Duration>>,
+}
+
+#[async_trait]
+impl FirmwareObjectFetcher for StaticFirmwareObjectFetcher {
+    async fn fetch(&self, url: &str, timeout: std::time::Duration) -> Result<String, String> {
+        self.requested_urls.lock().unwrap().push(url.to_string());
+        self.requested_timeouts.lock().unwrap().push(timeout);
+        self.response.lock().unwrap().clone()
+    }
+}
 
 fn test_capabilities() -> RackCapabilitiesSet {
     RackCapabilitiesSet {
@@ -154,6 +174,7 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
                 "Simple".to_string(),
                 RackProfile {
                     product_family: Some(RackProductFamily::Gb200),
+                    firmware_object: None,
                     rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_hardware_type: Some(RackHardwareType::any()),
                     rack_hardware_class: Some(RackHardwareClass::Prod),
@@ -165,6 +186,7 @@ pub(crate) fn config_with_rack_profiles() -> crate::cfg::file::CarbideConfig {
                 "Single".to_string(),
                 RackProfile {
                     product_family: Some(RackProductFamily::Gb200),
+                    firmware_object: None,
                     rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
                     rack_hardware_type: Some(RackHardwareType::any()),
                     rack_hardware_class: Some(RackHardwareClass::Prod),
@@ -1380,13 +1402,275 @@ async fn test_firmware_upgrade_start_skips_without_json(
 }
 
 #[crate::sqlx_test]
-async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
+async fn test_ingestion_transitions_to_firmware_upgrade_and_submits_rack_profile_firmware_object(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    const FIRMWARE_OBJECT_URL: &str =
+        "https://firmware.example.invalid/sot/single-rack-ingestion.json";
+
+    const CONFIG_JSON: &str = r#"{"Id":"single-rack-ingestion"}"#;
+
+    let firmware_object_fetcher = Arc::new(StaticFirmwareObjectFetcher {
+        response: Mutex::new(Err("temporary SOT host failure".to_string())),
+        requested_urls: Mutex::new(Vec::new()),
+        requested_timeouts: Mutex::new(Vec::new()),
+    });
+
+    let mut config = config_with_rack_profiles();
+
+    config
+        .rack_profiles
+        .rack_profiles
+        .get_mut("Single")
+        .unwrap()
+        .rack_capabilities
+        .compute
+        .name = Some("GB200".to_string());
+
+    let switch = &mut config
+        .rack_profiles
+        .rack_profiles
+        .get_mut("Single")
+        .unwrap()
+        .rack_capabilities
+        .switch;
+
+    switch.count = 1;
+    switch.name = Some("NVLinkSwitch".to_string());
+
+    config
+        .rack_profiles
+        .rack_profiles
+        .get_mut("Single")
+        .unwrap()
+        .firmware_object = Some(RackFirmwareObjectConfig {
+        url: url::Url::parse(FIRMWARE_OBJECT_URL).unwrap(),
+        fetch_timeout: std::time::Duration::from_secs(17),
+    });
+
     let env = create_test_env_with_overrides(
         pool.clone(),
         TestEnvOverrides {
-            config: Some(config_with_rack_profiles()),
+            config: Some(config),
+            firmware_object_fetcher: Some(firmware_object_fetcher.clone()),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let (rack_id, host) = create_single_compute_rack(&env, &pool).await?;
+    let machine_id = host.host_snapshot.id.to_string();
+    let switch_id = attach_switch_with_nvos_credentials(&env, &rack_id).await?;
+    set_switch_state(
+        pool.acquire().await?.as_mut(),
+        &switch_id,
+        model::switch::SwitchControllerState::Ready,
+    )
+    .await;
+    let switch_id = switch_id.to_string();
+
+    env.rms_sim
+        .queue_apply_firmware_object_response(rms::ApplyFirmwareObjectResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                message: "accepted".to_string(),
+                job_id: "parent-job".to_string(),
+                stats: Some(rms::NodeOperationStats {
+                    total_nodes: 2,
+                    successful_nodes: 2,
+                    failed_nodes: 0,
+                }),
+                ..Default::default()
+            }),
+            object_id: "single-rack-ingestion".to_string(),
+            jobs: vec![
+                rms::NodeFirmwareJobInfo {
+                    node_id: machine_id.clone(),
+                    job_id: "compute-child-job".to_string(),
+                },
+                rms::NodeFirmwareJobInfo {
+                    node_id: switch_id.clone(),
+                    job_id: "switch-child-job".to_string(),
+                },
+            ],
+        })
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let handler = RackStateHandler::default();
+
+    let mut services = env.rack_state_handler_services();
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let ingestion_outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &RackState::Discovering, &mut ctx)
+        .await?;
+    let StateHandlerOutcome::Transition {
+        next_state: firmware_state,
+        ..
+    } = ingestion_outcome
+    else {
+        panic!("ready ingestion inventory should transition to firmware maintenance");
+    };
+    assert!(matches!(
+        firmware_state,
+        RackState::Maintenance {
+            maintenance_state: RackMaintenanceState::FirmwareUpgrade {
+                rack_firmware_upgrade: FirmwareUpgradeState::Start,
+            },
+        }
+    ));
+
+    let error = match handler
+        .handle_object_state(&rack_id, &mut rack, &firmware_state, &mut ctx)
+        .await
+    {
+        Err(error) => error,
+        Ok(_) => panic!("SOT fetch failure should keep the state retryable"),
+    };
+    assert!(error.to_string().contains("temporary SOT host failure"));
+    assert!(
+        env.rms_sim
+            .submitted_apply_firmware_object_requests()
+            .await
+            .is_empty()
+    );
+
+    *firmware_object_fetcher.response.lock().unwrap() = Ok("[]".to_string());
+
+    let error = match handler
+        .handle_object_state(&rack_id, &mut rack, &firmware_state, &mut ctx)
+        .await
+    {
+        Err(error) => error,
+        Ok(_) => panic!("non-object SOT JSON should be rejected"),
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("configured SOT firmware object is not a JSON object")
+    );
+    assert!(
+        env.rms_sim
+            .submitted_apply_firmware_object_requests()
+            .await
+            .is_empty()
+    );
+
+    *firmware_object_fetcher.response.lock().unwrap() = Ok(CONFIG_JSON.to_string());
+
+    let mut outcome = handler
+        .handle_object_state(&rack_id, &mut rack, &firmware_state, &mut ctx)
+        .await?;
+
+    if let Some(txn) = outcome.take_transaction() {
+        txn.commit().await?;
+    }
+
+    assert!(matches!(
+        outcome,
+        StateHandlerOutcome::Transition {
+            next_state: RackState::Maintenance {
+                maintenance_state: RackMaintenanceState::FirmwareUpgrade {
+                    rack_firmware_upgrade: FirmwareUpgradeState::WaitForComplete,
+                },
+            },
+            ..
+        }
+    ));
+
+    assert_eq!(
+        *firmware_object_fetcher.requested_urls.lock().unwrap(),
+        vec![
+            FIRMWARE_OBJECT_URL.to_string(),
+            FIRMWARE_OBJECT_URL.to_string(),
+            FIRMWARE_OBJECT_URL.to_string(),
+        ]
+    );
+
+    assert_eq!(
+        *firmware_object_fetcher.requested_timeouts.lock().unwrap(),
+        vec![
+            std::time::Duration::from_secs(17),
+            std::time::Duration::from_secs(17),
+            std::time::Duration::from_secs(17),
+        ]
+    );
+
+    let requests = env.rms_sim.submitted_apply_firmware_object_requests().await;
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].config_json, CONFIG_JSON);
+
+    let requested_node_ids = requests[0]
+        .nodes
+        .as_ref()
+        .unwrap()
+        .nodes
+        .iter()
+        .map(|node| node.node_id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+
+    assert_eq!(
+        requested_node_ids,
+        std::collections::HashSet::from([machine_id.as_str(), switch_id.as_str()])
+    );
+
+    assert_eq!(
+        requests[0].access_token.as_deref(),
+        Some(carbide_rack::firmware_object::RMS_NOAUTH_ACCESS_TOKEN)
+    );
+
+    assert!(requests[0].component_filters.is_empty());
+    assert!(!requests[0].force_update);
+
+    let machine = db::machine::find_one(
+        &pool,
+        &host.host_snapshot.id,
+        model::machine::machine_search_config::MachineSearchConfig::default(),
+    )
+    .await?
+    .expect("machine should exist");
+
+    assert!(machine.host_reprovision_requested.is_some());
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let firmware_object_fetcher = Arc::new(StaticFirmwareObjectFetcher {
+        response: Mutex::new(Err(
+            "explicit firmware request must not fetch the profile URL".to_string(),
+        )),
+        requested_urls: Mutex::new(Vec::new()),
+        requested_timeouts: Mutex::new(Vec::new()),
+    });
+    let mut config = config_with_rack_profiles();
+    config
+        .rack_profiles
+        .rack_profiles
+        .get_mut("NVL72")
+        .unwrap()
+        .firmware_object = Some(RackFirmwareObjectConfig {
+        url: url::Url::parse("https://firmware.example.invalid/sot/nvl72.json").unwrap(),
+        fetch_timeout: std::time::Duration::from_secs(11),
+    });
+
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config),
+            firmware_object_fetcher: Some(firmware_object_fetcher.clone()),
             ..Default::default()
         },
     )
@@ -1484,6 +1768,13 @@ async fn test_firmware_upgrade_start_submits_json_and_deletes_access_token(
     assert_eq!(requests[0].firmware_type, "prod");
     assert!(requests[0].force_update);
     assert_eq!(requests[0].nodes.as_ref().unwrap().nodes.len(), 1);
+    assert!(
+        firmware_object_fetcher
+            .requested_urls
+            .lock()
+            .unwrap()
+            .is_empty()
+    );
 
     let token_after = env
         .test_credential_manager

--- a/crates/api-model/Cargo.toml
+++ b/crates/api-model/Cargo.toml
@@ -77,7 +77,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 uuid = { features = ["v4", "serde"], workspace = true }
 version-compare = { workspace = true }
 tokio = { workspace = true }

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
+use carbide_utils::config::as_std_duration;
+use duration_str::deserialize_duration;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -371,6 +373,33 @@ pub struct RackCapabilitiesSet {
 /*           RackProfile              */
 /* ********************************** */
 
+/// Optional source for a rack-wide SOT firmware-object document.
+///
+/// When present on a [`RackProfile`], rack ingestion fetches this document and
+/// uses it as the default firmware request for the profile's compute and switch
+/// inventory.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RackFirmwareObjectConfig {
+    /// URL from which rack ingestion fetches the SOT JSON document.
+    pub url: url::Url,
+
+    /// Maximum duration for the complete HTTP request.
+    ///
+    /// Configuration that omits this field uses 30 seconds.
+    #[serde(
+        default = "RackFirmwareObjectConfig::default_fetch_timeout",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub fetch_timeout: std::time::Duration,
+}
+
+impl RackFirmwareObjectConfig {
+    const fn default_fetch_timeout() -> std::time::Duration {
+        std::time::Duration::from_secs(30)
+    }
+}
+
 /// RackProfile describes the hardware identity and expected device
 /// capabilities for a class of rack. The profile is referenced by name
 /// (the map key in the config file) from expected racks and rack configs.
@@ -379,6 +408,13 @@ pub struct RackProfile {
     /// Product family used for product-level component behavior.
     #[serde(default)]
     pub product_family: Option<RackProductFamily>,
+
+    /// Default firmware-object source for ingestion.
+    ///
+    /// When absent, ingestion skips the automatic firmware update unless an
+    /// explicit maintenance request supplies a firmware object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub firmware_object: Option<RackFirmwareObjectConfig>,
 
     #[serde(default)]
     pub rack_hardware_type: Option<RackHardwareType>,
@@ -582,6 +618,62 @@ count = 2
         assert_eq!(nvl36.rack_capabilities.compute.count, 9);
         assert_eq!(nvl36.rack_capabilities.switch.count, 9);
         assert_eq!(nvl36.rack_capabilities.power_shelf.count, 2);
+    }
+
+    #[test]
+    fn test_rack_profile_firmware_object_toml_deserialization() {
+        const CAPABILITIES: &str = r#"
+[Rack.rack_capabilities.compute]
+count = 0
+[Rack.rack_capabilities.switch]
+count = 0
+[Rack.rack_capabilities.power_shelf]
+count = 0
+"#;
+
+        let cases = [
+            (
+                "configured timeout",
+                r#"
+[Rack.firmware_object]
+url = "https://firmware.example.invalid/sot/rack.json"
+fetch_timeout = "45s"
+"#,
+                Some((
+                    "https://firmware.example.invalid/sot/rack.json",
+                    std::time::Duration::from_secs(45),
+                )),
+            ),
+            (
+                "default timeout",
+                r#"
+[Rack.firmware_object]
+url = "https://firmware.example.invalid/sot/rack.json"
+"#,
+                Some((
+                    "https://firmware.example.invalid/sot/rack.json",
+                    std::time::Duration::from_secs(30),
+                )),
+            ),
+            ("not configured", "[Rack]\n", None),
+        ];
+
+        for (name, input, expected) in cases {
+            let input = format!("{input}{CAPABILITIES}");
+            let config: RackProfileConfig =
+                toml::from_str(&input).unwrap_or_else(|error| panic!("{name}: {error}"));
+            let actual =
+                config
+                    .get("Rack")
+                    .unwrap()
+                    .firmware_object
+                    .as_ref()
+                    .map(|firmware_object| {
+                        (firmware_object.url.as_str(), firmware_object.fetch_timeout)
+                    });
+
+            assert_eq!(actual, expected, "{name}");
+        }
     }
 
     #[test]

--- a/crates/rack-controller/Cargo.toml
+++ b/crates/rack-controller/Cargo.toml
@@ -42,6 +42,7 @@ eyre = { workspace = true }
 librms = { workspace = true }
 mac_address = { workspace = true }
 opentelemetry = { workspace = true }
+reqwest = { workspace = true, default-features = false, features = ["rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/rack-controller/src/context.rs
+++ b/crates/rack-controller/src/context.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use carbide_health_metrics::PerObjectMetricsRegistry;
 use carbide_rack::rms_client::SwitchSystemImageRmsClient;
 use carbide_rack_controller::config::RackConfig;
+use carbide_rack_controller::firmware_object::FirmwareObjectFetcher;
 use carbide_rack_controller::metrics::RackMetrics;
 use carbide_secrets::credentials::CredentialManager;
 use component_manager::component_manager::ComponentManager;
@@ -30,6 +31,8 @@ use state_controller::state_handler::StateHandlerContextObjects;
 use crate as carbide_rack_controller;
 
 pub struct RackStateHandlerContextObjects {}
+
+/// Dependencies shared by rack state-handler operations.
 #[derive(Clone)]
 pub struct RackStateHandlerServices {
     pub db_pool: PgPool,
@@ -48,6 +51,10 @@ pub struct RackStateHandlerServices {
     /// Switch mTLS services passed to RMS during NMX cluster certificate
     /// configuration. Sourced from `[rack_state_controller].nmx_cluster_switch_mtls_services`.
     pub nmx_cluster_switch_mtls_services: Vec<i32>,
+
+    /// Fetches SOT firmware-object documents selected by rack profiles.
+    pub firmware_object_fetcher: Arc<dyn FirmwareObjectFetcher>,
+
     /// Shared registry backing the generic per-object health metrics.
     pub per_object_metrics_registry: Arc<PerObjectMetricsRegistry>,
 }

--- a/crates/rack-controller/src/context.rs
+++ b/crates/rack-controller/src/context.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use carbide_health_metrics::PerObjectMetricsRegistry;
 use carbide_rack::rms_client::SwitchSystemImageRmsClient;
 use carbide_rack_controller::config::RackConfig;
-use carbide_rack_controller::firmware_object::FirmwareObjectFetcher;
 use carbide_rack_controller::metrics::RackMetrics;
 use carbide_secrets::credentials::CredentialManager;
 use component_manager::component_manager::ComponentManager;
@@ -29,6 +28,7 @@ use sqlx::PgPool;
 use state_controller::state_handler::StateHandlerContextObjects;
 
 use crate as carbide_rack_controller;
+use crate::firmware_object::FirmwareObjectFetcher;
 
 pub struct RackStateHandlerContextObjects {}
 

--- a/crates/rack-controller/src/firmware_object.rs
+++ b/crates/rack-controller/src/firmware_object.rs
@@ -24,6 +24,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
+/// Firmware objects contain metadata, not firmware binaries. This generous
+/// limit bounds state-controller memory if the configured endpoint is wrong or
+/// compromised.
+const MAX_FIRMWARE_OBJECT_BYTES: usize = 16 * 1024 * 1024;
+
 /// Loads a SOT firmware-object document for rack ingestion.
 #[async_trait]
 pub trait FirmwareObjectFetcher: std::fmt::Debug + Send + Sync {
@@ -42,7 +47,7 @@ pub trait FirmwareObjectFetcher: std::fmt::Debug + Send + Sync {
 #[async_trait]
 impl FirmwareObjectFetcher for reqwest::Client {
     async fn fetch(&self, url: &str, timeout: Duration) -> Result<String, String> {
-        let response = self
+        let mut response = self
             .get(url)
             .timeout(timeout)
             .send()
@@ -61,11 +66,34 @@ impl FirmwareObjectFetcher for reqwest::Client {
                 )
             })?;
 
-        response.text().await.map_err(|error| {
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_FIRMWARE_OBJECT_BYTES as u64)
+        {
+            return Err(format!(
+                "configured SOT firmware object exceeds the {MAX_FIRMWARE_OBJECT_BYTES}-byte size limit"
+            ));
+        }
+
+        let mut body = Vec::new();
+
+        while let Some(chunk) = response.chunk().await.map_err(|error| {
             format!(
                 "failed to read configured SOT firmware object: {}",
                 error.without_url()
             )
+        })? {
+            if body.len().saturating_add(chunk.len()) > MAX_FIRMWARE_OBJECT_BYTES {
+                return Err(format!(
+                    "configured SOT firmware object exceeds the {MAX_FIRMWARE_OBJECT_BYTES}-byte size limit"
+                ));
+            }
+
+            body.extend_from_slice(&chunk);
+        }
+
+        String::from_utf8(body).map_err(|error| {
+            format!("configured SOT firmware object body is not valid UTF-8: {error}")
         })
     }
 }

--- a/crates/rack-controller/src/firmware_object.rs
+++ b/crates/rack-controller/src/firmware_object.rs
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Firmware-object retrieval boundary for rack ingestion.
+//!
+//! Fetching is separate from the state handler so callers can provide the
+//! production HTTP client or a deterministic implementation for tests.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+/// Loads a SOT firmware-object document for rack ingestion.
+#[async_trait]
+pub trait FirmwareObjectFetcher: std::fmt::Debug + Send + Sync {
+    /// Fetches the complete document body from `url` within `timeout`.
+    ///
+    /// A successful call returns the body unchanged. JSON validation belongs
+    /// to the state handler that consumes the document.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error message when the URL cannot be fetched or its response
+    /// cannot be read.
+    async fn fetch(&self, url: &str, timeout: Duration) -> Result<String, String>;
+}
+
+#[async_trait]
+impl FirmwareObjectFetcher for reqwest::Client {
+    async fn fetch(&self, url: &str, timeout: Duration) -> Result<String, String> {
+        let response = self
+            .get(url)
+            .timeout(timeout)
+            .send()
+            .await
+            .map_err(|error| {
+                format!(
+                    "failed to fetch configured SOT firmware object: {}",
+                    error.without_url()
+                )
+            })?
+            .error_for_status()
+            .map_err(|error| {
+                format!(
+                    "configured SOT firmware object returned an unsuccessful HTTP status: {}",
+                    error.without_url()
+                )
+            })?;
+
+        response.text().await.map_err(|error| {
+            format!(
+                "failed to read configured SOT firmware object: {}",
+                error.without_url()
+            )
+        })
+    }
+}

--- a/crates/rack-controller/src/lib.rs
+++ b/crates/rack-controller/src/lib.rs
@@ -35,6 +35,7 @@ pub mod deleting;
 pub mod discovering;
 pub mod error_state;
 pub mod fabric_manager;
+pub mod firmware_object;
 pub mod handler;
 pub mod io;
 pub mod maintenance;

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -615,6 +615,36 @@ fn requested_firmware_object_json_upgrade(
     })
 }
 
+/// Loads and validates the default firmware object selected by a rack profile.
+///
+/// A missing or unknown profile, or a profile without a firmware-object
+/// source, returns `Ok(None)`. Fetch and JSON validation failures are returned
+/// so the state controller can retry `FirmwareUpgrade(Start)`.
+async fn configured_ingestion_firmware_object_json(
+    rack_id: &RackId,
+    rack_profile_id: Option<&RackProfileId>,
+    ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
+) -> Result<Option<String>, String> {
+    let Some(profile) = super::resolve_profile(rack_id, rack_profile_id, ctx) else {
+        return Ok(None);
+    };
+
+    let Some(firmware_object) = profile.firmware_object.clone() else {
+        return Ok(None);
+    };
+
+    let config_json = ctx
+        .services
+        .firmware_object_fetcher
+        .fetch(firmware_object.url.as_str(), firmware_object.fetch_timeout)
+        .await?;
+
+    serde_json::from_str::<std::collections::HashMap<String, serde::de::IgnoredAny>>(&config_json)
+        .map_err(|error| format!("configured SOT firmware object is not a JSON object: {error}"))?;
+
+    Ok(Some(config_json))
+}
+
 async fn load_rack_maintenance_access_token(
     credential_manager: &dyn CredentialManager,
     rack_id: &RackId,
@@ -2181,6 +2211,16 @@ async fn verify_scale_up_fabric_manager_v2(
     }))
 }
 
+/// Advances the rack's current maintenance substate.
+///
+/// At firmware-upgrade start, an explicit maintenance activity takes
+/// precedence over the optional rack-profile firmware object. When neither
+/// source exists, the firmware step is skipped.
+///
+/// # Errors
+///
+/// Returns an error when a required database, credential, firmware-source, or
+/// backend operation fails.
 pub async fn handle_maintenance(
     id: &RackId,
     state: &mut Rack,
@@ -2212,24 +2252,43 @@ pub async fn handle_maintenance(
             rack_firmware_upgrade,
         } => match rack_firmware_upgrade {
             FirmwareUpgradeState::Start => {
-                let Some((config_json, components, force_update)) =
-                    requested_firmware_object_json_upgrade(scope)
-                else {
-                    if explicit_firmware_upgrade_requested(scope) {
-                        return transition_to_rack_error(
-                            id,
-                            state,
-                            "firmware-upgrade rack maintenance requires SOT JSON and access token",
-                            ctx,
-                        )
-                        .await;
+                // A stored access token exists only for explicit maintenance requests
+                // and must be cleaned up by the branches that consume those requests.
+                let requested_source = requested_firmware_object_json_upgrade(scope);
+                let uses_stored_token = requested_source.is_some();
+
+                let (config_json, components, force_update) = match requested_source {
+                    Some(requested_source) => requested_source,
+                    None => {
+                        if explicit_firmware_upgrade_requested(scope) {
+                            return transition_to_rack_error(
+                                id,
+                                state,
+                                "firmware-upgrade rack maintenance requires SOT JSON and access token",
+                                ctx,
+                            )
+                            .await;
+                        }
+
+                        let config_json =
+                            configured_ingestion_firmware_object_json(id, rack_profile_id, ctx)
+                                .await
+                                .map_err(|error| {
+                                    StateHandlerError::GenericError(eyre::eyre!(error))
+                                })?;
+
+                        let Some(config_json) = config_json else {
+                            return Ok(skip_firmware_upgrade_outcome(
+                                id,
+                                "firmware object JSON source is not configured for rack maintenance; skipping firmware update",
+                                scope,
+                            ));
+                        };
+
+                        (Some(config_json), Vec::new(), false)
                     }
-                    return Ok(skip_firmware_upgrade_outcome(
-                        id,
-                        "firmware object JSON source is not configured for rack maintenance; skipping firmware update",
-                        scope,
-                    ));
                 };
+
                 // Defensive: older persisted maintenance state may predate API-side JSON
                 // validation.
                 let Some(config_json) = config_json.filter(|json| !json.trim().is_empty()) else {
@@ -2241,27 +2300,39 @@ pub async fn handle_maintenance(
                     )
                     .await;
                 };
+
                 let nvos_json_pending = requested_nvos_config_json(scope).is_some();
+
                 let Some(rms_client) = ctx.services.rms_client.as_ref() else {
-                    delete_rack_maintenance_access_token(
-                        ctx.services.credential_manager.as_ref(),
-                        id,
-                    )
-                    .await;
+                    if uses_stored_token {
+                        delete_rack_maintenance_access_token(
+                            ctx.services.credential_manager.as_ref(),
+                            id,
+                        )
+                        .await;
+                    }
+
                     return transition_to_rack_error(id, state, "RMS client not configured", ctx)
                         .await;
                 };
-                let access_token = match load_rack_maintenance_access_token(
-                    ctx.services.credential_manager.as_ref(),
-                    id,
-                )
-                .await
-                {
-                    Ok(access_token) => access_token,
-                    Err(error) => {
-                        let message = error.to_string();
-                        return transition_to_rack_error(id, state, &message, ctx).await;
+
+                // Profile-driven ingestion has no caller token, so it uses the RMS
+                // NOAUTH sentinel.
+                let access_token = if uses_stored_token {
+                    match load_rack_maintenance_access_token(
+                        ctx.services.credential_manager.as_ref(),
+                        id,
+                    )
+                    .await
+                    {
+                        Ok(access_token) => access_token,
+                        Err(error) => {
+                            let message = error.to_string();
+                            return transition_to_rack_error(id, state, &message, ctx).await;
+                        }
                     }
+                } else {
+                    rms_access_token_or_noauth(None)
                 };
                 let profile = super::resolve_profile(id, rack_profile_id, ctx);
                 let rack_hardware_type = profile_hardware_type_or_any(profile);
@@ -2284,7 +2355,7 @@ pub async fn handle_maintenance(
                 let inventory = filter_inventory_by_scope(inventory, scope);
 
                 if inventory.machines.is_empty() && inventory.switches.is_empty() {
-                    if !nvos_json_pending {
+                    if uses_stored_token && !nvos_json_pending {
                         delete_rack_maintenance_access_token(
                             ctx.services.credential_manager.as_ref(),
                             id,
@@ -2302,11 +2373,14 @@ pub async fn handle_maintenance(
                     // Keep this aligned with the NVOS missing-profile path.
                     // Startup validation deliberately does not scan rack rows,
                     // so this call-time error still owns token cleanup.
-                    delete_rack_maintenance_access_token(
-                        ctx.services.credential_manager.as_ref(),
-                        id,
-                    )
-                    .await;
+                    if uses_stored_token {
+                        delete_rack_maintenance_access_token(
+                            ctx.services.credential_manager.as_ref(),
+                            id,
+                        )
+                        .await;
+                    }
+
                     return transition_to_rack_error(
                         id,
                         state,
@@ -2342,7 +2416,8 @@ pub async fn handle_maintenance(
                     },
                 )
                 .await;
-                if submit_result.is_err() || !nvos_json_pending {
+
+                if uses_stored_token && (submit_result.is_err() || !nvos_json_pending) {
                     delete_rack_maintenance_access_token(
                         ctx.services.credential_manager.as_ref(),
                         id,

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -588,13 +588,6 @@ fn requested_nvos_config_json(scope: &MaintenanceScope) -> Option<String> {
     })
 }
 
-fn explicit_firmware_upgrade_requested(scope: &MaintenanceScope) -> bool {
-    scope
-        .activities
-        .iter()
-        .any(|activity| matches!(activity, MaintenanceActivity::FirmwareUpgrade { .. }))
-}
-
 fn profile_hardware_type_or_any(profile: Option<&RackProfile>) -> String {
     profile
         .map(profile_hardware_type_wire_value)
@@ -2260,16 +2253,6 @@ pub async fn handle_maintenance(
                 let (config_json, components, force_update) = match requested_source {
                     Some(requested_source) => requested_source,
                     None => {
-                        if explicit_firmware_upgrade_requested(scope) {
-                            return transition_to_rack_error(
-                                id,
-                                state,
-                                "firmware-upgrade rack maintenance requires SOT JSON and access token",
-                                ctx,
-                            )
-                            .await;
-                        }
-
                         let config_json =
                             configured_ingestion_firmware_object_json(id, rack_profile_id, ctx)
                                 .await
@@ -2277,28 +2260,28 @@ pub async fn handle_maintenance(
                                     StateHandlerError::GenericError(eyre::eyre!(error))
                                 })?;
 
-                        let Some(config_json) = config_json else {
-                            return Ok(skip_firmware_upgrade_outcome(
-                                id,
-                                "firmware object JSON source is not configured for rack maintenance; skipping firmware update",
-                                scope,
-                            ));
-                        };
-
-                        (Some(config_json), Vec::new(), false)
+                        (config_json, Vec::new(), false)
                     }
                 };
 
                 // Defensive: older persisted maintenance state may predate API-side JSON
                 // validation.
                 let Some(config_json) = config_json.filter(|json| !json.trim().is_empty()) else {
-                    return transition_to_rack_error(
+                    if uses_stored_token {
+                        return transition_to_rack_error(
+                            id,
+                            state,
+                            "firmware-upgrade rack maintenance requires SOT JSON and access token",
+                            ctx,
+                        )
+                        .await;
+                    }
+
+                    return Ok(skip_firmware_upgrade_outcome(
                         id,
-                        state,
-                        "firmware object JSON source is configured but target firmware version does not contain SOT JSON",
-                        ctx,
-                    )
-                    .await;
+                        "firmware object JSON source is not configured for rack maintenance; skipping firmware update",
+                        scope,
+                    ));
                 };
 
                 let nvos_json_pending = requested_nvos_config_json(scope).is_some();

--- a/crates/rpc/src/model/rack_type.rs
+++ b/crates/rpc/src/model/rack_type.rs
@@ -395,6 +395,7 @@ mod tests {
     fn test_rack_profile_proto_conversion() {
         let profile = RackProfile {
             product_family: Some(RackProductFamily::Gb200),
+            firmware_object: None,
             rack_hardware_type: Some(RackHardwareType::from("dsx_gb200nvl_72x1")),
             rack_hardware_topology: Some(RackHardwareTopology::Gb200Nvl72r1C2g4Topology),
             rack_hardware_class: Some(RackHardwareClass::Prod),

--- a/docs/operations/firmware-updates/configuration.md
+++ b/docs/operations/firmware-updates/configuration.md
@@ -182,31 +182,6 @@ NICo also supports host definitions embedded in the static `host_models`
 configuration. This is the base catalog supplied with the NICo deployment and
 uses the same firmware data model as `metadata.toml`.
 
-Rack profiles may optionally specify one rack-wide SOT firmware-object
-document:
-
-```toml
-[rack_profiles.NVL72]
-product_family = "gb200"
-
-[rack_profiles.NVL72.firmware_object]
-url = "https://firmware.example.com/sot/nvl72.json"
-fetch_timeout = "30s"
-```
-
-The optional `firmware_object` block enables ingestion firmware update for that
-rack profile. Core validates `url` during configuration parsing.
-`fetch_timeout` defaults to 30 seconds when omitted. The existing RMS request
-includes both compute and switch inventory. At
-`FirmwareUpgrade(Start)`, NICo fetches the document, verifies that the top-level
-JSON value is an object, and passes the JSON string to the existing RMS
-`ApplyFirmwareObject` path.
-Automatic ingestion uses RMS `NOAUTH`; artifact credentials remain part of the
-SOT/RMS contract. The URL is not persisted as desired firmware state. Missing
-profile blocks skip firmware update. Fetch, HTTP status, and JSON
-validation errors leave the rack at `FirmwareUpgrade(Start)` for retry.
-The RMS client must be configured before enabling this workflow.
-
 NICo builds the effective host firmware catalog in this order:
 
 | Applied | Source |
@@ -406,3 +381,20 @@ Rack and component firmware do not use either of the configuration models
 above. Their target version comes from the update request or from the default
 selected by the rack or component backend. Refer to
 [Rack and Tray Firmware Updates](rack-component-firmware.md).
+
+### Rack profile firmware object
+
+A rack profile can specify one firmware-object JSON document to use as the
+default firmware input during rack ingestion:
+
+```toml
+[rack_profiles.NVL72]
+product_family = "gb200"
+
+[rack_profiles.NVL72.firmware_object]
+url = "https://firmware.example.com/objects/nvl72.json"
+fetch_timeout = "30s"
+```
+
+The `url` field identifies the document location. The optional `fetch_timeout`
+field defaults to 30 seconds.

--- a/docs/operations/firmware-updates/configuration.md
+++ b/docs/operations/firmware-updates/configuration.md
@@ -397,4 +397,6 @@ fetch_timeout = "30s"
 ```
 
 The `url` field identifies the document location. The optional `fetch_timeout`
-field defaults to 30 seconds.
+field accepts duration strings such as `30s` and `60s` and defaults to `30s`.
+Use seconds for this request timeout, although the parser accepts other
+duration units such as milliseconds (`ms`), minutes (`m`), and hours (`h`).

--- a/docs/operations/firmware-updates/configuration.md
+++ b/docs/operations/firmware-updates/configuration.md
@@ -182,6 +182,31 @@ NICo also supports host definitions embedded in the static `host_models`
 configuration. This is the base catalog supplied with the NICo deployment and
 uses the same firmware data model as `metadata.toml`.
 
+Rack profiles may optionally specify one rack-wide SOT firmware-object
+document:
+
+```toml
+[rack_profiles.NVL72]
+product_family = "gb200"
+
+[rack_profiles.NVL72.firmware_object]
+url = "https://firmware.example.com/sot/nvl72.json"
+fetch_timeout = "30s"
+```
+
+The optional `firmware_object` block enables ingestion firmware update for that
+rack profile. Core validates `url` during configuration parsing.
+`fetch_timeout` defaults to 30 seconds when omitted. The existing RMS request
+includes both compute and switch inventory. At
+`FirmwareUpgrade(Start)`, NICo fetches the document, verifies that the top-level
+JSON value is an object, and passes the JSON string to the existing RMS
+`ApplyFirmwareObject` path.
+Automatic ingestion uses RMS `NOAUTH`; artifact credentials remain part of the
+SOT/RMS contract. The URL is not persisted as desired firmware state. Missing
+profile blocks skip firmware update. Fetch, HTTP status, and JSON
+validation errors leave the rack at `FirmwareUpgrade(Start)` for retry.
+The RMS client must be configured before enabling this workflow.
+
 NICo builds the effective host firmware catalog in this order:
 
 | Applied | Source |


### PR DESCRIPTION
Rack ingestion currently skips compute and switch firmware updates when no explicit firmware maintenance request supplies firmware object JSON. This PR allows each rack profile to optionally define a firmware-object URL and fetch timeout. During ingestion, NICo fetches and validates the JSON document, then passes it unchanged through the existing rack firmware path for the profile's discovered compute and switch inventory.

Explicit maintenance requests retain precedence. Profiles without a firmware-object configuration preserve existing behavior and skip the update. Fetch and validation failures remain retryable through the state machine.

This PR adds an optional firmware-object source to each rack profile:

```toml
[rack_profiles.NVL72.firmware_object]
url = "https://firmware.example.com/sot/nvl72.json"
fetch_timeout = "30s"
```

## Related issues

Resolves #2974 and #2976

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)