### PR TITLE
fix(machine-controller): power on off DPUs during restart

### DIFF
--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11933,7 +11933,6 @@ async fn restart_dpu(
     Ok(())
 }
 
-#[inline]
 fn dpu_restart_power_action(
     power_state: libredfish::PowerState,
 ) -> Result<SystemPowerControl, StateHandlerError> {

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11916,7 +11916,7 @@ async fn restart_dpu(
     }
 
     let power_state = host_power_state(dpu_redfish_client.as_ref()).await?;
-    let power_action = dpu_restart_power_action(power_state);
+    let power_action = dpu_restart_power_action(power_state)?;
     if power_action == SystemPowerControl::On {
         tracing::warn!(
             machine_id = %machine.id,
@@ -11933,11 +11933,20 @@ async fn restart_dpu(
     Ok(())
 }
 
-fn dpu_restart_power_action(power_state: libredfish::PowerState) -> SystemPowerControl {
-    if power_state == libredfish::PowerState::Off {
-        SystemPowerControl::On
-    } else {
-        SystemPowerControl::ForceRestart
+#[inline]
+fn dpu_restart_power_action(
+    power_state: libredfish::PowerState,
+) -> Result<SystemPowerControl, StateHandlerError> {
+    match power_state {
+        libredfish::PowerState::Off => Ok(SystemPowerControl::On),
+        libredfish::PowerState::On => Ok(SystemPowerControl::ForceRestart),
+        libredfish::PowerState::PoweringOff
+        | libredfish::PowerState::PoweringOn
+        | libredfish::PowerState::Paused
+        | libredfish::PowerState::Reset
+        | libredfish::PowerState::Unknown => Err(StateHandlerError::GenericError(eyre!(
+            "cannot restart DPU while its power state is {power_state}; retrying"
+        ))),
     }
 }
 
@@ -13293,21 +13302,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dpu_restart_powers_on_an_off_dpu() {
+    fn dpu_restart_requires_a_stable_power_state() {
         check_values(
             [
                 Check {
                     scenario: "powered-off DPU is powered on",
                     input: libredfish::PowerState::Off,
-                    expect: SystemPowerControl::On,
+                    expect: Ok(SystemPowerControl::On),
                 },
                 Check {
                     scenario: "powered-on DPU is restarted",
                     input: libredfish::PowerState::On,
-                    expect: SystemPowerControl::ForceRestart,
+                    expect: Ok(SystemPowerControl::ForceRestart),
+                },
+                Check {
+                    scenario: "DPU that is powering off is retried",
+                    input: libredfish::PowerState::PoweringOff,
+                    expect: Err(()),
+                },
+                Check {
+                    scenario: "DPU that is powering on is retried",
+                    input: libredfish::PowerState::PoweringOn,
+                    expect: Err(()),
+                },
+                Check {
+                    scenario: "paused DPU is retried",
+                    input: libredfish::PowerState::Paused,
+                    expect: Err(()),
+                },
+                Check {
+                    scenario: "resetting DPU is retried",
+                    input: libredfish::PowerState::Reset,
+                    expect: Err(()),
+                },
+                Check {
+                    scenario: "DPU with unknown power state is retried",
+                    input: libredfish::PowerState::Unknown,
+                    expect: Err(()),
                 },
             ],
-            dpu_restart_power_action,
+            |power_state| dpu_restart_power_action(power_state).map_err(|_| ()),
         );
     }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -11915,12 +11915,30 @@ async fn restart_dpu(
             });
     }
 
+    let power_state = host_power_state(dpu_redfish_client.as_ref()).await?;
+    let power_action = dpu_restart_power_action(power_state);
+    if power_action == SystemPowerControl::On {
+        tracing::warn!(
+            machine_id = %machine.id,
+            %power_state,
+            "DPU is powered off; powering it on instead of restarting it"
+        );
+    }
+
     dpu_redfish_client
-        .power(SystemPowerControl::ForceRestart)
+        .power(power_action)
         .await
         .map_err(|error| redfish_error("reboot dpu", error))?;
 
     Ok(())
+}
+
+fn dpu_restart_power_action(power_state: libredfish::PowerState) -> SystemPowerControl {
+    if power_state == libredfish::PowerState::Off {
+        SystemPowerControl::On
+    } else {
+        SystemPowerControl::ForceRestart
+    }
 }
 
 /// Returns true if this machine needs IPMI restart to avoid killing its DPUs.
@@ -13265,6 +13283,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_test_support::{Check, check_values};
     use model::firmware::FirmwareComponent;
     use model::site_explorer::{
         EndpointExplorationReport, EndpointType, Inventory, PreingestionState, Service,
@@ -13272,6 +13291,25 @@ mod tests {
     use regex::Regex;
 
     use super::*;
+
+    #[test]
+    fn dpu_restart_powers_on_an_off_dpu() {
+        check_values(
+            [
+                Check {
+                    scenario: "powered-off DPU is powered on",
+                    input: libredfish::PowerState::Off,
+                    expect: SystemPowerControl::On,
+                },
+                Check {
+                    scenario: "powered-on DPU is restarted",
+                    input: libredfish::PowerState::On,
+                    expect: SystemPowerControl::ForceRestart,
+                },
+            ],
+            dpu_restart_power_action,
+        );
+    }
 
     #[test]
     fn terminal_ready_boot_config_failure_is_deferred_until_lockdown_restoration() {


### PR DESCRIPTION
## Summary

- check a DPU's current Redfish power state before issuing a restart
- power on an off DPU instead of sending an invalid `ForceRestart`
- add a table-driven regression test for the power-action selection

## Root cause

The machine-a-tron rack test can overlap a host power-off with a DPU power cycle. The host power-off cancels the simulated DPU's pending power-on, leaving the DPU off. The machine controller then repeatedly sends `ForceRestart`, which Redfish rejects for an already-off system. That DPU never recovers and the rack test eventually times out waiting for every machine to reach `Ready`.

The host restart path already handles this condition by converting a restart request into `On` when the system is off. This change applies the same recovery behavior to DPU restarts without changing Redfish or simulator semantics.

## Validation

- `cargo test -p carbide-machine-controller dpu_restart_powers_on_an_off_dpu`
- `cargo clippy -p carbide-machine-controller --all-targets -- -D warnings`
- 10 consecutive `test_machine_a_tron_rack_integration` runs on `office-dev`: 10 passed, 0 failed, 96.67-103 seconds each
  - the new off-DPU recovery path was exercised 4 times
  - 0 `DPU restart failed` messages
  - 0 rack readiness timeouts
- after rebasing onto current upstream `main`, reran the focused test and one full rack integration test; both passed (rack: 94.73 seconds)
