### PR TITLE
feat(machine-a-tron): ingestion-scale test harness and 4,500-host multipod values

### DIFF
--- a/dev/k8s/dpf-sim-controller/Makefile
+++ b/dev/k8s/dpf-sim-controller/Makefile
@@ -71,7 +71,9 @@ install-crds: ## Install ONLY the DPF CRDs the simulator drives (never the opera
 	kubectl apply -f $(CRD_DIR)
 	# apply returns before discovery serves the new types; starting the
 	# manager that early fails its cache/watch init on a fresh cluster.
-	kubectl wait --for condition=established --timeout=60s -f $(CRD_DIR)
+	# 300s: right after a full site reinstall the apiserver can be slow
+	# enough that already-established CRDs miss a 60s wait window.
+	kubectl wait --for condition=established --timeout=300s -f $(CRD_DIR)
 
 .PHONY: deploy
 deploy: install-crds ## One-command deploy: CRDs + RBAC + Deployment (override IMG=, DPF_NAMESPACE=, PULL_SECRET=)

--- a/dev/k8s/dpf-sim-controller/README.md
+++ b/dev/k8s/dpf-sim-controller/README.md
@@ -123,26 +123,29 @@ compatible. `crates/dpf/crds/` is that version.
 
 ## Quick start (against a machine-a-tron cluster)
 
