### PR TITLE
docs(security): add architecture context, threat model, and security …

### DIFF
--- a/.security-triage.yaml
+++ b/.security-triage.yaml
@@ -1,0 +1,27 @@
+# Security triage decisions for NVIDIA Infra Controller (NICo).
+# Read by NVIDIA security tooling on each scan to suppress known false
+# positives and previously accepted risks. Committed alongside SECURITY.md so
+# the whole team inherits the triage. Hand-editable: delete an entry to
+# un-suppress it, and keep last_updated current.
+version: "1.0"
+project: "infra-controller"
+last_updated: "2026-08-03T16:19:24Z"
+
+repository_exposure_classification:
+  visibility: "Public"
+  basis: "origin remote is github.com and the repository is publicly readable under Apache-2.0"
+  confirmed_by: "Amir Hatamzad <ahatamzad@nvidia.com>"
+  date: "2026-08-03"
+
+service_exposure_classification:
+  tier: "External / Regulated"
+  confidence: "high"
+  basis: "externally distributed container images and Helm charts with public product documentation; customer-facing bare-metal control plane; handles infrastructure credentials, secrets, and multi-tenant isolation boundaries"
+  confirmed_by: "Amir Hatamzad <ahatamzad@nvidia.com>"
+  date: "2026-08-03"
+
+false_positives: []
+
+accepted_risks: []
+
+suppressed_cves: []

--- a/.security-triage.yaml
+++ b/.security-triage.yaml
@@ -5,19 +5,19 @@
 # un-suppress it, and keep last_updated current.
 version: "1.0"
 project: "infra-controller"
-last_updated: "2026-08-03T16:19:24Z"
+last_updated: "2026-08-03T17:23:18Z"
 
 repository_exposure_classification:
   visibility: "Public"
-  basis: "origin remote is github.com and the repository is publicly readable under Apache-2.0"
-  confirmed_by: "Amir Hatamzad <ahatamzad@nvidia.com>"
+  basis: "origin remote is GitHub and the repository is publicly readable under Apache-2.0"
+  confirmed_by: "NVIDIA Infra Controller maintainers"
   date: "2026-08-03"
 
 service_exposure_classification:
   tier: "External / Regulated"
   confidence: "high"
   basis: "externally distributed container images and Helm charts with public product documentation; customer-facing bare-metal control plane; handles infrastructure credentials, secrets, and multi-tenant isolation boundaries"
-  confirmed_by: "Amir Hatamzad <ahatamzad@nvidia.com>"
+  confirmed_by: "NVIDIA Infra Controller maintainers"
   date: "2026-08-03"
 
 false_positives: []

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ This software operates at the **Service** level — a distributed control plane 
 Its primary security responsibility is to **protect privileged infrastructure credentials and enforce isolation between tenants sharing physical infrastructure.** Specifically: BMC, UEFI, and switch management credentials; the integrity of the machine provisioning and boot path; and the correctness of network, InfiniBand, and NVLink partitioning that separates one tenant's compute from another's.
 
 **Repository Exposure Classification:** Public.
-Basis: origin remote is github.com and the repository is publicly readable under Apache-2.0; this document is written to public-safe detail.
+Basis: origin remote is GitHub and the repository is publicly readable under Apache-2.0; this document is written to public-safe detail.
 
 **Service Exposure Classification:** External / Regulated (high confidence).
 Basis: externally distributed as container images and Helm charts with public product documentation; operates as a customer-facing bare-metal control plane; handles infrastructure credentials, secrets, and multi-tenant isolation boundaries.
@@ -66,7 +66,9 @@ The following scenarios represent the primary security concerns for this project
 
 3. **Interception on the hardware-management path:** The Redfish client pool is constructed with certificate validation disabled (`crates/api-core/src/setup.rs`), and a permissive TLS verifier exists for optional-validation cases (`crates/tls/src/dummy_tls_verifier.rs`), used by fabric and telemetry clients including `crates/ib-fabric/`, `crates/nvlink-manager/`, and `crates/health/`. This is a deliberate accommodation for the self-signed certificates that BMCs and fabric appliances ship with, but it means an attacker positioned on the management network can intercept or modify those sessions, including credential material presented to devices.
 
