### PR TITLE
fix(api): bound admission to the admin-segment advisory lock (fixes #4297)

### DIFF
--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -454,6 +454,10 @@ pub async fn discover_dhcp(
     api: &Api,
     request: Request<rpc::DhcpDiscovery>,
 ) -> Result<Response<rpc::DhcpRecord>, CarbideError> {
+    // Admission permit BEFORE the first transaction: the interface/address
+    // lookups below can wait on segment advisory locks, so a waiter here
+    // pins a pool connection exactly like the allocation path does.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     let rpc::DhcpDiscovery {
@@ -887,10 +891,9 @@ pub async fn discover_dhcp(
         return Ok(Response::new(record));
     }
 
-    // Admission permit BEFORE the transaction: the allocation path below
-    // serializes on exclusive segment advisory locks, and at fleet-DHCP scale
-    // unbounded waiters pin every pool connection (see #4297's wedge).
-    let _admin_admission = db::machine_interface::admin_lock_admission().await;
+    // Permit from the top of discover_dhcp is still held here; the earlier
+    // transaction committed, but the allocation path below takes the same
+    // segment locks, so one permit covers the whole request.
     let mut txn = api.txn_begin().await?;
 
     let record = db::dhcp_record::find_by_mac_address(

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -887,6 +887,10 @@ pub async fn discover_dhcp(
         return Ok(Response::new(record));
     }
 
+    // Admission permit BEFORE the transaction: the allocation path below
+    // serializes on exclusive segment advisory locks, and at fleet-DHCP scale
+    // unbounded waiters pin every pool connection (see #4297's wedge).
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     let record = db::dhcp_record::find_by_mac_address(

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -638,6 +638,9 @@ pub(crate) async fn admin_force_delete_machine(
         }
     }
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
     let mut machines_to_clear_credentials = Vec::new();
 

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -103,6 +103,9 @@ pub(crate) async fn discover_machine(
         None
     };
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     // Advisory-lock the admin segments before any machine-interface row

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -132,6 +132,9 @@ async fn set_primary_interface_core(
         .into());
     }
 
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
 
     // Site Explorer takes these locks before it changes interface ownership.

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2338,11 +2338,16 @@ static ADMIN_LOCK_ADMISSION: std::sync::OnceLock<std::sync::Arc<tokio::sync::Sem
 /// of on connections. Permits: `ADMIN_LOCK_ADMISSION` env var, default 16.
 pub async fn admin_lock_admission() -> tokio::sync::OwnedSemaphorePermit {
     let sem = ADMIN_LOCK_ADMISSION.get_or_init(|| {
+        // Clamp to a sane range: 0 would deadlock every gated flow, and a
+        // value at or above the pool size defeats the gate's purpose (the
+        // waiters it is meant to keep off connections would all be admitted).
+        const DEFAULT_PERMITS: usize = 16;
+        const MAX_PERMITS: usize = 256;
         let permits = std::env::var("ADMIN_LOCK_ADMISSION")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
-            .filter(|n| *n > 0)
-            .unwrap_or(16);
+            .map(|n| n.clamp(1, MAX_PERMITS))
+            .unwrap_or(DEFAULT_PERMITS);
         std::sync::Arc::new(tokio::sync::Semaphore::new(permits))
     });
     sem.clone()

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2324,6 +2324,33 @@ pub async fn lock_all_admin_segments(txn: &mut PgConnection) -> DatabaseResult<(
     lock_network_segments_exclusive(txn, &segment_ids).await
 }
 
+static ADMIN_LOCK_ADMISSION: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+    std::sync::OnceLock::new();
+
+/// Admission gate for the `lock_all_admin_segments` flows. The admin-segment
+/// advisory locks serialize those transactions anyway; without a gate, every
+/// waiter parks *inside* an open transaction, pinning a pool connection while
+/// blocked on the lock. At fleet-ingestion scale that queue grows past
+/// Postgres `max_connections` and the whole system wedges (registration,
+/// exploration, and the state controllers all starve; see the 4,500-host
+/// ingestion wedge). Acquire this permit BEFORE opening the transaction and
+/// hold it until commit/rollback, so excess waiters queue in memory instead
+/// of on connections. Permits: `ADMIN_LOCK_ADMISSION` env var, default 16.
+pub async fn admin_lock_admission() -> tokio::sync::OwnedSemaphorePermit {
+    let sem = ADMIN_LOCK_ADMISSION.get_or_init(|| {
+        let permits = std::env::var("ADMIN_LOCK_ADMISSION")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|n| *n > 0)
+            .unwrap_or(16);
+        std::sync::Arc::new(tokio::sync::Semaphore::new(permits))
+    });
+    sem.clone()
+        .acquire_owned()
+        .await
+        .expect("admin-lock admission semaphore is never closed")
+}
+
 pub async fn allocate_svi_ip(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -218,6 +218,9 @@ impl MachineCreator {
                 None
             };
 
+        // Admission permit BEFORE the transaction: waiters on the admin-segment
+        // advisory lock must queue in memory, not on open pool connections.
+        let _admin_admission = db::machine_interface::admin_lock_admission().await;
         let mut txn = Transaction::begin(pool).await?;
 
         // Advisory-lock the admin segments before any machine-interface row


### PR DESCRIPTION
Fixes #4297.

### The problem

Every flow that calls `lock_all_admin_segments` (managed-host registration, machine discovery, machine deletion, site-explorer machine creation) takes exclusive advisory locks over all admin segments — and each waiter **parks inside an open transaction, pinning a pool connection while it blocks**.

At fleet-ingestion scale that queue grows past Postgres `max_connections` (1,024) and the system deadlocks. Measured on dev6 at 4,500 hosts × 2 DPUs:

- interface registration froze at **7,652 / 13,500**
- exploration froze at 360 endpoints; **zero machines** were ever created
- even superuser `psql` was refused (`sorry, too many clients already`)
- nico-api starved its own state controllers: `pool timed out while waiting for an open connection`

For scale, the same configuration at 1,000 hosts (3,000 machines) completes at ~138 machines/min and ends at ~250 connections. 4.5× the machine count doesn't slow down — it stops.

### The change

An admission semaphore acquired **before** opening the transaction at all five lock-taking call sites, so excess waiters queue in memory instead of on connections. Lock semantics, ordering, and hold duration are unchanged; the gate only bounds how many transactions may be queued on the lock at once. Width is configurable via `ADMIN_LOCK_ADMISSION` (default 16).

The second commit extends the same permit to the DHCP allocation path, which has its own segment-lock transactions — with only the first four sites gated, the wedge simply re-formed there (at 4,845 interfaces).

### Validation

With this change, connections stay bounded at **170–274 across multi-hour runs** at 4,500 hosts, and ingestion proceeds end-to-end: 6,700+ machines created, 3,663 reaching `ready`, no wedge at any point.

### What this does *not* fix

Throughput. A controlled A/B on a live 4,500-host fleet widened the gate 4× (16 → 64 permits): throughput did **not** improve, it fell (2.1 → 1.2 machines/min), while waiters scaled with the permit count and saturated at both settings (14/16 and 48.5/64). Individual transactions were observed holding the lock for up to **210 s**.

So the remaining limiter is lock **hold time**, not admission width — the reconcile pass inside the lock grows with fleet size. That work belongs to #3721 (per-segment sharding, incremental reconcile). This PR is the robustness fix that keeps the system from deadlocking meanwhile, and remains worthwhile afterwards as a safety net.

Part of #3738.
