### PR TITLE
test: cover site-wide DPU credential recovery

### DIFF
--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -1423,6 +1423,7 @@ impl Redfish for RedfishSimClient {
     ) -> libredfish::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
         Box::pin(async move {
             let state = self.state.lock().unwrap();
+            // Check auth so credential fallback is observable.
             self.authorize(&state, "Systems")?;
             Ok(Vec::new())
         })

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use carbide_secrets::credentials::CredentialReader;
+use carbide_secrets::credentials::{CredentialReader, Credentials};
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use chrono::Utc;
 use libredfish::model::certificate::Certificate;
@@ -97,6 +97,7 @@ struct RedfishSimState {
     /// `Direct` credential whose password matches the seeded `users` entry, so
     /// credential-probe paths (e.g. `bmc_credentials_valid`) can be exercised.
     enforce_auth: bool,
+    auth_attempts: Vec<RedfishSimAuthAttempt>,
     /// When set, `get_accounts` fails with a non-authentication transport error
     /// (`503`), so callers' error-propagation paths can be exercised distinctly
     /// from an unauthorized rejection.
@@ -140,6 +141,13 @@ fn sim_http_error(status: http::StatusCode, url: &str, body: &str) -> RedfishErr
 pub struct CreateClientCall {
     pub host: String,
     pub vendor: Option<RedfishVendor>,
+}
+
+/// Credential and result observed when the simulator checks direct authentication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RedfishSimAuthAttempt {
+    pub credentials: Credentials,
+    pub authorized: bool,
 }
 
 #[derive(Debug)]
