### PR TITLE
refactor(api): fence Vault imports with work locks

### DIFF
--- a/crates/api-core/src/bootstrap.rs
+++ b/crates/api-core/src/bootstrap.rs
@@ -22,11 +22,16 @@
 //! in `carbide-api-core`.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_rack::rms_node_type::warn_rms_node_descriptor_attribute_overrides;
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::CredentialManager;
+use db::work_lock_manager::{AcquireLockError, WorkLock, WorkLockManagerHandle};
+use eyre::WrapErr;
 use sqlx::PgPool;
+#[cfg(test)]
+use tokio::sync::Notify;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -39,6 +44,11 @@ pub use crate::logging::level_filter::{ActiveLevel, ReloadableFilter};
 pub use crate::logging::setup::{Logging, dep_log_filter};
 pub use crate::logging::stream::LogStreamLayer;
 use crate::secrets::SecretsContext;
+
+// Replicas only contend when they name the same work, so keep this key stable
+// across releases.
+const VAULT_IMPORT_WORK_KEY: &str = "secrets::import_vault_secrets_once";
+const VAULT_IMPORT_LOCK_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Opaque core runtime state initialized before external resources.
 #[doc(hidden)]
@@ -112,6 +122,7 @@ pub struct RuntimeInputs<'a> {
     pub credential_manager: Arc<dyn CredentialManager>,
     pub certificate_provider: Arc<dyn CertificateProvider>,
     pub db_pool: PgPool,
+    pub work_lock_manager_handle: WorkLockManagerHandle,
     pub secrets_context: Option<SecretsContext>,
     pub admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     pub cancel_token: CancellationToken,
