### PR TITLE
fix: wait for Scout boot NIC before rootfs fetch

### DIFF
--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -108,10 +108,16 @@ dependencies = [
 ]
 
 [tasks.stage-scout-loader-rclocal]
-description = "Copies the rc.local script to the scout loader profile directories"
+description = "Copies the Scout loader helpers to the scout loader profile directories"
 script = '''
   cp ${REPO_ROOT}/pxe/common_files/scout-loader-rclocal ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/etc/rc.local
   cp ${REPO_ROOT}/pxe/common_files/scout-loader-rclocal ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/etc/rc.local
+
+  mkdir -p ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/opt/forge/
+  cp ${REPO_ROOT}/pxe/common_files/forge-scout-network.sh ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/opt/forge/
+
+  mkdir -p ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/opt/forge/
+  cp ${REPO_ROOT}/pxe/common_files/forge-scout-network.sh ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/opt/forge/
 '''
 
 [tasks.stage-scout-update-check]
@@ -196,6 +202,7 @@ dependencies = [
 dependencies = [
   "mkdir-static",
   { name = "package-scout-aarch64-release-cross", path = "${REPO_ROOT}" },
+  "create-ephemeral-image-arm-host",
   "bfb-aarch64-sa",
   "ipxe-aarch64-sa",
   "setup-apt-repo-arm64",

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -110,6 +110,8 @@ dependencies = [
 [tasks.stage-scout-loader-rclocal]
 description = "Copies the Scout loader helpers to the scout loader profile directories"
 script = '''
+  set -e
+
   cp ${REPO_ROOT}/pxe/common_files/scout-loader-rclocal ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/etc/rc.local
   cp ${REPO_ROOT}/pxe/common_files/scout-loader-rclocal ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/etc/rc.local
 

--- a/pxe/common_files/forge-scout-network.sh
+++ b/pxe/common_files/forge-scout-network.sh
@@ -24,6 +24,8 @@ ip_command=${SCOUT_IP_COMMAND:-ip}
 networkctl_command=${SCOUT_NETWORKCTL_COMMAND:-networkctl}
 networkd_runtime_dir=${SCOUT_NETWORKD_RUNTIME_DIR:-/run/systemd/network}
 networkd_dhcp_file=${SCOUT_NETWORKD_DHCP_FILE:-/etc/systemd/network/dhcp.network}
+network_wait_seconds=${SCOUT_NETWORK_WAIT_SECONDS:-60}
+network_poll_interval=${SCOUT_NETWORK_POLL_INTERVAL:-1}
 
 if ! cmdline=$(cat "$cmdline_file"); then
 	echo "Skipping Scout network configuration: reason=cmdline_unreadable" >&2
@@ -58,41 +60,60 @@ case "$preferred_mac" in
 esac
 preferred_mac=$(printf '%s\n' "$preferred_mac" | tr '[:upper:]' '[:lower:]')
 
+probe_attempts=0
+probe_max_attempts=$((network_wait_seconds / network_poll_interval))
+[ "$probe_max_attempts" -lt 1 ] && probe_max_attempts=1
+
 preferred_interface=
-preferred_interface_count=0
-for net_path in "$sys_class_net"/*
+while :
 do
-	[ -e "$net_path" ] || continue
-	[ -r "$net_path/address" ] || continue
+	preferred_interface=
+	preferred_interface_count=0
+	for net_path in "$sys_class_net"/*
+	do
+		[ -e "$net_path" ] || continue
+		[ -r "$net_path/address" ] || continue
 
-	interface_mac=$(cat "$net_path/address") || continue
-	interface_mac=$(printf '%s\n' "$interface_mac" | tr '[:upper:]' '[:lower:]')
-	if [ "$interface_mac" = "$preferred_mac" ]; then
-		preferred_interface=${net_path##*/}
-		preferred_interface_count=$((preferred_interface_count + 1))
-	fi
-done
+		interface_mac=$(cat "$net_path/address") || continue
+		interface_mac=$(printf '%s\n' "$interface_mac" | tr '[:upper:]' '[:lower:]')
+		if [ "$interface_mac" = "$preferred_mac" ]; then
+			preferred_interface=${net_path##*/}
+			preferred_interface_count=$((preferred_interface_count + 1))
+		fi
+	done
 
-if [ "$preferred_interface_count" -ne 1 ]; then
-	echo "Skipping Scout network configuration: reason=preferred_interface_count count=$preferred_interface_count" >&2
-	exit 0
-fi
-
-carrier_file="$sys_class_net/$preferred_interface/carrier"
-if [ ! -r "$carrier_file" ] || [ "$(cat "$carrier_file")" != 1 ]; then
-	echo "Skipping Scout network configuration: interface=$preferred_interface reason=no_carrier" >&2
-	exit 0
-fi
-
-if global_addresses=$("$ip_command" -o address show dev "$preferred_interface" scope global); then
-	if [ -z "$global_addresses" ]; then
-		echo "Skipping Scout network configuration: interface=$preferred_interface reason=no_global_address" >&2
+	# More than one interface owning the same MAC is a configuration fault, not
+	# a timing issue. Waiting cannot resolve it, so give up immediately.
+	if [ "$preferred_interface_count" -gt 1 ]; then
+		echo "Skipping Scout network configuration: reason=preferred_interface_count count=$preferred_interface_count" >&2
 		exit 0
 	fi
-else
-	echo "Skipping Scout network configuration: interface=$preferred_interface reason=address_inspection_failed" >&2
-	exit 0
-fi
+
+	not_ready=
+	if [ "$preferred_interface_count" -ne 1 ]; then
+		not_ready=no_interface
+	else
+		carrier_file="$sys_class_net/$preferred_interface/carrier"
+		# Reading `carrier` fails with EINVAL while the link is
+		# administratively down, so treat an unreadable value as no carrier yet.
+		if [ ! -r "$carrier_file" ] || [ "$(cat "$carrier_file" 2>/dev/null)" != 1 ]; then
+			not_ready=no_carrier
+		elif ! global_addresses=$("$ip_command" -o address show dev "$preferred_interface" scope global); then
+			not_ready=address_inspection_failed
+		elif [ -z "$global_addresses" ]; then
+			not_ready=no_global_address
+		fi
+	fi
+
+	[ -z "$not_ready" ] && break
+
+	probe_attempts=$((probe_attempts + 1))
+	if [ "$probe_attempts" -ge "$probe_max_attempts" ]; then
+		echo "Scout network configuration timed out: interface=${preferred_interface:-<none>} mac=$preferred_mac reason=$not_ready waited=${network_wait_seconds}s" >&2
+		exit 1
+	fi
+	sleep "$network_poll_interval"
+done
 
 runtime_network_file="$networkd_runtime_dir/00-forge-scout-nonpreferred.network"
 

--- a/pxe/common_files/forge-scout-network.sh
+++ b/pxe/common_files/forge-scout-network.sh
@@ -27,6 +27,21 @@ networkd_dhcp_file=${SCOUT_NETWORKD_DHCP_FILE:-/etc/systemd/network/dhcp.network
 network_wait_seconds=${SCOUT_NETWORK_WAIT_SECONDS:-60}
 network_poll_interval=${SCOUT_NETWORK_POLL_INTERVAL:-1}
 
+validate_positive_integer() {
+	value=$1
+	name=$2
+
+	case "$value" in
+		''|*[!0-9]*|0|0*)
+			echo "Invalid Scout network timing value: variable=$name value=$value reason=positive_integer_required" >&2
+			exit 1
+			;;
+	esac
+}
+
+validate_positive_integer "$network_wait_seconds" SCOUT_NETWORK_WAIT_SECONDS
+validate_positive_integer "$network_poll_interval" SCOUT_NETWORK_POLL_INTERVAL
+
 if ! cmdline=$(cat "$cmdline_file"); then
 	echo "Skipping Scout network configuration: reason=cmdline_unreadable" >&2
 	exit 0

--- a/pxe/common_files/scout-loader-rclocal
+++ b/pxe/common_files/scout-loader-rclocal
@@ -204,9 +204,21 @@ then
     detect_pcr_hash
 
     DONE=0
+    NIC_FILTERED=0
     send_msg "LOADER: Downloading ${newrootfsurl}"
     while (( ${DONE} != 1 ))
     do
+      if (( ${NIC_FILTERED} != 1 )) && [ -x /opt/forge/forge-scout-network.sh ]
+      then
+        send_msg "LOADER: Selecting boot NIC from kernel mac= parameter"
+        if /opt/forge/forge-scout-network.sh
+        then
+          NIC_FILTERED=1
+        else
+          send_msg "LOADER: Scout NIC filtering incomplete; retrying"
+        fi
+      fi
+
       # We store the HTTP HEAD info for the script which will check for updates later.
       curl -sSf --head "${newrootfsurl}" 2> "${CURL_ERR}" | sed 's/\r//g' > "${ROOTFS_INFO_TMP}"
       if (( $? == 0 ))

--- a/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.conf
@@ -24,6 +24,7 @@ Packages=
          dbus
          file
          isc-dhcp-client
+         iproute2
          kmod
          linux-nvidia-64k-hwe-24.04
          net-tools

--- a/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.conf
@@ -22,6 +22,7 @@ Packages=
          curl
          dbus
          isc-dhcp-client
+         iproute2
          kmod
          linux-image-6.8.0-111-generic
          net-tools


### PR DESCRIPTION
Scout can try to fetch the secondary rootfs before the NIC named by the kernel
`mac=` parameter has appeared, gained carrier, or received DHCP. On multi-NIC
hosts, that can route rootfs and API traffic over the wrong interface.

This packages the existing preferred-NIC helper into the Scout loader image,
runs it before the rootfs fetch loop, and waits for the expected NIC before
disabling DHCP on other interfaces. If the NIC is not ready yet, the loader
reports and retries instead of treating the filter as applied.

This also adds the ARM host ephemeral image dependency to the BFB boot-artifact
task so the ARM host boot artifacts are packaged.

Related: #1909, #3024, #4120. Complements #4121.
