### PR TITLE
ci: Optimize Core CI using increased actions cache quota, parallelization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,10 @@ pxe/mkiso/
 **/.mkosi*
 pxe/static/blobs/internal/*/.mkosi*
 **/.mkosi*
+
+# mkosi staging inputs and the extracted extras tree. No Dockerfile reads these,
+# but the boot/ephemeral jobs fill them with multi-GB payloads that would
+# otherwise be shipped to BuildKit as build context. pxe/static/blobs/ is
+# deliberately NOT excluded -- it is what the release-artifacts images COPY.
+pxe/mkosi.profiles/
+pxe/.scout-extras/

--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -105,28 +105,54 @@ runs:
         # Ensure cargo is in PATH
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+    # `cargo install cargo-make` compiled the tool from source on every run,
+    # which cost several minutes and hurt most on arm64. Upstream publishes
+    # prebuilt binaries for x86_64 Linux only, so arm64 still has to build it
+    # once -- caching the resulting binary is what keeps that off the critical
+    # path on subsequent runs.
+    - name: Restore cargo-make
+      id: cargo-make-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-make
+        key: cargo-make-0.37.24-${{ runner.os }}-${{ runner.arch }}
+
     - name: Install cargo-make
+      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        CARGO_MAKE_VERSION: '0.37.24'
       run: |
+        set -euo pipefail
         source $HOME/.cargo/env || true
-        if ! command -v cargo-make &> /dev/null; then
-          echo "Installing cargo-make..."
-          cargo install cargo-make --locked
-        else
-          echo "cargo-make is already installed"
-          cargo-make --version
+
+        if command -v cargo-make &> /dev/null; then
+          echo "cargo-make is already installed: $(cargo-make --version)"
+          exit 0
         fi
 
-    - name: Install sccache (optional build cache)
-      shell: bash
-      run: |
-        source $HOME/.cargo/env || true
-        if ! command -v sccache &> /dev/null; then
-          echo "Installing sccache..."
-          cargo install sccache --locked
+        mkdir -p "$HOME/.cargo/bin"
+
+        # Upstream publishes x86_64-unknown-linux-{gnu,musl} only; there is no
+        # aarch64 asset, so that arch intentionally falls through to a source
+        # build and is served by the cache above from then on.
+        asset_arch=""
+        if [ "$(uname -m)" = "x86_64" ]; then
+          asset_arch="x86_64-unknown-linux-musl"
+        fi
+
+        tmp="$(mktemp -d)"
+        trap 'rm -rf "${tmp}"' EXIT
+
+        url="https://github.com/sagiegurari/cargo-make/releases/download/${CARGO_MAKE_VERSION}/cargo-make-v${CARGO_MAKE_VERSION}-${asset_arch}.zip"
+
+        if [ -n "${asset_arch}" ] && curl -fsSL "${url}" -o "${tmp}/cargo-make.zip"; then
+          unzip -q -o "${tmp}/cargo-make.zip" -d "${tmp}"
+          install -m 0755 "$(find "${tmp}" -name cargo-make -type f | head -1)" "$HOME/.cargo/bin/cargo-make"
+          echo "Installed prebuilt cargo-make: $(cargo-make --version)"
         else
-          echo "sccache is already installed"
-          sccache --version
+          echo "No prebuilt cargo-make for $(uname -m); building from source (cached for later runs)"
+          cargo install cargo-make --locked --version "${CARGO_MAKE_VERSION}"
         fi
 
     - name: Verify mkosi installation
@@ -166,7 +192,6 @@ runs:
         echo "Rust: $(rustc --version 2>/dev/null || echo 'not installed')"
         echo "Cargo: $(cargo --version 2>/dev/null || echo 'not installed')"
         echo "cargo-make: $(cargo-make --version 2>/dev/null || echo 'not installed')"
-        echo "sccache: $(sccache --version 2>/dev/null || echo 'not installed')"
         echo ""
         echo "=== mkosi Ecosystem ==="
         echo "mkosi: $(mkosi --version 2>&1 | head -1 || echo 'not installed')"

--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -129,7 +129,7 @@ runs:
         source $HOME/.cargo/env || true
 
         if command -v cargo-make &> /dev/null; then
-          installed_version="$(cargo-make --version | awk '{print $2}')"
+          installed_version="$(cargo make --version | awk '{print $NF}')"
           if [[ "${installed_version}" == "${CARGO_MAKE_VERSION}" ]]; then
             echo "cargo-make ${installed_version} is already installed"
             exit 0
@@ -155,13 +155,13 @@ runs:
         if [ -n "${asset_arch}" ] && curl -fsSL "${url}" -o "${tmp}/cargo-make.zip"; then
           unzip -q -o "${tmp}/cargo-make.zip" -d "${tmp}"
           install -m 0755 "$(find "${tmp}" -name cargo-make -type f | head -1)" "$HOME/.cargo/bin/cargo-make"
-          echo "Installed prebuilt cargo-make: $(cargo-make --version)"
+          echo "Installed prebuilt cargo-make: $("$HOME/.cargo/bin/cargo-make" make --version)"
         else
           echo "No prebuilt cargo-make for $(uname -m); building from source (cached for later runs)"
           cargo install cargo-make --locked --version "${CARGO_MAKE_VERSION}"
         fi
 
-        installed_version="$("$HOME/.cargo/bin/cargo-make" --version | awk '{print $2}')"
+        installed_version="$("$HOME/.cargo/bin/cargo-make" make --version | awk '{print $NF}')"
         if [[ "${installed_version}" != "${CARGO_MAKE_VERSION}" ]]; then
           echo "::error::Expected cargo-make ${CARGO_MAKE_VERSION}, installed ${installed_version}"
           exit 1
@@ -203,7 +203,7 @@ runs:
         source $HOME/.cargo/env || true
         echo "Rust: $(rustc --version 2>/dev/null || echo 'not installed')"
         echo "Cargo: $(cargo --version 2>/dev/null || echo 'not installed')"
-        echo "cargo-make: $(cargo-make --version 2>/dev/null || echo 'not installed')"
+        echo "cargo-make: $(cargo make --version 2>/dev/null || echo 'not installed')"
         echo ""
         echo "=== mkosi Ecosystem ==="
         echo "mkosi: $(mkosi --version 2>&1 | head -1 || echo 'not installed')"

--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Rust toolchain version to install'
     required: false
     default: '1.96.0'
+  cargo-make-version:
+    description: 'cargo-make version to install (keep in sync with Makefile.toml config.min_version)'
+    required: false
+    default: '0.37.24'
   arch:
     description: 'Target architecture (x86_64 or aarch64)'
     required: false
@@ -111,24 +115,26 @@ runs:
     # once -- caching the resulting binary is what keeps that off the critical
     # path on subsequent runs.
     - name: Restore cargo-make
-      id: cargo-make-cache
       uses: actions/cache@v4
       with:
         path: ~/.cargo/bin/cargo-make
-        key: cargo-make-0.37.24-${{ runner.os }}-${{ runner.arch }}
+        key: cargo-make-${{ inputs.cargo-make-version }}-${{ runner.os }}-${{ runner.arch }}
 
     - name: Install cargo-make
-      if: steps.cargo-make-cache.outputs.cache-hit != 'true'
       shell: bash
       env:
-        CARGO_MAKE_VERSION: '0.37.24'
+        CARGO_MAKE_VERSION: ${{ inputs.cargo-make-version }}
       run: |
         set -euo pipefail
         source $HOME/.cargo/env || true
 
         if command -v cargo-make &> /dev/null; then
