### PR TITLE
fix(helm): Generate strong Temporal payload encryption key

### DIFF
--- a/helm/rest/nico-rest/charts/nico-rest-common/templates/secrets.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-common/templates/secrets.yaml
@@ -8,8 +8,10 @@
   {{- $existingKey := dig "data" "temporal-encryption-key" "" $existingSecret }}
   {{- if $existingKey }}
     {{- $temporalEncryptionKey = $existingKey | b64dec }}
-  {{- else }}
+  {{- else if .Release.IsInstall }}
     {{- $temporalEncryptionKey = randBytes 32 }}
+  {{- else }}
+    {{- fail "nico-rest-common requires an existing or explicitly configured Temporal encryption key on upgrade" }}
   {{- end }}
 {{- end }}
 # db-creds and image-pull-secret are annotated as pre-install / pre-upgrade

--- a/helm/rest/nico-rest/charts/nico-rest-common/templates/secrets.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-common/templates/secrets.yaml
@@ -2,6 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.secrets.create }}
+{{- $temporalEncryptionKey := .Values.secrets.temporalEncryptionKey.value }}
+{{- if not $temporalEncryptionKey }}
+  {{- $existingSecret := lookup "v1" "Secret" (include "nico-rest-common.namespace" .) "temporal-encryption-key" }}
+  {{- $existingKey := dig "data" "temporal-encryption-key" "" $existingSecret }}
+  {{- if $existingKey }}
+    {{- $temporalEncryptionKey = $existingKey | b64dec }}
+  {{- else }}
+    {{- $temporalEncryptionKey = randBytes 32 }}
+  {{- end }}
+{{- end }}
 # db-creds and image-pull-secret are annotated as pre-install / pre-upgrade
 # hooks (weight -10) because the nico-rest-db migration Job runs as its own
 # pre-install hook at weight -5 and needs both to exist before it starts.
@@ -45,7 +55,7 @@ metadata:
     {{- include "nico-rest-common.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  temporal-encryption-key: {{ .Values.secrets.temporalEncryptionKey.value | quote }}
+  temporal-encryption-key: {{ $temporalEncryptionKey | quote }}
 ---
 apiVersion: v1
 kind: Secret

--- a/helm/rest/nico-rest/charts/nico-rest-common/tests/secrets_test.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-common/tests/secrets_test.yaml
@@ -23,6 +23,39 @@ tests:
           value: configured-key
         documentIndex: 2
 
+  - it: reuses the existing Temporal encryption key on upgrade
+    release:
+      namespace: nico-rest
+      upgrade: true
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: temporal-encryption-key
+            namespace: nico-rest
+          data:
+            temporal-encryption-key: ZXhpc3Rpbmcta2V5
+    asserts:
+      - equal:
+          path: stringData.temporal-encryption-key
+          value: existing-key
+        documentIndex: 2
+
+  - it: fails an upgrade when the Temporal encryption key is unavailable
+    release:
+      namespace: nico-rest
+      upgrade: true
+    asserts:
+      - failedTemplate:
+          errorMessage: nico-rest-common requires an existing or explicitly configured Temporal encryption key on upgrade
+
   - it: omits all Secrets when creation is disabled
     set:
       secrets:

--- a/helm/rest/nico-rest/charts/nico-rest-common/tests/secrets_test.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-common/tests/secrets_test.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: common secrets
+templates:
+  - secrets.yaml
+tests:
+  - it: generates the Temporal encryption key from 32 random bytes by default
+    asserts:
+      - matchRegex:
+          path: stringData.temporal-encryption-key
+          pattern: ^[A-Za-z0-9+/]{43}=$
+        documentIndex: 2
+
+  - it: uses an explicitly configured Temporal encryption key
+    set:
+      secrets:
+        temporalEncryptionKey:
+          value: configured-key
+    asserts:
+      - equal:
+          path: stringData.temporal-encryption-key
+          value: configured-key
+        documentIndex: 2
+
+  - it: omits all Secrets when creation is disabled
+    set:
+      secrets:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/rest/nico-rest/charts/nico-rest-common/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-common/values.yaml
@@ -16,8 +16,9 @@ secrets:
     # -- Keycloak client secret. Replace in production.
     value: "nico-local-secret"
   temporalEncryptionKey:
-    # -- Temporal payload encryption key. Replace in production.
-    value: "local-dev"
+    # -- Temporal payload encryption key. When empty, Helm generates a key from
+    # 32 random bytes on install and reuses the existing Secret on upgrade.
+    value: ""
   imagePullSecret:
     # -- base64-encoded docker config JSON. Default is valid empty auth placeholder ({"auths":{}}).
     # Replace with real credentials for private registries.

--- a/helm/rest/nico-rest/charts/nico-rest-common/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-common/values.yaml
@@ -16,8 +16,11 @@ secrets:
     # -- Keycloak client secret. Replace in production.
     value: "nico-local-secret"
   temporalEncryptionKey:
-    # -- Temporal payload encryption key. When empty, Helm generates a key from
-    # 32 random bytes on install and reuses the existing Secret on upgrade.
+    # -- Temporal payload encryption key. Default is empty. When Secret creation
+    # is enabled, an explicit value takes precedence over an existing Secret. An
+    # empty value reuses the existing Secret, generates 32 random bytes on a fresh
+    # install, or fails an upgrade when no existing key is available. Setting
+    # secrets.create to false disables this resolution.
     value: ""
   imagePullSecret:
     # -- base64-encoded docker config JSON. Default is valid empty auth placeholder ({"auths":{}}).


### PR DESCRIPTION
Fresh NICo REST installs currently use a fixed Temporal payload encryption key. This change generates the key from 32 random bytes while preserving existing Secrets on upgrades and honoring explicit values.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Existing installations keep their current key during upgrades so encrypted Temporal payloads remain readable.