### PR TITLE
fix: health report uses now() for alert since

### DIFF
--- a/crates/api-core/src/handlers/health.rs
+++ b/crates/api-core/src/handlers/health.rs
@@ -121,7 +121,7 @@ pub async fn insert_machine_health_report(
     };
     let mode: HealthReportApplyMode = mode.into();
     let mut txn = api.txn_begin().await?;
-    let _machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
+    let machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
         .await?
         .ok_or_else(|| CarbideError::NotFoundError {
             kind: "machine",
@@ -134,7 +134,7 @@ pub async fn insert_machine_health_report(
         report.observed_at = Some(chrono::Utc::now());
     }
     report.triggered_by = triggered_by;
-    report.update_in_alert_since(None);
+    report.update_in_alert_since(machine.health_reports.by_source(&report.source));
 
     // In case a report with the same source exists, either as merge or replace,
     // remove it. If such a report does not exist, ignore error.

--- a/crates/api-core/src/handlers/nvlink_domain.rs
+++ b/crates/api-core/src/handlers/nvlink_domain.rs
@@ -88,7 +88,7 @@ pub async fn insert_nv_link_domain_health_report(
         report.observed_at = Some(chrono::Utc::now());
     }
     report.triggered_by = triggered_by;
-    report.update_in_alert_since(None);
+    report.update_in_alert_since(health_reports.by_source(&report.source));
 
     match remove_by_source(&mut txn, &domain_id, &health_reports, report.source.clone()).await {
         Ok(_) | Err(CarbideError::NotFoundError { .. }) => {}

--- a/crates/api-core/src/handlers/power_shelf.rs
+++ b/crates/api-core/src/handlers/power_shelf.rs
@@ -536,7 +536,7 @@ pub async fn insert_power_shelf_health_report(
         report.observed_at = Some(chrono::Utc::now());
     }
     report.triggered_by = triggered_by;
-    report.update_in_alert_since(None);
+    report.update_in_alert_since(power_shelf.health_reports.by_source(&report.source));
 
     match remove_power_shelf_health_report_by_source(&power_shelf, &mut txn, report.source.clone())
         .await

--- a/crates/api-core/src/handlers/rack.rs
+++ b/crates/api-core/src/handlers/rack.rs
@@ -381,7 +381,7 @@ pub async fn insert_rack_health_report(
         report.observed_at = Some(chrono::Utc::now());
     }
     report.triggered_by = triggered_by;
-    report.update_in_alert_since(None);
+    report.update_in_alert_since(rack.health_reports.by_source(&report.source));
 
     match remove_rack_override_by_source(&rack, &mut txn, report.source.clone()).await {
         Ok(_) | Err(CarbideError::NotFoundError { .. }) => {}

--- a/crates/api-core/src/handlers/switch.rs
+++ b/crates/api-core/src/handlers/switch.rs
@@ -491,7 +491,7 @@ pub async fn insert_switch_health_report(
         report.observed_at = Some(chrono::Utc::now());
     }
     report.triggered_by = triggered_by;
-    report.update_in_alert_since(None);
+    report.update_in_alert_since(switch.health_reports.by_source(&report.source));
 
     match remove_switch_health_report_by_source(&switch, &mut txn, report.source.clone()).await {
         Ok(_) | Err(CarbideError::NotFoundError { .. }) => {}

--- a/crates/api-core/src/tests/common/health_crud.rs
+++ b/crates/api-core/src/tests/common/health_crud.rs
@@ -126,6 +126,53 @@ where
         assert_eq!(entries.len(), 1, "repeated inserts should collapse to one");
     }
 
+    /// A continuously-firing alert keeps the `in_alert_since` of its first
+    /// report, so operators can tell how long the condition has lasted. Without
+    /// this, every re-report restamps the alert and it always looks brand new.
+    pub async fn check_retains_in_alert_since(&self) {
+        let in_alert_since = async || {
+            let entries = (self.list)(self.real_id.clone())
+                .await
+                .expect("list overrides");
+            assert_eq!(entries.len(), 1, "exactly one override should be listed");
+            let listed: HealthReport = entries[0]
+                .report
+                .clone()
+                .unwrap()
+                .try_into()
+                .expect("listed report converts back");
+            assert_eq!(listed.alerts.len(), 1);
+            listed.alerts[0]
+                .in_alert_since
+                .expect("in_alert_since is stamped on insert")
+        };
+
+        (self.insert)(
+            self.real_id.clone(),
+            self.alert.clone(),
+            HealthReportApplyMode::Merge,
+        )
+        .await
+        .expect("insert override");
+        let first_seen = in_alert_since().await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // The same alert reported again must not be restamped.
+        (self.insert)(
+            self.real_id.clone(),
+            self.alert.clone(),
+            HealthReportApplyMode::Merge,
+        )
+        .await
+        .expect("re-insert override");
+        assert_eq!(
+            in_alert_since().await,
+            first_seen,
+            "re-reported alert must retain its original in_alert_since"
+        );
+    }
+
     /// Removing a source that was never filed is a `NotFound`.
     pub async fn check_remove_nonexistent_source(&self) {
         let status = (self.remove)(self.real_id.clone(), "nonexistent-source".to_string())

--- a/crates/api-core/src/tests/machine_health.rs
+++ b/crates/api-core/src/tests/machine_health.rs
@@ -769,6 +769,91 @@ async fn test_double_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     Ok(())
 }
 
+/// A continuously-firing alert re-reported through `InsertMachineHealthReport`
+/// must keep the `in_alert_since` of its first occurrence, so operators can tell
+/// how long the condition has lasted. New alerts appearing in a later report
+/// still get a fresh timestamp.
+#[crate::sqlx_test]
+async fn test_insert_machine_health_report_retains_in_alert_since(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_env(pool).await;
+    let (host_machine_id, _) = create_managed_host(&env).await.into();
+
+    let insert = async |report: health_report::HealthReport| {
+        env.api
+            .insert_machine_health_report(Request::new(
+                rpc::forge::InsertMachineHealthReportRequest {
+                    machine_id: Some(host_machine_id),
+                    health_report_entry: Some(rpc::forge::HealthReportEntry {
+                        report: Some(report.into()),
+                        mode: HealthReportApplyMode::Merge as i32,
+                    }),
+                },
+            ))
+            .await
+            .unwrap();
+    };
+
+    // Alert fires for the first time.
+    let report = hr("bmc-sensors", vec![], vec![("Sensor", Some("Fan1"), "hot")]);
+    insert(report.clone()).await;
+
+    let first = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    let first_seen = first.alerts[0].in_alert_since.expect("in_alert_since set");
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Same alert still firing on the next poll: the original timestamp is kept.
+    insert(report.clone()).await;
+
+    let second = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    assert_eq!(second.alerts.len(), 1);
+    assert_eq!(
+        second.alerts[0].in_alert_since,
+        Some(first_seen),
+        "re-reported alert must retain its original in_alert_since"
+    );
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // A second alert appears alongside the first: the pre-existing alert keeps
+    // its timestamp, the new one is stamped now.
+    let grown = hr(
+        "bmc-sensors",
+        vec![],
+        vec![
+            ("Sensor", Some("Fan1"), "hot"),
+            ("Sensor", Some("Fan2"), "hot"),
+        ],
+    );
+    insert(grown).await;
+
+    let third = load_health_via_find_machines_by_ids(&env, &host_machine_id)
+        .await
+        .unwrap();
+    let find = |target: &str| {
+        third
+            .alerts
+            .iter()
+            .find(|a| a.target.as_deref() == Some(target))
+            .unwrap_or_else(|| panic!("alert for {target} missing"))
+            .in_alert_since
+            .expect("in_alert_since set")
+    };
+    assert_eq!(find("Fan1"), first_seen, "existing alert keeps timestamp");
+    assert!(
+        find("Fan2") > first_seen,
+        "newly appearing alert is stamped with the current time"
+    );
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 async fn test_count_unhealthy_nonupgrading_host_machines(
     pool: sqlx::PgPool,

--- a/crates/api-core/src/tests/power_shelf_health.rs
+++ b/crates/api-core/src/tests/power_shelf_health.rs
@@ -161,6 +161,16 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 }
 
 #[crate::sqlx_test]
+async fn test_retains_in_alert_since(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = test_env(pool).await;
+    let id = new_power_shelf(&env, None, None, None, None).await?;
+    power_shelf_crud(&env, id)
+        .check_retains_in_alert_since()
+        .await;
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_remove_nonexistent_source(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-core/src/tests/rack_health.rs
+++ b/crates/api-core/src/tests/rack_health.rs
@@ -166,6 +166,16 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 }
 
 #[crate::sqlx_test]
+async fn test_retains_in_alert_since(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = test_env(pool.clone()).await;
+    let rack_id = new_rack(&pool).await?;
+    rack_crud(&env, rack_id)
+        .check_retains_in_alert_since()
+        .await;
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_remove_nonexistent_source(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-core/src/tests/switch_health.rs
+++ b/crates/api-core/src/tests/switch_health.rs
@@ -157,6 +157,14 @@ async fn test_idempotent_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::e
 }
 
 #[crate::sqlx_test]
+async fn test_retains_in_alert_since(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = test_env(pool).await;
+    let id = new_switch(&env, None, None).await?;
+    switch_crud(&env, id).check_retains_in_alert_since().await;
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_remove_nonexistent_source(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -149,8 +149,21 @@ mod tests {
                 },
                 Case {
                     // Mirrors the removal path, which resolves replace before merges.
+                    // The lookup keys on the `merges` map key, so the entry's own
+                    // `source` field is free to carry a marker that reveals which
+                    // branch answered; a merges-first regression yields the marker.
                     scenario: "replace wins when both hold the same source",
-                    input: (sources(Some("dup"), &["dup"]), "dup"),
+                    input: (
+                        HealthReportSources {
+                            replace: Some(HealthReport::empty("dup".to_string())),
+                            merges: [(
+                                "dup".to_string(),
+                                HealthReport::empty("dup-from-merges".to_string()),
+                            )]
+                            .into(),
+                        },
+                        "dup",
+                    ),
                     expect: Yields(Some("dup".to_string())),
                 },
                 Case {

--- a/crates/api-model/src/health.rs
+++ b/crates/api-model/src/health.rs
@@ -56,6 +56,16 @@ impl HealthReportSources {
                 .contains_key(health_report::REQUEST_ONLINE_REPAIR_MERGE_SOURCE)
     }
 
+    /// The currently stored report for `source`, whichever mode it was applied
+    /// with. Used to carry per-alert state (such as `in_alert_since`) over from
+    /// the previous report when the same source reports again.
+    pub fn by_source(&self, source: &str) -> Option<&HealthReport> {
+        self.replace
+            .as_ref()
+            .filter(|r| r.source == source)
+            .or_else(|| self.merges.get(source))
+    }
+
     #[allow(clippy::should_implement_trait)]
     pub fn iter(&self) -> impl Iterator<Item = (&HealthReport, HealthReportApplyMode)> {
         self.merges
@@ -102,6 +112,57 @@ mod tests {
         assert!(sources.replace.is_none());
         assert!(sources.merges.is_empty());
         assert_eq!(sources.into_iter().count(), 0);
+    }
+
+    #[test]
+    fn health_reports_by_source() {
+        // `by_source` finds the stored report for a source under either apply
+        // mode, checking `replace` first and falling back to `merges`. Each row
+        // projects the result to the found report's own source name, or None.
+        // Infallible, so every row `Yields`.
+        check_cases(
+            [
+                Case {
+                    scenario: "empty finds nothing",
+                    input: (sources(None, &[]), "absent"),
+                    expect: Yields(None),
+                },
+                Case {
+                    scenario: "finds a merge source",
+                    input: (sources(None, &["source-a", "source-b"]), "source-b"),
+                    expect: Yields(Some("source-b".to_string())),
+                },
+                Case {
+                    scenario: "finds the replace source",
+                    input: (sources(Some("admin-replace"), &[]), "admin-replace"),
+                    expect: Yields(Some("admin-replace".to_string())),
+                },
+                Case {
+                    // A replace source under a different name must not shadow a
+                    // matching merge source.
+                    scenario: "falls through a non-matching replace to merges",
+                    input: (
+                        sources(Some("sre-override"), &["bmc-sensors"]),
+                        "bmc-sensors",
+                    ),
+                    expect: Yields(Some("bmc-sensors".to_string())),
+                },
+                Case {
+                    // Mirrors the removal path, which resolves replace before merges.
+                    scenario: "replace wins when both hold the same source",
+                    input: (sources(Some("dup"), &["dup"]), "dup"),
+                    expect: Yields(Some("dup".to_string())),
+                },
+                Case {
+                    scenario: "unknown source finds nothing",
+                    input: (sources(Some("sre-override"), &["bmc-sensors"]), "other"),
+                    expect: Yields(None),
+                },
+            ],
+            |(sources, source): (HealthReportSources, &str)| {
+                Ok::<_, ()>(sources.by_source(source).map(|r| r.source.clone()))
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
Right now all health alerts uses Instant now during creation, this elimiates age of the alert.

Fix passes existing alert age to properly calcualte alert age.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4537

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

