### PR TITLE
feat(rest-api): Recovery of missing VPCs from Site inventory

### DIFF
--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -442,7 +442,6 @@ func (vpc *Vpc) FromProto(proto *corev1.Vpc) {
 	if proto.Metadata != nil && proto.Metadata.Name != "" {
 		vpc.Name = proto.Metadata.Name
 	}
-
 	cfg := proto.GetConfig()
 	if cfg == nil {
 		cfg = &corev1.VpcConfig{}
@@ -513,6 +512,7 @@ type VpcCreateInput struct {
 	RoutingProfile                         *string
 	RoutingProfileOverrides                *VpcRoutingProfileOverrides
 	ControllerVpcID                        *uuid.UUID
+	ActiveVni                              *int
 	NetworkSecurityGroupID                 *string
 	NetworkSecurityGroupPropagationDetails *NetworkSecurityGroupPropagationDetails
 	Labels                                 map[string]string
@@ -553,12 +553,14 @@ type VpcClearInput struct {
 	NetworkSecurityGroupID                 bool
 	NetworkSecurityGroupPropagationDetails bool
 	Labels                                 bool
+	Deleted                                bool
 }
 
 // VpcFilterInput input parameters for Filter method
 type VpcFilterInput struct {
 	Name                      *string
 	VpcIDs                    []uuid.UUID
+	ControllerVpcIDs          []uuid.UUID
 	InfrastructureProviderID  *uuid.UUID
 	TenantIDs                 []uuid.UUID
 	SiteIDs                   []uuid.UUID
@@ -568,6 +570,7 @@ type VpcFilterInput struct {
 	NetworkVirtualizationType *string
 	Statuses                  []string
 	SearchQuery               *string
+	IncludeDeleted            bool
 }
 
 var _ bun.BeforeAppendModelHook = (*Vpc)(nil)
@@ -795,6 +798,14 @@ func (vsd VpcSQLDAO) setQueryWithFilter(filter VpcFilterInput, query *bun.Select
 		}
 	}
 
+	if filter.ControllerVpcIDs != nil {
+		query = query.Where("v.controller_vpc_id IN (?)", bun.In(filter.ControllerVpcIDs))
+
+		if vpcDAOSpan != nil {
+			vsd.tracerSpan.SetAttribute(vpcDAOSpan, "controller_vpc_ids", filter.ControllerVpcIDs)
+		}
+	}
+
 	searchQuery, searchTokens, ok := db.NormalizeSearchQuery(filter.SearchQuery)
 	if ok {
 		query = query.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
@@ -827,6 +838,9 @@ func (vsd VpcSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter VpcFilterInpu
 	// var vpcs []Vpc
 	vpcs := []Vpc{}
 	query := db.GetIDB(tx, vsd.dbSession).NewSelect().Model(&vpcs)
+	if filter.IncludeDeleted {
+		query = query.WhereAllWithDeleted()
+	}
 
 	query, err := vsd.setQueryWithFilter(filter, query, vpcDAOSpan)
 	if err != nil {
@@ -883,6 +897,7 @@ func (vsd VpcSQLDAO) Create(ctx context.Context, tx *db.Tx, input VpcCreateInput
 		RoutingProfile:                         input.RoutingProfile,
 		RoutingProfileOverrides:                input.RoutingProfileOverrides,
 		ControllerVpcID:                        input.ControllerVpcID,
+		ActiveVni:                              input.ActiveVni,
 		NetworkSecurityGroupID:                 input.NetworkSecurityGroupID,
 		NetworkSecurityGroupPropagationDetails: input.NetworkSecurityGroupPropagationDetails,
 		Labels:                                 input.Labels,
@@ -1092,12 +1107,30 @@ func (vsd VpcSQLDAO) Clear(ctx context.Context, tx *db.Tx, input VpcClearInput) 
 		updatedFields = append(updatedFields, "network_security_group_propagation_details")
 	}
 
+	if input.Deleted {
+		v.Deleted = nil
+		updatedFields = append(updatedFields, "deleted")
+	}
+
 	if len(updatedFields) > 0 {
 		updatedFields = append(updatedFields, "updated")
 
-		_, err := db.GetIDB(tx, vsd.dbSession).NewUpdate().Model(v).Column(updatedFields...).Where("id = ?", input.VpcID).Exec(ctx)
+		query := db.GetIDB(tx, vsd.dbSession).NewUpdate().Model(v).Column(updatedFields...).Where("id = ?", input.VpcID)
+		if input.Deleted {
+			query = query.WhereAllWithDeleted()
+		}
+		result, err := query.Exec(ctx)
 		if err != nil {
 			return nil, err
+		}
+		if input.Deleted {
+			rowsAffected, rowsErr := result.RowsAffected()
+			if rowsErr != nil {
+				return nil, rowsErr
+			}
+			if rowsAffected == 0 {
+				return nil, db.ErrDoesNotExist
+			}
 		}
 	}
 

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -553,7 +553,8 @@ type VpcClearInput struct {
 	NetworkSecurityGroupID                 bool
 	NetworkSecurityGroupPropagationDetails bool
 	Labels                                 bool
-	Deleted                                bool
+	// Deleted clears the soft-delete timestamp (undelete).
+	Deleted bool
 }
 
 // VpcFilterInput input parameters for Filter method
@@ -570,7 +571,8 @@ type VpcFilterInput struct {
 	NetworkVirtualizationType *string
 	Statuses                  []string
 	SearchQuery               *string
-	IncludeDeleted            bool
+	// IncludeDeleted returns soft-deleted rows in addition to active ones.
+	IncludeDeleted bool
 }
 
 var _ bun.BeforeAppendModelHook = (*Vpc)(nil)
@@ -835,9 +837,9 @@ func (vsd VpcSQLDAO) GetAll(ctx context.Context, tx *db.Tx, filter VpcFilterInpu
 		defer vpcDAOSpan.End()
 	}
 
-	// var vpcs []Vpc
 	vpcs := []Vpc{}
 	query := db.GetIDB(tx, vsd.dbSession).NewSelect().Model(&vpcs)
+	// Soft-deleted rows are excluded by default.
 	if filter.IncludeDeleted {
 		query = query.WhereAllWithDeleted()
 	}
@@ -1116,6 +1118,7 @@ func (vsd VpcSQLDAO) Clear(ctx context.Context, tx *db.Tx, input VpcClearInput) 
 		updatedFields = append(updatedFields, "updated")
 
 		query := db.GetIDB(tx, vsd.dbSession).NewUpdate().Model(v).Column(updatedFields...).Where("id = ?", input.VpcID)
+		// Soft-deleted rows are excluded by default; include them when undeleting.
 		if input.Deleted {
 			query = query.WhereAllWithDeleted()
 		}

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -519,6 +519,7 @@ type VpcCreateInput struct {
 	Status                                 string
 	CreatedBy                              User
 	Vni                                    *int
+	EffectiveRoutingProfile                *VpcEffectiveRoutingProfile
 }
 
 // VpcUpdateInput input parameters for Update method
@@ -907,6 +908,7 @@ func (vsd VpcSQLDAO) Create(ctx context.Context, tx *db.Tx, input VpcCreateInput
 		IsMissingOnSite:                        false,
 		CreatedBy:                              input.CreatedBy.ID,
 		Vni:                                    input.Vni,
+		EffectiveRoutingProfile:                input.EffectiveRoutingProfile,
 	}
 
 	_, err := db.GetIDB(tx, vsd.dbSession).NewInsert().Model(v).Exec(ctx)

--- a/rest-api/db/pkg/db/model/vpc.go
+++ b/rest-api/db/pkg/db/model/vpc.go
@@ -1124,18 +1124,9 @@ func (vsd VpcSQLDAO) Clear(ctx context.Context, tx *db.Tx, input VpcClearInput) 
 		if input.Deleted {
 			query = query.WhereAllWithDeleted()
 		}
-		result, err := query.Exec(ctx)
+		_, err := query.Exec(ctx)
 		if err != nil {
 			return nil, err
-		}
-		if input.Deleted {
-			rowsAffected, rowsErr := result.RowsAffected()
-			if rowsErr != nil {
-				return nil, rowsErr
-			}
-			if rowsAffected == 0 {
-				return nil, db.ErrDoesNotExist
-			}
 		}
 	}
 

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -1475,6 +1475,25 @@ func TestVpcSQLDAO_ClearDeleted(t *testing.T) {
 		assert.False(t, updated.IsMissingOnSite)
 	})
 
+	t.Run("clears soft-delete marker and description together", func(t *testing.T) {
+		_, err := vpcDAO.Update(context.Background(), nil, VpcUpdateInput{
+			VpcID:       vpc.ID,
+			Description: cutil.GetPtr("description to clear"),
+		})
+		require.NoError(t, err)
+		require.NoError(t, vpcDAO.DeleteByID(context.Background(), nil, vpc.ID))
+
+		cleared, err := vpcDAO.Clear(context.Background(), nil, VpcClearInput{
+			VpcID:       vpc.ID,
+			Deleted:     true,
+			Description: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cleared)
+		assert.Nil(t, cleared.Deleted)
+		assert.Nil(t, cleared.Description)
+	})
+
 	t.Run("returns not found for unknown VPC", func(t *testing.T) {
 		_, err := vpcDAO.Clear(context.Background(), nil, VpcClearInput{
 			VpcID:   uuid.New(),
@@ -1931,10 +1950,6 @@ func TestVpc_FromProto(t *testing.T) {
 		assert.Nil(t, v.EffectiveRoutingProfile)
 		assert.Nil(t, v.Description)
 		assert.Nil(t, v.Labels)
-		assert.Nil(t, v.NetworkVirtualizationType)
-		assert.Nil(t, v.RoutingProfile)
-		assert.Nil(t, v.Vni)
-		assert.Nil(t, v.ActiveVni)
 	})
 
 	t.Run("invalid NVLink partition id clears the field", func(t *testing.T) {

--- a/rest-api/db/pkg/db/model/vpc_test.go
+++ b/rest-api/db/pkg/db/model/vpc_test.go
@@ -1423,6 +1423,67 @@ func TestVpcSQLDAO_DeleteByID(t *testing.T) {
 	}
 }
 
+func TestVpcSQLDAO_ClearDeleted(t *testing.T) {
+	dbSession := testInitDB(t)
+	defer dbSession.Close()
+	testVpcSetupSchema(t, dbSession)
+
+	ipu := testBuildUser(t, dbSession, nil, testGenerateStarfleetID(), cutil.GetPtr("johnd@test.com"), cutil.GetPtr("John"), cutil.GetPtr("Doe"))
+	ip := testBuildInfrastructureProvider(t, dbSession, nil, "test-ip", "Test Provider", ipu.ID)
+	tnu := testBuildUser(t, dbSession, nil, testGenerateStarfleetID(), cutil.GetPtr("jdoe@test.com"), cutil.GetPtr("John"), cutil.GetPtr("Doe"))
+	tn := testBuildTenant(t, dbSession, nil, "test-tenant", "test-tenant-org", tnu.ID)
+	st := testBuildSite(t, dbSession, nil, ip.ID, "test-site", "Test Site", ip.Org, ipu.ID)
+	controllerID := uuid.New()
+	vpc := testBuildVpc(
+		t,
+		dbSession,
+		nil,
+		"test-vpc",
+		nil,
+		tn.Org,
+		ip.ID,
+		tn.ID,
+		st.ID,
+		nil,
+		cutil.GetPtr(VpcEthernetVirtualizer),
+		&controllerID,
+		nil,
+		cutil.GetPtr(VpcStatusError),
+		tnu.ID,
+		nil,
+	)
+
+	vpcDAO := NewVpcDAO(dbSession)
+	require.NoError(t, vpcDAO.DeleteByID(context.Background(), nil, vpc.ID))
+
+	t.Run("clears soft-delete marker", func(t *testing.T) {
+		cleared, err := vpcDAO.Clear(context.Background(), nil, VpcClearInput{
+			VpcID:   vpc.ID,
+			Deleted: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, cleared)
+		assert.Nil(t, cleared.Deleted)
+
+		updated, err := vpcDAO.Update(context.Background(), nil, VpcUpdateInput{
+			VpcID:           vpc.ID,
+			Status:          cutil.GetPtr(VpcStatusReady),
+			IsMissingOnSite: cutil.GetPtr(false),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, VpcStatusReady, updated.Status)
+		assert.False(t, updated.IsMissingOnSite)
+	})
+
+	t.Run("returns not found for unknown VPC", func(t *testing.T) {
+		_, err := vpcDAO.Clear(context.Background(), nil, VpcClearInput{
+			VpcID:   uuid.New(),
+			Deleted: true,
+		})
+		assert.ErrorIs(t, err, db.ErrDoesNotExist)
+	})
+}
+
 func TestVpcSQLDAO_ClearFromParams(t *testing.T) {
 	// Create test DB
 	dbSession := testInitDB(t)
@@ -1870,6 +1931,10 @@ func TestVpc_FromProto(t *testing.T) {
 		assert.Nil(t, v.EffectiveRoutingProfile)
 		assert.Nil(t, v.Description)
 		assert.Nil(t, v.Labels)
+		assert.Nil(t, v.NetworkVirtualizationType)
+		assert.Nil(t, v.RoutingProfile)
+		assert.Nil(t, v.Vni)
+		assert.Nil(t, v.ActiveVni)
 	})
 
 	t.Run("invalid NVLink partition id clears the field", func(t *testing.T) {

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -6,6 +6,7 @@ package vpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"slices"
 	"time"
@@ -76,21 +77,22 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 	vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
 	sdDAO := cdbm.NewStatusDetailDAO(mv.dbSession)
 
-	existingVpcs, _, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{SiteIDs: []uuid.UUID{site.ID}}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
+	existingVpcs, _, err := vpcDAO.GetAll(ctx, nil, cdbm.VpcFilterInput{
+		SiteIDs: []uuid.UUID{site.ID},
+	}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to get VPCs for Site from DB")
 		return nil, err
 	}
 
-	// Construct a map of Controller VPC ID to VPC
 	existingVpcIDMap := make(map[string]*cdbm.Vpc)
 	existingVpcCtrlIDMap := make(map[string]*cdbm.Vpc)
 
-	for _, vpc := range existingVpcs {
-		curVPC := vpc
-		existingVpcIDMap[vpc.ID.String()] = &curVPC
+	for i := range existingVpcs {
+		vpc := &existingVpcs[i]
+		existingVpcIDMap[vpc.ID.String()] = vpc
 		if vpc.ControllerVpcID != nil {
-			existingVpcCtrlIDMap[vpc.ControllerVpcID.String()] = &curVPC
+			existingVpcCtrlIDMap[vpc.ControllerVpcID.String()] = vpc
 		}
 	}
 
@@ -122,22 +124,37 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 
 	// Iterate through VPC Inventory and update DB
 	for _, controllerVpc := range vpcInventory.Vpcs {
-		slogger := logger.With().Str("VPC Controller ID", controllerVpc.Id.Value).Logger()
+		if controllerVpc == nil || controllerVpc.GetId().GetValue() == "" {
+			logger.Error().Msg("received VPC inventory entry with missing controller ID, skipping")
+			continue
+		}
+		controllerVpcIDStr := controllerVpc.GetId().GetValue()
+		slogger := logger.With().Str("VPC Controller ID", controllerVpcIDStr).Logger()
 
-		sitePropagationStatus := vpcPropagationStatus[controllerVpc.Id.Value]
-		logger.Debug().Str("Controller VPC ID", controllerVpc.Id.Value).Msgf("cached propagation status for VPC %+v", sitePropagationStatus)
+		sitePropagationStatus := vpcPropagationStatus[controllerVpcIDStr]
+		slogger.Debug().Msgf("cached propagation status for VPC %+v", sitePropagationStatus)
 
-		vpc, ok := existingVpcCtrlIDMap[controllerVpc.Id.Value]
-		if !ok {
-			// Check if the VPC is found by ID (controllerVpc.Name == cloudVpc.ID)
-			vpc, ok = existingVpcIDMap[controllerVpc.Name]
-			if ok {
-				existingVpcCtrlIDMap[controllerVpc.Id.Value] = vpc
-			}
+		vpc := existingVpcCtrlIDMap[controllerVpcIDStr]
+		if vpc == nil {
+			vpc = existingVpcIDMap[controllerVpcIDStr]
 		}
 
 		if vpc == nil {
-			logger.Warn().Str("Controller VPC ID", controllerVpc.Id.Value).Msg("VPC does not have a record in DB, possibly created directly on Site")
+			vpc, serr := mv.createOrUpdateVpcFromSite(ctx, site, controllerVpc, sitePropagationStatus)
+			if serr != nil {
+				slogger.Warn().Err(serr).Msg("failed to create or update VPC from Site")
+				continue
+			}
+			if vpc == nil {
+				continue
+			}
+
+			existingVpcIDMap[vpc.ID.String()] = vpc
+			if vpc.ControllerVpcID != nil {
+				existingVpcCtrlIDMap[vpc.ControllerVpcID.String()] = vpc
+			}
+			reportedVpcIDMap[vpc.ID] = true
+			slogger.Info().Str("VPC ID", vpc.ID.String()).Msg("created or updated VPC from Site inventory")
 			continue
 		}
 
@@ -398,6 +415,374 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 	}
 
 	return vpcLifecycleEvents, nil
+}
+
+// createOrUpdateVpcFromSite caches a VPC reported by Site inventory that has
+// no active REST row. Soft-deleted rows are undeleted via Clear; otherwise a
+// new row is created. Returns nil when the inventory entry is skipped.
+func (mv ManageVpc) createOrUpdateVpcFromSite(
+	ctx context.Context,
+	site *cdbm.Site,
+	controllerVpc *corev1.Vpc,
+	propagationDetails *cdbm.NetworkSecurityGroupPropagationDetails,
+) (*cdbm.Vpc, error) {
+	logger := log.With().
+		Str("Activity", "UpdateVpcsInDB").
+		Str("Site ID", site.ID.String()).
+		Str("VPC Controller ID", controllerVpc.GetId().GetValue()).
+		Logger()
+
+	controllerVpcID, err := uuid.Parse(controllerVpc.GetId().GetValue())
+	if err != nil {
+		logger.Warn().Err(err).Msg("skipping VPC from Site: controller VPC ID is not a valid UUID")
+		return nil, nil
+	}
+
+	reportedVpc := new(cdbm.Vpc)
+	reportedVpc.FromProto(controllerVpc)
+	if reportedVpc.NetworkSecurityGroupID != nil && *reportedVpc.NetworkSecurityGroupID == "" {
+		reportedVpc.NetworkSecurityGroupID = nil
+	}
+	// FromProto clears NVLinkLogicalPartitionID when the proto value is invalid.
+	if controllerVpc.GetConfig().GetDefaultNvlinkLogicalPartitionId().GetValue() != "" &&
+		reportedVpc.NVLinkLogicalPartitionID == nil {
+		logger.Warn().Msg("skipping VPC from Site: default NVLink Logical Partition ID is not a valid UUID")
+		return nil, nil
+	}
+	if reportedVpc.Name == "" {
+		logger.Warn().Msg("skipping VPC from Site: VPC metadata does not contain a name")
+		return nil, nil
+	}
+	if reportedVpc.Org == "" {
+		logger.Warn().Msg("skipping VPC from Site: VPC does not report a tenant organization")
+		return nil, nil
+	}
+
+	page := cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}
+	vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
+
+	// Look up a soft-deleted VPC matching this Site inventory identity.
+	deletedVpc, err := mv.findSoftDeletedVpc(ctx, site.ID, controllerVpcID)
+	if err != nil {
+		return nil, fmt.Errorf("find soft-deleted VPC: %w", err)
+	}
+
+	var tenant *cdbm.Tenant
+	if deletedVpc != nil {
+		if deletedVpc.Org != reportedVpc.Org {
+			logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant organization differs from Site inventory")
+			return nil, nil
+		}
+		if deletedVpc.Tenant == nil {
+			logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant does not exist")
+			return nil, nil
+		}
+		tenant = deletedVpc.Tenant
+	} else {
+		tenantDAO := cdbm.NewTenantDAO(mv.dbSession)
+		tenants, _, tenantErr := tenantDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.TenantFilterInput{Orgs: []string{reportedVpc.Org}},
+			cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		if tenantErr != nil {
+			return nil, fmt.Errorf("get VPC tenant by organization: %w", tenantErr)
+		}
+		if len(tenants) == 0 {
+			logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
+			return nil, nil
+		}
+		tenant = &tenants[0]
+	}
+
+	networkSecurityGroupID := reportedVpc.NetworkSecurityGroupID
+	nvLinkLogicalPartitionID := reportedVpc.NVLinkLogicalPartitionID
+	if deletedVpc != nil {
+		if networkSecurityGroupID == nil {
+			networkSecurityGroupID = deletedVpc.NetworkSecurityGroupID
+		}
+		// Existing REST configuration remains authoritative for this field.
+		nvLinkLogicalPartitionID = deletedVpc.NVLinkLogicalPartitionID
+	}
+
+	if networkSecurityGroupID != nil {
+		networkSecurityGroupDAO := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession)
+		_, nsgErr := networkSecurityGroupDAO.GetByID(ctx, nil, *networkSecurityGroupID, nil)
+		if errors.Is(nsgErr, cdb.ErrDoesNotExist) {
+			logger.Warn().Msg("skipping VPC from Site: referenced Network Security Group does not exist in REST")
+			return nil, nil
+		}
+		if nsgErr != nil {
+			return nil, fmt.Errorf("get inventory VPC Network Security Group: %w", nsgErr)
+		}
+	}
+
+	if nvLinkLogicalPartitionID != nil {
+		nvLinkLogicalPartitionDAO := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession)
+		nvLinkLogicalPartition, nvLinkErr := nvLinkLogicalPartitionDAO.GetByID(ctx, nil, *nvLinkLogicalPartitionID, nil)
+		if errors.Is(nvLinkErr, cdb.ErrDoesNotExist) {
+			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition does not exist in REST")
+			return nil, nil
+		}
+		if nvLinkErr != nil {
+			return nil, fmt.Errorf("get inventory VPC NVLink Logical Partition: %w", nvLinkErr)
+		}
+		if nvLinkLogicalPartition.SiteID != site.ID || nvLinkLogicalPartition.TenantID != tenant.ID {
+			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition belongs to a different Tenant or Site")
+			return nil, nil
+		}
+		if deletedVpc == nil && nvLinkLogicalPartition.Status != cdbm.NVLinkLogicalPartitionStatusReady {
+			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition is not Ready")
+			return nil, nil
+		}
+	}
+
+	return cdb.WithTxResult(ctx, mv.dbSession, func(tx *cdb.Tx) (*cdbm.Vpc, error) {
+		// Re-read inside the transaction so concurrent inventory pages cannot
+		// create duplicate VPC rows.
+		matchingVpcs, _, reloadErr := vpcDAO.GetAll(
+			ctx,
+			tx,
+			cdbm.VpcFilterInput{
+				VpcIDs:         []uuid.UUID{controllerVpcID},
+				SiteIDs:        []uuid.UUID{site.ID},
+				IncludeDeleted: true,
+			},
+			page,
+			[]string{cdbm.TenantRelationName},
+		)
+		if reloadErr != nil {
+			return nil, fmt.Errorf("reload VPC by inventory identity: %w", reloadErr)
+		}
+		if len(matchingVpcs) == 0 {
+			matchingVpcs, _, reloadErr = vpcDAO.GetAll(
+				ctx,
+				tx,
+				cdbm.VpcFilterInput{
+					ControllerVpcIDs: []uuid.UUID{controllerVpcID},
+					SiteIDs:          []uuid.UUID{site.ID},
+					IncludeDeleted:   true,
+				},
+				page,
+				[]string{cdbm.TenantRelationName},
+			)
+			if reloadErr != nil {
+				return nil, fmt.Errorf("reload VPC by controller identity: %w", reloadErr)
+			}
+		}
+
+		var activeVpc *cdbm.Vpc
+		deletedVpc = nil
+		for i := range matchingVpcs {
+			if matchingVpcs[i].Deleted == nil {
+				if activeVpc != nil {
+					logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple active VPCs")
+					return nil, nil
+				}
+				activeVpc = &matchingVpcs[i]
+			} else {
+				if deletedVpc != nil {
+					logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple soft-deleted VPCs")
+					return nil, nil
+				}
+				deletedVpc = &matchingVpcs[i]
+			}
+		}
+		if activeVpc != nil {
+			return activeVpc, nil
+		}
+
+		name := reportedVpc.Name
+		if deletedVpc != nil {
+			name = deletedVpc.Name
+		}
+		vpcsWithName, _, nameErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+			Name:      &name,
+			TenantIDs: []uuid.UUID{tenant.ID},
+			SiteIDs:   []uuid.UUID{site.ID},
+		}, page, nil)
+		if nameErr != nil {
+			return nil, fmt.Errorf("check inventory VPC name conflict: %w", nameErr)
+		}
+		for i := range vpcsWithName {
+			if deletedVpc == nil || vpcsWithName[i].ID != deletedVpc.ID {
+				logger.Warn().Msg("skipping VPC from Site: an active VPC with the same name already exists for the Tenant and Site")
+				return nil, nil
+			}
+		}
+
+		statusDetailDAO := cdbm.NewStatusDetailDAO(mv.dbSession)
+		message := "VPC was found on Site, Ready for use"
+
+		if deletedVpc != nil {
+			if deletedVpc.Deleted != nil && !time.Now().After(*deletedVpc.Deleted) {
+				logger.Warn().Msg("skipping VPC from Site: soft-delete marker is not in the past")
+				return nil, nil
+			}
+
+			networkVirtualizationType := reportedVpc.NetworkVirtualizationType
+			if networkVirtualizationType == nil {
+				networkVirtualizationType = deletedVpc.NetworkVirtualizationType
+			}
+			activeVni := reportedVpc.ActiveVni
+			if activeVni == nil {
+				activeVni = deletedVpc.ActiveVni
+			}
+			requestedVni := reportedVpc.Vni
+			if requestedVni == nil {
+				requestedVni = deletedVpc.Vni
+			}
+			routingProfile := reportedVpc.RoutingProfile
+			if routingProfile == nil {
+				routingProfile = deletedVpc.RoutingProfile
+			}
+			routingProfileOverrides := reportedVpc.RoutingProfileOverrides
+			if routingProfileOverrides == nil {
+				routingProfileOverrides = deletedVpc.RoutingProfileOverrides
+			}
+			effectiveRoutingProfile := reportedVpc.EffectiveRoutingProfile
+			if effectiveRoutingProfile == nil {
+				effectiveRoutingProfile = deletedVpc.EffectiveRoutingProfile
+			}
+
+			_, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{
+				VpcID:   deletedVpc.ID,
+				Deleted: true,
+			})
+			if clearErr != nil {
+				return nil, fmt.Errorf("clear soft-deleted VPC: %w", clearErr)
+			}
+
+			restoredVpc, updateErr := vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
+				VpcID:                                  deletedVpc.ID,
+				ControllerVpcID:                        &controllerVpcID,
+				NetworkVirtualizationType:              networkVirtualizationType,
+				RoutingProfile:                         routingProfile,
+				RoutingProfileOverrides:                routingProfileOverrides,
+				EffectiveRoutingProfile:                effectiveRoutingProfile,
+				ActiveVni:                              activeVni,
+				NetworkSecurityGroupID:                 networkSecurityGroupID,
+				NetworkSecurityGroupPropagationDetails: propagationDetails,
+				Status:                                 cwutil.GetPtr(cdbm.VpcStatusReady),
+				IsMissingOnSite:                        cwutil.GetPtr(false),
+				Vni:                                    requestedVni,
+			})
+			if updateErr != nil {
+				return nil, fmt.Errorf("update restored VPC from Site: %w", updateErr)
+			}
+			_, statusErr := statusDetailDAO.Create(
+				ctx,
+				tx,
+				cdbm.StatusDetailCreateInput{
+					EntityID: restoredVpc.ID.String(),
+					Status:   cdbm.VpcStatusReady,
+					Message:  &message,
+				},
+			)
+			if statusErr != nil {
+				return nil, fmt.Errorf("create restored VPC status detail: %w", statusErr)
+			}
+			return restoredVpc, nil
+		}
+
+		createdBy := cdbm.User{}
+		createdBy.ID = site.ID
+		createdVpc, createErr := vpcDAO.Create(ctx, tx, cdbm.VpcCreateInput{
+			ID:                                     &controllerVpcID,
+			Name:                                   reportedVpc.Name,
+			Description:                            reportedVpc.Description,
+			Org:                                    reportedVpc.Org,
+			InfrastructureProviderID:               site.InfrastructureProviderID,
+			TenantID:                               tenant.ID,
+			SiteID:                                 site.ID,
+			NVLinkLogicalPartitionID:               nvLinkLogicalPartitionID,
+			NetworkVirtualizationType:              reportedVpc.NetworkVirtualizationType,
+			RoutingProfile:                         reportedVpc.RoutingProfile,
+			RoutingProfileOverrides:                reportedVpc.RoutingProfileOverrides,
+			ControllerVpcID:                        &controllerVpcID,
+			ActiveVni:                              reportedVpc.ActiveVni,
+			NetworkSecurityGroupID:                 networkSecurityGroupID,
+			NetworkSecurityGroupPropagationDetails: propagationDetails,
+			Labels:                                 reportedVpc.Labels,
+			Status:                                 cdbm.VpcStatusReady,
+			CreatedBy:                              createdBy,
+			Vni:                                    reportedVpc.Vni,
+		})
+		if createErr != nil {
+			return nil, fmt.Errorf("create VPC from Site: %w", createErr)
+		}
+		if reportedVpc.EffectiveRoutingProfile != nil {
+			createdVpc, createErr = vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
+				VpcID:                   createdVpc.ID,
+				EffectiveRoutingProfile: reportedVpc.EffectiveRoutingProfile,
+			})
+			if createErr != nil {
+				return nil, fmt.Errorf("update created VPC effective routing profile: %w", createErr)
+			}
+		}
+		_, statusErr := statusDetailDAO.Create(
+			ctx,
+			tx,
+			cdbm.StatusDetailCreateInput{
+				EntityID: createdVpc.ID.String(),
+				Status:   cdbm.VpcStatusReady,
+				Message:  &message,
+			},
+		)
+		if statusErr != nil {
+			return nil, fmt.Errorf("create inventory VPC status detail: %w", statusErr)
+		}
+		return createdVpc, nil
+	})
+}
+
+func (mv ManageVpc) findSoftDeletedVpc(ctx context.Context, siteID, controllerVpcID uuid.UUID) (*cdbm.Vpc, error) {
+	vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
+	page := cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}
+	relations := []string{cdbm.TenantRelationName}
+
+	byID, _, err := vpcDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.VpcFilterInput{
+			VpcIDs:         []uuid.UUID{controllerVpcID},
+			SiteIDs:        []uuid.UUID{siteID},
+			IncludeDeleted: true,
+		},
+		page,
+		relations,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for i := range byID {
+		if byID[i].Deleted != nil {
+			return &byID[i], nil
+		}
+	}
+
+	byControllerID, _, err := vpcDAO.GetAll(
+		ctx,
+		nil,
+		cdbm.VpcFilterInput{
+			ControllerVpcIDs: []uuid.UUID{controllerVpcID},
+			SiteIDs:          []uuid.UUID{siteID},
+			IncludeDeleted:   true,
+		},
+		page,
+		relations,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for i := range byControllerID {
+		if byControllerID[i].Deleted != nil {
+			return &byControllerID[i], nil
+		}
+	}
+	return nil, nil
 }
 
 // updateVpcStatusInDB is helper function to write VPC updates to DB

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -139,7 +139,8 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			vpc = existingVpcIDMap[controllerVpcIDStr]
 		}
 
-		// No active REST row for this inventory VPC: create one or undelete a soft-deleted match.
+		// No active REST row for this inventory VPC: create one or undelete a soft-deleted match,
+		// then fall through so the main inventory loop applies Site-reported field updates.
 		if vpc == nil {
 			vpc = mv.createOrUpdateVpcFromSite(ctx, site, controllerVpc, sitePropagationStatus)
 			if vpc == nil {
@@ -151,9 +152,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			if vpc.ControllerVpcID != nil {
 				existingVpcCtrlIDMap[vpc.ControllerVpcID.String()] = vpc
 			}
-			reportedVpcIDMap[vpc.ID] = true
-			slogger.Info().Str("VPC ID", vpc.ID.String()).Msg("created or updated VPC from Site inventory")
-			continue
+			slogger.Info().Str("VPC ID", vpc.ID.String()).Msg("created or undeleted VPC from Site inventory")
 		}
 
 		reportedVpcIDMap[vpc.ID] = true
@@ -416,7 +415,8 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 }
 
 // createOrUpdateVpcFromSite creates a REST VPC from Site inventory, or undeletes
-// a matching soft-deleted row. Returns nil when skipped or on failure.
+// a matching soft-deleted row. Field refresh after undelete is left to UpdateVpcsInDB.
+// Returns nil when skipped or on failure.
 func (mv ManageVpc) createOrUpdateVpcFromSite(
 	ctx context.Context,
 	site *cdbm.Site,
@@ -446,83 +446,54 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		return nil
 	}
 
-	// Create/restore under one transaction so concurrent inventory pages cannot insert duplicates.
+	// Create/undelete under one transaction so concurrent inventory pages cannot insert duplicates.
 	vpc, err := cdb.WithTxResult(ctx, mv.dbSession, func(tx *cdb.Tx) (*cdbm.Vpc, error) {
 		vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
 
-		// Match by primary key first; DAO ANDs VpcIDs with ControllerVpcIDs, so fall back separately.
+		// ID and ControllerVpcID are aligned, so primary-key lookup is sufficient.
 		matches, _, reloadErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
 			VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true,
-		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, []string{cdbm.TenantRelationName})
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if reloadErr != nil {
 			return nil, fmt.Errorf("reload VPC by inventory ID: %w", reloadErr)
 		}
-		if len(matches) == 0 {
-			matches, _, reloadErr = vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
-				ControllerVpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true,
-			}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, []string{cdbm.TenantRelationName})
-			if reloadErr != nil {
-				return nil, fmt.Errorf("reload VPC by controller ID: %w", reloadErr)
-			}
-		}
 
-		// Split matches into at most one active and one soft-deleted row for this identity.
-		var activeVpc, softDeletedVpc *cdbm.Vpc
-		for i := range matches {
-			row := &matches[i]
-			if row.Deleted == nil {
-				if activeVpc != nil {
-					logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple active VPCs")
-					return nil, nil
-				}
-				activeVpc = row
-				continue
+		if len(matches) > 0 {
+			existingVpc := &matches[0]
+			if existingVpc.Deleted == nil {
+				return existingVpc, nil
 			}
-			if softDeletedVpc != nil {
-				logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple soft-deleted VPCs")
-				return nil, nil
-			}
-			softDeletedVpc = row
-		}
-		if activeVpc != nil {
-			return activeVpc, nil
-		}
-
-		// Restore keeps the soft-deleted row's tenant; create resolves tenant from the Site org.
-		var tenant *cdbm.Tenant
-		if softDeletedVpc != nil {
-			if softDeletedVpc.Org != fromSite.Org {
+			if existingVpc.Org != fromSite.Org {
 				logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant organization differs from Site inventory")
 				return nil, nil
 			}
-			if softDeletedVpc.Tenant == nil {
-				logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant does not exist")
+			// Bun soft-delete requires the deleted timestamp to already be in the past.
+			if !time.Now().After(*existingVpc.Deleted) {
+				logger.Warn().Msg("skipping VPC from Site: soft-delete marker is not in the past")
 				return nil, nil
 			}
-			tenant = softDeletedVpc.Tenant
-		} else {
-			tenants, _, tenantErr := cdbm.NewTenantDAO(mv.dbSession).GetAll(
-				ctx, tx, cdbm.TenantFilterInput{Orgs: []string{fromSite.Org}}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil,
-			)
-			if tenantErr != nil {
-				return nil, fmt.Errorf("get VPC tenant by organization: %w", tenantErr)
+			// Undelete only; UpdateVpcsInDB applies Site-reported field updates.
+			restored, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{VpcID: existingVpc.ID, Deleted: true})
+			if clearErr != nil {
+				return nil, fmt.Errorf("clear soft-deleted VPC: %w", clearErr)
 			}
-			if len(tenants) == 0 {
-				logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
-				return nil, nil
-			}
-			tenant = &tenants[0]
+			return restored, nil
 		}
+
+		tenants, _, tenantErr := cdbm.NewTenantDAO(mv.dbSession).GetAll(
+			ctx, tx, cdbm.TenantFilterInput{Orgs: []string{fromSite.Org}}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil,
+		)
+		if tenantErr != nil {
+			return nil, fmt.Errorf("get VPC tenant by organization: %w", tenantErr)
+		}
+		if len(tenants) == 0 {
+			logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
+			return nil, nil
+		}
+		tenant := &tenants[0]
 
 		nsgID := fromSite.NetworkSecurityGroupID
 		nvLinkID := fromSite.NVLinkLogicalPartitionID
-		if softDeletedVpc != nil {
-			if nsgID == nil {
-				nsgID = softDeletedVpc.NetworkSecurityGroupID
-			}
-			// Existing REST NVLink assignment stays authoritative on restore.
-			nvLinkID = softDeletedVpc.NVLinkLogicalPartitionID
-		}
 
 		// Skip when referenced NSG/NVLink is missing or not owned by this tenant/site.
 		if nsgID != nil {
@@ -549,96 +520,25 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition belongs to a different Tenant or Site")
 				return nil, nil
 			}
-			// Restore may keep a non-Ready NVLink; new creates require Ready.
-			if softDeletedVpc == nil && nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
+			if nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
 				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition is not Ready")
 				return nil, nil
 			}
 		}
 
 		// Reject inventoring a VPC whose name is already taken by another active row.
-		vpcName := fromSite.Name
-		if softDeletedVpc != nil {
-			vpcName = softDeletedVpc.Name
-		}
 		nameConflictVpcs, _, nameErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
-			Name: &vpcName, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID},
+			Name: &fromSite.Name, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID},
 		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if nameErr != nil {
 			return nil, fmt.Errorf("check inventory VPC name conflict: %w", nameErr)
 		}
-		// Soft-deleted rows are excluded by GetAll, so any hit is an active conflict.
 		if len(nameConflictVpcs) > 0 {
 			logger.Warn().Msg("skipping VPC from Site: an active VPC with the same name already exists for the Tenant and Site")
 			return nil, nil
 		}
 
-		statusDetailDAO := cdbm.NewStatusDetailDAO(mv.dbSession)
 		readyMsg := "VPC was found on Site, Ready for use"
-
-		if softDeletedVpc != nil {
-			// Bun soft-delete requires the deleted timestamp to already be in the past.
-			if softDeletedVpc.Deleted != nil && !time.Now().After(*softDeletedVpc.Deleted) {
-				logger.Warn().Msg("skipping VPC from Site: soft-delete marker is not in the past")
-				return nil, nil
-			}
-
-			// Prefer Site inventory values; fall back to the soft-deleted row.
-			nvt := softDeletedVpc.NetworkVirtualizationType
-			if fromSite.NetworkVirtualizationType != nil {
-				nvt = fromSite.NetworkVirtualizationType
-			}
-			activeVni := softDeletedVpc.ActiveVni
-			if fromSite.ActiveVni != nil {
-				activeVni = fromSite.ActiveVni
-			}
-			requestedVni := softDeletedVpc.Vni
-			if fromSite.Vni != nil {
-				requestedVni = fromSite.Vni
-			}
-			routingProfile := softDeletedVpc.RoutingProfile
-			if fromSite.RoutingProfile != nil {
-				routingProfile = fromSite.RoutingProfile
-			}
-			routingOverrides := softDeletedVpc.RoutingProfileOverrides
-			if fromSite.RoutingProfileOverrides != nil {
-				routingOverrides = fromSite.RoutingProfileOverrides
-			}
-			effectiveRouting := softDeletedVpc.EffectiveRoutingProfile
-			if fromSite.EffectiveRoutingProfile != nil {
-				effectiveRouting = fromSite.EffectiveRoutingProfile
-			}
-
-			// Clear(Deleted) undeletes the row; Update then refreshes inventory fields to Ready.
-			if _, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{VpcID: softDeletedVpc.ID, Deleted: true}); clearErr != nil {
-				return nil, fmt.Errorf("clear soft-deleted VPC: %w", clearErr)
-			}
-			restored, updateErr := vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
-				VpcID:                                  softDeletedVpc.ID,
-				ControllerVpcID:                        &vpcID,
-				NetworkVirtualizationType:              nvt,
-				RoutingProfile:                         routingProfile,
-				RoutingProfileOverrides:                routingOverrides,
-				EffectiveRoutingProfile:                effectiveRouting,
-				ActiveVni:                              activeVni,
-				NetworkSecurityGroupID:                 nsgID,
-				NetworkSecurityGroupPropagationDetails: propagationDetails,
-				Status:                                 cwutil.GetPtr(cdbm.VpcStatusReady),
-				IsMissingOnSite:                        cwutil.GetPtr(false),
-				Vni:                                    requestedVni,
-			})
-			if updateErr != nil {
-				return nil, fmt.Errorf("update restored VPC from Site: %w", updateErr)
-			}
-			if _, statusErr := statusDetailDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
-				EntityID: restored.ID.String(), Status: cdbm.VpcStatusReady, Message: &readyMsg,
-			}); statusErr != nil {
-				return nil, fmt.Errorf("create restored VPC status detail: %w", statusErr)
-			}
-			return restored, nil
-		}
-
-		// No soft-deleted match: insert a new Ready VPC keyed by the Site inventory ID.
 		createdBy := cdbm.User{}
 		createdBy.ID = site.ID
 		created, createErr := vpcDAO.Create(ctx, tx, cdbm.VpcCreateInput{
@@ -666,7 +566,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		if createErr != nil {
 			return nil, fmt.Errorf("create VPC from Site: %w", createErr)
 		}
-		if _, statusErr := statusDetailDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
+		if _, statusErr := cdbm.NewStatusDetailDAO(mv.dbSession).Create(ctx, tx, cdbm.StatusDetailCreateInput{
 			EntityID: created.ID.String(), Status: cdbm.VpcStatusReady, Message: &readyMsg,
 		}); statusErr != nil {
 			return nil, fmt.Errorf("create inventory VPC status detail: %w", statusErr)

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -567,11 +567,10 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		if nameErr != nil {
 			return nil, fmt.Errorf("check inventory VPC name conflict: %w", nameErr)
 		}
-		for i := range nameConflictVpcs {
-			if softDeletedVpc == nil || nameConflictVpcs[i].ID != softDeletedVpc.ID {
-				logger.Warn().Msg("skipping VPC from Site: an active VPC with the same name already exists for the Tenant and Site")
-				return nil, nil
-			}
+		// Soft-deleted rows are excluded by GetAll, so any hit is an active conflict.
+		if len(nameConflictVpcs) > 0 {
+			logger.Warn().Msg("skipping VPC from Site: an active VPC with the same name already exists for the Tenant and Site")
+			return nil, nil
 		}
 
 		statusDetailDAO := cdbm.NewStatusDetailDAO(mv.dbSession)
@@ -654,6 +653,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			NetworkVirtualizationType:              fromSite.NetworkVirtualizationType,
 			RoutingProfile:                         fromSite.RoutingProfile,
 			RoutingProfileOverrides:                fromSite.RoutingProfileOverrides,
+			EffectiveRoutingProfile:                fromSite.EffectiveRoutingProfile,
 			ControllerVpcID:                        &vpcID,
 			ActiveVni:                              fromSite.ActiveVni,
 			NetworkSecurityGroupID:                 nsgID,
@@ -665,15 +665,6 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		})
 		if createErr != nil {
 			return nil, fmt.Errorf("create VPC from Site: %w", createErr)
-		}
-		// EffectiveRoutingProfile is not part of CreateInput, so set it in a follow-up Update.
-		if fromSite.EffectiveRoutingProfile != nil {
-			created, createErr = vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
-				VpcID: created.ID, EffectiveRoutingProfile: fromSite.EffectiveRoutingProfile,
-			})
-			if createErr != nil {
-				return nil, fmt.Errorf("update created VPC effective routing profile: %w", createErr)
-			}
 		}
 		if _, statusErr := statusDetailDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
 			EntityID: created.ID.String(), Status: cdbm.VpcStatusReady, Message: &readyMsg,

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -140,11 +140,7 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 		}
 
 		if vpc == nil {
-			vpc, serr := mv.createOrUpdateVpcFromSite(ctx, site, controllerVpc, sitePropagationStatus)
-			if serr != nil {
-				slogger.Warn().Err(serr).Msg("failed to create or update VPC from Site")
-				continue
-			}
+			vpc = mv.createOrUpdateVpcFromSite(ctx, site, controllerVpc, sitePropagationStatus)
 			if vpc == nil {
 				continue
 			}
@@ -417,253 +413,241 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 	return vpcLifecycleEvents, nil
 }
 