-          echo "cargo-make is already installed: $(cargo-make --version)"
-          exit 0
+          installed_version="$(cargo-make --version | awk '{print $2}')"
+          if [[ "${installed_version}" == "${CARGO_MAKE_VERSION}" ]]; then
+            echo "cargo-make ${installed_version} is already installed"
+            exit 0
+          fi
+          echo "Replacing cargo-make ${installed_version} with ${CARGO_MAKE_VERSION}"
         fi
 
         mkdir -p "$HOME/.cargo/bin"
@@ -153,6 +159,12 @@ runs:
         else
           echo "No prebuilt cargo-make for $(uname -m); building from source (cached for later runs)"
           cargo install cargo-make --locked --version "${CARGO_MAKE_VERSION}"
+        fi
+
+        installed_version="$("$HOME/.cargo/bin/cargo-make" --version | awk '{print $2}')"
+        if [[ "${installed_version}" != "${CARGO_MAKE_VERSION}" ]]; then
+          echo "::error::Expected cargo-make ${CARGO_MAKE_VERSION}, installed ${installed_version}"
+          exit 1
         fi
 
     - name: Verify mkosi installation

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -149,6 +149,18 @@ jobs:
           rust-version: '1.96.0'
           arch: ${{ inputs.arch }}
 
+      # Persist mkosi's downloaded distro packages between runs. Restore-keys let
+      # a run start from the most recent cache for this arch even when the
+      # profile set has changed, which is the common case.
+      - name: Restore mkosi package cache
+        if: inputs.build_type == 'ephemeral'
+        uses: actions/cache@v4
+        with:
+          path: pxe/.mkosi-package-cache
+          key: mkosi-pkgs-${{ inputs.arch }}-${{ hashFiles('pxe/mkosi.conf', 'pxe/mkosi.profiles/**/mkosi.conf') }}
+          restore-keys: |
+            mkosi-pkgs-${{ inputs.arch }}-
+
       # Setup Docker for container-based builds
       - name: Derive registry hosts
         id: registry-hosts
@@ -549,6 +561,17 @@ jobs:
           echo "paths=${ARTIFACTS}" >> $GITHUB_OUTPUT
           echo "Artifacts to upload: ${ARTIFACTS}"
 
+      # Only paths that a downstream job actually consumes are uploaded. The
+      # ephemeral build takes the packaged .deb (see copy-forge-scout-* in
+      # pxe/Makefile.toml) and the release-artifacts carriers only COPY
+      # pxe/static/blobs/internal/, so the cargo target tree and the
+      # mkosi.profiles staging inputs are deliberately excluded -- they added
+      # ~14 GB of upload/download to the critical path for no consumer. The
+      # unstripped forge-scout binary is kept so crashes from the shipped image
+      # can still be symbolicated.
+      #
+      # compression-level: 0 because squashfs/bfb/efi payloads are already
+      # compressed; re-deflating them burns CPU for a rounding error of savings.
       - name: Upload artifacts
         if: always()  # Upload artifacts even if build fails (matches GitLab CI 'when: always')
         uses: actions/upload-artifact@v4
@@ -558,9 +581,9 @@ jobs:
             pxe/static/blobs/
             target/debug/nico-admin-cli
             target/debs/
-            target/aarch64-unknown-linux-gnu/
-            pxe/mkosi.profiles/
+            target/aarch64-unknown-linux-gnu/release/forge-scout
           if-no-files-found: warn
+          compression-level: 0
           retention-days: 1
 
       - name: Upload build log on failure

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1462,7 +1462,9 @@ jobs:
         run: make -C rest-api core-proto
 
       - name: Check repository is clean
-        run: bash scripts/check-repo-clean.sh "REST Core protobuf sync"
+        run: >-
+          bash scripts/check-repo-clean.sh "REST Core protobuf sync"
+          "make sync-protobuf (from the repository root)"
 
   lint-police:
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -678,6 +678,10 @@ jobs:
   # ============================================================================
   # BUILD STAGE - Release Container
   # ============================================================================
+  # Deliberately does NOT depend on lint-police. The container build consumes
+  # nothing lint-police produces, and gating on it serialized ~11m of linting in
+  # front of a ~29m build. Lint failures still block the merge independently via
+  # core-ci-pass, so the gate is preserved while the two now run in parallel.
   build-release-container-x86_64:
     if: >-
       ${{
@@ -687,14 +691,12 @@ jobs:
         && contains('success,skipped', needs.build-container-x86_64.result)
         && contains('success,skipped', needs.build-runtime-container-x86_64.result)
         && contains('success,skipped', needs.check-rest-core-proto-sync.result)
-        && contains('success,skipped', needs.lint-police.result)
       }}
     needs:
       - prepare
       - build-container-x86_64
       - build-runtime-container-x86_64
       - check-rest-core-proto-sync
-      - lint-police
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
@@ -886,6 +888,19 @@ jobs:
           username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
           token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
+      # This job already mounts a host sccache directory into the build
+      # container, but nothing ever persisted it, so every run started from an
+      # empty cache and recompiled the whole workspace. Cargo.lock keys the
+      # entry; restore-keys let a lockfile bump start from the previous cache
+      # instead of from nothing.
+      - name: Restore sccache
+        uses: actions/cache@v4
+        with:
+          path: .sccache
+          key: sccache-test-release-x86_64-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            sccache-test-release-x86_64-
+
       - name: Run release-container service tests
         env:
           BUILD_CONTAINER: ${{ needs.prepare.outputs.build_container_x86_64_ref }}
@@ -904,6 +919,7 @@ jobs:
             -e CARGO_MAKE_SKIP_CODECOV=true \
             -e DATABASE_URL='postgresql://root@%2Fvar%2Frun%2Fpostgresql/root' \
             -e SCCACHE_DIR=/sccache \
+            -e SCCACHE_CACHE_SIZE=5G \
             -e RUSTC_WRAPPER=sccache \
             -e CI_COMMIT_SHORT_SHA="${CI_COMMIT_SHORT_SHA}" \
             -e VERSION="${VERSION}" \
@@ -916,6 +932,7 @@ jobs:
               sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;"
               createdb root
               cargo make test-release-container-services
+              sccache --show-stats || true
             '
 
       - name: Final repository clean check
@@ -1113,7 +1130,10 @@ jobs:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
-      # No RUN steps to cache, and the multi-GB blob COPY layer alone can exhaust the 10 GB per-repo Actions cache quota.
+      # No RUN steps, so there are no expensive layers worth reusing. The
+      # multi-GB blob COPY layer would also take a large bite out of the 50 GB
+      # per-repo Actions cache quota now shared with the layer and sccache
+      # caches the rest of the pipeline depends on.
       cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1129,6 +1149,7 @@ jobs:
       load: true
       scan: true
       download_artifacts: true  # Download boot and ephemeral artifacts for packaging
+      artifact_pattern: '*-x86_64-${{ github.run_id }}'
       build_args: |
         {
           "VERSION": "${{ needs.prepare.outputs.version }}",
@@ -1149,7 +1170,10 @@ jobs:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
-      # No RUN steps to cache, and the multi-GB blob COPY layer alone can exhaust the 10 GB per-repo Actions cache quota.
+      # No RUN steps, so there are no expensive layers worth reusing. The
+      # multi-GB blob COPY layer would also take a large bite out of the 50 GB
+      # per-repo Actions cache quota now shared with the layer and sccache
+      # caches the rest of the pipeline depends on.
       cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1165,6 +1189,7 @@ jobs:
       load: true
       scan: true
       download_artifacts: true  # Download boot and ephemeral artifacts for packaging
+      artifact_pattern: '*-aarch64-${{ github.run_id }}'
       build_args: |
         {
           "VERSION": "${{ needs.prepare.outputs.version }}",
@@ -1734,6 +1759,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       download_artifacts: true
+      artifact_pattern: '{bluefield-binaries,mft-aarch64-deb}-${{ github.run_id }}'
     secrets: inherit
 
   build-bluefield-forge-dhcp-server:
@@ -1754,6 +1780,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       download_artifacts: true
+      artifact_pattern: 'bluefield-binaries-${{ github.run_id }}'
     secrets: inherit
 
   build-bluefield-carbide-fmds:
@@ -1774,6 +1801,7 @@ jobs:
       push: ${{ needs.prepare.outputs.publish_images == 'true' }}
       load: false
       download_artifacts: true
+      artifact_pattern: 'bluefield-binaries-${{ github.run_id }}'
     secrets: inherit
 
   # ============================================================================

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -147,8 +147,8 @@ jobs:
           merge-multiple: true
 
       # Must run unconditionally, not just when pushing. The default docker
-      # driver cannot export a build cache at all, so gating this on `push` is
-      # what silently disabled layer caching on every PR build.
+      # driver can neither import nor export a build cache, so gating this on
+      # `push` is what silently disabled layer caching on every PR build.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -281,11 +281,14 @@ jobs:
           provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
-          # cache-to is deliberately not gated on `push`. Only pushing refs used
-          # to write the cache, so a developer iterating on a PR recompiled
-          # everything from scratch on every single push.
+          # Every ref reads the cache; only main writes it. The Rust images
+          # `COPY . ./` before the compile, so any new commit invalidates the
+          # builder layer and a PR can never hit its own exported cache -- a
+          # measured 18-21 min per job spent exporting layers that only a
+          # byte-identical tree could ever reuse. sccache, not the layer cache,
+          # is what carries reuse across commits.
           cache-from: ${{ inputs.cache && format('type=gha,scope={0}', steps.cache.outputs.scope) || '' }}
-          cache-to: ${{ inputs.cache && format('type=gha,mode=max,scope={0}', steps.cache.outputs.scope) || '' }}
+          cache-to: ${{ inputs.cache && github.ref == 'refs/heads/main' && format('type=gha,mode=max,scope={0}', steps.cache.outputs.scope) || '' }}
           # Lets sccache in the builder stage use the Actions cache as a shared
           # backend. Always passed and never empty -- buildx rejects a secret
           # with an empty value outright. The Dockerfiles check the URL for a

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,13 +70,18 @@ on:
         required: false
         default: false
         type: boolean
+      artifact_pattern:
+        description: 'Glob for which run artifacts to download. Defaults to every artifact in the run, which is rarely what a build needs -- set this to the arch/type the Dockerfile actually consumes.'
+        required: false
+        default: ''
+        type: string
       scan:
         description: 'Run a Grype vulnerability scan on main after the built image has been pushed.'
         required: false
         default: false
         type: boolean
       cache:
-        description: 'Use the GitHub Actions buildx layer cache. Turn off for images whose Dockerfile has no RUN steps.'
+        description: 'Use the GitHub Actions buildx layer cache, scoped per image and architecture. Turn off for images whose Dockerfile has no RUN steps: there are no expensive layers to reuse, and caching them just pushes gigabytes of payload into the cache for no gain.'
         required: false
         default: true
         type: boolean
@@ -134,13 +139,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download all artifacts
+      - name: Download build artifacts
         if: inputs.download_artifacts == true
         uses: actions/download-artifact@v4
         with:
-          pattern: '*-${{ github.run_id }}'
+          pattern: ${{ inputs.artifact_pattern != '' && inputs.artifact_pattern || format('*-{0}', github.run_id) }}
           merge-multiple: true
 
+      # Must run unconditionally, not just when pushing. The default docker
+      # driver cannot export a build cache at all, so gating this on `push` is
+      # what silently disabled layer caching on every PR build.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -201,6 +209,45 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # A per-image, per-arch cache scope. Without this every image shares one
+      # unscoped namespace and they evict each other; with it, an x86 release
+      # container build only ever reads layers from previous x86 release
+      # container builds.
+      - name: Compute cache scope
+        id: cache
+        if: inputs.cache
+        env:
+          IMAGE_NAME: ${{ inputs.image_name }}
+          PLATFORMS: ${{ inputs.platforms }}
+        run: |
+          set -euo pipefail
+          scope="$(basename -- "$IMAGE_NAME")-$(echo "$PLATFORMS" | tr '/,' '--')"
+          echo "scope=${scope}" >> "$GITHUB_OUTPUT"
+          echo "Cache scope: ${scope}"
+
+      # sccache inside the build needs to reach the Actions cache service, but
+      # ACTIONS_RUNTIME_TOKEN is only visible to JS actions, never to `run:`
+      # steps. github-script is first-party, so we use it to re-export the two
+      # values instead of taking on a third-party action for this.
+      #
+      # Runs unconditionally and always exports a non-empty value. buildx
+      # rejects a secret whose value is empty, so a skipped step or an unset
+      # token would fail the build outright instead of merely disabling the
+      # cache. The sentinel is what the Dockerfiles detect.
+      - name: Expose Actions cache credentials to the build
+        uses: actions/github-script@v7
+        env:
+          CACHE_ENABLED: ${{ inputs.cache }}
+        with:
+          script: |
+            const enabled = process.env.CACHE_ENABLED === 'true';
+            const token = enabled ? (process.env.ACTIONS_RUNTIME_TOKEN || '') : '';
+            const url = enabled ? (process.env.ACTIONS_RESULTS_URL || '') : '';
+            if (token) core.setSecret(token);
+            core.exportVariable('BUILD_ACTIONS_RUNTIME_TOKEN', token || 'unavailable');
+            core.exportVariable('BUILD_ACTIONS_RESULTS_URL', url || 'unavailable');
+            core.info(`In-build sccache backend: ${token && url ? 'enabled' : 'disabled'}`);
+
       - name: Parse build arguments
         id: parse-args
         run: |
@@ -234,8 +281,19 @@ jobs:
           provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
-          cache-from: ${{ inputs.cache && 'type=gha' || '' }}
-          cache-to: ${{ inputs.cache && inputs.push && 'type=gha,mode=max' || '' }}
+          # cache-to is deliberately not gated on `push`. Only pushing refs used
+          # to write the cache, so a developer iterating on a PR recompiled
+          # everything from scratch on every single push.
+          cache-from: ${{ inputs.cache && format('type=gha,scope={0}', steps.cache.outputs.scope) || '' }}
+          cache-to: ${{ inputs.cache && format('type=gha,mode=max,scope={0}', steps.cache.outputs.scope) || '' }}
+          # Lets sccache in the builder stage use the Actions cache as a shared
+          # backend. Always passed and never empty -- buildx rejects a secret
+          # with an empty value outright. The Dockerfiles check the URL for a
+          # real endpoint and fall back to the local BuildKit cache mount when
+          # it is absent, so a plain local `docker build` still works.
+          secrets: |
+            actions_results_url=${{ env.BUILD_ACTIONS_RESULTS_URL }}
+            actions_runtime_token=${{ env.BUILD_ACTIONS_RUNTIME_TOKEN }}
 
       - name: Login to target registry
         if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -293,10 +293,12 @@ jobs:
           # backend. Always passed and never empty -- buildx rejects a secret
           # with an empty value outright. The Dockerfiles check the URL for a
           # real endpoint and fall back to the local BuildKit cache mount when
-          # it is absent, so a plain local `docker build` still works.
+          # it is absent, so a plain local `docker build` still works. PRs can
+          # read compiler entries populated by main but never upload their own.
           secrets: |
             actions_results_url=${{ env.BUILD_ACTIONS_RESULTS_URL }}
             actions_runtime_token=${{ env.BUILD_ACTIONS_RUNTIME_TOKEN }}
+            sccache_gha_rw_mode=${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
 
       - name: Login to target registry
         if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -215,6 +215,8 @@ jobs:
     name: Check Protobuf Generated Code
     runs-on: linux-amd64-cpu4
     continue-on-error: false
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -207,7 +207,9 @@ jobs:
         run: make generate-sdk
 
       - name: Check for uncommitted changes
-        run: bash ../scripts/check-repo-clean.sh "REST SDK generation"
+        run: >-
+          bash ../scripts/check-repo-clean.sh "REST SDK generation"
+          "make rest-api/generate-sdk (from the repository root)"
 
   check-protobuf-generated:
     name: Check Protobuf Generated Code
@@ -230,7 +232,9 @@ jobs:
         run: make core-proto
 
       - name: Check for uncommitted changes
-        run: bash ../scripts/check-repo-clean.sh "REST protobuf generation"
+        run: >-
+          bash ../scripts/check-repo-clean.sh "REST protobuf generation"
+          "make sync-protobuf (from the repository root)"
 
   test:
     name: Test (${{ matrix.module }})

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,6 +17,11 @@
 
 extend = [{ path = "Makefile-package.toml" }, { path = "Makefile-build.toml" }]
 
+[config]
+# CI installs this exact version in setup-mkosi-environment. Newer local
+# versions remain allowed, but older versions fail before running tasks.
+min_version = "0.37.24"
+
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 REPO_ROOT = { script = [

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -40,7 +40,8 @@ COPY . ./
 # The cache mount alone is only useful on a machine that keeps its BuildKit
 # state. CI runners get a fresh builder per job, so when the workflow supplies
 # Actions cache credentials we point sccache at that shared service instead and
-# the mount just becomes local scratch.
+# the mount just becomes local scratch. dev/docker/sccache-cache.sh picks
+# between the two and reports on whether the choice worked.
 RUN --mount=type=cache,id=sccache-aarch64,target=/sccache \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
@@ -49,25 +50,14 @@ RUN --mount=type=cache,id=sccache-aarch64,target=/sccache \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
   export CARGO_PROFILE_RELEASE_DEBUG=true && \
-  if grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then \
-    export SCCACHE_GHA_ENABLED=true; \
-    export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
-    export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
-    if sccache --start-server >/dev/null 2>&1; then \
-      echo "sccache: using GitHub Actions cache backend"; \
-    else \
-      echo "sccache: Actions cache unreachable, falling back to local cache mount"; \
-      unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN; \
-    fi; \
-  else \
-    echo "sccache: using local cache mount at ${SCCACHE_DIR}"; \
-  fi && \
+  . /carbide/dev/docker/sccache-cache.sh && \
+  sccache_setup && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
   cargo make build-release-container-services && \
   echo "$(date): Finished cargo make build-release-container-services\n" && \
-  { sccache --show-stats || true; } && \
+  sccache_report && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -45,6 +45,7 @@ COPY . ./
 RUN --mount=type=cache,id=sccache-aarch64,target=/sccache \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
+    --mount=type=secret,id=sccache_gha_rw_mode \
   export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://root@%2Fvar%2Frun%2Fpostgresql/root" && \
   export SCCACHE_DIR=/sccache && \

--- a/dev/docker/Dockerfile.release-container-aarch64
+++ b/dev/docker/Dockerfile.release-container-aarch64
@@ -36,17 +36,38 @@ COPY . ./
 # --mount=type=cache persists the sccache directory across docker build invocations.
 # Uses id=sccache-aarch64 (separate from x86_64 cache) since compiled artifacts are arch-specific.
 # Requires BuildKit (default in Docker 23+).
+#
+# The cache mount alone is only useful on a machine that keeps its BuildKit
+# state. CI runners get a fresh builder per job, so when the workflow supplies
+# Actions cache credentials we point sccache at that shared service instead and
+# the mount just becomes local scratch.
 RUN --mount=type=cache,id=sccache-aarch64,target=/sccache \
+    --mount=type=secret,id=actions_results_url \
+    --mount=type=secret,id=actions_runtime_token \
   export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://root@%2Fvar%2Frun%2Fpostgresql/root" && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
   export CARGO_PROFILE_RELEASE_DEBUG=true && \
+  if grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then \
+    export SCCACHE_GHA_ENABLED=true; \
+    export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
+    export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
+    if sccache --start-server >/dev/null 2>&1; then \
+      echo "sccache: using GitHub Actions cache backend"; \
+    else \
+      echo "sccache: Actions cache unreachable, falling back to local cache mount"; \
+      unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN; \
+    fi; \
+  else \
+    echo "sccache: using local cache mount at ${SCCACHE_DIR}"; \
+  fi && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
   cargo make build-release-container-services && \
   echo "$(date): Finished cargo make build-release-container-services\n" && \
+  { sccache --show-stats || true; } && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -40,7 +40,8 @@ COPY . ./
 # The cache mount alone is only useful on a machine that keeps its BuildKit
 # state. CI runners get a fresh builder per job, so when the workflow supplies
 # Actions cache credentials we point sccache at that shared service instead and
-# the mount just becomes local scratch.
+# the mount just becomes local scratch. dev/docker/sccache-cache.sh picks
+# between the two and reports on whether the choice worked.
 RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
@@ -49,25 +50,14 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
   export CARGO_PROFILE_RELEASE_DEBUG=true && \
-  if grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then \
-    export SCCACHE_GHA_ENABLED=true; \
-    export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
-    export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
-    if sccache --start-server >/dev/null 2>&1; then \
-      echo "sccache: using GitHub Actions cache backend"; \
-    else \
-      echo "sccache: Actions cache unreachable, falling back to local cache mount"; \
-      unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN; \
-    fi; \
-  else \
-    echo "sccache: using local cache mount at ${SCCACHE_DIR}"; \
-  fi && \
+  . /carbide/dev/docker/sccache-cache.sh && \
+  sccache_setup && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
   cargo make build-release-container-services && \
   echo "$(date): Finished cargo make build-release-container-services\n" && \
-  { sccache --show-stats || true; } && \
+  sccache_report && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -45,6 +45,7 @@ COPY . ./
 RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
+    --mount=type=secret,id=sccache_gha_rw_mode \
   export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://root@%2Fvar%2Frun%2Fpostgresql/root" && \
   export SCCACHE_DIR=/sccache && \

--- a/dev/docker/Dockerfile.release-container-x86_64
+++ b/dev/docker/Dockerfile.release-container-x86_64
@@ -36,17 +36,38 @@ COPY . ./
 # --mount=type=cache persists the sccache directory across docker build invocations.
 # Uses id=sccache-x86_64 so this build shares the cache with Dockerfile.release-container-sa-x86_64
 # (both compile the same targets on the same arch). Requires BuildKit (default in Docker 23+).
+#
+# The cache mount alone is only useful on a machine that keeps its BuildKit
+# state. CI runners get a fresh builder per job, so when the workflow supplies
+# Actions cache credentials we point sccache at that shared service instead and
+# the mount just becomes local scratch.
 RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
+    --mount=type=secret,id=actions_results_url \
+    --mount=type=secret,id=actions_runtime_token \
   export CARGO_MAKE_SKIP_CODECOV="true" && \
   export DATABASE_URL="postgresql://root@%2Fvar%2Frun%2Fpostgresql/root" && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
   export CARGO_PROFILE_RELEASE_DEBUG=true && \
+  if grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then \
+    export SCCACHE_GHA_ENABLED=true; \
+    export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
+    export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
+    if sccache --start-server >/dev/null 2>&1; then \
+      echo "sccache: using GitHub Actions cache backend"; \
+    else \
+      echo "sccache: Actions cache unreachable, falling back to local cache mount"; \
+      unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN; \
+    fi; \
+  else \
+    echo "sccache: using local cache mount at ${SCCACHE_DIR}"; \
+  fi && \
   /etc/init.d/postgresql start && \
   sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;" && \
   createdb root && \
   cargo make build-release-container-services && \
   echo "$(date): Finished cargo make build-release-container-services\n" && \
+  { sccache --show-stats || true; } && \
   mkdir -p /carbide/target/bin && \
   find /carbide/target/release -maxdepth 1 -type f -exec cp -t /carbide/target/bin {} + && \
   rm -rf /carbide/target/debug && \

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -25,12 +25,30 @@ WORKDIR ./carbide
 COPY . ./
 
 # --mount=type=cache persists the sccache directory across builds. Requires BuildKit (default in Docker 23+).
+# On CI the BuildKit state is discarded per job, so prefer the shared Actions
+# cache backend when the workflow supplies credentials.
 RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
+    --mount=type=secret,id=actions_results_url \
+    --mount=type=secret,id=actions_runtime_token \
   cd /carbide && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
   export CARGO_PROFILE_RELEASE_DEBUG=true && \
-  cargo build --release -p nico-admin-cli
+  if grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then \
+    export SCCACHE_GHA_ENABLED=true; \
+    export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
+    export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
+    if sccache --start-server >/dev/null 2>&1; then \
+      echo "sccache: using GitHub Actions cache backend"; \
+    else \
+      echo "sccache: Actions cache unreachable, falling back to local cache mount"; \
+      unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN; \
+    fi; \
+  else \
+    echo "sccache: using local cache mount at ${SCCACHE_DIR}"; \
+  fi && \
+  cargo build --release -p nico-admin-cli && \
+  { sccache --show-stats || true; }
 
 FROM debian:12-slim
 ARG CI_COMMIT_SHORT_SHA

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -32,6 +32,7 @@ COPY . ./
 RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
+    --mount=type=secret,id=sccache_gha_rw_mode \
   cd /carbide && \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \

--- a/dev/docker/Dockerfile.release-forge-cli
+++ b/dev/docker/Dockerfile.release-forge-cli
@@ -27,6 +27,8 @@ COPY . ./
 # --mount=type=cache persists the sccache directory across builds. Requires BuildKit (default in Docker 23+).
 # On CI the BuildKit state is discarded per job, so prefer the shared Actions
 # cache backend when the workflow supplies credentials.
+# dev/docker/sccache-cache.sh picks between the two and reports on whether the
+# choice worked.
 RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
     --mount=type=secret,id=actions_results_url \
     --mount=type=secret,id=actions_runtime_token \
@@ -34,21 +36,10 @@ RUN --mount=type=cache,id=sccache-x86_64,target=/sccache \
   export SCCACHE_DIR=/sccache && \
   export RUSTC_WRAPPER=sccache && \
   export CARGO_PROFILE_RELEASE_DEBUG=true && \
-  if grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then \
-    export SCCACHE_GHA_ENABLED=true; \
-    export ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"; \
-    export ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"; \
-    if sccache --start-server >/dev/null 2>&1; then \
-      echo "sccache: using GitHub Actions cache backend"; \
-    else \
-      echo "sccache: Actions cache unreachable, falling back to local cache mount"; \
-      unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN; \
-    fi; \
-  else \
-    echo "sccache: using local cache mount at ${SCCACHE_DIR}"; \
-  fi && \
+  . /carbide/dev/docker/sccache-cache.sh && \
+  sccache_setup && \
   cargo build --release -p nico-admin-cli && \
-  { sccache --show-stats || true; }
+  sccache_report
 
 FROM debian:12-slim
 ARG CI_COMMIT_SHORT_SHA

--- a/dev/docker/sccache-cache.sh
+++ b/dev/docker/sccache-cache.sh
@@ -14,9 +14,9 @@
 #
 # POSIX sh only -- a Dockerfile RUN is interpreted by /bin/sh.
 
-# Number of backend writes sccache has failed so far, or 0 when it cannot be
-# determined. The text output is parsed as a fallback because --stats-format is
-# the newer of the two interfaces.
+# Number of backend writes sccache has failed so far, or "unknown" when it
+# cannot be determined. The text output is parsed as a fallback because
+# --stats-format is the newer of the two interfaces.
 sccache_write_errors() {
 	_errors="$(sccache --show-stats --stats-format=json 2>/dev/null |
 		grep -oE '"cache_write_errors" *: *[0-9]+' |
@@ -27,7 +27,7 @@ sccache_write_errors() {
 			awk '/^Cache write errors/ { print $NF; exit }')"
 	fi
 	case "${_errors}" in
-	'' | *[!0-9]*) echo 0 ;;
+	'' | *[!0-9]*) echo unknown ;;
 	*) echo "${_errors}" ;;
 	esac
 }
@@ -76,7 +76,7 @@ sccache_backend_writable() {
 	# counter is not necessarily up to date the instant the compile returns.
 	sleep 3
 	SCCACHE_PROBE_WRITE_ERRORS="$(sccache_write_errors)"
-	[ "${SCCACHE_PROBE_WRITE_ERRORS}" -eq 0 ]
+	[ "${SCCACHE_PROBE_WRITE_ERRORS}" = 0 ]
 }
 
 sccache_setup() {
@@ -87,7 +87,7 @@ sccache_setup() {
 
 	# No credentials: a plain local `docker build`, where the BuildKit cache
 	# mount is the only backend available.
-	if ! grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then
+	if ! grep -qE "^https://" /run/secrets/actions_results_url 2>/dev/null; then
 		echo "sccache: using local cache mount at ${SCCACHE_DIR}"
 		sccache --start-server >/dev/null 2>&1 || true
 		return 0
@@ -101,7 +101,11 @@ sccache_setup() {
 	if ! sccache --start-server >/dev/null 2>&1; then
 		_reason="the sccache server would not start"
 	elif ! sccache_backend_writable; then
-		_reason="the Actions cache rejected the write probe (${SCCACHE_PROBE_WRITE_ERRORS} write errors)"
+		if [ "${SCCACHE_PROBE_WRITE_ERRORS}" = unknown ]; then
+			_reason="the Actions cache write probe statistics were unavailable"
+		else
+			_reason="the Actions cache rejected the write probe (${SCCACHE_PROBE_WRITE_ERRORS} write errors)"
+		fi
 	else
 		echo "sccache: using GitHub Actions cache backend"
 		return 0
@@ -121,7 +125,9 @@ sccache_report() {
 	sccache --show-stats || true
 	sccache_dump_log
 	_errors="$(sccache_write_errors)"
-	if [ "${_errors}" -gt 0 ]; then
+	if [ "${_errors}" = unknown ]; then
+		sccache_degraded_banner "cache write statistics unavailable after the build"
+	elif [ "${_errors}" -gt 0 ]; then
 		sccache_degraded_banner "${_errors} cache write errors during the build"
 	fi
 	return 0

--- a/dev/docker/sccache-cache.sh
+++ b/dev/docker/sccache-cache.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cache-backend selection for the Rust builder stages.
+#
+# Sourced rather than executed, so that the variables sccache_setup exports
+# reach the cargo invocation that follows it:
+#
+#   . /carbide/dev/docker/sccache-cache.sh && \
+#     sccache_setup && \
+#     cargo build ... && \
+#     sccache_report
+#
+# POSIX sh only -- a Dockerfile RUN is interpreted by /bin/sh.
+
+# Number of backend writes sccache has failed so far, or 0 when it cannot be
+# determined. The text output is parsed as a fallback because --stats-format is
+# the newer of the two interfaces.
+sccache_write_errors() {
+	_errors="$(sccache --show-stats --stats-format=json 2>/dev/null |
+		grep -oE '"cache_write_errors" *: *[0-9]+' |
+		head -n 1 |
+		grep -oE '[0-9]+$')"
+	if [ -z "${_errors}" ]; then
+		_errors="$(sccache --show-stats 2>/dev/null |
+			awk '/^Cache write errors/ { print $NF; exit }')"
+	fi
+	case "${_errors}" in
+	'' | *[!0-9]*) echo 0 ;;
+	*) echo "${_errors}" ;;
+	esac
+}
+
+sccache_dump_log() {
+	[ -n "${SCCACHE_ERROR_LOG}" ] && [ -s "${SCCACHE_ERROR_LOG}" ] || return 0
+	echo "--- sccache server log (deduplicated, last 40 lines) ---"
+	# A failing backend produces one near-identical line per compilation, so
+	# thousands of them collapse to a handful of distinct messages.
+	sort -u "${SCCACHE_ERROR_LOG}" | tail -n 40
+	echo "--- end sccache server log ---"
+	# Truncated so that a later dump reports only what happened since, rather
+	# than reprinting the setup-time failure.
+	: >"${SCCACHE_ERROR_LOG}"
+	return 0
+}
+
+# A single greppable marker for both the "never worked" and the "stopped
+# working partway through" case.
+sccache_degraded_banner() {
+	echo "=============================================================="
+	echo "SCCACHE_BACKEND_DEGRADED: $1"
+	echo "Compiled output is not being shared with the next build."
+	echo "=============================================================="
+	return 0
+}
+
+# Whether the configured backend actually stores anything. `sccache
+# --start-server` only proves the local daemon came up: sccache latches into
+# read-only mode for the life of the process once a backend write fails, so a
+# server that starts cleanly can still silently discard every artifact for the
+# rest of the build. The only reliable check is to compile something and look
+# at the resulting write-error count.
+sccache_backend_writable() {
+	_probe_dir="$(mktemp -d)" || return 1
+	echo 'pub fn probe() {}' >"${_probe_dir}/probe.rs"
+	# Deliberately an ordinary rlib compile. sccache only writes to the
+	# backend for invocations it considers cacheable, so a probe using an
+	# exotic --emit would pass without exercising a write.
+	sccache rustc --crate-name sccache_probe --crate-type lib \
+		"${_probe_dir}/probe.rs" --out-dir "${_probe_dir}" >/dev/null 2>&1
+	_probe_rc=$?
+	rm -rf "${_probe_dir}"
+	[ "${_probe_rc}" -eq 0 ] || return 1
+	# The server stores the result after answering the client, so the
+	# counter is not necessarily up to date the instant the compile returns.
+	sleep 3
+	SCCACHE_PROBE_WRITE_ERRORS="$(sccache_write_errors)"
+	[ "${SCCACHE_PROBE_WRITE_ERRORS}" -eq 0 ]
+}
+
+sccache_setup() {
+	SCCACHE_ERROR_LOG=/tmp/sccache-server.log
+	SCCACHE_LOG=warn
+	SCCACHE_PROBE_WRITE_ERRORS=unknown
+	export SCCACHE_ERROR_LOG SCCACHE_LOG
+
+	# No credentials: a plain local `docker build`, where the BuildKit cache
+	# mount is the only backend available.
+	if ! grep -qE "^https?://" /run/secrets/actions_results_url 2>/dev/null; then
+		echo "sccache: using local cache mount at ${SCCACHE_DIR}"
+		sccache --start-server >/dev/null 2>&1 || true
+		return 0
+	fi
+
+	SCCACHE_GHA_ENABLED=true
+	ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"
+	ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"
+	export SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN
+
+	if ! sccache --start-server >/dev/null 2>&1; then
+		_reason="the sccache server would not start"
+	elif ! sccache_backend_writable; then
+		_reason="the Actions cache rejected the write probe (${SCCACHE_PROBE_WRITE_ERRORS} write errors)"
+	else
+		echo "sccache: using GitHub Actions cache backend"
+		return 0
+	fi
+
+	sccache_dump_log
+	sccache_degraded_banner "${_reason}; falling back to the local cache mount"
+	# A restart is required, not just a reconfigure: read-only mode is held
+	# by the running server and survives any change to the environment.
+	sccache --stop-server >/dev/null 2>&1 || true
+	unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN
+	sccache --start-server >/dev/null 2>&1 || true
+	return 0
+}
+
+sccache_report() {
+	sccache --show-stats || true
+	sccache_dump_log
+	_errors="$(sccache_write_errors)"
+	if [ "${_errors}" -gt 0 ]; then
+		sccache_degraded_banner "${_errors} cache write errors during the build"
+	fi
+	return 0
+}

--- a/dev/docker/sccache-cache.sh
+++ b/dev/docker/sccache-cache.sh
@@ -150,6 +150,27 @@ sccache_setup() {
 	return 0
 }
 
+# `sccache --show-stats` with the write-error row relabelled. sccache reports
+# every declined write as an error, which reads as a broken backend to anyone
+# scanning the log, so the row is renamed to what it actually counts here. The
+# figure itself is left alone, and the row keeps its width so the table stays
+# aligned.
+sccache_show_stats_read_only() {
+	sccache --show-stats 2>&1 | awk '
+		index($0, "Cache write errors") == 1 {
+			label = "Cache writes skipped (read-only)"
+			pad = length($0) - length(label) - length($NF)
+			if (pad < 1) {
+				pad = 1
+			}
+			printf "%s%*s\n", label, pad + length($NF), $NF
+			next
+		}
+		{ print }
+	'
+	return 0
+}
+
 # Health of a deliberately read-only backend. sccache has no "do not attempt
 # the write" mode: READ_ONLY is implemented by failing every put, and each
 # rejection lands in the write-error counter, so that counter is guaranteed to
@@ -157,6 +178,8 @@ sccache_setup() {
 # backend. Reads are the only signal. Misses are logged as NotFound warnings,
 # which makes the server log pure noise unless a read actually errored.
 sccache_report_read_only() {
+	sccache_show_stats_read_only
+	echo "sccache: writes are declined on this ref by design -- only main publishes to the shared cache."
 	_read_errors="$(sccache_stat cache_read_errors 'Cache read errors')"
 	case "${_read_errors}" in
 	0) ;;
@@ -172,18 +195,17 @@ sccache_report_read_only() {
 		;;
 	esac
 	if [ "$(sccache_stat cache_hits 'Cache hits')" = 0 ]; then
-		echo "sccache: read-only backend reachable but empty for this build."
-		echo "sccache: it is populated by main, so a branch that compiles code main has not seen yet gets no hits."
+		echo "sccache: the backend was reachable but held nothing matching this build, so every crate was compiled from scratch."
 	fi
 	return 0
 }
 
 sccache_report() {
-	sccache --show-stats || true
 	if [ "${SCCACHE_BACKEND_READ_ONLY}" = 1 ]; then
 		sccache_report_read_only
 		return 0
 	fi
+	sccache --show-stats || true
 	sccache_dump_log
 	_errors="$(sccache_write_errors)"
 	if [ "${_errors}" = unknown ]; then

--- a/dev/docker/sccache-cache.sh
+++ b/dev/docker/sccache-cache.sh
@@ -96,10 +96,28 @@ sccache_setup() {
 	SCCACHE_GHA_ENABLED=true
 	ACTIONS_RESULTS_URL="$(cat /run/secrets/actions_results_url)"
 	ACTIONS_RUNTIME_TOKEN="$(cat /run/secrets/actions_runtime_token)"
+	SCCACHE_GHA_RW_MODE="$(cat /run/secrets/sccache_gha_rw_mode 2>/dev/null || true)"
+	case "${SCCACHE_GHA_RW_MODE}" in
+	READ_ONLY | READ_WRITE) ;;
+	*)
+		echo "sccache: missing or invalid GHA access mode; defaulting to READ_ONLY"
+		SCCACHE_GHA_RW_MODE=READ_ONLY
+		;;
+	esac
+
+	# sccache 0.17 uses OpenDAL 0.55, which defaults to the retired v1
+	# artifact-cache API unless this flag is present. ACTIONS_RESULTS_URL is
+	# the v2 endpoint; combining it with v1 paths makes every lookup and write
+	# fail with 404.
+	ACTIONS_CACHE_SERVICE_V2=true
 	export SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN
+	export SCCACHE_GHA_RW_MODE ACTIONS_CACHE_SERVICE_V2
 
 	if ! sccache --start-server >/dev/null 2>&1; then
 		_reason="the sccache server would not start"
+	elif [ "${SCCACHE_GHA_RW_MODE}" = READ_ONLY ]; then
+		echo "sccache: using GitHub Actions cache backend (read-only)"
+		return 0
 	elif ! sccache_backend_writable; then
 		if [ "${SCCACHE_PROBE_WRITE_ERRORS}" = unknown ]; then
 			_reason="the Actions cache write probe statistics were unavailable"
@@ -117,6 +135,7 @@ sccache_setup() {
 	# by the running server and survives any change to the environment.
 	sccache --stop-server >/dev/null 2>&1 || true
 	unset SCCACHE_GHA_ENABLED ACTIONS_RESULTS_URL ACTIONS_RUNTIME_TOKEN
+	unset SCCACHE_GHA_RW_MODE ACTIONS_CACHE_SERVICE_V2
 	sccache --start-server >/dev/null 2>&1 || true
 	return 0
 }

--- a/dev/docker/sccache-cache.sh
+++ b/dev/docker/sccache-cache.sh
@@ -14,22 +14,30 @@
 #
 # POSIX sh only -- a Dockerfile RUN is interpreted by /bin/sh.
 
-# Number of backend writes sccache has failed so far, or "unknown" when it
-# cannot be determined. The text output is parsed as a fallback because
-# --stats-format is the newer of the two interfaces.
-sccache_write_errors() {
-	_errors="$(sccache --show-stats --stats-format=json 2>/dev/null |
-		grep -oE '"cache_write_errors" *: *[0-9]+' |
+# One counter from `sccache --show-stats`, or "unknown" when it cannot be read.
+# $1 is the JSON field, $2 the label in the human-readable output. The text
+# output is parsed as a fallback because --stats-format is the newer of the two
+# interfaces, and it is the only source for counters that JSON reports as a
+# per-language object rather than a number.
+sccache_stat() {
+	_stat="$(sccache --show-stats --stats-format=json 2>/dev/null |
+		grep -oE "\"$1\" *: *[0-9]+" |
 		head -n 1 |
 		grep -oE '[0-9]+$')"
-	if [ -z "${_errors}" ]; then
-		_errors="$(sccache --show-stats 2>/dev/null |
-			awk '/^Cache write errors/ { print $NF; exit }')"
+	if [ -z "${_stat}" ]; then
+		_stat="$(sccache --show-stats 2>/dev/null |
+			awk -v label="$2" 'index($0, label) == 1 { print $NF; exit }')"
 	fi
-	case "${_errors}" in
+	case "${_stat}" in
 	'' | *[!0-9]*) echo unknown ;;
-	*) echo "${_errors}" ;;
+	*) echo "${_stat}" ;;
 	esac
