### PR TITLE
test site-wide DPU credential recovery

### DIFF
--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -81,6 +81,9 @@ struct RedfishSimState {
     /// Tests set it to an unrecognized value to force `probe_bmc_vendor` down
     /// the Chassis `Manufacturer` fallback path.
     service_root_vendor: Option<String>,
+    /// When set, overrides the `Product` field returned by `get_service_root`.
+    /// Tests use this to model a specific DPU generation.
+    service_root_product: Option<String>,
     /// When set, overrides the `Manufacturer` returned by `get_chassis`, so
     /// tests can drive `probe_bmc_vendor`'s Lite-On/Delta chassis fallback.
     chassis_manufacturer: Option<String>,
@@ -405,6 +408,12 @@ impl RedfishSim {
     /// service-root probe and into the Chassis `Manufacturer` fallback.
     pub fn set_service_root_vendor(&self, vendor: Option<String>) {
         self.state.lock().unwrap().service_root_vendor = vendor;
+    }
+
+    /// Override the `Product` reported by `get_service_root`, allowing tests to
+    /// drive model-specific behavior such as DPU factory credential selection.
+    pub fn set_service_root_product(&self, product: Option<String>) {
+        self.state.lock().unwrap().service_root_product = product;
     }
 
     /// Override the `Manufacturer` reported by `get_chassis`, so tests can
@@ -1389,16 +1398,18 @@ impl Redfish for RedfishSimClient {
         Result<libredfish::model::service_root::ServiceRoot, RedfishError>,
     > {
         Box::pin(async move {
-            let vendor = self
-                .state
-                .lock()
-                .unwrap()
+            let state = self.state.lock().unwrap();
+            let vendor = state
                 .service_root_vendor
                 .clone()
                 .unwrap_or_else(|| "Nvidia".to_string());
+            let product = state
+                .service_root_product
+                .clone()
+                .unwrap_or_else(|| "GB200 NVL".to_string());
             Ok(ServiceRoot {
                 vendor: Some(vendor),
-                product: Some("GB200 NVL".to_string()),
+                product: Some(product),
                 component_integrity: Some(ODataId {
                     odata_id: "Valid Data".to_string(),
                 }),
@@ -1410,7 +1421,11 @@ impl Redfish for RedfishSimClient {
     fn get_systems<'a>(
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { Ok(Vec::new()) })
+        Box::pin(async move {
+            let state = self.state.lock().unwrap();
+            self.authorize(&state, "Systems")?;
+            Ok(Vec::new())
+        })
     }
 
     fn get_managers<'a>(

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -1765,6 +1765,9 @@ mod tests {
     use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
     use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
+    use carbide_secrets::credentials::{
+        BmcCredentialType, CredentialKey, CredentialReader, CredentialWriter,
+    };
     use carbide_secrets::test_support::credentials::TestCredentialManager;
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, check_cases_async, value_scenarios};
@@ -1901,6 +1904,86 @@ mod tests {
                 },
             ],
             explore_after_credential_bootstrap,
+        )
+        .await;
+    }
+
+    async fn reingest_dpu_with_sitewide_password(
+        (product, username): (&'static str, &'static str),
+    ) -> Result<Credentials, String> {
+        let sim = Arc::new(RedfishSim::default());
+        sim.set_service_root_product(Some(product.to_string()));
+        sim.set_enforce_auth(true);
+        sim.seed_user(username, "sitewide-password");
+        sim.seed_user("service", "factory-service-password");
+
+        let credential_manager = Arc::new(TestCredentialManager::default());
+        credential_manager
+            .set_credentials(
+                &CredentialKey::BmcCredentials {
+                    credential_type: BmcCredentialType::SiteWideRoot,
+                },
+                &Credentials::UsernamePassword {
+                    username: String::new(),
+                    password: "sitewide-password".to_string(),
+                },
+            )
+            .await
+            .expect("seed site-wide BMC credentials");
+
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let explorer = BmcEndpointExplorer::new(
+            sim,
+            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            carbide_ipmi::test_support(),
+            credential_manager.clone(),
+            Arc::new(AtomicBool::new(false)),
+            SiteExplorerExploreMode::LibRedfish,
+            None,
+        );
+        let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
+        let bmc_mac_address: MacAddress = "02:00:00:00:00:01".parse().expect("valid test BMC MAC");
+        let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
+
+        explorer
+            .explore_endpoint(bmc_ip_address, &interface, None, None, None)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        credential_manager
+            .get_credentials(&get_bmc_root_credential_key(bmc_mac_address))
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "per-BMC credentials were not restored".to_string())
+    }
+
+    /// Reingestion has no per-BMC Vault secret even though the hardware still
+    /// carries the site-wide password from its prior ingestion. For every DPU
+    /// generation, the factory attempt must fail authentication, after which
+    /// site-explorer validates the site-wide password and restores the
+    /// per-BMC secret with that generation's administrative username.
+    #[tokio::test(start_paused = true)]
+    async fn reingested_dpus_restore_missing_bmc_credentials_from_sitewide_password() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "BlueField-3 restores the root credential",
+                    input: ("BlueField-3 DPU", "root"),
+                    expect: Yields(Credentials::UsernamePassword {
+                        username: "root".to_string(),
+                        password: "sitewide-password".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "BlueField-4 restores the admin credential",
+                    input: ("BlueField-4 DPU", "admin"),
+                    expect: Yields(Credentials::UsernamePassword {
+                        username: "admin".to_string(),
+                        password: "sitewide-password".to_string(),
+                    }),
+                },
+            ],
+            reingest_dpu_with_sitewide_password,
         )
         .await;
     }


### PR DESCRIPTION
## What changed

- add a mocked functional regression test for DPU re-ingestion when the per-BMC Vault credential has been deleted but the hardware still carries the site-wide password
- cover both BlueField-3 (`root`) and BlueField-4 (`admin`) credential selection
- extend `RedfishSim` with configurable ServiceRoot product data and opt-in authentication on the `/Systems` probe used to validate fallback credentials

## Why

The recovery added in #1396 had only manual coverage. Later refactors changed Redfish password rotation, per-model DPU factory credentials, and BF4 service-account rotation without an end-to-end test protecting this sequence:

1. factory authentication fails
2. site-wide authentication succeeds
3. the per-BMC Vault credential is restored

## Regression investigation

The new test passes for both BF3 and BF4 on current `main`; no regression was reproduced in this path.

## Validation

- `cargo test -p carbide-site-explorer --lib` — 58 passed
- `cargo test -p carbide-redfish --lib --features test-support` — 36 passed
- focused BF3/BF4 regression test — passed
- `rustfmt --check` on changed Rust files — passed
- `git diff --check` — passed

Clippy with the locally available Rust 1.97 toolchain is blocked by pre-existing lints outside this change; the repository pins Rust 1.96.