-// createOrUpdateVpcFromSite caches a VPC reported by Site inventory that has
-// no active REST row. Soft-deleted rows are undeleted via Clear; otherwise a
-// new row is created. Returns nil when the inventory entry is skipped.
+// createOrUpdateVpcFromSite creates a REST VPC from Site inventory, or undeletes
+// a matching soft-deleted row. Returns nil when skipped or on failure.
 func (mv ManageVpc) createOrUpdateVpcFromSite(
 	ctx context.Context,
 	site *cdbm.Site,
-	controllerVpc *corev1.Vpc,
+	siteInventoryVpc *corev1.Vpc,
 	propagationDetails *cdbm.NetworkSecurityGroupPropagationDetails,
-) (*cdbm.Vpc, error) {
+) *cdbm.Vpc {
 	logger := log.With().
 		Str("Activity", "UpdateVpcsInDB").
 		Str("Site ID", site.ID.String()).
-		Str("VPC Controller ID", controllerVpc.GetId().GetValue()).
+		Str("VPC Controller ID", siteInventoryVpc.GetId().GetValue()).
 		Logger()
 
-	controllerVpcID, err := uuid.Parse(controllerVpc.GetId().GetValue())
+	vpcID, err := uuid.Parse(siteInventoryVpc.GetId().GetValue())
 	if err != nil {
 		logger.Warn().Err(err).Msg("skipping VPC from Site: controller VPC ID is not a valid UUID")
-		return nil, nil
+		return nil
 	}
 
-	reportedVpc := new(cdbm.Vpc)
-	reportedVpc.FromProto(controllerVpc)
-	if reportedVpc.NetworkSecurityGroupID != nil && *reportedVpc.NetworkSecurityGroupID == "" {
-		reportedVpc.NetworkSecurityGroupID = nil
+	fromSite := new(cdbm.Vpc)
+	fromSite.FromProto(siteInventoryVpc)
+	if fromSite.NetworkSecurityGroupID != nil && *fromSite.NetworkSecurityGroupID == "" {
+		fromSite.NetworkSecurityGroupID = nil
 	}
 	// FromProto clears NVLinkLogicalPartitionID when the proto value is invalid.
-	if controllerVpc.GetConfig().GetDefaultNvlinkLogicalPartitionId().GetValue() != "" &&
-		reportedVpc.NVLinkLogicalPartitionID == nil {
+	if siteInventoryVpc.GetConfig().GetDefaultNvlinkLogicalPartitionId().GetValue() != "" &&
+		fromSite.NVLinkLogicalPartitionID == nil {
 		logger.Warn().Msg("skipping VPC from Site: default NVLink Logical Partition ID is not a valid UUID")
-		return nil, nil
+		return nil
 	}
-	if reportedVpc.Name == "" {
+	if fromSite.Name == "" {
 		logger.Warn().Msg("skipping VPC from Site: VPC metadata does not contain a name")
-		return nil, nil
+		return nil
 	}
-	if reportedVpc.Org == "" {
+	if fromSite.Org == "" {
 		logger.Warn().Msg("skipping VPC from Site: VPC does not report a tenant organization")
-		return nil, nil
+		return nil
 	}
 
-	page := cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}
 	vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
+	page := cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}
+	tenantRel := []string{cdbm.TenantRelationName}
+	identityFilters := []cdbm.VpcFilterInput{
+		{VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true},
+		{ControllerVpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true},
+	}
 
-	// Look up a soft-deleted VPC matching this Site inventory identity.
-	deletedVpc, err := mv.findSoftDeletedVpc(ctx, site.ID, controllerVpcID)
-	if err != nil {
-		return nil, fmt.Errorf("find soft-deleted VPC: %w", err)
+	// Prefer a soft-deleted row keyed by inventory ID, then by controller VPC ID.
+	var softDeletedVpc *cdbm.Vpc
+	for _, filter := range identityFilters {
+		rows, _, lookupErr := vpcDAO.GetAll(ctx, nil, filter, page, tenantRel)
+		if lookupErr != nil {
+			logger.Warn().Err(lookupErr).Msg("failed to find soft-deleted VPC from Site")
+			return nil
+		}
+		for i := range rows {
+			if rows[i].Deleted != nil {
+				softDeletedVpc = &rows[i]
+				break
+			}
+		}
+		if softDeletedVpc != nil {
+			break
+		}
 	}
 
 	var tenant *cdbm.Tenant
-	if deletedVpc != nil {
-		if deletedVpc.Org != reportedVpc.Org {
+	if softDeletedVpc != nil {
+		if softDeletedVpc.Org != fromSite.Org {
 			logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant organization differs from Site inventory")
-			return nil, nil
+			return nil
 		}
-		if deletedVpc.Tenant == nil {
+		if softDeletedVpc.Tenant == nil {
 			logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant does not exist")
-			return nil, nil
+			return nil
 		}
-		tenant = deletedVpc.Tenant
+		tenant = softDeletedVpc.Tenant
 	} else {
-		tenantDAO := cdbm.NewTenantDAO(mv.dbSession)
-		tenants, _, tenantErr := tenantDAO.GetAll(
-			ctx,
-			nil,
-			cdbm.TenantFilterInput{Orgs: []string{reportedVpc.Org}},
-			cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)},
-			nil,
+		tenants, _, tenantErr := cdbm.NewTenantDAO(mv.dbSession).GetAll(
+			ctx, nil, cdbm.TenantFilterInput{Orgs: []string{fromSite.Org}}, page, nil,
 		)
 		if tenantErr != nil {
-			return nil, fmt.Errorf("get VPC tenant by organization: %w", tenantErr)
+			logger.Warn().Err(tenantErr).Msg("failed to get VPC tenant by organization")
+			return nil
 		}
 		if len(tenants) == 0 {
 			logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
-			return nil, nil
+			return nil
 		}
 		tenant = &tenants[0]
 	}
 
-	networkSecurityGroupID := reportedVpc.NetworkSecurityGroupID
-	nvLinkLogicalPartitionID := reportedVpc.NVLinkLogicalPartitionID
-	if deletedVpc != nil {
-		if networkSecurityGroupID == nil {
-			networkSecurityGroupID = deletedVpc.NetworkSecurityGroupID
+	nsgID := fromSite.NetworkSecurityGroupID
+	nvLinkID := fromSite.NVLinkLogicalPartitionID
+	if softDeletedVpc != nil {
+		if nsgID == nil {
+			nsgID = softDeletedVpc.NetworkSecurityGroupID
 		}
 		// Existing REST configuration remains authoritative for this field.
-		nvLinkLogicalPartitionID = deletedVpc.NVLinkLogicalPartitionID
+		nvLinkID = softDeletedVpc.NVLinkLogicalPartitionID
 	}
 
-	if networkSecurityGroupID != nil {
-		networkSecurityGroupDAO := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession)
-		_, nsgErr := networkSecurityGroupDAO.GetByID(ctx, nil, *networkSecurityGroupID, nil)
+	if nsgID != nil {
+		_, nsgErr := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession).GetByID(ctx, nil, *nsgID, nil)
 		if errors.Is(nsgErr, cdb.ErrDoesNotExist) {
 			logger.Warn().Msg("skipping VPC from Site: referenced Network Security Group does not exist in REST")
-			return nil, nil
+			return nil
 		}
 		if nsgErr != nil {
-			return nil, fmt.Errorf("get inventory VPC Network Security Group: %w", nsgErr)
+			logger.Warn().Err(nsgErr).Msg("failed to get inventory VPC Network Security Group")
+			return nil
 		}
 	}
 
-	if nvLinkLogicalPartitionID != nil {
-		nvLinkLogicalPartitionDAO := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession)
-		nvLinkLogicalPartition, nvLinkErr := nvLinkLogicalPartitionDAO.GetByID(ctx, nil, *nvLinkLogicalPartitionID, nil)
+	if nvLinkID != nil {
+		nvLink, nvLinkErr := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession).GetByID(ctx, nil, *nvLinkID, nil)
 		if errors.Is(nvLinkErr, cdb.ErrDoesNotExist) {
 			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition does not exist in REST")
-			return nil, nil
+			return nil
 		}
 		if nvLinkErr != nil {
-			return nil, fmt.Errorf("get inventory VPC NVLink Logical Partition: %w", nvLinkErr)
+			logger.Warn().Err(nvLinkErr).Msg("failed to get inventory VPC NVLink Logical Partition")
+			return nil
 		}
-		if nvLinkLogicalPartition.SiteID != site.ID || nvLinkLogicalPartition.TenantID != tenant.ID {
+		if nvLink.SiteID != site.ID || nvLink.TenantID != tenant.ID {
 			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition belongs to a different Tenant or Site")
-			return nil, nil
+			return nil
 		}
-		if deletedVpc == nil && nvLinkLogicalPartition.Status != cdbm.NVLinkLogicalPartitionStatusReady {
+		if softDeletedVpc == nil && nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
 			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition is not Ready")
-			return nil, nil
+			return nil
 		}
 	}
 
-	return cdb.WithTxResult(ctx, mv.dbSession, func(tx *cdb.Tx) (*cdbm.Vpc, error) {
-		// Re-read inside the transaction so concurrent inventory pages cannot
-		// create duplicate VPC rows.
-		matchingVpcs, _, reloadErr := vpcDAO.GetAll(
-			ctx,
-			tx,
-			cdbm.VpcFilterInput{
-				VpcIDs:         []uuid.UUID{controllerVpcID},
-				SiteIDs:        []uuid.UUID{site.ID},
-				IncludeDeleted: true,
-			},
-			page,
-			[]string{cdbm.TenantRelationName},
-		)
-		if reloadErr != nil {
-			return nil, fmt.Errorf("reload VPC by inventory identity: %w", reloadErr)
-		}
-		if len(matchingVpcs) == 0 {
-			matchingVpcs, _, reloadErr = vpcDAO.GetAll(
-				ctx,
-				tx,
-				cdbm.VpcFilterInput{
-					ControllerVpcIDs: []uuid.UUID{controllerVpcID},
-					SiteIDs:          []uuid.UUID{site.ID},
-					IncludeDeleted:   true,
-				},
-				page,
-				[]string{cdbm.TenantRelationName},
-			)
+	vpc, err := cdb.WithTxResult(ctx, mv.dbSession, func(tx *cdb.Tx) (*cdbm.Vpc, error) {
+		// Re-read under the transaction so concurrent inventory pages cannot create duplicates.
+		var matches []cdbm.Vpc
+		for _, filter := range identityFilters {
+			rows, _, reloadErr := vpcDAO.GetAll(ctx, tx, filter, page, tenantRel)
 			if reloadErr != nil {
-				return nil, fmt.Errorf("reload VPC by controller identity: %w", reloadErr)
+				return nil, fmt.Errorf("reload VPC by inventory identity: %w", reloadErr)
+			}
+			if len(rows) > 0 {
+				matches = rows
+				break
 			}
 		}
 
-		var activeVpc *cdbm.Vpc
-		deletedVpc = nil
-		for i := range matchingVpcs {
-			if matchingVpcs[i].Deleted == nil {
-				if activeVpc != nil {
+		var active *cdbm.Vpc
+		softDeletedVpc = nil
+		for i := range matches {
+			row := &matches[i]
+			if row.Deleted == nil {
+				if active != nil {
 					logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple active VPCs")
 					return nil, nil
 				}
-				activeVpc = &matchingVpcs[i]
-			} else {
-				if deletedVpc != nil {
-					logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple soft-deleted VPCs")
-					return nil, nil
-				}
-				deletedVpc = &matchingVpcs[i]
+				active = row
+				continue
 			}
+			if softDeletedVpc != nil {
+				logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple soft-deleted VPCs")
+				return nil, nil
+			}
+			softDeletedVpc = row
 		}
-		if activeVpc != nil {
-			return activeVpc, nil
+		if active != nil {
+			return active, nil
 		}
 
-		name := reportedVpc.Name
-		if deletedVpc != nil {
-			name = deletedVpc.Name
+		vpcName := fromSite.Name
+		if softDeletedVpc != nil {
+			vpcName = softDeletedVpc.Name
 		}
-		vpcsWithName, _, nameErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
-			Name:      &name,
-			TenantIDs: []uuid.UUID{tenant.ID},
-			SiteIDs:   []uuid.UUID{site.ID},
+		nameConflictVpcs, _, nameErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+			Name: &vpcName, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID},
 		}, page, nil)
 		if nameErr != nil {
 			return nil, fmt.Errorf("check inventory VPC name conflict: %w", nameErr)
 		}
-		for i := range vpcsWithName {
-			if deletedVpc == nil || vpcsWithName[i].ID != deletedVpc.ID {
+		for i := range nameConflictVpcs {
+			if softDeletedVpc == nil || nameConflictVpcs[i].ID != softDeletedVpc.ID {
 				logger.Warn().Msg("skipping VPC from Site: an active VPC with the same name already exists for the Tenant and Site")
 				return nil, nil
 			}
 		}
 
 		statusDetailDAO := cdbm.NewStatusDetailDAO(mv.dbSession)
-		message := "VPC was found on Site, Ready for use"
+		readyMsg := "VPC was found on Site, Ready for use"
 
-		if deletedVpc != nil {
-			if deletedVpc.Deleted != nil && !time.Now().After(*deletedVpc.Deleted) {
+		if softDeletedVpc != nil {
+			if softDeletedVpc.Deleted != nil && !time.Now().After(*softDeletedVpc.Deleted) {
 				logger.Warn().Msg("skipping VPC from Site: soft-delete marker is not in the past")
 				return nil, nil
 			}
 
-			networkVirtualizationType := reportedVpc.NetworkVirtualizationType
-			if networkVirtualizationType == nil {
-				networkVirtualizationType = deletedVpc.NetworkVirtualizationType
+			// Prefer Site inventory values; fall back to the soft-deleted row.
+			nvt := softDeletedVpc.NetworkVirtualizationType
+			if fromSite.NetworkVirtualizationType != nil {
+				nvt = fromSite.NetworkVirtualizationType
 			}
-			activeVni := reportedVpc.ActiveVni
-			if activeVni == nil {
-				activeVni = deletedVpc.ActiveVni
+			activeVni := softDeletedVpc.ActiveVni
+			if fromSite.ActiveVni != nil {
+				activeVni = fromSite.ActiveVni
 			}
-			requestedVni := reportedVpc.Vni
-			if requestedVni == nil {
-				requestedVni = deletedVpc.Vni
+			requestedVni := softDeletedVpc.Vni
+			if fromSite.Vni != nil {
+				requestedVni = fromSite.Vni
 			}
-			routingProfile := reportedVpc.RoutingProfile
-			if routingProfile == nil {
-				routingProfile = deletedVpc.RoutingProfile
+			routingProfile := softDeletedVpc.RoutingProfile
+			if fromSite.RoutingProfile != nil {
+				routingProfile = fromSite.RoutingProfile
 			}
-			routingProfileOverrides := reportedVpc.RoutingProfileOverrides
-			if routingProfileOverrides == nil {
-				routingProfileOverrides = deletedVpc.RoutingProfileOverrides
+			routingOverrides := softDeletedVpc.RoutingProfileOverrides
+			if fromSite.RoutingProfileOverrides != nil {
+				routingOverrides = fromSite.RoutingProfileOverrides
 			}
-			effectiveRoutingProfile := reportedVpc.EffectiveRoutingProfile
-			if effectiveRoutingProfile == nil {
-				effectiveRoutingProfile = deletedVpc.EffectiveRoutingProfile
+			effectiveRouting := softDeletedVpc.EffectiveRoutingProfile
+			if fromSite.EffectiveRoutingProfile != nil {
+				effectiveRouting = fromSite.EffectiveRoutingProfile
 			}
 
-			_, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{
-				VpcID:   deletedVpc.ID,
-				Deleted: true,
-			})
-			if clearErr != nil {
+			if _, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{VpcID: softDeletedVpc.ID, Deleted: true}); clearErr != nil {
 				return nil, fmt.Errorf("clear soft-deleted VPC: %w", clearErr)
 			}
-
-			restoredVpc, updateErr := vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
-				VpcID:                                  deletedVpc.ID,
-				ControllerVpcID:                        &controllerVpcID,
-				NetworkVirtualizationType:              networkVirtualizationType,
+			restored, updateErr := vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
+				VpcID:                                  softDeletedVpc.ID,
+				ControllerVpcID:                        &vpcID,
+				NetworkVirtualizationType:              nvt,
 				RoutingProfile:                         routingProfile,
-				RoutingProfileOverrides:                routingProfileOverrides,
-				EffectiveRoutingProfile:                effectiveRoutingProfile,
+				RoutingProfileOverrides:                routingOverrides,
+				EffectiveRoutingProfile:                effectiveRouting,
 				ActiveVni:                              activeVni,
-				NetworkSecurityGroupID:                 networkSecurityGroupID,
+				NetworkSecurityGroupID:                 nsgID,
 				NetworkSecurityGroupPropagationDetails: propagationDetails,
 				Status:                                 cwutil.GetPtr(cdbm.VpcStatusReady),
 				IsMissingOnSite:                        cwutil.GetPtr(false),
@@ -672,117 +656,60 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			if updateErr != nil {
 				return nil, fmt.Errorf("update restored VPC from Site: %w", updateErr)
 			}
-			_, statusErr := statusDetailDAO.Create(
-				ctx,
-				tx,
-				cdbm.StatusDetailCreateInput{
-					EntityID: restoredVpc.ID.String(),
-					Status:   cdbm.VpcStatusReady,
-					Message:  &message,
-				},
-			)
-			if statusErr != nil {
+			if _, statusErr := statusDetailDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
+				EntityID: restored.ID.String(), Status: cdbm.VpcStatusReady, Message: &readyMsg,
+			}); statusErr != nil {
 				return nil, fmt.Errorf("create restored VPC status detail: %w", statusErr)
 			}
-			return restoredVpc, nil
+			return restored, nil
 		}
 
 		createdBy := cdbm.User{}
 		createdBy.ID = site.ID
-		createdVpc, createErr := vpcDAO.Create(ctx, tx, cdbm.VpcCreateInput{
-			ID:                                     &controllerVpcID,
-			Name:                                   reportedVpc.Name,
-			Description:                            reportedVpc.Description,
-			Org:                                    reportedVpc.Org,
+		created, createErr := vpcDAO.Create(ctx, tx, cdbm.VpcCreateInput{
+			ID:                                     &vpcID,
+			Name:                                   fromSite.Name,
+			Description:                            fromSite.Description,
+			Org:                                    fromSite.Org,
 			InfrastructureProviderID:               site.InfrastructureProviderID,
 			TenantID:                               tenant.ID,
 			SiteID:                                 site.ID,
-			NVLinkLogicalPartitionID:               nvLinkLogicalPartitionID,
-			NetworkVirtualizationType:              reportedVpc.NetworkVirtualizationType,
-			RoutingProfile:                         reportedVpc.RoutingProfile,
-			RoutingProfileOverrides:                reportedVpc.RoutingProfileOverrides,
-			ControllerVpcID:                        &controllerVpcID,
-			ActiveVni:                              reportedVpc.ActiveVni,
-			NetworkSecurityGroupID:                 networkSecurityGroupID,
+			NVLinkLogicalPartitionID:               nvLinkID,
+			NetworkVirtualizationType:              fromSite.NetworkVirtualizationType,
+			RoutingProfile:                         fromSite.RoutingProfile,
+			RoutingProfileOverrides:                fromSite.RoutingProfileOverrides,
+			ControllerVpcID:                        &vpcID,
+			ActiveVni:                              fromSite.ActiveVni,
+			NetworkSecurityGroupID:                 nsgID,
 			NetworkSecurityGroupPropagationDetails: propagationDetails,
-			Labels:                                 reportedVpc.Labels,
+			Labels:                                 fromSite.Labels,
 			Status:                                 cdbm.VpcStatusReady,
 			CreatedBy:                              createdBy,
-			Vni:                                    reportedVpc.Vni,
+			Vni:                                    fromSite.Vni,
 		})
 		if createErr != nil {
 			return nil, fmt.Errorf("create VPC from Site: %w", createErr)
 		}
-		if reportedVpc.EffectiveRoutingProfile != nil {
-			createdVpc, createErr = vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
-				VpcID:                   createdVpc.ID,
-				EffectiveRoutingProfile: reportedVpc.EffectiveRoutingProfile,
+		if fromSite.EffectiveRoutingProfile != nil {
+			created, createErr = vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
+				VpcID: created.ID, EffectiveRoutingProfile: fromSite.EffectiveRoutingProfile,
 			})
 			if createErr != nil {
 				return nil, fmt.Errorf("update created VPC effective routing profile: %w", createErr)
 			}
 		}
-		_, statusErr := statusDetailDAO.Create(
-			ctx,
-			tx,
-			cdbm.StatusDetailCreateInput{
-				EntityID: createdVpc.ID.String(),
-				Status:   cdbm.VpcStatusReady,
-				Message:  &message,
-			},
-		)
-		if statusErr != nil {
+		if _, statusErr := statusDetailDAO.Create(ctx, tx, cdbm.StatusDetailCreateInput{
+			EntityID: created.ID.String(), Status: cdbm.VpcStatusReady, Message: &readyMsg,
+		}); statusErr != nil {
 			return nil, fmt.Errorf("create inventory VPC status detail: %w", statusErr)
 		}
-		return createdVpc, nil
+		return created, nil
 	})
-}
-
-func (mv ManageVpc) findSoftDeletedVpc(ctx context.Context, siteID, controllerVpcID uuid.UUID) (*cdbm.Vpc, error) {
-	vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
-	page := cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}
-	relations := []string{cdbm.TenantRelationName}
-
-	byID, _, err := vpcDAO.GetAll(
-		ctx,
-		nil,
-		cdbm.VpcFilterInput{
-			VpcIDs:         []uuid.UUID{controllerVpcID},
-			SiteIDs:        []uuid.UUID{siteID},
-			IncludeDeleted: true,
-		},
-		page,
-		relations,
-	)
 	if err != nil {
-		return nil, err
+		logger.Warn().Err(err).Msg("failed to create or update VPC from Site")
+		return nil
 	}
-	for i := range byID {
-		if byID[i].Deleted != nil {
-			return &byID[i], nil
-		}
-	}
-
-	byControllerID, _, err := vpcDAO.GetAll(
-		ctx,
-		nil,
-		cdbm.VpcFilterInput{
-			ControllerVpcIDs: []uuid.UUID{controllerVpcID},
-			SiteIDs:          []uuid.UUID{siteID},
-			IncludeDeleted:   true,
-		},
-		page,
-		relations,
-	)
-	if err != nil {
-		return nil, err
-	}
-	for i := range byControllerID {
-		if byControllerID[i].Deleted != nil {
-			return &byControllerID[i], nil
-		}
-	}
-	return nil, nil
+	return vpc
 }
 
 // updateVpcStatusInDB is helper function to write VPC updates to DB

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -420,29 +420,28 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 func (mv ManageVpc) createOrUpdateVpcFromSite(
 	ctx context.Context,
 	site *cdbm.Site,
-	siteInventoryVpc *corev1.Vpc,
+	controllerVpc *corev1.Vpc,
 	propagationDetails *cdbm.NetworkSecurityGroupPropagationDetails,
 ) *cdbm.Vpc {
 	logger := log.With().
 		Str("Activity", "UpdateVpcsInDB").
 		Str("Site ID", site.ID.String()).
-		Str("VPC Controller ID", siteInventoryVpc.GetId().GetValue()).
+		Str("VPC Controller ID", controllerVpc.GetId().GetValue()).
 		Logger()
 
-	vpcID, err := uuid.Parse(siteInventoryVpc.GetId().GetValue())
+	vpcID, err := uuid.Parse(controllerVpc.GetId().GetValue())
 	if err != nil {
-		logger.Warn().Err(err).Msg("skipping VPC from Site: controller VPC ID is not a valid UUID")
+		logger.Warn().Msg(fmt.Sprintf("unable to create VPC found on Site: failed to parse VPC Controller ID, not a valid UUID %s", controllerVpc.GetId().GetValue()))
 		return nil
 	}
 
-	fromSite := new(cdbm.Vpc)
-	fromSite.FromProto(siteInventoryVpc)
-	if fromSite.Name == "" {
-		logger.Warn().Msg("skipping VPC from Site: VPC metadata does not contain a name")
-		return nil
+	reportedVpc := new(cdbm.Vpc)
+	reportedVpc.FromProto(controllerVpc)
+	if reportedVpc.Name == "" {
+		reportedVpc.Name = fmt.Sprintf("recovered-%s", vpcID.String()[:8])
 	}
-	if fromSite.Org == "" {
-		logger.Warn().Msg("skipping VPC from Site: VPC does not report a tenant organization")
+	if reportedVpc.Org == "" {
+		logger.Warn().Msg(fmt.Sprintf("unable to create VPC found on Site: VPC does not report a tenant organization %s", reportedVpc.Org))
 		return nil
 	}
 
@@ -455,7 +454,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true,
 		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if reloadErr != nil {
-			return nil, fmt.Errorf("reload VPC by inventory ID: %w", reloadErr)
+			return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve VPC by controller ID, DB error: %w", reloadErr)
 		}
 
 		if len(matches) > 0 {
@@ -463,79 +462,73 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			if existingVpc.Deleted == nil {
 				return existingVpc, nil
 			}
-			if existingVpc.Org != fromSite.Org {
-				logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant organization differs from Site inventory")
-				return nil, nil
-			}
-			// Bun soft-delete requires the deleted timestamp to already be in the past.
-			if !time.Now().After(*existingVpc.Deleted) {
-				logger.Warn().Msg("skipping VPC from Site: soft-delete marker is not in the past")
+			if existingVpc.Org != reportedVpc.Org {
+				logger.Warn().Msg(fmt.Sprintf("unable to create VPC found on Site: tenant organization differs in REST cache and Site record %s", reportedVpc.Org))
 				return nil, nil
 			}
 			// Undelete only; UpdateVpcsInDB applies Site-reported field updates.
 			restored, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{VpcID: existingVpc.ID, Deleted: true})
 			if clearErr != nil {
-				return nil, fmt.Errorf("clear soft-deleted VPC: %w", clearErr)
+				return nil, fmt.Errorf("unable to create VPC found on Site: failed to clear soft-delete timestamp for VPC, DB error: %w", clearErr)
 			}
 			return restored, nil
 		}
 
 		tenants, _, tenantErr := cdbm.NewTenantDAO(mv.dbSession).GetAll(
-			ctx, tx, cdbm.TenantFilterInput{Orgs: []string{fromSite.Org}}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil,
+			ctx, tx, cdbm.TenantFilterInput{Orgs: []string{reportedVpc.Org}}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil,
 		)
 		if tenantErr != nil {
-			return nil, fmt.Errorf("get VPC tenant by organization: %w", tenantErr)
+			return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve Tenant by organization, DB error: %w", tenantErr)
 		}
 		if len(tenants) == 0 {
-			logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
+			logger.Warn().Msgf("unable to create VPC found on Site: no Tenants were found for org: %s", reportedVpc.Org)
 			return nil, nil
 		}
 		tenant := &tenants[0]
 
-		nsgID := fromSite.NetworkSecurityGroupID
-		nvLinkID := fromSite.NVLinkLogicalPartitionID
+		nsgID := reportedVpc.NetworkSecurityGroupID
+		nvLinkID := reportedVpc.NVLinkLogicalPartitionID
 
 		// Skip when referenced NSG/NVLink is missing or not owned by this tenant/site.
 		if nsgID != nil {
 			_, nsgErr := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession).GetByID(ctx, tx, *nsgID, nil)
 			if errors.Is(nsgErr, cdb.ErrDoesNotExist) {
-				logger.Warn().Msg("skipping VPC from Site: referenced Network Security Group does not exist in REST")
+				logger.Warn().Msgf("unable to create VPC found on Site: no Network Security Group was found for ID: %s", *nsgID)
 				return nil, nil
 			}
 			if nsgErr != nil {
-				return nil, fmt.Errorf("get inventory VPC Network Security Group: %w", nsgErr)
+				return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve Network Security Group by ID: %s, DB error: %w", *nsgID, nsgErr)
 			}
 		}
 
 		if nvLinkID != nil {
 			nvLink, nvLinkErr := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession).GetByID(ctx, tx, *nvLinkID, nil)
 			if errors.Is(nvLinkErr, cdb.ErrDoesNotExist) {
-				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition does not exist in REST")
+				logger.Warn().Msgf("unable to create VPC found on Site: no NVLink Logical Partition was found for ID: %s", *nvLinkID)
 				return nil, nil
 			}
 			if nvLinkErr != nil {
-				return nil, fmt.Errorf("get inventory VPC NVLink Logical Partition: %w", nvLinkErr)
+				return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve NVLink Logical Partition by ID: %s, DB error: %w", *nvLinkID, nvLinkErr)
 			}
 			if nvLink.SiteID != site.ID || nvLink.TenantID != tenant.ID {
-				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition belongs to a different Tenant or Site")
+				logger.Warn().Msgf("unable to create VPC found on Site: NVLink Logical Partition differs in REST cache and Site record for Tenant or Site %s", *nvLinkID)
 				return nil, nil
 			}
 			if nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
-				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition is not Ready")
+				logger.Warn().Msgf("unable to create VPC found on Site: NVLink Logical Partition is not Ready for ID: %s", *nvLinkID)
 				return nil, nil
 			}
 		}
 
-		// Reject inventoring a VPC whose name is already taken by another active row.
+		// If an active VPC already uses this name for the Tenant/Site, append a recovered suffix.
 		nameConflictVpcs, _, nameErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
-			Name: &fromSite.Name, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID},
+			Name: &reportedVpc.Name, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID},
 		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if nameErr != nil {
-			return nil, fmt.Errorf("check inventory VPC name conflict: %w", nameErr)
+			return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve VPC by name, DB error: %w", nameErr)
 		}
 		if len(nameConflictVpcs) > 0 {
-			logger.Warn().Msg("skipping VPC from Site: an active VPC with the same name already exists for the Tenant and Site")
-			return nil, nil
+			reportedVpc.Name = fmt.Sprintf("%s-recovered-%s", reportedVpc.Name, vpcID.String()[:8])
 		}
 
 		readyMsg := "VPC was found on Site, Ready for use"
@@ -543,38 +536,38 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		createdBy.ID = site.ID
 		created, createErr := vpcDAO.Create(ctx, tx, cdbm.VpcCreateInput{
 			ID:                                     &vpcID,
-			Name:                                   fromSite.Name,
-			Description:                            fromSite.Description,
-			Org:                                    fromSite.Org,
+			Name:                                   reportedVpc.Name,
+			Description:                            reportedVpc.Description,
+			Org:                                    reportedVpc.Org,
 			InfrastructureProviderID:               site.InfrastructureProviderID,
 			TenantID:                               tenant.ID,
 			SiteID:                                 site.ID,
 			NVLinkLogicalPartitionID:               nvLinkID,
-			NetworkVirtualizationType:              fromSite.NetworkVirtualizationType,
-			RoutingProfile:                         fromSite.RoutingProfile,
-			RoutingProfileOverrides:                fromSite.RoutingProfileOverrides,
-			EffectiveRoutingProfile:                fromSite.EffectiveRoutingProfile,
+			NetworkVirtualizationType:              reportedVpc.NetworkVirtualizationType,
+			RoutingProfile:                         reportedVpc.RoutingProfile,
+			RoutingProfileOverrides:                reportedVpc.RoutingProfileOverrides,
+			EffectiveRoutingProfile:                reportedVpc.EffectiveRoutingProfile,
 			ControllerVpcID:                        &vpcID,
-			ActiveVni:                              fromSite.ActiveVni,
+			ActiveVni:                              reportedVpc.ActiveVni,
 			NetworkSecurityGroupID:                 nsgID,
 			NetworkSecurityGroupPropagationDetails: propagationDetails,
-			Labels:                                 fromSite.Labels,
+			Labels:                                 reportedVpc.Labels,
 			Status:                                 cdbm.VpcStatusReady,
 			CreatedBy:                              createdBy,
-			Vni:                                    fromSite.Vni,
+			Vni:                                    reportedVpc.Vni,
 		})
 		if createErr != nil {
-			return nil, fmt.Errorf("create VPC from Site: %w", createErr)
+			return nil, fmt.Errorf("unable to create VPC found on Site: failed to create VPC, DB error: %w", createErr)
 		}
 		if _, statusErr := cdbm.NewStatusDetailDAO(mv.dbSession).Create(ctx, tx, cdbm.StatusDetailCreateInput{
 			EntityID: created.ID.String(), Status: cdbm.VpcStatusReady, Message: &readyMsg,
 		}); statusErr != nil {
-			return nil, fmt.Errorf("create inventory VPC status detail: %w", statusErr)
+			return nil, fmt.Errorf("unable to create VPC found on Site: failed to create Status Detail, DB error: %w", statusErr)
 		}
 		return created, nil
 	})
 	if err != nil {
-		logger.Warn().Err(err).Msg("failed to create or update VPC from Site")
+		logger.Warn().Err(err).Msg(err.Error())
 		return nil
 	}
 	return vpc

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -441,7 +441,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		reportedVpc.Name = fmt.Sprintf("recovered-%s", vpcID.String()[:8])
 	}
 	if reportedVpc.Org == "" {
-		logger.Warn().Msg(fmt.Sprintf("unable to create VPC found on Site: VPC does not report a tenant organization %s", reportedVpc.Org))
+		logger.Warn().Msg("unable to create VPC found on Site: VPC on Site is reporting empty Tenant organization ID")
 		return nil
 	}
 
@@ -487,11 +487,11 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		tenant := &tenants[0]
 
 		nsgID := reportedVpc.NetworkSecurityGroupID
-		nvLinkID := reportedVpc.NVLinkLogicalPartitionID
+		nvllpID := reportedVpc.NVLinkLogicalPartitionID
 
 		// Skip when referenced NSG/NVLink is missing or not owned by this tenant/site.
 		if nsgID != nil {
-			_, nsgErr := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession).GetByID(ctx, tx, *nsgID, nil)
+			nsg, nsgErr := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession).GetByID(ctx, tx, *nsgID, nil)
 			if errors.Is(nsgErr, cdb.ErrDoesNotExist) {
 				logger.Warn().Msgf("unable to create VPC found on Site: no Network Security Group was found for ID: %s", *nsgID)
 				return nil, nil
@@ -499,23 +499,23 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			if nsgErr != nil {
 				return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve Network Security Group by ID: %s, DB error: %w", *nsgID, nsgErr)
 			}
+			if nsg.TenantID != tenant.ID {
+				logger.Warn().Msgf("unable to create VPC found on Site: Network Security Group differs in REST cache and Site record for Tenant %s", *nsgID)
+				return nil, nil
+			}
 		}
 
-		if nvLinkID != nil {
-			nvLink, nvLinkErr := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession).GetByID(ctx, tx, *nvLinkID, nil)
+		if nvllpID != nil {
+			nvllp, nvLinkErr := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession).GetByID(ctx, tx, *nvllpID, nil)
 			if errors.Is(nvLinkErr, cdb.ErrDoesNotExist) {
-				logger.Warn().Msgf("unable to create VPC found on Site: no NVLink Logical Partition was found for ID: %s", *nvLinkID)
+				logger.Warn().Msgf("unable to create VPC found on Site: no NVLink Logical Partition was found for ID: %s", *nvllpID)
 				return nil, nil
 			}
 			if nvLinkErr != nil {
-				return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve NVLink Logical Partition by ID: %s, DB error: %w", *nvLinkID, nvLinkErr)
+				return nil, fmt.Errorf("unable to create VPC found on Site: failed to retrieve NVLink Logical Partition by ID: %s, DB error: %w", *nvllpID, nvLinkErr)
 			}
-			if nvLink.SiteID != site.ID || nvLink.TenantID != tenant.ID {
-				logger.Warn().Msgf("unable to create VPC found on Site: NVLink Logical Partition differs in REST cache and Site record for Tenant or Site %s", *nvLinkID)
-				return nil, nil
-			}
-			if nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
-				logger.Warn().Msgf("unable to create VPC found on Site: NVLink Logical Partition is not Ready for ID: %s", *nvLinkID)
+			if nvllp.TenantID != tenant.ID {
+				logger.Warn().Msgf("unable to create VPC found on Site: NVLink Logical Partition differs in REST cache and Site record for Tenant %s", *nvllpID)
 				return nil, nil
 			}
 		}
@@ -542,7 +542,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			InfrastructureProviderID:               site.InfrastructureProviderID,
 			TenantID:                               tenant.ID,
 			SiteID:                                 site.ID,
-			NVLinkLogicalPartitionID:               nvLinkID,
+			NVLinkLogicalPartitionID:               nvllpID,
 			NetworkVirtualizationType:              reportedVpc.NetworkVirtualizationType,
 			RoutingProfile:                         reportedVpc.RoutingProfile,
 			RoutingProfileOverrides:                reportedVpc.RoutingProfileOverrides,

--- a/rest-api/workflow/pkg/activity/vpc/vpc.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc.go
@@ -139,12 +139,14 @@ func (mv ManageVpc) UpdateVpcsInDB(ctx context.Context, siteID uuid.UUID, vpcInv
 			vpc = existingVpcIDMap[controllerVpcIDStr]
 		}
 
+		// No active REST row for this inventory VPC: create one or undelete a soft-deleted match.
 		if vpc == nil {
 			vpc = mv.createOrUpdateVpcFromSite(ctx, site, controllerVpc, sitePropagationStatus)
 			if vpc == nil {
 				continue
 			}
 
+			// Keep in-memory maps in sync so later inventory entries and missing-on-Site detection see this VPC.
 			existingVpcIDMap[vpc.ID.String()] = vpc
 			if vpc.ControllerVpcID != nil {
 				existingVpcCtrlIDMap[vpc.ControllerVpcID.String()] = vpc
@@ -435,15 +437,6 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 
 	fromSite := new(cdbm.Vpc)
 	fromSite.FromProto(siteInventoryVpc)
-	if fromSite.NetworkSecurityGroupID != nil && *fromSite.NetworkSecurityGroupID == "" {
-		fromSite.NetworkSecurityGroupID = nil
-	}
-	// FromProto clears NVLinkLogicalPartitionID when the proto value is invalid.
-	if siteInventoryVpc.GetConfig().GetDefaultNvlinkLogicalPartitionId().GetValue() != "" &&
-		fromSite.NVLinkLogicalPartitionID == nil {
-		logger.Warn().Msg("skipping VPC from Site: default NVLink Logical Partition ID is not a valid UUID")
-		return nil
-	}
 	if fromSite.Name == "" {
 		logger.Warn().Msg("skipping VPC from Site: VPC metadata does not contain a name")
 		return nil
@@ -453,125 +446,36 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		return nil
 	}
 
-	vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
-	page := cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}
-	tenantRel := []string{cdbm.TenantRelationName}
-	identityFilters := []cdbm.VpcFilterInput{
-		{VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true},
-		{ControllerVpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true},
-	}
-
-	// Prefer a soft-deleted row keyed by inventory ID, then by controller VPC ID.
-	var softDeletedVpc *cdbm.Vpc
-	for _, filter := range identityFilters {
-		rows, _, lookupErr := vpcDAO.GetAll(ctx, nil, filter, page, tenantRel)
-		if lookupErr != nil {
-			logger.Warn().Err(lookupErr).Msg("failed to find soft-deleted VPC from Site")
-			return nil
-		}
-		for i := range rows {
-			if rows[i].Deleted != nil {
-				softDeletedVpc = &rows[i]
-				break
-			}
-		}
-		if softDeletedVpc != nil {
-			break
-		}
-	}
-
-	var tenant *cdbm.Tenant
-	if softDeletedVpc != nil {
-		if softDeletedVpc.Org != fromSite.Org {
-			logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant organization differs from Site inventory")
-			return nil
-		}
-		if softDeletedVpc.Tenant == nil {
-			logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant does not exist")
-			return nil
-		}
-		tenant = softDeletedVpc.Tenant
-	} else {
-		tenants, _, tenantErr := cdbm.NewTenantDAO(mv.dbSession).GetAll(
-			ctx, nil, cdbm.TenantFilterInput{Orgs: []string{fromSite.Org}}, page, nil,
-		)
-		if tenantErr != nil {
-			logger.Warn().Err(tenantErr).Msg("failed to get VPC tenant by organization")
-			return nil
-		}
-		if len(tenants) == 0 {
-			logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
-			return nil
-		}
-		tenant = &tenants[0]
-	}
-
-	nsgID := fromSite.NetworkSecurityGroupID
-	nvLinkID := fromSite.NVLinkLogicalPartitionID
-	if softDeletedVpc != nil {
-		if nsgID == nil {
-			nsgID = softDeletedVpc.NetworkSecurityGroupID
-		}
-		// Existing REST configuration remains authoritative for this field.
-		nvLinkID = softDeletedVpc.NVLinkLogicalPartitionID
-	}
-
-	if nsgID != nil {
-		_, nsgErr := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession).GetByID(ctx, nil, *nsgID, nil)
-		if errors.Is(nsgErr, cdb.ErrDoesNotExist) {
-			logger.Warn().Msg("skipping VPC from Site: referenced Network Security Group does not exist in REST")
-			return nil
-		}
-		if nsgErr != nil {
-			logger.Warn().Err(nsgErr).Msg("failed to get inventory VPC Network Security Group")
-			return nil
-		}
-	}
-
-	if nvLinkID != nil {
-		nvLink, nvLinkErr := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession).GetByID(ctx, nil, *nvLinkID, nil)
-		if errors.Is(nvLinkErr, cdb.ErrDoesNotExist) {
-			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition does not exist in REST")
-			return nil
-		}
-		if nvLinkErr != nil {
-			logger.Warn().Err(nvLinkErr).Msg("failed to get inventory VPC NVLink Logical Partition")
-			return nil
-		}
-		if nvLink.SiteID != site.ID || nvLink.TenantID != tenant.ID {
-			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition belongs to a different Tenant or Site")
-			return nil
-		}
-		if softDeletedVpc == nil && nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
-			logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition is not Ready")
-			return nil
-		}
-	}
-
+	// Create/restore under one transaction so concurrent inventory pages cannot insert duplicates.
 	vpc, err := cdb.WithTxResult(ctx, mv.dbSession, func(tx *cdb.Tx) (*cdbm.Vpc, error) {
-		// Re-read under the transaction so concurrent inventory pages cannot create duplicates.
-		var matches []cdbm.Vpc
-		for _, filter := range identityFilters {
-			rows, _, reloadErr := vpcDAO.GetAll(ctx, tx, filter, page, tenantRel)
+		vpcDAO := cdbm.NewVpcDAO(mv.dbSession)
+
+		// Match by primary key first; DAO ANDs VpcIDs with ControllerVpcIDs, so fall back separately.
+		matches, _, reloadErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+			VpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true,
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, []string{cdbm.TenantRelationName})
+		if reloadErr != nil {
+			return nil, fmt.Errorf("reload VPC by inventory ID: %w", reloadErr)
+		}
+		if len(matches) == 0 {
+			matches, _, reloadErr = vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
+				ControllerVpcIDs: []uuid.UUID{vpcID}, SiteIDs: []uuid.UUID{site.ID}, IncludeDeleted: true,
+			}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, []string{cdbm.TenantRelationName})
 			if reloadErr != nil {
-				return nil, fmt.Errorf("reload VPC by inventory identity: %w", reloadErr)
-			}
-			if len(rows) > 0 {
-				matches = rows
-				break
+				return nil, fmt.Errorf("reload VPC by controller ID: %w", reloadErr)
 			}
 		}
 
-		var active *cdbm.Vpc
-		softDeletedVpc = nil
+		// Split matches into at most one active and one soft-deleted row for this identity.
+		var activeVpc, softDeletedVpc *cdbm.Vpc
 		for i := range matches {
 			row := &matches[i]
 			if row.Deleted == nil {
-				if active != nil {
+				if activeVpc != nil {
 					logger.Warn().Msg("skipping VPC from Site: inventory identity matches multiple active VPCs")
 					return nil, nil
 				}
-				active = row
+				activeVpc = row
 				continue
 			}
 			if softDeletedVpc != nil {
@@ -580,17 +484,86 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			}
 			softDeletedVpc = row
 		}
-		if active != nil {
-			return active, nil
+		if activeVpc != nil {
+			return activeVpc, nil
 		}
 
+		// Restore keeps the soft-deleted row's tenant; create resolves tenant from the Site org.
+		var tenant *cdbm.Tenant
+		if softDeletedVpc != nil {
+			if softDeletedVpc.Org != fromSite.Org {
+				logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant organization differs from Site inventory")
+				return nil, nil
+			}
+			if softDeletedVpc.Tenant == nil {
+				logger.Warn().Msg("skipping VPC from Site: soft-deleted VPC tenant does not exist")
+				return nil, nil
+			}
+			tenant = softDeletedVpc.Tenant
+		} else {
+			tenants, _, tenantErr := cdbm.NewTenantDAO(mv.dbSession).GetAll(
+				ctx, tx, cdbm.TenantFilterInput{Orgs: []string{fromSite.Org}}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil,
+			)
+			if tenantErr != nil {
+				return nil, fmt.Errorf("get VPC tenant by organization: %w", tenantErr)
+			}
+			if len(tenants) == 0 {
+				logger.Warn().Msg("skipping VPC from Site: tenant organization does not have a REST Tenant")
+				return nil, nil
+			}
+			tenant = &tenants[0]
+		}
+
+		nsgID := fromSite.NetworkSecurityGroupID
+		nvLinkID := fromSite.NVLinkLogicalPartitionID
+		if softDeletedVpc != nil {
+			if nsgID == nil {
+				nsgID = softDeletedVpc.NetworkSecurityGroupID
+			}
+			// Existing REST NVLink assignment stays authoritative on restore.
+			nvLinkID = softDeletedVpc.NVLinkLogicalPartitionID
+		}
+
+		// Skip when referenced NSG/NVLink is missing or not owned by this tenant/site.
+		if nsgID != nil {
+			_, nsgErr := cdbm.NewNetworkSecurityGroupDAO(mv.dbSession).GetByID(ctx, tx, *nsgID, nil)
+			if errors.Is(nsgErr, cdb.ErrDoesNotExist) {
+				logger.Warn().Msg("skipping VPC from Site: referenced Network Security Group does not exist in REST")
+				return nil, nil
+			}
+			if nsgErr != nil {
+				return nil, fmt.Errorf("get inventory VPC Network Security Group: %w", nsgErr)
+			}
+		}
+
+		if nvLinkID != nil {
+			nvLink, nvLinkErr := cdbm.NewNVLinkLogicalPartitionDAO(mv.dbSession).GetByID(ctx, tx, *nvLinkID, nil)
+			if errors.Is(nvLinkErr, cdb.ErrDoesNotExist) {
+				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition does not exist in REST")
+				return nil, nil
+			}
+			if nvLinkErr != nil {
+				return nil, fmt.Errorf("get inventory VPC NVLink Logical Partition: %w", nvLinkErr)
+			}
+			if nvLink.SiteID != site.ID || nvLink.TenantID != tenant.ID {
+				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition belongs to a different Tenant or Site")
+				return nil, nil
+			}
+			// Restore may keep a non-Ready NVLink; new creates require Ready.
+			if softDeletedVpc == nil && nvLink.Status != cdbm.NVLinkLogicalPartitionStatusReady {
+				logger.Warn().Msg("skipping VPC from Site: referenced NVLink Logical Partition is not Ready")
+				return nil, nil
+			}
+		}
+
+		// Reject inventoring a VPC whose name is already taken by another active row.
 		vpcName := fromSite.Name
 		if softDeletedVpc != nil {
 			vpcName = softDeletedVpc.Name
 		}
 		nameConflictVpcs, _, nameErr := vpcDAO.GetAll(ctx, tx, cdbm.VpcFilterInput{
 			Name: &vpcName, TenantIDs: []uuid.UUID{tenant.ID}, SiteIDs: []uuid.UUID{site.ID},
-		}, page, nil)
+		}, cdbp.PageInput{Limit: cwutil.GetPtr(cdbp.TotalLimit)}, nil)
 		if nameErr != nil {
 			return nil, fmt.Errorf("check inventory VPC name conflict: %w", nameErr)
 		}
@@ -605,6 +578,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		readyMsg := "VPC was found on Site, Ready for use"
 
 		if softDeletedVpc != nil {
+			// Bun soft-delete requires the deleted timestamp to already be in the past.
 			if softDeletedVpc.Deleted != nil && !time.Now().After(*softDeletedVpc.Deleted) {
 				logger.Warn().Msg("skipping VPC from Site: soft-delete marker is not in the past")
 				return nil, nil
@@ -636,6 +610,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 				effectiveRouting = fromSite.EffectiveRoutingProfile
 			}
 
+			// Clear(Deleted) undeletes the row; Update then refreshes inventory fields to Ready.
 			if _, clearErr := vpcDAO.Clear(ctx, tx, cdbm.VpcClearInput{VpcID: softDeletedVpc.ID, Deleted: true}); clearErr != nil {
 				return nil, fmt.Errorf("clear soft-deleted VPC: %w", clearErr)
 			}
@@ -664,6 +639,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 			return restored, nil
 		}
 
+		// No soft-deleted match: insert a new Ready VPC keyed by the Site inventory ID.
 		createdBy := cdbm.User{}
 		createdBy.ID = site.ID
 		created, createErr := vpcDAO.Create(ctx, tx, cdbm.VpcCreateInput{
@@ -690,6 +666,7 @@ func (mv ManageVpc) createOrUpdateVpcFromSite(
 		if createErr != nil {
 			return nil, fmt.Errorf("create VPC from Site: %w", createErr)
 		}
+		// EffectiveRoutingProfile is not part of CreateInput, so set it in a follow-up Update.
 		if fromSite.EffectiveRoutingProfile != nil {
 			created, createErr = vpcDAO.Update(ctx, tx, cdbm.VpcUpdateInput{
 				VpcID: created.ID, EffectiveRoutingProfile: fromSite.EffectiveRoutingProfile,

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -1101,9 +1101,10 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 	tests := []struct {
 		name          string
 		controllerVpc *corev1.Vpc
-		wantVpc      bool
-		wantName     string
-		wantNamePref string
+		wantVpc       bool
+		wantName      string
+		wantNamePref  string
+		wantNVLinkID  *uuid.UUID
 	}{
 		{
 			name: "unknown tenant organization",
@@ -1135,7 +1136,7 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 			},
 		},
 		{
-			name: "non-Ready inventory NVLink Logical Partition is rejected",
+			name: "creates VPC with non-Ready inventory NVLink Logical Partition",
 			controllerVpc: &corev1.Vpc{
 				Id: &corev1.VpcId{Value: uuid.NewString()},
 				Config: &corev1.VpcConfig{
@@ -1146,6 +1147,9 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 				},
 				Metadata: &corev1.Metadata{Name: "non-ready-nvlink-vpc"},
 			},
+			wantVpc:      true,
+			wantName:     "non-ready-nvlink-vpc",
+			wantNVLinkID: &nonReadyNVLink.ID,
 		},
 		{
 			name: "renames VPC when active name already exists",
@@ -1205,6 +1209,10 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 				if tt.wantNamePref != "" {
 					assert.True(t, strings.HasPrefix(vpc.Name, tt.wantNamePref), "name %q should have prefix %q", vpc.Name, tt.wantNamePref)
 					assert.Len(t, strings.TrimPrefix(vpc.Name, tt.wantNamePref), 8)
+				}
+				if tt.wantNVLinkID != nil {
+					require.NotNil(t, vpc.NVLinkLogicalPartitionID)
+					assert.Equal(t, *tt.wantNVLinkID, *vpc.NVLinkLogicalPartitionID)
 				}
 				return
 			}

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -988,6 +988,55 @@ func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
 		}
 		assert.True(t, foundReadyMessage)
 	})
+
+	t.Run("inventory skips restore when tenant organization differs", func(t *testing.T) {
+		require.NoError(t, vpcDAO.DeleteByID(ctx, nil, controllerVpcID))
+		deletedVpcs, _, err := vpcDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcFilterInput{VpcIDs: []uuid.UUID{controllerVpcID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deletedVpcs, 1)
+		require.NotNil(t, deletedVpcs[0].Deleted)
+		deletedAt := *deletedVpcs[0].Deleted
+
+		mismatchedInventory := &corev1.VPCInventory{
+			Vpcs: []*corev1.Vpc{{
+				Id: &corev1.VpcId{Value: controllerVpcID.String()},
+				Config: &corev1.VpcConfig{
+					TenantOrganizationId:      "other-tenant-org",
+					NetworkVirtualizationType: &networkVirtualizationType,
+					RoutingProfileType:        &routingProfile,
+					Vni:                       &requestedVni,
+				},
+				Status: &corev1.VpcStatus{Vni: &activeVni},
+				Metadata: &corev1.Metadata{
+					Name:        "site-created-vpc",
+					Description: "created directly on Site",
+				},
+			}},
+		}
+		_, err = manager.UpdateVpcsInDB(ctx, site.ID, mismatchedInventory)
+		require.NoError(t, err)
+
+		stillDeleted, _, err := vpcDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcFilterInput{VpcIDs: []uuid.UUID{controllerVpcID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, stillDeleted, 1)
+		require.NotNil(t, stillDeleted[0].Deleted)
+		assert.Equal(t, deletedAt, *stillDeleted[0].Deleted)
+
+		_, err = vpcDAO.GetByID(ctx, nil, controllerVpcID, nil)
+		assert.ErrorIs(t, err, cdb.ErrDoesNotExist)
+	})
 }
 
 func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing.T) {
@@ -1099,6 +1148,22 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 			},
 		},
 		{
+			name: "empty VPC name is rejected",
+			controllerVpc: &corev1.Vpc{
+				Id:       &corev1.VpcId{Value: uuid.NewString()},
+				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
+				Metadata: &corev1.Metadata{Name: ""},
+			},
+		},
+		{
+			name: "empty tenant organization is rejected",
+			controllerVpc: &corev1.Vpc{
+				Id:       &corev1.VpcId{Value: uuid.NewString()},
+				Config:   &corev1.VpcConfig{TenantOrganizationId: ""},
+				Metadata: &corev1.Metadata{Name: "missing-tenant-org-vpc"},
+			},
+		},
+		{
 			name: "creates VPC without Site allocation",
 			controllerVpc: &corev1.Vpc{
 				Id:       &corev1.VpcId{Value: uuid.NewString()},
@@ -1120,6 +1185,7 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 			if tt.wantVpc {
 				require.NotNil(t, vpc)
 				assert.Equal(t, cdbm.VpcStatusReady, vpc.Status)
+				assert.Equal(t, authorizedTenant.ID, vpc.TenantID)
 				return
 			}
 			assert.Nil(t, vpc)

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -938,6 +938,10 @@ func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
 		_, err := vpcDAO.Update(ctx, nil, cdbm.VpcUpdateInput{
 			VpcID:                    controllerVpcID,
 			NVLinkLogicalPartitionID: &nonReadyNVLink.ID,
+			Status:                   cutil.GetPtr(cdbm.VpcStatusError),
+			IsMissingOnSite:          cutil.GetPtr(true),
+			ActiveVni:                cutil.GetPtr(1),
+			RoutingProfile:           cutil.GetPtr("EXTERNAL"),
 		})
 		require.NoError(t, err)
 
@@ -968,6 +972,7 @@ func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
 		assert.Equal(t, 202, *restoredVpc.ActiveVni)
 		require.NotNil(t, restoredVpc.RoutingProfile)
 		assert.Equal(t, "INTERNAL", *restoredVpc.RoutingProfile)
+		// Soft-deleted NVLink is preserved; inventory does not overwrite it.
 		require.NotNil(t, restoredVpc.NVLinkLogicalPartitionID)
 		assert.Equal(t, nonReadyNVLink.ID, *restoredVpc.NVLinkLogicalPartitionID)
 
@@ -981,7 +986,7 @@ func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
 		foundReadyMessage := false
 		for i := range statusDetails {
 			if statusDetails[i].Message != nil &&
-				*statusDetails[i].Message == "VPC was found on Site, Ready for use" {
+				*statusDetails[i].Message == "VPC is ready for use" {
 				foundReadyMessage = true
 				break
 			}

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -88,6 +88,12 @@ func testVPCSetupSchema(t *testing.T, dbSession *cdb.Session) {
 	// create Status Details table
 	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.StatusDetail)(nil))
 	assert.Nil(t, err)
+	// create Network Security Group table
+	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.NetworkSecurityGroup)(nil))
+	assert.Nil(t, err)
+	// create NVLink Logical Partition table
+	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.NVLinkLogicalPartition)(nil))
+	assert.Nil(t, err)
 	// create VPC table
 	err = dbSession.DB.ResetModel(context.Background(), (*cdbm.Vpc)(nil))
 	assert.Nil(t, err)
@@ -488,6 +494,8 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 							Id:   &corev1.VpcId{Value: vpc8.ControllerVpcID.String()},
 							Name: vpc8.ID.String(),
 						},
+						// These unmatched entries intentionally omit tenant config,
+						// so create-or-update from Site skips rather than creating them.
 						{
 							Id:   &corev1.VpcId{Value: uuid.NewString()},
 							Name: vpc9.ID.String(),
@@ -544,10 +552,10 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 				vpc15.ID: cutil.GetPtr(networkSecurityGroupB.ID),
 				vpc16.ID: nil,
 			},
-			deletedVpcs:           []*cdbm.Vpc{vpc5, vpc6},
+			deletedVpcs:           []*cdbm.Vpc{vpc5, vpc6, vpc10},
 			missingVpcs:           []*cdbm.Vpc{vpc7, vpc11},
 			restoredVpcs:          []*cdbm.Vpc{vpc8},
-			unpairedVpcs:          []*cdbm.Vpc{vpc9, vpc10},
+			unpairedVpcs:          []*cdbm.Vpc{vpc9},
 			readyStatusDetailVpcs: []*cdbm.Vpc{vpc1},
 			wantErr:               false,
 		},
@@ -777,11 +785,10 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 			}
 
 			for _, vpc := range tt.unpairedVpcs {
-				uv, _ := vpcDAO.GetByID(ctx, nil, vpc.ID, nil)
-				assert.NotNil(t, uv.ControllerVpcID)
-				if vpc.Status != cdbm.VpcStatusDeleting {
-					assert.Equal(t, cdbm.VpcStatusReady, uv.Status)
-				}
+				uv, err := vpcDAO.GetByID(ctx, nil, vpc.ID, nil)
+				require.NoError(t, err)
+				assert.Nil(t, uv.ControllerVpcID)
+				assert.Equal(t, vpc.Status, uv.Status)
 			}
 
 			for _, vpc := range tt.restoredVpcs {
@@ -807,6 +814,316 @@ func TestManageVpc_UpdateVpcsInDB(t *testing.T) {
 				require.NotNil(t, statusDetails[0].Message)
 				assert.Equal(t, "VPC is ready for use", *statusDetails[0].Message)
 			}
+		})
+	}
+}
+
+func TestManageVpc_UpdateVpcsInDB_AutoCreatesAndRestores(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testVPCInitDB(t)
+	defer dbSession.Close()
+	testVPCSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	tenantOrg := "test-tenant-org"
+	tenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), tenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	tenant := testVPCBuildTenant(t, dbSession, "test-tenant", tenantOrg, tenantUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+
+	siteClientPool := testTemporalSiteClientPool(t)
+	siteClientPool.IDClientMap[site.ID.String()] = &tmocks.Client{}
+	manager := ManageVpc{
+		dbSession:      dbSession,
+		siteClientPool: siteClientPool,
+	}
+
+	controllerVpcID := uuid.New()
+	networkVirtualizationType := corev1.VpcVirtualizationType_FNN
+	requestedVni := uint32(101)
+	activeVni := uint32(202)
+	routingProfile := "INTERNAL"
+	controllerVpc := &corev1.Vpc{
+		Id: &corev1.VpcId{Value: controllerVpcID.String()},
+		Config: &corev1.VpcConfig{
+			TenantOrganizationId:      tenantOrg,
+			NetworkVirtualizationType: &networkVirtualizationType,
+			RoutingProfileType:        &routingProfile,
+			Vni:                       &requestedVni,
+		},
+		Status: &corev1.VpcStatus{Vni: &activeVni},
+		Metadata: &corev1.Metadata{
+			Name:        "site-created-vpc",
+			Description: "created directly on Site",
+			Labels: []*corev1.Label{
+				{Key: "origin", Value: cutil.GetPtr("site")},
+			},
+		},
+	}
+	inventory := &corev1.VPCInventory{
+		Vpcs: []*corev1.Vpc{controllerVpc},
+	}
+
+	vpcDAO := cdbm.NewVpcDAO(dbSession)
+	statusDetailDAO := cdbm.NewStatusDetailDAO(dbSession)
+
+	if !t.Run("auto creates VPC from inventory", func(t *testing.T) {
+		_, err := manager.UpdateVpcsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+
+		createdVpc, err := vpcDAO.GetByID(ctx, nil, controllerVpcID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, controllerVpcID, createdVpc.ID)
+		require.NotNil(t, createdVpc.ControllerVpcID)
+		assert.Equal(t, controllerVpcID, *createdVpc.ControllerVpcID)
+		assert.Equal(t, tenant.ID, createdVpc.TenantID)
+		assert.Equal(t, site.ID, createdVpc.SiteID)
+		assert.Equal(t, site.InfrastructureProviderID, createdVpc.InfrastructureProviderID)
+		assert.Equal(t, site.ID, createdVpc.CreatedBy)
+		assert.Equal(t, cdbm.VpcStatusReady, createdVpc.Status)
+		assert.Equal(t, "site-created-vpc", createdVpc.Name)
+		assert.Equal(t, cdbm.Labels{"origin": "site"}, createdVpc.Labels)
+		require.NotNil(t, createdVpc.NetworkVirtualizationType)
+		assert.Equal(t, cdbm.VpcFNN, *createdVpc.NetworkVirtualizationType)
+		require.NotNil(t, createdVpc.RoutingProfile)
+		assert.Equal(t, "INTERNAL", *createdVpc.RoutingProfile)
+		require.NotNil(t, createdVpc.Vni)
+		assert.Equal(t, 101, *createdVpc.Vni)
+		require.NotNil(t, createdVpc.ActiveVni)
+		assert.Equal(t, 202, *createdVpc.ActiveVni)
+
+		statusDetails, _, statusErr := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{createdVpc.ID.String()}},
+			cdbp.PageInput{},
+		)
+		require.NoError(t, statusErr)
+		require.Len(t, statusDetails, 1)
+		require.NotNil(t, statusDetails[0].Message)
+		assert.Equal(t, "VPC was found on Site, Ready for use", *statusDetails[0].Message)
+	}) {
+		t.FailNow()
+	}
+
+	if !t.Run("inventory replay is idempotent", func(t *testing.T) {
+		_, err := manager.UpdateVpcsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+		vpcs, count, err := vpcDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcFilterInput{VpcIDs: []uuid.UUID{controllerVpcID}},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, vpcs, 1)
+		assert.Equal(t, 1, count)
+	}) {
+		t.FailNow()
+	}
+
+	t.Run("inventory restores soft-deleted VPC", func(t *testing.T) {
+		nonReadyNVLink := cwu.TestBuildNVLinkLogicalPartition(
+			t,
+			dbSession,
+			"test-restore-non-ready-nvlink",
+			nil,
+			site,
+			tenant,
+			cdbm.NVLinkLogicalPartitionStatusPending,
+			false,
+		)
+		_, err := vpcDAO.Update(ctx, nil, cdbm.VpcUpdateInput{
+			VpcID:                    controllerVpcID,
+			NVLinkLogicalPartitionID: &nonReadyNVLink.ID,
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, vpcDAO.DeleteByID(ctx, nil, controllerVpcID))
+		deletedVpcs, _, err := vpcDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.VpcFilterInput{VpcIDs: []uuid.UUID{controllerVpcID}, IncludeDeleted: true},
+			cdbp.PageInput{Limit: cutil.GetPtr(cdbp.TotalLimit)},
+			nil,
+		)
+		require.NoError(t, err)
+		require.Len(t, deletedVpcs, 1)
+		require.NotNil(t, deletedVpcs[0].Deleted)
+
+		_, err = manager.UpdateVpcsInDB(ctx, site.ID, inventory)
+		require.NoError(t, err)
+		restoredVpc, err := vpcDAO.GetByID(ctx, nil, controllerVpcID, nil)
+		require.NoError(t, err)
+		assert.Nil(t, restoredVpc.Deleted)
+		assert.False(t, restoredVpc.IsMissingOnSite)
+		assert.Equal(t, cdbm.VpcStatusReady, restoredVpc.Status)
+		require.NotNil(t, restoredVpc.ControllerVpcID)
+		assert.Equal(t, controllerVpcID, *restoredVpc.ControllerVpcID)
+		require.NotNil(t, restoredVpc.Vni)
+		assert.Equal(t, 101, *restoredVpc.Vni)
+		require.NotNil(t, restoredVpc.ActiveVni)
+		assert.Equal(t, 202, *restoredVpc.ActiveVni)
+		require.NotNil(t, restoredVpc.RoutingProfile)
+		assert.Equal(t, "INTERNAL", *restoredVpc.RoutingProfile)
+		require.NotNil(t, restoredVpc.NVLinkLogicalPartitionID)
+		assert.Equal(t, nonReadyNVLink.ID, *restoredVpc.NVLinkLogicalPartitionID)
+
+		statusDetails, _, statusErr := statusDetailDAO.GetAll(
+			ctx,
+			nil,
+			cdbm.StatusDetailFilterInput{EntityIDs: []string{restoredVpc.ID.String()}},
+			cdbp.PageInput{},
+		)
+		require.NoError(t, statusErr)
+		foundReadyMessage := false
+		for i := range statusDetails {
+			if statusDetails[i].Message != nil &&
+				*statusDetails[i].Message == "VPC was found on Site, Ready for use" {
+				foundReadyMessage = true
+				break
+			}
+		}
+		assert.True(t, foundReadyMessage)
+	})
+}
+
+func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing.T) {
+	ctx := context.Background()
+	dbSession := testVPCInitDB(t)
+	defer dbSession.Close()
+	testVPCSetupSchema(t, dbSession)
+
+	providerOrg := "test-provider-org"
+	providerUser := testVPCBuildUser(t, dbSession, uuid.NewString(), providerOrg, []string{"FORGE_PROVIDER_ADMIN"})
+	provider := testVPCSiteBuildInfrastructureProvider(t, dbSession, "test-provider", providerOrg, providerUser)
+	site := testVPCBuildSite(t, dbSession, provider, "test-site", providerUser)
+	manager := ManageVpc{dbSession: dbSession}
+
+	authorizedTenantOrg := "test-authorized-tenant"
+	authorizedTenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), authorizedTenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	authorizedTenant := testVPCBuildTenant(t, dbSession, "test-authorized-tenant", authorizedTenantOrg, authorizedTenantUser)
+
+	otherTenantOrg := "test-other-tenant"
+	otherTenantUser := testVPCBuildUser(t, dbSession, uuid.NewString(), otherTenantOrg, []string{"FORGE_TENANT_ADMIN"})
+	otherTenant := testVPCBuildTenant(t, dbSession, "test-other-tenant", otherTenantOrg, otherTenantUser)
+	otherTenantNVLink := cwu.TestBuildNVLinkLogicalPartition(
+		t,
+		dbSession,
+		"test-other-tenant-nvlink",
+		nil,
+		site,
+		otherTenant,
+		cdbm.NVLinkLogicalPartitionStatusReady,
+		false,
+	)
+	nonReadyNVLink := cwu.TestBuildNVLinkLogicalPartition(
+		t,
+		dbSession,
+		"test-non-ready-nvlink",
+		nil,
+		site,
+		authorizedTenant,
+		cdbm.NVLinkLogicalPartitionStatusPending,
+		false,
+	)
+	existingVpc := testVPCBuildVPC(
+		t,
+		dbSession,
+		"test-existing-name",
+		provider,
+		authorizedTenant,
+		site,
+		cutil.GetPtr(cdbm.VpcEthernetVirtualizer),
+		cutil.GetPtr(uuid.New()),
+		nil,
+		authorizedTenantUser,
+		cdbm.VpcStatusReady,
+	)
+
+	tests := []struct {
+		name          string
+		controllerVpc *corev1.Vpc
+		wantVpc       bool
+	}{
+		{
+			name: "unknown tenant organization",
+			controllerVpc: &corev1.Vpc{
+				Id:       &corev1.VpcId{Value: uuid.NewString()},
+				Config:   &corev1.VpcConfig{TenantOrganizationId: "unknown-tenant-org"},
+				Metadata: &corev1.Metadata{Name: "unknown-tenant-vpc"},
+			},
+		},
+		{
+			name: "invalid controller VPC ID",
+			controllerVpc: &corev1.Vpc{
+				Id:       &corev1.VpcId{Value: "not-a-uuid"},
+				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
+				Metadata: &corev1.Metadata{Name: "invalid-id-vpc"},
+			},
+		},
+		{
+			name: "NVLink Logical Partition from another tenant is rejected",
+			controllerVpc: &corev1.Vpc{
+				Id: &corev1.VpcId{Value: uuid.NewString()},
+				Config: &corev1.VpcConfig{
+					TenantOrganizationId: authorizedTenantOrg,
+					DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{
+						Value: otherTenantNVLink.ID.String(),
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "cross-tenant-nvlink-vpc"},
+			},
+		},
+		{
+			name: "non-Ready inventory NVLink Logical Partition is rejected",
+			controllerVpc: &corev1.Vpc{
+				Id: &corev1.VpcId{Value: uuid.NewString()},
+				Config: &corev1.VpcConfig{
+					TenantOrganizationId: authorizedTenantOrg,
+					DefaultNvlinkLogicalPartitionId: &corev1.NVLinkLogicalPartitionId{
+						Value: nonReadyNVLink.ID.String(),
+					},
+				},
+				Metadata: &corev1.Metadata{Name: "non-ready-nvlink-vpc"},
+			},
+		},
+		{
+			name: "active VPC name conflict is rejected",
+			controllerVpc: &corev1.Vpc{
+				Id:       &corev1.VpcId{Value: uuid.NewString()},
+				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
+				Metadata: &corev1.Metadata{Name: existingVpc.Name},
+			},
+		},
+		{
+			name: "creates VPC without Site allocation",
+			controllerVpc: &corev1.Vpc{
+				Id:       &corev1.VpcId{Value: uuid.NewString()},
+				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
+				Metadata: &corev1.Metadata{Name: "unallocated-tenant-vpc"},
+			},
+			wantVpc: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vpc, err := manager.createOrUpdateVpcFromSite(
+				ctx,
+				site,
+				tt.controllerVpc,
+				nil,
+			)
+			require.NoError(t, err)
+			if tt.wantVpc {
+				require.NotNil(t, vpc)
+				assert.Equal(t, cdbm.VpcStatusReady, vpc.Status)
+				return
+			}
+			assert.Nil(t, vpc)
 		})
 	}
 }

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -1111,13 +1111,12 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			vpc, err := manager.createOrUpdateVpcFromSite(
+			vpc := manager.createOrUpdateVpcFromSite(
 				ctx,
 				site,
 				tt.controllerVpc,
 				nil,
 			)
-			require.NoError(t, err)
 			if tt.wantVpc {
 				require.NotNil(t, vpc)
 				assert.Equal(t, cdbm.VpcStatusReady, vpc.Status)

--- a/rest-api/workflow/pkg/activity/vpc/vpc_test.go
+++ b/rest-api/workflow/pkg/activity/vpc/vpc_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1100,7 +1101,9 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 	tests := []struct {
 		name          string
 		controllerVpc *corev1.Vpc
-		wantVpc       bool
+		wantVpc      bool
+		wantName     string
+		wantNamePref string
 	}{
 		{
 			name: "unknown tenant organization",
@@ -1145,20 +1148,24 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 			},
 		},
 		{
-			name: "active VPC name conflict is rejected",
+			name: "renames VPC when active name already exists",
 			controllerVpc: &corev1.Vpc{
 				Id:       &corev1.VpcId{Value: uuid.NewString()},
 				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
 				Metadata: &corev1.Metadata{Name: existingVpc.Name},
 			},
+			wantVpc:      true,
+			wantNamePref: existingVpc.Name + "-recovered-",
 		},
 		{
-			name: "empty VPC name is rejected",
+			name: "assigns recovered name when metadata name is empty",
 			controllerVpc: &corev1.Vpc{
 				Id:       &corev1.VpcId{Value: uuid.NewString()},
 				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
 				Metadata: &corev1.Metadata{Name: ""},
 			},
+			wantVpc:      true,
+			wantNamePref: "recovered-",
 		},
 		{
 			name: "empty tenant organization is rejected",
@@ -1175,7 +1182,8 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 				Config:   &corev1.VpcConfig{TenantOrganizationId: authorizedTenantOrg},
 				Metadata: &corev1.Metadata{Name: "unallocated-tenant-vpc"},
 			},
-			wantVpc: true,
+			wantVpc:  true,
+			wantName: "unallocated-tenant-vpc",
 		},
 	}
 
@@ -1191,6 +1199,13 @@ func TestManageVpc_CreateOrUpdateVpcFromSite_SkipsIncompleteOwnership(t *testing
 				require.NotNil(t, vpc)
 				assert.Equal(t, cdbm.VpcStatusReady, vpc.Status)
 				assert.Equal(t, authorizedTenant.ID, vpc.TenantID)
+				if tt.wantName != "" {
+					assert.Equal(t, tt.wantName, vpc.Name)
+				}
+				if tt.wantNamePref != "" {
+					assert.True(t, strings.HasPrefix(vpc.Name, tt.wantNamePref), "name %q should have prefix %q", vpc.Name, tt.wantNamePref)
+					assert.Len(t, strings.TrimPrefix(vpc.Name, tt.wantNamePref), 8)
+				}
 				return
 			}
 			assert.Nil(t, vpc)


### PR DESCRIPTION
## Description
Site inventory previously skipped VPCs (which are existed in Site) that had no active REST database record, leaving Site and REST state inconsistent. This PR reconciles those VPCs using their controller ID.

Soft-deleted VPCs are restored when reported by a newer inventory snapshot, while true orphans are auto-created after validating tenant ownership, Site allocation, NSG, NVLink partition, and name conflicts. Recovery writes are transactional and retry-safe.

## Related issues
This PR part of the issue (https://github.com/NVIDIA/infra-controller/issues/3436)

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Unit tests added/updated

Tests executed:
make test-workflow
make test-db
go vet ./workflow/pkg/util ./workflow/pkg/activity/vpc

## Additional Notes
- Recovery currently applies only to VPC inventory.
- VPC identity matching uses controller IDs, not names.
- No database schema migration is required.
- Generic inventory recovery result types were added for reuse by future inventory implementations.