### PR TITLE
feat(instrument): declare gauges as Events

### DIFF
--- a/crates/api-integration-tests/tests/secrets_import.rs
+++ b/crates/api-integration-tests/tests/secrets_import.rs
@@ -249,9 +249,7 @@ async fn exercise_import(test_pool: &PgPool) -> eyre::Result<()> {
         vault_cacert: Some(vault.ca_cert.clone()),
         ..Default::default()
     };
-
-    let meter = opentelemetry::global::meter("secrets-import-test");
-    let vault_client = create_vault_client(&vault_config, meter)?;
+    let vault_client = create_vault_client(&vault_config)?;
 
     // --- Populate Vault with secrets ---
     let secrets = generate_test_secrets(100);

--- a/crates/api-integration-tests/tests/vault_catalogue.rs
+++ b/crates/api-integration-tests/tests/vault_catalogue.rs
@@ -57,9 +57,7 @@ async fn setup_vault_with_secrets() -> Option<(
         vault_cacert: Some(vault.ca_cert.clone()),
         ..Default::default()
     };
-
-    let meter = opentelemetry::global::meter("vault-catalogue-test");
-    let client = create_vault_client(&config, meter).expect("create vault client");
+    let client = create_vault_client(&config).expect("create vault client");
 
     // Populate a mix of secrets across prefixes.
     let secrets = vec![

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -218,7 +218,7 @@ pub async fn start_api_server(
         db_url,
         root_dir,
         carbide_metrics_addrs,
-        metrics,
+        metrics: _,
         credential_config,
         _vault_handle,
     } = test_env;
@@ -255,7 +255,7 @@ pub async fn start_api_server(
     // Dependencies: Postgres, Vault and a Redfish BMC
     db::migrations::migrate(&db_pool).await?;
 
-    populate_initial_vault_secrets(&credential_config, &metrics).await?;
+    populate_initial_vault_secrets(&credential_config).await?;
 
     let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
     let join_handle = tokio::spawn({
@@ -299,10 +299,8 @@ impl ApiServerHandle {
 
 pub async fn populate_initial_vault_secrets(
     credential_config: &CredentialConfig,
-    metrics: &MetricsSetup,
 ) -> Result<(), Report> {
-    let credential_manager =
-        create_credential_manager(credential_config, metrics.meter.clone()).await?;
+    let credential_manager = create_credential_manager(credential_config).await?;
     credential_manager
         .set_credentials(
             &CredentialKey::BmcCredentials {

--- a/crates/api/src/resources.rs
+++ b/crates/api/src/resources.rs
@@ -33,7 +33,6 @@ use carbide_secrets::{
     create_certificate_provider, create_credential_manager_from, create_vault_client,
 };
 use eyre::WrapErr;
-use opentelemetry::metrics::Meter;
 use sqlx::postgres::PgSslMode;
 use sqlx::{ConnectOptions, PgPool};
 use sqlx_query_tracing::SQLX_STATEMENTS_LOG_LEVEL;
@@ -51,14 +50,13 @@ pub(crate) struct RuntimeResources {
 pub(crate) async fn setup_resources(
     carbide_config: &CarbideConfig,
     credential_config: &CredentialConfig,
-    meter: &Meter,
     join_set: &mut JoinSet<()>,
     cancel_token: &CancellationToken,
 ) -> eyre::Result<RuntimeResources> {
     let vault_config = vault_config_for_site(&credential_config.vault, carbide_config);
 
     // One vault client serves every credential vault role below.
-    let vault_client = create_vault_client(&vault_config, meter.clone())?;
+    let vault_client = create_vault_client(&vault_config)?;
 
     // Certificate vending is selected independently of the credential store.
     // SharedVault (the default) reuses `vault_client` (no second client or token
@@ -74,7 +72,6 @@ pub(crate) async fn setup_resources(
             trust_domain: vault_config.spiffe_trust_domain(),
             machine_base_path: vault_config.spiffe_machine_base_path(),
         },
-        meter.clone(),
     )?;
 
     let db_pool = connect_postgres(carbide_config).await?;

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -109,7 +109,6 @@ pub async fn run(
     } = setup_resources(
         &carbide_config,
         &credential_config,
-        &meter,
         &mut join_set,
         &cancel_token,
     )

--- a/crates/dsx-exchange-consumer/src/lib.rs
+++ b/crates/dsx-exchange-consumer/src/lib.rs
@@ -74,12 +74,10 @@ pub async fn run_service(config: Config) -> Result<(), DsxConsumerError> {
     let join_listener =
         tokio::spawn(async move { metrics_endpoint::run_metrics_endpoint(&metrics_config).await });
 
-    let credential_manager = carbide_secrets::create_credential_manager(
-        &carbide_secrets::CredentialConfig::default(),
-        meter.clone(),
-    )
-    .await
-    .map_err(|e| DsxConsumerError::Secrets(e.to_string()))?;
+    let credential_manager =
+        carbide_secrets::create_credential_manager(&carbide_secrets::CredentialConfig::default())
+            .await
+            .map_err(|e| DsxConsumerError::Secrets(e.to_string()))?;
 
     // Connect to MQTT and get the processing channel. mqttea tracks
     // subscriptions and replays them after reconnect when the broker reports

--- a/crates/instrument-macros/src/lib.rs
+++ b/crates/instrument-macros/src/lib.rs
@@ -126,7 +126,16 @@ enum LogSpec {
 enum MetricSpec {
     Counter,
     Histogram,
+    Gauge,
     None,
+}
+
+impl MetricSpec {
+    /// Whether the kind takes its value from an `#[observation]` rather than
+    /// counting the emit.
+    fn records_observation(self) -> bool {
+        matches!(self, MetricSpec::Histogram | MetricSpec::Gauge)
+    }
 }
 
 /// The metric-side declaration shared by an inline `#[event(...)]` metric and a
@@ -134,7 +143,7 @@ enum MetricSpec {
 /// held to the same naming and documentation conventions.
 struct MetricDeclaration<'a> {
     metric_name: &'a LitStr,
-    counter: bool,
+    kind: MetricSpec,
     unit: Option<&'a LitStr>,
     describe: Option<&'a LitStr>,
     metric_name_unchecked: bool,
@@ -154,9 +163,9 @@ fn validate_metric(
     // dashboard greps straight back to this line. Validate the conventions
     // unless the site is migrating a grandfathered pre-standard name.
     let metric_name_value = decl.metric_name.value();
-    let mut histogram_unit: Option<&'static str> = None;
-    if !decl.counter {
-        histogram_unit = UNIT_SUFFIXES
+    let mut suffix_unit: Option<&'static str> = None;
+    if decl.kind.records_observation() {
+        suffix_unit = UNIT_SUFFIXES
             .iter()
             .find(|(suffix, _)| metric_name_value.ends_with(suffix))
             .map(|(_, unit)| *unit);
@@ -165,11 +174,11 @@ fn validate_metric(
     // otherwise the histogram rule below reports a condition a counter cannot
     // satisfy and the diagnostic names the wrong mistake.
     if let Some(unit) = decl.unit
-        && decl.counter
+        && decl.kind == MetricSpec::Counter
     {
         return Err(syn::Error::new_spanned(
             unit,
-            "`unit` is only valid for histogram metrics",
+            "`unit` is only valid for histogram and gauge metrics",
         ));
     }
     if !decl.metric_name_unchecked {
@@ -180,7 +189,7 @@ fn validate_metric(
                  keep a grandfathered pre-standard name)",
             ));
         }
-        if decl.counter {
+        if decl.kind == MetricSpec::Counter {
             if !metric_name_value.ends_with("_total") {
                 return Err(syn::Error::new_spanned(
                     decl.metric_name,
@@ -202,7 +211,19 @@ fn validate_metric(
                      `_total` (use metric_name_unchecked only to keep a grandfathered doubled name)",
                 ));
             }
-        } else if histogram_unit.is_none() {
+        } else if decl.kind == MetricSpec::Gauge {
+            // A gauge rises and falls, so the counter's `_total` reads as the
+            // wrong instrument to anyone querying it. Its unit suffix is
+            // optional: plenty of gauges count things rather than measure one.
+            if metric_name_value.ends_with("_total") {
+                return Err(syn::Error::new_spanned(
+                    decl.metric_name,
+                    "`_total` is the counter suffix (Prometheus convention); a gauge names what \
+                     it measures, optionally ending in its unit (use metric_name_unchecked only \
+                     to keep a grandfathered pre-standard name)",
+                ));
+            }
+        } else if suffix_unit.is_none() {
             return Err(syn::Error::new_spanned(
                 decl.metric_name,
                 "histogram names end in their unit: one of `_seconds`, `_milliseconds`, \
@@ -223,7 +244,19 @@ fn validate_metric(
     // `describe_unchecked` is the escape hatch for a grandfathered describe --
     // legacy phrasings, or the "Total number of ..." on a metric_name_unchecked
     // counter -- mirroring `metric_name_unchecked` for names.
-    if decl.counter && !decl.describe_unchecked {
+    if decl.kind == MetricSpec::Gauge
+        && !decl.describe_unchecked
+        && decl
+            .describe
+            .is_none_or(|describe| describe.value().is_empty())
+    {
+        return Err(syn::Error::new_spanned(
+            item,
+            "a gauge must document itself: add describe = \"...\" (its Prometheus HELP text, and \
+             the core_metrics.md catalogue row)",
+        ));
+    }
+    if decl.kind == MetricSpec::Counter && !decl.describe_unchecked {
         match decl.describe {
             None => {
                 return Err(syn::Error::new_spanned(
@@ -244,12 +277,12 @@ fn validate_metric(
         }
     }
 
-    let unit_value: String = match (decl.unit, histogram_unit) {
+    let unit_value: String = match (decl.unit, suffix_unit) {
         (Some(explicit), _) => explicit.value(),
         (None, Some(from_suffix)) => from_suffix.to_string(),
         (None, None) => String::new(),
     };
-    if !decl.counter && unit_value.is_empty() {
+    if decl.kind == MetricSpec::Histogram && unit_value.is_empty() {
         return Err(syn::Error::new_spanned(
             decl.metric_name,
             "a metric_name_unchecked histogram without a recognized suffix needs an explicit \
@@ -380,6 +413,7 @@ fn parse_event_args(input: &DeriveInput) -> syn::Result<EventArgs> {
                 args.metric = match ident.to_string().as_str() {
                     "counter" => MetricSpec::Counter,
                     "histogram" => MetricSpec::Histogram,
+                    "gauge" => MetricSpec::Gauge,
                     "none" => MetricSpec::None,
                     other => {
                         return Err(meta.error(format!(
@@ -791,13 +825,13 @@ fn expand_event_enum(input: &DeriveInput, args: &EventArgs) -> syn::Result<Token
     }
     // A family owns the metric side; without one the enum declares it, under
     // the same name/unit/describe conventions a struct Event follows.
-    let (unit_value, is_histogram) = match (family, args.metric_name.as_ref()) {
-        (Some(_), _) => (String::new(), false),
+    let (unit_value, declared_kind) = match (family, args.metric_name.as_ref()) {
+        (Some(_), _) => (String::new(), MetricSpec::None),
         (None, Some(metric_name)) => {
             let unit = validate_metric(
                 &MetricDeclaration {
                     metric_name,
-                    counter: args.metric == MetricSpec::Counter,
+                    kind: args.metric,
                     unit: args.unit.as_ref(),
                     describe: args.describe.as_ref(),
                     metric_name_unchecked: args.metric_name_unchecked,
@@ -805,7 +839,7 @@ fn expand_event_enum(input: &DeriveInput, args: &EventArgs) -> syn::Result<Token
                 },
                 enum_ident,
             )?;
-            (unit, args.metric == MetricSpec::Histogram)
+            (unit, args.metric)
         }
         (None, None) => {
             return Err(syn::Error::new_spanned(
@@ -836,7 +870,9 @@ fn expand_event_enum(input: &DeriveInput, args: &EventArgs) -> syn::Result<Token
     // an `#[observation]` is settled here. With one the kind is only known at
     // the type level, so the variants are held to each other and then to the
     // family in a const assertion below.
-    let declared_observation = family.is_none().then_some(is_histogram);
+    let declared_observation = family
+        .is_none()
+        .then(|| declared_kind.records_observation());
     let mut inferred_observation: Option<bool> = None;
     let observation_unit = match family {
         Some(family) => quote! {
@@ -1277,10 +1313,14 @@ fn expand_event_enum(input: &DeriveInput, args: &EventArgs) -> syn::Result<Token
                 .as_ref()
                 .map(LitStr::value)
                 .unwrap_or_default();
-            let kind = if is_histogram {
-                quote! { ::carbide_instrument::MetricKind::Histogram { unit: #unit_value } }
-            } else {
-                quote! { ::carbide_instrument::MetricKind::Counter }
+            let kind = match declared_kind {
+                MetricSpec::Histogram => {
+                    quote! { ::carbide_instrument::MetricKind::Histogram { unit: #unit_value } }
+                }
+                MetricSpec::Gauge => {
+                    quote! { ::carbide_instrument::MetricKind::Gauge { unit: #unit_value } }
+                }
+                _ => quote! { ::carbide_instrument::MetricKind::Counter },
             };
             (
                 quote! { ::std::option::Option::Some(#metric_name) },
@@ -1316,7 +1356,7 @@ fn expand_event_enum(input: &DeriveInput, args: &EventArgs) -> syn::Result<Token
         quote! {
             const _: () = {
                 assert!(
-                    ::carbide_instrument::__private::is_histogram(
+                    ::carbide_instrument::__private::records_observation(
                         <#family as ::carbide_instrument::MetricFamily>::METRIC,
                     ) == #has_observation,
                     "a histogram metric family needs exactly one #[observation] field on every \
@@ -1501,7 +1541,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         Some(metric_name) => validate_metric(
             &MetricDeclaration {
                 metric_name,
-                counter: matches!(args.metric, MetricSpec::Counter),
+                kind: args.metric,
                 unit: args.unit.as_ref(),
                 describe: args.describe.as_ref(),
                 metric_name_unchecked: args.metric_name_unchecked,
@@ -1595,11 +1635,17 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
     }
 
     match (&args.metric, observations.len()) {
-        (MetricSpec::Histogram, 1) => {}
+        (MetricSpec::Histogram | MetricSpec::Gauge, 1) => {}
         (MetricSpec::Histogram, _) => {
             return Err(syn::Error::new_spanned(
                 &input.ident,
                 "a histogram event needs exactly one #[observation] field",
+            ));
+        }
+        (MetricSpec::Gauge, _) => {
+            return Err(syn::Error::new_spanned(
+                &input.ident,
+                "a gauge event needs exactly one #[observation] field: the value to set",
             ));
         }
         // A family declares the kind, which is only known at the type level
@@ -1691,6 +1737,9 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
                 MetricSpec::Histogram => {
                     quote! { ::carbide_instrument::MetricKind::Histogram { unit: #unit_value } }
                 }
+                MetricSpec::Gauge => {
+                    quote! { ::carbide_instrument::MetricKind::Gauge { unit: #unit_value } }
+                }
                 _ => quote! { ::carbide_instrument::MetricKind::None },
             };
             let metric_name_const = match metric_name {
@@ -1752,7 +1801,7 @@ fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         quote! {
             const _: () = {
                 assert!(
-                    ::carbide_instrument::__private::is_histogram(
+                    ::carbide_instrument::__private::records_observation(
                         <#family as ::carbide_instrument::MetricFamily>::METRIC,
                     ) == #has_observation,
                     "a histogram metric family needs exactly one #[observation] field on each \
@@ -1941,7 +1990,7 @@ pub fn derive_metric_family(input: TokenStream) -> TokenStream {
 
 struct MetricArgs {
     name: Option<LitStr>,
-    counter: Option<bool>,
+    kind: Option<MetricSpec>,
     component: Option<LitStr>,
     describe: Option<LitStr>,
     unit: Option<LitStr>,
@@ -1952,7 +2001,7 @@ struct MetricArgs {
 fn parse_metric_args(input: &DeriveInput) -> syn::Result<MetricArgs> {
     let mut args = MetricArgs {
         name: None,
-        counter: None,
+        kind: None,
         component: None,
         describe: None,
         unit: None,
@@ -1974,13 +2023,14 @@ fn parse_metric_args(input: &DeriveInput) -> syn::Result<MetricArgs> {
                 args.name = Some(meta.value()?.parse()?);
             } else if meta.path.is_ident("kind") {
                 let ident: Ident = meta.value()?.parse()?;
-                args.counter = Some(match ident.to_string().as_str() {
-                    "counter" => true,
-                    "histogram" => false,
+                args.kind = Some(match ident.to_string().as_str() {
+                    "counter" => MetricSpec::Counter,
+                    "histogram" => MetricSpec::Histogram,
+                    "gauge" => MetricSpec::Gauge,
                     other => {
                         return Err(meta.error(format!(
-                            "unknown metric kind `{other}`; a family is counter | histogram (an \
-                             Event with no metric declares metric = none instead)"
+                            "unknown metric kind `{other}`; a family is counter | histogram | \
+                             gauge (an Event with no metric declares metric = none instead)"
                         )));
                     }
                 });
@@ -2036,17 +2086,17 @@ fn expand_metric_family(input: DeriveInput) -> syn::Result<TokenStream> {
     let component = args.component.as_ref().ok_or_else(|| {
         syn::Error::new_spanned(&input.ident, "#[metric(...)] requires component = \"...\"")
     })?;
-    let counter = args.counter.ok_or_else(|| {
+    let kind = args.kind.ok_or_else(|| {
         syn::Error::new_spanned(
             &input.ident,
-            "#[metric(...)] requires kind = counter or kind = histogram",
+            "#[metric(...)] requires kind = counter, kind = histogram, or kind = gauge",
         )
     })?;
 
     let unit_value = validate_metric(
         &MetricDeclaration {
             metric_name: name,
-            counter,
+            kind,
             unit: args.unit.as_ref(),
             describe: args.describe.as_ref(),
             metric_name_unchecked: args.metric_name_unchecked,
@@ -2113,10 +2163,14 @@ fn expand_metric_family(input: DeriveInput) -> syn::Result<TokenStream> {
         .as_ref()
         .map(LitStr::value)
         .unwrap_or_default();
-    let metric_const = if counter {
-        quote! { ::carbide_instrument::MetricKind::Counter }
-    } else {
-        quote! { ::carbide_instrument::MetricKind::Histogram { unit: #unit_value } }
+    let metric_const = match kind {
+        MetricSpec::Gauge => {
+            quote! { ::carbide_instrument::MetricKind::Gauge { unit: #unit_value } }
+        }
+        MetricSpec::Histogram => {
+            quote! { ::carbide_instrument::MetricKind::Histogram { unit: #unit_value } }
+        }
+        _ => quote! { ::carbide_instrument::MetricKind::Counter },
     };
 
     let label_types: Vec<&syn::Type> = labels_fields.iter().map(|field| &field.ty).collect();
@@ -2276,6 +2330,21 @@ mod tests {
                 scenario: "event name is declared once",
                 source: r#"#[event(event_name = "first", event_name = "second", component = "demo", message = "demo")] struct Demo {}"#,
                 expected: "duplicate `event_name`",
+            },
+            Case {
+                scenario: "a gauge does not wear the counter's suffix",
+                source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_total", component = "demo", log = off, metric = gauge, describe = "Number of demo things")] struct Demo { #[observation] value: f64 }"#,
+                expected: "`_total` is the counter suffix",
+            },
+            Case {
+                scenario: "a gauge documents itself for the catalogue",
+                source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_things", component = "demo", log = off, metric = gauge)] struct Demo { #[observation] value: f64 }"#,
+                expected: "a gauge must document itself",
+            },
+            Case {
+                scenario: "a gauge needs the value it sets",
+                source: r#"#[event(event_name = "demo", metric_name = "carbide_demo_things", component = "demo", log = off, metric = gauge, describe = "Number of demo things")] struct Demo {}"#,
+                expected: "a gauge event needs exactly one #[observation] field",
             },
             Case {
                 scenario: "metric name is declared once",
@@ -2622,7 +2691,7 @@ mod tests {
                     scenario: "a family declares its instrument kind",
                     input: DiagnosticInput {
                         source: r#"#[metric(name = "carbide_f_total", component = "c", describe = "Number of things")] struct F {}"#,
-                        expected: "requires kind = counter or kind = histogram",
+                        expected: "requires kind = counter, kind = histogram, or kind = gauge",
                     },
                     expect: None,
                 },
@@ -2670,7 +2739,7 @@ mod tests {
                     scenario: "a counter takes no unit, whatever its name",
                     input: DiagnosticInput {
                         source: r#"#[metric(name = "carbide_f_total", kind = counter, component = "c", describe = "Number of things", unit = "ms")] struct F {}"#,
-                        expected: "`unit` is only valid for histogram metrics",
+                        expected: "`unit` is only valid for histogram and gauge metrics",
                     },
                     expect: None,
                 },

--- a/crates/instrument/src/lib.rs
+++ b/crates/instrument/src/lib.rs
@@ -341,6 +341,18 @@ pub enum MetricKind {
         /// The OpenTelemetry unit string, derived from the name suffix.
         unit: &'static str,
     },
+    /// A gauge set to the latest [`Event::observation`]: a value that rises and
+    /// falls, sampled at the moment the event happens. A gauge takes a unit
+    /// suffix when it measures one, and never ends in `_total`.
+    ///
+    /// This is the *synchronous* form, for a value something observes as it
+    /// works. A value that only answers "what is it now?" at scrape time is an
+    /// observable gauge, which has no occurrence to log and stays a hand-rolled
+    /// callback instrument.
+    Gauge {
+        /// The OpenTelemetry unit string, derived from the name suffix.
+        unit: &'static str,
+    },
     /// No metric; the event is a structured log only.
     None,
 }
@@ -527,6 +539,9 @@ pub fn emit<E: Event>(event: E) {
         __private::CachedInstrument::Histogram(histogram) => {
             histogram.record(event.observation(), event.labels().as_ref());
         }
+        __private::CachedInstrument::Gauge(gauge) => {
+            gauge.record(event.observation(), event.labels().as_ref());
+        }
         __private::CachedInstrument::None => {}
     }
 }
@@ -550,7 +565,9 @@ pub fn initialize_counter_series<E: Event>(event: &E) -> bool {
             counter.add(0, event.labels().as_ref());
             true
         }
-        __private::CachedInstrument::Histogram(_) | __private::CachedInstrument::None => false,
+        __private::CachedInstrument::Histogram(_)
+        | __private::CachedInstrument::Gauge(_)
+        | __private::CachedInstrument::None => false,
     }
 }
 
@@ -600,6 +617,7 @@ pub mod __private {
     pub enum CachedInstrument {
         Counter(opentelemetry::metrics::Counter<u64>),
         Histogram(opentelemetry::metrics::Histogram<f64>),
+        Gauge(opentelemetry::metrics::Gauge<f64>),
         None,
     }
 
@@ -631,18 +649,7 @@ pub mod __private {
                 CachedInstrument::Counter(builder.build())
             }
             crate::MetricKind::Histogram { unit } => {
-                let suffix = match unit {
-                    "s" => "_seconds",
-                    "ms" => "_milliseconds",
-                    "us" => "_microseconds",
-                    "By" => "_bytes",
-                    _ => "",
-                };
-                let name = if suffix.is_empty() {
-                    metric_name
-                } else {
-                    metric_name.strip_suffix(suffix).unwrap_or(metric_name)
-                };
+                let name = strip_unit_suffix(metric_name, unit);
                 let mut builder = meter.f64_histogram(name);
                 if !unit.is_empty() {
                     builder = builder.with_unit(unit);
@@ -652,23 +659,55 @@ pub mod __private {
                 }
                 CachedInstrument::Histogram(builder.build())
             }
+            crate::MetricKind::Gauge { unit } => {
+                let name = strip_unit_suffix(metric_name, unit);
+                let mut builder = meter.f64_gauge(name);
+                if !unit.is_empty() {
+                    builder = builder.with_unit(unit);
+                }
+                if !describe.is_empty() {
+                    builder = builder.with_description(describe);
+                }
+                CachedInstrument::Gauge(builder.build())
+            }
             crate::MetricKind::None => CachedInstrument::None,
         }
     }
 
-    /// Whether a declared metric records a histogram. The `Event` derive uses
-    /// this in a `const` assertion: an Event that names a histogram family
-    /// needs an `#[observation]` field, and the family's kind is only known at
-    /// the type level from the Event's declaration site.
-    pub const fn is_histogram(metric: crate::MetricKind) -> bool {
-        matches!(metric, crate::MetricKind::Histogram { .. })
+    /// The exporter appends a unit's conventional suffix itself, so the
+    /// instrument registers without it and `/metrics` shows `metric_name`.
+    fn strip_unit_suffix(metric_name: &'static str, unit: &'static str) -> &'static str {
+        let suffix = match unit {
+            "s" => "_seconds",
+            "ms" => "_milliseconds",
+            "us" => "_microseconds",
+            "By" => "_bytes",
+            _ => "",
+        };
+        if suffix.is_empty() {
+            metric_name
+        } else {
+            metric_name.strip_suffix(suffix).unwrap_or(metric_name)
+        }
+    }
+
+    /// Whether a declared metric takes its value from [`Event::observation`]
+    /// rather than counting the emit. The `Event` derive uses this in a `const`
+    /// assertion: an Event that names a histogram or gauge family needs an
+    /// `#[observation]` field, and the family's kind is only known at the type
+    /// level from the Event's declaration site.
+    pub const fn records_observation(metric: crate::MetricKind) -> bool {
+        matches!(
+            metric,
+            crate::MetricKind::Histogram { .. } | crate::MetricKind::Gauge { .. }
+        )
     }
 
     /// The unit a declared metric records in, for converting an
     /// `#[observation]` when the kind lives on a `MetricFamily`.
     pub const fn metric_unit(metric: crate::MetricKind) -> &'static str {
         match metric {
-            crate::MetricKind::Histogram { unit } => unit,
+            crate::MetricKind::Histogram { unit } | crate::MetricKind::Gauge { unit } => unit,
             crate::MetricKind::Counter | crate::MetricKind::None => "",
         }
     }

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -249,6 +249,13 @@ impl MetricsCapture {
         self.counter_delta(&format!("{name}#sum"), labels)
     }
 
+    /// The named gauge's current value (with exactly these label pairs). A
+    /// gauge holds a level rather than accumulating, so this reads the value
+    /// as it stands rather than the movement since [`MetricsCapture::start`].
+    pub fn gauge_value(&self, name: &str, labels: &[(&str, &str)]) -> f64 {
+        snapshot(test_registry()).value(name, labels)
+    }
+
     /// The current registry contents in Prometheus text exposition format --
     /// handy for eyeballing exact rendered names and labels in a failing test.
     pub fn render(&self) -> String {
@@ -292,6 +299,12 @@ fn snapshot(registry: &prometheus::Registry) -> Snapshot {
                     values.insert(
                         (family.name().to_string(), labels),
                         metric.get_counter().value(),
+                    );
+                }
+                prometheus::proto::MetricType::GAUGE => {
+                    values.insert(
+                        (family.name().to_string(), labels),
+                        metric.get_gauge().value(),
                     );
                 }
                 prometheus::proto::MetricType::HISTOGRAM => {

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -1272,3 +1272,79 @@ fn enum_event_context_answers_for_the_variant() {
         ]
     );
 }
+
+/// A gauge Event sets its metric to the latest `#[observation]`: it holds a
+/// level rather than accumulating, so a second emit replaces the first rather
+/// than adding to it.
+#[test]
+fn a_gauge_event_holds_the_latest_observation() {
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_pool_size_observed",
+        metric_name = "carbide_test_matrix_pool_members",
+        component = "matrix-test",
+        log = off,
+        metric = gauge,
+        describe = "Number of members in the matrix test pool"
+    )]
+    struct PoolSizeObserved {
+        #[observation]
+        members: u64,
+    }
+
+    assert_eq!(
+        <PoolSizeObserved as Event>::METRIC,
+        MetricKind::Gauge { unit: "" }
+    );
+
+    let metrics = MetricsCapture::start();
+    emit(PoolSizeObserved { members: 7 });
+    assert_eq!(
+        metrics.gauge_value("carbide_test_matrix_pool_members", &[]),
+        7.0
+    );
+
+    // A level, not a total: the second emit replaces the first.
+    emit(PoolSizeObserved { members: 3 });
+    assert_eq!(
+        metrics.gauge_value("carbide_test_matrix_pool_members", &[]),
+        3.0
+    );
+}
+
+/// A gauge whose name ends in a unit suffix records through that unit, the same
+/// conversion a histogram gets.
+#[test]
+fn a_gauge_converts_through_its_unit_suffix() {
+    #[derive(Event)]
+    #[event(
+        event_name = "test_matrix_refresh_window_observed",
+        metric_name = "carbide_test_matrix_refresh_window_seconds",
+        component = "matrix-test",
+        log = off,
+        metric = gauge,
+        describe = "Time remaining in the matrix test refresh window"
+    )]
+    struct RefreshWindowObserved {
+        #[observation]
+        remaining: Duration,
+    }
+
+    assert_eq!(
+        <RefreshWindowObserved as Event>::METRIC,
+        MetricKind::Gauge { unit: "s" }
+    );
+
+    let event = RefreshWindowObserved {
+        remaining: Duration::from_millis(2500),
+    };
+    // 2500ms observed as 2.5 seconds, per the name's suffix.
+    assert!((Event::observation(&event) - 2.5).abs() < f64::EPSILON);
+
+    let metrics = MetricsCapture::start();
+    emit(event);
+    assert_eq!(
+        metrics.gauge_value("carbide_test_matrix_refresh_window_seconds", &[]),
+        2.5
+    );
+}

--- a/crates/secrets/src/forge_vault.rs
+++ b/crates/secrets/src/forge_vault.rs
@@ -27,7 +27,6 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
 use eyre::{ContextCompat, WrapErr, eyre};
 use opentelemetry::StringValue;
-use opentelemetry::metrics::{Gauge, Meter};
 use rand::RngExt;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::sleep;
@@ -181,6 +180,25 @@ impl LabelValue for VaultFailureStatusCode {
     fn label_value(&self) -> StringValue {
         StringValue::from(self.0.map(|code| code.to_string()).unwrap_or_default())
     }
+}
+
+/// How long the current Vault token has before it must be refreshed, sampled
+/// each time the refresher loop checks. Metric-only (`log = off`): the value
+/// matters as a series, not as a line per check.
+#[derive(Event)]
+#[event(
+    event_name = "vault_token_refresh_window_observed",
+    metric_name = "carbide_api_vault_token_time_until_refresh_seconds",
+    metric_name_unchecked,
+    component = "nico-api",
+    log = off,
+    metric = gauge,
+    unit = "s",
+    describe = "The amount of time, in seconds, until the Vault token is required to be refreshed"
+)]
+struct VaultTokenRefreshWindowObserved {
+    #[observation]
+    time_until_refresh: Duration,
 }
 
 /// A Vault request was attempted. Metric-only (`log = off`): counted, never
@@ -423,13 +441,6 @@ struct VaultRequestDuration {
 }
 
 /// The one Vault metric that stays a hand-rolled OpenTelemetry instrument: a
-/// periodic state gauge for the time remaining on the current token, recorded
-/// from the refresher loop rather than emitted per request.
-#[derive(Debug, Clone)]
-pub struct ForgeVaultMetrics {
-    pub vault_token_gauge: Gauge<f64>,
-}
-
 struct RefresherMessage {
     response_tx: tokio::sync::oneshot::Sender<Result<Arc<VaultClient>, eyre::Report>>,
 }
@@ -588,7 +599,6 @@ async fn vault_token_refresh(
 
 async fn maybe_refresh_vault_client(
     vault_client_config: &ForgeVaultClientConfig,
-    vault_metrics: &ForgeVaultMetrics,
     vault_auth_status: ForgeVaultAuthenticationStatus,
 ) -> Result<(ForgeVaultAuthentication, Arc<VaultClient>), eyre::ErrReport> {
     let refresh_fut = vault_token_refresh(vault_client_config);
@@ -599,9 +609,9 @@ async fn maybe_refresh_vault_client(
                 .expiry
                 .saturating_duration_since(Instant::now());
 
-            vault_metrics
-                .vault_token_gauge
-                .record(time_remaining_until_refresh.as_secs_f64(), &[]);
+            emit(VaultTokenRefreshWindowObserved {
+                time_until_refresh: time_remaining_until_refresh,
+            });
 
             if Instant::now() >= authentication.expiry {
                 refresh_fut.await
@@ -615,11 +625,10 @@ async fn maybe_refresh_vault_client(
 async fn vault_refresher_loop(
     mut vault_refresher_rx: Receiver<RefresherMessage>,
     vault_client_config: ForgeVaultClientConfig,
-    vault_metrics: ForgeVaultMetrics,
 ) {
     let mut auth_status = ForgeVaultAuthenticationStatus::Initialized;
     while let Some(message) = vault_refresher_rx.recv().await {
-        match maybe_refresh_vault_client(&vault_client_config, &vault_metrics, auth_status).await {
+        match maybe_refresh_vault_client(&vault_client_config, auth_status).await {
             Ok((auth, client)) => {
                 message.response_tx.send(Ok(client.clone())).ok();
                 auth_status = ForgeVaultAuthenticationStatus::Authenticated(auth, client);
@@ -645,12 +654,11 @@ impl From<VaultClientSettingsBuilderError> for SecretsError {
 }
 
 impl ForgeVaultClient {
-    fn new(vault_client_config: ForgeVaultClientConfig, vault_metrics: ForgeVaultMetrics) -> Self {
+    fn new(vault_client_config: ForgeVaultClientConfig) -> Self {
         let (vault_refresher_tx, vault_refresher_rx) = tokio::sync::mpsc::channel(1);
         let vault_client_config_clone = vault_client_config.clone();
         tokio::spawn(async move {
-            vault_refresher_loop(vault_refresher_rx, vault_client_config_clone, vault_metrics)
-                .await;
+            vault_refresher_loop(vault_refresher_rx, vault_client_config_clone).await;
         });
         Self {
             vault_client_config,
@@ -1417,10 +1425,7 @@ impl VaultConfig {
     }
 }
 
-pub fn create_vault_client(
-    vault_config: &VaultConfig,
-    meter: Meter,
-) -> eyre::Result<Arc<ForgeVaultClient>> {
+pub fn create_vault_client(vault_config: &VaultConfig) -> eyre::Result<Arc<ForgeVaultClient>> {
     let configured_ca_path = vault_config
         .vault_cacert()
         .unwrap_or_else(|_| DEFAULT_VAULT_CA_PATH.to_string());
@@ -1435,8 +1440,6 @@ pub fn create_vault_client(
         ForgeVaultAuthenticationType::Root(vault_config.token()?)
     };
 
-    let forge_vault_metrics = build_vault_metrics(&meter);
-
     let vault_client_config = ForgeVaultClientConfig {
         auth_type,
         vault_address: vault_config.address()?,
@@ -1448,26 +1451,8 @@ pub fn create_vault_client(
         vault_root_ca_path,
     };
 
-    let forge_vault_client = ForgeVaultClient::new(vault_client_config, forge_vault_metrics);
+    let forge_vault_client = ForgeVaultClient::new(vault_client_config);
     Ok(Arc::new(forge_vault_client))
-}
-
-/// Build the hand-rolled Vault instruments shared by every Vault client. The
-/// attempted / succeeded / failed counters and the request-duration histogram
-/// are now `carbide-instrument` events (the `VaultRequest*` types); only the
-/// token-refresh state gauge stays a hand-rolled instrument.
-fn build_vault_metrics(meter: &Meter) -> ForgeVaultMetrics {
-    let vault_token_time_remaining_until_refresh_gauge = meter
-        .f64_gauge("carbide-api.vault.token_time_until_refresh")
-        .with_description(
-            "The amount of time, in seconds, until the Vault token is required to be refreshed",
-        )
-        .with_unit("s")
-        .build();
-
-    ForgeVaultMetrics {
-        vault_token_gauge: vault_token_time_remaining_until_refresh_gauge,
-    }
 }
 
 /// Site-wide SPIFFE identity namespace used when minting machine certificates.
@@ -1528,7 +1513,6 @@ impl std::fmt::Debug for DedicatedVaultConfig {
 pub fn create_dedicated_vault_client(
     config: &DedicatedVaultConfig,
     spiffe: SpiffeIdentity,
-    meter: Meter,
 ) -> eyre::Result<Arc<ForgeVaultClient>> {
     // Required fields are non-`Option`, but an empty string would still slip
     // through serde and build a client that fails confusingly on first use.
@@ -1580,10 +1564,7 @@ pub fn create_dedicated_vault_client(
         vault_root_ca_path,
     };
 
-    Ok(Arc::new(ForgeVaultClient::new(
-        vault_client_config,
-        build_vault_metrics(&meter),
-    )))
+    Ok(Arc::new(ForgeVaultClient::new(vault_client_config)))
 }
 
 /// Build raw vaultrs client settings for a separate vault consumer (the
@@ -1618,12 +1599,14 @@ pub fn create_raw_vault_client_settings(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use base64::Engine;
     use serde_json::json;
 
     use super::{
-        DedicatedVaultConfig, SpiffeIdentity, create_dedicated_vault_client, machine_spiffe_uri,
-        service_account_role_name_from_jwt,
+        DedicatedVaultConfig, SpiffeIdentity, VaultTokenRefreshWindowObserved,
+        create_dedicated_vault_client, machine_spiffe_uri, service_account_role_name_from_jwt,
     };
 
     fn dedicated_config() -> DedicatedVaultConfig {
@@ -1643,9 +1626,32 @@ mod tests {
         }
     }
 
+    /// The token-refresh gauge is queried by the API performance dashboards by
+    /// its exported name, which the exporter derives from the instrument name
+    /// and unit. Moving it onto the framework must not move that name.
+    #[test]
+    fn token_refresh_gauge_keeps_its_exported_name() {
+        use carbide_instrument::testing::MetricsCapture;
+
+        assert_eq!(
+            <VaultTokenRefreshWindowObserved as carbide_instrument::Event>::METRIC,
+            carbide_instrument::MetricKind::Gauge { unit: "s" }
+        );
+
+        let metrics = MetricsCapture::start();
+        carbide_instrument::emit(VaultTokenRefreshWindowObserved {
+            time_until_refresh: Duration::from_secs(42),
+        });
+        assert_eq!(
+            metrics.gauge_value("carbide_api_vault_token_time_until_refresh_seconds", &[]),
+            42.0,
+            "the dashboards query this exact name:\n{}",
+            metrics.render()
+        );
+    }
+
     #[test]
     fn dedicated_vault_rejects_empty_required_fields() {
-        let meter = opentelemetry::global::meter("test");
         for mutate in [
             |c: &mut DedicatedVaultConfig| c.address = "  ".to_string(),
             |c: &mut DedicatedVaultConfig| c.pki_mount_location = String::new(),
@@ -1653,7 +1659,7 @@ mod tests {
         ] {
             let mut config = dedicated_config();
             mutate(&mut config);
-            let err = match create_dedicated_vault_client(&config, test_spiffe(), meter.clone()) {
+            let err = match create_dedicated_vault_client(&config, test_spiffe()) {
                 Ok(_) => panic!("empty required field must be rejected"),
                 Err(err) => err,
             };

--- a/crates/secrets/src/lib.rs
+++ b/crates/secrets/src/lib.rs
@@ -17,8 +17,6 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use opentelemetry::metrics::Meter;
-
 pub use crate::chained_reader::ChainedCredentialReader;
 /// Direct vault access for the narrow cases that need it: `CertificateProvider`
 /// (PKI), and the Transit KMS provider, which builds its own raw vault client
@@ -104,7 +102,6 @@ pub fn create_certificate_provider(
     config: &CertificateConfig,
     shared_vault: &Arc<ForgeVaultClient>,
     spiffe: SpiffeIdentity,
-    meter: Meter,
 ) -> eyre::Result<Arc<dyn CertificateProvider>> {
     match &config.backend {
         CertBackend::SharedVault => {
@@ -113,7 +110,7 @@ pub fn create_certificate_provider(
         }
         CertBackend::DedicatedVault(dedicated) => {
             let provider: Arc<dyn CertificateProvider> =
-                create_dedicated_vault_client(dedicated, spiffe, meter)?;
+                create_dedicated_vault_client(dedicated, spiffe)?;
             Ok(provider)
         }
     }
@@ -122,7 +119,6 @@ pub fn create_certificate_provider(
 /// create_credential_manager builds the default credential chain: env -> file -> vault.
 pub async fn create_credential_manager(
     config: &CredentialConfig,
-    meter: Meter,
 ) -> eyre::Result<Arc<dyn CredentialManager>> {
     let mut readers: Vec<Box<dyn CredentialReader>> = Vec::new();
 
@@ -136,7 +132,7 @@ pub async fn create_credential_manager(
         ));
     }
 
-    let vault_client = create_vault_client(&config.vault, meter)?;
+    let vault_client = create_vault_client(&config.vault)?;
     readers.push(Box::new(vault_client.clone()));
 
     let chained = ChainedCredentialReader::from(readers);

--- a/crates/xtask/src/metric_docs.rs
+++ b/crates/xtask/src/metric_docs.rs
@@ -80,7 +80,7 @@ pub fn check(fix: bool) -> eyre::Result<()> {
 
     if missing.is_empty() {
         println!(
-            "OK: all {} framework counters/histograms are documented in {CATALOGUE}.",
+            "OK: all {} framework metrics are documented in {CATALOGUE}.",
             declared.len(),
         );
         return Ok(());
@@ -107,7 +107,7 @@ pub fn check(fix: bool) -> eyre::Result<()> {
         eprintln!("      {}", suggested_row(m));
     }
     eprintln!(
-        "\nEvery counter/histogram declared through the instrumentation framework needs a row \
+        "\nEvery metric declared through the instrumentation framework needs a row \
          in {CATALOGUE}, so the metric is documented even when no test scrapes it. Run \
          `cargo xtask check-metric-docs --fix` to add the row(s) above automatically, name-sorted and \
          with the Description column taken from the declaration's `describe`, then commit \
@@ -314,6 +314,7 @@ fn event_metric(attrs: &[Attribute], source: &Path) -> eyre::Result<Option<Decla
     let kind = match metric.as_deref() {
         Some("counter") => "counter",
         Some("histogram") => "histogram",
+        Some("gauge") => "gauge",
         // metric = none, or no metric side: nothing to catalogue.
         _ => return Ok(None),
     };
@@ -416,6 +417,7 @@ fn family_metric(item: &ItemStruct, source: &Path) -> eyre::Result<Option<Declar
     let kind = match kind.as_deref() {
         Some("counter") => "counter",
         Some("histogram") => "histogram",
+        Some("gauge") => "gauge",
         // The derive requires a kind; a family without one does not compile.
         _ => return Ok(None),
     };


### PR DESCRIPTION
## Summary

This extends the instrumentation framework to the one metric kind it did not cover, so a value that rises and falls is declared where it is observed rather than assembled by hand from a `Meter` threaded down to the call site.

`#[derive(Event)]` takes `metric = gauge`, and a `MetricFamily` takes `kind = gauge`. A gauge reads its value from an `#[observation]` field exactly as a histogram does, so nothing new has to be learned to use one:

```rust
#[event(
    event_name = "vault_token_refresh_window_observed",
    metric_name = "carbide_api_vault_token_time_until_refresh_seconds",
    metric_name_unchecked,   // two dashboards query this exact name
    component = "nico-api",
    log = off,
    metric = gauge,
    unit = "s",
    describe = "The amount of time, in seconds, until the Vault token is required to be refreshed"
)]
struct VaultTokenRefreshWindowObserved {
    #[observation]
    time_until_refresh: Duration,
}
```

Only the synchronous gauges are in scope at all. The 136 observable ones answer "what is the value now?" at scrape time, so there is no occurrence, no call site, and nothing to log. The Event model is push, and those stay hand-rolled on purpose.

## Callouts

- **`carbide_api_vault_token_time_until_refresh_seconds` migrates and keeps its exported name exactly**, because two dashboards query it. Its declaration only ever matched by accident: the instrument was named `carbide-api.vault.token_time_until_refresh` and the exporter rewrote the dots and appended the unit. A test now emits the Event and asserts the rendered name, so the next edit cannot quietly move it.
- **Two places silently skipped the new kind, both failing open.** `check-metric-docs` matched only counters and histograms, so a gauge would have gone uncatalogued while the gate printed OK; the test harness's snapshot did the same, so a gauge read as `0.0` and an assertion of "unchanged" would have passed for the wrong reason.
- **`ssh-console`'s three synchronous gauges are deliberately left hand-rolled.** A derived Event caches its instrument in a `OnceLock` bound to the global meter provider at first emit, while `ssh-console` installs a provider per service instance -- so one process-wide instrument would report into whichever instance happened to emit first. Its own metrics test already spawns a child process for this reason. CI caught this: the migrated metrics were absent from five of the six services the integration suite starts. That mismatch wants solving in the framework before those gauges move, so this PR leaves them alone.

Retiring the vault gauge left the `Meter` that built it with no remaining use, and the parameter carrying it dead through five crates. **No metric was lost**: `build_vault_metrics` held that one gauge and nothing else, and the only instrument creation removed anywhere in this diff is that gauge. The instrument now resolves from the global meter like every other Event, so the plumbing goes with it.

## Testing

- `cargo test --workspace` -- 253 suites pass. The failures that remain are pre-existing and environmental: `ipmitool` and `kea-dhcp6` are not installed locally, which takes out `bmc-mock`, four `carbide-dhcp` targets, and `carbide-ssh-console`'s mock SSH server.
- Framework tests cover the new kind: a gauge holds its latest observation (a second emit replaces the first rather than adding), a gauge converts through its unit suffix, and three rejection cases -- `_total` on a gauge, a gauge with no `describe`, and a gauge with no `#[observation]`.
- `carbide-secrets` gains a test asserting the vault gauge's exported name, since two dashboards depend on that exact string.
- Both metric gates pass: `check-metric-docs` (123 metrics -- the migrated gauge keeps its existing catalogue row) and `check-event-names` (195 event names).
- `cargo make --no-workspace clippy-flow`, `carbide-lints`, `lint-error-messages`, `check-format-nightly`, and `check-workspace-deps` are all clean.
