### PR TITLE
feat(instrument): enable INFO logs for selected Events

### DIFF
--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -202,8 +202,8 @@ struct DpuAgentReport {
 }
 
 /// `InventoryReportSucceeded` records the inventory loop's successful
-/// completion and owns its DEBUG diagnostic. The other successful loops are
-/// metric-only.
+/// completion and owns its DEBUG diagnostic. The other successful report
+/// loops below write concise INFO records for operators.
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "dpu_agent_inventory_report_succeeded",
@@ -238,7 +238,8 @@ struct InventoryReportFailed {
 #[event(
     event_name = "dpu_agent_config_fetch_succeeded",
     metric_family = DpuAgentReport,
-    log = off
+    log = info,
+    message = "Successfully fetched the latest configuration"
 )]
 struct ConfigFetchSucceeded {
     #[label]
@@ -285,7 +286,8 @@ struct ConfigNotFound {
 #[event(
     event_name = "dpu_agent_fmds_push_succeeded",
     metric_family = DpuAgentReport,
-    log = off
+    log = info,
+    message = "Successfully completed external FMDS update"
 )]
 struct FmdsPushSucceeded {
     #[label]
@@ -316,7 +318,8 @@ struct FmdsPushFailed {
 #[event(
     event_name = "dpu_agent_network_status_succeeded",
     metric_family = DpuAgentReport,
-    log = off
+    log = info,
+    message = "Successfully recorded DPU network status"
 )]
 struct NetworkStatusSucceeded {
     #[label]
@@ -857,7 +860,7 @@ mod report_loop_tests {
                     },
                 },
                 Check {
-                    scenario: "config fetch success remains metric-only",
+                    scenario: "config fetch success logs at info",
                     input: EventCase {
                         emit: || ConfigFetch::Succeeded.emit(),
                         report_loop: "config_fetch",
@@ -865,7 +868,15 @@ mod report_loop_tests {
                     },
                     expect: EventObservation {
                         metric_delta: 1.0,
-                        logs: Vec::new(),
+                        logs: expected_log(
+                            "dpu_agent_config_fetch_succeeded",
+                            tracing::Level::INFO,
+                            "Successfully fetched the latest configuration",
+                            "config_fetch",
+                            "ok",
+                            &[],
+                            None,
+                        ),
                     },
                 },
                 Check {
@@ -898,7 +909,7 @@ mod report_loop_tests {
                     },
                 },
                 Check {
-                    scenario: "FMDS success remains metric-only",
+                    scenario: "FMDS success logs at info",
                     input: EventCase {
                         emit: || FmdsPush::Succeeded.emit(),
                         report_loop: "fmds_push",
@@ -906,7 +917,15 @@ mod report_loop_tests {
                     },
                     expect: EventObservation {
                         metric_delta: 1.0,
-                        logs: Vec::new(),
+                        logs: expected_log(
+                            "dpu_agent_fmds_push_succeeded",
+                            tracing::Level::INFO,
+                            "Successfully completed external FMDS update",
+                            "fmds_push",
+                            "ok",
+                            &[],
+                            None,
+                        ),
                     },
                 },
                 Check {
@@ -939,7 +958,7 @@ mod report_loop_tests {
                     },
                 },
                 Check {
-                    scenario: "network status success remains metric-only",
+                    scenario: "network status success logs at info",
                     input: EventCase {
                         emit: || NetworkStatus::Succeeded.emit(),
                         report_loop: "network_status",
@@ -947,7 +966,15 @@ mod report_loop_tests {
                     },
                     expect: EventObservation {
                         metric_delta: 1.0,
-                        logs: Vec::new(),
+                        logs: expected_log(
+                            "dpu_agent_network_status_succeeded",
+                            tracing::Level::INFO,
+                            "Successfully recorded DPU network status",
+                            "network_status",
+                            "ok",
+                            &[],
+                            None,
+                        ),
                     },
                 },
                 Check {

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -167,15 +167,17 @@ fn get_tls_acceptor(tls_config: &ApiTlsConfig) -> Option<TlsAcceptor> {
     }
 }
 
-/// The five-minute TLS acceptor refresh, counted instead of logged: the
-/// steady tick is a rate, not news, so the per-refresh log line retires.
+/// `TlsCertsRefreshed` records TLS acceptor reload attempts. The first reload
+/// starts on the first accepted connection; later reloads start on the next
+/// accepted connection once the five-minute interval has elapsed.
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "api_tls_certs_refreshed",
     metric_name = "carbide_api_tls_cert_refreshes_total",
     component = "nico-api",
-    log = off,
+    log = info,
     metric = counter,
+    message = "Refreshing certs",
     describe = "Number of TLS acceptor refreshes performed by the API listener"
 )]
 struct TlsCertsRefreshed;
@@ -556,9 +558,10 @@ mod tests {
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
-    use super::{ConnectionFailReason, TcpAcceptFailed, TlsConnectionFailed};
+    use super::{ConnectionFailReason, TcpAcceptFailed, TlsCertsRefreshed, TlsConnectionFailed};
 
     const FAILURE_METRIC: &str = "carbide_api_tls_connection_fail_total";
+    const TLS_CERT_REFRESH_METRIC: &str = "carbide_api_tls_cert_refreshes_total";
 
     struct FailureInput {
         reason: &'static str,
@@ -688,5 +691,23 @@ mod tests {
             ],
             observe_failure,
         );
+    }
+
+    /// A certificate refresh keeps the existing counter and restores the INFO
+    /// record operators use to see when the listener triggers a reload.
+    #[test]
+    fn tls_cert_refresh_emits_its_metric_and_info_log() {
+        let metrics = MetricsCapture::start();
+        let logs = capture_logs(|| carbide_instrument::emit(TlsCertsRefreshed));
+
+        assert_eq!(metrics.counter_delta(TLS_CERT_REFRESH_METRIC, &[]), 1.0);
+        let [log] = logs.as_slice() else {
+            panic!("a TLS certificate refresh should write one log, got {logs:?}");
+        };
+        assert_eq!(log.level, tracing::Level::INFO);
+        assert_eq!(log.metadata_name, "api_tls_certs_refreshed");
+        assert_eq!(log.message, "Refreshing certs");
+        assert_eq!(log.field("event_name"), Some("api_tls_certs_refreshed"));
+        assert_eq!(log.field("metric_name"), Some(TLS_CERT_REFRESH_METRIC));
     }
 }

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -41,7 +41,7 @@ use forge_tls::client_config::ClientCert;
 use forge_tls::default::{default_client_cert, default_client_key, default_root_ca};
 use grpc_server::{ControlRequest, run_grpc_server};
 use lru::LruCache;
