### PR TITLE
refactor(rpc): centralize Forge service paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,6 +1541,7 @@ name = "carbide-authn"
 version = "0.0.0"
 dependencies = [
  "carbide-instrument",
+ "carbide-rpc",
  "carbide-test-support",
  "hyper",
  "rcgen",
@@ -2897,6 +2898,7 @@ dependencies = [
  "chrono",
  "clap",
  "config-version",
+ "const_format",
  "criterion",
  "csv",
  "data-encoding",

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -289,30 +289,36 @@ async fn run_common_parts(
     // additional bits of context (just like carbide-api would).
     let app = Router::new()
         .route("/up", get(handle_up))
-        .route("/forge.Forge/DiscoverMachine", post(handle_discover))
         .route(
-            "/forge.Forge/GetManagedHostNetworkConfig",
+            ::rpc::service_path!("DiscoverMachine"),
+            post(handle_discover),
+        )
+        .route(
+            ::rpc::service_path!("GetManagedHostNetworkConfig"),
             post(handle_netconf),
         )
         .route(
-            "/forge.Forge/RecordDpuNetworkStatus",
+            ::rpc::service_path!("RecordDpuNetworkStatus"),
             post(handle_record_netstat),
         )
         .route(
-            "/forge.Forge/DpuAgentUpgradeCheck",
+            ::rpc::service_path!("DpuAgentUpgradeCheck"),
             post(handle_dpu_agent_upgrade_check),
         )
         .route(
-            "/forge.Forge/UpdateAgentReportedInventory",
+            ::rpc::service_path!("UpdateAgentReportedInventory"),
             post(handle_update_agent_reported_inventory),
         )
         .route(
-            "/forge.Forge/GetDpuInfoList",
+            ::rpc::service_path!("GetDpuInfoList"),
             post(handle_get_dpu_info_list),
         )
-        .route("/forge.Forge/FindInterfaces", post(handle_find_interfaces))
+        .route(
+            ::rpc::service_path!("FindInterfaces"),
+            post(handle_find_interfaces),
+        )
         // ForgeApiClient needs a working Version route for connection retrying
-        .route("/forge.Forge/Version", post(handle_version))
+        .route(::rpc::service_path!("Version"), post(handle_version))
         .fallback(handler)
         .with_state(state.clone());
     let (addr, join_handle) = common::run_grpc_server(app).await?;

--- a/crates/agent/src/tests/test_network_monitor.rs
+++ b/crates/agent/src/tests/test_network_monitor.rs
@@ -60,11 +60,11 @@ pub async fn test_network_monitor() -> eyre::Result<()> {
     let app = Router::new()
         .route("/up", get(handle_up))
         .route(
-            "/forge.Forge/GetDpuInfoList",
+            ::rpc::service_path!("GetDpuInfoList"),
             post(handle_get_dpu_info_list),
         )
         // ForgeApiClient needs a working Version route for connection retrying
-        .route("/forge.Forge/Version", post(handle_version))
+        .route(::rpc::service_path!("Version"), post(handle_version))
         .fallback(handler)
         .with_state(state.clone());
     let (addr, join_handle) = common::run_grpc_server(app).await?;

--- a/crates/agent/src/tests/upgrade.rs
+++ b/crates/agent/src/tests/upgrade.rs
@@ -43,11 +43,11 @@ async fn test_upgrade_check() -> eyre::Result<()> {
     let app = axum::Router::new()
         .route("/up", get(handle_up))
         .route(
-            "/forge.Forge/DpuAgentUpgradeCheck",
+            ::rpc::service_path!("DpuAgentUpgradeCheck"),
             post(dpu_agent_upgrade_check),
         )
         // ForgeApiClient needs a working Version route for connection retrying
-        .route("/forge.Forge/Version", post(handle_version));
+        .route(::rpc::service_path!("Version"), post(handle_version));
     let (addr, join_handle) = common::run_grpc_server(app).await?;
 
     let client_config =

--- a/crates/api-core/src/auth/middleware.rs
+++ b/crates/api-core/src/auth/middleware.rs
@@ -248,7 +248,7 @@ impl<B> From<&Request<B>> for RequestClass {
 
         if let Some((service_name, method_name)) = endpoint_path.split_once('/') {
             match (service_name, method_name) {
-                ("forge.Forge", m) => ForgeMethod(m.into()),
+                (::rpc::forge::forge_server::SERVICE_NAME, m) => ForgeMethod(m.into()),
                 (s, "ServerReflectionInfo") if s.ends_with(".ServerReflection") => GrpcReflection,
                 _ => Unrecognized,
             }
@@ -419,8 +419,10 @@ mod tests {
         handler: MissingAuthContextHandler,
     ) -> MissingAuthContextObservation {
         let metrics = MetricsCapture::start();
-        let request =
-            forge_request_without_auth_context("/forge.Forge/PowerControl", "203.0.113.15:41000");
+        let request = forge_request_without_auth_context(
+            ::rpc::service_path!("PowerControl"),
+            "203.0.113.15:41000",
+        );
         let mut status = None;
 
         let logs = capture_logs(|| {
@@ -516,7 +518,7 @@ mod tests {
 
         let logs = capture_logs(|| {
             let request = forge_request(
-                "/forge.Forge/PowerControl",
+                ::rpc::service_path!("PowerControl"),
                 vec![Principal::TrustedCertificate],
                 "203.0.113.9:52011",
             );
@@ -569,7 +571,7 @@ mod tests {
             // MachineSetup permits only the admin CLI, never a bare trusted
             // certificate.
             let request = forge_request(
-                "/forge.Forge/MachineSetup",
+                ::rpc::service_path!("MachineSetup"),
                 vec![Principal::TrustedCertificate],
                 "198.51.100.4:40000",
             );

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -358,7 +358,7 @@ pub async fn start(
     let router = axum::Router::new()
         .route("/", axum::routing::get(root_url))
         .route_service(
-            "/forge.Forge/{*rpc}",
+            ::rpc::service_path!("{*rpc}"),
             rpc::forge_server::ForgeServer::from_arc(api_service.clone()),
         )
         .route_service(

--- a/crates/api-test-helper/src/grpcurl.rs
+++ b/crates/api-test-helper/src/grpcurl.rs
@@ -42,7 +42,7 @@ pub async fn grpcurl_for<T: ToString>(
         .choose(&mut rand::rng())
         .context("no API servers configured")?
         .to_string();
-    let grpc_endpoint = format!("forge.Forge/{endpoint}");
+    let grpc_endpoint = format!("{}/{endpoint}", rpc::forge::forge_server::SERVICE_NAME);
     let mut args = vec![
         "-cacert",
         LOCALHOST_CERTS.ca_cert.to_str().unwrap(),

--- a/crates/authn/Cargo.toml
+++ b/crates/authn/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
+carbide-rpc = { path = "../rpc" }
 carbide-test-support = { path = "../test-support" }
 rcgen = { workspace = true }
 

--- a/crates/authn/src/middleware.rs
+++ b/crates/authn/src/middleware.rs
@@ -696,7 +696,7 @@ mod tests {
 
         let logs = capture_logs(|| {
             let request = Request::builder()
-                .uri("/forge.Forge/Anything")
+                .uri(rpc::service_path!("Anything"))
                 .body(String::new())
                 .expect("request");
             let _response_future = service.call(request);
@@ -743,7 +743,7 @@ mod tests {
 
         capture_logs(|| {
             let mut request = Request::builder()
-                .uri("/forge.Forge/Anything")
+                .uri(rpc::service_path!("Anything"))
                 .body(String::new())
                 .expect("request");
             request
@@ -779,7 +779,7 @@ mod tests {
 
         let logs = capture_logs(|| {
             let mut request = Request::builder()
-                .uri("/forge.Forge/Anything")
+                .uri(rpc::service_path!("Anything"))
                 .body(String::new())
                 .expect("request");
             request

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -42,8 +42,8 @@ use tokio::task::JoinHandle;
 
 use crate::machine::Machine;
 
-pub const ENDPOINT_DISCOVER_DHCP: &str = "/forge.Forge/DiscoverDhcp";
-pub const ENDPOINT_EXPIRE_DHCP_LEASE: &str = "/forge.Forge/ExpireDhcpLease";
+pub const ENDPOINT_DISCOVER_DHCP: &str = ::rpc::service_path!("DiscoverDhcp");
+pub const ENDPOINT_EXPIRE_DHCP_LEASE: &str = ::rpc::service_path!("ExpireDhcpLease");
 
 // Contents of the response
 pub const DHCP_RESPONSE_FQDN: &str = "december-nitrogen.forge.local";
@@ -426,10 +426,10 @@ impl MockAPIServer {
                     status: rpc::ExpireDhcpLeaseStatus::Released.into(),
                 })
             }
-            "/forge.Forge/Echo" => respond(rpc::EchoResponse {
+            path if path == ::rpc::service_path!("Echo") => respond(rpc::EchoResponse {
                 message: "dhcp_echo".into(),
             }),
-            "/forge.Forge/Version" => respond(rpc::BuildInfo::default()),
+            path if path == ::rpc::service_path!("Version") => respond(rpc::BuildInfo::default()),
             _ => panic!("DHCP -> API wrong uri: {}", req.uri().path()),
         }
     }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -60,6 +60,7 @@ dns-record = { path = "../dns-record" }
 carbide-uuid = { path = "../uuid" }
 
 chrono = { features = ["serde"], workspace = true }
+const_format = { workspace = true }
 eyre = { workspace = true }
 hyper = { workspace = true, features = ["full"] }
 hyper-rustls = { workspace = true, features = ["http2"] }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -28,6 +28,8 @@ use std::pin::Pin;
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
+#[doc(hidden)]
+pub use const_format;
 use dns_record::DnsResourceRecordReply;
 use errors::RpcDataConversionError;
 use mac_address::{MacAddress, MacParseError};
@@ -37,6 +39,20 @@ use serde_json::{Value, json};
 use tokio_stream::Stream;
 
 use crate::forge_agent_control_response::LegacyAction;
+
+/// Returns the compile-time gRPC path for a Forge service method.
+#[macro_export]
+macro_rules! service_path {
+    ($method:literal) => {
+        $crate::const_format::concatcp!(
+            "/",
+            $crate::forge::forge_server::SERVICE_NAME,
+            "/",
+            $method
+        )
+    };
+}
+
 pub use crate::protos::common::{self, Uuid};
 pub use crate::protos::dns::{self};
 pub use crate::protos::forge::machine_credentials_update_request::CredentialPurpose;


### PR DESCRIPTION
Forge gRPC service paths were repeated as handwritten `forge.Forge` strings across multiple Rust crates. This PR introduces the compile-time `rpc::service_path!("Method")` macro, backed by the service name from the generated Forge bindings, and replaces those duplicated paths without changing runtime behavior.

Requested here:
https://github.com/NVIDIA/infra-controller/pull/4467#discussion_r3701673562
by @chet .

## Related issues

Related to #4467 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

