### PR TITLE
fix(log-parser): validate configured delimiter

### DIFF
--- a/crates/log-parser/src/main.rs
+++ b/crates/log-parser/src/main.rs
@@ -121,6 +121,21 @@ struct Configuration {
     pub logs_hash: HashMap<Vec<u8>, usize>,
 }
 
+impl Configuration {
+    fn delimiter_byte(&self) -> Result<u8, anyhow::Error> {
+        match self.delimiter.as_deref() {
+            None => Ok(b'\n'),
+            Some(delimiter) => match delimiter.as_bytes() {
+                [delimiter] => Ok(*delimiter),
+                bytes => Err(anyhow!(
+                    "delimiter must be exactly one byte, got {delimiter:?} ({} bytes)",
+                    bytes.len()
+                )),
+            },
+        }
+    }
+}
+
 /// track each log file we're looking for events in
 /// we only care about the current offset into the file we want to read and search from
 /// the length should always be the latest known length of the file to read up to
@@ -279,6 +294,7 @@ async fn process_log_file_events(
     log_index: usize,
     set_offset: bool,
 ) -> Result<(), anyhow::Error> {
+    let delimiter = cfg.delimiter_byte()?;
     if let Some(log) = cfg.logs.get_mut(log_index) {
         let file_length = tokio::fs::metadata(&log.file_path).await?.len();
         if file_length == log.length {
@@ -304,11 +320,6 @@ async fn process_log_file_events(
         let mut file = tokio::fs::File::open(&log.file_path).await?;
 
         let mut consumed = 0;
-        let delimiter: u8 = if let Some(delim) = cfg.delimiter.clone() {
-            delim.as_bytes()[0]
-        } else {
-            b'\n'
-        };
 
         while consumed < len {
             let mut buffer = vec![0u8; buffer_length as usize];
@@ -451,6 +462,7 @@ async fn scan_files(cfg: &mut Configuration, set_offset: bool) -> Result<(), any
 async fn read_event_definition(path: &Path) -> Result<Configuration, anyhow::Error> {
     let json = tokio::fs::read_to_string(path).await?;
     let mut config: Configuration = serde_json::from_str(&json)?;
+    config.delimiter_byte()?;
     config.filename = Some(
         path.file_name()
             .unwrap_or_default()

--- a/crates/log-parser/src/main.rs
+++ b/crates/log-parser/src/main.rs
@@ -327,7 +327,7 @@ async fn process_log_file_events(
             file.read_exact(&mut buffer).await?;
             consumed += buffer_length;
 
-            if buffer.contains(&b'\n') {
+            if buffer.contains(&delimiter) {
                 // find last delimiter and move seek offset to that, truncate buffer to that
                 if let Some(seek_position) = buffer.iter().rev().position(|&c| c == delimiter) {
                     log.offset += buffer_length - seek_position as u64;
@@ -335,7 +335,7 @@ async fn process_log_file_events(
                 } else {
                     log.offset += buffer_length;
                 }
-                let segments = buffer.split(|&c| c == b'\n');
+                let segments = buffer.split(|&c| c == delimiter);
                 for segment in segments {
                     if segment.is_empty() {
                         continue;

--- a/crates/log-parser/src/tests.rs
+++ b/crates/log-parser/src/tests.rs
@@ -17,7 +17,8 @@
 
 use std::collections::HashMap;
 
-use carbide_test_support::{Check, check_values};
+use carbide_test_support::Outcome::{Fails, Yields};
+use carbide_test_support::{Case, Check, check_cases, check_values};
 use regex::Regex;
 use serde_json::json;
 
@@ -937,5 +938,78 @@ fn event_definitions_compile_filename_and_event_regexes() {
             },
         ],
         |row| inspect_definition(&runtime, &directory, row),
+    );
+}
+
+struct DelimiterRow {
+    delimiter: Option<&'static str>,
+}
+
+fn inspect_delimiter(
+    runtime: &tokio::runtime::Runtime,
+    directory: &tempfile::TempDir,
+    row: DelimiterRow,
+) -> Result<(), ()> {
+    let definition = json!({
+        "pipeline": "test",
+        "delimiter": row.delimiter,
+        "filename_format": ".*",
+        "logs_path": "/unused",
+        "events": [],
+    });
+    let path = directory.path().join("delimiter-definition.json");
+    std::fs::write(&path, serde_json::to_vec(&definition).unwrap()).unwrap();
+
+    runtime
+        .block_on(read_event_definition(&path))
+        .map(drop)
+        .map_err(drop)
+}
+
+#[test]
+fn event_definition_delimiter_is_exactly_one_byte() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let directory = tempfile::tempdir().unwrap();
+
+    check_cases(
+        [
+            Case {
+                scenario: "omitted delimiter defaults to newline",
+                input: DelimiterRow { delimiter: None },
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "single-byte delimiter",
+                input: DelimiterRow {
+                    delimiter: Some("|"),
+                },
+                expect: Yields(()),
+            },
+            Case {
+                scenario: "empty delimiter",
+                input: DelimiterRow {
+                    delimiter: Some(""),
+                },
+                expect: Fails,
+            },
+            Case {
+                scenario: "multiple-byte ASCII delimiter",
+                input: DelimiterRow {
+                    delimiter: Some("||"),
+                },
+                expect: Fails,
+            },
+            Case {
+                scenario: "multiple-byte UTF-8 delimiter",
+                input: DelimiterRow {
+                    delimiter: Some("→"),
+                },
+                expect: Fails,
+            },
+        ],
+        |row| inspect_delimiter(&runtime, &directory, row),
     );
 }

--- a/crates/log-parser/src/tests.rs
+++ b/crates/log-parser/src/tests.rs
@@ -23,8 +23,8 @@ use regex::Regex;
 use serde_json::json;
 
 use super::{
-    Event, EventConstraints, EventSeverity, EventType, LogFile, MAX_EVENTS, check_constraints,
-    process_events, queue_event, read_event_definition,
+    Configuration, Event, EventConstraints, EventSeverity, EventType, LogFile, MAX_EVENTS,
+    check_constraints, process_events, process_log_file_events, queue_event, read_event_definition,
 };
 
 fn event_type(name: impl Into<String>) -> EventType {
@@ -1011,5 +1011,42 @@ fn event_definition_delimiter_is_exactly_one_byte() {
             },
         ],
         |row| inspect_delimiter(&runtime, &directory, row),
+    );
+}
+
+#[tokio::test]
+async fn log_records_use_the_configured_delimiter() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("events.log");
+    std::fs::write(&path, b"matched|unfinished").unwrap();
+
+    let mut configuration = Configuration {
+        filename: None,
+        pipeline: "test".to_string(),
+        delimiter: Some("|".to_string()),
+        filename_format: ".*".to_string(),
+        filename_regex: None,
+        logs_path: path.to_string_lossy().into_owned(),
+        events: vec![event_type("matched")],
+        events_regex: Some(vec![Regex::new("^matched$").unwrap()]),
+        logs: vec![LogFile {
+            file_path: path.to_string_lossy().into_owned(),
+            ..Default::default()
+        }],
+        logs_hash: HashMap::new(),
+    };
+
+    process_log_file_events(&mut configuration, 0, false)
+        .await
+        .unwrap();
+
+    let log = &configuration.logs[0];
+    assert_eq!(log.offset, b"matched|".len() as u64);
+    assert_eq!(
+        log.events
+            .iter()
+            .map(|event| event.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["matched"]
     );
 }


### PR DESCRIPTION
## Summary

Validate the log parser's configured delimiter before processing log files.

The delimiter must contain exactly one byte. Invalid configurations now return a descriptive error instead of panicking or silently using only the first byte.

Fixes #4401.

## Root cause

`process_log_file_events` accessed `delim.as_bytes()[0]` without validating its length:

- An empty delimiter caused an index-out-of-bounds panic.
- A multi-byte delimiter was silently truncated.
- A non-ASCII delimiter used only the first byte of its UTF-8 encoding.

## Changes

- Validate delimiters while loading event definitions.
- Preserve newline as the default when the delimiter is omitted.
- Accept single-byte delimiters.
- Reject empty, multi-byte ASCII, and multi-byte UTF-8 delimiters.
- Reuse the validated conversion when processing log files.
- Add table-driven regression coverage.

## Validation

- `cargo test -p carbide-log-parser`
- `cargo clippy -p carbide-log-parser --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The regression test was confirmed to fail before the fix and pass afterward.

## Note
This is an attempt at fully automated issue resolution using Codex with Sol 5.6 Medium.