-4. **Authorization gaps in the control-plane RPC surface:** The control plane exposes a large gRPC surface (`crates/rpc/proto/forge.proto`), with every method gated by an entry in the internal rule table. A small number of methods are intentionally reachable without a service certificate — including version reporting, machine discovery, attestation quote submission, and JWKS retrieval — because they sit on the onboarding path before a machine has an identity. A missing or overly broad rule for a newly added method, or a defect in the anonymous-path matching logic, would expose privileged operations to unauthenticated callers.
+4. **Authorization gaps in the control-plane RPC surface:** The control plane exposes a large gRPC surface (`crates/rpc/proto/forge.proto`). Authorization is layered: TLS client certificates establish a SPIFFE service or machine principal (`crates/authn/`), a static rule table maps each method to the principals allowed to call it (`crates/api-core/src/auth/internal_rbac_rules.rs`), and a Casbin policy engine evaluates external user identity separately (`crates/api-core/src/auth/casbin_engine.rs`). Methods absent from the rule table are denied, so the failure mode is closed rather than open. Three methods are deliberately reachable without a client certificate — version reporting, machine discovery, and attestation quote submission — because they sit on the onboarding path before a machine has an identity; a defect in that matching logic, or an overly broad rule on a newly added method, would widen unauthenticated access.
+
+   Note that the internal rule layer is **disabled entirely** when `bypass_rbac` is set (`crates/api-core/src/listener.rs`), and several shipped configuration files under `deploy/` and `dev/` enable it. Deployments that inherit those defaults without overriding them rely solely on transport authentication and Casbin, not on the per-method rule table.
 
 5. **Tenant isolation failure in network virtualization:** Tenant separation is enforced through VPC and network segment management (`crates/api-core/src/handlers/vpc.rs`, `crates/vpc-prefix-controller/`), InfiniBand partitioning (`crates/ib-partition-controller/`), NVLink domain assignment (`crates/nvlink-manager/`), and DPU-side flow programming (`crates/agent/src/ovs.rs`). An error in segment, partition, or domain assignment — particularly during reprovisioning or decommissioning, when a machine transitions between tenants — could leave one tenant reachable from another's network or fabric.
 
@@ -91,7 +93,7 @@ The following are conditions this software assumes are already satisfied by anot
 ## Deployment Assumptions
 
 - NICo is deployed into a Kubernetes cluster the operator controls, with the Helm values under `helm-prereqs/values/` adapted to site-specific network pools, VLAN ranges, and VIP assignments.
-- Service-to-service mTLS requires a functioning certificate authority and rotation path (`crates/certs/src/cert_renewal.rs`); expired or unrotated certificates fail closed.
+- Service-to-service mTLS requires a functioning certificate authority and rotation path (`crates/certs/src/cert_renewal.rs`). Enforcement is not unconditional: certificate validation can be relaxed by environment (`DISABLE_TLS_ENFORCEMENT`, honored in `crates/rpc/src/forge_tls_client.rs`), clients fall back to connecting without client authentication when no usable client material is present, and the internal authorization layer can be switched off by configuration. Operators should confirm these are set for enforcement in production rather than assuming the defaults are safe.
 - PostgreSQL, the secret manager, and the identity provider are operated as trusted site services with their own access controls and backup policy.
 
 ## Scope and Out of Scope
@@ -102,7 +104,7 @@ The following are conditions this software assumes are already satisfied by anot
 
 ## Dependency Security
 