@@ -144,6 +155,7 @@ pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<()> {
         credential_manager,
         certificate_provider,
         db_pool,
+        work_lock_manager_handle,
         secrets_context,
         admin_ui_routes_builder,
         cancel_token,
@@ -161,6 +173,7 @@ pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<()> {
         credential_manager,
         certificate_provider,
         db_pool,
+        work_lock_manager_handle,
         secrets_context,
         admin_ui_routes_builder,
         cancel_token,
@@ -169,9 +182,327 @@ pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<()> {
     .await
 }
 
-/// Acquire the session-level lock that serializes the one-time Vault import.
-pub async fn lock_vault_import_session(
-    connection: &mut sqlx::PgConnection,
-) -> db::DatabaseResult<()> {
-    db::secrets::lock_path_session(connection, crate::secrets::VAULT_IMPORT_MARKER_PATH).await
+/// Wait for the work lock that serializes the one-time Vault import.
+///
+/// `None` means another replica wrote the permanent completion marker while
+/// this caller waited. Cancellation is only observed between acquisition
+/// attempts: dropping an in-flight acquisition future could leave a leased row
+/// without returning the [`WorkLock`] that releases it.
+pub async fn acquire_vault_import_work_lock(
+    db_pool: &PgPool,
+    work_lock_manager: &WorkLockManagerHandle,
+    cancel_token: &CancellationToken,
+) -> eyre::Result<Option<WorkLock>> {
+    #[cfg(not(test))]
+    {
+        acquire_vault_import_work_lock_with_retry(
+            db_pool,
+            work_lock_manager,
+            cancel_token,
+            VAULT_IMPORT_LOCK_RETRY_INTERVAL,
+        )
+        .await
+    }
+    #[cfg(test)]
+    {
+        acquire_vault_import_work_lock_with_retry(
+            db_pool,
+            work_lock_manager,
+            cancel_token,
+            VAULT_IMPORT_LOCK_RETRY_INTERVAL,
+            None,
+        )
+        .await
+    }
+}
+
+async fn acquire_vault_import_work_lock_with_retry(
+    db_pool: &PgPool,
+    work_lock_manager: &WorkLockManagerHandle,
+    cancel_token: &CancellationToken,
+    retry_interval: Duration,
+    #[cfg(test)] contention_signal: Option<&Notify>,
+) -> eyre::Result<Option<WorkLock>> {
+    let mut logged_contention = false;
+    loop {
+        if cancel_token.is_cancelled() {
+            eyre::bail!("vault import canceled while waiting for its work lock");
+        }
+
+        match work_lock_manager
+            .try_acquire_lock(VAULT_IMPORT_WORK_KEY.into())
+            .await
+        {
+            Ok(work_lock) => {
+                if cancel_token.is_cancelled() {
+                    if let Err(error) = work_lock.release().await {
+                        tracing::warn!(
+                            error = %error,
+                            "Vault import was canceled but its work lock could not be released"
+                        );
+                    }
+                    eyre::bail!("vault import canceled after acquiring its work lock");
+                }
+
+                let marker_status = crate::secrets::is_vault_import_complete(db_pool)
+                    .await
+                    .wrap_err("check vault import status after acquiring its work lock");
+                let import_complete = match marker_status {
+                    Ok(import_complete) => import_complete,
+                    Err(marker_error) => {
+                        if let Err(error) = work_lock.release().await {
+                            tracing::warn!(
+                                error = %error,
+                                "Vault import marker check failed and its work lock could not be released"
+                            );
+                        }
+                        return Err(marker_error);
+                    }
+                };
+                if import_complete {
+                    if let Err(error) = work_lock.release().await {
+                        tracing::warn!(
+                            %error,
+                            "Vault import is complete but its work lock could not be released"
+                        );
+                    }
+                    return Ok(None);
+                }
+                if cancel_token.is_cancelled() {
+                    if let Err(error) = work_lock.release().await {
+                        tracing::warn!(
+                            error = %error,
+                            "Vault import was canceled but its work lock could not be released"
+                        );
+                    }
+                    eyre::bail!("vault import canceled after acquiring its work lock");
+                }
+                return Ok(Some(work_lock));
+            }
+            Err(AcquireLockError::WorkAlreadyLocked(_)) => {
+                if !logged_contention {
+                    tracing::info!("Vault import is running on another replica; waiting");
+                    logged_contention = true;
+                }
+                #[cfg(test)]
+                if let Some(contention_signal) = contention_signal {
+                    contention_signal.notify_one();
+                }
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        eyre::bail!("vault import canceled while waiting for its work lock");
+                    }
+                    _ = tokio::time::sleep(retry_interval) => {}
+                }
+                if crate::secrets::is_vault_import_complete(db_pool)
+                    .await
+                    .wrap_err("check vault import status while waiting for its work lock")?
+                {
+                    return Ok(None);
+                }
+            }
+            Err(error) => {
+                return Err(error).wrap_err("acquire vault import work lock");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_RETRY_INTERVAL: Duration = Duration::from_millis(10);
+
+    async fn start_test_work_lock_manager(pool: &PgPool) -> (WorkLockManagerHandle, JoinSet<()>) {
+        let mut tasks = JoinSet::new();
+        let handle = db::work_lock_manager::start(&mut tasks, pool.clone(), Default::default())
+            .await
+            .expect("start work lock manager");
+        (handle, tasks)
+    }
+
+    async fn write_vault_import_marker(pool: &PgPool) {
+        // Lock coordination only checks that the reserved path exists, so
+        // these fields do not need to contain an encrypted marker value.
+        let bytes = b"test";
+        let mut connection = pool.acquire().await.expect("acquire marker connection");
+        db::secrets::insert(
+            &mut connection,
+            &db::secrets::NewSecretEntry {
+                path: crate::secrets::VAULT_IMPORT_MARKER_PATH,
+                encrypted_value: bytes,
+                nonce: bytes,
+                kek_id: "test",
+                encrypted_dek: bytes,
+                dek_nonce: bytes,
+            },
+        )
+        .await
+        .expect("write vault import marker");
+    }
+
+    fn spawn_waiter(
+        pool: PgPool,
+        work_lock_manager: WorkLockManagerHandle,
+        cancel_token: CancellationToken,
+        contention_signal: Arc<Notify>,
+    ) -> tokio::task::JoinHandle<eyre::Result<Option<WorkLock>>> {
+        tokio::spawn(async move {
+            acquire_vault_import_work_lock_with_retry(
+                &pool,
+                &work_lock_manager,
+                &cancel_token,
+                TEST_RETRY_INTERVAL,
+                Some(&contention_signal),
+            )
+            .await
+        })
+    }
+
+    async fn wait_for_contention(contention_signal: &Notify) {
+        tokio::time::timeout(Duration::from_secs(3), contention_signal.notified())
+            .await
+            .expect("waiter did not observe lock contention");
+    }
+
+    // A replica that acquires the work key must re-check the marker before it
+    // starts Vault I/O, then release the unused key.
+    #[crate::sqlx_test]
+    async fn vault_import_owner_observes_completion_marker(pool: PgPool) {
+        let (work_lock_manager, _work_lock_tasks) = start_test_work_lock_manager(&pool).await;
+        write_vault_import_marker(&pool).await;
+
+        let work_lock = acquire_vault_import_work_lock_with_retry(
+            &pool,
+            &work_lock_manager,
+            &CancellationToken::new(),
+            TEST_RETRY_INTERVAL,
+            None,
+        )
+        .await
+        .expect("check marker after acquiring vault import lock");
+        assert!(
+            work_lock.is_none(),
+            "a completed import must not retain the work key"
+        );
+
+        let work_lock = work_lock_manager
+            .try_acquire_lock(VAULT_IMPORT_WORK_KEY.into())
+            .await
+            .expect("marker check must release the work key");
+        work_lock
+            .release()
+            .await
+            .expect("release verification lock");
+    }
+
+    // A waiting replica can finish as soon as the importer writes its marker;
+    // it does not need the owner to release the work key first.
+    #[crate::sqlx_test]
+    async fn vault_import_waiter_observes_completion_marker(pool: PgPool) {
+        let (owner_manager, _owner_tasks) = start_test_work_lock_manager(&pool).await;
+        let (waiter_manager, _waiter_tasks) = start_test_work_lock_manager(&pool).await;
+        let owner = owner_manager
+            .try_acquire_lock(VAULT_IMPORT_WORK_KEY.into())
+            .await
+            .expect("acquire owner lock");
+        let contention_signal = Arc::new(Notify::new());
+
+        let waiter = spawn_waiter(
+            pool.clone(),
+            waiter_manager.clone(),
+            CancellationToken::new(),
+            contention_signal.clone(),
+        );
+        wait_for_contention(&contention_signal).await;
+        write_vault_import_marker(&pool).await;
+
+        let work_lock = tokio::time::timeout(Duration::from_secs(3), waiter)
+            .await
+            .expect("waiter did not observe the marker")
+            .expect("waiter task panicked")
+            .expect("wait for vault import lock");
+        assert!(
+            work_lock.is_none(),
+            "a completed import must not acquire the work key"
+        );
+        assert!(
+            matches!(
+                waiter_manager
+                    .try_acquire_lock(VAULT_IMPORT_WORK_KEY.into())
+                    .await,
+                Err(AcquireLockError::WorkAlreadyLocked(_))
+            ),
+            "owner must retain the work key while the waiter observes the marker"
+        );
+
+        owner.release().await.expect("release owner lock");
+    }
+
+    // If the owner exits before writing the marker, its Drop queues a release
+    // and the waiting replica can acquire the same work key on its next retry.
+    #[crate::sqlx_test]
+    async fn vault_import_waiter_retries_after_owner_drops(pool: PgPool) {
+        let (owner_manager, _owner_tasks) = start_test_work_lock_manager(&pool).await;
+        let (waiter_manager, _waiter_tasks) = start_test_work_lock_manager(&pool).await;
+        let owner = owner_manager
+            .try_acquire_lock(VAULT_IMPORT_WORK_KEY.into())
+            .await
+            .expect("acquire owner lock");
+        let contention_signal = Arc::new(Notify::new());
+
+        let waiter = spawn_waiter(
+            pool.clone(),
+            waiter_manager,
+            CancellationToken::new(),
+            contention_signal.clone(),
+        );
+        wait_for_contention(&contention_signal).await;
+
+        drop(owner);
+        let work_lock = tokio::time::timeout(Duration::from_secs(3), waiter)
+            .await
+            .expect("waiter did not retry")
+            .expect("waiter task panicked")
+            .expect("wait for vault import lock")
+            .expect("waiter must acquire the released work key");
+        work_lock.release().await.expect("release waiter lock");
+    }
+
+    // Cancellation stops the retry sleep, but never drops an in-flight
+    // acquisition future that could have inserted a `work_locks` row.
+    #[crate::sqlx_test]
+    async fn vault_import_waiter_stops_after_cancellation(pool: PgPool) {
+        let (owner_manager, _owner_tasks) = start_test_work_lock_manager(&pool).await;
+        let (waiter_manager, _waiter_tasks) = start_test_work_lock_manager(&pool).await;
+        let owner = owner_manager
+            .try_acquire_lock(VAULT_IMPORT_WORK_KEY.into())
+            .await
+            .expect("acquire owner lock");
+        let cancel_token = CancellationToken::new();
+        let contention_signal = Arc::new(Notify::new());
+
+        let waiter = spawn_waiter(
+            pool,
+            waiter_manager,
+            cancel_token.clone(),
+            contention_signal.clone(),
+        );
+        wait_for_contention(&contention_signal).await;
+        cancel_token.cancel();
+
+        let error = tokio::time::timeout(Duration::from_secs(3), waiter)
+            .await
+            .expect("waiter ignored cancellation")
+            .expect("waiter task panicked")
+            .err()
+            .expect("cancellation must stop the waiter");
+        assert!(
+            error.to_string().contains("vault import canceled"),
+            "unexpected error: {error}"
+        );
+
+        owner.release().await.expect("release owner lock");
+    }
 }

--- a/crates/api-core/src/secrets/import.rs
+++ b/crates/api-core/src/secrets/import.rs
@@ -23,96 +23,102 @@
 
 use carbide_kms_provider::KmsBackend;
 use carbide_secrets::credentials::Credentials;
+use db::work_lock_manager::WorkLock;
 use sqlx::PgPool;
 use zeroize::Zeroizing;
 
 use super::routing::SecretRouting;
 use super::{ImportApproach, ImportResult, PgSecretsError, VAULT_IMPORT_MARKER_PATH};
 
-/// Import pre-read secrets into Postgres.
+/// Import pre-read Vault secrets into Postgres and record completion.
 ///
-/// With `MissingOnly`, a path that already has entries is skipped before
-/// any encryption happens; the per-path advisory lock inside
-/// `insert_if_missing` keeps a concurrent writer from sneaking an entry in
-/// between the check and the insert. With `All`, every secret appends a new
-/// journal entry unconditionally.
-pub async fn import_secrets(
+/// With `MissingOnly`, every secret is prepared before the transaction, then
+/// paths that already have entries are skipped under the `secrets` table lock.
+/// With `All`, every secret appends a new journal entry unconditionally.
+///
+/// Vault and KMS work finishes before the transaction begins. The transaction
+/// first takes the marker advisory lock used by the legacy importer, then
+/// fences `work_lock`, writes the complete snapshot, and records the permanent
+/// marker atomically. The table lock keeps lock-table use constant even when a
+/// Vault snapshot has thousands of paths; one query finds existing paths and
+/// the selected entries are inserted in bind-limit-sized chunks. Legacy
+/// importers serialize with this batch while their session lock remains live,
+/// and a worker whose lease was taken over can commit neither stale credentials
+/// nor a completion marker.
+pub async fn import_vault_secrets(
     pool: &PgPool,
+    work_lock: &WorkLock,
     routing: &SecretRouting,
     kms: &dyn KmsBackend,
     secrets: &[(String, Credentials)],
     approach: ImportApproach,
 ) -> Result<ImportResult, PgSecretsError> {
-    let mut result = ImportResult::default();
+    let mut skipped = 0;
+    let mut prepared_secrets = Vec::with_capacity(secrets.len());
 
     for (path, credentials) in secrets {
-        // Cheap existence pre-check so MissingOnly re-imports skip the
-        // DEK generation and encryption for secrets that already landed.
-        // The locked check inside insert_if_missing is still the one that
-        // decides.
-        if matches!(approach, ImportApproach::MissingOnly)
-            && db::secrets::exists(pool, path).await?
-        {
-            result.skipped += 1;
-            continue;
-        }
-
         let json_bytes = Zeroizing::new(serde_json::to_vec(credentials)?);
         let envelope = super::encrypt_envelope(routing, kms, path, &json_bytes).await?;
-
-        match approach {
-            ImportApproach::MissingOnly => {
-                let mut txn = pool
-                    .begin()
-                    .await
-                    .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?;
-                let inserted =
-                    db::secrets::insert_if_missing(&mut txn, &envelope.as_new_entry(path)).await?;
-                txn.commit().await.map_err(|e| {
-                    PgSecretsError::Database(db::DatabaseError::new("commit import", e))
-                })?;
-                if inserted {
-                    result.imported += 1;
-                } else {
-                    result.skipped += 1;
-                }
-            }
-            ImportApproach::All => {
-                let mut conn = pool
-                    .acquire()
-                    .await
-                    .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?;
-                db::secrets::insert(&mut conn, &envelope.as_new_entry(path)).await?;
-                result.imported += 1;
-            }
-        }
+        prepared_secrets.push((path, envelope));
     }
 
-    Ok(result)
+    let marker_envelope =
+        super::encrypt_envelope(routing, kms, VAULT_IMPORT_MARKER_PATH, b"completed").await?;
+    let mut txn = pool
+        .begin()
+        .await
+        .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?;
+
+    // This is the same advisory key used by the old session-lock importer.
+    // Take it before the table lock so an old importer can finish its writes,
+    // then recheck its marker before this batch changes anything.
+    db::secrets::lock_path_advisory(&mut txn, VAULT_IMPORT_MARKER_PATH).await?;
+    if db::secrets::exists(&mut *txn, VAULT_IMPORT_MARKER_PATH).await? {
+        txn.rollback().await.map_err(|e| {
+            PgSecretsError::Database(db::DatabaseError::new(
+                "roll back completed vault import",
+                e,
+            ))
+        })?;
+        return Ok(ImportResult::AlreadyComplete);
+    }
+
+    work_lock.fence_transaction(&mut txn).await?;
+    db::secrets::lock_for_bulk_write(&mut txn).await?;
+
+    let mut occupied_paths = match approach {
+        ImportApproach::MissingOnly => {
+            let paths = prepared_secrets
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>();
+            db::secrets::find_existing_paths(&mut *txn, &paths).await?
+        }
+        ImportApproach::All => Default::default(),
+    };
+    let mut entries = Vec::with_capacity(prepared_secrets.len() + 1);
+    for (path, envelope) in &prepared_secrets {
+        if matches!(approach, ImportApproach::MissingOnly)
+            && !occupied_paths.insert((*path).clone())
+        {
+            skipped += 1;
+            continue;
+        }
+        entries.push(envelope.as_new_entry(path));
+    }
+
+    let imported = entries.len() as u64;
+    entries.push(marker_envelope.as_new_entry(VAULT_IMPORT_MARKER_PATH));
+    db::secrets::insert_many(&mut txn, &entries).await?;
+    txn.commit()
+        .await
+        .map_err(|e| PgSecretsError::Database(db::DatabaseError::new("commit vault import", e)))?;
+
+    Ok(ImportResult::Completed { imported, skipped })
 }
 
 /// Whether the vault import has already completed (the marker secret
 /// exists).
 pub async fn is_vault_import_complete(pool: &PgPool) -> Result<bool, PgSecretsError> {
     Ok(db::secrets::exists(pool, VAULT_IMPORT_MARKER_PATH).await?)
-}
-
-/// Record vault import completion by writing the marker secret. The marker
-/// is an ordinary encrypted journal entry, so it needs no schema of its
-/// own.
-pub async fn mark_vault_import_complete(
-    pool: &PgPool,
-    routing: &SecretRouting,
-    kms: &dyn KmsBackend,
-) -> Result<(), PgSecretsError> {
-    let envelope =
-        super::encrypt_envelope(routing, kms, VAULT_IMPORT_MARKER_PATH, b"completed").await?;
-
-    let mut conn = pool
-        .acquire()
-        .await
-        .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?;
-
-    db::secrets::insert(&mut conn, &envelope.as_new_entry(VAULT_IMPORT_MARKER_PATH)).await?;
-    Ok(())
 }

--- a/crates/api-core/src/secrets/mod.rs
+++ b/crates/api-core/src/secrets/mod.rs
@@ -52,7 +52,7 @@ pub mod routing;
 #[cfg(test)]
 mod tests;
 
-pub use import::{import_secrets, is_vault_import_complete, mark_vault_import_complete};
+pub use import::{import_vault_secrets, is_vault_import_complete};
 pub use metrics::{OperationTimer, SecretsOperation};
 pub use re_wrap::{ReWrapStaleResult, re_wrap_stale};
 pub use routing::SecretRouting;
@@ -100,14 +100,20 @@ pub enum ImportApproach {
     All,
 }
 
-/// What an import did.
-#[derive(Debug, Default)]
-pub struct ImportResult {
-    /// Secrets written to Postgres.
-    pub imported: u64,
-    /// Secrets left alone because their path already had entries
-    /// (`MissingOnly` only).
-    pub skipped: u64,
+/// What happened after a Vault import acquired its database interlock.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ImportResult {
+    /// This transaction committed the secrets and completion marker.
+    Completed {
+        /// Secrets written to Postgres.
+        imported: u64,
+        /// Secrets left alone because their path already had entries
+        /// (`MissingOnly` only).
+        skipped: u64,
+    },
+    /// The permanent marker was already present after taking the import
+    /// interlock, so this transaction wrote nothing.
+    AlreadyComplete,
 }
 
 /// Errors from the Postgres secrets backend.
@@ -422,30 +428,22 @@ impl CredentialWriter for PostgresCredentialManager {
             Zeroizing::new(serde_json::to_vec(credentials).map_err(PgSecretsError::from)?);
         let envelope = self.encrypt_envelope(&path, &json_bytes).await?;
 
-        // Create-only means check-then-insert, and those are two
-        // statements: hold the path's advisory lock for the transaction so
-        // a concurrent create cannot slip between them. Vault gave us this
-        // through its compare-and-set; Postgres needs the lock because the
-        // journal has no unique index to enforce it.
+        // Create-only means check-then-insert, and those are two statements:
+        // hold the path's advisory lock to serialize creates and the table's
+        // write lock to order the check against a bulk import. Vault gave us
+        // the first property through its compare-and-set; Postgres needs both
+        // locks because the journal has no unique path index to enforce it.
         let mut txn = self
             .pool
             .begin()
             .await
             .map_err(|e| PgSecretsError::Database(db::DatabaseError::acquire(e)))?;
-        db::secrets::lock_path(&mut txn, &path)
+        let inserted = db::secrets::insert_if_missing(&mut txn, &envelope.as_new_entry(&path))
             .await
             .map_err(PgSecretsError::from)?;
-
-        if db::secrets::exists(&mut *txn, &path)
-            .await
-            .map_err(PgSecretsError::from)?
-        {
+        if !inserted {
             return Err(PgSecretsError::AlreadyExists(path.to_string()).into());
         }
-
-        db::secrets::insert(&mut txn, &envelope.as_new_entry(&path))
-            .await
-            .map_err(PgSecretsError::from)?;
         txn.commit()
             .await
             .map_err(|e| PgSecretsError::Database(db::DatabaseError::new("commit create", e)))?;

--- a/crates/api-core/src/secrets/tests.rs
+++ b/crates/api-core/src/secrets/tests.rs
@@ -21,17 +21,22 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
-use carbide_kms_provider::{IntegratedKmsProvider, KmsBackend};
+use async_trait::async_trait;
+use carbide_kms_provider::{EncryptedDek, IntegratedKmsProvider, KmsBackend, KmsError};
 use carbide_secrets::credentials::{
     CredentialKey, CredentialReader, CredentialWriter, Credentials,
 };
-use db::work_lock_manager::{self, WorkLockManagerHandle};
+use db::work_lock_manager::{self, AcquireLockError, KeepaliveConfig, WorkLockManagerHandle};
+use tokio::sync::Notify;
 use tokio::task::JoinSet;
+use zeroize::Zeroizing;
 
 use super::re_wrap::{RE_WRAP_WORK_KEY, re_wrap_stale};
 use super::routing::SecretRouting;
-use super::{PgSecretsError, PostgresCredentialManager};
+use super::{ImportResult, PgSecretsError, PostgresCredentialManager};
 
 fn test_key(seed: u8) -> [u8; 32] {
     let mut key = [0u8; 32];
@@ -48,6 +53,66 @@ fn kms_with_keys(keys: &[(&str, u8)]) -> Arc<dyn KmsBackend> {
         .map(|(kek_id, seed)| (kek_id.to_string(), test_key(*seed)))
         .collect();
     Arc::new(IntegratedKmsProvider::new(map))
+}
+
+struct PausingKms {
+    inner: Arc<dyn KmsBackend>,
+    paused_once: AtomicBool,
+    pause_reached: Notify,
+    resume: Notify,
+}
+
+impl PausingKms {
+    fn new(inner: Arc<dyn KmsBackend>) -> Self {
+        Self {
+            inner,
+            paused_once: AtomicBool::new(false),
+            pause_reached: Notify::new(),
+            resume: Notify::new(),
+        }
+    }
+
+    async fn wait_until_paused(&self) {
+        self.pause_reached.notified().await;
+    }
+
+    fn resume(&self) {
+        self.resume.notify_one();
+    }
+}
+
+#[async_trait]
+impl KmsBackend for PausingKms {
+    async fn encrypt_dek(&self, kek_id: &str, dek: &[u8; 32]) -> Result<EncryptedDek, KmsError> {
+        self.inner.encrypt_dek(kek_id, dek).await
+    }
+
+    async fn decrypt_dek(
+        &self,
+        kek_id: &str,
+        encrypted: &EncryptedDek,
+    ) -> Result<Zeroizing<[u8; 32]>, KmsError> {
+        self.inner.decrypt_dek(kek_id, encrypted).await
+    }
+
+    fn can_decrypt_kek(&self, kek_id: &str) -> bool {
+        self.inner.can_decrypt_kek(kek_id)
+    }
+
+    fn kek_ids(&self) -> Vec<String> {
+        self.inner.kek_ids()
+    }
+
+    async fn generate_and_wrap_dek(
+        &self,
+        kek_id: &str,
+    ) -> Result<(Zeroizing<[u8; 32]>, EncryptedDek), KmsError> {
+        if !self.paused_once.swap(true, Ordering::AcqRel) {
+            self.pause_reached.notify_one();
+            self.resume.notified().await;
+        }
+        self.inner.generate_and_wrap_dek(kek_id).await
+    }
 }
 
 fn catch_all_routing(kek_id: &str) -> SecretRouting {
@@ -283,6 +348,516 @@ async fn ciphertext_copied_to_another_path_does_not_decrypt(pool: sqlx::PgPool) 
         stolen.is_err(),
         "a transplanted ciphertext must fail decryption, got: {stolen:?}"
     );
+}
+
+#[crate::sqlx_test]
+async fn bulk_secret_write_blocks_create_before_exists_check(pool: sqlx::PgPool) {
+    let key = ufm_key("bulk-write-create-race");
+    let path = key.to_key_str().to_string();
+    let create_manager = manager(&pool, catch_all_routing("k1"), kms_with_keys(&[("k1", 1)]));
+    let mut bulk_txn = pool.begin().await.expect("begin bulk transaction");
+    db::secrets::lock_for_bulk_write(&mut bulk_txn)
+        .await
+        .expect("lock secrets for bulk write");
+
+    let create_task = tokio::spawn(async move {
+        create_manager
+            .create_credentials(&key, &cred("create", "value"))
+            .await
+    });
+
+    // `insert_if_missing` needs to wait on its table lock before it checks the
+    // path. If it checked first and only blocked at `INSERT`, both transactions
+    // could decide that the path was missing.
+    let wait_result = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM pg_locks
+                    WHERE database = (
+                            SELECT oid FROM pg_database
+                            WHERE datname = current_database()
+                        )
+                      AND relation = 'secrets'::regclass
+                      AND mode = 'RowExclusiveLock'
+                      AND NOT granted
+                )",
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("check create table lock");
+            if waiting {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    if wait_result.is_err() {
+        bulk_txn
+            .rollback()
+            .await
+            .expect("roll back timed-out bulk transaction");
+        create_task.abort();
+        panic!("create did not wait before its existence check");
+    }
+
+    db::secrets::insert(
+        &mut bulk_txn,
+        &db::secrets::NewSecretEntry {
+            path: &path,
+            encrypted_value: b"bulk",
+            nonce: b"nonce",
+            kek_id: "kek",
+            encrypted_dek: b"dek",
+            dek_nonce: b"dek-nonce",
+        },
+    )
+    .await
+    .expect("insert bulk secret");
+    bulk_txn.commit().await.expect("commit bulk transaction");
+
+    let create_error = create_task
+        .await
+        .expect("create task panicked")
+        .expect_err("create must observe the bulk entry after its table lock is granted");
+    assert!(
+        create_error.to_string().contains("already exists"),
+        "unexpected create error: {create_error}"
+    );
+    let row_count: i64 = sqlx::query_scalar("SELECT count(*) FROM secrets WHERE path = $1")
+        .bind(path)
+        .fetch_one(&pool)
+        .await
+        .expect("count raced secret entries");
+    assert_eq!(row_count, 1, "the create race must leave one journal entry");
+}
+
+#[crate::sqlx_test]
+async fn create_waiting_on_path_lock_does_not_block_bulk_write(pool: sqlx::PgPool) {
+    let key = ufm_key("legacy-path-lock-race");
+    let path = key.to_key_str().to_string();
+    let create_manager = manager(&pool, catch_all_routing("k1"), kms_with_keys(&[("k1", 1)]));
+
+    // Model a create from an older replica: it takes the path advisory lock,
+    // checks for an existing entry, and does not request its table-write lock
+    // until the later INSERT.
+    let mut legacy_txn = pool.begin().await.expect("begin legacy create transaction");
+    db::secrets::lock_path_advisory(&mut legacy_txn, &path)
+        .await
+        .expect("take legacy path advisory lock");
+    assert!(
+        !db::secrets::exists(&mut *legacy_txn, &path)
+            .await
+            .expect("check legacy path"),
+        "test path must start empty"
+    );
+
+    let create_task = tokio::spawn(async move {
+        create_manager
+            .create_credentials(&key, &cred("create", "value"))
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            let waiting: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                    SELECT 1 FROM pg_locks
+                    WHERE database = (
+                            SELECT oid FROM pg_database
+                            WHERE datname = current_database()
+                        )
+                      AND locktype = 'advisory'
+                      AND NOT granted
+                )",
+            )
+            .fetch_one(&pool)
+            .await
+            .expect("check create advisory lock");
+            if waiting {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("create did not wait on the legacy path lock");
+
+    let mut bulk_txn = pool.begin().await.expect("begin bulk transaction");
+    sqlx::query("SET LOCAL lock_timeout = '250ms'")
+        .execute(&mut *bulk_txn)
+        .await
+        .expect("set bulk table-lock timeout");
+    let bulk_lock_result = db::secrets::lock_for_bulk_write(&mut bulk_txn).await;
+    if let Err(error) = bulk_lock_result {
+        create_task.abort();
+        drop(bulk_txn);
+        drop(legacy_txn);
+        panic!("create held a table-write lock while waiting on its path lock: {error}");
+    }
+    db::secrets::insert(
+        &mut bulk_txn,
+        &db::secrets::NewSecretEntry {
+            path: &path,
+            encrypted_value: b"bulk",
+            nonce: b"nonce",
+            kek_id: "kek",
+            encrypted_dek: b"dek",
+            dek_nonce: b"dek-nonce",
+        },
+    )
+    .await
+    .expect("insert bulk secret");
+    bulk_txn.commit().await.expect("commit bulk transaction");
+    legacy_txn
+        .rollback()
+        .await
+        .expect("roll back legacy transaction");
+
+    let create_error = create_task
+        .await
+        .expect("create task panicked")
+        .expect_err("create must observe the bulk entry after the legacy lock is released");
+    assert!(
+        create_error.to_string().contains("already exists"),
+        "unexpected create error: {create_error}"
+    );
+}
+
+#[crate::sqlx_test]
+async fn vault_import_missing_only_preserves_existing_and_marker_stops_late_batch(
+    pool: sqlx::PgPool,
+) {
+    let routing = catch_all_routing("k1");
+    let kms = kms_with_keys(&[("k1", 1)]);
+    let pg_manager = manager(&pool, routing.clone(), kms.clone());
+    let existing_key = ufm_key("existing");
+    let missing_key = ufm_key("missing");
+    pg_manager
+        .set_credentials(&existing_key, &cred("postgres", "existing"))
+        .await
+        .expect("seed existing credential");
+
+    let (work_lock_manager, work_lock_tasks) = start_test_work_lock_manager(&pool).await;
+    let work_lock = work_lock_manager
+        .try_acquire_lock("vault-import-missing-only".to_string())
+        .await
+        .expect("acquire vault import work lock");
+    let secrets = vec![
+        (
+            existing_key.to_key_str().to_string(),
+            cred("vault", "existing"),
+        ),
+        (
+            missing_key.to_key_str().to_string(),
+            cred("vault", "missing"),
+        ),
+    ];
+
+    let result = super::import_vault_secrets(
+        &pool,
+        &work_lock,
+        &routing,
+        kms.as_ref(),
+        &secrets,
+        super::ImportApproach::MissingOnly,
+    )
+    .await
+    .expect("import missing Vault credentials");
+    assert_eq!(
+        result,
+        ImportResult::Completed {
+            imported: 1,
+            skipped: 1,
+        }
+    );
+    assert_eq!(
+        pg_manager
+            .get_credentials(&existing_key)
+            .await
+            .expect("read existing credential"),
+        Some(cred("postgres", "existing"))
+    );
+    assert_eq!(
+        pg_manager
+            .get_credentials(&missing_key)
+            .await
+            .expect("read imported credential"),
+        Some(cred("vault", "missing"))
+    );
+
+    let late_key = ufm_key("late");
+    let late_result = super::import_vault_secrets(
+        &pool,
+        &work_lock,
+        &routing,
+        kms.as_ref(),
+        &[(late_key.to_key_str().to_string(), cred("vault", "late"))],
+        super::ImportApproach::All,
+    )
+    .await
+    .expect("recognize completed Vault import");
+    assert_eq!(late_result, ImportResult::AlreadyComplete);
+    assert_eq!(
+        pg_manager
+            .get_credentials(&late_key)
+            .await
+            .expect("read late credential"),
+        None,
+        "the permanent marker must keep a late batch out"
+    );
+
+    work_lock
+        .release()
+        .await
+        .expect("release vault import work lock");
+    drop(work_lock_manager);
+    tokio::time::timeout(Duration::from_secs(3), work_lock_tasks.join_all())
+        .await
+        .expect("WorkLockManager did not shut down in a timely manner");
+}
+
+#[crate::sqlx_test]
+async fn vault_import_missing_only_restores_path_deleted_during_preparation(pool: sqlx::PgPool) {
+    let routing = catch_all_routing("k1");
+    let kms = kms_with_keys(&[("k1", 1)]);
+    let pg_manager = manager(&pool, routing.clone(), kms.clone());
+    let existing_key = ufm_key("deleted-during-preparation");
+    let missing_key = ufm_key("missing-during-preparation");
+    pg_manager
+        .set_credentials(&existing_key, &cred("postgres", "existing"))
+        .await
+        .expect("seed existing credential");
+
+    let (work_lock_manager, work_lock_tasks) = start_test_work_lock_manager(&pool).await;
+    let work_lock = work_lock_manager
+        .try_acquire_lock("vault-import-missing-only-delete-race".to_string())
+        .await
+        .expect("acquire vault import work lock");
+    let pausing_kms = Arc::new(PausingKms::new(kms));
+    let secrets = vec![
+        (
+            existing_key.to_key_str().to_string(),
+            cred("vault", "restored"),
+        ),
+        (
+            missing_key.to_key_str().to_string(),
+            cred("vault", "missing"),
+        ),
+    ];
+    let import_pool = pool.clone();
+    let import_routing = routing.clone();
+    let import_kms = pausing_kms.clone();
+    let import_task = tokio::spawn(async move {
+        let result = super::import_vault_secrets(
+            &import_pool,
+            &work_lock,
+            &import_routing,
+            import_kms.as_ref(),
+            &secrets,
+            super::ImportApproach::MissingOnly,
+        )
+        .await;
+        (result, work_lock)
+    });
+
+    tokio::time::timeout(Duration::from_secs(3), pausing_kms.wait_until_paused())
+        .await
+        .expect("Vault import did not pause during preparation");
+    pg_manager
+        .delete_credentials(&existing_key)
+        .await
+        .expect("delete credential during preparation");
+    pausing_kms.resume();
+
+    let (result, work_lock) = tokio::time::timeout(Duration::from_secs(3), import_task)
+        .await
+        .expect("Vault import did not finish")
+        .expect("Vault import task panicked");
+    assert_eq!(
+        result.expect("import Vault credentials"),
+        ImportResult::Completed {
+            imported: 2,
+            skipped: 0,
+        }
+    );
+    assert_eq!(
+        pg_manager
+            .get_credentials(&existing_key)
+            .await
+            .expect("read restored credential"),
+        Some(cred("vault", "restored"))
+    );
+    assert_eq!(
+        pg_manager
+            .get_credentials(&missing_key)
+            .await
+            .expect("read missing credential"),
+        Some(cred("vault", "missing"))
+    );
+
+    work_lock
+        .release()
+        .await
+        .expect("release vault import work lock");
+    drop(work_lock_manager);
+    tokio::time::timeout(Duration::from_secs(3), work_lock_tasks.join_all())
+        .await
+        .expect("WorkLockManager did not shut down in a timely manner");
+}
+
+#[crate::sqlx_test]
+async fn stale_vault_import_owner_cannot_write_or_mark_after_takeover(pool: sqlx::PgPool) {
+    let keepalive_config = KeepaliveConfig {
+        interval: Duration::from_secs(60),
+        timeout: Duration::from_millis(100),
+    };
+    let mut work_lock_tasks = JoinSet::new();
+    let owner_manager =
+        work_lock_manager::start(&mut work_lock_tasks, pool.clone(), keepalive_config)
+            .await
+            .expect("start owner work lock manager");
+    let replacement_manager =
+        work_lock_manager::start(&mut work_lock_tasks, pool.clone(), keepalive_config)
+            .await
+            .expect("start replacement work lock manager");
+    let work_key = "vault-import-takeover".to_string();
+    let owner_lock = owner_manager
+        .try_acquire_lock(work_key.clone())
+        .await
+        .expect("acquire owner work lock");
+
+    let routing = catch_all_routing("k1");
+    let owner_kms = Arc::new(PausingKms::new(kms_with_keys(&[("k1", 1)])));
+    let first_key = ufm_key("first");
+    let second_key = ufm_key("second");
+    let owner_secrets = vec![
+        (first_key.to_key_str().to_string(), cred("old", "first")),
+        (second_key.to_key_str().to_string(), cred("old", "second")),
+    ];
+    let owner_pool = pool.clone();
+    let owner_routing = routing.clone();
+    let owner_kms_for_import = owner_kms.clone();
+    let owner_import = tokio::spawn(async move {
+        let result = super::import_vault_secrets(
+            &owner_pool,
+            &owner_lock,
+            &owner_routing,
+            owner_kms_for_import.as_ref(),
+            &owner_secrets,
+            super::ImportApproach::All,
+        )
+        .await;
+        (result, owner_lock)
+    });
+    tokio::time::timeout(Duration::from_secs(3), owner_kms.wait_until_paused())
+        .await
+        .expect("owner import did not reach KMS pause");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let acquisition_started = Instant::now();
+    let replacement_lock = loop {
+        match replacement_manager.try_acquire_lock(work_key.clone()).await {
+            Ok(work_lock) => break work_lock,
+            Err(AcquireLockError::WorkAlreadyLocked(_))
+                if acquisition_started.elapsed() < Duration::from_secs(3) =>
+            {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            Err(error) => panic!("could not acquire replacement work lock: {error}"),
+        }
+    };
+
+    owner_kms.resume();
+    let (owner_result, owner_lock) = tokio::time::timeout(Duration::from_secs(3), owner_import)
+        .await
+        .expect("stale owner import did not finish")
+        .expect("stale owner import task panicked");
+    let owner_error = owner_result.expect_err("stale owner import must be fenced out");
+    assert!(
+        matches!(
+            &owner_error,
+            PgSecretsError::Database(db::DatabaseError::FailedPrecondition(_))
+        ),
+        "unexpected stale-owner error: {owner_error}"
+    );
+    owner_lock
+        .release()
+        .await
+        .expect_err("stale owner must not release the replacement lock");
+
+    let replacement_kms = kms_with_keys(&[("k1", 1)]);
+    let replacement_secrets = vec![
+        (first_key.to_key_str().to_string(), cred("new", "first")),
+        (second_key.to_key_str().to_string(), cred("new", "second")),
+    ];
+    let replacement_result = super::import_vault_secrets(
+        &pool,
+        &replacement_lock,
+        &routing,
+        replacement_kms.as_ref(),
+        &replacement_secrets,
+        super::ImportApproach::MissingOnly,
+    )
+    .await
+    .expect("replacement import must complete");
+    assert_eq!(
+        replacement_result,
+        ImportResult::Completed {
+            imported: 2,
+            skipped: 0,
+        }
+    );
+
+    let pg_manager = manager(&pool, routing, replacement_kms);
+    assert_eq!(
+        pg_manager
+            .get_credentials(&first_key)
+            .await
+            .expect("read first credential"),
+        Some(cred("new", "first"))
+    );
+    assert_eq!(
+        pg_manager
+            .get_credentials(&second_key)
+            .await
+            .expect("read second credential"),
+        Some(cred("new", "second"))
+    );
+    assert_eq!(
+        pg_manager
+            .get_history(&first_key)
+            .await
+            .expect("read first history")
+            .len(),
+        1,
+        "stale owner must not append the first credential"
+    );
+    assert_eq!(
+        pg_manager
+            .get_history(&second_key)
+            .await
+            .expect("read second history")
+            .len(),
+        1,
+        "stale owner must not append the second credential"
+    );
+    let marker_count: i64 = sqlx::query_scalar("SELECT count(*) FROM secrets WHERE path = $1")
+        .bind(super::VAULT_IMPORT_MARKER_PATH)
+        .fetch_one(&pool)
+        .await
+        .expect("count vault import markers");
+    assert_eq!(marker_count, 1, "only the replacement may write the marker");
+
+    replacement_lock
+        .release()
+        .await
+        .expect("release replacement work lock");
+    drop(owner_manager);
+    drop(replacement_manager);
+    tokio::time::timeout(Duration::from_secs(3), work_lock_tasks.join_all())
+        .await
+        .expect("work lock managers did not shut down in a timely manner");
 }
 
 // Verifies that re-wrap moves every stale row to the KEK routing assigns,

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -66,9 +66,10 @@ use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_vpc_prefix_controller::context::VpcPrefixStateHandlerServices;
 use carbide_vpc_prefix_controller::handler::VpcPrefixStateHandler;
 use carbide_vpc_prefix_controller::io::VpcPrefixStateControllerIO;
+use db::Transaction;
 use db::machine::{update_dpu_asns, update_dpu_loopback_ips_v6};
 use db::resource_pool::DefineResourcePoolError;
-use db::{Transaction, work_lock_manager};
+use db::work_lock_manager::WorkLockManagerHandle;
 use eyre::WrapErr;
 use futures_util::TryFutureExt;
 use librms::RackManagerClientPool;
@@ -198,6 +199,7 @@ pub(crate) async fn start_runtime(
     credential_manager: Arc<dyn CredentialManager>,
     certificate_provider: Arc<dyn CertificateProvider>,
     db_pool: PgPool,
+    work_lock_manager_handle: WorkLockManagerHandle,
     secrets_context: Option<crate::secrets::SecretsContext>,
     admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     cancel_token: CancellationToken,
@@ -212,13 +214,6 @@ pub(crate) async fn start_runtime(
         &carbide_config,
         dynamic_settings.bmc_proxy.clone(),
     );
-
-    let work_lock_manager_handle = work_lock_manager::start(
-        join_set,
-        db_pool.clone(),
-        work_lock_manager::KeepaliveConfig::default(),
-    )
-    .await?;
 
     let (rms_client, switch_system_image_rms_api) = match carbide_config.rms.api_url.clone() {
         Some(url) if !url.is_empty() => {

--- a/crates/api-db/src/secrets.rs
+++ b/crates/api-db/src/secrets.rs
@@ -27,12 +27,16 @@
 //! callers that decrypt and parse whole result sets never trip over a
 //! non-credential payload.
 
+use std::collections::HashSet;
+
 use carbide_uuid::secret::SecretId;
 use model::secrets::SecretRow;
 use sqlx::{PgConnection, PgTransaction};
 
 use crate::db_read::DbReader;
-use crate::{DatabaseError, DatabaseResult};
+use crate::{BIND_LIMIT, DatabaseError, DatabaseResult};
+
+const SECRET_ENTRY_BINDS: usize = 7;
 
 /// The envelope-encryption columns for one journal entry, exactly as the
 /// manager produced them. Grouped so the insert paths cannot mix up five
@@ -78,6 +82,78 @@ pub async fn insert(txn: &mut PgConnection, entry: &NewSecretEntry<'_>) -> Datab
     Ok(())
 }
 
+/// Append a batch of journal entries with as few INSERT statements as the
+/// PostgreSQL bind limit permits. Each row binds seven values, so oversized
+/// batches are split at [`BIND_LIMIT`] / 7 entries per statement.
+///
+/// When `entries` spans multiple chunks, callers that require all-or-nothing
+/// behavior must pass a connection borrowed from an open transaction. On a
+/// bare connection, an error in a later chunk leaves earlier chunks committed.
+pub async fn insert_many(
+    txn: &mut PgConnection,
+    entries: &[NewSecretEntry<'_>],
+) -> DatabaseResult<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let sql = "INSERT INTO secrets
+         (secret_id, path, encrypted_value, nonce,
+          kek_id, encrypted_dek, dek_nonce) ";
+    for chunk in entries.chunks(BIND_LIMIT / SECRET_ENTRY_BINDS) {
+        let mut query = sqlx::QueryBuilder::new(sql);
+        query.push_values(chunk, |mut row, entry| {
+            row.push_bind(SecretId::new())
+                .push_bind(entry.path)
+                .push_bind(entry.encrypted_value)
+                .push_bind(entry.nonce)
+                .push_bind(entry.kek_id)
+                .push_bind(entry.encrypted_dek)
+                .push_bind(entry.dek_nonce);
+        });
+        query
+            .build()
+            .execute(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::query(sql, e))?;
+    }
+    Ok(())
+}
+
+/// Return the requested paths that already have journal entries.
+pub async fn find_existing_paths(
+    txn: impl DbReader<'_>,
+    paths: &[&str],
+) -> DatabaseResult<HashSet<String>> {
+    if paths.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    let sql = "SELECT DISTINCT path FROM secrets WHERE path = ANY($1)";
+    let existing = sqlx::query_scalar(sql)
+        .bind(paths)
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(sql, e))?;
+    Ok(existing.into_iter().collect())
+}
+
+/// `lock_for_bulk_write` blocks concurrent mutations of `secrets` until
+/// `txn` ends while leaving ordinary reads available.
+///
+/// An atomic batch would otherwise retain one transaction-scoped advisory
+/// lock per path. `SHARE ROW EXCLUSIVE` gives the whole batch one table lock
+/// instead. Callers must take it before reading or writing any of the batch's
+/// credential paths.
+pub async fn lock_for_bulk_write(txn: &mut PgTransaction<'_>) -> DatabaseResult<()> {
+    let sql = "LOCK TABLE secrets IN SHARE ROW EXCLUSIVE MODE";
+    sqlx::query(sql)
+        .execute(&mut **txn)
+        .await
+        .map_err(|e| DatabaseError::query(sql, e))?;
+    Ok(())
+}
+
 /// Append a new journal entry only if the path has no entries yet. Returns
 /// true when the row was inserted, false when entries already existed.
 ///
@@ -97,45 +173,43 @@ pub async fn insert_if_missing(
     Ok(true)
 }
 
-/// Take the transaction-scoped advisory lock for a path. Callers that need
-/// check-then-write semantics on a path (there is no unique index -- the
-/// journal allows many rows per path) take this lock first so concurrent
-/// writers serialize.
+/// Serialize a check-then-write operation for one path. There is no unique
+/// path index -- the journal allows many rows per path -- so concurrent
+/// callers take the path's advisory lock and a compatible table-write lock
+/// before checking whether it exists.
 ///
 /// The hashed string is namespaced with "secrets:" so this can never
 /// collide with other subsystems that take advisory locks on their own
 /// hashed strings.
 pub async fn lock_path(txn: &mut PgTransaction<'_>, path: &str) -> DatabaseResult<()> {
+    // Keep the advisory-first order used by older replicas. If a new caller
+    // held `ROW EXCLUSIVE` while waiting on an old caller's advisory lock, a
+    // queued bulk writer could otherwise complete a three-way deadlock.
+    lock_path_advisory(txn, path).await?;
+
+    // A bulk writer takes `SHARE ROW EXCLUSIVE` before checking any paths.
+    // Take our compatible `ROW EXCLUSIVE` lock before the existence check too:
+    // if a bulk write is active, we need to wait before deciding the path is
+    // missing rather than after the later `INSERT`.
+    let table_lock_sql = "LOCK TABLE secrets IN ROW EXCLUSIVE MODE";
+    sqlx::query(table_lock_sql)
+        .execute(&mut **txn)
+        .await
+        .map_err(|e| DatabaseError::query(table_lock_sql, e))?;
+    Ok(())
+}
+
+/// Take only the transaction-scoped advisory lock for `path`.
+///
+/// Most check-then-write callers need [`lock_path`], which also orders their
+/// existence check against bulk writes. The Vault import uses this narrower
+/// helper for its legacy marker interlock, then takes the batch's stronger
+/// table lock once without an unnecessary `ROW EXCLUSIVE` lock for the marker.
+pub async fn lock_path_advisory(txn: &mut PgTransaction<'_>, path: &str) -> DatabaseResult<()> {
     let sql = "SELECT pg_advisory_xact_lock(hashtextextended('secrets:' || $1, 0))";
     sqlx::query(sql)
         .bind(path)
         .execute(&mut **txn)
-        .await
-        .map_err(|e| DatabaseError::query(sql, e))?;
-    Ok(())
-}
-
-/// Take the session-scoped advisory lock for a path on this connection,
-/// waiting until it is free. The lock is held until
-/// [`unlock_path_session`] runs or the connection drops.
-pub async fn lock_path_session(conn: &mut PgConnection, path: &str) -> DatabaseResult<()> {
-    let sql = "SELECT pg_advisory_lock(hashtextextended('secrets:' || $1, 0))";
-    sqlx::query(sql)
-        .bind(path)
-        .execute(conn)
-        .await
-        .map_err(|e| DatabaseError::query(sql, e))?;
-    Ok(())
-}
-
-/// Release a session-scoped advisory lock taken by [`lock_path_session`].
-/// Dropping the connection releases it too, so this is only needed when the
-/// connection is kept for further work.
-pub async fn unlock_path_session(conn: &mut PgConnection, path: &str) -> DatabaseResult<()> {
-    let sql = "SELECT pg_advisory_unlock(hashtextextended('secrets:' || $1, 0))";
-    sqlx::query(sql)
-        .bind(path)
-        .execute(conn)
         .await
         .map_err(|e| DatabaseError::query(sql, e))?;
     Ok(())
@@ -295,4 +369,40 @@ pub async fn update_dek_wrap(
         .await
         .map_err(|e| DatabaseError::query(sql, e))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[crate::sqlx_test]
+    async fn batched_insert_splits_at_bind_limit(pool: sqlx::PgPool) {
+        let entry_count = BIND_LIMIT / SECRET_ENTRY_BINDS + 1;
+        let paths = (0..entry_count)
+            .map(|index| format!("batch/{index}"))
+            .collect::<Vec<_>>();
+        let entries = paths
+            .iter()
+            .map(|path| NewSecretEntry {
+                path,
+                encrypted_value: b"value",
+                nonce: b"nonce",
+                kek_id: "kek",
+                encrypted_dek: b"dek",
+                dek_nonce: b"dek-nonce",
+            })
+            .collect::<Vec<_>>();
+        let mut connection = pool.acquire().await.expect("acquire database connection");
+
+        insert_many(&mut connection, &entries)
+            .await
+            .expect("insert secret batch");
+        drop(connection);
+
+        let row_count: i64 = sqlx::query_scalar("SELECT count(*) FROM secrets")
+            .fetch_one(&pool)
+            .await
+            .expect("count inserted secrets");
+        assert_eq!(row_count, entry_count as i64);
+    }
 }

--- a/crates/api-db/src/work_lock_manager.rs
+++ b/crates/api-db/src/work_lock_manager.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use carbide_instrument::{Event, LabelValue, emit};
 use sqlx::pool::PoolConnection;
-use sqlx::{PgConnection, PgPool, Postgres};
+use sqlx::{PgConnection, PgPool, PgTransaction, Postgres};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, mpsc, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::MissedTickBehavior;
@@ -148,6 +148,12 @@ static COMMAND_BUFFER_SIZE: usize = 100;
 /// services while holding the lock, a WorkLockManager instead does an atomic write to a
 /// `work_locks` table, vending [`WorkLock`] objects back, which release the lock on Drop. In case
 /// of a crash where drop is not called, each work lock expires after a time interval.
+///
+/// This is a lease, not a fencing token. Exclusivity lasts while keepalives
+/// retain the lease; after expiry, another worker can acquire the key while old
+/// code is still running. PostgreSQL mutations can use
+/// [`WorkLock::fence_transaction`]; external side effects need their own
+/// fencing or idempotency mechanism.
 ///
 /// This is returned by [`start`], and can be used to communicate to acquire [`WorkLock`] items for doing
 #[derive(Clone)]
@@ -289,8 +295,9 @@ async fn run_loop(
             WorkLockManagerCommand::ReleaseLock(WorkLockReleaseCommand {
                 work_key,
                 worker_id,
+                reply_tx,
             }) => {
-                release_lock(db, &work_key, worker_id)
+                let result = release_lock(db, &work_key, worker_id)
                     .await
                     .inspect_err(|e| {
                         emit(WorkLockFailed::Release {
@@ -299,9 +306,13 @@ async fn run_loop(
                             failure: WorkLockFailure::from_release_error(e),
                             error: e.to_string(),
                         });
-                    })
-                    .ok();
-                tracing::debug!(%work_key, "Released work lock");
+                    });
+                if result.is_ok() {
+                    tracing::debug!(%work_key, "Released work lock");
+                }
+                if let Some(reply_tx) = reply_tx {
+                    reply_tx.send(result).ok();
+                }
             }
 
             WorkLockManagerCommand::KeepLockAlive {
@@ -397,24 +408,30 @@ pub struct WorkLock {
     manager: WorkLockManagerHandle,
     work_key: WorkKey,
     worker_id: WorkerId,
+    release_on_drop: bool,
 }
 
 impl Drop for WorkLock {
     fn drop(&mut self) {
+        // Let the keepalive loop stop.
+        self.keepalive_stop_tx.take();
+        if !self.release_on_drop {
+            return;
+        }
+
         tracing::debug!(
             work_key = %self.work_key,
             worker_id = %self.worker_id,
             "Releasing work lock",
         );
 
-        // Let the keepalive loop stop
-        self.keepalive_stop_tx.take();
-
-        // Release the lock now
+        // Queue the release. Callers that will immediately shut down the
+        // manager can use `release` to wait for the database acknowledgment.
         self.manager
             .send_release_command(WorkLockReleaseCommand {
                 work_key: self.work_key.clone(),
                 worker_id: self.worker_id,
+                reply_tx: None,
             })
             .inspect_err(|e| {
                 emit(WorkLockFailed::ReleaseDispatch {
@@ -486,9 +503,81 @@ impl WorkLock {
             manager,
             work_key,
             worker_id,
+            release_on_drop: true,
             #[cfg(test)]
             join_handle,
         }
+    }
+
+    /// Release this lock and wait until the manager processes the database
+    /// deletion.
+    ///
+    /// Dropping a lock normally queues the same deletion. Use this method when
+    /// the caller may shut down the manager immediately afterward.
+    pub async fn release(mut self) -> Result<(), ReleaseLockError> {
+        self.keepalive_stop_tx.take();
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        // Explicit release owns the attempt from here. A dispatch failure means
+        // the receiver is gone, so Drop cannot recover by sending it again.
+        self.release_on_drop = false;
+        self.manager
+            .send_release_command(WorkLockReleaseCommand {
+                work_key: self.work_key.clone(),
+                worker_id: self.worker_id,
+                reply_tx: Some(reply_tx),
+            })
+            .inspect_err(|error| {
+                emit(WorkLockFailed::ReleaseDispatch {
+                    work_key: self.work_key.clone(),
+                    worker_id: self.worker_id,
+                    error: error.to_string(),
+                });
+            })
+            .map_err(|error| ReleaseLockError::WorkLockManagerSend(error.to_string()))?;
+
+        reply_rx.await??;
+        Ok(())
+    }
+
+    /// Fence database writes performed under this lock.
+    ///
+    /// This takes a key-share lock on the `work_locks` row until `txn` ends and
+    /// verifies that it still names this worker. A replacement acquisition
+    /// changes `worker_id`, which is part of
+    /// `idx_work_locks_on_worker_id_and_key`, so PostgreSQL must wait for the
+    /// fence before it can update that key. Deletion waits too, while the
+    /// manager's non-key `last_keepalive` updates can continue normally.
+    ///
+    /// Nominal lease expiry without takeover is allowed: locking this row
+    /// serializes any later takeover behind the transaction, and callers must
+    /// finish all protected writes before committing it.
+    ///
+    /// Keep the transaction short and free of external I/O. A replica that
+    /// tries to acquire this key waits for the fence in its single manager
+    /// loop, which also delays that replica's unrelated lock commands.
+    pub async fn fence_transaction(&self, txn: &mut PgTransaction<'_>) -> DatabaseResult<()> {
+        let query = r#"
+SELECT true
+FROM work_locks
+WHERE work_key = $1 AND worker_id = $2
+FOR KEY SHARE
+        "#;
+        let still_held: Option<bool> = sqlx::query_scalar(query)
+            .bind(&self.work_key)
+            .bind(self.worker_id)
+            .fetch_optional(&mut **txn)
+            .await
+            .map_err(|e| DatabaseError::query(query, e))?;
+
+        if still_held.is_none() {
+            return Err(DatabaseError::FailedPrecondition(format!(
+                "work lock is no longer held for work_key={}, worker_id={}",
+                self.work_key, self.worker_id,
+            )));
+        }
+
+        Ok(())
     }
 
     #[cfg(test)]
@@ -674,6 +763,7 @@ struct QueuedWorkLockManagerCommand {
 struct WorkLockReleaseCommand {
     work_key: WorkKey,
     worker_id: WorkerId,
+    reply_tx: Option<oneshot::Sender<DatabaseResult<()>>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -703,6 +793,18 @@ pub enum AcquireLockError {
     WorkLockManagerReply(#[from] tokio::sync::oneshot::error::RecvError),
     #[error(transparent)]
     Timeout(#[from] tokio::time::error::Elapsed),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ReleaseLockError {
+    #[error(transparent)]
+    Database(#[from] DatabaseError),
+    #[error("error sending ReleaseLock command to WorkLockManager: {0}")]
+    WorkLockManagerSend(String),
+    #[error(
+        "error receiving ReleaseLock reply from WorkLockManager, database connections are likely failing; the lease will expire instead: {0}"
+    )]
+    WorkLockManagerReply(#[from] tokio::sync::oneshot::error::RecvError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1202,6 +1304,162 @@ mod tests {
     }
 
     #[crate::sqlx_test]
+    async fn explicit_release_waits_for_database_deletion(pool: PgPool) {
+        let mut join_set = JoinSet::new();
+        let manager = start(&mut join_set, pool.clone(), Default::default())
+            .await
+            .expect("start work lock manager");
+        let work_key = "acknowledged-release".to_string();
+        let work_lock = manager
+            .try_acquire_lock(work_key.clone())
+            .await
+            .expect("acquire work lock");
+
+        work_lock
+            .release()
+            .await
+            .expect("release work lock with acknowledgment");
+        join_set.abort_all();
+        drop(join_set);
+
+        let query = "SELECT count(*) FROM work_locks WHERE work_key = $1";
+        let row_count: i64 = sqlx::query_scalar(query)
+            .bind(work_key)
+            .fetch_one(&pool)
+            .await
+            .expect("check released work lock");
+        assert_eq!(
+            row_count, 0,
+            "release acknowledgment returned before the work_locks row was deleted"
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn fenced_transaction_allows_keepalive_and_rejects_stale_owner(pool: PgPool) {
+        // Isolate the deliberate stale-release metric from neighboring tests.
+        let _metrics_guard = MetricsCapture::start();
+        let mut join_set = JoinSet::new();
+        let owner_manager = start(
+            &mut join_set,
+            pool.clone(),
+            KeepaliveConfig {
+                interval: Duration::from_secs(60),
+                timeout: Duration::from_millis(500),
+            },
+        )
+        .await
+        .expect("start work lock manager");
+        let replacement_manager = start(
+            &mut join_set,
+            pool.clone(),
+            KeepaliveConfig {
+                interval: Duration::from_secs(60),
+                timeout: Duration::from_millis(500),
+            },
+        )
+        .await
+        .expect("start replacement work lock manager");
+        let work_key = "fenced-transaction".to_string();
+        let old_lock = owner_manager
+            .try_acquire_lock(work_key.clone())
+            .await
+            .expect("acquire original work lock");
+
+        let mut fence_txn = pool.begin().await.expect("begin fenced transaction");
+        old_lock
+            .fence_transaction(&mut fence_txn)
+            .await
+            .expect("fence original owner");
+        let fence_task = tokio::spawn(async move {
+            sqlx::query("SELECT pg_sleep(1)")
+                .execute(&mut *fence_txn)
+                .await
+                .expect("hold fenced transaction");
+            fence_txn.commit().await.expect("commit fenced transaction");
+        });
+
+        // `FOR KEY SHARE` must leave the manager's non-key keepalive update
+        // unblocked while the fence keeps ownership changes out.
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            owner_manager.keep_lock_alive(work_key.clone(), old_lock.worker_id),
+        )
+        .await
+        .expect("keepalive blocked behind fenced transaction")
+        .expect("keep fenced owner alive");
+
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            sqlx::query(
+                "UPDATE work_locks SET last_keepalive = now() - interval '1 second' \
+             WHERE work_key = $1",
+            )
+            .bind(&work_key)
+            .execute(&pool),
+        )
+        .await
+        .expect("lease expiry update blocked behind fenced transaction")
+        .expect("expire original lease");
+
+        let replacement_manager_for_acquire = replacement_manager.clone();
+        let replacement_work_key = work_key.clone();
+        let replacement_task = tokio::spawn(async move {
+            replacement_manager_for_acquire
+                .try_acquire_lock(replacement_work_key)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !replacement_task.is_finished(),
+            "lease takeover passed the fenced transaction"
+        );
+
+        fence_task.await.expect("fence task panicked");
+        let new_lock = replacement_task
+            .await
+            .expect("replacement task panicked")
+            .expect("acquire replacement work lock");
+
+        let mut stale_txn = pool.begin().await.expect("begin stale transaction");
+        let stale_error = old_lock
+            .fence_transaction(&mut stale_txn)
+            .await
+            .expect_err("superseded owner must not fence writes");
+        assert!(
+            matches!(&stale_error, DatabaseError::FailedPrecondition(_)),
+            "unexpected stale-owner error: {stale_error}"
+        );
+        stale_txn
+            .rollback()
+            .await
+            .expect("roll back stale transaction");
+
+        let mut current_txn = pool.begin().await.expect("begin current transaction");
+        new_lock
+            .fence_transaction(&mut current_txn)
+            .await
+            .expect("replacement owner must fence writes");
+        current_txn
+            .rollback()
+            .await
+            .expect("roll back current transaction");
+
+        old_lock
+            .release()
+            .await
+            .expect_err("superseded owner must not release replacement lock");
+        new_lock
+            .release()
+            .await
+            .expect("release replacement work lock");
+        drop(owner_manager);
+        drop(replacement_manager);
+        tokio::time::timeout(Duration::from_secs(3), join_set.join_all())
+            .await
+            .expect("WorkLockManager did not shut down in a timely manner");
+    }
+
+    #[crate::sqlx_test]
     async fn commands_and_releases_keep_fifo_order(pool: PgPool) {
         let keepalive_config = KeepaliveConfig::default();
         let mut db = pool.acquire().await.unwrap();
@@ -1230,6 +1488,7 @@ mod tests {
             .send_release_command(WorkLockReleaseCommand {
                 work_key: work_key.clone(),
                 worker_id,
+                reply_tx: None,
             })
             .unwrap();
         let (acquire_reply_tx, acquire_reply_rx) = oneshot::channel();
@@ -1256,6 +1515,7 @@ mod tests {
             .send_release_command(WorkLockReleaseCommand {
                 work_key,
                 worker_id: replacement_worker_id,
+                reply_tx: None,
             })
             .unwrap();
         drop(manager);

--- a/crates/api-integration-tests/tests/secrets_import.rs
+++ b/crates/api-integration-tests/tests/secrets_import.rs
@@ -20,6 +20,7 @@
 //! Requires: `vault` binary in PATH, `DATABASE_URL` env var set.
 
 use std::str::FromStr;
+use std::time::Duration;
 
 use bmc_vendor::DpuModel;
 use carbide_secrets::credentials::{
@@ -29,6 +30,7 @@ use carbide_secrets::credentials::{
 use carbide_secrets::{VaultConfig, create_vault_client};
 use sqlx::PgPool;
 use sqlx::postgres::PgConnectOptions;
+use tokio::task::JoinSet;
 
 /// make_test_key creates a deterministic 32-byte key from a seed byte.
 fn make_test_key(seed: u8) -> [u8; 32] {
@@ -272,9 +274,17 @@ async fn exercise_import(test_pool: &PgPool) -> eyre::Result<()> {
     // --- Import into Postgres ---
     let encryption_key = make_test_key(42);
     let (routing, kms) = make_routing_and_kms(encryption_key);
+    let mut work_lock_tasks = JoinSet::new();
+    let work_lock_manager =
+        db::work_lock_manager::start(&mut work_lock_tasks, test_pool.clone(), Default::default())
+            .await?;
+    let work_lock = work_lock_manager
+        .try_acquire_lock("secrets-import-integration-test".to_string())
+        .await?;
 
-    let result = carbide_api_core::secrets::import_secrets(
+    let result = carbide_api_core::secrets::import_vault_secrets(
         test_pool,
+        &work_lock,
         &routing,
         kms.as_ref(),
         &vault_secrets,
@@ -282,9 +292,14 @@ async fn exercise_import(test_pool: &PgPool) -> eyre::Result<()> {
     )
     .await?;
 
-    assert_eq!(result.imported, secrets.len() as u64);
-    assert_eq!(result.skipped, 0);
-    eprintln!("Imported {} secrets into Postgres", result.imported);
+    assert_eq!(
+        result,
+        carbide_api_core::secrets::ImportResult::Completed {
+            imported: secrets.len() as u64,
+            skipped: 0,
+        }
+    );
+    eprintln!("Imported {} secrets into Postgres", secrets.len());
 
     // --- Verify all secrets are readable from Postgres ---
     let pg_mgr = carbide_api_core::secrets::PostgresCredentialManager::new(
@@ -303,9 +318,10 @@ async fn exercise_import(test_pool: &PgPool) -> eyre::Result<()> {
     }
     eprintln!("All {} secrets verified in Postgres", secrets.len());
 
-    // --- Re-import with MissingOnly — should be a noop ---
-    let result2 = carbide_api_core::secrets::import_secrets(
+    // --- The permanent marker makes any later import a no-op ---
+    let result2 = carbide_api_core::secrets::import_vault_secrets(
         test_pool,
+        &work_lock,
         &routing,
         kms.as_ref(),
         &vault_secrets,
@@ -313,22 +329,24 @@ async fn exercise_import(test_pool: &PgPool) -> eyre::Result<()> {
     )
     .await?;
 
-    assert_eq!(result2.imported, 0, "re-import should not import anything");
     assert_eq!(
-        result2.skipped,
-        secrets.len() as u64,
-        "re-import should skip all"
+        result2,
+        carbide_api_core::secrets::ImportResult::AlreadyComplete
     );
-    eprintln!("Re-import was a noop (skipped {})", result2.skipped);
+    eprintln!("Permanent marker prevented a second import");
 
     // --- Verify marker ---
-    carbide_api_core::secrets::mark_vault_import_complete(test_pool, &routing, kms.as_ref())
-        .await?;
     assert!(
         carbide_api_core::secrets::is_vault_import_complete(test_pool).await?,
         "import marker should be set"
     );
     eprintln!("Import marker verified");
+
+    work_lock.release().await?;
+    drop(work_lock_manager);
+    tokio::time::timeout(Duration::from_secs(3), work_lock_tasks.join_all())
+        .await
+        .expect("WorkLockManager did not shut down in a timely manner");
 
     Ok(())
 }

--- a/crates/api/src/resources.rs
+++ b/crates/api/src/resources.rs
@@ -18,7 +18,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use carbide_api_core::bootstrap::lock_vault_import_session;
+use carbide_api_core::bootstrap::acquire_vault_import_work_lock;
 use carbide_api_core::cfg::file::{
     CarbideConfig, CredentialBackend, ImportSource, ProviderConfig, SecretsConfig,
 };
@@ -32,6 +32,7 @@ use carbide_secrets::{
     CredentialConfig, ForgeVaultClient, MemoryCredentialStore, SpiffeIdentity, VaultConfig,
     create_certificate_provider, create_credential_manager_from, create_vault_client,
 };
+use db::work_lock_manager::{self, WorkLockManagerHandle};
 use eyre::WrapErr;
 use opentelemetry::metrics::Meter;
 use sqlx::postgres::PgSslMode;
@@ -45,6 +46,7 @@ pub(crate) struct RuntimeResources {
     pub credential_manager: Arc<dyn CredentialManager>,
     pub certificate_provider: Arc<dyn CertificateProvider>,
     pub db_pool: PgPool,
+    pub work_lock_manager_handle: WorkLockManagerHandle,
     pub secrets_context: Option<SecretsContext>,
 }
 
@@ -78,6 +80,12 @@ pub(crate) async fn setup_resources(
     )?;
 
     let db_pool = connect_postgres(carbide_config).await?;
+    let work_lock_manager_handle = work_lock_manager::start(
+        join_set,
+        db_pool.clone(),
+        work_lock_manager::KeepaliveConfig::default(),
+    )
+    .await?;
 
     // Build the local-override readers (env, file); each is consulted only when
     // its [credentials.*] section is enabled. The backends (postgres,
@@ -146,10 +154,12 @@ pub(crate) async fn setup_resources(
         if secrets_config.import_from == Some(ImportSource::Vault) {
             import_vault_secrets_once(
                 &db_pool,
+                &work_lock_manager_handle,
                 secrets_config,
                 &routing,
                 kms.as_ref(),
                 &vault_client,
+                cancel_token,
             )
             .await?;
         }
@@ -204,6 +214,7 @@ pub(crate) async fn setup_resources(
         credential_manager,
         certificate_provider,
         db_pool,
+        work_lock_manager_handle,
         secrets_context,
     })
 }
@@ -439,15 +450,26 @@ fn build_kms_backend(
 /// where they are stranded. Site-explorer credential rotation is the writer
 /// to worry about; keep it disabled until the whole fleet runs a consistent
 /// config.
-/// TODO(@chet): Migrate this to using WorkLockManager to do scoped locks of
-/// work without holding open a database connection or transaction.
-#[allow(txn_held_across_await)]
+///
+/// During a rolling upgrade, the fenced transaction also takes the marker
+/// advisory lock used by the old session-lock importer. Healthy old and new
+/// importer sessions therefore serialize even though only the new replicas use
+/// `WorkLockManager`. The old implementation cannot be fenced if its detached
+/// lock session dies while its importer keeps running, so deploy this code to
+/// every API replica before starting an import on a site without the marker.
+///
+/// Normal returns and errors wait for the manager to release the work lock; a
+/// hard crash falls back to its lease expiry. Vault and KMS work is prepared
+/// before the transaction atomically commits every secret plus the marker, so
+/// an expired owner cannot write after a replacement takes over.
 async fn import_vault_secrets_once(
     db_pool: &PgPool,
+    work_lock_manager: &WorkLockManagerHandle,
     config: &SecretsConfig,
     routing: &SecretRouting,
     kms: &dyn KmsBackend,
     vault_client: &ForgeVaultClient,
+    cancel_token: &CancellationToken,
 ) -> eyre::Result<()> {
     if is_import_complete(db_pool).await? {
         tracing::info!("Vault import already completed");
@@ -455,71 +477,82 @@ async fn import_vault_secrets_once(
     }
 
     // Several replicas can boot against the same empty database at once.
-    // The marker path's advisory lock lets one of them import while the
-    // rest wait here, re-check the marker, and move on. It is a session
-    // lock on a dedicated connection rather than a transaction-scoped one:
-    // the import awaits Vault enumeration and pool-backed writes, and
-    // holding a transaction across those would trip `txn_held_across_await`
-    // and, under concurrent startup, risk waiters starving the pool the
-    // importer itself needs. Detaching the connection guarantees the lock
-    // releases when it drops, including on an early error return.
-    let mut lock_connection = db_pool
-        .acquire()
-        .await
-        .wrap_err("acquire vault import lock connection")?
-        .detach();
-    lock_vault_import_session(&mut lock_connection)
-        .await
-        .map_err(eyre::Report::new)
-        .wrap_err("acquire vault import lock")?;
-    if is_import_complete(db_pool).await? {
+    // The work lock coordinates healthy replicas without keeping a dedicated
+    // database session open across Vault and KMS calls. Waiters keep checking
+    // the permanent marker so they can finish as soon as the importer writes it.
+    let Some(work_lock) =
+        acquire_vault_import_work_lock(db_pool, work_lock_manager, cancel_token).await?
+    else {
         tracing::info!("Vault import completed by another replica");
         return Ok(());
-    }
+    };
 
-    // Strict enumeration: any list or read failure aborts the boot rather
-    // than importing a subset and recording it as complete. The marker is
-    // permanent, so a partial import here would be silent credential loss.
-    let secrets = vault_client
-        .get_secrets_strict()
-        .await
-        .map_err(eyre::Report::from)
-        .wrap_err("enumerate vault secrets for import")?;
-    if secrets.is_empty() {
-        return Err(eyre::eyre!(
-            "vault enumeration returned no secrets; refusing to record an import from an empty vault. if this site really has no vault secrets, remove import_from from the [secrets] config; otherwise fix vault and restart"
-        ));
-    }
+    let import_result: eyre::Result<()> = async {
+        // Strict enumeration: any list or read failure aborts the boot rather
+        // than importing a subset and recording it as complete. The marker is
+        // permanent, so a partial import here would be silent credential loss.
+        let secrets = vault_client
+            .get_secrets_strict()
+            .await
+            .map_err(eyre::Report::from)
+            .wrap_err("enumerate vault secrets for import")?;
+        if secrets.is_empty() {
+            return Err(eyre::eyre!(
+                "vault enumeration returned no secrets; refusing to record an import from an empty vault. if this site really has no vault secrets, remove import_from from the [secrets] config; otherwise fix vault and restart"
+            ));
+        }
 
-    tracing::info!(
-        vault_secret_count = secrets.len(),
-        approach = ?config.import_approach,
-        "Importing secrets from vault"
-    );
-    let result = carbide_api_core::secrets::import_secrets(
-        db_pool,
-        routing,
-        kms,
-        &secrets,
-        config.import_approach,
-    )
-    .await
-    .map_err(eyre::Report::new)
-    .wrap_err("vault secret import")?;
-    tracing::info!(
-        imported_secret_count = result.imported,
-        skipped_secret_count = result.skipped,
-        "Vault secret import completed"
-    );
-    carbide_api_core::secrets::mark_vault_import_complete(db_pool, routing, kms)
+        tracing::info!(
+            vault_secret_count = secrets.len(),
+            approach = ?config.import_approach,
+            "Importing secrets from vault"
+        );
+        let stats = carbide_api_core::secrets::import_vault_secrets(
+            db_pool,
+            &work_lock,
+            routing,
+            kms,
+            &secrets,
+            config.import_approach,
+        )
         .await
         .map_err(eyre::Report::new)
-        .wrap_err("mark vault import complete")?;
-    tracing::info!("Vault import marked complete");
+        .wrap_err("vault secret import")?;
+        match stats {
+            carbide_api_core::secrets::ImportResult::Completed { imported, skipped } => {
+                tracing::info!(
+                    imported_secret_count = imported,
+                    skipped_secret_count = skipped,
+                    "Vault secret import completed"
+                );
+            }
+            carbide_api_core::secrets::ImportResult::AlreadyComplete => {
+                tracing::info!("Vault import completed by another replica");
+            }
+        }
 
-    // lock_connection drops here, closing the connection and releasing the
-    // session advisory lock.
-    Ok(())
+        Ok(())
+    }
+    .await;
+
+    match (import_result, work_lock.release().await) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(import_error), Ok(())) => Err(import_error),
+        (Ok(()), Err(release_error)) => {
+            tracing::warn!(
+                error = %release_error,
+                "Vault import committed but its work lock could not be released"
+            );
+            Ok(())
+        }
+        (Err(import_error), Err(release_error)) => {
+            tracing::warn!(
+                error = %release_error,
+                "Vault import failed and its work lock could not be released"
+            );
+            Err(import_error)
+        }
+    }
 }
 
 async fn is_import_complete(db_pool: &PgPool) -> eyre::Result<bool> {

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -105,6 +105,7 @@ pub async fn run(
         credential_manager,
         certificate_provider,
         db_pool,
+        work_lock_manager_handle,
         secrets_context,
     } = setup_resources(
         &carbide_config,
@@ -125,6 +126,7 @@ pub async fn run(
         credential_manager,
         certificate_provider,
         db_pool,
+        work_lock_manager_handle,
         secrets_context,
         admin_ui_routes_builder,
         cancel_token,


### PR DESCRIPTION
The one-time Vault import used to hold a dedicated PostgreSQL session from startup through every Vault and KMS call. Moving that coordination to `WorkLockManager` frees the checkout earlier, but its expiring leases mean the database write needs its own ownership fence.

So, this prepares the Vault/KMS data before opening a transaction, then commits every secret and the permanent marker behind the matching `work_locks` row. An expired owner cannot write after a replacement takes over, and a crash cannot leave a partially imported store.

Primary callouts are:

- Use `FOR KEY SHARE` to block lease takeover and release while still allowing `last_keepalive` updates.
- Keep the existing `secrets:/_vault_import` advisory lock as the mixed-version interlock while a legacy importer's detached lock session remains live.
- Preserve advisory-first lock ordering for normal creates so mixed-version writers cannot deadlock the bulk table lock.
- Use one `secrets` table lock, one existing-path query, and bind-limit-sized inserts so large batches avoid per-path lock and round-trip growth.
- Make `insert_if_missing` acquire its table-write lock before checking the path, keeping normal creates ordered against the batch.
- Treat a release failure after the import commits as lease cleanup trouble, not a failed import.

Tests added!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4393

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The reviewed implementation passed:

```text
cargo test --locked -p carbide-api-db work_lock_manager::tests --lib
cargo test --locked -p carbide-api-db batched_insert_splits_at_bind_limit --lib
cargo test --locked -p carbide-api-core vault_import_ --lib
cargo test --locked -p carbide-api-core bulk_secret_write_blocks_create_before_exists_check --lib
cargo test --locked -p carbide-api-core create_fails_when_credential_exists --lib
cargo test --locked -p carbide-api zero_database_pool_durations_are_rejected_at_startup --lib
cargo test --locked -p carbide-api-integration-tests --test secrets_import vault_to_postgres_import -- --nocapture
cargo make format-nightly
cargo make check-format-nightly
cargo make lint-error-messages
cargo make clippy
cargo make carbide-lints
```

The database regressions keep a fenced transaction open long enough to prove that keepalives continue while lease takeover waits, verify that the replacement acquires the lock and the stale owner can no longer fence or release it, and cross the SQL bind limit to exercise multi-statement batch insertion. The API-core coverage exercises takeover during KMS work, `MissingOnly` preservation, deletion during preparation, the permanent-marker no-op, and normal credential creates racing both the bulk table lock and a legacy path lock. The Vault/Postgres integration test imports and reads back 100 secrets through the batched path, then verifies the marker prevents another import.

## Additional Notes

- `WorkLock::fence_transaction` relies on the unique `(work_key, worker_id)` index: `FOR KEY SHARE` permits the non-key `last_keepalive` update while blocking the key-changing takeover and row deletion until commit.
- The marker advisory lock is taken before the table lock. That keeps the new transaction coordinated with a legacy importer while its detached lock session remains live, without introducing a lock-order inversion.
- An old importer cannot be fenced if its detached lock session dies while its pool-backed writes keep running, and an old credential writer does not know about the new bulk table-lock protocol. Deploy this code to every API replica before starting an import on a site without the marker, and keep credential rotation disabled until every replica runs a consistent writer configuration.
- Documentation corrections remain isolated to a follow-up docs-only issue and PR, per repository policy.

Closes #4393

