### PR TITLE
fix(devspace): align machine-a-tron configuration with mat-0 pod naming

### DIFF
--- a/dev/deployment/devspace/README.md
+++ b/dev/deployment/devspace/README.md
@@ -111,7 +111,7 @@ The DevSpace images also use Dockerfile-specific ignore files: [`Dockerfile.api.
 
 DevSpace watches the Rust workspace, toolchain metadata, and the runtime Dockerfiles to decide when images need rebuilding. On kind clusters, the pre-deploy hooks load all Core and REST images into the cluster selected by the current kube context.
 
-The `nico-machine-a-tron` Helm subchart configuration is in [`values.base.yaml`](values.base.yaml). The local API and BMC proxy configs point BMC traffic at `nico-machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266`.
+The `nico-machine-a-tron` Helm subchart configuration is in [`values.base.yaml`](values.base.yaml). The local API and BMC proxy configs point BMC traffic at `nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266`.
 
 Common usage:
 

--- a/dev/deployment/devspace/setup-rest-integration.sh
+++ b/dev/deployment/devspace/setup-rest-integration.sh
@@ -9,6 +9,8 @@ REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../../.." && pwd)"
 
 CORE_NAMESPACE="${LOCAL_DEV_NAMESPACE:-nico-system}"
 REST_NAMESPACE="nico-rest"
+MACHINE_A_TRON_DEPLOYMENT="nico-machine-a-tron-mat-0"
+MACHINE_A_TRON_BMC_SERVICE="${MACHINE_A_TRON_DEPLOYMENT}-bmc-mock"
 API_FORWARD_PORT="${LOCAL_DEV_REST_API_FORWARD_PORT:-18388}"
 KEYCLOAK_FORWARD_PORT="${LOCAL_DEV_KEYCLOAK_FORWARD_PORT:-18082}"
 WORK_DIR="${LOCAL_DEV_REST_WORK_DIR:-${HOME}/Developer/_agent-tmp/devspace-rest}"
@@ -42,7 +44,8 @@ require_bin base64
 mkdir -p "${WORK_DIR}"
 
 kubectl rollout status deployment/nico-api -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
-kubectl rollout status deployment/nico-machine-a-tron -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
+kubectl rollout status "deployment/${MACHINE_A_TRON_DEPLOYMENT}" \
+  -n "${CORE_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-api -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-cert-manager -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
 kubectl rollout status deployment/nico-rest-cloud-worker -n "${REST_NAMESPACE}" --timeout=300s >/dev/null
@@ -128,7 +131,7 @@ inventory_started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 machine_status="$(kubectl exec deployment/nico-api -n "${CORE_NAMESPACE}" -- \
   curl --fail --insecure --silent --max-time 5 \
-  https://nico-machine-a-tron-bmc-mock:1266/machines/status 2>/dev/null || true)"
+  "https://${MACHINE_A_TRON_BMC_SERVICE}:1266/machines/status" 2>/dev/null || true)"
 expected_host_count="$(jq -r \
   'if (.machines | type) == "array" then .machines | length else 0 end' \
   <<<"${machine_status}" 2>/dev/null || printf '0')"

--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -101,7 +101,7 @@ nico-api:
       enabled = true
       create_machines = true
       allow_changing_bmc_proxy = true
-      bmc_proxy = "nico-machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266"
+      bmc_proxy = "nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266"
       run_interval = "10s"
       machines_created_per_run = 1000
       explorations_per_run = 1000
@@ -123,7 +123,7 @@ nico-bmc-proxy:
       metrics_endpoint = "[::]:1080"
       database_url = "postgres://replaced-by-env-var"
       allowed_principals = ["trusted-certificate"]
-      bmc_proxy = "nico-machine-a-tron-bmc-mock.nico-system.svc.cluster.local:1266"
+      bmc_proxy = "nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266"
 
       [tls]
       identity_pemfile_path = "/var/run/secrets/spiffe.io/tls.crt"
@@ -160,7 +160,7 @@ nico-machine-a-tron:
     uris:
       - "spiffe://nico.local/nico-system/sa/machine-a-tron"
   pods:
-    default:
+    mat-0:
       machines:
         rack-machines:
           hwType: wiwynn_gb200_nvl


### PR DESCRIPTION
# Summary
Update the local DevSpace configuration to use the machine-a-tron chart’s current mat-0 pod naming and generated service name following https://github.com/NVIDIA/infra-controller/pull/3955.

# Problem
The machine-a-tron chart now defines its default pod as mat-0, while the DevSpace values still define a pod named default.
Because Helm merges these maps, both pods remain active. Chart validation therefore treats the local deployment as multi-pod and rejects it because mat-k8s-controller is disabled:
multi-pod machine-a-tron deployments require mat-k8s-controller.enabled=true
The chart also suffixes the BMC mock service with the pod name, making the previous unsuffixed service reference invalid.

# Changes
Rename the DevSpace machine-a-tron pod override from default to mat-0.
Update the NICo API and BMC proxy configurations to use:
nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266
Update the REST integration check to query the renamed service.
Update the DevSpace documentation with the current service name.

# Validation
Rendered the complete parent Helm chart using the DevSpace base and generated values.
Confirmed Helm validation succeeds.
Confirmed exactly one machine-a-tron deployment is rendered.
Confirmed the rendered deployment and service use the mat-0 suffix.
Ran shell syntax and ShellCheck validation on the updated integration script.