### PR TITLE
fix: deprecate benchpress related machine-validation tests

### DIFF
--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -1191,7 +1191,7 @@ async fn test_machine_validation_test_disabled(
         .unwrap()
         .into_inner()
         .tests;
-    assert_eq!(existing_test_list.len(), 24);
+    assert_eq!(existing_test_list.len(), 13);
 
     let _ = env
         .api

--- a/crates/api-db/migrations/20260804132001_drop_benchpress_validation_tests.sql
+++ b/crates/api-db/migrations/20260804132001_drop_benchpress_validation_tests.sql
@@ -1,0 +1,5 @@
+-- Benchpress is no longer a supported CLI, so remove all machine validation
+-- tests that invoke it. These tests used /opt/benchpress/benchpress as the
+-- binary
+DELETE FROM machine_validation_tests
+WHERE command = '/opt/benchpress/benchpress';


### PR DESCRIPTION
  * We no longer support benchpress machine validation tests, this removes them from SQL migrations

Related to NV 6430925

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [X] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes


