### PR TITLE
Add gitattributes file, indicate generated go code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+rest-api/proto/**/gen/**/*.pb.go linguist-generated


### PR DESCRIPTION
See [docs] for details, this adds metadata to our `.pb.go` paths that makes GitHub not render them by default in PR's, and not count them in our source code statistics. Hopefully it also excludes these files from the diff stat such that the "lines changed" excludes them as well, although I can't tell for sure from the docs whether that's the case.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

[docs]: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github