### PR TITLE
feat(machine-a-tron): simulate Lenovo GB300 racks

### DIFF
--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -28,8 +28,8 @@ use carbide_uuid::rack::{RackId, RackProfileId};
 use eyre::ContextCompat;
 use futures::future::join_all;
 use machine_a_tron::{
-    BmcMockRegistry, DhcpType, MachineATronConfig, RackConfig, RackModelConfig,
-    WiwynnGb200RackConfig,
+    BmcMockRegistry, DhcpType, LenovoGb300RackConfig, MachineATronConfig, RackConfig,
+    RackModelConfig, WiwynnGb200RackConfig,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -39,7 +39,7 @@ fn setup() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_machine_a_tron_rack_integration() -> eyre::Result<()> {
+async fn test_machine_a_tron_racks_integration() -> eyre::Result<()> {
     let Some(mut test_env) = IntegrationTestEnvironment::try_from_environment(
         1,
         "api_server_test_machine_a_tron_rack_integration",
@@ -78,7 +78,7 @@ async fn test_machine_a_tron_rack_integration() -> eyre::Result<()> {
     )
     .await?;
 
-    run_machine_a_tron_rack_test(
+    run_machine_a_tron_racks_test(
         &test_env,
         &bmc_address_registry,
         Ipv4Addr::new(172, 20, 0, 2),
@@ -92,12 +92,13 @@ async fn test_machine_a_tron_rack_integration() -> eyre::Result<()> {
     Ok(())
 }
 
-async fn run_machine_a_tron_rack_test(
+async fn run_machine_a_tron_racks_test(
     test_env: &IntegrationTestEnvironment,
     bmc_mock_registry: &BmcMockRegistry,
     admin_dhcp_relay_address: Ipv4Addr,
 ) -> eyre::Result<()> {
-    let rack_id = RackId::new("machine-a-tron-nvl72");
+    let gb200_rack_id = RackId::new("machine-a-tron-gb200-nvl72");
+    let gb300_rack_id = RackId::new("machine-a-tron-gb300-nvl72");
     let api_addr = test_env
         .carbide_api_addrs
         .first()
@@ -108,30 +109,56 @@ async fn run_machine_a_tron_rack_test(
         .map(|address| format!("https://{}:{}", address.ip(), address.port()))
         .collect();
     let mat_config = MachineATronConfig {
-        racks: BTreeMap::from([(
-            "default".to_string(),
-            RackConfig {
-                rack_profile_id: RackProfileId::new("NVL72"),
-                ids: vec![rack_id.clone()],
-                model: RackModelConfig::WiwynnGb200Nvl72 {
-                    simulation: WiwynnGb200RackConfig {
-                        dpu_reboot_delay: 1,
-                        host_reboot_delay: 1,
-                        scout_run_interval: Duration::from_secs(1),
-                        oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
-                        admin_dhcp_relay_address,
-                        host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
-                        run_interval_working: Duration::from_millis(100),
-                        run_interval_idle: Duration::from_secs(1),
-                        network_status_run_interval: Duration::from_secs(1),
-                        network_virtualization_type: None,
-                        dpus_in_nic_mode: false,
-                        dpu_firmware_versions: None,
-                        dpu_agent_version: None,
+        racks: BTreeMap::from([
+            (
+                "gb200".to_string(),
+                RackConfig {
+                    rack_profile_id: RackProfileId::new("NVL72"),
+                    ids: vec![gb200_rack_id.clone()],
+                    model: RackModelConfig::WiwynnGb200Nvl72 {
+                        simulation: WiwynnGb200RackConfig {
+                            dpu_reboot_delay: 1,
+                            host_reboot_delay: 1,
+                            scout_run_interval: Duration::from_secs(1),
+                            oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
+                            admin_dhcp_relay_address,
+                            host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
+                            run_interval_working: Duration::from_millis(100),
+                            run_interval_idle: Duration::from_secs(1),
+                            network_status_run_interval: Duration::from_secs(1),
+                            network_virtualization_type: None,
+                            dpus_in_nic_mode: false,
+                            dpu_firmware_versions: None,
+                            dpu_agent_version: None,
+                        },
                     },
                 },
-            },
-        )]),
+            ),
+            (
+                "gb300".to_string(),
+                RackConfig {
+                    rack_profile_id: RackProfileId::new("NVL72_GB300"),
+                    ids: vec![gb300_rack_id.clone()],
+                    model: RackModelConfig::LenovoGb300Nvl72 {
+                        simulation: LenovoGb300RackConfig {
+                            dpu_reboot_delay: 1,
+                            host_reboot_delay: 1,
+                            scout_run_interval: Duration::from_secs(1),
+                            oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
+                            admin_dhcp_relay_address,
+                            host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
+                            run_interval_working: Duration::from_millis(100),
+                            run_interval_idle: Duration::from_secs(1),
+                            network_status_run_interval: Duration::from_secs(1),
+                            network_virtualization_type: None,
+                            dpus_in_nic_mode: false,
+                            dpu_firmware_versions: None,
+                            dpu_agent_version: None,
+                        },
+                    },
+                },
+            ),
+        ]),
         machines: BTreeMap::new(),
         carbide_api_url: format!("https://{}:{}", api_addr.ip(), api_addr.port()),
         dhcp: DhcpType::Api {},
@@ -165,7 +192,7 @@ async fn run_machine_a_tron_rack_test(
     .await?;
 
     let assertion_result = async {
-        assert_eq!(provisionable_handles.len(), 18);
+        assert_eq!(provisionable_handles.len(), 36);
         let machine_ids = join_all(
             provisionable_handles
                 .iter()
@@ -184,42 +211,51 @@ async fn run_machine_a_tron_rack_test(
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(machine_ids.len(), 18);
+        assert_eq!(machine_ids.len(), 36);
 
-        let managed_machine_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM machines WHERE rack_id = $1")
-                .bind(rack_id.as_str())
-                .fetch_one(&test_env.db_pool)
-                .await?;
-        assert_eq!(managed_machine_count, 18);
+        for (rack_id, expected_profile_id, expected_power_shelf_count) in [
+            (&gb200_rack_id, "NVL72", 8),
+            (&gb300_rack_id, "NVL72_GB300", 6),
+        ] {
+            let managed_machine_count: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM machines WHERE rack_id = $1")
+                    .bind(rack_id.as_str())
+                    .fetch_one(&test_env.db_pool)
+                    .await?;
+            assert_eq!(managed_machine_count, 18, "rack {rack_id}");
 
-        let expected_machine_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM expected_machines WHERE rack_id = $1")
-                .bind(rack_id.as_str())
-                .fetch_one(&test_env.db_pool)
-                .await?;
-        assert_eq!(expected_machine_count, 18);
+            let expected_machine_count: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM expected_machines WHERE rack_id = $1")
+                    .bind(rack_id.as_str())
+                    .fetch_one(&test_env.db_pool)
+                    .await?;
+            assert_eq!(expected_machine_count, 18, "rack {rack_id}");
 
-        let expected_switch_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM expected_switches WHERE rack_id = $1")
-                .bind(rack_id.as_str())
-                .fetch_one(&test_env.db_pool)
-                .await?;
-        assert_eq!(expected_switch_count, 9);
+            let expected_switch_count: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM expected_switches WHERE rack_id = $1")
+                    .bind(rack_id.as_str())
+                    .fetch_one(&test_env.db_pool)
+                    .await?;
+            assert_eq!(expected_switch_count, 9, "rack {rack_id}");
 
-        let expected_power_shelf_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM expected_power_shelves WHERE rack_id = $1")
-                .bind(rack_id.as_str())
-                .fetch_one(&test_env.db_pool)
-                .await?;
-        assert_eq!(expected_power_shelf_count, 8);
+            let actual_power_shelf_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM expected_power_shelves WHERE rack_id = $1",
+            )
+            .bind(rack_id.as_str())
+            .fetch_one(&test_env.db_pool)
+            .await?;
+            assert_eq!(
+                actual_power_shelf_count, expected_power_shelf_count,
+                "rack {rack_id}"
+            );
 
-        let rack_profile_id: String =
-            sqlx::query_scalar("SELECT rack_profile_id FROM expected_racks WHERE rack_id = $1")
-                .bind(rack_id.as_str())
-                .fetch_one(&test_env.db_pool)
-                .await?;
-        assert_eq!(rack_profile_id, "NVL72");
+            let rack_profile_id: String =
+                sqlx::query_scalar("SELECT rack_profile_id FROM expected_racks WHERE rack_id = $1")
+                    .bind(rack_id.as_str())
+                    .fetch_one(&test_env.db_pool)
+                    .await?;
+            assert_eq!(rack_profile_id, expected_profile_id, "rack {rack_id}");
+        }
 
         Ok::<(), eyre::Report>(())
     }

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -257,6 +257,20 @@ pub async fn start(
         [rack_profiles.NVL72.rack_capabilities.power_shelf]
         count = 0
 
+        [rack_profiles.NVL72_GB300]
+        product_family = "gb300"
+
+        [rack_profiles.NVL72_GB300.rack_capabilities.compute]
+        name = "GB300"
+        count = 18
+        vendor = "Lenovo"
+
+        [rack_profiles.NVL72_GB300.rack_capabilities.switch]
+        count = 0
+
+        [rack_profiles.NVL72_GB300.rack_capabilities.power_shelf]
+        count = 0
+
         [firmware_global]
         autoupdate = true
         host_enable_autoupdate = []

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl72_rack.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl72_rack.rs
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::hw::rack::RackElevation;
+use crate::{HardwareType, hw};
+
+pub struct LenovoGB300Nvl72Rack;
+
+impl LenovoGB300Nvl72Rack {
+    pub fn rack_elevation(&self) -> RackElevation {
+        hw::nvidia_gb300::nvl72_rack_elevation(
+            HardwareType::LenovoGB300Nvl,
+            HardwareType::LiteOnPowerShelf,
+            HardwareType::NvidiaSwitchN5700Ld,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::*;
+
+    #[test]
+    fn has_expected_elevation() {
+        let elevation = LenovoGB300Nvl72Rack.rack_elevation();
+
+        assert_eq!(elevation.version, 1);
+        assert_eq!(elevation.units.len(), 33);
+        assert_eq!(
+            elevation
+                .units
+                .iter()
+                .map(|unit| unit.position)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            33
+        );
+        assert_eq!(
+            elevation
+                .units
+                .iter()
+                .filter(|unit| unit.hardware_type == HardwareType::LenovoGB300Nvl)
+                .map(|unit| unit.position)
+                .collect::<Vec<_>>(),
+            (11..=18).chain(28..=37).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            elevation
+                .units
+                .iter()
+                .filter(|unit| unit.hardware_type == HardwareType::NvidiaSwitchN5700Ld)
+                .map(|unit| unit.position)
+                .collect::<Vec<_>>(),
+            (19..=27).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            elevation
+                .units
+                .iter()
+                .filter(|unit| unit.hardware_type == HardwareType::LiteOnPowerShelf)
+                .map(|unit| unit.position)
+                .collect::<Vec<_>>(),
+            (7..=9).chain(39..=41).collect::<Vec<_>>()
+        );
+        assert!(
+            elevation
+                .units
+                .iter()
+                .all(|unit| unit.hardware_type.fixed_number_of_dpu().is_some())
+        );
+    }
+}

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -48,6 +48,9 @@ pub(super) mod rack;
 /// WIWYNN GB200 NVL72 rack.
 pub(super) mod wiwynn_gb200_nvl72_rack;
 
+/// Lenovo GB300 NVL72 rack.
+pub mod lenovo_gb300_nvl72_rack;
+
 /// Support of Lenovo GB300 NVL servers.
 pub(super) mod lenovo_gb300_nvl;
 

--- a/crates/bmc-mock/src/hw/nvidia_gb300.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb300.rs
@@ -17,7 +17,32 @@
 
 use std::borrow::Cow;
 
-use crate::redfish;
+use crate::hw::rack::{RackElevation, RackUnit};
+use crate::{HardwareType, redfish};
+
+pub(crate) fn nvl72_rack_elevation(
+    compute_tray: HardwareType,
+    power_shelf: HardwareType,
+    nvlink_switch_tray: HardwareType,
+) -> RackElevation {
+    let mut units = Vec::with_capacity(33);
+
+    units.extend((11..=18).chain(28..=37).map(|position| RackUnit {
+        position,
+        hardware_type: compute_tray,
+    }));
+    units.extend((19..=27).map(|position| RackUnit {
+        position,
+        hardware_type: nvlink_switch_tray,
+    }));
+    units.extend((7..=9).chain(39..=41).map(|position| RackUnit {
+        position,
+        hardware_type: power_shelf,
+    }));
+    units.sort_unstable_by_key(|unit| unit.position);
+
+    RackElevation { version: 1, units }
+}
 
 pub(crate) struct NvidiaGB300Gpu<'a> {
     pub(crate) serial_number: Cow<'a, str>,

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -63,12 +63,15 @@ pub const DUMMY_FACTORY_PASSWORD: &str = "factory_password";
 pub enum RackType {
     #[serde(rename = "wiwynn_gb200_nvl72")]
     WiwynnGb200Nvl72,
+    #[serde(rename = "lenovo_gb300_nvl72")]
+    LenovoGb300Nvl72,
 }
 
 impl fmt::Display for RackType {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::WiwynnGb200Nvl72 => formatter.write_str("WIWYNN GB200 NVL72"),
+            Self::LenovoGb300Nvl72 => formatter.write_str("Lenovo GB300 NVL72"),
         }
     }
 }

--- a/crates/bmc-mock/src/rack_info.rs
+++ b/crates/bmc-mock/src/rack_info.rs
@@ -16,6 +16,7 @@
  */
 
 use crate::RackType;
+use crate::hw::lenovo_gb300_nvl72_rack::LenovoGB300Nvl72Rack;
 use crate::hw::rack::RackElevation;
 use crate::hw::wiwynn_gb200_nvl72_rack::WiwynnGB200Nvl72Rack;
 
@@ -28,10 +29,15 @@ impl RackInfo {
     pub fn rack_elevation(&self) -> RackElevation {
         match self.rack_type {
             RackType::WiwynnGb200Nvl72 => self.wiwynn_gb200_nvl72_rack().rack_elevation(),
+            RackType::LenovoGb300Nvl72 => self.lenovo_gb300_nvl72_rack().rack_elevation(),
         }
     }
 
     fn wiwynn_gb200_nvl72_rack(&self) -> WiwynnGB200Nvl72Rack {
         WiwynnGB200Nvl72Rack
+    }
+
+    fn lenovo_gb300_nvl72_rack(&self) -> LenovoGB300Nvl72Rack {
+        LenovoGB300Nvl72Rack
     }
 }

--- a/crates/machine-a-tron/config/mat.toml
+++ b/crates/machine-a-tron/config/mat.toml
@@ -78,13 +78,13 @@ enable_ipmi_simulation = false
 # host_bmc_password = "vault-password"
 # dpu_bmc_password = "vault-password"
 
-# Selecting the concrete WIWYNN GB200 rack supplies its 18 WIWYNN compute
-# trays, 9 NVIDIA ND5200 switch trays, and 8 LiteOn power shelves. The rack
-# profile tells NICo core how to manage the simulated rack.
+# A rack type creates all of its devices automatically:
+# - wiwynn_gb200_nvl72: 18 compute trays, 9 ND5200 switches, 8 power shelves
+# - lenovo_gb300_nvl72: 18 compute trays, 9 N5700 switches, 6 power shelves
 #
 # [racks.default]
-# type = "wiwynn_gb200_nvl72"
-# rack_profile_id = "NVL72"
+# type = "lenovo_gb300_nvl72"
+# rack_profile_id = "NVL72_GB300"
 # ids = ["rack-001", "rack-002"]
 # dpu_reboot_delay = 20
 # host_reboot_delay = 10

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -212,6 +212,79 @@ impl WiwynnGb200RackConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct LenovoGb300RackConfig {
+    pub dpu_reboot_delay: u64,
+    pub host_reboot_delay: u64,
+    #[serde(
+        default = "default_scout_run_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub scout_run_interval: Duration,
+    pub oob_dhcp_relay_address: Ipv4Addr,
+    pub admin_dhcp_relay_address: Ipv4Addr,
+    #[serde(default)]
+    pub host_inband_dhcp_relay_address: Option<Ipv4Addr>,
+    #[serde(
+        default = "default_run_interval_working",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub run_interval_working: Duration,
+    #[serde(
+        default = "default_run_interval_idle",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub run_interval_idle: Duration,
+    #[serde(
+        default = "default_network_status_run_interval",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub network_status_run_interval: Duration,
+    #[serde(default)]
+    pub network_virtualization_type: Option<String>,
+    #[serde(default)]
+    pub dpus_in_nic_mode: bool,
+    #[serde(default)]
+    pub dpu_firmware_versions: Option<DpuFirmwareVersions>,
+    #[serde(default)]
+    pub dpu_agent_version: Option<String>,
+}
+
+impl LenovoGb300RackConfig {
+    fn component_machine_config(
+        &self,
+        rack_id: RackId,
+        hw_type: HardwareType,
+        dpu_per_host_count: u32,
+    ) -> MachineConfig {
+        MachineConfig {
+            rack_id: Some(rack_id),
+            hw_type,
+            host_count: 1,
+            vpc_count: 0,
+            subnets_per_vpc: 0,
+            dpu_per_host_count,
+            dpu_reboot_delay: self.dpu_reboot_delay,
+            host_reboot_delay: self.host_reboot_delay,
+            scout_run_interval: self.scout_run_interval,
+            oob_dhcp_relay_address: self.oob_dhcp_relay_address,
+            admin_dhcp_relay_address: self.admin_dhcp_relay_address,
+            host_inband_dhcp_relay_address: self.host_inband_dhcp_relay_address,
+            run_interval_working: self.run_interval_working,
+            run_interval_idle: self.run_interval_idle,
+            network_status_run_interval: self.network_status_run_interval,
+            network_virtualization_type: self.network_virtualization_type.clone(),
+            dpus_in_nic_mode: self.dpus_in_nic_mode,
+            dpu_firmware_versions: self.dpu_firmware_versions.clone(),
+            dpu_agent_version: self.dpu_agent_version.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct RackConfig {
     pub rack_profile_id: RackProfileId,
     pub ids: Vec<RackId>,
@@ -226,12 +299,17 @@ pub enum RackModelConfig {
         #[serde(flatten)]
         simulation: WiwynnGb200RackConfig,
     },
+    LenovoGb300Nvl72 {
+        #[serde(flatten)]
+        simulation: LenovoGb300RackConfig,
+    },
 }
 
 impl RackModelConfig {
     fn rack_type(&self) -> RackType {
         match self {
             Self::WiwynnGb200Nvl72 { .. } => RackType::WiwynnGb200Nvl72,
+            Self::LenovoGb300Nvl72 { .. } => RackType::LenovoGb300Nvl72,
         }
     }
 
@@ -243,6 +321,9 @@ impl RackModelConfig {
     ) -> MachineConfig {
         match self {
             Self::WiwynnGb200Nvl72 { simulation } => {
+                simulation.component_machine_config(rack_id, hardware_type, dpu_per_host_count)
+            }
+            Self::LenovoGb300Nvl72 { simulation } => {
                 simulation.component_machine_config(rack_id, hardware_type, dpu_per_host_count)
             }
         }
@@ -867,6 +948,24 @@ scout_run_interval = "5s"
         }
     }
 
+    fn lenovo_gb300_rack_from_machine(machine: &MachineConfig) -> LenovoGb300RackConfig {
+        LenovoGb300RackConfig {
+            dpu_reboot_delay: machine.dpu_reboot_delay,
+            host_reboot_delay: machine.host_reboot_delay,
+            scout_run_interval: machine.scout_run_interval,
+            oob_dhcp_relay_address: machine.oob_dhcp_relay_address,
+            admin_dhcp_relay_address: machine.admin_dhcp_relay_address,
+            host_inband_dhcp_relay_address: machine.host_inband_dhcp_relay_address,
+            run_interval_working: machine.run_interval_working,
+            run_interval_idle: machine.run_interval_idle,
+            network_status_run_interval: machine.network_status_run_interval,
+            network_virtualization_type: machine.network_virtualization_type.clone(),
+            dpus_in_nic_mode: machine.dpus_in_nic_mode,
+            dpu_firmware_versions: machine.dpu_firmware_versions.clone(),
+            dpu_agent_version: machine.dpu_agent_version.clone(),
+        }
+    }
+
     fn gb200_rack_config() -> MachineATronConfig {
         let mut config = rack_config();
         let template = config.machines["config"].clone();
@@ -884,6 +983,23 @@ scout_run_interval = "5s"
         config
     }
 
+    fn gb300_rack_config() -> MachineATronConfig {
+        let mut config = rack_config();
+        let template = config.machines["config"].clone();
+        config.machines.clear();
+        config.racks.insert(
+            "default".to_string(),
+            RackConfig {
+                ids: vec![RackId::new("rack-002"), RackId::new("rack-001")],
+                rack_profile_id: RackProfileId::new("NVL72_GB300"),
+                model: RackModelConfig::LenovoGb300Nvl72 {
+                    simulation: lenovo_gb300_rack_from_machine(&template),
+                },
+            },
+        );
+        config
+    }
+
     #[test]
     fn test_serialize_config() {
         let cfg = rack_config();
@@ -895,78 +1011,151 @@ scout_run_interval = "5s"
     }
 
     #[test]
-    fn gb200_rack_config_round_trips() {
-        let config = gb200_rack_config();
-        config.validate().unwrap();
-
-        let serialized = toml::to_string(&config).unwrap();
-        assert!(serialized.contains("[racks.default]"));
-        assert!(serialized.contains("type = \"wiwynn_gb200_nvl72\""));
-        assert!(serialized.contains("rack_profile_id = \"NVL72\""));
-        assert!(serialized.contains("ids = [\"rack-002\", \"rack-001\"]"));
-        let round_tripped = toml::from_str::<MachineATronConfig>(&serialized).unwrap();
-
-        assert_eq!(round_tripped, config);
+    fn rack_configs_round_trip() {
+        check_cases(
+            [
+                Case {
+                    scenario: "WIWYNN GB200 rack",
+                    input: (
+                        gb200_rack_config(),
+                        "type = \"wiwynn_gb200_nvl72\"",
+                        "rack_profile_id = \"NVL72\"",
+                    ),
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "Lenovo GB300 rack",
+                    input: (
+                        gb300_rack_config(),
+                        "type = \"lenovo_gb300_nvl72\"",
+                        "rack_profile_id = \"NVL72_GB300\"",
+                    ),
+                    expect: Yields(()),
+                },
+            ],
+            |(config, expected_type, expected_profile)| {
+                (|| -> eyre::Result<()> {
+                    config.validate()?;
+                    let serialized = toml::to_string(&config)?;
+                    eyre::ensure!(serialized.contains("[racks.default]"));
+                    eyre::ensure!(serialized.contains(expected_type));
+                    eyre::ensure!(serialized.contains(expected_profile));
+                    eyre::ensure!(serialized.contains("ids = [\"rack-002\", \"rack-001\"]"));
+                    let round_tripped = toml::from_str::<MachineATronConfig>(&serialized)?;
+                    eyre::ensure!(round_tripped == config);
+                    Ok(())
+                })()
+                .map_err(drop)
+            },
+        );
     }
 
     #[test]
-    fn wiwynn_gb200_rack_expands_its_managed_hardware() {
-        let config = gb200_rack_config();
-
-        let first = config.resolved_device_configs().unwrap();
-        let second = config.resolved_device_configs().unwrap();
-
-        assert_eq!(first.machines.len(), 70);
-        assert_eq!(
-            first.machines.keys().collect::<Vec<_>>(),
-            second.machines.keys().collect::<Vec<_>>()
-        );
-        assert_eq!(first.racks.len(), 2);
-        assert_eq!(first.racks[0].rack_id, RackId::new("rack-001"));
-        assert_eq!(first.racks[1].rack_id, RackId::new("rack-002"));
-        for rack in &first.racks {
-            assert_eq!(rack.rack_profile_id, RackProfileId::new("NVL72"));
-            assert_eq!(rack.members.len(), 35);
-            assert_eq!(
-                rack.members
-                    .iter()
-                    .map(|member| member.position)
-                    .collect::<BTreeSet<_>>()
-                    .len(),
-                35
-            );
+    fn rack_models_expand_their_managed_hardware() {
+        #[derive(Debug)]
+        struct ExpectedExpansion {
+            config: MachineATronConfig,
+            rack_profile_id: &'static str,
+            rack_type: RackType,
+            member_count: usize,
+            compute_type: HardwareType,
+            compute_count: usize,
+            switch_type: HardwareType,
+            switch_count: usize,
+            power_shelf_type: HardwareType,
+            power_shelf_count: usize,
         }
 
-        for machine in first.machines.values() {
-            assert_eq!(machine.host_count, 1);
-            assert!(
-                machine.rack_id == Some(RackId::new("rack-001"))
-                    || machine.rack_id == Some(RackId::new("rack-002"))
-            );
-        }
-        assert_eq!(
-            first
-                .machines
-                .values()
-                .filter(|machine| machine.hw_type == HardwareType::WiwynnGB200Nvl)
-                .count(),
-            36
-        );
-        assert_eq!(
-            first
-                .machines
-                .values()
-                .filter(|machine| machine.hw_type == HardwareType::NvidiaSwitchNd5200Ld)
-                .count(),
-            18
-        );
-        assert_eq!(
-            first
-                .machines
-                .values()
-                .filter(|machine| machine.hw_type == HardwareType::LiteOnPowerShelf)
-                .count(),
-            16
+        check_cases(
+            [
+                Case {
+                    scenario: "WIWYNN GB200 rack",
+                    input: ExpectedExpansion {
+                        config: gb200_rack_config(),
+                        rack_profile_id: "NVL72",
+                        rack_type: RackType::WiwynnGb200Nvl72,
+                        member_count: 35,
+                        compute_type: HardwareType::WiwynnGB200Nvl,
+                        compute_count: 36,
+                        switch_type: HardwareType::NvidiaSwitchNd5200Ld,
+                        switch_count: 18,
+                        power_shelf_type: HardwareType::LiteOnPowerShelf,
+                        power_shelf_count: 16,
+                    },
+                    expect: Yields(()),
+                },
+                Case {
+                    scenario: "Lenovo GB300 rack",
+                    input: ExpectedExpansion {
+                        config: gb300_rack_config(),
+                        rack_profile_id: "NVL72_GB300",
+                        rack_type: RackType::LenovoGb300Nvl72,
+                        member_count: 33,
+                        compute_type: HardwareType::LenovoGB300Nvl,
+                        compute_count: 36,
+                        switch_type: HardwareType::NvidiaSwitchN5700Ld,
+                        switch_count: 18,
+                        power_shelf_type: HardwareType::LiteOnPowerShelf,
+                        power_shelf_count: 12,
+                    },
+                    expect: Yields(()),
+                },
+            ],
+            |expected| {
+                (|| -> eyre::Result<()> {
+                    let first = expected.config.resolved_device_configs()?;
+                    let second = expected.config.resolved_device_configs()?;
+
+                    eyre::ensure!(first.machines.len() == expected.member_count * 2);
+                    eyre::ensure!(
+                        first.machines.keys().collect::<Vec<_>>()
+                            == second.machines.keys().collect::<Vec<_>>()
+                    );
+                    eyre::ensure!(first.racks.len() == 2);
+                    eyre::ensure!(first.racks[0].rack_id == RackId::new("rack-001"));
+                    eyre::ensure!(first.racks[1].rack_id == RackId::new("rack-002"));
+                    for rack in &first.racks {
+                        eyre::ensure!(
+                            rack.rack_profile_id == RackProfileId::new(expected.rack_profile_id)
+                        );
+                        eyre::ensure!(rack.rack_type == expected.rack_type);
+                        eyre::ensure!(rack.members.len() == expected.member_count);
+                        eyre::ensure!(
+                            rack.members
+                                .iter()
+                                .map(|member| member.position)
+                                .collect::<BTreeSet<_>>()
+                                .len()
+                                == expected.member_count
+                        );
+                    }
+
+                    for machine in first.machines.values() {
+                        eyre::ensure!(machine.host_count == 1);
+                        eyre::ensure!(
+                            machine.rack_id == Some(RackId::new("rack-001"))
+                                || machine.rack_id == Some(RackId::new("rack-002"))
+                        );
+                    }
+                    for (hardware_type, count) in [
+                        (expected.compute_type, expected.compute_count),
+                        (expected.switch_type, expected.switch_count),
+                        (expected.power_shelf_type, expected.power_shelf_count),
+                    ] {
+                        eyre::ensure!(
+                            first
+                                .machines
+                                .values()
+                                .filter(|machine| machine.hw_type == hardware_type)
+                                .count()
+                                == count
+                        );
+                    }
+
+                    Ok(())
+                })()
+                .map_err(drop)
+            },
         );
     }
 

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -49,8 +49,9 @@ use std::time::{Duration, Instant};
 
 pub use bmc_mock_wrapper::BmcMockRegistry;
 pub use config::{
-    DhcpType, MachineATronArgs, MachineATronConfig, MachineATronContext, MachineConfig,
-    PersistedDevice, PersistedDpuMachine, RackConfig, RackModelConfig, WiwynnGb200RackConfig,
+    DhcpType, LenovoGb300RackConfig, MachineATronArgs, MachineATronConfig, MachineATronContext,
+    MachineConfig, PersistedDevice, PersistedDpuMachine, RackConfig, RackModelConfig,
+    WiwynnGb200RackConfig,
 };
 pub use control_router::{ControlState, append as append_control_routes};
 pub use device_handle::DeviceHandle;

--- a/dev/deployment/tilt/README.md
+++ b/dev/deployment/tilt/README.md
@@ -44,6 +44,8 @@ Tilt forwards these endpoints:
 
 | Service | URL |
 | --- | --- |
+| NICo Web UI | `https://localhost:1079/admin/` |
+| Machine-A-Tron UI | `https://localhost:1266/` |
 | REST API | `http://localhost:18388` |
 | Keycloak | `http://localhost:18082` |
 | MCP | `http://localhost:18080/mcp` |

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -83,6 +83,7 @@ def helm_chart(
         image_dep='',
         image_keys=[],
         port_forwards=[],
+        links=[],
         manual=False,
         wait=True,
         timeout='5m'):
@@ -105,6 +106,7 @@ def helm_chart(
         labels=['application'],
         pod_readiness='wait' if wait else 'ignore',
         port_forwards=port_forwards,
+        links=links,
         flags=flags,
     )
     if manual:
@@ -729,6 +731,8 @@ helm_chart(
     resource_deps=nico_api_dependencies,
     image_dep='nico-api',
     image_keys=[('global.image.repository', 'global.image.tag')],
+    port_forwards=[port_forward(1079, 1079)],
+    links=[link('https://localhost:1079/admin/', 'NICo Web UI')],
     manual=True,
 )
 helm_chart(
@@ -749,6 +753,8 @@ helm_chart(
     resource_deps=['nico-api'],
     image_dep='machine-a-tron',
     image_keys=[('image.repository', 'image.tag')],
+    port_forwards=[port_forward(1266, 1266)],
+    links=[link('https://localhost:1266/', 'Machine-A-Tron UI')],
     manual=True,
 )
 

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -173,6 +173,8 @@ nico-machine-a-tron:
   enabled: true
   machineATron:
     nicoApiUrl: https://nico-api.nico-system.svc.cluster.local:1079
+  persistence:
+    enabled: true
   certificate:
     uris:
       - spiffe://nico.local/nico-system/sa/machine-a-tron


### PR DESCRIPTION
This change extends the WIWYNN GB200 rack simulation by adding a concrete Lenovo GB300 NVL72 rack model.

The GB300 rack model defines a versioned rack elevation containing:
- 18 Lenovo GB300 compute trays
- 9 NVIDIA N5700 NVLink switch trays
- 6 LiteOn power shelves

Machine-a-tron expands each configured rack into its component devices and registers the expected rack, machines, switches, and power shelves with NICo. The rack is associated with the `NVL72_GB300` rack profile.

This follows the existing GB200 implementation rather than introducing a separate generic rack-design abstraction. 

## Related issues

Closes #4280

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The description of #4280 predates the rack-model approach introduced by #4422. This implementation follows that newer approach and adds GB300 alongside the existing GB200 model.

Manual testing with a local Tilt cluster verified the GB300 rack elevation and expected inventory registration. The simulated rack contained 18 Lenovo compute trays, 9 N5700 switches, and 6 LiteOn power shelves.