### PR TITLE
feat(ci): add migration-police for migration filenames

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1362,6 +1362,25 @@ jobs:
       - name: Run Protolint
         run: protolint lint -config_path=.protolint.yaml crates/rpc/proto/
 
+  migration-police:
+    permissions:
+      contents: read
+    needs:
+      - changes
+    if: ${{ contains(github.ref, 'pull-request/') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Check new migration timestamps
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          bash scripts/check-migration-filenames.sh --base origin/main
+
   proto-breaking-changes:
     name: Proto Breaking Changes Check
     runs-on: ubuntu-latest
@@ -2059,6 +2078,7 @@ jobs:
       - build-release-artifacts-arm-host
       - security-secret-scan
       - lint-police
+      - migration-police
       - check-rest-core-proto-sync
       - build-machine-a-tron
       - build-mat-k8s-controller

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,11 @@ verification expectations.
 See [`STYLE_GUIDE.md`](STYLE_GUIDE.md) for detailed Rust coding conventions.
 Make sure to review it to ensure changes meet the expected style of the codebase.
 
+Name new Core database migrations with the fully populated
+`YYYYMMDDhhmmss_description.sql` format described in
+[`STYLE_GUIDE.md`](STYLE_GUIDE.md#database-migrations). The `migration-police`
+CI job checks only newly added migrations, so existing filenames remain accepted.
+
 ### Documentation
 
 Give every fenced code block a language identifier. Use `bash` or `sh` for

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -342,6 +342,14 @@ your interface `async` just so you can use the tokio Mutex. That way callers can
 async themselves. Async work should generally be traceable to some I/O or timer that needs to be used, otherwise
 code should typically be synchronous.
 
+## Database migrations
+
+Name new Core database migration files with a fully populated 14-digit timestamp:
+`YYYYMMDDhhmmss_description.sql`. Use the actual hour, minute, and second values instead of a
+trailing `0000` minute-and-second placeholder so independently authored migrations are less likely
+to collide. Existing migration filenames remain unchanged, and migrations already on `main` are
+immutable.
+
 ## Database transactions
 
 Transactions should be used to group write operations together such that they can be rolled back on failure. But do

--- a/scripts/check-migration-filenames.sh
+++ b/scripts/check-migration-filenames.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-migration-filenames.sh --base REVISION"
+	echo "       check-migration-filenames.sh MIGRATION_FILE..."
+}
+
+escape_workflow_data() {
+	local value="$1"
+
+	value="${value//'%'/'%25'}"
+	value="${value//$'\r'/'%0D'}"
+	value="${value//$'\n'/'%0A'}"
+	printf '%s' "${value}"
+}
+
+migration_files=()
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+elif [[ "${1:-}" == "--base" ]]; then
+	if (( $# != 2 )); then
+		usage >&2
+		exit 2
+	fi
+
+	base_revision="$2"
+	migration_list="$(mktemp)"
+	trap 'rm -f "${migration_list}"' EXIT
+
+	git diff --no-renames --diff-filter=A --name-only -z \
+		"${base_revision}...HEAD" \
+		-- ':(top,glob)crates/api-db/migrations/*.sql' >"${migration_list}"
+
+	while IFS= read -r -d '' migration_file; do
+		migration_files+=("${migration_file}")
+	done <"${migration_list}"
+elif (( $# > 0 )); then
+	migration_files=("$@")
+else
+	usage >&2
+	exit 2
+fi
+
+failed=0
+
+for migration_file in "${migration_files[@]}"; do
+	filename="${migration_file##*/}"
+	timestamp="${filename%%_*}"
+
+	if [[ ! "${filename}" =~ ^[0-9]{14}_.+\.sql$ ]]; then
+		message="New Core database migration ${migration_file} must use the YYYYMMDDhhmmss_description.sql filename format."
+		printf '::error title=Invalid migration filename::%s\n' \
+			"$(escape_workflow_data "${message}")"
+		failed=1
+	elif [[ "${timestamp}" =~ ^[0-9]{10}0000$ ]]; then
+		message="New Core database migration ${migration_file} must use a fully populated YYYYMMDDhhmmss timestamp; replace the trailing 0000 minute/second placeholder."
+		printf '::error title=Placeholder migration timestamp::%s\n' \
+			"$(escape_workflow_data "${message}")"
+		failed=1
+	fi
+done
+
+if (( failed )); then
+	echo "migration-police rejected one or more new database migrations."
+	exit 1
+fi
+
+printf 'migration-police checked %d new database migration(s).\n' "${#migration_files[@]}"


### PR DESCRIPTION
## What happened

The failures on #4422 and #4424 looked flaky because they surfaced as a very large test cascade, but the underlying failure was deterministic: SQLx migration versions are keyed by the numeric timestamp prefix, and two different migration files had the same version.

On #4422, these files both used `20260722120000`:

- `20260722120000_bmc_suppressions.sql`
- `20260722120000_preserve_machine_ipv6_loopback.sql`

That made template-database migration fail on the `_sqlx_migrations_pkey` constraint. Every database-backed test that tried to create a template then failed from the same setup error, producing 1,114 failures rather than 1,114 independent test bugs.

Two stale fixes later composed on #4424 and moved both files to `20260722120001`, recreating the same collision under a different version. #4432 repaired `main` by restoring the already-published loopback migration to `20260722120000` and leaving the newer BMC migration at `20260722120001`; the SQL contents themselves did not change.

## What this changes

This adds a separate `migration-police` job that looks only at migration files newly added by a pull request and rejects timestamp prefixes whose minute and second fields are both `00`. New Core migrations must use a fully populated `YYYYMMDDhhmmss_description.sql` timestamp.

The existing duplicate-version test remains the definitive backstop once migrations are in the same tree. This earlier CI rule reduces the chance that independent branches choose the same convenient `...0000` placeholder before they can be compared together. Existing migrations remain accepted.

The checker compares the PR head with the merge base (`base...HEAD`), so a stale PR does not incorrectly claim that a migration renamed only on `main` was added by the PR. `STYLE_GUIDE.md` and `AGENTS.md` document the same naming rule.

## Related issues

Fixes https://github.com/NVIDIA/infra-controller/issues/4431

Related failure investigations: #4422, #4424

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Focused checks covered:

- accepting a valid fully populated timestamp
- rejecting a `0000` minute/second placeholder
- accepting zero seconds when the minute is populated
- rejecting malformed migration basenames
- a stale PR whose migration was renamed only on `main`
- invalid base-revision handling
- shell syntax, workflow YAML parsing, and `git diff --check`
- `cargo test -p carbide-api-db migration_versions_are_unique --lib`

The required local gates passed:

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

Local CodeRabbit produced no findings. Claude review identified the stale-PR two-dot diff problem; the checker was changed to merge-base diff semantics and the stale #4422 branch was used as a focused regression case. Cloud CodeRabbit subsequently completed a full review of the amended commit with no actionable findings.

## Additional Notes

The immediate migration collision is already repaired on current `main` by #4432. This PR prevents the naming pattern that allowed two independent branches to select the same placeholder timestamp; it does not rename published migrations.

Closes #4431
