### PR TITLE
fix(api,cicd): avoid Vault test port allocation race

### DIFF
--- a/crates/api-core/src/bootstrap.rs
+++ b/crates/api-core/src/bootstrap.rs
@@ -21,6 +21,7 @@
 //! types that must cross the crate boundary while service implementation stays
 //! in `carbide-api-core`.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -32,7 +33,6 @@ use eyre::WrapErr;
 use sqlx::PgPool;
 #[cfg(test)]
 use tokio::sync::Notify;
-use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
@@ -126,7 +126,6 @@ pub struct RuntimeInputs<'a> {
     pub secrets_context: Option<SecretsContext>,
     pub admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     pub cancel_token: CancellationToken,
-    pub ready_channel: Sender<()>,
 }
 
 /// Enter api-core's private service runtime with fully prepared resources.
@@ -143,8 +142,10 @@ pub struct RuntimeInputs<'a> {
 /// "offer the UI", not "force it on". The flag also gates the log-stream
 /// layer feeding the UI's live log viewer: with the UI off, no per-event
 /// work is spent collecting lines nothing can read.
+///
+/// Returns the effective API listener address after startup completes.
 #[doc(hidden)]
-pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<()> {
+pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<SocketAddr> {
     let RuntimeInputs {
         carbide_config,
         initial_objects,
@@ -159,7 +160,6 @@ pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<()> {
         secrets_context,
         admin_ui_routes_builder,
         cancel_token,
-        ready_channel,
     } = inputs;
     let RuntimePrelude { dynamic_settings } = runtime_prelude;
 
@@ -177,7 +177,6 @@ pub async fn start_runtime(inputs: RuntimeInputs<'_>) -> eyre::Result<()> {
         secrets_context,
         admin_ui_routes_builder,
         cancel_token,
-        ready_channel,
     )
     .await
 }

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -277,7 +277,9 @@ struct TlsConnectionFailed {
 ///
 /// This method will return an error if any preconditions fail (could not bind to the port, issues
 /// with tls configuration), then moves processing to a background task spawned into `join_set`. The
-/// background task does not return unless `cancel_token` is canceled, or if something panics.
+/// background task does not return unless `cancel_token` is canceled, or if something panics. On
+/// success, this returns the effective listener address, including an OS-selected port when
+/// `listen_port` uses port zero.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip_all)]
 pub async fn start(
@@ -289,7 +291,7 @@ pub async fn start(
     meter: Meter,
     admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     cancel_token: CancellationToken,
-) -> eyre::Result<()> {
+) -> eyre::Result<SocketAddr> {
     let api_reflection_service = Builder::configure()
         .register_encoded_file_descriptor_set(::rpc::REFLECTION_API_SERVICE_DESCRIPTOR)
         .build_v1alpha()?;
@@ -308,6 +310,8 @@ pub async fn start(
     };
 
     let listener = TcpListener::bind(listen_port).await?;
+    let listen_address = listener.local_addr()?;
+    tracing::info!(effective_listen_address = %listen_address, "API listener started");
     let http = http2::Builder::new(TokioExecutor::new());
 
     let extra_cli_certs = if let Some(auth_config) = auth_config {
@@ -552,7 +556,7 @@ pub async fn start(
             tracing::info!("carbide-api shutting down");
         })?;
 
-    Ok(())
+    Ok(listen_address)
 }
 
 /// Handle the root URL. Health check services often expect a 200 here.

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -16,6 +16,7 @@
  */
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -87,7 +88,6 @@ use state_controller::controller::{Enqueuer, StateController};
 use state_controller::per_object::{PerObjectStateMetrics, PerObjectStateRecorder};
 use state_controller::state_change_emitter::StateChangeEmitterBuilder;
 use tokio::sync::Semaphore;
-use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
@@ -203,8 +203,7 @@ pub(crate) async fn start_runtime(
     secrets_context: Option<crate::secrets::SecretsContext>,
     admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     cancel_token: CancellationToken,
-    ready_channel: Sender<()>,
-) -> eyre::Result<()> {
+) -> eyre::Result<SocketAddr> {
     eyre::ensure!(
         !matches!(
             (carbide_config.dpf.enabled, &carbide_config.vmaas_config),
@@ -514,7 +513,7 @@ pub(crate) async fn start_runtime(
         None
     };
 
-    listener::start(
+    let listen_address = listener::start(
         join_set,
         api_service,
         listen_mode,
@@ -526,18 +525,7 @@ pub(crate) async fn start_runtime(
     )
     .await?;
 
-    ready_channel
-        .send(())
-        .inspect_err(|_e| {
-            // Note: the `_e` here is just sending us back (rejecting) the () that we sent to the ready
-            // channel. This will only happen if the other end is closed.
-            tracing::warn!(
-                "Bug: api server ready_channel is closed, could not notify readiness status"
-            )
-        })
-        .ok();
-
-    Ok(())
+    Ok(listen_address)
 }
 
 /// Initialize the DPF SDK and create all required Kubernetes CRs.

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -51,14 +51,12 @@ async fn test_integration() -> eyre::Result<()> {
     // NOTE: These tests run two carbide-api servers, and the clients are configured to randomly
     // switch between them on every API call. This helps prevent issues that arise when multiple API
     // severs may be running in production.
-    let Some(test_env) =
+    let Some(mut test_env) =
         IntegrationTestEnvironment::try_from_environment(2, "api_server_test_integration").await?
     else {
         println!("test_integration: SKIPPED (set REPO_ROOT and DATABASE_URL to run)");
         return Ok(());
     };
-
-    let carbide_api_addrs = &test_env.carbide_api_addrs;
 
     let bmc_address_registry = BmcMockRegistry::default();
     let certs_dir = PathBuf::from(format!("{}/crates/bmc-mock", test_env.root_dir.display()));
@@ -82,38 +80,43 @@ async fn test_integration() -> eyre::Result<()> {
     // Begin the integration test by starting an API server. This will be shared between multiple
     // individual machine-a-tron-based tests, which can run in parallel against the same instance.
     let cancel_token = CancellationToken::new();
-    let (server_handle_1, server_handle_2) = (
-        utils::start_api_server(
-            test_env.clone(),
-            TestApiServerArgs {
-                bmc_proxy: Some(HostPortPair::HostAndPort(
-                    "127.0.0.1".to_string(),
-                    bmc_mock_handle.address.port(),
-                )),
-                firmware_directory: empty_firmware_dir.path().to_owned(),
-                addr_index: 0,
-                put_dev_bin_in_path: true,
-                insecure_discovery: true,
-            },
-            cancel_token.clone(),
-        )
-        .await?,
-        utils::start_api_server(
-            test_env.clone(),
-            TestApiServerArgs {
-                bmc_proxy: Some(HostPortPair::HostAndPort(
-                    "127.0.0.1".to_string(),
-                    bmc_mock_handle.address.port(),
-                )),
-                firmware_directory: empty_firmware_dir.path().to_owned(),
-                addr_index: 1,
-                put_dev_bin_in_path: true,
-                insecure_discovery: true,
-            },
-            cancel_token.clone(),
-        )
-        .await?,
+    let server_handle_1 = utils::start_api_server(
+        &mut test_env,
+        TestApiServerArgs {
+            bmc_proxy: Some(HostPortPair::HostAndPort(
+                "127.0.0.1".to_string(),
+                bmc_mock_handle.address.port(),
+            )),
+            firmware_directory: empty_firmware_dir.path().to_owned(),
+            addr_index: 0,
+            put_dev_bin_in_path: true,
+            insecure_discovery: true,
+        },
+        cancel_token.clone(),
+    )
+    .await?;
+    let server_handle_2 = utils::start_api_server(
+        &mut test_env,
+        TestApiServerArgs {
+            bmc_proxy: Some(HostPortPair::HostAndPort(
+                "127.0.0.1".to_string(),
+                bmc_mock_handle.address.port(),
+            )),
+            firmware_directory: empty_firmware_dir.path().to_owned(),
+            addr_index: 1,
+            put_dev_bin_in_path: true,
+            insecure_discovery: true,
+        },
+        cancel_token.clone(),
+    )
+    .await?;
+
+    assert_ne!(test_env.carbide_api_addrs[0], test_env.carbide_api_addrs[1]);
+    assert_ne!(
+        test_env.carbide_metrics_addrs[0],
+        test_env.carbide_metrics_addrs[1]
     );
+    let carbide_api_addrs = &test_env.carbide_api_addrs;
 
     let tenant_org_id = "tenant_organization";
     tenant::create(carbide_api_addrs, tenant_org_id, "Tenant Organization").await?;
@@ -402,24 +405,12 @@ pub(crate) const METRIC_DOC_PATH: &str = concat!(
 /// test, to make the values in the metrics buckets predictable.
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_metrics_integration() -> eyre::Result<()> {
-    let Some(test_env) =
+    let Some(mut test_env) =
         IntegrationTestEnvironment::try_from_environment(1, "api_server_test_metrics_integration")
             .await?
     else {
         return Ok(());
     };
-
-    // Save typing...
-    let IntegrationTestEnvironment {
-        carbide_api_addrs,
-        root_dir: _,
-        carbide_metrics_addrs,
-        db_pool,
-        metrics: _,
-        db_url: _,
-        credential_config: _,
-        _vault_handle,
-    } = test_env.clone();
 
     let bmc_address_registry = BmcMockRegistry::default();
     let certs_dir = PathBuf::from(format!("{}/crates/bmc-mock", test_env.root_dir.display()));
@@ -444,7 +435,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
     // individual machine-a-tron-based tests, which can run in parallel against the same instance.
     let cancel_token = CancellationToken::new();
     let server_handle = utils::start_api_server(
-        test_env.clone(),
+        &mut test_env,
         TestApiServerArgs {
             bmc_proxy: Some(HostPortPair::HostAndPort(
                 "127.0.0.1".to_string(),
@@ -458,6 +449,18 @@ async fn test_metrics_integration() -> eyre::Result<()> {
         cancel_token.clone(),
     )
     .await?;
+
+    // Save typing after the server has replaced the port-zero placeholders.
+    let IntegrationTestEnvironment {
+        carbide_api_addrs,
+        root_dir: _,
+        carbide_metrics_addrs,
+        db_pool,
+        metrics: _,
+        db_url: _,
+        credential_config: _,
+        _vault_handle,
+    } = test_env.clone();
 
     // Before the initial host bootstrap, the dns_records view
     // should contain 0 entries.

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -40,7 +40,7 @@ fn setup() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_machine_a_tron_rack_integration() -> eyre::Result<()> {
-    let Some(test_env) = IntegrationTestEnvironment::try_from_environment(
+    let Some(mut test_env) = IntegrationTestEnvironment::try_from_environment(
         1,
         "api_server_test_machine_a_tron_rack_integration",
     )
@@ -63,7 +63,7 @@ async fn test_machine_a_tron_rack_integration() -> eyre::Result<()> {
     let empty_firmware_dir = temp_dir::TempDir::with_prefix("firmware")?;
     let cancel_token = CancellationToken::new();
     let server_handle = utils::start_api_server(
-        test_env.clone(),
+        &mut test_env,
         TestApiServerArgs {
             bmc_proxy: Some(HostPortPair::HostAndPort(
                 "127.0.0.1".to_string(),

--- a/crates/api-test-helper/src/api_server.rs
+++ b/crates/api-test-helper/src/api_server.rs
@@ -35,7 +35,7 @@ pub struct StartArgs {
     pub bmc_proxy: Option<HostPortPair>,
     pub firmware_directory: PathBuf,
     pub cancel_token: CancellationToken,
-    pub ready_channel: Sender<()>,
+    pub ready_channel: Sender<carbide::ApiServerAddresses>,
     pub credential_config: CredentialConfig,
     pub insecure_discovery: bool,
 }

--- a/crates/api-test-helper/src/utils.rs
+++ b/crates/api-test-helper/src/utils.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
-use std::net::{SocketAddr, TcpListener};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -55,8 +55,12 @@ lazy_static::lazy_static! {
 
 #[derive(Debug, Clone)]
 pub struct IntegrationTestEnvironment {
+    /// API client addresses. Each slot starts at `127.0.0.1:0`; [`start_api_server`] replaces it
+    /// with the runtime-selected port before returning.
     pub carbide_api_addrs: Vec<SocketAddr>,
     pub root_dir: PathBuf,
+    /// Metrics listener addresses. Each slot starts at `127.0.0.1:0`;
+    /// [`start_api_server`] replaces it with the bound address before returning.
     pub carbide_metrics_addrs: Vec<SocketAddr>,
     pub db_url: String,
     pub db_pool: Pool<Postgres>,
@@ -87,30 +91,9 @@ impl IntegrationTestEnvironment {
         };
         let root_dir = PathBuf::from(repo_root.clone());
 
-        // Pick free ports for addresses we need. This is still racy, as it's not guaranteed that
-        // the ports will still be available when we start the servers, but it's better than
-        // hardcoding them.
-        let (carbide_api_addrs, carbide_metrics_addrs) = {
-            let mut listeners = vec![]; // hold the listeners so that we don't get the same port twice
-            let mut api_addrs = vec![];
-            let mut metrics_addrs = vec![];
-            for _ in 0..api_server_count {
-                api_addrs.push({
-                    let l = TcpListener::bind("127.0.0.1:0")?;
-                    let addr = l.local_addr()?;
-                    listeners.push(l);
-                    addr
-                });
-                metrics_addrs.push({
-                    let l = TcpListener::bind("127.0.0.1:0")?;
-                    let addr = l.local_addr()?;
-                    listeners.push(l);
-                    addr
-                });
-            }
-
-            (api_addrs, metrics_addrs)
-        };
+        let unbound_address = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+        let carbide_api_addrs = vec![unbound_address; usize::from(api_server_count)];
+        let carbide_metrics_addrs = vec![unbound_address; usize::from(api_server_count)];
 
         // vault picks its own free port (retrying past races) and reports it
         // back on the handle, so we don't reserve one here.
@@ -201,7 +184,7 @@ pub struct TestApiServerArgs {
 }
 
 pub async fn start_api_server(
-    test_env: IntegrationTestEnvironment,
+    test_env: &mut IntegrationTestEnvironment,
     TestApiServerArgs {
         bmc_proxy,
         firmware_directory,
@@ -211,17 +194,18 @@ pub async fn start_api_server(
     }: TestApiServerArgs,
     cancel_token: CancellationToken,
 ) -> eyre::Result<ApiServerHandle> {
-    // Destructure into vars to save typing
-    let IntegrationTestEnvironment {
-        carbide_api_addrs,
-        db_pool,
-        db_url,
-        root_dir,
-        carbide_metrics_addrs,
-        metrics: _,
-        credential_config,
-        _vault_handle,
-    } = test_env;
+    let api_address = *test_env
+        .carbide_api_addrs
+        .get(addr_index)
+        .ok_or_else(|| eyre::eyre!("API address index {addr_index} is out of range"))?;
+    let metrics_address = *test_env
+        .carbide_metrics_addrs
+        .get(addr_index)
+        .ok_or_else(|| eyre::eyre!("metrics address index {addr_index} is out of range"))?;
+    let db_pool = test_env.db_pool.clone();
+    let db_url = test_env.db_url.clone();
+    let root_dir = test_env.root_dir.clone();
+    let credential_config = test_env.credential_config.clone();
 
     unsafe {
         env::set_var("DISABLE_TLS_ENFORCEMENT", "true");
@@ -263,8 +247,8 @@ pub async fn start_api_server(
         let cancel_token = cancel_token.clone();
         async move {
             api_server::start(StartArgs {
-                addr: carbide_api_addrs[addr_index],
-                metrics_addr: carbide_metrics_addrs[addr_index],
+                addr: api_address,
+                metrics_addr: metrics_address,
                 root_dir,
                 db_url,
                 bmc_proxy,
@@ -281,7 +265,29 @@ pub async fn start_api_server(
         }
     });
 
-    ready_rx.await.unwrap();
+    let addresses = match ready_rx.await {
+        Ok(addresses) => addresses,
+        Err(_error) => match join_handle.await {
+            Ok(Err(error)) => return Err(error),
+            Ok(Ok(())) => eyre::bail!("API server exited before reporting readiness"),
+            Err(error) => return Err(error.into()),
+        },
+    };
+
+    // `api_server::start` binds `[::]`, but test clients authenticate `127.0.0.1`; use the
+    // listener's selected port without replacing the client IP.
+    let listen_address = SocketAddr::new(api_address.ip(), addresses.listen_address.port());
+    let Some(metrics_address) = addresses.metrics_address else {
+        cancel_token.cancel();
+        match join_handle.await {
+            Ok(Err(error)) => return Err(error),
+            Ok(Ok(())) => eyre::bail!("API server reported readiness without a metrics listener"),
+            Err(error) => return Err(error.into()),
+        }
+    };
+
+    test_env.carbide_api_addrs[addr_index] = listen_address;
+    test_env.carbide_metrics_addrs[addr_index] = metrics_address;
 
     Ok(ApiServerHandle { join_handle })
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -39,4 +39,4 @@ mod run;
 
 pub use carbide_api_core::AdminUiRoutesBuilder;
 pub use command_line::{Command, Options};
-pub use run::run;
+pub use run::{ApiServerAddresses, run};

--- a/crates/api/src/run.rs
+++ b/crates/api/src/run.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use carbide_api_core::AdminUiRoutesBuilder;
@@ -22,6 +23,7 @@ use carbide_api_core::bootstrap::{Logging, RuntimeInputs, start_runtime, start_r
 use carbide_secrets::CredentialConfig;
 use eyre::WrapErr;
 use ipnetwork::IpNetwork;
+use tokio::net::TcpListener;
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -31,7 +33,19 @@ use crate::logging::setup_logging;
 use crate::metrics::{Metrics, setup_metrics};
 use crate::resources::{RuntimeResources, setup_resources};
 
+/// Effective addresses owned by a running carbide-api server.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ApiServerAddresses {
+    /// Address of the API listener.
+    pub listen_address: SocketAddr,
+    /// Address of the metrics listener, when configured.
+    pub metrics_address: Option<SocketAddr>,
+}
+
 /// Run the carbide-api server until `cancel_token` is cancelled.
+///
+/// Once startup completes, `ready_channel` receives the effective API and metrics listener
+/// addresses. This includes OS-selected ports when either endpoint is configured with port zero.
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     debug: u8,
@@ -41,7 +55,7 @@ pub async fn run(
     skip_logging_setup: bool,
     admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     cancel_token: CancellationToken,
-    ready_channel: Sender<()>,
+    ready_channel: Sender<ApiServerAddresses>,
 ) -> eyre::Result<()> {
     let carbide_config = carbide_api_core::cfg::load::parse_carbide_config(
         &config_path,
@@ -89,12 +103,13 @@ pub async fn run(
     // initialization is complete, we use [`JoinSet::join_all`] to wait for them all to complete,
     // while propagating any panics to the current task.
     let mut join_set = JoinSet::new();
-    start_metrics_endpoint(
+    let metrics_address = start_metrics_endpoint(
         &mut join_set,
         &carbide_config,
         registry,
         cancel_token.clone(),
-    )?;
+    )
+    .await?;
     let per_object_metrics =
         start_per_object_metrics_endpoint(&mut join_set, &carbide_config, cancel_token.clone())?;
 
@@ -115,7 +130,7 @@ pub async fn run(
     )
     .await?;
 
-    start_runtime(RuntimeInputs {
+    let listen_address = start_runtime(RuntimeInputs {
         carbide_config,
         initial_objects,
         meter,
@@ -129,9 +144,20 @@ pub async fn run(
         secrets_context,
         admin_ui_routes_builder,
         cancel_token,
-        ready_channel,
     })
     .await?;
+
+    if ready_channel
+        .send(ApiServerAddresses {
+            listen_address,
+            metrics_address,
+        })
+        .is_err()
+    {
+        tracing::warn!(
+            "Bug: api server ready_channel is closed, could not notify readiness status"
+        );
+    }
 
     // Block forever until all spawned tasks complete. Any panics in spawned tasks will be
     // propagated here.
@@ -139,15 +165,24 @@ pub async fn run(
     Ok(())
 }
 
-fn start_metrics_endpoint(
+async fn start_metrics_endpoint(
     join_set: &mut JoinSet<()>,
     carbide_config: &carbide_api_core::cfg::file::CarbideConfig,
     registry: prometheus::Registry,
     cancel_token: CancellationToken,
-) -> eyre::Result<()> {
+) -> eyre::Result<Option<SocketAddr>> {
     let Some(metrics_address) = carbide_config.metrics_endpoint else {
-        return Ok(());
+        return Ok(None);
     };
+
+    let listener = TcpListener::bind(metrics_address)
+        .await
+        .wrap_err_with(|| format!("could not bind metrics endpoint at {metrics_address}"))?;
+    let metrics_address = listener
+        .local_addr()
+        .wrap_err("could not read metrics endpoint address")?;
+
+    tracing::info!(%metrics_address, "Starting metrics listener");
 
     // Spin up the web server which serves `/metrics` requests
     // If a replacement prefix for "carbide_" is configured, also emit metrics under that
@@ -163,7 +198,7 @@ fn start_metrics_endpoint(
         .build_task()
         .name("metrics_endpoint")
         .spawn(async move {
-            if let Err(error) = metrics_endpoint::run_metrics_endpoint_with_cancellation(
+            if let Err(error) = metrics_endpoint::run_metrics_endpoint_with_listener(
                 &metrics_endpoint::MetricsEndpointConfig {
                     address: metrics_address,
                     registry,
@@ -171,6 +206,7 @@ fn start_metrics_endpoint(
                     additional_prefix,
                 },
                 cancel_token,
+                listener,
             )
             .await
             {
@@ -182,7 +218,7 @@ fn start_metrics_endpoint(
             }
         })?;
 
-    Ok(())
+    Ok(Some(metrics_address))
 }
 
 /// Starts the dedicated listener for the opt-in per-object state metrics and


### PR DESCRIPTION
`test_machine_a_tron_rack_integration` is flaky because its harness gives the API a port it no longer owns. The helper used to bind a temporary listener, record its port, drop the listener, and ask the real API to bind the same port much later. E.g. in a failed PR #4541 run, Vault grabbed port `36195` during that gap, so API startup failed with `Address already in use`.

This closes the gap by letting the real API and metrics listeners bind port `0` themselves. Once both listeners are live, `ApiServerAddresses` reports the kernel-selected addresses and the test helper updates its `IntegrationTestEnvironment`. API clients keep using `127.0.0.1` because that is the IP in the test certificate; only the selected port is copied from the API's `[::]:<port>` listener.

The old readiness path also hid the useful startup error behind `RecvError(())`. The helper now waits for the server task and returns the original error. A configured metrics bind failure likewise stops startup before readiness instead of leaving the API running without metrics.

ssh-console tests had the same issue, which we fixed in #4142.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4559

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo check -p carbide-api -p carbide-api-test-helper -p carbide-api-integration-tests --tests`
- `cargo test -p carbide-api --lib`
- `cargo test -p metrics-endpoint`
- `cargo test -p carbide-api-integration-tests --test rack test_machine_a_tron_rack_integration -- --nocapture`
- `cargo test -p carbide-api-integration-tests --test lib test_integration`
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`

## Additional Notes

Configured nonzero listener addresses still bind exactly as configured. This removes the bind/drop/rebind TOCTOU window; it does not add the bounded retry from #4265 for a rare failure of an actual `:0` bind.

Closes #4559