+}
+
+# Number of backend writes sccache has failed so far, or "unknown" when it
+# cannot be determined.
+sccache_write_errors() {
+	sccache_stat cache_write_errors 'Cache write errors'
 }
 
 sccache_dump_log() {
@@ -83,6 +91,7 @@ sccache_setup() {
 	SCCACHE_ERROR_LOG=/tmp/sccache-server.log
 	SCCACHE_LOG=warn
 	SCCACHE_PROBE_WRITE_ERRORS=unknown
+	SCCACHE_BACKEND_READ_ONLY=0
 	export SCCACHE_ERROR_LOG SCCACHE_LOG
 
 	# No credentials: a plain local `docker build`, where the BuildKit cache
@@ -117,6 +126,7 @@ sccache_setup() {
 		_reason="the sccache server would not start"
 	elif [ "${SCCACHE_GHA_RW_MODE}" = READ_ONLY ]; then
 		echo "sccache: using GitHub Actions cache backend (read-only)"
+		SCCACHE_BACKEND_READ_ONLY=1
 		return 0
 	elif ! sccache_backend_writable; then
 		if [ "${SCCACHE_PROBE_WRITE_ERRORS}" = unknown ]; then
@@ -140,8 +150,40 @@ sccache_setup() {
 	return 0
 }
 
+# Health of a deliberately read-only backend. sccache has no "do not attempt
+# the write" mode: READ_ONLY is implemented by failing every put, and each
+# rejection lands in the write-error counter, so that counter is guaranteed to
+# equal the number of cacheable compilations and says nothing about the
+# backend. Reads are the only signal. Misses are logged as NotFound warnings,
+# which makes the server log pure noise unless a read actually errored.
+sccache_report_read_only() {
+	_read_errors="$(sccache_stat cache_read_errors 'Cache read errors')"
+	case "${_read_errors}" in
+	0) ;;
+	unknown)
+		sccache_dump_log
+		sccache_degraded_banner "cache statistics unavailable after the build"
+		return 0
+		;;
+	*)
+		sccache_dump_log
+		sccache_degraded_banner "${_read_errors} cache read errors during the build"
+		return 0
+		;;
+	esac
+	if [ "$(sccache_stat cache_hits 'Cache hits')" = 0 ]; then
+		echo "sccache: read-only backend reachable but empty for this build."
+		echo "sccache: it is populated by main, so a branch that compiles code main has not seen yet gets no hits."
+	fi
+	return 0
+}
+
 sccache_report() {
 	sccache --show-stats || true
+	if [ "${SCCACHE_BACKEND_READ_ONLY}" = 1 ]; then
+		sccache_report_read_only
+		return 0
+	fi
 	sccache_dump_log
 	_errors="$(sccache_write_errors)"
 	if [ "${_errors}" = unknown ]; then

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -23,6 +23,13 @@ PKG_VERSION = { script = [
 ], condition = { env_not_set = ["PKG_VERSION"] } }
 FORGE_CA_PATH = { value = "${REPO_ROOT}/dev/forge_prodroot.pem" }
 
+# Where mkosi keeps downloaded distro packages. Without this mkosi re-downloads
+# the full package set on every build, which dominated the ephemeral image jobs
+# in CI. Purely a download cache -- mkosi still revalidates package metadata, so
+# a stale entry cannot silently change what lands in the image. CI persists this
+# across runs with actions/cache; locally it just makes rebuilds faster.
+MKOSI_PACKAGE_CACHE_DIR = { value = "${REPO_ROOT}/pxe/.mkosi-package-cache", condition = { env_not_set = ["MKOSI_PACKAGE_CACHE_DIR"] } }
+
 # BlueField Bundle (BFB) Version
 # NOTE: Update `crates/api/src/cfg/file.rs` to set the DOCA BFB component versions (BMC, NIC, CEC fw)
 # so that Carbide treats them as the expected DPU fw versions.
@@ -511,7 +518,8 @@ category = "Ephemeral Image"
 script = '''
   PROFILE="scout-oss-x86_64"
   export PATH=${PATH}:/sbin
-  ${REPO_ROOT}/pxe/mkosi/bin/mkosi -E PKG_VERSION="${PKG_VERSION}" --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} --with-network build
+  mkdir -p "${MKOSI_PACKAGE_CACHE_DIR}"
+  ${REPO_ROOT}/pxe/mkosi/bin/mkosi -E PKG_VERSION="${PKG_VERSION}" --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} --package-cache-directory=${MKOSI_PACKAGE_CACHE_DIR} --with-network build
 '''
 
 [tasks.mkosi-build-scout-loader-x86_64]
@@ -519,7 +527,7 @@ category = "Ephemeral Image"
 command = "/bin/bash"
 args = [
   "-c",
-  "export PATH=${PATH}:/sbin && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile scout-loader-x86_64 --output-dir=${MKOSI_BUILD_TMP} build",
+  "export PATH=${PATH}:/sbin && mkdir -p ${MKOSI_PACKAGE_CACHE_DIR} && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile scout-loader-x86_64 --output-dir=${MKOSI_BUILD_TMP} --package-cache-directory=${MKOSI_PACKAGE_CACHE_DIR} build",
 ]
 
 [tasks.mkosi-build-scout-aarch64]
@@ -527,7 +535,8 @@ category = "Ephemeral Image"
 script = '''
   PROFILE="scout-oss-aarch64"
   export PATH=${PATH}:/sbin
-  ${REPO_ROOT}/pxe/mkosi/bin/mkosi -E PKG_VERSION="${PKG_VERSION}" --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} build
+  mkdir -p "${MKOSI_PACKAGE_CACHE_DIR}"
+  ${REPO_ROOT}/pxe/mkosi/bin/mkosi -E PKG_VERSION="${PKG_VERSION}" --profile ${PROFILE} --output-dir=${MKOSI_BUILD_TMP} --package-cache-directory=${MKOSI_PACKAGE_CACHE_DIR} build
 '''
 
 [tasks.mkosi-build-scout-loader-aarch64]
@@ -535,7 +544,7 @@ category = "Ephemeral Image"
 command = "/bin/bash"
 args = [
   "-c",
-  "export PATH=${PATH}:/sbin && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile scout-loader-aarch64 --output-dir=${MKOSI_BUILD_TMP} build",
+  "export PATH=${PATH}:/sbin && mkdir -p ${MKOSI_PACKAGE_CACHE_DIR} && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile scout-loader-aarch64 --output-dir=${MKOSI_BUILD_TMP} --package-cache-directory=${MKOSI_PACKAGE_CACHE_DIR} build",
 ]
 
 [tasks.mkosi-build-qcow-imager]
@@ -543,7 +552,7 @@ category = "Ephemeral Image"
 command = "/bin/bash"
 args = [
   "-c",
-  "export PATH=${PATH}:/sbin && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile qcow-imager --output-dir=${MKOSI_BUILD_TMP} build",
+  "export PATH=${PATH}:/sbin && mkdir -p ${MKOSI_PACKAGE_CACHE_DIR} && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile qcow-imager --output-dir=${MKOSI_BUILD_TMP} --package-cache-directory=${MKOSI_PACKAGE_CACHE_DIR} build",
 ]
 
 [tasks.mkosi-build-qcow-imager-aarch64]
@@ -551,7 +560,7 @@ category = "Ephemeral Image"
 command = "/bin/bash"
 args = [
   "-c",
-  "export PATH=${PATH}:/sbin && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile qcow-imager-aarch64 --output-dir=${MKOSI_BUILD_TMP} build",
+  "export PATH=${PATH}:/sbin && mkdir -p ${MKOSI_PACKAGE_CACHE_DIR} && ${REPO_ROOT}/pxe/mkosi/bin/mkosi --profile qcow-imager-aarch64 --output-dir=${MKOSI_BUILD_TMP} --package-cache-directory=${MKOSI_PACKAGE_CACHE_DIR} build",
 ]
 
 [tasks.mkosi-copy-qcow-imager-to-webroot-x86_64]

--- a/scripts/check-repo-clean.sh
+++ b/scripts/check-repo-clean.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 context="${1:-Repository check}"
+remediation="${2:-}"
 
 if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
 	git config --global --add safe.directory "$(pwd -P)"
@@ -17,7 +18,12 @@ if git diff --quiet --exit-code && [[ -z "${untracked}" ]]; then
 	exit 0
 fi
 
-echo "::error::${context} left uncommitted changes. Regenerate and commit the results."
+message="${context} left uncommitted changes. Regenerate and commit the results."
+if [[ -n "${remediation}" ]]; then
+	message="${message} To fix, run: ${remediation}"
+fi
+
+echo "::error::${message}"
 echo
 echo "Changed files:"
 git status --porcelain


### PR DESCRIPTION
Currently CI pipelines are taking ~1hr when certain code paths are touched. This PR enhances caching strategies to reduce producing the same outputs in various jobs. It also cuts down on artifact storage that are unlikely to be used anywhere.

The expected new runtime once cache is populated by post-merge `main` pipeline ~25m

One important change is that image build no longer waits on lint-police, allowing it to start early.

> [!NOTE]
> GitHub Actions Cache size for this repo has been increase from `10GB` to `50GB` (maximum allowed by NVIDIA org)

## Related issues
This supports https://github.com/NVIDIA/infra-controller/issues/4574

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Cuts CI wall-clock time using the following. No application code changes.
- **Caching that was silently inert.** `setup-buildx-action` only ran when pushing, and the default docker driver cannot export a build cache, so PR builds never reused layers. Buildx now runs unconditionally, `cache-to` is no longer gated on `push`, and the layer cache is scoped per image and arch instead of sharing one namespace. sccache's BuildKit cache mount was discarded with the per-job builder; it now uses the Actions cache service, with the runtime token re-exported via first-party `actions/github-script` and passed in as a BuildKit secret. The `test-release-container-services` job bind-mounted an sccache dir that nothing ever persisted; it now uses `actions/cache`.
- **Artifact traffic.** The boot/ephemeral jobs uploaded the cargo `target/` tree and `pxe/mkosi.profiles/` wholesale (~14 GB of upload plus download on the critical path). Nothing downstream reads them: the ephemeral build consumes the packaged `.deb`, and the release-artifacts carriers only `COPY pxe/static/blobs/internal/`. Uploads are now limited to consumed paths plus the unstripped `forge-scout` for symbolication, and consumers fetch only their own arch via a new `artifact_pattern` input.
- **Serialization.** `build-release-container-x86_64` no longer waits on `lint-police`, which put ~11m of linting in front of a ~29m build for no dependency. `core-ci-pass` still gates the merge on lint independently.
- **Also:** mkosi package cache persisted across runs; `cargo-make` binary cached instead of compiled from source every run.

Closes #4574
