### PR TITLE
dev: add Tilt-based local development workflow

### DIFF
--- a/dev/deployment/tilt/README.md
+++ b/dev/deployment/tilt/README.md
@@ -1,0 +1,133 @@
+# Local development with Tilt
+
+Tilt runs the complete local NICo development stack from the repository's Helm
+charts and Kubernetes sources. DevSpace remains available as a separate
+workflow.
+
+> [!WARNING]
+> This workflow is intended only for local development and is
+> provided as-is. Use it at your own risk.
+
+## Requirements
+
+- Docker
+- Tilt
+- Helm 3 or Helm 4, plus Python 3 for Tilt's `helm_resource` extension
+- `kubectl` connected to a kind cluster
+
+The Tiltfile refuses to load unless the active Kubernetes context starts with
+`kind-`. This is stricter than Tilt's built-in local-cluster safety check and
+prevents this development stack from targeting another cluster type.
+
+## Start
+
+From the repository root, run:
+
+```bash
+tilt up -f dev/deployment/tilt/Tiltfile
+```
+
+The default stack includes:
+
+- cert-manager
+- the CloudNativePG operator and one PostgreSQL cluster
+- Vault in local development mode
+- NICo API, BMC proxy, and machine-a-tron
+- Temporal and its local namespaces
+- Keycloak and the `nico-dev` realm
+- NICo REST API, database migrations, certificate manager, site manager,
+  workflow workers, and site agent
+- NICo MCP
+- automatic local site registration
+
+Tilt forwards these endpoints:
+
+| Service | URL |
+| --- | --- |
+| REST API | `http://localhost:18388` |
+| Keycloak | `http://localhost:18082` |
+| MCP | `http://localhost:18080/mcp` |
+| Temporal UI | `http://localhost:18233` |
+
+All Tilt settings are in [`values.yaml`](values.yaml). NICo Core values are at
+the document root, while the `tilt` section contains the prerequisite and REST
+settings.
+
+## Image builds
+
+Core uses the existing Dockerfiles under
+[`dev/deployment/devspace/`](../devspace). REST and MCP use the existing
+Dockerfiles under [`rest-api/docker/local/`](../../../rest-api/docker/local).
+The Tilt setup does not add or modify a Dockerfile.
+
+Each deployable image has its own Tilt resource and rebuild control. Images build
+once during startup, then wait for their resource's update button before
+rebuilding. REST build contexts are restricted to the source directories copied
+by that image's Dockerfile. Docker and Cargo or Go build caches are reused across
+rebuilds.
+
+## Optional profiles
+
+The `tilt.profiles` switches in [`values.yaml`](values.yaml) control REST, MCP,
+and DSX Exchange. REST brings Temporal and Keycloak, MCP automatically brings
+REST, and DSX Exchange brings NATS. The committed defaults enable REST and MCP
+and disable DSX Exchange.
+
+Changes to `values.yaml` reload the running Tilt session. For temporary
+overrides, use `tilt args`. Start only Core with:
+
+```bash
+tilt args -- --rest=false --mcp=false
+```
+
+Run REST without MCP with:
+
+```bash
+tilt args -- --rest=true --mcp=false
+```
+
+Add DSX Exchange with:
+
+```bash
+tilt args -- --dsx-exchange=true
+```
+
+Return to the values-file defaults with:
+
+```bash
+tilt args --clear
+```
+
+## Existing local clusters
+
+An earlier draft of this Tilt setup deployed Core as one Helm release named
+`nico`. Remove that release once before starting the component-based setup:
+
+```bash
+helm uninstall nico -n nico-system
+```
+
+Tilt and DevSpace deploy the same application object names and should not manage
+the same cluster simultaneously. Before switching an existing DevSpace kind
+cluster to Tilt, run:
+
+```bash
+LOCAL_DEV_INSTALL_REST_PREREQS=0 devspace purge -n nico-system
+```
+
+To switch back to DevSpace, remove the Tilt stack and use the existing DevSpace
+bootstrap and deploy commands:
+
+```bash
+tilt down -f dev/deployment/tilt/Tiltfile
+dev/deployment/devspace/bootstrap-prereqs.sh
+devspace deploy -n nico-system
+```
+
+## Stop and remove
+
+Stopping `tilt up` leaves the stack running. Remove Tilt-managed resources with:
+
+```bash
+tilt down -f dev/deployment/tilt/Tiltfile
+```

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -1,0 +1,924 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load('ext://helm_resource', 'helm_repo', 'helm_resource')
+
+update_settings(max_parallel_updates=4, k8s_upsert_timeout_secs=1020)
+
+cluster_context = k8s_context()
+if not cluster_context.startswith('kind-'):
+    fail('NICo local development requires a Kind context; current context is %s' % cluster_context)
+
+repo_root = os.path.realpath(os.path.join(os.path.dirname(__file__), '../../..'))
+tilt_dir = os.path.join(repo_root, 'dev/deployment/tilt')
+devspace_dir = os.path.join(repo_root, 'dev/deployment/devspace')
+core_charts = os.path.join(repo_root, 'helm/charts')
+rest_charts = os.path.join(repo_root, 'helm/rest')
+rest_api_dir = os.path.join(repo_root, 'rest-api')
+values_file = os.path.join(tilt_dir, 'values.yaml')
+
+all_values = read_yaml(values_file)
+tilt_values = all_values['tilt']
+profiles = tilt_values['profiles']
+config.define_bool('rest')
+config.define_bool('mcp')
+config.define_bool('dsx-exchange')
+options = config.parse()
+enable_mcp = options.get('mcp', profiles['mcp'])
+enable_rest = options.get('rest', profiles['rest']) or enable_mcp
+enable_dsx_exchange = options.get('dsx-exchange', profiles['dsxExchange'])
+local_config = tilt_values['localConfig']
+core_namespace = local_config['coreNamespace']
+rest_namespace = local_config['restNamespace']
+temporal_namespace = local_config['temporalNamespace']
+
+def merged(first, second):
+    result = {}
+    for key, value in first.items():
+        result[key] = value
+    for key, value in second.items():
+        result[key] = value
+    return result
+
+def component_values(global_values, values):
+    return merged({'global': global_values}, values)
+
+def object_metadata(name, namespace=None):
+    result = {'name': name}
+    if namespace:
+        result['namespace'] = namespace
+    return result
+
+def object_selector(obj):
+    name = obj['metadata']['name']
+    kind = obj['kind'].lower()
+    namespace = obj['metadata'].get('namespace', '')
+    if namespace:
+        return '%s:%s:%s' % (name, kind, namespace)
+    return '%s:%s' % (name, kind)
+
+def secret(name, namespace, string_data, secret_type='Opaque', labels={}):
+    return {
+        'apiVersion': 'v1',
+        'kind': 'Secret',
+        'metadata': merged(object_metadata(name, namespace), {'labels': labels}),
+        'type': secret_type,
+        'stringData': string_data,
+    }
+
+def config_map(name, namespace, data):
+    return {
+        'apiVersion': 'v1',
+        'kind': 'ConfigMap',
+        'metadata': object_metadata(name, namespace),
+        'data': data,
+    }
+
+def helm_chart(
+        name,
+        chart,
+        namespace,
+        values,
+        resource_deps=[],
+        image_dep='',
+        image_keys=[],
+        port_forwards=[],
+        manual=False,
+        wait=True,
+        timeout='5m'):
+    flags = [
+        '--create-namespace',
+        '--set-json',
+        encode_json(values),
+    ]
+    if wait:
+        flags.extend(['--wait', '--wait-for-jobs', '--timeout=%s' % timeout])
+    helm_resource(
+        name=name,
+        chart=chart,
+        release_name=name,
+        namespace=namespace,
+        deps=[chart, values_file],
+        resource_deps=resource_deps,
+        image_deps=[image_dep] if image_dep else [],
+        image_keys=image_keys,
+        labels=['application'],
+        pod_readiness='wait' if wait else 'ignore',
+        port_forwards=port_forwards,
+        flags=flags,
+    )
+    if manual:
+        k8s_resource(name, trigger_mode=TRIGGER_MODE_MANUAL)
+
+def prerequisite(
+        name,
+        chart,
+        release_name,
+        namespace,
+        version,
+        values,
+        repo,
+        resource_deps=[]):
+    helm_resource(
+        name=name,
+        chart=chart,
+        release_name=release_name,
+        namespace=namespace,
+        deps=[values_file],
+        resource_deps=[repo] + resource_deps,
+        labels=['infrastructure'],
+        pod_readiness='wait',
+        flags=[
+            '--version=%s' % version,
+            '--create-namespace',
+            '--set-json',
+            encode_json(values),
+            '--wait',
+            '--timeout=5m',
+        ],
+    )
+
+def rest_image(name, dockerfile, only):
+    docker_build(
+        'localhost/%s' % name,
+        rest_api_dir,
+        dockerfile=os.path.join(rest_api_dir, 'docker/local', dockerfile),
+        only=only + [
+            'go.mod',
+            'go.sum',
+            'sdk/standard/go.mod',
+            'docker/local/%s' % dockerfile,
+        ],
+    )
+
+helm_repo(
+    'jetstack',
+    'https://charts.jetstack.io',
+    resource_name='repo-jetstack',
+    labels=['infrastructure'],
+)
+helm_repo(
+    'cnpg',
+    'https://cloudnative-pg.github.io/charts',
+    resource_name='repo-cnpg',
+    labels=['infrastructure'],
+)
+helm_repo(
+    'hashicorp',
+    'https://helm.releases.hashicorp.com',
+    resource_name='repo-hashicorp',
+    labels=['infrastructure'],
+)
+
+prerequisite(
+    name='cert-manager',
+    chart='jetstack/cert-manager',
+    release_name='cert-manager',
+    namespace='cert-manager',
+    version='v1.21.1',
+    values=tilt_values['certManager'],
+    repo='repo-jetstack',
+)
+prerequisite(
+    name='cnpg-operator',
+    chart='cnpg/cloudnative-pg',
+    release_name='cnpg',
+    namespace='cnpg-system',
+    version='0.29.0',
+    values=tilt_values['cnpgOperator'],
+    repo='repo-cnpg',
+)
+prerequisite(
+    name='vault',
+    chart='hashicorp/vault',
+    release_name='nico-vault',
+    namespace=core_namespace,
+    version='0.34.0',
+    values=tilt_values['vault'],
+    repo='repo-hashicorp',
+)
+
+local_ca_certificate = str(read_file(
+    os.path.join(repo_root, 'dev/certs/localhost/ca.crt'),
+))
+local_ca_key = str(read_file(
+    os.path.join(repo_root, 'dev/certs/localhost/ca.key'),
+))
+database_config = local_config['database']
+rest_database = database_config['rest']
+keycloak_database = database_config['keycloak']
+temporal_database = database_config['temporal']
+rest_labels = {'app.kubernetes.io/part-of': 'nico-rest'}
+cnpg_labels = {'cnpg.io/reload': 'true'}
+
+namespace_objects = [
+    {
+        'apiVersion': 'v1',
+        'kind': 'Namespace',
+        'metadata': object_metadata(rest_namespace),
+    },
+    {
+        'apiVersion': 'v1',
+        'kind': 'Namespace',
+        'metadata': object_metadata(temporal_namespace),
+    },
+]
+
+for obj in namespace_objects:
+    k8s_yaml(encode_yaml(obj))
+
+k8s_resource(
+    new_name='nico-local-namespaces',
+    objects=[object_selector(obj) for obj in namespace_objects],
+    labels=['infrastructure'],
+    pod_readiness='ignore',
+)
+
+local_objects = [
+    secret(
+        'nico-local-ca',
+        core_namespace,
+        {'tls.crt': local_ca_certificate, 'tls.key': local_ca_key},
+        secret_type='kubernetes.io/tls',
+    ),
+    secret('nico-roots', core_namespace, {'ca.crt': local_ca_certificate}),
+    {
+        'apiVersion': 'cert-manager.io/v1',
+        'kind': 'Issuer',
+        'metadata': object_metadata('local-ca-issuer', core_namespace),
+        'spec': {'ca': {'secretName': 'nico-local-ca'}},
+    },
+    secret(
+        'nico-vault-token',
+        core_namespace,
+        {'token': local_config['vault']['token']},
+    ),
+    secret(
+        'nico-vault-approle-tokens',
+        core_namespace,
+        {'VAULT_ROLE_ID': '', 'VAULT_SECRET_ID': ''},
+    ),
+    config_map(
+        'vault-cluster-info',
+        core_namespace,
+        {
+            'VAULT_SERVICE': local_config['vault']['service'],
+            'NICO_VAULT_MOUNT': local_config['vault']['mount'],
+            'NICO_VAULT_PKI_MOUNT': local_config['vault']['pkiMount'],
+        },
+    ),
+    config_map(
+        'nico-system-nico-database-config',
+        core_namespace,
+        {
+            'DB_HOST': database_config['host'],
+            'DB_PORT': str(database_config['port']),
+            'DB_NAME': database_config['name'],
+        },
+    ),
+]
+
+if enable_rest:
+    local_objects.extend([
+        secret(
+            'ca-signing-secret',
+            'cert-manager',
+            {'tls.crt': local_ca_certificate, 'tls.key': local_ca_key},
+            secret_type='kubernetes.io/tls',
+        ),
+        secret(
+            'ca-signing-secret',
+            rest_namespace,
+            {'tls.crt': local_ca_certificate, 'tls.key': local_ca_key},
+            secret_type='kubernetes.io/tls',
+        ),
+        {
+            'apiVersion': 'cert-manager.io/v1',
+            'kind': 'ClusterIssuer',
+            'metadata': object_metadata('nico-rest-ca-issuer'),
+            'spec': {'ca': {'secretName': 'ca-signing-secret'}},
+        },
+        secret(
+            'nico-rest-db-user',
+            core_namespace,
+            {'username': rest_database['user'], 'password': rest_database['password']},
+            secret_type='kubernetes.io/basic-auth',
+            labels=cnpg_labels,
+        ),
+        secret(
+            'keycloak-db-user',
+            core_namespace,
+            {'username': keycloak_database['user'], 'password': keycloak_database['password']},
+            secret_type='kubernetes.io/basic-auth',
+            labels=cnpg_labels,
+        ),
+        secret(
+            'temporal-db-user',
+            core_namespace,
+            {'username': temporal_database['user'], 'password': temporal_database['password']},
+            secret_type='kubernetes.io/basic-auth',
+            labels=cnpg_labels,
+        ),
+        secret(
+            'db-creds',
+            rest_namespace,
+            {'password': rest_database['password']},
+            labels=rest_labels,
+        ),
+        secret(
+            'keycloak-client-secret',
+            rest_namespace,
+            {'keycloak-client-secret': local_config['keycloak']['clientSecret']},
+            labels=rest_labels,
+        ),
+        secret(
+            'temporal-encryption-key',
+            rest_namespace,
+            {'temporal-encryption-key': local_config['temporal']['encryptionKey']},
+            labels=rest_labels,
+        ),
+        {
+            'apiVersion': 'v1',
+            'kind': 'Secret',
+            'metadata': merged(
+                object_metadata('image-pull-secret', rest_namespace),
+                {'labels': rest_labels},
+            ),
+            'type': 'kubernetes.io/dockerconfigjson',
+            'data': {'.dockerconfigjson': 'eyJhdXRocyI6e319'},
+        },
+        secret(
+            'site-registration',
+            rest_namespace,
+            {
+                'site-uuid': local_config['site']['id'],
+                'otp': 'local-dev-otp-token',
+                'creds-url': 'https://nico-rest-site-manager:8100/v1/sitecreds',
+                'cacert': local_ca_certificate,
+            },
+        ),
+        secret(
+            'db-creds',
+            temporal_namespace,
+            {'password': temporal_database['password']},
+            labels={'app.kubernetes.io/part-of': 'temporal'},
+        ),
+    ])
+
+for obj in local_objects:
+    k8s_yaml(encode_yaml(obj))
+
+local_config_dependencies = ['cert-manager', 'cnpg-operator', 'vault']
+if enable_rest:
+    local_config_dependencies.append('nico-local-namespaces')
+
+k8s_resource(
+    new_name='nico-local-config',
+    objects=[object_selector(obj) for obj in local_objects],
+    resource_deps=local_config_dependencies,
+    labels=['infrastructure'],
+    pod_readiness='ignore',
+)
+
+postgres_values = tilt_values['postgres']
+if not enable_rest:
+    postgres_values['cluster']['roles'] = []
+
+prerequisite(
+    name='nico-postgres',
+    chart='cnpg/cluster',
+    release_name='nico-postgres',
+    namespace=core_namespace,
+    version='0.8.1',
+    values=postgres_values,
+    repo='repo-cnpg',
+    resource_deps=['cnpg-operator', 'nico-local-config'],
+)
+
+k8s_kind(
+    'Cluster',
+    api_version='postgresql.cnpg.io/v1',
+    pod_readiness='wait',
+)
+k8s_resource(
+    'nico-postgres',
+    extra_pod_selectors=[{'cnpg.io/cluster': 'nico-pg-cluster'}],
+    pod_readiness='wait',
+)
+
+database_objects = []
+for database in [rest_database, keycloak_database, temporal_database]:
+    database_objects.append({
+        'apiVersion': 'postgresql.cnpg.io/v1',
+        'kind': 'Database',
+        'metadata': object_metadata(database['resourceName'], core_namespace),
+        'spec': {
+            'name': database['name'],
+            'owner': database['user'],
+            'cluster': {'name': 'nico-pg-cluster'},
+        },
+    })
+
+database_objects.append({
+    'apiVersion': 'postgresql.cnpg.io/v1',
+    'kind': 'Database',
+    'metadata': object_metadata(
+        temporal_database['visibilityResourceName'],
+        core_namespace,
+    ),
+    'spec': {
+        'name': temporal_database['visibilityName'],
+        'owner': temporal_database['user'],
+        'cluster': {'name': 'nico-pg-cluster'},
+    },
+})
+database_objects[0]['spec']['extensions'] = [
+    {'name': 'pg_trgm', 'ensure': 'present'},
+]
+
+for obj in database_objects:
+    k8s_yaml(encode_yaml(obj))
+
+k8s_resource(
+    new_name='rest-databases',
+    objects=[object_selector(obj) for obj in database_objects],
+    resource_deps=['nico-postgres', 'nico-local-config'],
+    labels=['infrastructure'],
+    pod_readiness='ignore',
+)
+local_resource(
+    'rest-databases-ready',
+    [
+        'kubectl',
+        'wait',
+        '--namespace=%s' % core_namespace,
+        '--for=jsonpath={.status.applied}=true',
+        '--timeout=5m',
+    ] + [
+        'database/%s' % obj['metadata']['name']
+        for obj in database_objects
+    ],
+    resource_deps=['rest-databases'],
+    labels=['infrastructure'],
+)
+
+k8s_yaml(os.path.join(
+    rest_api_dir,
+    'deploy/kustomize/base/temporal-helm/certificates.yaml',
+))
+k8s_resource(
+    new_name='temporal-certificates',
+    objects=[
+        'server-interservice-cert:certificate:%s' % temporal_namespace,
+        'server-cloud-cert:certificate:%s' % temporal_namespace,
+        'server-site-cert:certificate:%s' % temporal_namespace,
+    ],
+    resource_deps=['nico-local-config'],
+    labels=['infrastructure'],
+    pod_readiness='ignore',
+)
+local_resource(
+    'temporal-certificates-ready',
+    [
+        'kubectl',
+        'wait',
+        '--namespace=%s' % temporal_namespace,
+        '--for=condition=Ready',
+        '--timeout=5m',
+        'certificate/server-interservice-cert',
+        'certificate/server-cloud-cert',
+        'certificate/server-site-cert',
+    ],
+    resource_deps=['temporal-certificates'],
+    labels=['infrastructure'],
+)
+
+temporal_values = tilt_values['temporal']
+
+helm_resource(
+    name='temporal',
+    chart=os.path.join(rest_api_dir, 'temporal-helm/temporal'),
+    release_name='temporal',
+    namespace=temporal_namespace,
+    deps=[
+        os.path.join(rest_api_dir, 'temporal-helm/temporal'),
+        values_file,
+    ],
+    resource_deps=[
+        'rest-databases-ready',
+        'temporal-certificates-ready',
+    ],
+    labels=['infrastructure'],
+    pod_readiness='wait',
+    flags=[
+        '--create-namespace',
+        '--values=%s' % os.path.join(
+            rest_api_dir,
+            'temporal-helm/temporal/values-kind.yaml',
+        ),
+        '--set-json',
+        encode_json(temporal_values),
+        '--wait',
+        '--wait-for-jobs',
+        '--timeout=16m',
+    ],
+)
+local_resource(
+    'temporal-ui',
+    serve_cmd=[
+        'kubectl',
+        'port-forward',
+        '--namespace=%s' % temporal_namespace,
+        'service/temporal-web',
+        '18233:8080',
+    ],
+    resource_deps=['temporal'],
+    labels=['infrastructure'],
+    links=['http://localhost:18233'],
+)
+
+setup_local = os.path.join(rest_api_dir, 'scripts/setup-local.sh')
+temporal_namespaces_command = '\n'.join([
+    'set -e',
+    '"%s" temporal-namespace cloud' % setup_local,
+    '"%s" temporal-namespace site' % setup_local,
+    '"%s" temporal-namespace "%s"' % (
+        setup_local,
+        local_config['site']['id'],
+    ),
+])
+local_resource(
+    'temporal-namespaces',
+    ['bash', '-c', temporal_namespaces_command],
+    resource_deps=['temporal'],
+    labels=['infrastructure'],
+)
+
+keycloak_values = tilt_values['keycloak']
+keycloak_objects = decode_yaml_stream(kustomize(os.path.join(
+    rest_api_dir,
+    'deploy/kustomize/base/keycloak',
+)))
+for obj in keycloak_objects:
+    if obj['kind'] == 'Deployment' and obj['metadata']['name'] == 'keycloak':
+        container = obj['spec']['template']['spec']['containers'][0]
+        container['image'] = keycloak_values['image']
+        for variable in container['env']:
+            if variable['name'] == 'KC_DB_URL':
+                variable['value'] = keycloak_values['databaseUrl']
+            if variable['name'] == 'KC_DB_USERNAME':
+                variable['value'] = keycloak_database['user']
+            if variable['name'] == 'KC_DB_PASSWORD':
+                variable['value'] = keycloak_database['password']
+
+k8s_yaml(encode_yaml_stream(keycloak_objects))
+k8s_resource(
+    'keycloak',
+    objects=['keycloak-realm:configmap:%s' % rest_namespace],
+    resource_deps=['rest-databases-ready', 'nico-local-config'],
+    labels=['application'],
+    port_forwards=[port_forward(18082, 8080)],
+    pod_readiness='wait',
+)
+
+k8s_yaml(os.path.join(
+    rest_api_dir,
+    'deploy/kustomize/base/common/temporal-client-cloud-cert.yaml',
+))
+k8s_resource(
+    new_name='rest-certificate',
+    objects=['temporal-client-cloud-cert:certificate:%s' % rest_namespace],
+    resource_deps=['nico-local-config'],
+    labels=['infrastructure'],
+    pod_readiness='ignore',
+)
+local_resource(
+    'rest-certificate-ready',
+    [
+        'kubectl',
+        'wait',
+        '--namespace=%s' % rest_namespace,
+        '--for=condition=Ready',
+        '--timeout=5m',
+        'certificate/temporal-client-cloud-cert',
+    ],
+    resource_deps=['rest-certificate'],
+    labels=['infrastructure'],
+)
+
+docker_build(
+    'build-container-localdev',
+    os.path.join(repo_root, 'dev/docker'),
+    dockerfile=os.path.join(
+        repo_root,
+        'dev/docker/Dockerfile.build-container-x86_64',
+    ),
+)
+docker_build(
+    'nico-api',
+    repo_root,
+    dockerfile=os.path.join(devspace_dir, 'Dockerfile.api'),
+    ignore=['dev/deployment/tilt'],
+)
+docker_build(
+    'nico-bmc-proxy',
+    repo_root,
+    dockerfile=os.path.join(devspace_dir, 'Dockerfile.bmc-proxy'),
+    ignore=['dev/deployment/tilt'],
+)
+docker_build(
+    'machine-a-tron',
+    repo_root,
+    dockerfile=os.path.join(devspace_dir, 'Dockerfile.machine-a-tron'),
+    ignore=['dev/deployment/tilt'],
+)
+
+rest_image(
+    'nico-rest-api',
+    'Dockerfile.nico-rest-api',
+    [
+        'api',
+        'common',
+        'auth',
+        'db',
+        'proto',
+        'workflow',
+        'site-workflow',
+        'ipam',
+        'site-manager',
+        'cert-manager',
+        'openapi',
+        'cli',
+    ],
+)
+rest_image(
+    'nico-rest-workflow',
+    'Dockerfile.nico-rest-workflow',
+    [
+        'workflow',
+        'common',
+        'db',
+        'ipam',
+        'site-workflow',
+        'proto',
+        'site-manager',
+        'cert-manager',
+    ],
+)
+rest_image(
+    'nico-rest-site-manager',
+    'Dockerfile.nico-rest-site-manager',
+    ['site-manager', 'cert-manager'],
+)
+rest_image(
+    'nico-rest-site-agent',
+    'Dockerfile.nico-rest-site-agent',
+    [
+        'site-agent',
+        'common',
+        'site-manager',
+        'proto',
+        'site-workflow',
+        'cert-manager',
+    ],
+)
+rest_image(
+    'nico-rest-db',
+    'Dockerfile.nico-rest-db',
+    ['common', 'db', 'proto', 'ipam'],
+)
+rest_image(
+    'nico-rest-cert-manager',
+    'Dockerfile.nico-rest-cert-manager',
+    ['cert-manager'],
+)
+rest_image(
+    'nico-mcp',
+    'Dockerfile.nico-mcp',
+    ['mcp', 'cli', 'openapi'],
+)
+
+core_global = all_values['global']
+nico_api_values = component_values(core_global, all_values['nico-api'])
+nico_api_dependencies = ['nico-local-config', 'nico-postgres', 'vault']
+
+if enable_dsx_exchange:
+    helm_repo(
+        'nats',
+        'https://nats-io.github.io/k8s/helm/charts/',
+        resource_name='repo-nats',
+        labels=['infrastructure'],
+    )
+    prerequisite(
+        name='dsx-exchange',
+        chart='nats/nats',
+        release_name='dsx-exchange',
+        namespace=core_namespace,
+        version='2.12.6',
+        values=tilt_values['dsxExchange']['chart'],
+        repo='repo-nats',
+    )
+    nico_api_values['dsxExchangeEventBusConfig'] = tilt_values['dsxExchange']['nicoApiConfig']
+    nico_api_dependencies.append('dsx-exchange')
+
+helm_chart(
+    name='nico-api',
+    chart=os.path.join(core_charts, 'nico-api'),
+    namespace=core_namespace,
+    values=nico_api_values,
+    resource_deps=nico_api_dependencies,
+    image_dep='nico-api',
+    image_keys=[('global.image.repository', 'global.image.tag')],
+    manual=True,
+)
+helm_chart(
+    name='nico-bmc-proxy',
+    chart=os.path.join(core_charts, 'nico-bmc-proxy'),
+    namespace=core_namespace,
+    values=component_values(core_global, all_values['nico-bmc-proxy']),
+    resource_deps=['nico-api'],
+    image_dep='nico-bmc-proxy',
+    image_keys=[('image.repository', 'image.tag')],
+    manual=True,
+)
+helm_chart(
+    name='nico-machine-a-tron',
+    chart=os.path.join(core_charts, 'nico-machine-a-tron'),
+    namespace=core_namespace,
+    values=component_values(core_global, all_values['nico-machine-a-tron']),
+    resource_deps=['nico-api'],
+    image_dep='machine-a-tron',
+    image_keys=[('image.repository', 'image.tag')],
+    manual=True,
+)
+
+rest_values = tilt_values['rest']
+rest_global = rest_values['global']
+rest_image_keys = [(
+    'global.image.repository',
+    'image.name',
+    'global.image.tag',
+)]
+
+rest_db_chart = os.path.join(rest_charts, 'nico-rest/charts/nico-rest-db')
+rest_db_values = component_values(rest_global, rest_values['database'])
+rest_db_yaml = local(
+    [
+        'helm',
+        'template',
+        'nico-rest-db',
+        rest_db_chart,
+        '--namespace=%s' % rest_namespace,
+        '--show-only=templates/migration-job.yaml',
+        '--set-json',
+        encode_json(rest_db_values),
+        '--set=ttlSecondsAfterFinished=86400',
+    ],
+    quiet=True,
+)
+watch_file(rest_db_chart)
+k8s_yaml(rest_db_yaml)
+k8s_resource(
+    'nico-rest-db-migration-dev',
+    new_name='nico-rest-db',
+    resource_deps=['rest-databases-ready'],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    labels=['application'],
+    pod_readiness='wait',
+)
+helm_chart(
+    name='nico-rest-cert-manager',
+    chart=os.path.join(rest_charts, 'nico-rest/charts/nico-rest-cert-manager'),
+    namespace=rest_namespace,
+    values=component_values(rest_global, rest_values['certManager']),
+    resource_deps=['nico-local-config'],
+    image_dep='localhost/nico-rest-cert-manager',
+    image_keys=rest_image_keys,
+    manual=True,
+)
+helm_chart(
+    name='nico-rest-site-manager',
+    chart=os.path.join(rest_charts, 'nico-rest/charts/nico-rest-site-manager'),
+    namespace=rest_namespace,
+    values=component_values(rest_global, rest_values['siteManager']),
+    resource_deps=['nico-rest-cert-manager'],
+    image_dep='localhost/nico-rest-site-manager',
+    image_keys=rest_image_keys,
+    manual=True,
+)
+helm_chart(
+    name='nico-rest-api',
+    chart=os.path.join(rest_charts, 'nico-rest/charts/nico-rest-api'),
+    namespace=rest_namespace,
+    values=component_values(rest_global, rest_values['api']),
+    resource_deps=[
+        'keycloak',
+        'nico-rest-db',
+        'nico-rest-site-manager',
+        'rest-certificate-ready',
+        'temporal-namespaces',
+    ],
+    image_dep='localhost/nico-rest-api',
+    image_keys=rest_image_keys,
+    port_forwards=[port_forward(18388, 8388)],
+    manual=True,
+)
+helm_chart(
+    name='nico-rest-workflow',
+    chart=os.path.join(rest_charts, 'nico-rest/charts/nico-rest-workflow'),
+    namespace=rest_namespace,
+    values=component_values(rest_global, rest_values['workflow']),
+    resource_deps=[
+        'nico-rest-db',
+        'rest-certificate-ready',
+        'temporal-namespaces',
+    ],
+    image_dep='localhost/nico-rest-workflow',
+    image_keys=rest_image_keys,
+    manual=True,
+)
+helm_chart(
+    name='nico-rest-site-agent',
+    chart=os.path.join(rest_charts, 'nico-rest-site-agent'),
+    namespace=rest_namespace,
+    values=component_values(rest_global, rest_values['siteAgent']),
+    resource_deps=[
+        'nico-api',
+        'nico-rest-api',
+        'nico-rest-site-manager',
+        'nico-rest-workflow',
+    ],
+    image_dep='localhost/nico-rest-site-agent',
+    image_keys=rest_image_keys,
+    manual=True,
+    wait=False,
+)
+helm_chart(
+    name='nico-mcp',
+    chart=os.path.join(rest_charts, 'nico-mcp'),
+    namespace=rest_namespace,
+    values=component_values(rest_global, rest_values['mcp']),
+    resource_deps=['nico-rest-api'],
+    image_dep='localhost/nico-mcp',
+    image_keys=rest_image_keys,
+    port_forwards=[port_forward(18080, 8080)],
+    manual=True,
+)
+
+rest_integration_dependencies = ['nico-rest-site-agent']
+if enable_mcp:
+    rest_integration_dependencies.append('nico-mcp')
+
+local_resource(
+    'rest-integration',
+    [setup_local, 'site-agent'],
+    env={
+        'NAMESPACE': rest_namespace,
+        'API_URL': 'http://localhost:18388',
+        'KEYCLOAK_URL': 'http://localhost:18082',
+        'RESTART_API': '0',
+    },
+    resource_deps=rest_integration_dependencies,
+    labels=['application'],
+)
+
+enabled_resources = [
+    'repo-jetstack',
+    'repo-cnpg',
+    'repo-hashicorp',
+    'cert-manager',
+    'cnpg-operator',
+    'vault',
+    'nico-local-config',
+    'nico-postgres',
+    'nico-api',
+    'nico-bmc-proxy',
+    'nico-machine-a-tron',
+]
+if enable_rest:
+    enabled_resources.extend([
+        'nico-local-namespaces',
+        'rest-databases',
+        'rest-databases-ready',
+        'temporal-certificates',
+        'temporal-certificates-ready',
+        'temporal',
+        'temporal-ui',
+        'temporal-namespaces',
+        'keycloak',
+        'rest-certificate',
+        'rest-certificate-ready',
+        'nico-rest-db',
+        'nico-rest-cert-manager',
+        'nico-rest-site-manager',
+        'nico-rest-api',
+        'nico-rest-workflow',
+        'nico-rest-site-agent',
+        'rest-integration',
+    ])
+if enable_mcp:
+    enabled_resources.append('nico-mcp')
+if enable_dsx_exchange:
+    enabled_resources.extend(['repo-nats', 'dsx-exchange'])
+
+config.set_enabled_resources(enabled_resources)

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -1,0 +1,482 @@
+global:
+  image:
+    pullPolicy: IfNotPresent
+  certificate:
+    issuerRef:
+      kind: Issuer
+      name: local-ca-issuer
+      group: cert-manager.io
+
+nico-api:
+  legacyAlias:
+    enabled: false
+  automountServiceAccountToken: false
+  migrationJob:
+    sslMode: disable
+  resources:
+    limits:
+      cpu: "16"
+      memory: 16Gi
+    requests:
+      cpu: "1"
+      memory: 1Gi
+  envFrom:
+    databaseCredentials:
+      secretName: nico-pg-cluster-app
+  vaultClusterInfo: {}
+  databaseConfig: {}
+  extraEnv:
+    - name: DISABLE_TLS_ENFORCEMENT
+      value: "1"
+  webAuth:
+    mode: none
+  siteConfig:
+    enabled: true
+    nicoApiSiteConfig: |
+      bypass_rbac = true
+      attestation_enabled = false
+      dpu_ipmi_tool_impl = "test"
+      initial_domain_name = "local.nico"
+      initial_dpu_agent_upgrade_policy = "off"
+      allow_insecure_discovery = true
+      max_database_connections = 64
+
+      [pools.lo-ip]
+      type = "ipv4"
+      ranges = [{ start = "10.180.64.1", end = "10.180.127.254" }]
+
+      [pools.vlan-id]
+      type = "integer"
+      ranges = [{ start = "100", end = "501" }]
+
+      [pools.vni]
+      type = "integer"
+      ranges = [{ start = "1024500", end = "1024550" }]
+
+      [pools.vpc-vni]
+      type = "integer"
+      ranges = [{ start = "2024500", end = "2024550" }]
+
+      [pools.fnn-asn]
+      type = "integer"
+      ranges = [{ start = "1000", end = "10000" }]
+
+      [networks.admin]
+      type = "admin"
+      prefix = "192.168.64.0/18"
+      gateway = "192.168.64.1"
+      mtu = 9000
+      reserve_first = 2
+
+      [networks.DEV-K3S-DPU-ACORN-0]
+      type = "underlay"
+      prefix = "192.168.128.0/18"
+      gateway = "192.168.128.1"
+      mtu = 1500
+      reserve_first = 2
+
+      [networks.DEV-K3S-X86-BMC-UNDERLAY-ACORN-X86-0]
+      type = "underlay"
+      prefix = "192.168.192.0/18"
+      gateway = "192.168.192.1"
+      mtu = 1500
+      reserve_first = 2
+
+      [auth]
+      permissive_mode = true
+
+      [auth.trust]
+      spiffe_trust_domain = "nico.local"
+      spiffe_service_base_paths = ["/nico-system/sa/", "/default/sa/"]
+      spiffe_machine_base_path = "/nico-system/machine/"
+      additional_issuer_cns = []
+
+      [host_health]
+      hardware_health_reports = "MonitorOnly"
+
+      [machine_state_controller]
+      dpu_wait_time = "1s"
+      skip_polling_checks = true
+
+      [machine_state_controller.controller]
+      iteration_time = "30s"
+      max_concurrency = 100
+
+      [vpc_prefix_state_controller]
+      vpc_prefix_drain_time = "5m"
+
+      [machine_validation_config]
+      enabled = false
+
+      [site_explorer]
+      enabled = true
+      create_machines = true
+      allow_changing_bmc_proxy = true
+      bmc_proxy = "nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266"
+      run_interval = "10s"
+      machines_created_per_run = 1000
+      explorations_per_run = 1000
+      concurrent_explorations = 100
+      explore_mode = "nv-redfish"
+
+      [firmware_global]
+      autoupdate = true
+      run_interval = "10s"
+      concurrency_limit = 100
+
+nico-bmc-proxy:
+  enabled: true
+  replicas: 1
+  automountServiceAccountToken: false
+  envFrom:
+    databaseCredentials:
+      secretName: nico-pg-cluster-app
+  vaultClusterInfo: {}
+  databaseConfig: {}
+  extraEnv:
+    - name: DISABLE_TLS_ENFORCEMENT
+      value: "1"
+  configFiles:
+    enabled: true
+    nicoBmcProxyConfig: |
+      listen = "[::]:1079"
+      metrics_endpoint = "[::]:1080"
+      database_url = "postgres://replaced-by-env-var"
+      allowed_principals = ["trusted-certificate"]
+      bmc_proxy = "nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266"
+
+      [tls]
+      identity_pemfile_path = "/var/run/secrets/spiffe.io/tls.crt"
+      identity_keyfile_path = "/var/run/secrets/spiffe.io/tls.key"
+      root_cafile_path = "/var/run/secrets/spiffe.io/ca.crt"
+      admin_root_cafile_path = "/etc/forge/carbide-bmc-proxy/site/admin_root_cert_pem"
+
+      [auth.trust]
+      spiffe_trust_domain = "nico.local"
+      spiffe_service_base_paths = [
+        "/nico-system/sa/",
+        "/default/sa/",
+      ]
+      spiffe_machine_base_path = "/nico-system/machine/"
+      additional_issuer_cns = []
+
+      [auth.acls]
+      "trusted-certificate" = ["/**"]
+
+      [carbide_api]
+      api_url = "https://nico-api.nico-system.svc.cluster.local:1079"
+      root_ca = "/var/run/secrets/spiffe.io/ca.crt"
+      client_cert = "/var/run/secrets/spiffe.io/tls.crt"
+      client_key = "/var/run/secrets/spiffe.io/tls.key"
+
+nico-machine-a-tron:
+  enabled: true
+  machineATron:
+    nicoApiUrl: https://nico-api.nico-system.svc.cluster.local:1079
+  certificate:
+    uris:
+      - spiffe://nico.local/nico-system/sa/machine-a-tron
+  pods:
+    mat-0:
+      machines:
+        rack-machines:
+          hwType: wiwynn_gb200_nvl
+          hostCount: 2
+          dpuPerHostCount: 2
+          oobDhcpRelayAddress: 192.168.192.1
+          adminDhcpRelayAddress: 192.168.176.1
+
+tilt:
+  profiles: # Toggle REST, MCP, and DSX Exchange; required dependencies follow automatically.
+    rest: false
+    mcp: false
+    dsxExchange: false
+
+  certManager:
+    crds:
+      enabled: true
+      keep: false
+    global:
+      leaderElection:
+        namespace: cert-manager
+    featureGates: AdditionalCertificateOutputFormats=true
+    webhook:
+      extraArgs:
+        - --feature-gates=AdditionalCertificateOutputFormats=true
+    prometheus:
+      enabled: false
+
+  cnpgOperator:
+    replicaCount: 1
+    crds:
+      create: true
+    monitoring:
+      podMonitorEnabled: false
+      grafanaDashboard:
+        create: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
+
+  postgres:
+    fullnameOverride: nico-pg-cluster
+    type: postgresql
+    version:
+      postgresql: "16"
+    cluster:
+      instances: 1
+      storage:
+        size: 1Gi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: "2"
+          memory: 2Gi
+      enablePDB: false
+      roles:
+        - name: nico_rest
+          ensure: present
+          login: true
+          passwordSecret:
+            name: nico-rest-db-user
+        - name: keycloak
+          ensure: present
+          login: true
+          passwordSecret:
+            name: keycloak-db-user
+        - name: temporal
+          ensure: present
+          login: true
+          createdb: true
+          passwordSecret:
+            name: temporal-db-user
+      initdb:
+        database: nico_system_nico
+        owner: nico
+      monitoring:
+        enabled: false
+    backups:
+      enabled: false
+
+  vault:
+    global:
+      enabled: true
+      tlsDisable: true
+    injector:
+      enabled: false
+    csi:
+      enabled: false
+    server:
+      dataStorage:
+        enabled: false
+      auditStorage:
+        enabled: false
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      dev:
+        enabled: true
+        devRootToken: root
+      postStart:
+        - /bin/sh
+        - -ec
+        - |
+          export VAULT_ADDR=http://127.0.0.1:8200
+          export VAULT_TOKEN=root
+          until vault status >/dev/null 2>&1; do sleep 1; done
+          vault secrets enable -path=secrets -version=2 kv || true
+          vault secrets enable -path=certs pki || true
+          vault read certs/cert/ca >/dev/null 2>&1 || \
+            vault write certs/root/generate/internal \
+              common_name=local-vault-ca ttl=87600h >/dev/null
+          vault write certs/roles/nico-cluster \
+            allow_any_name=true allow_bare_domains=true allow_subdomains=true \
+            allow_localhost=true require_cn=false max_ttl=72h \
+            allowed_uri_sans='spiffe://nico.local/*' >/dev/null
+          printf '%s' '{"UsernamePassword":{"username":"root","password":"vault-password"}}' | \
+            vault kv put secrets/machines/bmc/site/root - >/dev/null
+          printf '%s' '{"UsernamePassword":{"username":"root","password":"vault-password"}}' | \
+            vault kv put secrets/machines/all_dpus/site_default/uefi-metadata-items/auth - >/dev/null
+          printf '%s' '{"UsernamePassword":{"username":"root","password":"vault-password"}}' | \
+            vault kv put secrets/machines/all_hosts/site_default/uefi-metadata-items/auth - >/dev/null
+
+  temporal:
+    server:
+      config:
+        persistence:
+          default:
+            sql:
+              host: nico-pg-cluster-rw.nico-system.svc.cluster.local
+          visibility:
+            sql:
+              host: nico-pg-cluster-rw.nico-system.svc.cluster.local
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0
+    databaseUrl: jdbc:postgresql://nico-pg-cluster-rw.nico-system.svc.cluster.local:5432/keycloak
+
+  rest:
+    global:
+      image:
+        repository: localhost
+        tag: dev
+        pullPolicy: IfNotPresent
+      imagePullSecrets: []
+      certificate:
+        issuerRef:
+          kind: ClusterIssuer
+          name: nico-rest-ca-issuer
+          group: cert-manager.io
+
+    database:
+      db:
+        host: nico-pg-cluster-rw.nico-system.svc.cluster.local
+        port: "5432"
+        name: nico_rest
+        user: nico_rest
+      secrets:
+        dbCreds: db-creds
+
+    certManager:
+      config:
+        debug: true
+
+    siteManager: {}
+
+    api:
+      config:
+        db:
+          host: nico-pg-cluster-rw.nico-system.svc.cluster.local
+          port: 5432
+          name: nico_rest
+          user: nico_rest
+        temporal:
+          host: temporal-frontend.temporal
+          port: 7233
+          namespace: cloud
+          queue: cloud
+        keycloak:
+          enabled: true
+          baseURL: http://keycloak:8082
+          externalBaseURL: http://localhost:18082
+          realm: nico-dev
+          clientID: nico-api
+          serviceAccount: true
+
+    workflow:
+      secrets:
+        dbCreds: db-creds
+      config:
+        db:
+          host: nico-pg-cluster-rw.nico-system.svc.cluster.local
+          port: 5432
+          name: nico_rest
+          user: nico_rest
+        temporal:
+          host: temporal-frontend.temporal
+          port: 7233
+          namespace: cloud
+          queue: cloud
+
+    siteAgent:
+      certificate:
+        uris:
+          - spiffe://nico.local/nico-system/sa/elektra-site-agent
+      envConfig:
+        NICO_ADDRESS: nico-api.nico-system.svc.cluster.local:1079
+        NICO_SEC_OPT: "2"
+        CORE_GRPC_ADDRESS: nico-api.nico-system.svc.cluster.local:1079
+        CORE_GRPC_SEC_OPT: "2"
+        FLOW_GRPC_ENABLED: "false"
+        CLUSTER_ID: 00000000-0000-4000-8000-000000000001
+        TEMPORAL_SERVER: site.server.temporal.local
+        TEMPORAL_SUBSCRIBE_NAMESPACE: 00000000-0000-4000-8000-000000000001
+        TEMPORAL_SUBSCRIBE_QUEUE: site
+
+    mcp:
+      config:
+        baseURL: http://nico-rest-api:8388
+        apiName: nico
+
+  dsxExchange:
+    nicoApiConfig: '{enabled=true,mqtt_endpoint="dsx-exchange",mqtt_broker_port=1883,auth={auth_mode="none"},periodic_state_republish={interval="10s"}}'
+    chart:
+      fullnameOverride: dsx-exchange
+      config:
+        cluster:
+          enabled: false
+        jetstream:
+          enabled: true
+          fileStore:
+            enabled: true
+            maxSize: 256Mi
+            pvc:
+              enabled: false
+          memoryStore:
+            enabled: true
+            maxSize: 64Mi
+        mqtt:
+          enabled: true
+          port: 1883
+          merge:
+            stream_replicas: 1
+            consumer_memory_storage: true
+      container:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      natsBox:
+        enabled: false
+      podDisruptionBudget:
+        enabled: false
+
+  localConfig:
+    coreNamespace: nico-system
+    restNamespace: nico-rest
+    temporalNamespace: temporal
+    vault:
+      service: http://nico-vault.nico-system.svc.cluster.local:8200
+      mount: secrets
+      pkiMount: certs
+      token: root
+    database:
+      host: nico-pg-cluster-rw.nico-system.svc.cluster.local
+      port: 5432
+      name: nico_system_nico
+      rest:
+        resourceName: nico-rest
+        name: nico_rest
+        user: nico_rest
+        password: nico_rest_password
+      keycloak:
+        resourceName: keycloak
+        name: keycloak
+        user: keycloak
+        password: keycloak_password
+      temporal:
+        resourceName: temporal
+        visibilityResourceName: temporal-visibility
+        name: temporal
+        visibilityName: temporal_visibility
+        user: temporal
+        password: temporal_password
+    keycloak:
+      clientSecret: nico-local-secret
+    temporal:
+      encryptionKey: local-dev
+    site:
+      id: 00000000-0000-4000-8000-000000000001


### PR DESCRIPTION
## Description

Add a Tilt-based workflow for running NICo in a local kind cluster. This gives
developers a single entry point for starting the local Core stack, viewing
resource status and logs, and rebuilding individual application images during
development.

The workflow reuses the repository's existing Helm charts, Kubernetes sources,
and development Dockerfiles. It provisions local dependencies including
cert-manager, CloudNativePG, PostgreSQL, and Vault, then deploys NICo API, BMC
proxy, and machine-a-tron. Optional profiles enable the REST stack, MCP, and DSX
Exchange when needed.

## Related issues

None.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Manually tested with a local kind cluster:

- Evaluated the Tiltfile successfully with Tilt.
- Started the default Core development stack.
- Verified cert-manager, CloudNativePG, PostgreSQL, Vault, NICo API, BMC proxy,
  and machine-a-tron resources became ready.
- Verified machine-a-tron generated its configuration and registered its mock
  machines with NICo API.
- Verified changes to the Tilt values file are detected and applied through the
  corresponding resources.

## Additional Notes

- Application image updates use manual Tilt triggers to avoid rebuilding on
  every source change.