-Dependencies are pinned through `Cargo.lock` and Go module files, with license and advisory policy enforced by `deny.toml` in CI. The cryptographic stack is `rustls` with `aws-lc-rs`, plus `aes-gcm`, `sha2`, `jsonwebtoken`, `x509-parser`, and `rcgen`; the project does not implement its own primitives.
+Dependencies are pinned through `Cargo.lock` for the Rust workspace and Go module files for the REST and DPU components. License and advisory policy is enforced by `cargo-deny` via `deny.toml` in CI, which covers the Rust dependency graph only; the Go modules are not currently covered by an equivalent advisory scan. The cryptographic stack is `rustls` with `aws-lc-rs`, plus `aes-gcm`, `sha2`, `jsonwebtoken`, `x509-parser`, and `rcgen`; the project does not implement its own primitives.
 
 ## Common False-Positive Patterns
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,116 @@
-## Security
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Security Policy: NVIDIA Infra Controller (NICo)
 
 NVIDIA is dedicated to the security and trust of our software products and services, including all source code repositories managed through our organization.
 
-If you need to report a security issue, please use the appropriate contact points outlined below. **Please do not report security vulnerabilities through GitHub.**
+## Reporting a Vulnerability
 
-## Reporting Potential Security Vulnerability in an NVIDIA Product
+If you discover a potential security vulnerability, please **do not open a public issue or pull request.**
 
 To report a potential security vulnerability in any NVIDIA product:
-- Web: [Security Vulnerability Submission Form](https://www.nvidia.com/object/submit-security-vulnerability.html)
 
-- E-Mail: psirt@nvidia.com
-	 - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key for communication](https://www.nvidia.com/en-us/security/pgp-key)
-	 - Please include the following information:
-	 - Product/Driver name and version/branch that contains the vulnerability
-	 - Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
-	 - Instructions to reproduce the vulnerability
-	 - Proof-of-concept or exploit code
-	 - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
+- **Web (preferred):** [NVIDIA Security Vulnerability Submission Form](https://www.nvidia.com/object/submit-security-vulnerability.html) — part of the [NVIDIA Vulnerability Disclosure Program](https://www.nvidia.com/en-us/security/)
+- **E-Mail:** [psirt@nvidia.com](mailto:psirt@nvidia.com)
+  - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key](https://www.nvidia.com/en-us/security/pgp-key)
+- **GitHub:** If private vulnerability reporting is enabled on this repository, you may also submit a report through the **Security** tab → **Report a vulnerability**. Never use public issues or pull requests for security reports.
+
+Please include the following information:
+
+- Product/project name and version/branch that contains the vulnerability
+- Type of vulnerability (code execution, denial of service, buffer overflow, privilege escalation, etc.)
+- Step-by-step instructions to reproduce the vulnerability
+- Proof-of-concept or exploit code, if available
+- Potential impact, including how an attacker could exploit the vulnerability
+
+**Detailed reports help NVIDIA evaluate and address issues faster.** NVIDIA's PSIRT team will acknowledge receipt, validate severity, develop fixes, and publish security bulletins as appropriate.
 
 While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
 
-## NVIDIA Product Security
+For all other security-related concerns, please visit NVIDIA's [Product Security portal](https://www.nvidia.com/en-us/security).
 
-For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security
+## Security Architecture & Context
+
+NVIDIA Infra Controller (NICo) is a site-local control plane that provides zero-touch lifecycle automation for bare-metal datacenter systems: discovery, provisioning, network virtualization, credential rotation, firmware management, and decommissioning, with DPU-enforced tenant isolation.
+
+This software operates at the **Service** level — a distributed control plane deployed as a set of Kubernetes workloads (Helm charts under `helm/` and `helm-prereqs/`), accompanied by an administrative CLI (`crates/admin-cli`) and a public REST API surface (`rest-api/`). It is a mix of Rust (~100 workspace crates under `crates/`) and Go (the REST/flow layer under `rest-api/`).
+
+Its primary security responsibility is to **protect privileged infrastructure credentials and enforce isolation between tenants sharing physical infrastructure.** Specifically: BMC, UEFI, and switch management credentials; the integrity of the machine provisioning and boot path; and the correctness of network, InfiniBand, and NVLink partitioning that separates one tenant's compute from another's.
+
+**Repository Exposure Classification:** Public.
+Basis: origin remote is github.com and the repository is publicly readable under Apache-2.0; this document is written to public-safe detail.
+
+**Service Exposure Classification:** External / Regulated (high confidence).
+Basis: externally distributed as container images and Helm charts with public product documentation; operates as a customer-facing bare-metal control plane; handles infrastructure credentials, secrets, and multi-tenant isolation boundaries.
+
+### Trust Boundaries and Interfaces
+
+- **Administrative / external API.** The Go REST layer authenticates callers via OIDC tokens issued by an external identity provider (`rest-api/auth/pkg/authentication/`), with organization-scoped authorization (`rest-api/auth/pkg/authorization/org.go`) and JWKS-based token validation (`rest-api/auth/pkg/config/jwks.go`). This is the boundary between customer/operator identity and the control plane.
+- **Internal control-plane RPC.** Services communicate over gRPC (`crates/rpc/proto/`) with mutual TLS. Peer identity is derived from SPIFFE IDs carried in X.509 certificates (`crates/authn/`), and access decisions are made by a Casbin policy engine (`crates/api-core/src/auth/casbin_engine.rs`) plus a static internal rule table (`crates/api-core/src/auth/internal_rbac_rules.rs`) that maps each RPC to the service principals allowed to call it.
+- **Provisioning network.** The PXE service (`crates/pxe/`) serves iPXE scripts and cloud-init documents (`user-data`, `meta-data`, `vendor-data`, `network-config`) to machines as they boot, alongside a DHCP server (`crates/dhcp-server/`). This boundary is deliberately unauthenticated — machines being provisioned have no credentials yet — and relies on network segmentation.
+- **Hardware management.** Redfish and IPMI traffic to baseboard management controllers is brokered through a proxy with a per-principal ACL (`crates/bmc-proxy/src/acl.rs`), with serial console access via an SSH front end (`crates/ssh-console/`) and switch management through dedicated clients (`crates/nvue-client`, `crates/libnmxc`).
+- **Secrets and key material.** Credentials are stored in an external secret manager (`crates/secrets/src/forge_vault.rs`) with envelope encryption (`crates/secrets/src/key_encryption.rs`, AES-GCM) and a pluggable KMS layer including a remote transit provider (`crates/kms-provider/src/providers/`).
+- **Attestation and machine identity.** Machine identity is established through measured boot records (`crates/measured-boot/`), SPDM device attestation (`crates/spdm-controller/`), and an RFC 8693 token exchange (`crates/api-core/src/machine_identity/token_exchange.rs`).
+- **Persistence.** State is held in PostgreSQL, accessed through `sqlx` with migrations under `crates/api-db/migrations/`.
+
+### Threat Model
+
+The following scenarios represent the primary security concerns for this project, including auxiliary and support code. They are derived from analysis of this repository, ordered roughly by severity and likelihood.
+
+1. **Machine impersonation on the provisioning network:** The PXE service resolves a caller's identity from the observed connection source IP and asks the control plane for that machine's boot instructions (`crates/pxe/src/extractors/machine.rs`). The cloud-init routes (`crates/pxe/src/routes/cloud_init.rs`) carry no authentication layer — the router applies only logging, metrics, URL normalization, and client-IP extraction (`crates/pxe/src/main.rs`). A host that can occupy or spoof a target machine's address on the provisioning segment can retrieve that machine's cloud-init payload and agent configuration. Note that the extractor deliberately ignores `X-Forwarded-For`, so an upstream proxy cannot be used to forge this identity.
+
+2. **Compromise of privileged hardware credentials:** BMC, UEFI, and switch credentials are held in the secret store and rotated by dedicated controllers (`crates/credential-rotation/`, `crates/machine-controller/src/handler/host_uefi_rotation.rs`, `crates/machine-controller/src/handler/dpu_uefi_rotation.rs`). An attacker who obtains a service principal permitted by the BMC proxy ACL, or who reaches the secret store directly, gains Redfish and IPMI control of physical hardware — power state, boot device, firmware, and virtual media — which is effectively unbounded control over tenant workloads.
+
+3. **Interception on the hardware-management path:** The Redfish client pool is constructed with certificate validation disabled (`crates/api-core/src/setup.rs`), and a permissive TLS verifier exists for optional-validation cases (`crates/tls/src/dummy_tls_verifier.rs`), used by fabric and telemetry clients including `crates/ib-fabric/`, `crates/nvlink-manager/`, and `crates/health/`. This is a deliberate accommodation for the self-signed certificates that BMCs and fabric appliances ship with, but it means an attacker positioned on the management network can intercept or modify those sessions, including credential material presented to devices.
+
+4. **Authorization gaps in the control-plane RPC surface:** The control plane exposes a large gRPC surface (`crates/rpc/proto/forge.proto`), with every method gated by an entry in the internal rule table. A small number of methods are intentionally reachable without a service certificate — including version reporting, machine discovery, attestation quote submission, and JWKS retrieval — because they sit on the onboarding path before a machine has an identity. A missing or overly broad rule for a newly added method, or a defect in the anonymous-path matching logic, would expose privileged operations to unauthenticated callers.
+
+5. **Tenant isolation failure in network virtualization:** Tenant separation is enforced through VPC and network segment management (`crates/api-core/src/handlers/vpc.rs`, `crates/vpc-prefix-controller/`), InfiniBand partitioning (`crates/ib-partition-controller/`), NVLink domain assignment (`crates/nvlink-manager/`), and DPU-side flow programming (`crates/agent/src/ovs.rs`). An error in segment, partition, or domain assignment — particularly during reprovisioning or decommissioning, when a machine transitions between tenants — could leave one tenant reachable from another's network or fabric.
+
+6. **Firmware and artifact integrity in the update path:** The firmware downloader verifies a SHA-256 checksum when one is supplied and skips verification when the supplied checksum is empty (`crates/firmware/src/downloader.rs`); the implementation notes that this check is intended to detect corruption rather than to serve as a security control. Combined with the component manager's update flows, a compromised artifact source or tampered catalogue metadata could result in attacker-chosen firmware being staged onto managed hardware.
+
+7. **Credential leakage through telemetry, logging, and diagnostics:** Tracing and metrics instrumentation is pervasive (`crates/instrument/`, `crates/instrument-macros/`), SSH console sessions are recorded (`crates/ssh-console/src/console_logger.rs`), and diagnostic tooling explores BMC endpoints and captures responses (`crates/bmc-explorer/`, `crates/api-core/src/handlers/bmc_endpoint_explorer.rs`). These paths run adjacent to credential handling, so an over-broad span field, error message, or captured response body could persist secrets into logs, traces, or metrics backends that have a wider audience than the control plane itself.
+
+### Critical Security Assumptions
+
+The following are conditions this software assumes are already satisfied by another layer. They are stated explicitly because the code does not enforce them.
+
+- **The provisioning network is a trusted, segmented L2 domain.** PXE, DHCP, and cloud-init delivery authenticate nothing; machine identity on that path is network position. Isolation of the provisioning VLAN from tenant and corporate networks is the operator's responsibility.
+- **The hardware management network is isolated.** Certificate validation toward BMCs and fabric appliances is intentionally relaxed to accommodate device-shipped self-signed certificates, so confidentiality and integrity on that path depend on the management network being physically or logically separated.
+- **External user identity is managed elsewhere.** The REST layer validates OIDC tokens and JWKS but does not own user lifecycle, password policy, MFA, or session revocation; it assumes the configured identity provider enforces these.
+- **The external secret manager and KMS are available and trustworthy.** NICo delegates secret storage, envelope key custody, and transit encryption to them, and assumes their access policies are correctly scoped.
+- **The Kubernetes substrate enforces workload isolation.** Pod-level isolation, cluster RBAC, secret mounting, and network policy are assumed to work correctly; the control plane does not independently defend against a compromised co-tenant pod.
+- **Firmware artifacts originate from a trusted catalogue.** Checksums confirm that a download matches what the catalogue advertised, not that the catalogue itself is authentic; supply-chain trust is assumed upstream.
+- **Hardware roots of trust behave correctly.** Measured-boot and SPDM decisions trust the values reported by the TPM and device firmware; NICo does not detect a compromised root of trust.
+- **Administrative CLI callers are already authenticated operators.** `crates/admin-cli` is an administrative interface that acts with the privileges of its service certificate; it is not itself a security boundary.
+- **Callers supply well-formed identifiers.** Handlers validate structure and referential integrity, but the control plane assumes upstream API authentication has already established who the caller is before authorization rules are applied.
+
+## Deployment Assumptions
+
+- NICo is deployed into a Kubernetes cluster the operator controls, with the Helm values under `helm-prereqs/values/` adapted to site-specific network pools, VLAN ranges, and VIP assignments.
+- Service-to-service mTLS requires a functioning certificate authority and rotation path (`crates/certs/src/cert_renewal.rs`); expired or unrotated certificates fail closed.
+- PostgreSQL, the secret manager, and the identity provider are operated as trusted site services with their own access controls and backup policy.
+
+## Scope and Out of Scope
+
+**In scope:** the Rust control-plane crates under `crates/`, the Go REST and flow services under `rest-api/`, the DPU-side agent and containers under `bluefield/`, the Helm charts under `helm/`, and the deployment automation under `helm-prereqs/`.
+
+**Out of scope:** vulnerabilities in third-party dependencies should be reported to their upstream maintainers (see `THIRD-PARTY-LICENSES` and `deny.toml`); defects in BMC, switch, or DPU firmware belong to the respective hardware product's disclosure process; and site-specific misconfiguration of the deployment values is an operational concern rather than a product vulnerability.
+
+## Dependency Security
+
+Dependencies are pinned through `Cargo.lock` and Go module files, with license and advisory policy enforced by `deny.toml` in CI. The cryptographic stack is `rustls` with `aws-lc-rs`, plus `aes-gcm`, `sha2`, `jsonwebtoken`, `x509-parser`, and `rcgen`; the project does not implement its own primitives.
+
+## Common False-Positive Patterns
+
+Automated scanning of this repository regularly surfaces the following, which are test and mock infrastructure rather than production exposure:
+
+- `crates/bmc-mock/` — a mock BMC used in integration tests, including deliberately permissive TLS handling.
+- `crates/api-core/src/auth/test_certs.rs`, `crates/secrets/src/test_support/`, `crates/test-support/`, `crates/test-harness/`, `crates/sqlx-testing/` — fixture certificates, placeholder credentials, and test doubles.
+- `DummyTlsVerifier::new_for_tests()` in `crates/tls/src/dummy_tls_verifier.rs` — the test-only constructor; the production constructor emits a warning when validation is skipped.
+- Placeholder values in documentation under `docs/` and `book/`, and in example Helm values.
+
+Confirmed triage decisions for this repository are recorded in `.security-triage.yaml` at the repository root.


### PR DESCRIPTION
The repo's SECURITY.md only had the PSIRT reporting boilerplate. The NVIDIA
security documentation standard asks for four sections, so this adds the three
that were missing: Security Architecture & Context, Threat Model, and Critical
Security Assumptions.

Everything is derived from the code rather than written generically. The seven
threats each name real components — the PXE cloud-init path and its source-IP
machine identity, BMC credential handling and the proxy ACL, relaxed
certificate validation toward BMCs and fabric appliances, the RPC authorization
table, tenant isolation across VPC/IB/NVLink, firmware checksum handling, and
credential exposure through telemetry and console logging. The assumptions
section states what the code deliberately leaves to another layer: provisioning
network segmentation, the management network, the external identity provider,
Vault/KMS, and the Kubernetes substrate.

This repo is public, so the content is written for external readers: no
internal hostnames, endpoints, ticket IDs, or exploitation detail beyond what
the source already shows.

Also adds `.security-triage.yaml`, which records the repository and service
exposure classifications and gives us a committed place to park false positives
and accepted risks so scanners stop re-reporting them on every run.

Note: `rest-api/SECURITY.md` still has the old boilerplate and should get the
same treatment in a follow-up.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Documentation only — no code paths change.