@@ -344,6 +352,11 @@ impl RedfishSim {
     /// passed at a given call site.
     pub fn create_client_calls(&self) -> Vec<CreateClientCall> {
         self.state.lock().unwrap().create_client_calls.clone()
+    }
+
+    /// Return direct authentication checks in the order the simulator performed them.
+    pub fn auth_attempts(&self) -> Vec<RedfishSimAuthAttempt> {
+        self.state.lock().unwrap().auth_attempts.clone()
     }
 
     /// Seed a user account so calls like `change_password` /
@@ -584,15 +597,22 @@ impl RedfishSimClient {
     /// client was created with against the seeded `users`. Returns a `401`
     /// error on a mismatch (or a non-`Direct` credential); a no-op when
     /// enforcement is off, preserving the behavior existing tests rely on.
-    fn authorize(&self, state: &RedfishSimState, url: &str) -> Result<(), RedfishError> {
+    fn authorize(&self, state: &mut RedfishSimState, url: &str) -> Result<(), RedfishError> {
         if !state.enforce_auth {
             return Ok(());
         }
         let authorized = match &self.auth {
-            RedfishAuth::Direct(user, password) => state
-                .users
-                .get(user)
-                .is_some_and(|stored| stored == password),
+            RedfishAuth::Direct(username, password) => {
+                let authorized = state
+                    .users
+                    .get(username)
+                    .is_some_and(|stored| stored == password);
+                state.auth_attempts.push(RedfishSimAuthAttempt {
+                    credentials: Credentials::new(username.clone(), password.clone()),
+                    authorized,
+                });
+                authorized
+            }
             RedfishAuth::Anonymous | RedfishAuth::Key(_) => false,
         };
         if authorized {
@@ -856,7 +876,7 @@ impl Redfish for RedfishSimClient {
             if state.password_change_required {
                 return Err(RedfishError::PasswordChangeRequired);
             }
-            self.authorize(&state, "AccountService/Accounts")?;
+            self.authorize(&mut state, "AccountService/Accounts")?;
             if !state.users.contains_key(&s_user) {
                 return Err(RedfishError::UserNotFound(s_user));
             }
@@ -890,7 +910,7 @@ impl Redfish for RedfishSimClient {
                     error: message.clone(),
                 });
             }
-            self.authorize(&state, "AccountService/Accounts")?;
+            self.authorize(&mut state, "AccountService/Accounts")?;
             if !state.users.contains_key(&s_acct) {
                 return Err(RedfishError::UserNotFound(s_acct));
             }
@@ -1422,9 +1442,9 @@ impl Redfish for RedfishSimClient {
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
         Box::pin(async move {
-            let state = self.state.lock().unwrap();
+            let mut state = self.state.lock().unwrap();
             // Check auth so credential fallback is observable.
-            self.authorize(&state, "Systems")?;
+            self.authorize(&mut state, "Systems")?;
             Ok(Vec::new())
         })
     }
@@ -1609,7 +1629,7 @@ impl Redfish for RedfishSimClient {
         Result<Vec<libredfish::model::account_service::ManagerAccount>, RedfishError>,
     > {
         Box::pin(async move {
-            let state = self.state.lock().unwrap();
+            let mut state = self.state.lock().unwrap();
             if state.get_accounts_error {
                 return Err(sim_http_error(
                     http::StatusCode::SERVICE_UNAVAILABLE,
@@ -1620,7 +1640,7 @@ impl Redfish for RedfishSimClient {
             // Reading the account collection is gated behind login on a real BMC,
             // so authorize the credential this client was created with (a no-op
             // unless enforcement is on).
-            self.authorize(&state, "AccountService/Accounts")?;
+            self.authorize(&mut state, "AccountService/Accounts")?;
             let accounts = state
                 .users
                 .keys()

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -81,6 +81,9 @@ struct RedfishSimState {
     /// Tests set it to an unrecognized value to force `probe_bmc_vendor` down
     /// the Chassis `Manufacturer` fallback path.
     service_root_vendor: Option<String>,
+    /// When set, overrides the `Product` field returned by `get_service_root`.
+    /// Tests use this to model a specific DPU generation.
+    service_root_product: Option<String>,
     /// When set, overrides the `Manufacturer` returned by `get_chassis`, so
     /// tests can drive `probe_bmc_vendor`'s Lite-On/Delta chassis fallback.
     chassis_manufacturer: Option<String>,
@@ -405,6 +408,12 @@ impl RedfishSim {
     /// service-root probe and into the Chassis `Manufacturer` fallback.
     pub fn set_service_root_vendor(&self, vendor: Option<String>) {
         self.state.lock().unwrap().service_root_vendor = vendor;
+    }
+
+    /// Override the `Product` reported by `get_service_root`, allowing tests to
+    /// drive model-specific behavior such as DPU factory credential selection.
+    pub fn set_service_root_product(&self, product: Option<String>) {
+        self.state.lock().unwrap().service_root_product = product;
     }
 
     /// Override the `Manufacturer` reported by `get_chassis`, so tests can
@@ -1389,16 +1398,18 @@ impl Redfish for RedfishSimClient {
         Result<libredfish::model::service_root::ServiceRoot, RedfishError>,
     > {
         Box::pin(async move {
-            let vendor = self
-                .state
-                .lock()
-                .unwrap()
+            let state = self.state.lock().unwrap();
+            let vendor = state
                 .service_root_vendor
                 .clone()
                 .unwrap_or_else(|| "Nvidia".to_string());
+            let product = state
+                .service_root_product
+                .clone()
+                .unwrap_or_else(|| "GB200 NVL".to_string());
             Ok(ServiceRoot {
                 vendor: Some(vendor),
-                product: Some("GB200 NVL".to_string()),
+                product: Some(product),
                 component_integrity: Some(ODataId {
                     odata_id: "Valid Data".to_string(),
                 }),
@@ -1410,7 +1421,11 @@ impl Redfish for RedfishSimClient {
     fn get_systems<'a>(
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { Ok(Vec::new()) })
+        Box::pin(async move {
+            let state = self.state.lock().unwrap();
+            self.authorize(&state, "Systems")?;
+            Ok(Vec::new())
+        })
     }
 
     fn get_managers<'a>(

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -1765,6 +1765,9 @@ mod tests {
     use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
     use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
+    use carbide_secrets::credentials::{
+        BmcCredentialType, CredentialKey, CredentialReader, CredentialWriter,
+    };
     use carbide_secrets::test_support::credentials::TestCredentialManager;
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, check_cases_async, value_scenarios};
@@ -1901,6 +1904,86 @@ mod tests {
                 },
             ],
             explore_after_credential_bootstrap,
+        )
+        .await;
+    }
+
+    async fn reingest_dpu_with_sitewide_password(
+        (product, username): (&'static str, &'static str),
+    ) -> Result<Credentials, String> {
+        let sim = Arc::new(RedfishSim::default());
+        sim.set_service_root_product(Some(product.to_string()));
+        sim.set_enforce_auth(true);
+        sim.seed_user(username, "sitewide-password");
+        sim.seed_user("service", "factory-service-password");
+
+        let credential_manager = Arc::new(TestCredentialManager::default());
+        credential_manager
+            .set_credentials(
+                &CredentialKey::BmcCredentials {
+                    credential_type: BmcCredentialType::SiteWideRoot,
+                },
+                &Credentials::UsernamePassword {
+                    username: String::new(),
+                    password: "sitewide-password".to_string(),
+                },
+            )
+            .await
+            .expect("seed site-wide BMC credentials");
+
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let explorer = BmcEndpointExplorer::new(
+            sim,
+            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            carbide_ipmi::test_support(),
+            credential_manager.clone(),
+            Arc::new(AtomicBool::new(false)),
+            SiteExplorerExploreMode::LibRedfish,
+            None,
+        );
+        let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
+        let bmc_mac_address: MacAddress = "02:00:00:00:00:01".parse().expect("valid test BMC MAC");
+        let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
+
+        explorer
+            .explore_endpoint(bmc_ip_address, &interface, None, None, None)
+            .await
+            .map_err(|error| error.to_string())?;
+
+        credential_manager
+            .get_credentials(&get_bmc_root_credential_key(bmc_mac_address))
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "per-BMC credentials were not restored".to_string())
+    }
+
+    /// Reingestion has no per-BMC Vault secret even though the hardware still
+    /// carries the site-wide password from its prior ingestion. For every DPU
+    /// generation, the factory attempt must fail authentication, after which
+    /// site-explorer validates the site-wide password and restores the
+    /// per-BMC secret with that generation's administrative username.
+    #[tokio::test(start_paused = true)]
+    async fn reingested_dpus_restore_missing_bmc_credentials_from_sitewide_password() {
+        check_cases_async(
+            [
+                Case {
+                    scenario: "BlueField-3 restores the root credential",
+                    input: ("BlueField-3 DPU", "root"),
+                    expect: Yields(Credentials::UsernamePassword {
+                        username: "root".to_string(),
+                        password: "sitewide-password".to_string(),
+                    }),
+                },
+                Case {
+                    scenario: "BlueField-4 restores the admin credential",
+                    input: ("BlueField-4 DPU", "admin"),
+                    expect: Yields(Credentials::UsernamePassword {
+                        username: "admin".to_string(),
+                        password: "sitewide-password".to_string(),
+                    }),
+                },
+            ],
+            reingest_dpu_with_sitewide_password,
         )
         .await;
     }

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -1763,7 +1763,9 @@ mod tests {
     use arc_swap::ArcSwap;
     use carbide_instrument::Outcome;
     use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
-    use carbide_redfish::libredfish::test_support::{RedfishSim, RedfishSimBootInterfaceRef};
+    use carbide_redfish::libredfish::test_support::{
+        RedfishSim, RedfishSimAuthAttempt, RedfishSimBootInterfaceRef,
+    };
     use carbide_redfish::nv_redfish::NvRedfishClientPool;
     use carbide_secrets::credentials::{
         BmcCredentialType, CredentialKey, CredentialReader, CredentialWriter,
@@ -1908,35 +1910,55 @@ mod tests {
         .await;
     }
 
-    async fn reingest_dpu_with_sitewide_password(
-        (product, username): (&'static str, &'static str),
-    ) -> Result<Credentials, String> {
+    struct DpuGeneration {
+        product: &'static str,
+        username: &'static str,
+    }
+
+    struct ReingestionFixture {
+        sim: Arc<RedfishSim>,
+        credential_manager: Arc<TestCredentialManager>,
+        explorer: BmcEndpointExplorer,
+        bmc_ip_address: SocketAddr,
+        interface: MachineInterfaceSnapshot,
+        sitewide_credential_key: CredentialKey,
+        per_bmc_credential_key: CredentialKey,
+        auth_attempt_count: usize,
+        username: &'static str,
+    }
+
+    const DPU_FACTORY_PASSWORD: &str = "0penBmc";
+    const SITEWIDE_PASSWORD: &str = "sitewide-password";
+
+    async fn prepare_reingestion_fixture(
+        generation: DpuGeneration,
+    ) -> Result<ReingestionFixture, String> {
+        // Start with model-specific factory credentials and no MAC-specific credential record.
+        // This makes the first exploration follow the initial-ingestion path.
         let sim = Arc::new(RedfishSim::default());
-        sim.set_service_root_product(Some(product.to_string()));
-        // Make the factory-default attempt fail so the fallback path is exercised.
+        sim.set_service_root_product(Some(generation.product.to_string()));
         sim.set_enforce_auth(true);
-        // Model hardware retaining the site-wide password from its previous ingestion.
-        sim.seed_user(username, "sitewide-password");
+        sim.seed_user(generation.username, DPU_FACTORY_PASSWORD);
+        // BF4 rotates both administrative accounts, so seed service to let ingestion finish.
         sim.seed_user("service", "factory-service-password");
 
-        // Reproduce deletion by retaining only the site-wide fallback secret.
+        // Store the site-wide password in Vault so initial ingestion can install it
+        // on the DPU and create its MAC-specific credential record.
         let credential_manager = Arc::new(TestCredentialManager::default());
+        let sitewide_credential_key = CredentialKey::BmcCredentials {
+            credential_type: BmcCredentialType::SiteWideRoot,
+        };
         credential_manager
             .set_credentials(
-                &CredentialKey::BmcCredentials {
-                    credential_type: BmcCredentialType::SiteWideRoot,
-                },
-                &Credentials::UsernamePassword {
-                    username: String::new(),
-                    password: "sitewide-password".to_string(),
-                },
+                &sitewide_credential_key,
+                &Credentials::new("", SITEWIDE_PASSWORD),
             )
             .await
             .expect("seed site-wide BMC credentials");
 
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
         let explorer = BmcEndpointExplorer::new(
-            sim,
+            sim.clone(),
             Arc::new(NvRedfishClientPool::new(proxy_address)),
             carbide_ipmi::test_support(),
             credential_manager.clone(),
@@ -1947,45 +1969,179 @@ mod tests {
         let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
         let bmc_mac_address: MacAddress = "02:00:00:00:00:01".parse().expect("valid test BMC MAC");
         let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
+        let per_bmc_credential_key = get_bmc_root_credential_key(bmc_mac_address);
 
+        // Run initial ingestion to establish the state that exists before deletion.
+        // It must rotate the DPU password and record the site-wide credential by MAC address.
         explorer
             .explore_endpoint(bmc_ip_address, &interface, None, None, None)
             .await
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| format!("initial ingestion failed: {error}"))?;
+        assert_eq!(
+            credential_manager
+                .get_credentials(&per_bmc_credential_key)
+                .await
+                .map_err(|error| error.to_string())?,
+            Some(Credentials::new(generation.username, SITEWIDE_PASSWORD)),
+            "initial ingestion must record the site-wide credential by MAC address"
+        );
+        assert_eq!(
+            sim.user_password(generation.username).as_deref(),
+            Some(SITEWIDE_PASSWORD),
+            "initial ingestion must rotate the hardware off its factory password"
+        );
 
+        // Record the current attempt count so later assertions inspect only re-ingestion.
+        let auth_attempt_count = sim.auth_attempts().len();
+        // Machine deletion is outside Site Explorer, but it removes this MAC-specific
+        // record. Delete only that record to reproduce the state passed to re-ingestion.
+        // Keep the global site-wide record because it survives deletion and enables fallback.
         credential_manager
-            .get_credentials(&get_bmc_root_credential_key(bmc_mac_address))
+            .delete_credentials(&per_bmc_credential_key)
             .await
-            .map_err(|error| error.to_string())?
-            .ok_or_else(|| "per-BMC credentials were not restored".to_string())
+            .expect("delete the MAC-specific credential record with the machine entry");
+
+        Ok(ReingestionFixture {
+            sim,
+            credential_manager,
+            explorer,
+            bmc_ip_address,
+            interface,
+            sitewide_credential_key,
+            per_bmc_credential_key,
+            auth_attempt_count,
+            username: generation.username,
+        })
     }
 
-    // Keep the production auth-throttle delay from slowing this fallback test.
+    async fn reingest_with_sitewide_password(
+        generation: DpuGeneration,
+    ) -> Result<Credentials, String> {
+        let fixture = prepare_reingestion_fixture(generation).await?;
+
+        // Keep the site-wide password on the DPU while its MAC-specific record is absent.
+        // This tests recovery through the site-wide credential after factory auth fails.
+        fixture
+            .explorer
+            .explore_endpoint(fixture.bmc_ip_address, &fixture.interface, None, None, None)
+            .await
+            .map_err(|error| format!("re-ingestion failed: {error}"))?;
+
+        let auth_attempts = fixture.sim.auth_attempts();
+        let auth_attempts = &auth_attempts[fixture.auth_attempt_count..];
+        assert_eq!(
+            auth_attempts.first(),
+            Some(&RedfishSimAuthAttempt {
+                credentials: Credentials::new(fixture.username, DPU_FACTORY_PASSWORD),
+                authorized: false,
+            }),
+            "factory-default credentials must be attempted and rejected first"
+        );
+        assert_eq!(
+            auth_attempts.get(1),
+            Some(&RedfishSimAuthAttempt {
+                credentials: Credentials::new(fixture.username, SITEWIDE_PASSWORD),
+                authorized: true,
+            }),
+            "site-wide credentials must authenticate after the factory default fails"
+        );
+
+        fixture
+            .credential_manager
+            .get_credentials(&fixture.per_bmc_credential_key)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| {
+                "re-ingestion did not restore the MAC-specific credential record".to_string()
+            })
+    }
+
+    // Authentication failures are throttled, so pause time to test fallback without waiting.
     #[tokio::test(start_paused = true)]
     async fn reingested_dpus_restore_missing_bmc_credentials_from_sitewide_password() {
-        // Cover both generations because their administrative usernames differ.
+        // Ingestion emits the rotation metric, so hold its test lock to isolate metric counts.
+        let _metrics_window = MetricsCapture::start();
+        // BF3 uses root and BF4 uses admin, so run the same recovery check for both.
         check_cases_async(
             [
                 Case {
                     scenario: "BlueField-3 restores the root credential",
-                    input: ("BlueField-3 DPU", "root"),
-                    expect: Yields(Credentials::UsernamePassword {
-                        username: "root".to_string(),
-                        password: "sitewide-password".to_string(),
-                    }),
+                    input: DpuGeneration {
+                        product: "BlueField-3 DPU",
+                        username: "root",
+                    },
+                    expect: Yields(Credentials::new("root", SITEWIDE_PASSWORD)),
                 },
                 Case {
                     scenario: "BlueField-4 restores the admin credential",
-                    input: ("BlueField-4 DPU", "admin"),
-                    expect: Yields(Credentials::UsernamePassword {
-                        username: "admin".to_string(),
-                        password: "sitewide-password".to_string(),
-                    }),
+                    input: DpuGeneration {
+                        product: "BlueField-4 DPU",
+                        username: "admin",
+                    },
+                    expect: Yields(Credentials::new("admin", SITEWIDE_PASSWORD)),
                 },
             ],
-            reingest_dpu_with_sitewide_password,
+            reingest_with_sitewide_password,
         )
         .await;
+    }
+
+    // Authentication failures are throttled, so pause time to test rejection without waiting.
+    #[tokio::test(start_paused = true)]
+    async fn reingested_dpu_rejects_stale_sitewide_password() {
+        let _metrics_window = MetricsCapture::start();
+        let fixture = prepare_reingestion_fixture(DpuGeneration {
+            product: "BlueField-4 DPU",
+            username: "admin",
+        })
+        .await
+        .expect("prepare a previously ingested DPU");
+
+        // Change the site-wide password in Vault without changing the DPU password.
+        // This tests that failure of primary and fallback authentication is a hard failure.
+        let stale_password = "stale-sitewide-password";
+        fixture
+            .credential_manager
+            .set_credentials(
+                &fixture.sitewide_credential_key,
+                &Credentials::new("", stale_password),
+            )
+            .await
+            .expect("replace the site-wide credential with a stale password");
+
+        let exploration = fixture
+            .explorer
+            .explore_endpoint(fixture.bmc_ip_address, &fixture.interface, None, None, None)
+            .await;
+        assert!(exploration.is_err(), "stale credentials must be rejected");
+
+        let auth_attempts = fixture.sim.auth_attempts();
+        let auth_attempts = &auth_attempts[fixture.auth_attempt_count..];
+        assert_eq!(
+            auth_attempts.first(),
+            Some(&RedfishSimAuthAttempt {
+                credentials: Credentials::new(fixture.username, DPU_FACTORY_PASSWORD),
+                authorized: false,
+            }),
+            "factory-default credentials must be attempted and rejected first"
+        );
+        assert_eq!(
+            auth_attempts.get(1),
+            Some(&RedfishSimAuthAttempt {
+                credentials: Credentials::new(fixture.username, stale_password),
+                authorized: false,
+            }),
+            "stale site-wide credentials must be attempted and rejected"
+        );
+        assert_eq!(
+            fixture
+                .credential_manager
+                .get_credentials(&fixture.per_bmc_credential_key)
+                .await
+                .expect("read the MAC-specific credential record after failed re-ingestion"),
+            None,
+            "hard failure must leave the MAC-specific credential record absent"
+        );
     }
 
     /// One emit per rotation attempt writes the INFO log line and moves

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -1913,10 +1913,13 @@ mod tests {
     ) -> Result<Credentials, String> {
         let sim = Arc::new(RedfishSim::default());
         sim.set_service_root_product(Some(product.to_string()));
+        // Make the factory-default attempt fail so the fallback path is exercised.
         sim.set_enforce_auth(true);
+        // Model hardware retaining the site-wide password from its previous ingestion.
         sim.seed_user(username, "sitewide-password");
         sim.seed_user("service", "factory-service-password");
 
+        // Reproduce deletion by retaining only the site-wide fallback secret.
         let credential_manager = Arc::new(TestCredentialManager::default());
         credential_manager
             .set_credentials(
@@ -1957,13 +1960,10 @@ mod tests {
             .ok_or_else(|| "per-BMC credentials were not restored".to_string())
     }
 
-    /// Reingestion has no per-BMC Vault secret even though the hardware still
-    /// carries the site-wide password from its prior ingestion. For every DPU
-    /// generation, the factory attempt must fail authentication, after which
-    /// site-explorer validates the site-wide password and restores the
-    /// per-BMC secret with that generation's administrative username.
+    // Keep the production auth-throttle delay from slowing this fallback test.
     #[tokio::test(start_paused = true)]
     async fn reingested_dpus_restore_missing_bmc_credentials_from_sitewide_password() {
+        // Cover both generations because their administrative usernames differ.
         check_cases_async(
             [
                 Case {


### PR DESCRIPTION
## Summary

- perform initial BF3 and BF4 ingestion from factory credentials
- verify hardware rotation and creation of the MAC-specific record containing the site-wide credential
- reproduce the state Site Explorer receives after machine deletion by removing that MAC-specific record
- verify successful re-ingestion in one focused test for BF3 and BF4
- verify stale site-wide credential rejection in a separate negative test
- record ordered direct-credential results at the existing Redfish simulator authorization check

## Regression assessment

No production-code regression was reproduced for either BlueField generation. The recovery test proves that re-ingestion rejects the factory password, accepts the site-wide password, and recreates the missing MAC-specific credential record. The negative test proves that failure of factory and site-wide authentication is a hard failure that leaves the record absent.

Machine deletion occurs outside Site Explorer. The shared fixture performs a real initial ingestion, then removes the MAC-specific credential record to reproduce the state passed to Site Explorer after the machine entry is deleted. The DPU keeps the site-wide password and the global site-wide credential record remains available because it belongs to the site.

## Validation

- `cargo test -p carbide-site-explorer --lib` with 59 passing tests
- `cargo test -p carbide-redfish --lib --features test-support` with 36 passing tests
- `cargo clippy -p carbide-site-explorer --all-targets -- -D warnings` under Rust 1.96.0
- `cargo clippy -p carbide-redfish --all-targets --features test-support -- -D warnings` under Rust 1.96.0
- `cargo fmt -p carbide-site-explorer -p carbide-redfish`
- `git diff --check`