-> **The usual path is automatic:** `helm-prereqs/setup-machine-a-tron.sh`
-> deploys this simulator by default (Phase 4b) whenever the nico-core config
-> has `[dpf] enabled = true` — including the DPF CRDs, the `nico-api-dpf`
-> RBAC, and the `CARBIDE_API_ALLOW_INSECURE_DISCOVERY` flag — using
-> `DPF_SIM_IMAGE` (or `${NICO_IMAGE_REGISTRY}/dpf-sim-controller:latest`).
-> On a site without DPF enabled the phase is a no-op, and it hard-fails if
-> the REAL DPF operator is deployed (both would drive `DPU.status.phase` —
-> **Installing NICo alongside this simulator: use `setup.sh --skip-dpf`.**
-> The simulator applies the DPF CRDs itself (`make install-crds`), so letting
-> `setup.sh` also helm-install `dpf-operator` makes Helm try to adopt CRDs it
-> does not own and the install fails with *"exists and cannot be imported into
-> the current release: missing key app.kubernetes.io/managed-by"*. This only
-> shows up on a genuinely clean cluster — an environment that previously ran a
-> real DPF install has Helm-labelled CRDs already, which masks the collision.
-> Likewise, do not pre-create the `nico-api-dpf` Role/RoleBinding: the
-> `nico-api` chart owns those (`dpf.rbacCreate`), and a hand-applied copy blocks
-> the whole `nico` release the same way.
+**The usual path is automatic:** `helm-prereqs/setup-machine-a-tron.sh`
+deploys this simulator by default (Phase 4b) whenever the nico-core config
+has `[dpf] enabled = true`, using the `DPF_SIM_IMAGE`
+(or `${NICO_IMAGE_REGISTRY}/dpf-sim-controller:latest`). This includes the
+DPF CRDs, the `nico-api-dpf` RBAC, and the `CARBIDE_API_ALLOW_INSECURE_DISCOVERY`
+flag.
 
-> remove the operator, or pass `--skip-dpf-sim` to keep it). The manual
-> steps below remain for iterating on the simulator itself.
+On a site without DPF enabled, the phase is a no-op, and it hard-fails if
+the REAL DPF operator is deployed (both would drive `DPU.status.phase` —
+remove the operator, or pass `--skip-dpf-sim` to keep it). The manual
+steps below remain for iterating on the simulator itself.
+
+**Installing NICo alongside this simulator: use `setup.sh --skip-dpf`.**
+The simulator applies the DPF CRDs itself (`make install-crds`), so letting
+`setup.sh` also helm-install `dpf-operator` makes Helm try to adopt CRDs it
+does not own and the install fails with an `exists and cannot be imported into
+the current release: missing key app.kubernetes.io/managed-by` error. This only
+shows up on a genuinely clean cluster: an environment that previously ran a
+real DPF install has Helm-labelled CRDs already, which masks the collision.
+
+Likewise, do not pre-create the `nico-api-dpf` Role/RoleBinding: the
+`nico-api` chart owns those (`dpf.rbacCreate`), and a hand-applied copy blocks
+the whole `nico` release the same way.
 
 ```bash
 export KUBECONFIG=/path/to/site/kubeconfig

--- a/dev/k8s/dpf-sim-controller/README.md
+++ b/dev/k8s/dpf-sim-controller/README.md
@@ -130,6 +130,17 @@ compatible. `crates/dpf/crds/` is that version.
 > `DPF_SIM_IMAGE` (or `${NICO_IMAGE_REGISTRY}/dpf-sim-controller:latest`).
 > On a site without DPF enabled the phase is a no-op, and it hard-fails if
 > the REAL DPF operator is deployed (both would drive `DPU.status.phase` —
+> **Installing NICo alongside this simulator: use `setup.sh --skip-dpf`.**
+> The simulator applies the DPF CRDs itself (`make install-crds`), so letting
+> `setup.sh` also helm-install `dpf-operator` makes Helm try to adopt CRDs it
+> does not own and the install fails with *"exists and cannot be imported into
+> the current release: missing key app.kubernetes.io/managed-by"*. This only
+> shows up on a genuinely clean cluster — an environment that previously ran a
+> real DPF install has Helm-labelled CRDs already, which masks the collision.
+> Likewise, do not pre-create the `nico-api-dpf` Role/RoleBinding: the
+> `nico-api` chart owns those (`dpf.rbacCreate`), and a hand-applied copy blocks
+> the whole `nico` release the same way.
+
 > remove the operator, or pass `--skip-dpf-sim` to keep it). The manual
 > steps below remain for iterating on the simulator itself.
 

--- a/docs/development/machine-a-tron-ingestion-tuning-plan.md
+++ b/docs/development/machine-a-tron-ingestion-tuning-plan.md
@@ -1,0 +1,66 @@
+# Ingestion tuning plan: one knob at a time
+
+Goal: make machine-ingestion time scale linearly with fleet size, by measuring
+the effect of each throughput knob in isolation. Companion to
+[machine-a-tron-scale-testing.md](machine-a-tron-scale-testing.md).
+
+## Knob inventory
+
+| # | Knob (TOML path) | Default | Scale-script value | Consumed in |
+|---|------------------|---------|--------------------|-------------|
+| K1 | `site_explorer.run_interval` | 120s | *(not overridden)* | `crates/site-explorer/src/lib.rs` — period of the explore→identify→create cycle |
+| K2 | `site_explorer.concurrent_explorations` | 30 | 100 | `lib.rs:2294` — semaphore width for parallel Redfish probes per cycle |
+| K3 | `site_explorer.explorations_per_run` | 90 | 120 | `lib.rs:2218` — cap on routine endpoints selected per cycle |
+| K4 | `site_explorer.machines_created_per_run` | 4 | 40 | `machine_creator.rs:106` — hard cap on managed hosts created per cycle |
+| K5 | `firmware_global.concurrency_limit` | 16 | *(not overridden)* | preingestion-manager — concurrent endpoint transactions (NOT a batch cap; all eligible endpoints are processed each 30s run, ≤N at a time). Also caps firmware flashing concurrency. |
+| K6 | `firmware_global.run_interval` | 30s | *(not overridden)* | preingestion loop period |
+| K7 | `state_controller.max_concurrency` | 10 | *(not overridden)* | `state-controller/src/controller/processor.rs:194` — parallel object state-machine tasks (hostinit/dpuinit advancement). Effective ceiling ≈100: `COMMAND_BUFFER_SIZE = 100` in `api-db/src/work_lock_manager.rs:33` is a hard-coded constant every work unit round-trips through. |
+
+Throughput model (creation phase): `hosts_per_hour ≈ K4 × (3600 / K1_secs)`,
+provided the cycle actually completes within `K1` (K3 too high breaks this —
+see issue 17). Defaults give 120 hosts/h; current scale settings give 1,200
+hosts/h → ~3.75 h floor for 4,500 hosts, consistent with observed runs.
+
+## Method
+
+- **Fleet**: 1000 hosts × 2 DPUs (3000 endpoints) for iteration speed; confirm
+  the winning combination at 4500×2 = 13,500.
+- **One knob per run.** Full `cleanup-machine-a-tron.sh -y` between runs so
+  every run starts from an identical state.
+- **Instrumentation first (run 0)**: sample the four pipeline counters
+  (explored / preingestion-complete / hosts / machines) plus site-explorer
+  cycle duration every 30–60 s into a CSV from the verification loop, so each
+  run yields per-phase rate curves, not just total wall clock.
+- **Record per run**: knob values, end-to-end wall clock, per-phase windows
+  (DHCP / exploration / preingestion / creation / init), postgres CPU, any
+  AvoidLockout or error storms, whether explore cycles complete within
+  `run_interval`.
+
+## Run matrix
+
+Baseline B0 = current scale settings (K1=120s, K2=100, K3=120, K4=40,
+K5=16, K6=30s, K7=10).
+
+| Run | Change vs B0 | Hypothesis / watch for |
+|-----|--------------|------------------------|
+| E1 | K1 120s → 30s | ~4× cycle rate → creation and sweep cadence up. Watch: does a cycle finish in <30 s, or do iterations back up? DB load. |
+| E2 | K4 40 → 100 | Creation per cycle up 2.5×. Watch: cycle-time inflation (creation runs inside the cycle — the known "big gating factor" of raising it too high). |
+| E3 | K3 120 → 240 → 360 | Faster sweep of unexplored endpoints. Known cliff: 400 stopped cycles completing. Find the knee. |
+| E4 | K2 100 → 200 → 400 | More parallel probes. Watch: bmc-mock/proxy saturation, exploration error rate. |
+| E5 | K5 16 → 32 → 64 | Preingestion width; matters most in the preingestion-heavy window at 13.5k endpoints. |
+| E6 | K7 10 → 50 → 100 | Faster hostinit/dpuinit advancement. Do NOT exceed 100 (work-lock channel). Watch: DB contention, work-lock channel pressure. |
+| E7 | Combine winners | Verify effects compose; then rerun at 4500 hosts. |
+
+Order rationale: E1/E2 first because K1×K4 sets the hard creation ceiling;
+E3/E4 shape the exploration tail; E5/E7 target the phases that dominate only
+at 13.5k scale.
+
+## Open items
+
+- Ask Matthias Einwag whether `COMMAND_BUFFER_SIZE = 100`
+  (`work_lock_manager.rs`) should become configurable before pushing K7
+  toward 100.
+- `site_explorer.run_interval`'s doc comment says "5 Minutes" but the default
+  is 120 s — fix the comment while we're in there.
+- Add env-var overrides in `setup-machine-a-tron.sh` for K1/K5/K6/K7 (K2–K4
+  already have them) so runs are scriptable.

--- a/docs/development/machine-a-tron-ingestion-tuning-plan.md
+++ b/docs/development/machine-a-tron-ingestion-tuning-plan.md
@@ -4,6 +4,11 @@ Goal: make machine-ingestion time scale linearly with fleet size, by measuring
 the effect of each throughput knob in isolation. Companion to
 [machine-a-tron-scale-testing.md](machine-a-tron-scale-testing.md).
 
+> Developer working notes, deliberately not registered in `docs/index.yml` —
+> same treatment as the scale-testing companion above. Tracked under epic
+> NVIDIA/infra-controller#3738; per-knob results are recorded on the
+> subtickets #3758-#3763.
+
 ## Knob inventory
 
 | # | Knob (TOML path) | Default | Scale-script value | Consumed in |
@@ -18,7 +23,7 @@ the effect of each throughput knob in isolation. Companion to
 
 Throughput model (creation phase): `hosts_per_hour ≈ K4 × (3600 / K1_secs)`,
 provided the cycle actually completes within `K1` (K3 too high breaks this —
-see issue 17). Defaults give 120 hosts/h; current scale settings give 1,200
+see the K3 row below and NVIDIA/infra-controller#3758). Defaults give 120 hosts/h; current scale settings give 1,200
 hosts/h → ~3.75 h floor for 4,500 hosts, consistent with observed runs.
 
 ## Method
@@ -57,9 +62,8 @@ at 13.5k scale.
 
 ## Open items
 
-- Ask Matthias Einwag whether `COMMAND_BUFFER_SIZE = 100`
-  (`work_lock_manager.rs`) should become configurable before pushing K7
-  toward 100.
+- Decide whether `COMMAND_BUFFER_SIZE = 100` (`work_lock_manager.rs`) should
+  become configurable before pushing K7 toward 100.
 - `site_explorer.run_interval`'s doc comment says "5 Minutes" but the default
   is 120 s — fix the comment while we're in there.
 - Add env-var overrides in `setup-machine-a-tron.sh` for K1/K5/K6/K7 (K2–K4

--- a/helm-prereqs/ingestion-rate-report.sh
+++ b/helm-prereqs/ingestion-rate-report.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# ingestion-rate-report.sh — exact ingestion curves from the DB's own clocks
+#
+# The Phase 10 CSV (setup-machine-a-tron.sh, #3756) samples counters and so
+# measures rates as floors. This report instead reads timestamps the pipeline
+# itself recorded, which makes runs exactly comparable for the #3738 knob
+# campaign:
+#   * machines.created            → machine-creation curve (per-minute + p50/p90 gap)
+#   * machine_interfaces.created  → interface registration curve
+# Output is plain text; pass --csv for machine-readable per-minute buckets.
+#
+# Environment (defaults match setup-machine-a-tron.sh):
+#   KUBECONFIG, POSTGRES_NS (postgres), NICO_DB (nico_system_nico)
+# =============================================================================
+set -euo pipefail
+
+POSTGRES_NS="${POSTGRES_NS:-postgres}"
+NICO_DB="${NICO_DB:-nico_system_nico}"
+CSV=false
+[[ "${1:-}" == "--csv" ]] && CSV=true
+
+PG="$(kubectl get pods -n "$POSTGRES_NS" -l application=spilo \
+    -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' 2>/dev/null \
+    | awk '$2=="master"{print $1}' | head -1)"
+[[ -n "$PG" ]] || { echo "ERROR: no Patroni primary in $POSTGRES_NS" >&2; exit 1; }
+q() { kubectl exec -n "$POSTGRES_NS" "$PG" -- su postgres -c "psql -d $NICO_DB -v ON_ERROR_STOP=1 -tAc \"$1\"" 2>/dev/null; }
+
+report_curve() {   # $1 = table  $2 = label
+    local tbl="$1" label="$2"
+    local stats
+    stats="$(q "SELECT count(*) || '|' || min(created) || '|' || max(created) || '|' ||
+        round(extract(epoch FROM (max(created) - min(created)))) || '|' ||
+        round(extract(epoch FROM (percentile_cont(0.5) WITHIN GROUP (ORDER BY created) - min(created)))) || '|' ||
+        round(extract(epoch FROM (percentile_cont(0.9) WITHIN GROUP (ORDER BY created) - min(created))))
+        FROM ${tbl};")"
+    [[ -n "$stats" ]] || { echo "${label}: no rows"; return; }
+    IFS='|' read -r n first last span p50 p90 <<< "$stats"
+    echo "${label}: ${n} rows over ${span}s (first ${first}, last ${last})"
+    echo "  p50 at +${p50}s, p90 at +${p90}s, avg $(awk -v n="$n" -v s="$span" 'BEGIN{printf (s>0)?"%.1f":"n/a", n*60/s}')/min"
+    if $CSV; then
+        echo "  per-minute buckets (${label}):"
+        q "SELECT date_trunc('minute', created) || ',' || count(*)
+           FROM ${tbl} GROUP BY 1 ORDER BY 1;" | sed 's/^/    /'
+    fi
+}
+
+report_curve machines "machines.created"
+report_curve machine_interfaces "machine_interfaces.created"
+
+# Terminal-state distribution for context (a knob that destabilizes the
+# pipeline shows up as machines wedged mid-state, not just as a slower rate).
+echo "state distribution:"
+q "SELECT '  ' || coalesce(controller_state->>'state','?') || ': ' || count(*)
+   FROM machines GROUP BY 1 ORDER BY 2 DESC;"

--- a/helm-prereqs/ingestion-rate-report.sh
+++ b/helm-prereqs/ingestion-rate-report.sh
@@ -62,7 +62,7 @@ report_curve() {   # $1 = table  $2 = label
     [[ -n "$stats" ]] || { echo "${label}: no rows"; return; }
     IFS='|' read -r n first last span p50 p90 <<< "$stats"
     echo "${label}: ${n} rows over ${span}s (first ${first}, last ${last})"
-    echo "  p50 at +${p50}s, p90 at +${p90}s, avg $(awk -v n="$n" -v s="$span" 'BEGIN{printf (s>0)?"%.1f":"n/a", n*60/s}')/min"
+    echo "  p50 at +${p50}s, p90 at +${p90}s, avg $(awk -v n="$n" -v s="$span" 'BEGIN{ if (s>0) printf "%.1f", n*60/s; else printf "n/a" }')/min"
     if $CSV; then
         echo "  per-minute buckets (${label}):"
         q "SELECT date_trunc('minute', created) || ',' || count(*)

--- a/helm-prereqs/ingestion-rate-report.sh
+++ b/helm-prereqs/ingestion-rate-report.sh
@@ -39,7 +39,17 @@ PG="$(kubectl get pods -n "$POSTGRES_NS" -l application=spilo \
     -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' 2>/dev/null \
     | awk '$2=="master"{print $1}' | head -1)"
 [[ -n "$PG" ]] || { echo "ERROR: no Patroni primary in $POSTGRES_NS" >&2; exit 1; }
-q() { kubectl exec -n "$POSTGRES_NS" "$PG" -- su postgres -c "psql -d $NICO_DB -v ON_ERROR_STOP=1 -tAc \"$1\"" 2>/dev/null; }
+# Surface query failures rather than returning an empty string that later
+# parses as a zero row.
+q() {
+    local out rc
+    out="$(kubectl exec -n "$POSTGRES_NS" "$PG" -- su postgres -c "psql -d $NICO_DB -v ON_ERROR_STOP=1 -tAc \"$1\"" 2>&1)"; rc=$?
+    if (( rc != 0 )); then
+        echo "ERROR: query failed (rc=$rc): ${out}" >&2
+        return "$rc"
+    fi
+    printf '%s' "$out"
+}
 
 report_curve() {   # $1 = table  $2 = label
     local tbl="$1" label="$2"

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -122,6 +122,15 @@
 #                          Default: <repo>/helm/charts/nico-machine-a-tron
 #   VALUES_FILE            Base values template.
 #                          Default: <this dir>/values/machine-a-tron.yaml
+#   SCALE_RUN_INTERVAL     Tuning override (#3738): [site_explorer] run_interval
+#                          (e.g. "30s"). Unset = leave the site's value.
+#   SCALE_FW_CONCURRENCY   Tuning override: [firmware_global] concurrency_limit.
+#   SCALE_FW_RUN_INTERVAL  Tuning override: [firmware_global] run_interval.
+#   SCALE_STATE_MAX_CONCURRENCY
+#                          Tuning override: [machine_state_controller.controller]
+#                          max_concurrency (parallel state-machine tasks).
+#   INGEST_RATE_CSV        Where the Phase 10 loop writes its per-sample
+#                          ingestion counters (CSV). Default: a file under /tmp.
 #   DPF_SIM_IMAGE          dpf-sim-controller image ref for Phase 4b. Default:
 #                          ${NICO_IMAGE_REGISTRY}/dpf-sim-controller:${DPF_SIM_IMAGE_TAG}
 #   DPF_SIM_IMAGE_TAG      Tag for the derived default above. Default: latest
@@ -626,14 +635,19 @@ elif [[ "$MAT_MODE" == "scale" ]]; then
         SCALE_RESERVE="$SCALE_RESERVE" \
         BMC_PROXY="${BMC_MOCK_FQDN}:${BMC_MOCK_PORT}" \
         KNOB_CONC="$SCALE_CONCURRENT_EXPLORATIONS" KNOB_EPR="$SCALE_EXPLORATIONS_PER_RUN" \
-        KNOB_MCPR="$SCALE_MACHINES_CREATED_PER_RUN" python3 - "$CM_JSON" <<'PY'
+        KNOB_MCPR="$SCALE_MACHINES_CREATED_PER_RUN" \
+        KNOB_SE_RUN_INTERVAL="${SCALE_RUN_INTERVAL:-}" \
+        KNOB_FW_CONC="${SCALE_FW_CONCURRENCY:-}" \
+        KNOB_FW_RUN_INTERVAL="${SCALE_FW_RUN_INTERVAL:-}" \
+        KNOB_STATE_CONC="${SCALE_STATE_MAX_CONCURRENCY:-}" \
+        python3 - "$CM_JSON" <<'PY'
 import json, os, sys
 path = sys.argv[1]
 cm = json.load(open(path))
 env = os.environ
 # lines managed by this script inside [site_explorer]
-drop = ("bmc_proxy", "override_target_host", "override_target_ip", "override_target_port",
-        "concurrent_explorations", "explorations_per_run", "machines_created_per_run")
+drop = ["bmc_proxy", "override_target_host", "override_target_ip", "override_target_port",
+        "concurrent_explorations", "explorations_per_run", "machines_created_per_run"]
 knobs = [
     # PROXY-DIRECT: the Redfish client injects "Forwarded: host=<BMC IP>"
     # whenever bmc_proxy is set; the mock's registry routes on it. One
@@ -648,6 +662,28 @@ knobs = [
     f'      explorations_per_run = {env["KNOB_EPR"]}',
     f'      machines_created_per_run = {env["KNOB_MCPR"]}',
 ]
+# Optional tuning override (issue #3738): the explore->create cycle period.
+# Only managed when explicitly set, so default runs keep the site's value.
+if env.get("KNOB_SE_RUN_INTERVAL"):
+    drop.append("run_interval")   # scoped to [site_explorer] by insertion point
+    knobs.append(f'      run_interval = "{env["KNOB_SE_RUN_INTERVAL"]}"')
+
+# Optional tuning overrides living OUTSIDE [site_explorer] (issue #3738):
+# managed as a sentinel-delimited tail block that each run regenerates. A
+# duplicate TOML table would be a parse error, so refuse if the operator
+# already defines these sections outside our block.
+TUNING_BEGIN = "# --- BEGIN scale tuning overrides (managed by setup-machine-a-tron.sh) ---"
+TUNING_END   = "# --- END scale tuning overrides ---"
+tuning = []
+if env.get("KNOB_FW_CONC") or env.get("KNOB_FW_RUN_INTERVAL"):
+    tuning.append("[firmware_global]")
+    if env.get("KNOB_FW_CONC"):
+        tuning.append(f'concurrency_limit = {env["KNOB_FW_CONC"]}')
+    if env.get("KNOB_FW_RUN_INTERVAL"):
+        tuning.append(f'run_interval = "{env["KNOB_FW_RUN_INTERVAL"]}"')
+if env.get("KNOB_STATE_CONC"):
+    tuning.append("[machine_state_controller.controller]")
+    tuning.append(f'max_concurrency = {env["KNOB_STATE_CONC"]}')
 networks = f'''
 # --- simulated networks for machine-a-tron scale testing (managed by
 # --- setup-machine-a-tron.sh --scale; safe to leave in place) ---
@@ -675,9 +711,21 @@ for k, v in cm["data"].items():
     if "[site_explorer]" not in v:
         continue
     out, in_lo = [], False
-    for ln in v.splitlines():
+    # Strip any previously-managed tuning block before re-rendering.
+    if TUNING_BEGIN in v:
+        pre, _, rest = v.partition(TUNING_BEGIN)
+        _, _, post = rest.partition(TUNING_END)
+        v_work = pre.rstrip("\n") + "\n" + post.lstrip("\n")
+    else:
+        v_work = v
+    in_sec = ""
+    for ln in v_work.splitlines():
         s = ln.strip()
-        if any(t in ln for t in drop):
+        if s.startswith("["):
+            in_sec = s
+        # drop-list is scoped: managed [site_explorer] keys only there, so a
+        # run_interval belonging to another section is never touched.
+        if in_sec == "[site_explorer]" and any(t in ln for t in drop) and not s.startswith("["):
             continue
         if s.startswith("[pools."):
             in_lo = (s == "[pools.lo-ip]")
@@ -687,9 +735,15 @@ for k, v in cm["data"].items():
         out.append(ln)
         if s == "[site_explorer]":
             out.extend(knobs)
-    new = "\n".join(out) + ("\n" if v.endswith("\n") else "")
+    new = "\n".join(out) + ("\n" if v_work.endswith("\n") else "")
     if "[networks.simulated-oob]" not in new:
         new = new.rstrip("\n") + "\n" + networks
+    if tuning:
+        for header in ("[firmware_global]", "[machine_state_controller"):
+            if any(l.strip().startswith(header) for l in new.splitlines()):
+                sys.stderr.write(f"ERROR: {header} already defined in the site config outside the managed block; set the knob there instead\n")
+                sys.exit(3)
+        new = new.rstrip("\n") + "\n\n" + TUNING_BEGIN + "\n" + "\n".join(tuning) + "\n" + TUNING_END + "\n"
     if new != v:
         cm["data"][k] = new
         changed = True
@@ -707,6 +761,8 @@ PY
             || warn "nico-api rollout did not complete in time; continuing"
         ok "scale networks: oob ${SCALE_OOB_PREFIX} (gw ${SCALE_OOB_GW}), admin ${SCALE_ADMIN_PREFIX} (gw ${SCALE_ADMIN_GW})"
         ok "site_explorer knobs: concurrent=${SCALE_CONCURRENT_EXPLORATIONS} per_run=${SCALE_EXPLORATIONS_PER_RUN} create/run=${SCALE_MACHINES_CREATED_PER_RUN}"
+        [[ -n "${SCALE_RUN_INTERVAL:-}${SCALE_FW_CONCURRENCY:-}${SCALE_FW_RUN_INTERVAL:-}${SCALE_STATE_MAX_CONCURRENCY:-}" ]] && \
+            ok "tuning overrides (#3738): se.run_interval=${SCALE_RUN_INTERVAL:-·} fw.concurrency=${SCALE_FW_CONCURRENCY:-·} fw.run_interval=${SCALE_FW_RUN_INTERVAL:-·} state.max_concurrency=${SCALE_STATE_MAX_CONCURRENCY:-·}"
     else
         ok "scale config already in place"
     fi
@@ -1193,15 +1249,39 @@ ok "cleared exploration lockouts + requested re-exploration"
 MACHINE_TARGET=$(( HOST_COUNT * (1 + DPU_PER_HOST) ))
 MACHINE_WAIT=$(( 420 + HOST_COUNT * 3 )); (( MACHINE_WAIT > 5400 )) && MACHINE_WAIT=5400
 info "waiting for explore → rotate → preingest → identify → create (target ${MACHINE_TARGET} machines, up to ${MACHINE_WAIT}s)..."
+
+# --- per-phase ingestion rate instrumentation (#3756) -----------------------
+# One CSV row per sample; counters are cumulative so post-processing derives
+# per-phase rates as deltas. `epoch` is wall-clock so rows from different runs
+# and the DB's own machines.created timestamps line up exactly. Effective knob
+# values are embedded as header comments so every CSV is self-describing.
+INGEST_RATE_CSV="${INGEST_RATE_CSV:-/tmp/mat-ingestion-rates-$(date +%Y%m%d-%H%M%S).csv}"
+{
+    echo "# setup-machine-a-tron ingestion rates  host_count=${HOST_COUNT} dpu_per_host=${DPU_PER_HOST} mode=${MAT_MODE}"
+    _KNOBS="$(kubectl get cm nico-api-site-config-files -n "$NICO_SYSTEM_NS" \
+        -o jsonpath='{.data.nico-api-site-config\.toml}' 2>/dev/null \
+        | grep -vE '^[[:space:]]*#' \
+        | grep -E 'run_interval|concurrent_explorations|explorations_per_run|machines_created_per_run|concurrency_limit|max_concurrency|max_concurrent_machine_updates' \
+        | sed 's/^[[:space:]]*//' | tr '\n' ';' )"
+    echo "# effective_knobs: ${_KNOBS}"
+    echo "epoch,dhcp_addresses,endpoints_ok,managed_hosts,machines,machines_ready"
+} > "$INGEST_RATE_CSV"
+info "per-phase rate samples → ${INGEST_RATE_CSV}"
+
 _end=$((SECONDS+MACHINE_WAIT)); MACHINES=0
 while (( SECONDS < _end )); do
-    MACHINES="$(psql_count "SELECT count(*) FROM machines;")"
-    (( MACHINES >= MACHINE_TARGET )) && break
-    # single round-trip for the progress line
+    # single round-trip for the progress line AND the CSV sample
     _prog="$(psql_q "SELECT
+        (SELECT count(*) FROM machine_interface_addresses) || '/' ||
         (SELECT count(*) FILTER (WHERE exploration_report->'LastExplorationError' = 'null'::jsonb) FROM explored_endpoints) || '/' ||
-        (SELECT count(*) FROM explored_managed_hosts);" || echo '?/?')"
-    info "  endpoints_ok=${_prog%%/*}/${IFACES}  managed_hosts=${_prog##*/}  machines=${MACHINES} ..."
+        (SELECT count(*) FROM explored_managed_hosts) || '/' ||
+        (SELECT count(*) FROM machines) || '/' ||
+        (SELECT count(*) FROM machines WHERE controller_state->>'state' = 'ready');" || echo '?/?/?/?/?')"
+    IFS=/ read -r _dhcp _eok _mh MACHINES _rdy <<< "$_prog"
+    MACHINES="${MACHINES:-0}"; [[ "$MACHINES" == "?" ]] && MACHINES=0
+    echo "$(date +%s),${_dhcp},${_eok},${_mh},${MACHINES},${_rdy}" >> "$INGEST_RATE_CSV"
+    (( MACHINES >= MACHINE_TARGET )) && break
+    info "  endpoints_ok=${_eok}/${IFACES}  managed_hosts=${_mh}  machines=${MACHINES} ..."
     # Re-clear any AvoidLockout that latched during the wait (e.g. an
     # exploration racing a mock reboot from preingestion's initial BMC reset).
     # Idempotent; scoped to latched endpoints only so successful reports keep
@@ -1223,6 +1303,26 @@ while (( SECONDS < _end )); do
 done
 ENDPOINTS="$(psql_count "SELECT count(*) FROM explored_endpoints;")"
 MHOSTS="$(psql_count "SELECT count(*) FROM explored_managed_hosts;")"
+# Per-phase rate summary (#3756): for each cumulative counter, the window is
+# first-movement → 90%-of-final; avg rate = delta/window. Sampling-based, so
+# rates are floors — exact curves come from ingestion-rate-report.sh, which
+# reads the DB's own timestamps.
+if [[ -s "$INGEST_RATE_CSV" ]]; then
+    awk -F, -v OFS=' ' '
+        /^#/ || /^epoch/ { next }
+        { for (i = 2; i <= 6; i++) { v[i] = $i + 0
+            if (v[i] > first_v[i] && first_t[i] == 0 && v[i] > 0) { if (base_seen[i]) { first_t[i] = $1; first_v[i] = v[i] } }
+            if (!base_seen[i]) { base_seen[i] = 1; base_v[i] = v[i]; if (v[i] > 0) { first_t[i] = $1; first_v[i] = v[i] } }
+            last_t[i] = $1; last_v[i] = v[i] } }
+        END {
+            split("dhcp_addresses endpoints_ok managed_hosts machines machines_ready", n, " ")
+            for (i = 2; i <= 6; i++) {
+                dt = last_t[i] - first_t[i]; dv = last_v[i] - first_v[i]
+                rate = (dt > 0) ? sprintf("%.1f", dv * 60 / dt) : "n/a"
+                printf "  %-16s %6d -> %-6d  %ss window  %s/min\n", n[i-1], first_v[i], last_v[i], dt, rate } }
+    ' "$INGEST_RATE_CSV" | while IFS= read -r l; do info "$l"; done
+    ok "rate samples: ${INGEST_RATE_CSV}"
+fi
 echo
 if (( MACHINES >= MACHINE_TARGET )); then
     ok "${GREEN}END TO END OK${NC} — endpoints=${ENDPOINTS}, managed_hosts=${MHOSTS}, machines=${MACHINES}/${MACHINE_TARGET}"

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -718,6 +718,12 @@ for k, v in cm["data"].items():
         v_work = pre.rstrip("\n") + "\n" + post.lstrip("\n")
     else:
         v_work = v
+    # The sim lo-ip range may already be present — the site's values file can
+    # carry it (possibly as a MULTI-LINE ranges array). Only splice it into a
+    # SINGLE-LINE `ranges = [...]` when it is genuinely absent; otherwise leave
+    # the array untouched. The actual pool CAPACITY is guaranteed by the
+    # Phase 5 resource_pool DB widening regardless, so a no-op here is safe.
+    SIM_LO_PRESENT = "10.103.0.1" in v_work
     in_sec = ""
     for ln in v_work.splitlines():
         s = ln.strip()
@@ -729,7 +735,8 @@ for k, v in cm["data"].items():
             continue
         if s.startswith("[pools."):
             in_lo = (s == "[pools.lo-ip]")
-        if in_lo and s.startswith("ranges") and "10.103.0.1" not in ln:
+        if (in_lo and s.startswith("ranges") and not SIM_LO_PRESENT
+                and ln.rstrip().endswith("]")):
             r = ln.rstrip(); idx = r.rfind("]")
             ln = r[:idx] + SIM_LO + r[idx+1:]
         out.append(ln)

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -1335,7 +1335,14 @@ while (( SECONDS < _end )); do
         (SELECT count(*) FROM machines WHERE controller_state->>'state' = 'ready');" || echo '?/?/?/?/?')"
     IFS=/ read -r _dhcp _eok _mh MACHINES _rdy <<< "$_prog"
     MACHINES="${MACHINES:-0}"; [[ "$MACHINES" == "?" ]] && MACHINES=0
-    echo "$(date +%s),${_dhcp},${_eok},${_mh},${MACHINES},${_rdy}" >> "$INGEST_RATE_CSV"
+    # Only record real samples: a failed query yields '?' placeholders, and
+    # writing those as rows corrupts the rate maths downstream (they parse as
+    # 0 and look like the fleet went backwards).
+    if [[ "$_prog" != *'?'* ]]; then
+        echo "$(date +%s),${_dhcp},${_eok},${_mh},${MACHINES},${_rdy}" >> "$INGEST_RATE_CSV"
+    else
+        warn "  progress query failed; sample skipped (not written to CSV)"
+    fi
     (( MACHINES >= MACHINE_TARGET )) && break
     info "  endpoints_ok=${_eok}/${IFACES}  managed_hosts=${_mh}  machines=${MACHINES} ..."
     # Re-clear any AvoidLockout that latched during the wait (e.g. an

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -1293,7 +1293,9 @@ ok "cleared exploration lockouts + requested re-exploration"
 
 # machine target = one row per host + per DPU; wait scales with host count
 MACHINE_TARGET=$(( HOST_COUNT * (1 + DPU_PER_HOST) ))
-MACHINE_WAIT=$(( 420 + HOST_COUNT * 3 )); (( MACHINE_WAIT > 5400 )) && MACHINE_WAIT=5400
+# 3s/host with a 4h cap: at 4500 hosts (13.5k machines) init alone can run
+# ~1h before the first machine appears; the old 90-min cap expired mid-run.
+MACHINE_WAIT=$(( 420 + HOST_COUNT * 3 )); (( MACHINE_WAIT > 14400 )) && MACHINE_WAIT=14400
 info "waiting for explore → rotate → preingest → identify → create (target ${MACHINE_TARGET} machines, up to ${MACHINE_WAIT}s)..."
 
 # --- per-phase ingestion rate instrumentation (#3756) -----------------------

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -58,18 +58,20 @@
 #    hostCount + hostCount*dpuPerHostCount. Overflowing the OOB pool yields
 #    "No IP addresses left in prefix ..." and machines never register.
 #
-#  * DPF simulation (Phase 4b): runs by default ONLY when the nico-core
-#    config enables DPF ([dpf] enabled = true; site config overrides global) —
-#    a simulation site with DPF enabled but no operator parks every host in
-#    dpuinit forever. GUARDRAIL: hard-fails if the real DPF operator is
-#    deployed (both would drive DPU.status.phase); bypass everything with
-#    --skip-dpf-sim. The phase deploys dev/k8s/dpf-sim-controller (namespace,
-#    DPF CRDs, RBAC, Deployment; see its README), grants nico-api its
-#    DPF-namespace Role (nico-api-dpf), and sets
-#    CARBIDE_API_ALLOW_INSECURE_DISCOVERY=true on nico-api — post-#3561 cores
-#    resolve DiscoverMachine callers by source IP, which every simulated
-#    machine shares, so without the flag all agent discovery fails and
-#    dpuinit parks at waitingfornetworkconfig.
+#  * DPF prerequisites + simulation (Phase 4b), when [dpf] enabled = true in
+#    the nico-core config (site config overrides global). Two parts:
+#    (a) INGESTION PREREQUISITES applied whether or not the simulator is
+#        deployed: the nico-api DPF-namespace Role (nico-api-dpf) and
+#        CARBIDE_API_ALLOW_INSECURE_DISCOVERY=true on nico-api. Post-#3561
+#        cores resolve DiscoverMachine callers by source IP, which every
+#        simulated machine shares — without the flag, discovery-gated machine
+#        CREATION stalls short of the target (a --skip-dpf-sim run once wedged
+#        at 2838/3000) and agent self-discovery fails.
+#    (b) SIMULATOR DEPLOYMENT (dev/k8s/dpf-sim-controller: namespace, DPF CRDs,
+#        RBAC, Deployment) — this is the part --skip-dpf-sim skips. Without a
+#        simulator (and no real operator) hosts finish ingestion but park in
+#        dpuinit. GUARDRAIL: hard-fails if the real DPF operator is deployed,
+#        since both would drive DPU.status.phase.
 #
 #  * SVI IPs on the simulated prefixes (Phase 5, scale mode): the host
 #    network-config builder under FNN requires network_prefixes.svi_ip on L2
@@ -495,56 +497,19 @@ for _src in \
     DPF_ENABLED="$(_toml_dpf_enabled "$(_cm_key $_src)")"
 done
 
-if $SKIP_DPF_SIM; then
-    warn "--skip-dpf-sim: not deploying the simulator. Hosts on a [dpf]-enabled"
-    warn "  site will park in dpuinit unless a real DPF operator (or a"
-    warn "  separately-deployed simulator) drives DPU.status.phase."
-elif [[ "$DPF_ENABLED" != "true" ]]; then
-    ok "DPF is not enabled in the nico-core config ([dpf] enabled = ${DPF_ENABLED:-absent}) — nothing to simulate, skipping"
+if [[ "$DPF_ENABLED" != "true" ]]; then
+    ok "DPF is not enabled in the nico-core config ([dpf] enabled = ${DPF_ENABLED:-absent}) — skipping DPF prerequisites and simulator"
 else
-    # GUARDRAIL: never beside a real operator — both would drive
-    # DPU.status.phase and fight. If the real DPF stack is deployed, this is
-    # not a simulation-only cluster: refuse loudly rather than risk it.
-    _REAL_DPF="$(kubectl get deploy -n "$DPF_NAMESPACE" -o name 2>/dev/null \
-        | grep -vE 'deployment.apps/dpf-sim-controller$' | grep -E 'dpf.*operator|operator.*dpf' || true)"
-    if [[ -n "$_REAL_DPF" ]]; then
-        die "the real DPF operator is deployed in ${DPF_NAMESPACE} (${_REAL_DPF#deployment.apps/}).
-       The DPF simulator must NOT run beside it — both drive DPU.status.phase.
-       To bring up the simulator, remove the real DPF operator first (this must
-       be a simulation-only cluster); to keep the real operator, re-run with
-       --skip-dpf-sim."
-    fi
-    command -v make >/dev/null 2>&1 || die "make is required for the simulator deploy (or pass --skip-dpf-sim)"
-    [[ -d "$DPF_SIM_DIR" ]] || die "simulator module not found at ${DPF_SIM_DIR} (or pass --skip-dpf-sim)"
-    if [[ -z "$DPF_SIM_IMAGE" ]]; then
-        [[ -n "${NICO_IMAGE_REGISTRY:-}" ]] \
-            || die "set DPF_SIM_IMAGE (or NICO_IMAGE_REGISTRY) for the dpf-sim-controller image, or pass --skip-dpf-sim"
-        DPF_SIM_IMAGE="${NICO_IMAGE_REGISTRY}/dpf-sim-controller:${DPF_SIM_IMAGE_TAG}"
-    fi
-
-    kubectl get ns "$DPF_NAMESPACE" >/dev/null 2>&1 || kubectl create ns "$DPF_NAMESPACE" >/dev/null
-    _DPF_PULL_ARGS=()
-    if [[ -n "${REGISTRY_PULL_SECRET:-}" ]]; then
-        kubectl -n "$DPF_NAMESPACE" create secret docker-registry dpf-sim-pull \
-            --docker-server="${DPF_SIM_IMAGE%%/*}" \
-            --docker-username="$REGISTRY_PULL_USERNAME" \
-            --docker-password="$REGISTRY_PULL_SECRET" \
-            --dry-run=client -o yaml | kubectl apply -f - >/dev/null
-        _DPF_PULL_ARGS=(PULL_SECRET=dpf-sim-pull)
-    fi
-    # `make deploy` = DPF CRDs (waits for Established) + RBAC + Deployment +
-    # rollout; everything idempotent. Keep the log for failure triage.
-    _DPF_LOG="$(mktemp)"
-    if ! make -C "$DPF_SIM_DIR" deploy IMG="$DPF_SIM_IMAGE" DPF_NAMESPACE="$DPF_NAMESPACE" ${_DPF_PULL_ARGS[@]+"${_DPF_PULL_ARGS[@]}"} >"$_DPF_LOG" 2>&1; then
-        tail -8 "$_DPF_LOG" >&2; rm -f "$_DPF_LOG"
-        die "simulator deploy failed (make -C ${DPF_SIM_DIR} deploy)"
-    fi
-    rm -f "$_DPF_LOG"
-    ok "dpf-sim-controller deployed: ${DPF_SIM_IMAGE} in ${DPF_NAMESPACE}"
-
-    # nico-api needs access to the DPF namespace for the DPF SDK (mirrors
-    # helm/charts/nico-api/templates/dpf-rbac.yaml on the setup-dpf-install
-    # branch, which is not on main yet — drop this once the chart ships it).
+    # -------------------------------------------------------------------------
+    # DPF-enabled INGESTION PREREQUISITES — applied whether or not the
+    # simulator is deployed (--skip-dpf-sim only skips the simulator itself).
+    # These gate machine INGESTION, not just the DPF walk: without them the
+    # last hosts never finish creating and ingestion stalls short of the
+    # target (learned the hard way — a --skip-dpf-sim run wedged at 2838/3000).
+    # -------------------------------------------------------------------------
+    # 1. nico-api's access to the DPF namespace for the DPF SDK (mirrors
+    #    helm/charts/nico-api/templates/dpf-rbac.yaml on the setup-dpf-install
+    #    branch, not on main yet — drop this once the chart ships it).
     kubectl apply -f - <<NICOAPIDPF >/dev/null
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -602,11 +567,11 @@ subjects:
 NICOAPIDPF
     ok "nico-api-dpf Role/RoleBinding applied in ${DPF_NAMESPACE}"
 
-    # Post-#3561 cores resolve DiscoverMachine callers by TCP source IP; every
-    # simulated machine shares the MAT pod IP, so without this flag all agent
-    # discovery fails ("machine_interface for discovery IP not found") and
-    # dpuinit parks at waitingfornetworkconfig. Only set + restart when it is
-    # not already true — re-runs must not bounce a healthy nico-api.
+    # 2. Post-#3561 cores resolve DiscoverMachine callers by TCP source IP;
+    #    every simulated machine shares the MAT pod IP, so without this flag
+    #    discovery-gated creation and agent self-discovery fail. Only set +
+    #    restart when not already true — re-runs must not bounce a healthy
+    #    nico-api.
     _INSECURE_NOW="$(kubectl get deploy nico-api -n "$NICO_SYSTEM_NS" \
         -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CARBIDE_API_ALLOW_INSECURE_DISCOVERY")].value}' 2>/dev/null || true)"
     if [[ "$_INSECURE_NOW" != "true" ]]; then
@@ -616,6 +581,57 @@ NICOAPIDPF
             || warn "nico-api rollout did not complete in time; continuing"
     fi
     ok "allow_insecure_discovery enabled on nico-api (test-env only; see #3561)"
+fi
+
+# -----------------------------------------------------------------------------
+# Simulator deployment — the part --skip-dpf-sim actually skips.
+# -----------------------------------------------------------------------------
+if $SKIP_DPF_SIM; then
+    warn "--skip-dpf-sim: prerequisites applied but the simulator is NOT deployed."
+    warn "  Ingestion completes; hosts then park in dpuinit until a DPF operator"
+    warn "  (or a separately-deployed simulator) drives DPU.status.phase."
+elif [[ "$DPF_ENABLED" != "true" ]]; then
+    : # non-DPF site: nothing to deploy (already reported above)
+else
+    # GUARDRAIL: never beside a real operator — both would drive
+    # DPU.status.phase and fight. If the real DPF stack is deployed, this is
+    # not a simulation-only cluster: refuse loudly rather than risk it.
+    _REAL_DPF="$(kubectl get deploy -n "$DPF_NAMESPACE" -o name 2>/dev/null \
+        | grep -vE 'deployment.apps/dpf-sim-controller$' | grep -E 'dpf.*operator|operator.*dpf' || true)"
+    if [[ -n "$_REAL_DPF" ]]; then
+        die "the real DPF operator is deployed in ${DPF_NAMESPACE} (${_REAL_DPF#deployment.apps/}).
+       The DPF simulator must NOT run beside it — both drive DPU.status.phase.
+       To bring up the simulator, remove the real DPF operator first (this must
+       be a simulation-only cluster); to keep the real operator, re-run with
+       --skip-dpf-sim."
+    fi
+    command -v make >/dev/null 2>&1 || die "make is required for the simulator deploy (or pass --skip-dpf-sim)"
+    [[ -d "$DPF_SIM_DIR" ]] || die "simulator module not found at ${DPF_SIM_DIR} (or pass --skip-dpf-sim)"
+    if [[ -z "$DPF_SIM_IMAGE" ]]; then
+        [[ -n "${NICO_IMAGE_REGISTRY:-}" ]] \
+            || die "set DPF_SIM_IMAGE (or NICO_IMAGE_REGISTRY) for the dpf-sim-controller image, or pass --skip-dpf-sim"
+        DPF_SIM_IMAGE="${NICO_IMAGE_REGISTRY}/dpf-sim-controller:${DPF_SIM_IMAGE_TAG}"
+    fi
+
+    kubectl get ns "$DPF_NAMESPACE" >/dev/null 2>&1 || kubectl create ns "$DPF_NAMESPACE" >/dev/null
+    _DPF_PULL_ARGS=()
+    if [[ -n "${REGISTRY_PULL_SECRET:-}" ]]; then
+        kubectl -n "$DPF_NAMESPACE" create secret docker-registry dpf-sim-pull \
+            --docker-server="${DPF_SIM_IMAGE%%/*}" \
+            --docker-username="$REGISTRY_PULL_USERNAME" \
+            --docker-password="$REGISTRY_PULL_SECRET" \
+            --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+        _DPF_PULL_ARGS=(PULL_SECRET=dpf-sim-pull)
+    fi
+    # `make deploy` = DPF CRDs (waits for Established) + RBAC + Deployment +
+    # rollout; everything idempotent. Keep the log for failure triage.
+    _DPF_LOG="$(mktemp)"
+    if ! make -C "$DPF_SIM_DIR" deploy IMG="$DPF_SIM_IMAGE" DPF_NAMESPACE="$DPF_NAMESPACE" ${_DPF_PULL_ARGS[@]+"${_DPF_PULL_ARGS[@]}"} >"$_DPF_LOG" 2>&1; then
+        tail -8 "$_DPF_LOG" >&2; rm -f "$_DPF_LOG"
+        die "simulator deploy failed (make -C ${DPF_SIM_DIR} deploy)"
+    fi
+    rm -f "$_DPF_LOG"
+    ok "dpf-sim-controller deployed: ${DPF_SIM_IMAGE} in ${DPF_NAMESPACE}"
 fi
 
 # =============================================================================

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -684,22 +684,34 @@ if env.get("KNOB_SE_RUN_INTERVAL"):
     drop.append("run_interval")   # scoped to [site_explorer] by insertion point
     knobs.append(f'      run_interval = "{env["KNOB_SE_RUN_INTERVAL"]}"')
 
-# Optional tuning overrides living OUTSIDE [site_explorer] (issue #3738):
-# managed as a sentinel-delimited tail block that each run regenerates. A
-# duplicate TOML table would be a parse error, so refuse if the operator
-# already defines these sections outside our block.
+# Optional tuning overrides living OUTSIDE [site_explorer] (issue #3738).
+# When the target section already exists in the site config, its managed keys
+# are rewritten IN PLACE (scoped, like [site_explorer]); a section that is
+# absent is emitted in a sentinel-delimited tail block regenerated each run.
+# Duplicating an existing table would be a TOML parse error — dev6's template
+# ships both [firmware_global] and [machine_state_controller].
 TUNING_BEGIN = "# --- BEGIN scale tuning overrides (managed by setup-machine-a-tron.sh) ---"
 TUNING_END   = "# --- END scale tuning overrides ---"
-tuning = []
+# Managed tuning keys are ALWAYS dropped from their sections in scale mode —
+# with no override env set they revert to the build's defaults, so one run's
+# override can never leak into the next (run independence for #3738). Set
+# them via the SCALE_* envs, not by editing these keys in the site config.
+MANAGED_TUNING = {
+    "[firmware_global]": ("concurrency_limit", "run_interval"),
+    "[machine_state_controller.controller]": ("max_concurrency",),
+}
+# section header -> (managed key names, replacement lines)
+tuning_secs = {}
 if env.get("KNOB_FW_CONC") or env.get("KNOB_FW_RUN_INTERVAL"):
-    tuning.append("[firmware_global]")
+    keys, lines = [], []
     if env.get("KNOB_FW_CONC"):
-        tuning.append(f'concurrency_limit = {env["KNOB_FW_CONC"]}')
+        keys.append("concurrency_limit"); lines.append(f'concurrency_limit = {env["KNOB_FW_CONC"]}')
     if env.get("KNOB_FW_RUN_INTERVAL"):
-        tuning.append(f'run_interval = "{env["KNOB_FW_RUN_INTERVAL"]}"')
+        keys.append("run_interval"); lines.append(f'run_interval = "{env["KNOB_FW_RUN_INTERVAL"]}"')
+    tuning_secs["[firmware_global]"] = (tuple(keys), lines)
 if env.get("KNOB_STATE_CONC"):
-    tuning.append("[machine_state_controller.controller]")
-    tuning.append(f'max_concurrency = {env["KNOB_STATE_CONC"]}')
+    tuning_secs["[machine_state_controller.controller]"] = (
+        ("max_concurrency",), [f'max_concurrency = {env["KNOB_STATE_CONC"]}'])
 networks = f'''
 # --- simulated networks for machine-a-tron scale testing (managed by
 # --- setup-machine-a-tron.sh --scale; safe to leave in place) ---
@@ -741,14 +753,19 @@ for k, v in cm["data"].items():
     # Phase 5 resource_pool DB widening regardless, so a no-op here is safe.
     SIM_LO_PRESENT = "10.103.0.1" in v_work
     in_sec = ""
+    seen_secs = set()
     for ln in v_work.splitlines():
         s = ln.strip()
         if s.startswith("["):
             in_sec = s
-        # drop-list is scoped: managed [site_explorer] keys only there, so a
-        # run_interval belonging to another section is never touched.
+        # drop-lists are scoped per section, so a key with the same name in
+        # another section is never touched.
         if in_sec == "[site_explorer]" and any(t in ln for t in drop) and not s.startswith("["):
             continue
+        if in_sec in MANAGED_TUNING and not s.startswith("["):
+            key = s.split("=", 1)[0].strip()
+            if key in MANAGED_TUNING[in_sec]:
+                continue   # managed key: replaced when overridden, reverted when not
         if s.startswith("[pools."):
             in_lo = (s == "[pools.lo-ip]")
         if (in_lo and s.startswith("ranges") and not SIM_LO_PRESENT
@@ -758,15 +775,21 @@ for k, v in cm["data"].items():
         out.append(ln)
         if s == "[site_explorer]":
             out.extend(knobs)
+        if s in tuning_secs:
+            seen_secs.add(s)
+            out.extend(tuning_secs[s][1])
     new = "\n".join(out) + ("\n" if v_work.endswith("\n") else "")
     if "[networks.simulated-oob]" not in new:
         new = new.rstrip("\n") + "\n" + networks
-    if tuning:
-        for header in ("[firmware_global]", "[machine_state_controller"):
-            if any(l.strip().startswith(header) for l in new.splitlines()):
-                sys.stderr.write(f"ERROR: {header} already defined in the site config outside the managed block; set the knob there instead\n")
-                sys.exit(3)
-        new = new.rstrip("\n") + "\n\n" + TUNING_BEGIN + "\n" + "\n".join(tuning) + "\n" + TUNING_END + "\n"
+    # Sections not present in the file are emitted in the sentinel tail.
+    # (A dotted subtable like [machine_state_controller.controller] is valid
+    # there even when its parent table exists elsewhere.)
+    tail = []
+    for sec, (_keys, lines) in tuning_secs.items():
+        if sec not in seen_secs:
+            tail.append(sec); tail.extend(lines)
+    if tail:
+        new = new.rstrip("\n") + "\n\n" + TUNING_BEGIN + "\n" + "\n".join(tail) + "\n" + TUNING_END + "\n"
     if new != v:
         cm["data"][k] = new
         changed = True

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -1187,6 +1187,13 @@ cat > "$MERGED_VALUES" <<EOF
 image:
   repository: "${MAT_IMAGE_REPO}"
   tag: "${MAT_IMAGE_TAG}"
+EOF
+# MAT_MULTIPOD=1: the values file defines its own pods map (mat-0..mat-N with
+# per-pod host counts and relay addresses); injecting the single-pod default
+# here would deep-merge a phantom extra pod on top of it. HOST_COUNT/DPU env
+# still drive the sizing math above -- set them to the fleet TOTALS.
+if [[ "${MAT_MULTIPOD:-0}" != "1" ]]; then
+cat >> "$MERGED_VALUES" <<EOF
 pods:
   default:
     machines:
@@ -1196,6 +1203,7 @@ pods:
         oobDhcpRelayAddress: "${OOB_DHCP_RELAY}"
         adminDhcpRelayAddress: "${ADMIN_DHCP_RELAY}"
 EOF
+fi
 if [[ "$MAT_MODE" == "scale" ]]; then
     # Pin every mock BMC's password to the site root ("emulates a BMC already
     # rotated by an operator"). At scale, the rotation dance is fatally racy:

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -1032,6 +1032,37 @@ import ipaddress, re, sys
 values_file, default_prefix, default_reserve = sys.argv[1], sys.argv[2], sys.argv[3]
 text = open(values_file).read()
 
+def groups_from_yaml(doc):
+    """Structural walk of a parsed values doc -> [{hosts,dpus,relay}]."""
+    out = []
+    for pod in (doc.get("pods") or {}).values():
+        if not isinstance(pod, dict):
+            continue
+        for grp in (pod.get("machines") or {}).values():
+            if not isinstance(grp, dict):
+                continue
+            hosts = int(grp.get("hostCount") or 0)
+            if hosts <= 0:
+                continue
+            out.append({
+                "hosts": hosts,
+                "dpus": int(grp.get("dpuPerHostCount") or 0),
+                "relay": str(grp.get("oobDhcpRelayAddress") or "").strip(),
+            })
+    return out
+
+yaml_groups = None
+try:
+    import yaml  # structural parse is authoritative when available
+    doc = yaml.safe_load(text)
+    if isinstance(doc, dict):
+        yaml_groups = groups_from_yaml(doc)
+except ImportError:
+    yaml_groups = None
+except Exception as e:                      # malformed values file
+    print(f"SKIP values file is not valid YAML: {e}")
+    sys.exit(0)
+
 # Dependency-free scan: walk the values file line by line and close off a
 # machine group whenever a line appears at or above the group's indentation.
 # Each group contributes hostCount*(1+dpuPerHostCount) BMC IPs to its relay.
@@ -1059,6 +1090,8 @@ for raw in text.splitlines():
 if cur is not None:
     groups.append(cur)
 
+if yaml_groups is not None:
+    groups = yaml_groups            # structural parse wins
 groups = [g for g in groups if g["hosts"] > 0]
 if not groups:
     print("SKIP values file defines no pod groups with hostCount")
@@ -1103,12 +1136,18 @@ print("\n".join(lines))
 if problems:
     print("FAIL " + "; ".join(problems))
 MPCHK
-)" || true
+)"; _MP_RC=$?
         printf '%s\n' "$_MP_REPORT" | while IFS= read -r _l; do [[ -n "$_l" ]] && info "$_l"; done
+        # Fail closed: a validator that cannot run must not look like a pass.
+        if (( _MP_RC != 0 )); then
+            die "multipod sizing check failed to run (rc=${_MP_RC}); refusing to deploy unvalidated. Output: ${_MP_REPORT:-<none>}"
+        fi
         if [[ "$_MP_REPORT" == *FAIL* ]]; then
             die "multipod sizing: $(printf '%s' "$_MP_REPORT" | sed -n 's/^FAIL //p') — widen that segment's prefix, lower its hostCount, or give the pod its own relay"
         fi
-        [[ "$_MP_REPORT" == SKIP* ]] && warn "multipod: ${_MP_REPORT#SKIP }"
+        if [[ "$_MP_REPORT" == SKIP* ]]; then
+            die "multipod sizing could not be validated: ${_MP_REPORT#SKIP } — set HOST_COUNT/DPU_PER_HOST explicitly or fix the values file so demand can be computed"
+        fi
         ok "multipod sizing validated across all pod groups"
     elif (( HOST_COUNT > FIT )); then
         (( FIT < 1 )) && die "pools too small for even 1 host × ${DPU_PER_HOST} DPUs — widen the admin/OOB prefixes or lower DPU_PER_HOST"

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -9,14 +9,14 @@
 #
 #   mat-0: 10.233.16.0/20 (4,094 IPs) → 1,350 hosts (4,050 BMCs)
 #   mat-1: 10.233.32.0/19 (8,190 IPs) → 2,700 hosts (8,100 BMCs)
-#   mat-2: 10.233.48.0/20 (4,094 IPs) →   450 hosts (1,350 BMCs)
+#   mat-2: 10.233.8.0/21  (2,046 IPs) →   450 hosts (1,350 BMCs)
 #                                        4,500 hosts / 13,500 BMCs total
 #
 # NICo siteConfig needs (added for the E7-v6 run):
 #   allow_insecure_discovery = true
 #   [networks.mat-bmc-0] type=underlay prefix=10.233.16.0/20 gateway=10.233.16.1
 #   [networks.mat-bmc-1] type=underlay prefix=10.233.32.0/19 gateway=10.233.32.1
-#   [networks.mat-bmc-2] type=underlay prefix=10.233.48.0/20 gateway=10.233.48.1
+#   [networks.mat-bmc-2] type=underlay prefix=10.233.8.0/21 gateway=10.233.8.1
 # =============================================================================
 
 image:
@@ -133,7 +133,7 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.48.1"
+        oobDhcpRelayAddress: "10.233.8.1"
         adminDhcpRelayAddress: "10.102.0.1"
         networkVirtualizationType: ""
         dpusInNicMode: false

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -1,0 +1,141 @@
+# =============================================================================
+# machine-a-tron-scale-4500.yaml — 4,500 hosts × 2 DPUs across 3 MAT pods
+# (Controller Mode, dev6). Derived from machine-a-tron-scale.yaml.
+#
+# dev6 ServiceCIDR is 10.233.0.0/18 (16,384 IPs). 4,500 hosts × 3 BMCs =
+# 13,500 per-BMC ClusterIP Services. Cluster services live in the low range,
+# so each pod gets its own carved segment from the upper space (NICo has a
+# one-IPv4-prefix-per-segment constraint → one segment per pod):
+#
+#   mat-0: 10.233.16.0/20 (4,094 IPs) → 1,350 hosts (4,050 BMCs)
+#   mat-1: 10.233.32.0/19 (8,190 IPs) → 2,700 hosts (8,100 BMCs)
+#   mat-2: 10.233.48.0/20 (4,094 IPs) →   450 hosts (1,350 BMCs)
+#                                        4,500 hosts / 13,500 BMCs total
+#
+# NICo siteConfig needs (added for the E7-v6 run):
+#   allow_insecure_discovery = true
+#   [networks.mat-bmc-0] type=underlay prefix=10.233.16.0/20 gateway=10.233.16.1
+#   [networks.mat-bmc-1] type=underlay prefix=10.233.32.0/19 gateway=10.233.32.1
+#   [networks.mat-bmc-2] type=underlay prefix=10.233.48.0/20 gateway=10.233.48.1
+# =============================================================================
+
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+
+global:
+  imagePullSecrets:
+    - name: machine-a-tron-pull
+
+certificate:
+  uris:
+    - "spiffe://nico.local/nico-system/sa/machine-a-tron"
+
+machineATron:
+  nicoApiUrl: "https://nico-api.nico-system.svc.cluster.local:1079"
+  configureBmcProxyHost: ""
+  registerExpectedMachines: true
+  useSingleBmcMock: true
+
+macAddressPool:
+  enabled: true
+  basePrefix: "02:00"
+
+hwMacAddressRanges:
+  enabled: true
+  basePrefix: "02:01"
+
+mat-k8s-controller:
+  enabled: true
+  config:
+    insecureSkipVerify: true
+
+# Init at thousands of hosts binds the redfish port only after registering
+# every expected machine; give probes a long bring-up window (see #4298).
+livenessProbe:
+  tcpSocket:
+    port: redfish
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 240
+  successThreshold: 1
+  timeoutSeconds: 10
+
+readinessProbe:
+  tcpSocket:
+    port: redfish
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  failureThreshold: 240
+  successThreshold: 1
+  timeoutSeconds: 5
+
+resources:
+  limits:
+    cpu: "8"
+    memory: 8Gi
+  requests:
+    cpu: "2"
+    memory: 2Gi
+
+pods:
+  default: null
+  mat-0:
+    machines:
+      compute:
+        hwType: dell_poweredge_r750
+        hostCount: 1350
+        dpuPerHostCount: 2
+        vpcCount: 0
+        subnetsPerVpc: 0
+        dpuRebootDelay: 1
+        hostRebootDelay: 1
+        scoutRunInterval: "300s"
+        runIntervalWorking: "5s"
+        runIntervalIdle: "60s"
+        networkStatusRunInterval: "120s"
+        oobDhcpRelayAddress: "10.233.16.1"
+        adminDhcpRelayAddress: "10.102.0.1"
+        networkVirtualizationType: ""
+        dpusInNicMode: false
+  mat-1:
+    machines:
+      compute:
+        hwType: dell_poweredge_r750
+        hostCount: 2700
+        dpuPerHostCount: 2
+        vpcCount: 0
+        subnetsPerVpc: 0
+        dpuRebootDelay: 1
+        hostRebootDelay: 1
+        scoutRunInterval: "300s"
+        runIntervalWorking: "5s"
+        runIntervalIdle: "60s"
+        networkStatusRunInterval: "120s"
+        oobDhcpRelayAddress: "10.233.32.1"
+        adminDhcpRelayAddress: "10.102.0.1"
+        networkVirtualizationType: ""
+        dpusInNicMode: false
+  mat-2:
+    machines:
+      compute:
+        hwType: dell_poweredge_r750
+        hostCount: 450
+        dpuPerHostCount: 2
+        vpcCount: 0
+        subnetsPerVpc: 0
+        dpuRebootDelay: 1
+        hostRebootDelay: 1
+        scoutRunInterval: "300s"
+        runIntervalWorking: "5s"
+        runIntervalIdle: "60s"
+        networkStatusRunInterval: "120s"
+        oobDhcpRelayAddress: "10.233.48.1"
+        adminDhcpRelayAddress: "10.102.0.1"
+        networkVirtualizationType: ""
+        dpusInNicMode: false
+
+extraEnv:
+  - name: RUST_LOG
+    value: "info"

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -48,6 +48,14 @@ hwMacAddressRanges:
 
 mat-k8s-controller:
   enabled: true
+  # The subchart defaults to a bare local image name with no registry; pin the
+  # published build or the controller ImagePullBackOffs and no BMC Services
+  # are ever created (so exploration finds nothing).
+  image:
+    repository: nvcr.io/0837451325059433/carbide-dev/mat-k8s-controller
+    tag: "v2.1.0-pr-614-g587165fcf"
+  imagePullSecrets:
+    - name: machine-a-tron-pull
   config:
     insecureSkipVerify: true
 

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -83,6 +83,8 @@ pods:
   default: null
   mat-0:
     machines:
+      # the chart's own mat-0 example deep-merges in without this
+      rack-machines: null
       compute:
         hwType: dell_poweredge_r750
         hostCount: 1350

--- a/helm-prereqs/values/machine-a-tron-scale.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale.yaml
@@ -55,6 +55,32 @@ mat-k8s-controller:
     insecureSkipVerify: true  # For self-signed certs
 
 # Larger resources for scale testing
+
+# At thousands of hosts MAT registers all expected machines BEFORE binding
+# the redfish port, so the chart-default liveness window (30s + 3×30s) kills
+# the pod mid-init and it crash-loops (observed: 30 restarts at 4500 hosts,
+# ~3 min per life, exit 137 from the kubelet). Give init up to 2h; steady-
+# state kill detection matters less in a sim harness than surviving bring-up.
+livenessProbe:
+  tcpSocket:
+    port: redfish
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 240
+  successThreshold: 1
+  timeoutSeconds: 10
+
+readinessProbe:
+  tcpSocket:
+    port: redfish
+  initialDelaySeconds: 5
+  periodSeconds: 30
+  failureThreshold: 240
+  successThreshold: 1
+  timeoutSeconds: 5
+
+# Larger resources: one tokio task per host + per DPU; at thousands of
+# machines the FSM/API chatter is CPU-bound.
 resources:
   limits:
     cpu: "8"


### PR DESCRIPTION
Test harness and instrumentation used for the ingestion-scale campaign (#3738), so the measurements are reproducible.

### What's here

- **Rate instrumentation (#3756)** — `setup-machine-a-tron.sh` samples the pipeline every ~40 s to a CSV: DHCP addresses, endpoints explored, managed hosts, machines, machines ready. Every number in the campaign report comes from these.
- **Knob overrides (#3757)** — `SCALE_*` env vars patch the site config in place (`run_interval`, `concurrent_explorations`, `explorations_per_run`, `machines_created_per_run`, firmware concurrency, state max-concurrency), so one knob can be swept per run without hand-editing config.
- **4,500-host multipod values** — `values/machine-a-tron-scale-4500.yaml`: 3 MAT pods (1,350 / 2,700 / 450 hosts × 2 DPUs) in controller mode, each with a BMC-service segment carved from the cluster ServiceCIDR. 13,500 per-BMC Services do not fit one prefix alongside cluster services, and NICo network segments take a single IPv4 prefix each.
- **`MAT_MULTIPOD=1`** — suppresses the script's injected single-pod default, which would otherwise deep-merge a phantom pod over a user-supplied pod map.
- **Scale hardening** — MAT liveness/readiness windows widened for fleet-size init (see #4298: MAT registers every expected host before binding the probed port, so the chart default kills it above ~2,300 hosts); machine-wait cap raised for 13,500-machine targets; dpf-sim CRD establish-wait raised, since a fresh reinstall can leave the apiserver too busy for the old window.

### Notes for review

Config-patching helpers here are deliberately conservative: they edit values in place inside existing sections rather than appending, after an earlier version corrupted a multi-line `lo-ip` ranges array.

Also fixes a gap where DPF ingestion prerequisites were skipped under `--skip-dpf-sim`, which made no-DPF control runs non-comparable.

Part of #3738. Depends on nothing else; the chart fixes it exercises are in the companion controller-mode PR.