-use metrics::{DhcpPacketDropped, DhcpReplySent, DhcpTimestampFileFailed, DropReason};
+use metrics::{DhcpPacketDropped, DhcpTimestampFileFailed, DropReason};
 use metrics_endpoint::{MetricsEndpointConfig, new_metrics_setup, run_metrics_endpoint};
 use modes::DhcpMode;
 use modes::controller::Controller;
@@ -697,10 +697,21 @@ async fn process(
         return;
     }
 
-    tracing::debug!(bootp_op = buf[0], source_address = %addr, "Received DHCP packet");
+    let Some(&bootp_op) = buf.first() else {
+        emit(DhcpPacketDropped {
+            reason: DropReason::TooShort,
+            error: format!("0 bytes is below the {MINIMUM_DHCP_PKT_SIZE}-byte minimum"),
+        });
+        return;
+    };
+
+    // Keep raw source/opcode visibility when validation or decoding fails
+    // before the structured request Event can be emitted.
+    tracing::debug!(bootp_op, source_address = %addr, "Received DHCP packet");
 
     let packet = match packet_handler::process_packet(
         buf,
+        addr,
         &config,
         circuit_id,
         handler,
@@ -719,18 +730,11 @@ async fn process(
     };
 
     let dest_address = handler.get_destination_address(&packet);
-    match packet.send(dest_address, socket).await {
-        Ok(_) => {
-            emit(DhcpReplySent {
-                message_type: packet.message_type,
-            });
-        }
-        Err(err) => {
-            emit(DhcpPacketDropped {
-                reason: DropReason::SendFailed,
-                error: err,
-            });
-        }
+    if let Err(err) = packet.send(dest_address, socket).await {
+        emit(DhcpPacketDropped {
+            reason: DropReason::SendFailed,
+            error: err,
+        });
     }
 
     // Tell forge-dpu-agent that an IP has been requested for this interface.
@@ -750,11 +754,12 @@ async fn process(
 #[cfg(test)]
 mod test {
     use std::env;
-    use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::path::PathBuf;
     use std::str::FromStr;
     use std::sync::Arc;
 
+    use carbide_instrument::testing::capture_logs_async;
     use carbide_rpc_utils::dhcp::{DhcpTimestamps, DhcpTimestampsFilePath};
     use chrono::{DateTime, Utc};
     use dhcproto::v4::{DhcpOption, Message, MessageType, OptionCode};
@@ -771,6 +776,9 @@ mod test {
         DhcpMode, Test, TestArm, cache, forge_client_config, handle_reload, init, packet_handler,
         process,
     };
+
+    const TEST_SOURCE_ADDRESS: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 10), 68));
 
     fn make_reload_args(td: &TempDir, interfaces: Vec<String>) -> Args {
         Args {
@@ -1002,6 +1010,7 @@ mod test {
         assert!(matches!(
             packet_handler::process_packet(
                 &byte_stream,
+                TEST_SOURCE_ADDRESS,
                 &config,
                 "vlan200",
                 &*handler,
@@ -1028,6 +1037,7 @@ mod test {
         assert!(
             packet_handler::process_packet(
                 &byte_stream,
+                TEST_SOURCE_ADDRESS,
                 &config,
                 "vlan200",
                 &*handler,
@@ -1058,6 +1068,7 @@ mod test {
         )));
         let packet = packet_handler::process_packet(
             &byte_stream,
+            TEST_SOURCE_ADDRESS,
             &config,
             "vlan200",
             &*handler,
@@ -1085,10 +1096,10 @@ mod test {
         );
     }
 
-    /// The request counter ticks for every decoded packet -- including one
-    /// whose processing then fails -- labelled by the packet's message type.
+    /// A decoded packet writes bounded request details at INFO, the complete
+    /// packet at DEBUG, and ticks the counter even when later processing fails.
     #[tokio::test]
-    async fn process_packet_counts_the_decoded_request() {
+    async fn process_packet_logs_and_counts_the_decoded_request() {
         // No other test in this binary processes an Inform, so this label's
         // delta is immune to tests running in parallel.
         let byte_stream =
@@ -1098,10 +1109,96 @@ mod test {
         let mut machine_cache = Arc::new(Mutex::new(LruCache::new(
             std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE).unwrap(),
         )));
+        let expected_received_packet = Message::decode(&mut Decoder::new(&byte_stream)).unwrap();
+        let expected_received_packet_text = expected_received_packet.to_string();
 
         let metrics = carbide_instrument::testing::MetricsCapture::start();
+        let (result, logs) = capture_logs_async(packet_handler::process_packet(
+            &byte_stream,
+            TEST_SOURCE_ADDRESS,
+            &config,
+            "vlan200",
+            &*handler,
+            &mut machine_cache,
+        ))
+        .await;
+
+        assert!(matches!(result, Err(DhcpError::UnhandledMessageType(..))));
+        let request_log_index = logs
+            .iter()
+            .position(|entry| entry.metadata_name == "dhcp_server_request_received")
+            .expect("the decoded request Event should write an INFO record");
+        let request_log = &logs[request_log_index];
+        assert_eq!(request_log.level, tracing::Level::INFO);
+        assert_eq!(request_log.field("bootp_op"), Some("1"));
+        assert_eq!(request_log.field("source_address"), Some("192.0.2.10:68"));
+        assert_eq!(
+            request_log.field("xid"),
+            Some(expected_received_packet.xid().to_string().as_str())
+        );
+        assert_eq!(
+            request_log.field("broadcast_flag"),
+            Some(
+                expected_received_packet
+                    .flags()
+                    .broadcast()
+                    .to_string()
+                    .as_str()
+            )
+        );
+        assert_eq!(
+            request_log.field("ciaddr"),
+            Some(expected_received_packet.ciaddr().to_string().as_str())
+        );
+        assert_eq!(
+            request_log.field("yiaddr"),
+            Some(expected_received_packet.yiaddr().to_string().as_str())
+        );
+        assert_eq!(
+            request_log.field("siaddr"),
+            Some(expected_received_packet.siaddr().to_string().as_str())
+        );
+        assert_eq!(
+            request_log.field("giaddr"),
+            Some(expected_received_packet.giaddr().to_string().as_str())
+        );
+        assert_eq!(
+            request_log.field("chaddr"),
+            Some(crate::util::u8_to_mac(expected_received_packet.chaddr()).as_str())
+        );
+        assert_eq!(request_log.field("received_packet"), None);
+
+        let debug_log = logs
+            .get(request_log_index + 1)
+            .expect("the full-packet DEBUG record should immediately follow the Event");
+        assert_eq!(debug_log.level, tracing::Level::DEBUG);
+        assert_eq!(debug_log.message, "Received Packet");
+        assert_eq!(
+            debug_log.field("packet.received"),
+            Some(expected_received_packet_text.as_str())
+        );
+        assert_eq!(
+            metrics.counter_delta("carbide_dhcp_requests_total", &[("message_type", "inform")]),
+            1.0
+        );
+    }
+
+    /// A wire-provided hardware-address length cannot make the structured INFO
+    /// field or full-packet DEBUG formatter index beyond BOOTP's fixed field.
+    #[tokio::test]
+    async fn process_packet_rejects_oversized_hardware_address_length() {
+        let mut byte_stream =
+            get_byte_stream(Ipv4Addr::new(0, 0, 0, 0), None, MessageType::Request, None);
+        byte_stream[2] = 17;
+        let handler: Box<dyn DhcpMode> = Box::new(Test {});
+        let config = init(get_test_args()).await.unwrap();
+        let mut machine_cache = Arc::new(Mutex::new(LruCache::new(
+            std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE).unwrap(),
+        )));
+
         let result = packet_handler::process_packet(
             &byte_stream,
+            TEST_SOURCE_ADDRESS,
             &config,
             "vlan200",
             &*handler,
@@ -1109,10 +1206,121 @@ mod test {
         )
         .await;
 
-        assert!(matches!(result, Err(DhcpError::UnhandledMessageType(..))));
+        assert!(matches!(
+            result,
+            Err(DhcpError::InvalidInput(error))
+                if error == "DHCP hardware address length 17 exceeds the 16-byte BOOTP field"
+        ));
+    }
+
+    #[tokio::test]
+    async fn process_packet_rejects_an_empty_buffer() {
+        let handler: Box<dyn DhcpMode> = Box::new(Test {});
+        let config = init(get_test_args()).await.unwrap();
+        let mut machine_cache = Arc::new(Mutex::new(LruCache::new(
+            std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE).unwrap(),
+        )));
+
+        let result = packet_handler::process_packet(
+            &[],
+            TEST_SOURCE_ADDRESS,
+            &config,
+            "vlan200",
+            &*handler,
+            &mut machine_cache,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DhcpError::PacketDecodeFailure(
+                dhcproto::error::DecodeError::NotEnoughBytes
+            ))
+        ));
+    }
+
+    /// A successful send writes bounded reply details at INFO and immediately
+    /// follows them with the complete packet at DEBUG.
+    #[tokio::test]
+    async fn send_logs_bounded_reply_details_before_the_full_packet() {
+        let byte_stream =
+            get_byte_stream(Ipv4Addr::new(0, 0, 0, 0), None, MessageType::Request, None);
+        let handler: Box<dyn DhcpMode> = Box::new(Test {});
+        let config = init(get_test_args()).await.unwrap();
+        let mut machine_cache = Arc::new(Mutex::new(LruCache::new(
+            std::num::NonZeroUsize::new(cache::MACHINE_CACHE_SIZE).unwrap(),
+        )));
+        let packet = packet_handler::process_packet(
+            &byte_stream,
+            TEST_SOURCE_ADDRESS,
+            &config,
+            "vlan200",
+            &*handler,
+            &mut machine_cache,
+        )
+        .await
+        .unwrap();
+        let expected_reply = Message::decode(&mut Decoder::new(packet.encoded_packet())).unwrap();
+        let expected_reply_text = expected_reply.to_string();
+
+        let receiver = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let SocketAddr::V4(destination_address) = receiver.local_addr().unwrap() else {
+            panic!("the IPv4 loopback receiver should have an IPv4 address");
+        };
+        let socket = Arc::new(UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap());
+
+        let (result, logs) = capture_logs_async(packet.send(destination_address, socket)).await;
+        result.unwrap();
+
+        let reply_log_index = logs
+            .iter()
+            .position(|entry| entry.metadata_name == "dhcp_server_reply_sent")
+            .expect("the successful send should write an INFO Event");
+        let reply_log = &logs[reply_log_index];
+        assert_eq!(reply_log.level, tracing::Level::INFO);
+        assert_eq!(reply_log.field("message_type"), Some("ack"));
         assert_eq!(
-            metrics.counter_delta("carbide_dhcp_requests_total", &[("message_type", "inform")]),
-            1.0
+            reply_log.field("destination_address"),
+            Some(destination_address.to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("xid"),
+            Some(expected_reply.xid().to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("broadcast_flag"),
+            Some(expected_reply.flags().broadcast().to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("ciaddr"),
+            Some(expected_reply.ciaddr().to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("yiaddr"),
+            Some(expected_reply.yiaddr().to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("siaddr"),
+            Some(expected_reply.siaddr().to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("giaddr"),
+            Some(expected_reply.giaddr().to_string().as_str())
+        );
+        assert_eq!(
+            reply_log.field("chaddr"),
+            Some(crate::util::u8_to_mac(expected_reply.chaddr()).as_str())
+        );
+        assert_eq!(reply_log.field("sent_packet"), None);
+
+        let debug_log = logs
+            .get(reply_log_index + 1)
+            .expect("the full-packet DEBUG record should immediately follow the Event");
+        assert_eq!(debug_log.level, tracing::Level::DEBUG);
+        assert_eq!(debug_log.message, "Sent DHCP packet");
+        assert_eq!(
+            debug_log.field("packet.send"),
+            Some(expected_reply_text.as_str())
         );
     }
 
@@ -1131,6 +1339,7 @@ mod test {
         )));
         let packet = packet_handler::process_packet(
             &byte_stream,
+            TEST_SOURCE_ADDRESS,
             &config,
             "vlan200",
             &*handler,
@@ -1268,6 +1477,7 @@ mod test {
 
         let encoded_packet = packet_handler::process_packet(
             &packet,
+            TEST_SOURCE_ADDRESS,
             &config,
             "vlan200",
             &*handler,
@@ -1307,6 +1517,7 @@ mod test {
 
         let encoded_packet = packet_handler::process_packet(
             &packet,
+            TEST_SOURCE_ADDRESS,
             &config,
             "vlan200",
             &*handler,

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -15,13 +15,15 @@
  * limitations under the License.
  */
 
-//! Packet-level counters for the DHCP server. The request and reply events
-//! are metric-only (`log = off`): their rates are the INFO-level signal,
-//! while the per-packet log lines stay reachable at DEBUG for forensics. A
-//! drop is the operational error, so its event also writes the ERROR line --
+//! Packet-level counters and logs for the DHCP server. Request and reply
+//! Events write INFO records with selected BOOTP header and socket details,
+//! while full packets (including their options) stay at DEBUG for forensics. A
+//! drop is the operational error, so its Event also writes the ERROR line --
 //! one declaration moves the counter and logs the reason together.
 //! Timestamp-file failures share a counter by operation while their paths,
 //! host interface, and errors remain log-only diagnostics.
+
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use carbide_instrument::{Event, LabelValue, MetricFamily};
 use dhcproto::v4::MessageType;
@@ -331,19 +333,40 @@ impl DhcpInterfaceBindFailed {
     }
 }
 
-/// A DHCP packet was decoded from the wire, whatever becomes of it next.
+/// A DHCP packet with a usable BOOTP header was decoded from the wire. Its
+/// selected header fields and source socket stay on the log line and never
+/// become metric labels; the option-rich full packet stays at DEBUG.
 #[derive(Event)]
 #[event(
     event_name = "dhcp_server_request_received",
     metric_name = "carbide_dhcp_requests_total",
     component = "nico-dhcp",
-    log = off,
+    log = info,
     metric = counter,
+    message = "Decoded DHCP packet",
     describe = "Number of DHCP packets received and decoded, by DHCP message type."
 )]
 pub struct DhcpRequestReceived {
     #[label]
     pub message_type: MessageTypeLabel,
+    #[context(value)]
+    pub bootp_op: i64,
+    #[context]
+    pub source_address: SocketAddr,
+    #[context(value)]
+    pub xid: i64,
+    #[context(value)]
+    pub broadcast_flag: bool,
+    #[context]
+    pub ciaddr: Ipv4Addr,
+    #[context]
+    pub yiaddr: Ipv4Addr,
+    #[context]
+    pub siaddr: Ipv4Addr,
+    #[context]
+    pub giaddr: Ipv4Addr,
+    #[context(value)]
+    pub chaddr: String,
 }
 
 /// A packet was dropped without a reply reaching the client -- anywhere from
@@ -369,19 +392,38 @@ pub struct DhcpPacketDropped {
 }
 
 /// A DHCP reply was sent, labelled by the reply's message type: an `offer` is
-/// a proposed lease, an `ack` a committed one, a `nak` a refusal.
+/// a proposed lease, an `ack` a committed one, a `nak` a refusal. Its selected
+/// BOOTP header fields and destination stay on the log line only; the
+/// option-rich full packet stays at DEBUG.
 #[derive(Event)]
 #[event(
     event_name = "dhcp_server_reply_sent",
     metric_name = "carbide_dhcp_replies_sent_total",
     component = "nico-dhcp",
-    log = off,
+    log = info,
     metric = counter,
+    message = "Sent DHCP reply",
     describe = "Number of DHCP replies sent, by reply message type."
 )]
 pub struct DhcpReplySent {
     #[label]
     pub message_type: MessageTypeLabel,
+    #[context]
+    pub destination_address: SocketAddrV4,
+    #[context(value)]
+    pub xid: i64,
+    #[context(value)]
+    pub broadcast_flag: bool,
+    #[context]
+    pub ciaddr: Ipv4Addr,
+    #[context]
+    pub yiaddr: Ipv4Addr,
+    #[context]
+    pub siaddr: Ipv4Addr,
+    #[context]
+    pub giaddr: Ipv4Addr,
+    #[context(value)]
+    pub chaddr: String,
 }
 
 /// A DHCP timestamp-file operation failed. Each variant is one operation, and
@@ -1089,13 +1131,11 @@ mod tests {
         );
     }
 
-    /// Every packet event moves exactly its counter, per label value. The
-    /// request and grant counters are silent (the counters are the INFO-level
-    /// signal, the packet logs stay DEBUG); a drop is the operational error,
-    /// so its event also writes the error line -- one declaration, both
-    /// signals.
+    /// Every packet Event moves exactly its counter and writes the matching
+    /// operational record: request and reply activity at INFO, and drops at
+    /// ERROR.
     #[test]
-    fn packet_events_count_per_label_and_drops_log_at_error() {
+    fn packet_events_count_per_label_and_log_at_their_operational_level() {
         let metrics = MetricsCapture::start();
         let logs = capture_logs(|| {
             // Labels deliberately unused by any other test in this binary:
@@ -1104,12 +1144,38 @@ mod tests {
             // with the end-to-end packet tests.
             emit(DhcpRequestReceived {
                 message_type: MessageTypeLabel::Release,
+                bootp_op: 1,
+                source_address: "192.0.2.10:68".parse().unwrap(),
+                xid: 0x0102_0304,
+                broadcast_flag: true,
+                ciaddr: Ipv4Addr::new(192, 0, 2, 20),
+                yiaddr: Ipv4Addr::new(192, 0, 2, 21),
+                siaddr: Ipv4Addr::new(192, 0, 2, 1),
+                giaddr: Ipv4Addr::new(192, 0, 2, 254),
+                chaddr: "00:11:22:33:44:55".to_string(),
             });
             emit(DhcpRequestReceived {
                 message_type: MessageTypeLabel::Release,
+                bootp_op: 1,
+                source_address: "192.0.2.10:68".parse().unwrap(),
+                xid: 0x0102_0304,
+                broadcast_flag: true,
+                ciaddr: Ipv4Addr::new(192, 0, 2, 20),
+                yiaddr: Ipv4Addr::new(192, 0, 2, 21),
+                siaddr: Ipv4Addr::new(192, 0, 2, 1),
+                giaddr: Ipv4Addr::new(192, 0, 2, 254),
+                chaddr: "00:11:22:33:44:55".to_string(),
             });
             emit(DhcpReplySent {
                 message_type: MessageTypeLabel::Nak,
+                destination_address: "192.0.2.10:68".parse().unwrap(),
+                xid: 0x0102_0304,
+                broadcast_flag: true,
+                ciaddr: Ipv4Addr::new(192, 0, 2, 20),
+                yiaddr: Ipv4Addr::new(192, 0, 2, 21),
+                siaddr: Ipv4Addr::new(192, 0, 2, 1),
+                giaddr: Ipv4Addr::new(192, 0, 2, 254),
+                chaddr: "00:11:22:33:44:55".to_string(),
             });
             emit(DhcpPacketDropped {
                 reason: DropReason::RateLimited,
@@ -1122,32 +1188,99 @@ mod tests {
             });
         });
 
-        let (drop_logs, other_logs): (Vec<_>, Vec<_>) = logs
+        assert_eq!(logs.len(), 5, "each packet Event writes one log record");
+        let request_logs: Vec<_> = logs
             .iter()
-            .partition(|entry| entry.message.contains("Dropped a DHCP packet"));
-        assert!(
-            other_logs.is_empty(),
-            "request/grant events are metric-only, got {other_logs:?}"
+            .filter(|entry| entry.metadata_name == "dhcp_server_request_received")
+            .collect();
+        let reply_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| entry.metadata_name == "dhcp_server_reply_sent")
+            .collect();
+        let drop_logs: Vec<_> = logs
+            .iter()
+            .filter(|entry| entry.metadata_name == "dhcp_server_packet_dropped")
+            .collect();
+
+        assert_eq!(request_logs.len(), 2, "each request writes one INFO line");
+        for entry in request_logs {
+            assert_eq!(entry.level, tracing::Level::INFO);
+            assert_eq!(entry.message, "Decoded DHCP packet");
+            assert_eq!(
+                entry.field("event_name"),
+                Some("dhcp_server_request_received")
+            );
+            assert_eq!(
+                entry.field("metric_name"),
+                Some("carbide_dhcp_requests_total")
+            );
+            assert_eq!(entry.field("message_type"), Some("release"));
+            assert_eq!(entry.field("bootp_op"), Some("1"));
+            assert_eq!(entry.field_kind("bootp_op"), Some(CapturedFieldKind::I64));
+            assert_eq!(entry.field("source_address"), Some("192.0.2.10:68"));
+            assert_eq!(entry.field("xid"), Some("16909060"));
+            assert_eq!(entry.field_kind("xid"), Some(CapturedFieldKind::I64));
+            assert_eq!(entry.field("broadcast_flag"), Some("true"));
+            assert_eq!(
+                entry.field_kind("broadcast_flag"),
+                Some(CapturedFieldKind::Bool)
+            );
+            assert_eq!(entry.field("ciaddr"), Some("192.0.2.20"));
+            assert_eq!(entry.field("yiaddr"), Some("192.0.2.21"));
+            assert_eq!(entry.field("siaddr"), Some("192.0.2.1"));
+            assert_eq!(entry.field("giaddr"), Some("192.0.2.254"));
+            assert_eq!(entry.field("chaddr"), Some("00:11:22:33:44:55"));
+            assert_eq!(entry.field_kind("chaddr"), Some(CapturedFieldKind::String));
+            assert_eq!(entry.field("received_packet"), None);
+        }
+
+        let [reply_log] = reply_logs.as_slice() else {
+            panic!("the reply Event should write one INFO line, got {reply_logs:?}");
+        };
+        assert_eq!(reply_log.level, tracing::Level::INFO);
+        assert_eq!(reply_log.message, "Sent DHCP reply");
+        assert_eq!(
+            reply_log.field("event_name"),
+            Some("dhcp_server_reply_sent")
         );
+        assert_eq!(
+            reply_log.field("metric_name"),
+            Some("carbide_dhcp_replies_sent_total")
+        );
+        assert_eq!(reply_log.field("message_type"), Some("nak"));
+        assert_eq!(
+            reply_log.field("destination_address"),
+            Some("192.0.2.10:68")
+        );
+        assert_eq!(reply_log.field("xid"), Some("16909060"));
+        assert_eq!(reply_log.field_kind("xid"), Some(CapturedFieldKind::I64));
+        assert_eq!(reply_log.field("broadcast_flag"), Some("true"));
+        assert_eq!(
+            reply_log.field_kind("broadcast_flag"),
+            Some(CapturedFieldKind::Bool)
+        );
+        assert_eq!(reply_log.field("ciaddr"), Some("192.0.2.20"));
+        assert_eq!(reply_log.field("yiaddr"), Some("192.0.2.21"));
+        assert_eq!(reply_log.field("siaddr"), Some("192.0.2.1"));
+        assert_eq!(reply_log.field("giaddr"), Some("192.0.2.254"));
+        assert_eq!(reply_log.field("chaddr"), Some("00:11:22:33:44:55"));
+        assert_eq!(
+            reply_log.field_kind("chaddr"),
+            Some(CapturedFieldKind::String)
+        );
+        assert_eq!(reply_log.field("sent_packet"), None);
+
         assert_eq!(drop_logs.len(), 2, "each drop writes one error line");
         assert!(
             drop_logs
                 .iter()
                 .all(|entry| entry.level == tracing::Level::ERROR)
         );
-        let field = |entry: &&carbide_instrument::testing::CapturedLog, name: &str| {
-            entry
-                .fields
-                .iter()
-                .find(|(key, _)| key == name)
-                .map(|(_, value)| value.clone())
-        };
-        assert_eq!(
-            field(&drop_logs[0], "reason").as_deref(),
-            Some("rate_limited")
-        );
+        assert_eq!(drop_logs[0].field("reason"), Some("rate_limited"));
         assert!(
-            field(&drop_logs[1], "error").is_some_and(|error| error.contains("api down")),
+            drop_logs[1]
+                .field("error")
+                .is_some_and(|error| error.contains("api down")),
             "the drop line carries the upstream error detail"
         );
         assert_eq!(

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -32,10 +32,11 @@ use tokio::sync::Mutex;
 
 use crate::cache::CacheEntry;
 use crate::errors::DhcpError;
-use crate::metrics::{DhcpRequestReceived, MessageTypeLabel};
+use crate::metrics::{DhcpReplySent, DhcpRequestReceived, MessageTypeLabel};
 use crate::{Config, DhcpMode, util};
 
 const PKT_TYPE_OP_REQUEST: u8 = 1;
+const BOOTP_CHADDR_LEN: u8 = 16;
 
 pub struct DecodedPacket {
     packet: Message,
@@ -210,6 +211,7 @@ impl DecodedPacket {
 
 pub struct Packet {
     encoded_packet: Vec<u8>,
+    sent_packet: Message,
     pub dst_address: Ipv4Addr,
     pub dst_port: u16,
     /// The reply's DHCP message type (an Offer, an Ack, a Nak), as the
@@ -233,11 +235,28 @@ impl Packet {
         dst_address: SocketAddrV4,
         socket: Arc<UdpSocket>,
     ) -> Result<(), String> {
-        tracing::debug!(destination_address = ?dst_address, "Sending packet");
-        socket
-            .send_to(&self.encoded_packet, dst_address)
-            .await
-            .map_err(|x| x.to_string())?;
+        if let Err(error) = socket.send_to(&self.encoded_packet, dst_address).await {
+            tracing::debug!(
+                packet.send = %self.sent_packet,
+                destination_address = %dst_address,
+                error = %error,
+                "Failed to send DHCP packet"
+            );
+            return Err(error.to_string());
+        }
+
+        emit(DhcpReplySent {
+            message_type: self.message_type,
+            destination_address: dst_address,
+            xid: i64::from(self.sent_packet.xid()),
+            broadcast_flag: self.sent_packet.flags().broadcast(),
+            ciaddr: self.sent_packet.ciaddr(),
+            yiaddr: self.sent_packet.yiaddr(),
+            siaddr: self.sent_packet.siaddr(),
+            giaddr: self.sent_packet.giaddr(),
+            chaddr: util::u8_to_mac(self.sent_packet.chaddr()),
+        });
+        tracing::debug!(packet.send = %self.sent_packet, "Sent DHCP packet");
 
         Ok(())
     }
@@ -245,24 +264,34 @@ impl Packet {
 
 pub async fn process_packet(
     buf: &[u8],
+    source_address: SocketAddr,
     config: &Config,
     circuit_id: &str,
     handler: &dyn DhcpMode,
     machine_cache: &mut Arc<Mutex<LruCache<String, CacheEntry>>>,
 ) -> Result<Packet, DhcpError> {
-    if buf[0] != PKT_TYPE_OP_REQUEST {
+    let (&bootp_op, _) = buf.split_first().ok_or(DhcpError::PacketDecodeFailure(
+        dhcproto::error::DecodeError::NotEnoughBytes,
+    ))?;
+
+    if bootp_op != PKT_TYPE_OP_REQUEST {
         // Not valid packet. Drop it.
-        return Err(DhcpError::UnknownPacket(buf[0]));
+        return Err(DhcpError::UnknownPacket(bootp_op));
     }
 
     let packet = Message::decode(&mut Decoder::new(buf))?;
-    tracing::debug!(packet.received=%packet, "Received Packet");
+    let hardware_address_len = packet.hlen();
+    if hardware_address_len > BOOTP_CHADDR_LEN {
+        return Err(DhcpError::InvalidInput(format!(
+            "DHCP hardware address length {hardware_address_len} exceeds the {BOOTP_CHADDR_LEN}-byte BOOTP field"
+        )));
+    }
     let decoded_packet = DecodedPacket { packet };
 
-    // Every decoded packet counts as a received request, labelled by its
-    // message type (`other` when the option is missing or unrecognised). The
-    // Result is consumed after the relay and ownership checks so that error
-    // precedence stays unchanged.
+    // Every packet with a usable decoded BOOTP header counts as a received
+    // request, labelled by its message type (`other` when the option is
+    // missing or unrecognised). The Result is consumed after the relay and
+    // ownership checks so that error precedence stays unchanged.
     let msg_type: Result<MessageType, DhcpError> =
         decoded_packet.get_option_val(OptionCode::MessageType, None);
     emit(DhcpRequestReceived {
@@ -271,7 +300,17 @@ pub async fn process_packet(
             .map_or(MessageTypeLabel::Other, |msg_type| {
                 MessageTypeLabel::from(*msg_type)
             }),
+        bootp_op: i64::from(bootp_op),
+        source_address,
+        xid: i64::from(decoded_packet.packet.xid()),
+        broadcast_flag: decoded_packet.packet.flags().broadcast(),
+        ciaddr: decoded_packet.packet.ciaddr(),
+        yiaddr: decoded_packet.packet.yiaddr(),
+        siaddr: decoded_packet.packet.siaddr(),
+        giaddr: decoded_packet.packet.giaddr(),
+        chaddr: util::u8_to_mac(decoded_packet.packet.chaddr()),
     });
+    tracing::debug!(packet.received = %decoded_packet.packet, "Received Packet");
 
     if handler.should_be_relayed() {
         decoded_packet.is_relayed()?;
@@ -292,7 +331,6 @@ pub async fn process_packet(
 
     let packet =
         create_dhcp_reply_packet(&decoded_packet, circuit_id, dhcp_response, config, msg_type)?;
-    tracing::debug!(packet.send=%packet, "Sending Packet");
 
     // Read the type off the reply itself: create_dhcp_reply_packet answers a
     // Request with either an Ack or a Nak.
@@ -303,10 +341,18 @@ pub async fn process_packet(
 
     let mut encoded_packet = Vec::new();
     let mut e = Encoder::new(&mut encoded_packet);
-    packet.encode(&mut e)?;
+    if let Err(error) = packet.encode(&mut e) {
+        tracing::debug!(
+            packet.encode = %packet,
+            error = %error,
+            "Failed to encode DHCP packet"
+        );
+        return Err(error.into());
+    }
 
     Ok(Packet {
         encoded_packet,
+        sent_packet: packet,
         dst_address,
         dst_port,
         message_type: reply_message_type,


### PR DESCRIPTION
Some activity we need while debugging DHCP, TLS certificate reloads, and DPU-agent reporting was only visible through metrics or DEBUG logs. The DHCP server and DPU agent do not have `carbide-api`'s runtime filter reload, so this uses the existing `Event` declarations to make selected records available at INFO while keeping metric names, labels, and outcome timing unchanged.

- `api_tls_certs_refreshed` restores the existing `Refreshing certs` record, while the DHCP Events restore INFO packet-flow records: `message_type` remains the metric label, and selected BOOTP header fields plus source and destination addresses are structured log-only context. Option-rich full packets remain available at DEBUG for valid receives, successful sends, and encode/send failures.
- `dpu_agent_config_fetch_succeeded`, `dpu_agent_fmds_push_succeeded`, and `dpu_agent_network_status_succeeded` now write INFO records alongside `carbide_dpu_agent_report_total`, so those loops are visible without restarting the agent with a broader filter.
- DHCP input validation rejects empty buffers and oversized hardware-address lengths before structured packet formatting.
- `Event` tests now pin the levels, messages, identities, label and context fields, INFO-to-DEBUG packet plumbing, and unchanged metric deltas.

## Related issues

No related issue -- this is a one-off observability change.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-agent report_loop_tests::semantic_events_preserve_the_loop_outcome_matrix_and_log_shapes --lib`
- `cargo test -p carbide-dhcp-server`
- `cargo test -p carbide-api-core tls_cert_refresh_emits_its_metric_and_info_log --lib`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `cargo make check-event-names`

## Additional Notes

No metric names, types, labels, or descriptions change. With the default intervals and external FMDS, the DPU-agent additions produce about six INFO records per minute while stable and fourteen per minute while active; that cadence is intentional so the activity remains visible without restarting the agent with a broader filter.

The DHCP records are intentionally unsampled and one-per-packet: a normal DORA exchange adds four INFO records, and the DPU DHCP configuration defaults to a 3,600-second renewal interval. This is a deliberate operational exception to the general hot-path guidance because operators rely on packet-flow records and this service cannot reload its log filter at runtime. INFO contains only bounded header/socket fields; DHCP options and other client-provided packet details stay at DEBUG.

The external-FMDS DEBUG record remains alongside the new `Event` summary because it uniquely includes `fmds_address`. The raw DHCP receive record remains before decode for early failure diagnostics. Valid request and successful reply Events are followed immediately by full-packet DEBUG records, and encode/send failures retain their own DEBUG packet dumps. Empty buffers and oversized wire-provided hardware-address lengths are rejected before packet formatting.
