### PR TITLE
feat: simulate NVIDIA N5700_LD switch in bmc-mock

### DIFF
--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -38,7 +38,8 @@ fn parse_hardware_profile(value: &str) -> Result<HardwareType, String> {
     match hardware_type {
         HardwareType::LiteOnPowerShelf
         | HardwareType::DeltaPowerShelf
-        | HardwareType::NvidiaSwitchNd5200Ld => {
+        | HardwareType::NvidiaSwitchNd5200Ld
+        | HardwareType::NvidiaSwitchN5700Ld => {
             Err(format!("hardware profile is not a host or DPU: {value}"))
         }
         hardware_type => Ok(hardware_type),
@@ -199,10 +200,21 @@ mod tests {
 
     #[test]
     fn rejects_non_host_hardware_profile() {
-        let error = Args::try_parse_from(["bmc-mock", "--hardware-profile", "liteon_power_shelf"])
-            .unwrap_err();
+        for profile in [
+            "liteon_power_shelf",
+            "delta_power_shelf",
+            "nvidia_switch_nd5200_ld",
+            "nvidia_switch_n5700_ld",
+        ] {
+            let error =
+                Args::try_parse_from(["bmc-mock", "--hardware-profile", profile]).unwrap_err();
 
-        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+            assert_eq!(
+                error.kind(),
+                ErrorKind::ValueValidation,
+                "profile {profile}"
+            );
+        }
     }
 
     #[test]

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -63,6 +63,9 @@ pub mod delta_power_shelf;
 /// Support of NVIDIA Switch ND5200_LD.
 pub mod nvidia_switch_nd5200_ld;
 
+/// Support of NVIDIA Switch N5700_LD.
+pub mod nvidia_switch_n5700_ld;
+
 /// Support of NVIDIA DGX H100.
 pub mod nvidia_dgx_h100;
 

--- a/crates/bmc-mock/src/hw/nvidia_switch_n5700_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_n5700_ld.rs
@@ -1,0 +1,307 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+
+use mac_address::MacAddress;
+
+use crate::redfish;
+
+const BMC_MODEL: &str = "P3809";
+const BMC_PART_NUMBER: &str = "692-13809-4404-000";
+const BMC_FIRMWARE_VERSION: &str = "88.0002.1978";
+const SWITCH_MODEL: &str = "N5700_LD";
+const SWITCH_PART_NUMBER: &str = "920-9K33D-00MV-GS0";
+
+pub struct NvidiaSwitchN5700Ld<'a> {
+    pub bmc_mac_address_eth0: MacAddress,
+    pub bmc_mac_address_eth1: MacAddress,
+    pub bmc_mac_address_usb0: MacAddress,
+    pub bmc_serial_number: Cow<'a, str>,
+    pub switch_serial_number: Cow<'a, str>,
+}
+
+impl NvidiaSwitchN5700Ld<'_> {
+    pub fn manager_config(&self) -> redfish::manager::Config {
+        let manager_id = "BMC_0";
+        let eth_builder = |eth| {
+            redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
+                manager_id, eth,
+            ))
+        };
+        redfish::manager::Config {
+            managers: vec![redfish::manager::SingleConfig {
+                id: manager_id,
+                eth_interfaces: Some(vec![
+                    eth_builder("eth0")
+                        .mac_address(self.bmc_mac_address_eth0)
+                        .interface_enabled(true)
+                        .build(),
+                    eth_builder("eth1")
+                        .mac_address(self.bmc_mac_address_eth1)
+                        .interface_enabled(true)
+                        .build(),
+                    eth_builder("usb0")
+                        .mac_address(self.bmc_mac_address_usb0)
+                        .interface_enabled(true)
+                        .build(),
+                ]),
+                host_interfaces: None,
+                serial_interfaces: None,
+                firmware_version: Some(BMC_FIRMWARE_VERSION),
+                oem: None,
+            }],
+        }
+    }
+
+    pub fn system_config(&self) -> redfish::computer_system::Config {
+        redfish::computer_system::Config {
+            systems: vec![redfish::computer_system::SingleSystemConfig {
+                id: Cow::Borrowed("System_0"),
+                manufacturer: Some("NVIDIA".into()),
+                model: Some(SWITCH_MODEL.into()),
+                eth_interfaces: None,
+                serial_number: Some(self.switch_serial_number.to_string().into()),
+                boot_order_mode: redfish::computer_system::BootOrderMode::Generic,
+                callbacks: None,
+                chassis: vec!["BMC_eeprom".into()],
+                boot_options: None,
+                bios_mode: redfish::computer_system::BiosMode::Generic,
+                oem: redfish::computer_system::Oem::Generic,
+                log_services: None,
+                storage: Some(vec![]),
+                processors: Some(vec![]),
+                base_bios: None,
+                serial_console: None,
+                secure_boot_available: false,
+            }],
+        }
+    }
+
+    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+        let mut chassis = vec![
+            self.bmc_eeprom_chassis(),
+            self.cpld_chassis(),
+            self.mgx_bmc_chassis(),
+        ];
+
+        chassis.extend(
+            [
+                ("MGX_ERoT_BMC_0", "0x0603031319002D12"),
+                ("MGX_ERoT_CPU_0", "0x0711030D1910221E"),
+                ("MGX_ERoT_FPGA_0", "0x0113090A180E1118"),
+                ("MGX_ERoT_NVSwitch_0", "0x0811030C19103B2C"),
+                ("MGX_ERoT_NVSwitch_1", "0x0211030C19103B1D"),
+            ]
+            .into_iter()
+            .map(
+                |(id, serial_number)| redfish::chassis::SingleChassisConfig {
+                    id: id.into(),
+                    chassis_type: "Component".into(),
+                    manufacturer: Some("NVIDIA".into()),
+                    serial_number: Some(serial_number.into()),
+                    sku: Some("0x4D35368B".into()),
+                    ..redfish::chassis::SingleChassisConfig::defaults()
+                },
+            ),
+        );
+
+        chassis.extend((0..2).map(|index| self.nvswitch_chassis(index)));
+        chassis.extend([
+            self.switch_identity_chassis("SYS_eeprom", "Module"),
+            self.switch_identity_chassis("System_0", "Component"),
+        ]);
+
+        redfish::chassis::ChassisConfig { chassis }
+    }
+
+    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+        let fw_inv_builder = |id: &str| {
+            redfish::software_inventory::builder(
+                &redfish::software_inventory::firmware_inventory_resource(id),
+            )
+        };
+        redfish::update_service::UpdateServiceConfig {
+            firmware_inventory: [
+                ("CPLD_0", "0.00", None, None),
+                (
+                    "MGX_FW_BMC_0",
+                    BMC_FIRMWARE_VERSION,
+                    Some("0x001B"),
+                    Some("/redfish/v1/Chassis/MGX_BMC_0"),
+                ),
+                // NVOS firmware from the switch CPU inventory resource.
+                ("MGX_FW_CPU_0", "0ACTV_01.01.020", Some("0x00DA"), None),
+                (
+                    "MGX_FW_ERoT_BMC_0",
+                    "01.04.0031.0000_n04",
+                    Some("0xFF00"),
+                    Some("/redfish/v1/Chassis/MGX_ERoT_BMC_0"),
+                ),
+                (
+                    "MGX_FW_ERoT_CPU_0",
+                    "01.04.0031.0000_n04",
+                    Some("0xFF00"),
+                    None,
+                ),
+                (
+                    "MGX_FW_ERoT_FPGA_0",
+                    "01.04.0031.0000_n04",
+                    Some("0xFF00"),
+                    Some("/redfish/v1/Chassis/MGX_ERoT_FPGA_0"),
+                ),
+                (
+                    "MGX_FW_ERoT_NVSwitch_0",
+                    "01.04.0031.0000_n04",
+                    Some("0xFF00"),
+                    Some("/redfish/v1/Chassis/MGX_ERoT_NVSwitch_0"),
+                ),
+                (
+                    "MGX_FW_ERoT_NVSwitch_1",
+                    "01.04.0031.0000_n04",
+                    Some("0xFF00"),
+                    Some("/redfish/v1/Chassis/MGX_ERoT_NVSwitch_1"),
+                ),
+                ("MGX_FW_FPGA_0", "0.24", Some("0x0050"), None),
+                (
+                    "MGX_FW_NVSwitch_0",
+                    "35_2014_4784",
+                    Some("0x00CF"),
+                    Some("/redfish/v1/Chassis/MGX_NVSwitch_0"),
+                ),
+                (
+                    "MGX_FW_NVSwitch_1",
+                    "35_2014_4784",
+                    Some("0x00CF"),
+                    Some("/redfish/v1/Chassis/MGX_NVSwitch_1"),
+                ),
+            ]
+            .into_iter()
+            .map(|(id, version, software_id, related_item)| {
+                let mut builder = fw_inv_builder(id)
+                    .name("Software Inventory")
+                    .version(version)
+                    .status(redfish::resource::Status::Ok)
+                    .updateable(true)
+                    .related_items(&related_item.into_iter().collect::<Vec<_>>());
+                if id != "CPLD_0" {
+                    builder = builder.manufacturer("NVIDIA");
+                }
+                if let Some(software_id) = software_id {
+                    builder = builder.software_id(software_id);
+                }
+                builder.build()
+            })
+            .collect(),
+        }
+    }
+
+    fn bmc_eeprom_chassis(&self) -> redfish::chassis::SingleChassisConfig {
+        redfish::chassis::SingleChassisConfig {
+            id: "BMC_eeprom".into(),
+            chassis_type: "Module".into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some(BMC_PART_NUMBER.into()),
+            model: Some(BMC_MODEL.into()),
+            serial_number: Some(self.bmc_serial_number.to_string().into()),
+            pcie_devices: Some(vec![]),
+            sensors: Some(vec![]),
+            ..redfish::chassis::SingleChassisConfig::defaults()
+        }
+    }
+
+    fn cpld_chassis(&self) -> redfish::chassis::SingleChassisConfig {
+        redfish::chassis::SingleChassisConfig {
+            id: "CPLD_0".into(),
+            chassis_type: "Module".into(),
+            manufacturer: Some("Lattice".into()),
+            part_number: Some("".into()),
+            model: Some("LCMXO3D-9400HC-5BG256C".into()),
+            serial_number: Some("CPLDSerialNumber".into()),
+            pcie_devices: Some(vec![]),
+            sensors: Some(vec![]),
+            ..redfish::chassis::SingleChassisConfig::defaults()
+        }
+    }
+
+    fn mgx_bmc_chassis(&self) -> redfish::chassis::SingleChassisConfig {
+        let sensor =
+            redfish::sensor::builder(&redfish::sensor::chassis_resource("MGX_BMC_0", "BMC_TEMP"))
+                .name("BMC TEMP")
+                .reading_f64(33.875)
+                .reading_type("Temperature")
+                .reading_units("Cel")
+                .threshold_lower_caution(5.0)
+                .threshold_upper_caution(105.0)
+                .threshold_upper_critical(108.0)
+                .build();
+
+        redfish::chassis::SingleChassisConfig {
+            id: "MGX_BMC_0".into(),
+            chassis_type: "Component".into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some(BMC_PART_NUMBER.into()),
+            model: Some(BMC_MODEL.into()),
+            serial_number: Some(self.bmc_serial_number.to_string().into()),
+            pcie_devices: Some(vec![]),
+            sensors: Some(vec![sensor]),
+            ..redfish::chassis::SingleChassisConfig::defaults()
+        }
+    }
+
+    fn nvswitch_chassis(&self, index: usize) -> redfish::chassis::SingleChassisConfig {
+        let chassis_id = format!("MGX_NVSwitch_{index}");
+        let sensors = redfish::sensor::generate_chassis_sensors(
+            &chassis_id,
+            redfish::sensor::Layout {
+                temperature: 1,
+                power: 1,
+                ..Default::default()
+            },
+        );
+        redfish::chassis::SingleChassisConfig {
+            id: chassis_id.into(),
+            chassis_type: "Component".into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some(SWITCH_PART_NUMBER.into()),
+            model: Some(SWITCH_MODEL.into()),
+            serial_number: Some(self.switch_serial_number.to_string().into()),
+            sku: Some("0x331400CF".into()),
+            pcie_devices: Some(vec![]),
+            sensors: Some(sensors),
+            ..redfish::chassis::SingleChassisConfig::defaults()
+        }
+    }
+
+    fn switch_identity_chassis(
+        &self,
+        id: &'static str,
+        chassis_type: &'static str,
+    ) -> redfish::chassis::SingleChassisConfig {
+        redfish::chassis::SingleChassisConfig {
+            id: id.into(),
+            chassis_type: chassis_type.into(),
+            manufacturer: Some("NVIDIA".into()),
+            part_number: Some(SWITCH_PART_NUMBER.into()),
+            model: Some(SWITCH_MODEL.into()),
+            serial_number: Some(self.switch_serial_number.to_string().into()),
+            pcie_devices: Some(vec![]),
+            sensors: Some(vec![]),
+            ..redfish::chassis::SingleChassisConfig::defaults()
+        }
+    }
+}

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -80,6 +80,8 @@ pub enum HardwareType {
     DeltaPowerShelf,
     #[serde(rename = "nvidia_switch_nd5200_ld")]
     NvidiaSwitchNd5200Ld,
+    #[serde(rename = "nvidia_switch_n5700_ld")]
+    NvidiaSwitchN5700Ld,
     #[serde(rename = "nvidia_dgx_h100")]
     NvidiaDgxH100,
     #[serde(rename = "generic_ami")]
@@ -106,6 +108,7 @@ impl fmt::Display for HardwareType {
             Self::LiteOnPowerShelf => "Lite-On Power Shelf".fmt(f),
             Self::DeltaPowerShelf => "Delta Power Shelf".fmt(f),
             Self::NvidiaSwitchNd5200Ld => "NVIDIA Switch ND5200_LD".fmt(f),
+            Self::NvidiaSwitchN5700Ld => "NVIDIA Switch N5700_LD".fmt(f),
             Self::NvidiaDgxH100 => "NVIDIA DGX H100".fmt(f),
             Self::GenericAmi => "Generic AMI Server".fmt(f),
             Self::HpeProliantDl380aGen11 => "HPE ProLiant DL380a Gen11".fmt(f),
@@ -130,6 +133,7 @@ impl HardwareType {
             Self::LiteOnPowerShelf => Some(0),
             Self::DeltaPowerShelf => Some(0),
             Self::NvidiaSwitchNd5200Ld => Some(0),
+            Self::NvidiaSwitchN5700Ld => Some(0),
             Self::NvidiaDgxH100 => Some(1),
             Self::GenericAmi => None,
             Self::HpeProliantDl380aGen11 => None,
@@ -259,4 +263,22 @@ pub trait LogService: Send + Sync {
 pub enum BootOptionKind {
     Disk,
     Network,
+}
+
+#[cfg(test)]
+mod hardware_type_tests {
+    use super::HardwareType;
+
+    #[test]
+    fn nvidia_switch_n5700_ld_serde_and_dpu_count() {
+        let hardware_type = HardwareType::NvidiaSwitchN5700Ld;
+        let serialized = serde_json::to_string(&hardware_type).expect("hardware type serializes");
+
+        assert_eq!(serialized, r#""nvidia_switch_n5700_ld""#);
+        assert_eq!(
+            serde_json::from_str::<HardwareType>(&serialized).expect("hardware type deserializes"),
+            hardware_type
+        );
+        assert_eq!(hardware_type.fixed_number_of_dpu(), Some(0));
+    }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -129,6 +129,7 @@ impl DpuMachineInfo {
             HardwareType::LiteOnPowerShelf
             | HardwareType::DeltaPowerShelf
             | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::NvidiaSwitchN5700Ld
             | HardwareType::NvidiaDgxVr
             | HardwareType::DellPowerEdgeR760Bf4 => {
                 panic!("Bluefield3 DPU is defined for {}", self.hw_type)
@@ -163,7 +164,8 @@ impl DpuMachineInfo {
             | HardwareType::SupermicroGb300Nvl
             | HardwareType::LiteOnPowerShelf
             | HardwareType::DeltaPowerShelf
-            | HardwareType::NvidiaSwitchNd5200Ld => {
+            | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::NvidiaSwitchN5700Ld => {
                 panic!("Bluefield4 DPU is defined for {}", self.hw_type)
             }
             HardwareType::NvidiaDgxVr => hw::bluefield4::Mode::B4240V,
@@ -191,7 +193,8 @@ impl DpuMachineInfo {
             | HardwareType::SupermicroGb300Nvl
             | HardwareType::LiteOnPowerShelf
             | HardwareType::DeltaPowerShelf
-            | HardwareType::NvidiaSwitchNd5200Ld => DpuType::Bluefield3,
+            | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::NvidiaSwitchN5700Ld => DpuType::Bluefield3,
             HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr => DpuType::Bluefield4,
         }
     }
@@ -268,7 +271,10 @@ impl HostMachineInfo {
     ) -> Self {
         let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         let bmc_mac_address = next_mac();
-        let nvos_mac_addresses = if matches!(hw_type, HardwareType::NvidiaSwitchNd5200Ld) {
+        let nvos_mac_addresses = if matches!(
+            hw_type,
+            HardwareType::NvidiaSwitchNd5200Ld | HardwareType::NvidiaSwitchN5700Ld
+        ) {
             vec![next_mac()]
         } else {
             vec![]
@@ -286,6 +292,7 @@ impl HostMachineInfo {
                     HardwareType::LiteOnPowerShelf
                         | HardwareType::DeltaPowerShelf
                         | HardwareType::NvidiaSwitchNd5200Ld
+                        | HardwareType::NvidiaSwitchN5700Ld
                 ) {
                 Some(next_mac())
             } else {
@@ -331,6 +338,7 @@ impl HostMachineInfo {
             | HardwareType::DeltaPowerShelf
             | HardwareType::NvidiaDgxH100
             | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::NvidiaSwitchN5700Ld
             | HardwareType::GenericAmi
             | HardwareType::HpeProliantDl380aGen11
             | HardwareType::GenericSupermicro => redfish::oem::State::Other,
@@ -359,6 +367,9 @@ impl HostMachineInfo {
             HardwareType::NvidiaSwitchNd5200Ld => {
                 redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
             }
+            HardwareType::NvidiaSwitchN5700Ld => {
+                redfish::oem::BmcVendor::Nvidia(redfish::oem::NvidiaNamestyle::Uppercase)
+            }
             HardwareType::NvidiaDgxH100 => redfish::oem::BmcVendor::Ami,
             HardwareType::GenericAmi => redfish::oem::BmcVendor::Ami,
             HardwareType::HpeProliantDl380aGen11 => redfish::oem::BmcVendor::Hpe,
@@ -378,6 +389,7 @@ impl HostMachineInfo {
             HardwareType::LiteOnPowerShelf => None,
             HardwareType::DeltaPowerShelf => None,
             HardwareType::NvidiaSwitchNd5200Ld => Some("P3809"),
+            HardwareType::NvidiaSwitchN5700Ld => Some("P3809"),
             HardwareType::NvidiaDgxH100 => Some("AMI Redfish Server"),
             HardwareType::GenericAmi => Some("AMI Redfish Server"),
             HardwareType::HpeProliantDl380aGen11 => Some("ProLiant DL380a Gen11"),
@@ -396,6 +408,7 @@ impl HostMachineInfo {
             HardwareType::LiteOnPowerShelf => "1.9.0",
             HardwareType::DeltaPowerShelf => "1.9.0",
             HardwareType::NvidiaSwitchNd5200Ld => "1.17.0",
+            HardwareType::NvidiaSwitchN5700Ld => "1.17.0",
             HardwareType::NvidiaDgxH100 => "1.11.0",
             HardwareType::GenericAmi => "1.17.0",
             HardwareType::HpeProliantDl380aGen11 => "1.13.0",
@@ -415,6 +428,7 @@ impl HostMachineInfo {
             HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().manager_config(),
             HardwareType::DeltaPowerShelf => self.delta_power_shelf().manager_config(),
             HardwareType::NvidiaSwitchNd5200Ld => self.nvidia_switch_nd5200_ld().manager_config(),
+            HardwareType::NvidiaSwitchN5700Ld => self.nvidia_switch_n5700_ld().manager_config(),
             HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().manager_config(),
             HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().manager_config()
@@ -444,6 +458,7 @@ impl HostMachineInfo {
             HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().system_config(),
             HardwareType::DeltaPowerShelf => self.delta_power_shelf().system_config(),
             HardwareType::NvidiaSwitchNd5200Ld => self.nvidia_switch_nd5200_ld().system_config(),
+            HardwareType::NvidiaSwitchN5700Ld => self.nvidia_switch_n5700_ld().system_config(),
             HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().system_config(callbacks),
             HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().system_config(callbacks)
@@ -466,6 +481,7 @@ impl HostMachineInfo {
             HardwareType::LiteOnPowerShelf => self.liteon_power_shelf().chassis_config(),
             HardwareType::DeltaPowerShelf => self.delta_power_shelf().chassis_config(),
             HardwareType::NvidiaSwitchNd5200Ld => self.nvidia_switch_nd5200_ld().chassis_config(),
+            HardwareType::NvidiaSwitchN5700Ld => self.nvidia_switch_n5700_ld().chassis_config(),
             HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().chassis_config(),
             HardwareType::HpeProliantDl380aGen11 => {
                 self.hpe_proliant_dl380a_gen11().chassis_config()
@@ -491,6 +507,9 @@ impl HostMachineInfo {
             HardwareType::DeltaPowerShelf => self.delta_power_shelf().update_service_config(),
             HardwareType::NvidiaSwitchNd5200Ld => {
                 self.nvidia_switch_nd5200_ld().update_service_config()
+            }
+            HardwareType::NvidiaSwitchN5700Ld => {
+                self.nvidia_switch_n5700_ld().update_service_config()
             }
             HardwareType::NvidiaDgxH100 => self.nvidia_dgx_h100().update_service_config(),
             HardwareType::HpeProliantDl380aGen11 => {
@@ -792,6 +811,22 @@ impl HostMachineInfo {
         let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
         let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
         hw::nvidia_switch_nd5200_ld::NvidiaSwitchNd5200Ld {
+            bmc_mac_address_eth0: self.bmc_mac_address,
+            bmc_mac_address_eth1: next_mac(),
+            bmc_mac_address_usb0: next_mac(),
+            bmc_serial_number: Cow::Borrowed(&self.serial),
+            switch_serial_number: self
+                .switch_serial_number
+                .as_deref()
+                .unwrap_or(&self.serial)
+                .into(),
+        }
+    }
+
+    fn nvidia_switch_n5700_ld(&self) -> hw::nvidia_switch_n5700_ld::NvidiaSwitchN5700Ld<'_> {
+        let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
+        let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
+        hw::nvidia_switch_n5700_ld::NvidiaSwitchN5700Ld {
             bmc_mac_address_eth0: self.bmc_mac_address,
             bmc_mac_address_eth1: next_mac(),
             bmc_mac_address_usb0: next_mac(),
@@ -1110,5 +1145,28 @@ mod tests {
             supermicro.serial
         );
         assert_ne!(dgx.serial, supermicro.serial);
+    }
+
+    #[test]
+    fn switch_profiles_allocate_one_nvos_mac() {
+        for hardware_type in [
+            HardwareType::NvidiaSwitchNd5200Ld,
+            HardwareType::NvidiaSwitchN5700Ld,
+        ] {
+            let pool_config =
+                PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+            let mut pool = MacAddressPool::new(Config {
+                ranges: None,
+                pool: Some(pool_config),
+            });
+            let hw_mac_addr_pool = PoolConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16)
+                .expect("valid hardware MAC pool");
+
+            let host = HostMachineInfo::new(hardware_type, vec![], &mut pool, hw_mac_addr_pool);
+
+            assert_eq!(host.nvos_mac_addresses.len(), 1, "{hardware_type}");
+            assert!(host.switch_serial_number.is_some(), "{hardware_type}");
+            assert_eq!(host.non_dpu_mac_address, None, "{hardware_type}");
+        }
     }
 }

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -140,6 +140,7 @@ pub struct SingleChassisConfig {
     pub manufacturer: Option<Cow<'static, str>>,
     pub model: Option<Cow<'static, str>>,
     pub part_number: Option<Cow<'static, str>>,
+    pub sku: Option<Cow<'static, str>>,
     pub network_adapters: Option<Vec<redfish::network_adapter::NetworkAdapter>>,
     pub pcie_devices: Option<Vec<redfish::pcie_device::PCIeDevice>>,
     pub sensors: Option<Vec<redfish::sensor::Sensor>>,
@@ -161,6 +162,7 @@ impl SingleChassisConfig {
             manufacturer: None,
             model: None,
             part_number: None,
+            sku: None,
             network_adapters: None,
             pcie_devices: None,
             sensors: None,
@@ -317,6 +319,7 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .maybe_with(ChassisBuilder::serial_number, &config.serial_number)
         .maybe_with(ChassisBuilder::manufacturer, &config.manufacturer)
         .maybe_with(ChassisBuilder::part_number, &config.part_number)
+        .maybe_with(ChassisBuilder::sku, &config.sku)
         .maybe_with(ChassisBuilder::power_subsystem, &power_subsystem)
         .maybe_with(ChassisBuilder::thermal_subsystem, &thermal_subsystem)
         .maybe_with(ChassisBuilder::model, &config.model);
@@ -644,6 +647,10 @@ impl ChassisBuilder {
 
     pub fn model(self, v: &str) -> Self {
         self.add_str_field("Model", v)
+    }
+
+    pub fn sku(self, v: &str) -> Self {
+        self.add_str_field("SKU", v)
     }
 
     pub fn assembly(self, v: &redfish::Resource<'_>) -> Self {

--- a/crates/bmc-mock/src/redfish/software_inventory.rs
+++ b/crates/bmc-mock/src/redfish/software_inventory.rs
@@ -17,6 +17,8 @@
 
 use std::borrow::Cow;
 
+use serde_json::json;
+
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
@@ -77,8 +79,39 @@ impl Builder for SoftwareInventoryBuilder {
 }
 
 impl SoftwareInventoryBuilder {
+    pub fn name(self, value: &str) -> Self {
+        self.add_str_field("Name", value)
+    }
+
+    pub fn manufacturer(self, value: &str) -> Self {
+        self.add_str_field("Manufacturer", value)
+    }
+
+    pub fn software_id(self, value: &str) -> Self {
+        self.add_str_field("SoftwareId", value)
+    }
+
     pub fn version(self, value: &str) -> Self {
         self.add_str_field("Version", value)
+    }
+
+    pub fn status(self, value: redfish::resource::Status) -> Self {
+        self.apply_patch(json!({ "Status": value.into_json() }))
+    }
+
+    pub fn updateable(self, value: bool) -> Self {
+        self.apply_patch(json!({ "Updateable": value }))
+    }
+
+    pub fn related_items(self, odata_ids: &[&str]) -> Self {
+        let items = odata_ids
+            .iter()
+            .map(|odata_id| json!({ "@odata.id": odata_id }))
+            .collect::<Vec<_>>();
+        self.apply_patch(json!({
+            "RelatedItem": items,
+            "RelatedItem@odata.count": odata_ids.len(),
+        }))
     }
 
     pub fn build(self) -> SoftwareInventory {

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -238,6 +238,17 @@ pub async fn nvidia_switch_nd5200_ld_bmc() -> TestBmcHandle {
     .await
 }
 
+pub async fn nvidia_switch_n5700_ld_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        &host_info(HardwareType::NvidiaSwitchN5700Ld),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+        false,
+        MachineRouterOptions::default(),
+    ))
+    .await
+}
+
 pub async fn dell_poweredge_r750_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         &host_info(HardwareType::DellPowerEdgeR750),

--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -90,6 +90,7 @@ fn vendor_class_for(machine: DhcpMachine, requester: DhcpRequester) -> Option<&'
                 | HardwareType::LiteOnPowerShelf
                 | HardwareType::DeltaPowerShelf
                 | HardwareType::NvidiaSwitchNd5200Ld
+                | HardwareType::NvidiaSwitchN5700Ld
                 | HardwareType::NvidiaDgxH100
                 | HardwareType::GenericAmi
                 | HardwareType::GenericSupermicro,
@@ -108,6 +109,7 @@ fn vendor_class_for(machine: DhcpMachine, requester: DhcpRequester) -> Option<&'
                 | HardwareType::LiteOnPowerShelf
                 | HardwareType::DeltaPowerShelf
                 | HardwareType::NvidiaSwitchNd5200Ld
+                | HardwareType::NvidiaSwitchN5700Ld
                 | HardwareType::NvidiaDgxH100
                 | HardwareType::GenericAmi
                 | HardwareType::HpeProliantDl380aGen11
@@ -387,6 +389,22 @@ mod tests {
                     scenario: "host system PXE client",
                     input: (
                         DhcpMachine::Host(HardwareType::GenericAmi),
+                        DhcpRequester::System,
+                    ),
+                    expect: Some("PXEClient:Arch:00007:UNDI:003000"),
+                },
+                Check {
+                    scenario: "N5700_LD BMC has no verified vendor class",
+                    input: (
+                        DhcpMachine::Host(HardwareType::NvidiaSwitchN5700Ld),
+                        DhcpRequester::Bmc,
+                    ),
+                    expect: None,
+                },
+                Check {
+                    scenario: "N5700_LD NVOS PXE client",
+                    input: (
+                        DhcpMachine::Host(HardwareType::NvidiaSwitchN5700Ld),
                         DhcpRequester::System,
                     ),
                     expect: Some("PXEClient:Arch:00007:UNDI:003000"),

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -46,7 +46,8 @@ fn for_dpu(dpu: &DpuMachineInfo) -> DiscoveryInfo {
         | HardwareType::GenericSupermicro => bluefield3(dpu),
         HardwareType::LiteOnPowerShelf
         | HardwareType::DeltaPowerShelf
-        | HardwareType::NvidiaSwitchNd5200Ld => {
+        | HardwareType::NvidiaSwitchNd5200Ld
+        | HardwareType::NvidiaSwitchN5700Ld => {
             panic!("DPU discovery is not defined for {}", dpu.hw_type)
         }
     }
@@ -76,7 +77,8 @@ fn for_host(host: &HostMachineInfo) -> DiscoveryInfo {
         | HardwareType::NvidiaDgxVr => DiscoveryInfo::default(),
         HardwareType::LiteOnPowerShelf
         | HardwareType::DeltaPowerShelf
-        | HardwareType::NvidiaSwitchNd5200Ld => {
+        | HardwareType::NvidiaSwitchNd5200Ld
+        | HardwareType::NvidiaSwitchN5700Ld => {
             panic!("discovery_info requested for {}", host.hw_type)
         }
     }

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -30,7 +30,7 @@ pub enum DeviceKind {
 impl From<HardwareType> for DeviceKind {
     fn from(hardware_type: HardwareType) -> Self {
         match hardware_type {
-            HardwareType::NvidiaSwitchNd5200Ld => Self::Switch,
+            HardwareType::NvidiaSwitchNd5200Ld | HardwareType::NvidiaSwitchN5700Ld => Self::Switch,
             HardwareType::LiteOnPowerShelf | HardwareType::DeltaPowerShelf => Self::PowerShelf,
             _ => Self::Machine,
         }
@@ -120,5 +120,48 @@ impl From<IpmiEndpoint> for EndpointStatus {
             reachable_port: endpoint.reachable_port,
             listen_port: endpoint.listen_port,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[test]
+    fn hardware_types_map_to_device_kinds() {
+        check_values(
+            [
+                Check {
+                    scenario: "ND5200_LD is a switch",
+                    input: HardwareType::NvidiaSwitchNd5200Ld,
+                    expect: DeviceKind::Switch,
+                },
+                Check {
+                    scenario: "N5700_LD is a switch",
+                    input: HardwareType::NvidiaSwitchN5700Ld,
+                    expect: DeviceKind::Switch,
+                },
+                Check {
+                    scenario: "power shelf is a power shelf",
+                    input: HardwareType::LiteOnPowerShelf,
+                    expect: DeviceKind::PowerShelf,
+                },
+                Check {
+                    scenario: "server is a machine",
+                    input: HardwareType::DellPowerEdgeR750,
+                    expect: DeviceKind::Machine,
+                },
+            ],
+            DeviceKind::from,
+        );
+    }
+
+    #[test]
+    fn n5700_ld_status_kind_serializes_as_switch() {
+        let kind = DeviceKind::from(HardwareType::NvidiaSwitchN5700Ld);
+
+        assert_eq!(serde_json::to_value(kind).unwrap(), "switch");
     }
 }


### PR DESCRIPTION
Adds a dedicated `NvidiaSwitchN5700Ld` hardware profile to bmc-mock so the NVIDIA GB300 N5700_LD NVLink switch tray can be simulated using Redfish data captured from real hardware.

The profile models the switch’s manager, system, chassis, network interfaces, sensors, assemblies, and firmware inventory. It exposes two distinct NVSwitch ASIC resources, allocates an NVOS management MAC address, and declares zero DPUs.

Machine-a-tron now recognizes the profile as a switch, applies the appropriate BMC and NVOS DHCP behavior, and reports it through `/machines/status` with `device_kind: "switch"`.

## Related issues

Closes #4414

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The following validation was performed:

- `cargo fmt --all -- --check`
- `cargo test -p bmc-mock n5700`
- `cargo test -p bmc-mock switch_profiles_allocate_one_nvos_mac`
- `cargo test -p carbide-machine-a-tron`
- `cargo clippy -p bmc-mock --all-targets -- -D warnings`
- `git diff --check`

The full machine-a-tron suite passed with 39 unit tests and one doctest. The full bmc-mock suite passed 75 of 76 tests; `real_ipmitool_resets_chassis` could not run because `ipmitool` was unavailable in the test environment.

## Additional Notes

This implementation uses `NvidiaSwitchN5700Ld` and the serialized value `nvidia_switch_n5700_ld` instead of the issue’s proposed P4093 naming. This follows the `N5700_LD` system model reported by the source Redfish dump and keeps the profile distinct from the existing ND5200_LD switch simulation.