### PR TITLE
feat(component-manager): add NVOS factory reset support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6874,7 +6874,7 @@ dependencies = [
 [[package]]
 name = "librms"
 version = "0.0.14"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.10.0#0769455549f85e64c4fcc471bd24aa7fa6622609"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.10.1#4bbd502d3d9822fb1dcb8d205b7edaecabb497a6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11903,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "tonic-client-wrapper"
 version = "1.0.0"
-source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.10.0#0769455549f85e64c4fcc471bd24aa7fa6622609"
+source = "git+https://github.com/NVIDIA/nv-rms-client.git?tag=v0.10.1#4bbd502d3d9822fb1dcb8d205b7edaecabb497a6"
 dependencies = [
  "async-trait",
  "heck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.3" }
-librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
+librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 
 tokio = { version = "1", features = ["full", "tracing"] }

--- a/crates/api-test-helper/src/mock_rms.rs
+++ b/crates/api-test-helper/src/mock_rms.rs
@@ -188,6 +188,11 @@ pub struct MockRmsApi {
     batch_reset_switch_sdn_factory_default_calls:
         Mutex<Vec<rms::BatchResetSwitchSdnFactoryDefaultRequest>>,
 
+    batch_reset_switch_factory_default_responses:
+        Mutex<VecDeque<Result<rms::BatchResetSwitchFactoryDefaultResponse, RackManagerError>>>,
+    batch_reset_switch_factory_default_calls:
+        Mutex<Vec<rms::BatchResetSwitchFactoryDefaultRequest>>,
+
     get_job_status_responses: Mutex<VecDeque<Result<rms::GetJobStatusResponse, RackManagerError>>>,
     get_job_status_calls: Mutex<Vec<rms::GetJobStatusRequest>>,
 
@@ -335,6 +340,8 @@ impl MockRmsApi {
             update_switch_system_password_calls: Default::default(),
             batch_reset_switch_sdn_factory_default_responses: Default::default(),
             batch_reset_switch_sdn_factory_default_calls: Default::default(),
+            batch_reset_switch_factory_default_responses: Default::default(),
+            batch_reset_switch_factory_default_calls: Default::default(),
             get_job_status_responses: Default::default(),
             get_job_status_calls: Default::default(),
             get_firmware_job_status_responses: Default::default(),
@@ -644,6 +651,15 @@ impl MockRmsApi {
         batch_reset_switch_sdn_factory_default_calls,
         rms::BatchResetSwitchSdnFactoryDefaultRequest,
         rms::BatchResetSwitchSdnFactoryDefaultResponse
+    );
+
+    impl_enqueue_inspect!(
+        enqueue_batch_reset_switch_factory_default,
+        batch_reset_switch_factory_default_calls,
+        batch_reset_switch_factory_default_responses,
+        batch_reset_switch_factory_default_calls,
+        rms::BatchResetSwitchFactoryDefaultRequest,
+        rms::BatchResetSwitchFactoryDefaultResponse
     );
 
     impl_enqueue_inspect!(
@@ -1120,6 +1136,23 @@ impl RmsApi for MockRmsApi {
         )
     }
 
+    async fn batch_reset_switch_factory_default(
+        &self,
+        cmd: rms::BatchResetSwitchFactoryDefaultRequest,
+    ) -> Result<rms::BatchResetSwitchFactoryDefaultResponse, RackManagerError> {
+        self.batch_reset_switch_factory_default_calls
+            .lock()
+            .await
+            .push(cmd);
+
+        pop_or_err(
+            &mut self
+                .batch_reset_switch_factory_default_responses
+                .lock()
+                .await,
+        )
+    }
+
     async fn get_job_status(
         &self,
         cmd: rms::GetJobStatusRequest,
@@ -1410,6 +1443,17 @@ impl RmsApi for MockRmsApi {
             .push(cmd);
         pop_or_err(&mut self.configure_switch_certificate_responses.lock().await)
     }
+
+    async fn batch_disable_switch_mtls(
+        &self,
+        _cmd: rms::BatchDisableSwitchMtlsRequest,
+    ) -> Result<rms::BatchDisableSwitchMtlsResponse, RackManagerError> {
+        Err(
+            tonic::Status::unimplemented("BatchDisableSwitchMtls is not implemented by MockRmsApi")
+                .into(),
+        )
+    }
+
     async fn get_configure_switch_certificate_job_status(
         &self,
         cmd: rms::GetConfigureSwitchCertificateJobStatusRequest,

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use carbide_rack::firmware_object::rack_maintenance_access_token_key;
 use carbide_redfish::libredfish::RedfishClientPool;
@@ -24,7 +25,8 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     Backend as NvSwitchBackend, ConfigureSwitchCertificateJobStatus, NvSwitchManager,
-    SwitchEndpoint, SwitchPasswordRotationState,
+    SwitchEndpoint, SwitchFactoryResetJobStatus, SwitchFactoryResetState,
+    SwitchPasswordRotationState,
 };
 use crate::power_shelf_manager::{Backend as PowerShelfBackend, PowerShelfManager};
 use crate::rms::{RmsSwitchSystemImageStatusApi, validate_rms_backend_rack_profiles};
@@ -466,6 +468,101 @@ impl ComponentManager {
             .await
     }
 
+    /// Submits a destructive, asynchronous switch factory-default reset through the
+    /// selected backend.
+    ///
+    /// This method returns as soon as the backend accepts the batch. It does not wait
+    /// for reboot or default-login recovery. Pass the returned opaque job ID to
+    /// [`Self::wait_for_switch_factory_reset_job`] to wait for the terminal result. An
+    /// ambiguous submission error does not prove that resubmission is safe.
+    pub async fn batch_reset_switch_factory_default(
+        &self,
+        endpoints: &[SwitchEndpoint],
+        tls_server_domain: Option<&str>,
+    ) -> Result<String, ComponentManagerError> {
+        self.nv_switch
+            .batch_reset_switch_factory_default(endpoints, tls_server_domain)
+            .await
+    }
+
+    /// Waits for a submitted switch factory-reset operation and every target switch to
+    /// reach a terminal state. The first observation starts immediately.
+    ///
+    /// `poll_interval` and `timeout` must be nonzero. The timeout is an absolute budget
+    /// that includes status calls and sleeps. Transient backend failures and unknown
+    /// observations are retried within that budget. Completed and failed operations
+    /// both return `Ok` with their terminal backend-neutral status; callers must inspect
+    /// [`SwitchFactoryResetJobStatus::state`]. Other observation errors return
+    /// immediately. A timeout or cancelled wait does not cancel the backend job, which
+    /// may still be running and must not be resubmitted automatically.
+    pub async fn wait_for_switch_factory_reset_job(
+        &self,
+        job_id: &str,
+        poll_interval: Duration,
+        timeout: Duration,
+    ) -> Result<SwitchFactoryResetJobStatus, ComponentManagerError> {
+        if job_id.trim().is_empty() {
+            return Err(ComponentManagerError::InvalidArgument(
+                "switch factory-reset job ID must be non-empty".to_string(),
+            ));
+        }
+
+        if poll_interval.is_zero() {
+            return Err(ComponentManagerError::InvalidArgument(
+                "switch factory-reset poll interval must be nonzero".to_string(),
+            ));
+        }
+
+        if timeout.is_zero() {
+            return Err(ComponentManagerError::InvalidArgument(
+                "switch factory-reset timeout must be nonzero".to_string(),
+            ));
+        }
+
+        let poll = async {
+            loop {
+                match self
+                    .nv_switch
+                    .get_switch_factory_reset_job_status(job_id)
+                    .await
+                {
+                    Ok(status)
+                        if matches!(
+                            status.state,
+                            SwitchFactoryResetState::Completed | SwitchFactoryResetState::Failed
+                        ) =>
+                    {
+                        return Ok(status);
+                    }
+                    Ok(_) => {}
+                    Err(ComponentManagerError::Unavailable(error)) => {
+                        tracing::debug!(
+                            job_id,
+                            error = %error,
+                            "Transient switch factory-reset job polling failure; retrying"
+                        );
+                    }
+                    Err(ComponentManagerError::OperationOutcomeUnknown(error)) => {
+                        tracing::debug!(
+                            job_id,
+                            error = %error,
+                            "Switch factory-reset job outcome is not observable yet; retrying"
+                        );
+                    }
+                    Err(error) => return Err(error),
+                }
+
+                tokio::time::sleep(poll_interval).await;
+            }
+        };
+
+        tokio::time::timeout(timeout, poll).await.map_err(|_| {
+            ComponentManagerError::OperationOutcomeUnknown(format!(
+                "timed out waiting for switch factory-reset job {job_id}; the reset may still be running"
+            ))
+        })?
+    }
+
     /// Routes ScaleUp Fabric Manager V2 configuration through the switch backend.
     pub async fn configure_scale_up_fabric_manager_v2(
         &self,
@@ -695,6 +792,7 @@ mod tests {
 
     use super::*;
     use crate::config::ComponentManagerConfig;
+    use crate::mock::{MockComputeTrayManager, MockNvSwitchManager, MockPowerShelfManager};
 
     struct FailingCredentialManager;
 
@@ -741,6 +839,203 @@ mod tests {
     }
 
     impl CredentialManager for FailingCredentialManager {}
+
+    fn component_manager_with_mock_switch(mock: &MockNvSwitchManager) -> ComponentManager {
+        ComponentManager::new(
+            Arc::new(mock.clone()),
+            Arc::new(MockPowerShelfManager),
+            Arc::new(MockComputeTrayManager),
+            false,
+            false,
+            false,
+        )
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_switch_factory_reset_polls_until_completed() {
+        let job_id = "factory-reset-job-1";
+
+        let mock = MockNvSwitchManager::default().with_factory_reset_job_status_responses([
+            Ok(SwitchFactoryResetJobStatus {
+                state: SwitchFactoryResetState::Pending,
+                error: None,
+            }),
+            Ok(SwitchFactoryResetJobStatus {
+                state: SwitchFactoryResetState::Completed,
+                error: None,
+            }),
+        ]);
+
+        let manager = component_manager_with_mock_switch(&mock);
+
+        let response = manager
+            .wait_for_switch_factory_reset_job(
+                job_id,
+                Duration::from_secs(1),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("factory-reset jobs should complete");
+
+        assert_eq!(response.state, SwitchFactoryResetState::Completed);
+
+        assert_eq!(
+            mock.factory_reset_job_status_calls(),
+            vec![job_id.to_string(), job_id.to_string()]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_switch_factory_reset_reports_child_failure() {
+        let job_id = "factory-reset-job-1";
+
+        let mock = MockNvSwitchManager::default().with_factory_reset_job_status_responses([Ok(
+            SwitchFactoryResetJobStatus {
+                state: SwitchFactoryResetState::Failed,
+                error: Some(
+                    "switch factory-reset job factory-reset-child-1 for node switch-1 failed: default login never became reachable"
+                        .to_string(),
+                ),
+            },
+        )]);
+
+        let manager = component_manager_with_mock_switch(&mock);
+
+        let status = manager
+            .wait_for_switch_factory_reset_job(
+                job_id,
+                Duration::from_secs(1),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("a failed factory-reset job should return its terminal status");
+
+        assert_eq!(status.state, SwitchFactoryResetState::Failed);
+
+        assert!(status.error.as_deref().is_some_and(|message| {
+            message.contains("factory-reset-child-1")
+                && message.contains("switch-1")
+                && message.contains("default login never became reachable")
+        }));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_switch_factory_reset_retries_transient_observation_failure() {
+        let job_id = "factory-reset-job-1";
+
+        let mock = MockNvSwitchManager::default().with_factory_reset_job_status_responses([
+            Err(ComponentManagerError::Unavailable(
+                "switch backend temporarily unavailable".to_string(),
+            )),
+            Ok(SwitchFactoryResetJobStatus {
+                state: SwitchFactoryResetState::Completed,
+                error: None,
+            }),
+        ]);
+
+        let manager = component_manager_with_mock_switch(&mock);
+
+        manager
+            .wait_for_switch_factory_reset_job(
+                job_id,
+                Duration::from_secs(1),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("transient polling errors should be retried");
+
+        assert_eq!(mock.factory_reset_job_status_calls().len(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_switch_factory_reset_retries_unknown_observation() {
+        let job_id = "factory-reset-job-1";
+
+        let mock = MockNvSwitchManager::default().with_factory_reset_job_status_responses([
+            Err(ComponentManagerError::OperationOutcomeUnknown(
+                "the parent job is not observable yet".to_string(),
+            )),
+            Ok(SwitchFactoryResetJobStatus {
+                state: SwitchFactoryResetState::Completed,
+                error: None,
+            }),
+        ]);
+
+        let manager = component_manager_with_mock_switch(&mock);
+
+        manager
+            .wait_for_switch_factory_reset_job(
+                job_id,
+                Duration::from_secs(1),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("an unknown observation should be retried while the job ID is durable");
+
+        assert_eq!(mock.factory_reset_job_status_calls().len(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_for_switch_factory_reset_timeout_preserves_unknown_outcome() {
+        let job_id = "factory-reset-job-1";
+
+        let mock = MockNvSwitchManager::default().with_factory_reset_job_status_responses([Ok(
+            SwitchFactoryResetJobStatus {
+                state: SwitchFactoryResetState::Pending,
+                error: None,
+            },
+        )]);
+
+        let manager = component_manager_with_mock_switch(&mock);
+
+        let error = manager
+            .wait_for_switch_factory_reset_job(
+                job_id,
+                Duration::from_secs(5),
+                Duration::from_secs(1),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ComponentManagerError::OperationOutcomeUnknown(message)
+                if message.contains("may still be running")
+        ));
+
+        assert_eq!(mock.factory_reset_job_status_calls().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn wait_for_switch_factory_reset_validates_inputs_before_polling() {
+        let mock = MockNvSwitchManager::default();
+        let manager = component_manager_with_mock_switch(&mock);
+
+        let cases = [
+            ("", Duration::from_secs(1), Duration::from_secs(1)),
+            (
+                "factory-reset-job-1",
+                Duration::ZERO,
+                Duration::from_secs(1),
+            ),
+            (
+                "factory-reset-job-1",
+                Duration::from_secs(1),
+                Duration::ZERO,
+            ),
+        ];
+
+        for (job_id, poll_interval, timeout) in cases {
+            assert!(matches!(
+                manager
+                    .wait_for_switch_factory_reset_job(job_id, poll_interval, timeout)
+                    .await,
+                Err(ComponentManagerError::InvalidArgument(_))
+            ));
+        }
+
+        assert!(mock.factory_reset_job_status_calls().is_empty());
+    }
 
     async fn create_rack_in_state(pool: &PgPool, state: RackState) -> RackId {
         let rack_id = RackId::new(uuid::Uuid::new_v4().to_string());

--- a/crates/component-manager/src/error.rs
+++ b/crates/component-manager/src/error.rs
@@ -20,9 +20,13 @@ pub enum ComponentManagerError {
     #[error("operation rejected before dispatch: {0}")]
     RejectedBeforeDispatch(String),
 
-    /// A mutating request may have reached the backend, but no job handle is
-    /// available. Callers must preserve the staged target until their
-    /// reconciliation policy decides whether it is safe to retry.
+    /// A mutating operation may still be running when local observation ends,
+    /// so its outcome cannot be determined yet.
+    ///
+    /// When a job handle is available, callers must retain it and continue
+    /// status observation rather than resubmitting the mutation. Without a job
+    /// handle, callers must preserve the staged target until their reconciliation
+    /// policy decides whether it is safe to retry.
     ///
     /// For [`crate::nv_switch_manager::NvSwitchManager::ensure_password_rotation`],
     /// callers retain the exact current-to-target request and retry it later.

--- a/crates/component-manager/src/mock.rs
+++ b/crates/component-manager/src/mock.rs
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
 use model::component_manager::{
     ComputeTrayComponent, ConfigureSwitchCertificateState, FirmwareState, NvSwitchComponent,
     PowerAction, PowerShelfComponent,
@@ -13,8 +16,8 @@ use crate::compute_tray_manager::{
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     ConfigureSwitchCertificateJobStatus, NvSwitchManager, SwitchComponentResult, SwitchEndpoint,
-    SwitchFirmwareUpdateStatus, SwitchPasswordRotationState, SwitchPowerStateResult,
-    SwitchSlotAndTrayResult,
+    SwitchFactoryResetJobStatus, SwitchFirmwareUpdateStatus, SwitchPasswordRotationState,
+    SwitchPowerStateResult, SwitchSlotAndTrayResult,
 };
 use crate::power_shelf_manager::{
     PowerShelfComponentResult, PowerShelfEndpoint, PowerShelfFirmwareUpdateStatus,
@@ -30,6 +33,8 @@ pub struct MockNvSwitchManager {
     password_rotation_start_result: Option<MockPasswordRotationStartResult>,
     password_rotation_job_status_result: Option<MockPasswordRotationJobStatusResult>,
     expected_password_rotation_password: Option<String>,
+    factory_reset_job_status_responses: Option<Arc<Mutex<VecDeque<FactoryResetJobStatusResult>>>>,
+    factory_reset_job_status_calls: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockNvSwitchManager {
@@ -93,7 +98,29 @@ impl MockNvSwitchManager {
         self.expected_password_rotation_password = Some(password.into());
         self
     }
+
+    /// Queues factory-reset job-status results in polling order.
+    pub fn with_factory_reset_job_status_responses(
+        mut self,
+        responses: impl IntoIterator<Item = FactoryResetJobStatusResult>,
+    ) -> Self {
+        self.factory_reset_job_status_responses =
+            Some(Arc::new(Mutex::new(responses.into_iter().collect())));
+
+        self
+    }
+
+    /// Returns the factory-reset parent job IDs requested by callers.
+    pub fn factory_reset_job_status_calls(&self) -> Vec<String> {
+        self.factory_reset_job_status_calls
+            .lock()
+            .expect("factory-reset job-status calls lock poisoned")
+            .clone()
+    }
 }
+
+/// Result returned by one configured factory-reset job-status poll.
+pub type FactoryResetJobStatusResult = Result<SwitchFactoryResetJobStatus, ComponentManagerError>;
 
 #[derive(Debug, Clone)]
 enum MockPasswordRotationStartResult {
@@ -217,6 +244,32 @@ impl NvSwitchManager for MockNvSwitchManager {
                 state: ConfigureSwitchCertificateState::Completed,
                 error: None,
             }))
+    }
+
+    async fn get_switch_factory_reset_job_status(
+        &self,
+        job_id: &str,
+    ) -> Result<SwitchFactoryResetJobStatus, ComponentManagerError> {
+        self.factory_reset_job_status_calls
+            .lock()
+            .expect("factory-reset job-status calls lock poisoned")
+            .push(job_id.to_string());
+
+        let Some(responses) = &self.factory_reset_job_status_responses else {
+            return Err(ComponentManagerError::Unsupported(
+                "mock switch factory-reset job status is disabled".to_string(),
+            ));
+        };
+
+        responses
+            .lock()
+            .expect("factory-reset job-status responses lock poisoned")
+            .pop_front()
+            .unwrap_or_else(|| {
+                Err(ComponentManagerError::Internal(
+                    "no mock switch factory-reset job-status response queued".to_string(),
+                ))
+            })
     }
 
     async fn ensure_password_rotation(

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -120,6 +120,30 @@ pub struct ConfigureSwitchCertificateJobStatus {
     pub error: Option<String>,
 }
 
+/// Aggregate lifecycle state for a switch factory-reset job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwitchFactoryResetState {
+    /// The parent job or at least one target switch has not completed.
+    Pending,
+
+    /// The parent job and every target switch completed successfully.
+    Completed,
+
+    /// The parent job or at least one target switch failed.
+    Failed,
+}
+
+/// Backend observation of a switch factory-reset job and its target switches.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SwitchFactoryResetJobStatus {
+    /// Aggregate state across the parent operation and every target switch.
+    pub state: SwitchFactoryResetState,
+
+    /// Backend-supplied failure details when [`SwitchFactoryResetState::Failed`] is returned.
+    /// This is `None` for pending and successful jobs.
+    pub error: Option<String>,
+}
+
 /// Backend trait for NV-Switch management operations.
 ///
 /// Implementations receive physical endpoint information (BMC + NVOS IPs/MACs)
@@ -190,6 +214,54 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
         &self,
         job_id: &str,
     ) -> Result<ConfigureSwitchCertificateJobStatus, ComponentManagerError>;
+
+    /// Submits asynchronous switch factory-default resets for `endpoints`.
+    ///
+    /// This destructive operation wipes switch operating-system configuration, reboots
+    /// each switch, and completes after the default login is reachable again. It
+    /// preserves the factory default password. `tls_server_domain` is the TLS server
+    /// domain shared by all targets. When it is absent, the selected backend uses its
+    /// configured default. A successful submission returns a non-empty, opaque job ID
+    /// that can be passed to [`Self::get_switch_factory_reset_job_status`]. Submission
+    /// does not wait for the switches to reboot or become reachable.
+    ///
+    /// `endpoints` must contain at least one switch. Backends that support this
+    /// operation return [`ComponentManagerError::InvalidArgument`] for an empty slice
+    /// without dispatching work.
+    ///
+    /// If dispatch may have reached the backend but no job ID is available, the
+    /// implementation returns [`ComponentManagerError::OperationOutcomeUnknown`].
+    /// Callers must not automatically resubmit this destructive operation. The default
+    /// implementation returns [`ComponentManagerError::Unsupported`].
+    async fn batch_reset_switch_factory_default(
+        &self,
+        _endpoints: &[SwitchEndpoint],
+        _tls_server_domain: Option<&str>,
+    ) -> Result<String, ComponentManagerError> {
+        Err(ComponentManagerError::Unsupported(format!(
+            "switch factory reset is not supported by the {} backend",
+            self.name()
+        )))
+    }
+
+    /// Returns the aggregate state for a submitted switch factory-reset job.
+    ///
+    /// [`SwitchFactoryResetState::Completed`] requires the parent operation and every
+    /// target switch to complete. [`SwitchFactoryResetState::Failed`] is also terminal
+    /// and carries backend failure details in [`SwitchFactoryResetJobStatus::error`].
+    /// A missing or unrecognized job observation cannot establish whether the reset
+    /// ran and returns [`ComponentManagerError::OperationOutcomeUnknown`]. Other
+    /// observation errors also do not establish that resubmission is safe. The default
+    /// implementation returns [`ComponentManagerError::Unsupported`].
+    async fn get_switch_factory_reset_job_status(
+        &self,
+        _job_id: &str,
+    ) -> Result<SwitchFactoryResetJobStatus, ComponentManagerError> {
+        Err(ComponentManagerError::Unsupported(format!(
+            "switch factory-reset job status is not supported by the {} backend",
+            self.name()
+        )))
+    }
 
     /// Submits rack-level ScaleUp Fabric Manager configuration.
     ///

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -47,8 +47,9 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     Backend as NvSwitchBackend, ConfigureSwitchCertificateJobStatus, NvSwitchManager,
-    SwitchComponentResult, SwitchEndpoint, SwitchFirmwareUpdateStatus, SwitchPasswordRotationState,
-    SwitchPowerStateResult, SwitchSlotAndTrayResult,
+    SwitchComponentResult, SwitchEndpoint, SwitchFactoryResetJobStatus, SwitchFactoryResetState,
+    SwitchFirmwareUpdateStatus, SwitchPasswordRotationState, SwitchPowerStateResult,
+    SwitchSlotAndTrayResult,
 };
 use crate::power_shelf_manager::{
     Backend as PowerShelfBackend, PowerShelfComponentResult, PowerShelfEndpoint,
@@ -1943,6 +1944,50 @@ impl NvSwitchManager for RmsBackend {
         rms_get_configure_switch_certificate_job_status(self.client.as_ref(), job_id).await
     }
 
+    #[instrument(skip(self, endpoints, tls_server_domain), fields(backend = "rms"))]
+    async fn batch_reset_switch_factory_default(
+        &self,
+        endpoints: &[SwitchEndpoint],
+        tls_server_domain: Option<&str>,
+    ) -> Result<String, ComponentManagerError> {
+        if endpoints.is_empty() {
+            return Err(ComponentManagerError::InvalidArgument(
+                "switch factory reset requires at least one endpoint".to_string(),
+            ));
+        }
+
+        let macs: Vec<MacAddress> = endpoints.iter().map(|endpoint| endpoint.bmc_mac).collect();
+        let identities = resolve_switch_identities(&self.db, &macs).await?;
+        let hostnames = resolve_switch_machine_interface_hostnames(&self.db, endpoints).await?;
+        let mut nodes = Vec::with_capacity(endpoints.len());
+
+        for endpoint in endpoints {
+            let resolved = self
+                .resolve_switch_or_power_shelf_node(
+                    &identities,
+                    endpoint.bmc_mac,
+                    SwitchOrPowerShelfRole::Switch,
+                )
+                .map_err(ComponentManagerError::Internal)?;
+
+            nodes.push(build_switch_node_info(
+                endpoint,
+                &resolved,
+                hostnames.get(&endpoint.nvos_mac).cloned(),
+            ));
+        }
+
+        rms_batch_reset_switch_factory_default(self.client.as_ref(), nodes, tls_server_domain).await
+    }
+
+    #[instrument(skip(self), fields(backend = "rms", job_id))]
+    async fn get_switch_factory_reset_job_status(
+        &self,
+        job_id: &str,
+    ) -> Result<SwitchFactoryResetJobStatus, ComponentManagerError> {
+        rms_get_switch_factory_reset_job_status(self.client.as_ref(), job_id).await
+    }
+
     #[instrument(skip(self, request), fields(backend = "rms"))]
     async fn configure_scale_up_fabric_manager_v2(
         &self,
@@ -2141,6 +2186,226 @@ fn map_rms_password_rotation_state(job: &rms::JobStatus) -> SwitchPasswordRotati
         Ok(rms::JobExecutionState::Completed) => SwitchPasswordRotationState::Completed,
         Ok(rms::JobExecutionState::Failed) => SwitchPasswordRotationState::Failed,
         Ok(rms::JobExecutionState::Unspecified) | Err(_) => SwitchPasswordRotationState::Unknown,
+    }
+}
+
+/// Submits one destructive factory-reset batch and requires a durable job handle.
+///
+/// The backend-neutral TLS server domain maps to the RMS `domain` field. RMS uses its
+/// configured switch domain when this value is absent.
+async fn rms_batch_reset_switch_factory_default(
+    client: &dyn RmsApi,
+    nodes: Vec<rms::NodeInfo>,
+    tls_server_domain: Option<&str>,
+) -> Result<String, ComponentManagerError> {
+    let request = rms::BatchResetSwitchFactoryDefaultRequest {
+        nodes: Some(rms::NodeSet { nodes }),
+        domain: tls_server_domain.map(str::to_owned),
+    };
+
+    let response = red::instrumented(
+        "rms",
+        "batch_reset_switch_factory_default",
+        client.batch_reset_switch_factory_default(request),
+    )
+    .await
+    .map_err(|error| match error {
+        // The contract guarantees that an unimplemented RPC accepted no reset work.
+        // Other status or transport failures can arrive after dispatch, so they must
+        // not invite an automatic retry of this destructive operation.
+        RackManagerError::ApiInvocationError(status)
+            if status.code() == tonic::Code::Unimplemented =>
+        {
+            ComponentManagerError::Unsupported(
+                "RMS does not support switch factory reset".to_string(),
+            )
+        }
+        _ => ComponentManagerError::OperationOutcomeUnknown(
+            "RMS switch factory-reset submission returned no durable job ID".to_string(),
+        ),
+    })?;
+
+    let batch = response.response.ok_or_else(|| {
+        ComponentManagerError::OperationOutcomeUnknown(
+            "RMS switch factory-reset submission returned no operation response or job ID"
+                .to_string(),
+        )
+    })?;
+
+    if !batch.job_id.trim().is_empty() {
+        return Ok(batch.job_id);
+    }
+
+    Err(ComponentManagerError::OperationOutcomeUnknown(format!(
+        "RMS switch factory-reset submission returned no job ID (status {}); the operation outcome is unknown",
+        batch.status
+    )))
+}
+
+fn rms_switch_factory_reset_job_failure(job: &rms::JobStatus) -> String {
+    let error_code = rms::JobError::try_from(job.error_code).map_or_else(
+        |_| format!("unknown({})", job.error_code),
+        |error| error.as_str_name().to_string(),
+    );
+
+    let node = job
+        .node_id
+        .as_deref()
+        .map(|node_id| format!(" for node {node_id}"))
+        .unwrap_or_default();
+
+    let message = if job.error_message.trim().is_empty() {
+        "no error message".to_string()
+    } else {
+        job.error_message.clone()
+    };
+
+    format!(
+        "switch factory-reset job {}{node} failed with {error_code}: {message}",
+        job.job_id
+    )
+}
+
+/// Aggregates the parent and per-switch RMS jobs into one backend-neutral state.
+///
+/// A completed parent is not sufficient evidence of success. RMS creates one child
+/// job per target switch, so completion requires every child declared by the parent to
+/// be present and completed. A missing child remains pending because RMS may expose it
+/// on a later poll. A missing parent or unknown execution state cannot establish the
+/// outcome and is reported as [`ComponentManagerError::OperationOutcomeUnknown`].
+fn summarize_rms_switch_factory_reset_jobs(
+    job_id: &str,
+    jobs: &[rms::JobStatus],
+) -> Result<SwitchFactoryResetJobStatus, ComponentManagerError> {
+    let parent = jobs
+        .iter()
+        .find(|job| job.job_id == job_id)
+        .ok_or_else(|| {
+            ComponentManagerError::OperationOutcomeUnknown(format!(
+                "RMS returned no state for switch factory-reset job {job_id}; the reset outcome is unknown"
+            ))
+        })?;
+
+    let children: Vec<&rms::JobStatus> = jobs
+        .iter()
+        .filter(|job| {
+            job.job_id != job_id
+                && (job.parent_job_id.as_deref() == Some(job_id)
+                    || parent
+                        .child_job_ids
+                        .iter()
+                        .any(|child_job_id| child_job_id == &job.job_id))
+        })
+        .collect();
+
+    // Child failures identify the affected switch and therefore provide more useful
+    // diagnostics than the aggregate parent failure.
+    if let Some(failed) = children.iter().find(|job| {
+        matches!(
+            rms::JobExecutionState::try_from(job.execution_state),
+            Ok(rms::JobExecutionState::Failed)
+        )
+    }) {
+        return Ok(SwitchFactoryResetJobStatus {
+            state: SwitchFactoryResetState::Failed,
+            error: Some(rms_switch_factory_reset_job_failure(failed)),
+        });
+    }
+
+    if matches!(
+        rms::JobExecutionState::try_from(parent.execution_state),
+        Ok(rms::JobExecutionState::Failed)
+    ) {
+        return Ok(SwitchFactoryResetJobStatus {
+            state: SwitchFactoryResetState::Failed,
+            error: Some(rms_switch_factory_reset_job_failure(parent)),
+        });
+    }
+
+    // A successful reset must include per-switch evidence. Keep polling when RMS has
+    // not exposed any children yet or omits a child declared by the parent.
+    let mut pending = children.is_empty()
+        || parent.child_job_ids.iter().any(|child_job_id| {
+            !children
+                .iter()
+                .any(|job| job.job_id.as_str() == child_job_id)
+        });
+
+    for job in std::iter::once(parent).chain(children) {
+        match rms::JobExecutionState::try_from(job.execution_state) {
+            Ok(rms::JobExecutionState::Queued | rms::JobExecutionState::Running) => {
+                pending = true;
+            }
+            Ok(rms::JobExecutionState::Completed) => {}
+            Ok(rms::JobExecutionState::Failed) => {
+                return Ok(SwitchFactoryResetJobStatus {
+                    state: SwitchFactoryResetState::Failed,
+                    error: Some(rms_switch_factory_reset_job_failure(job)),
+                });
+            }
+            Ok(rms::JobExecutionState::Unspecified) | Err(_) => {
+                return Err(ComponentManagerError::OperationOutcomeUnknown(format!(
+                    "RMS switch factory-reset job {} returned unknown execution state {}; the reset outcome is unknown",
+                    job.job_id, job.execution_state
+                )));
+            }
+        }
+    }
+
+    let state = if pending {
+        SwitchFactoryResetState::Pending
+    } else {
+        SwitchFactoryResetState::Completed
+    };
+
+    Ok(SwitchFactoryResetJobStatus { state, error: None })
+}
+
+/// Reads and aggregates the RMS parent and child states for a factory reset.
+async fn rms_get_switch_factory_reset_job_status(
+    client: &dyn RmsApi,
+    job_id: &str,
+) -> Result<SwitchFactoryResetJobStatus, ComponentManagerError> {
+    if job_id.trim().is_empty() {
+        return Err(ComponentManagerError::InvalidArgument(
+            "switch factory-reset job ID must be non-empty".to_string(),
+        ));
+    }
+
+    let request = rms::GetJobStatusRequest {
+        job_id: job_id.to_string(),
+        include_child_job_states: true,
+    };
+
+    match red::instrumented("rms", "get_job_status", client.get_job_status(request)).await {
+        Ok(response) => summarize_rms_switch_factory_reset_jobs(job_id, &response.job_states),
+        Err(RackManagerError::ApiInvocationError(status)) => match status.code() {
+            // Once submission returned a durable handle, a rejected or missing
+            // observation does not prove that the destructive job never started.
+            tonic::Code::NotFound => Err(ComponentManagerError::OperationOutcomeUnknown(format!(
+                "RMS has no state for switch factory-reset job {job_id}; the reset outcome is unknown"
+            ))),
+            tonic::Code::InvalidArgument => {
+                Err(ComponentManagerError::OperationOutcomeUnknown(format!(
+                    "RMS rejected observation of switch factory-reset job {job_id}; the reset outcome is unknown"
+                )))
+            }
+            tonic::Code::Unimplemented => Err(ComponentManagerError::Unsupported(
+                "RMS does not support switch factory-reset job status".to_string(),
+            )),
+            tonic::Code::Unavailable
+            | tonic::Code::DeadlineExceeded
+            | tonic::Code::Cancelled
+            | tonic::Code::ResourceExhausted => Err(ComponentManagerError::Unavailable(
+                "RMS switch factory-reset job status is temporarily unavailable".to_string(),
+            )),
+            _ => Err(ComponentManagerError::Rms(format!(
+                "RMS could not read switch factory-reset job {job_id}: {status}"
+            ))),
+        },
+        Err(RackManagerError::TlsError(_)) => Err(ComponentManagerError::Unavailable(
+            "RMS switch factory-reset job status is temporarily unavailable".to_string(),
+        )),
     }
 }
 
@@ -3039,6 +3304,124 @@ mod tests {
                 "{scenario}"
             );
         }
+    }
+
+    #[test]
+    fn factory_reset_job_summary_requires_parent_and_all_declared_children() {
+        let job = |job_id: &str,
+                   parent_job_id: Option<&str>,
+                   child_job_ids: &[&str],
+                   execution_state: rms::JobExecutionState| rms::JobStatus {
+            job_id: job_id.to_string(),
+            parent_job_id: parent_job_id.map(str::to_string),
+            child_job_ids: child_job_ids.iter().map(|id| (*id).to_string()).collect(),
+            execution_state: execution_state as i32,
+            ..Default::default()
+        };
+
+        let missing_child = vec![job(
+            "factory-reset-job",
+            None,
+            &["child-1"],
+            rms::JobExecutionState::Completed,
+        )];
+
+        assert_eq!(
+            summarize_rms_switch_factory_reset_jobs("factory-reset-job", &missing_child)
+                .expect("a missing declared child remains pending")
+                .state,
+            SwitchFactoryResetState::Pending
+        );
+
+        let no_children = vec![job(
+            "factory-reset-job",
+            None,
+            &[],
+            rms::JobExecutionState::Completed,
+        )];
+
+        assert_eq!(
+            summarize_rms_switch_factory_reset_jobs("factory-reset-job", &no_children)
+                .expect("a completed parent without per-switch state remains pending")
+                .state,
+            SwitchFactoryResetState::Pending
+        );
+
+        let completed = vec![
+            job(
+                "factory-reset-job",
+                None,
+                &["child-1"],
+                rms::JobExecutionState::Completed,
+            ),
+            job(
+                "child-1",
+                Some("factory-reset-job"),
+                &[],
+                rms::JobExecutionState::Completed,
+            ),
+        ];
+
+        assert_eq!(
+            summarize_rms_switch_factory_reset_jobs("factory-reset-job", &completed)
+                .expect("the complete job graph should succeed")
+                .state,
+            SwitchFactoryResetState::Completed
+        );
+    }
+
+    #[test]
+    fn factory_reset_job_summary_preserves_child_failure_details() {
+        let failed_child = rms::JobStatus {
+            job_id: "child-1".to_string(),
+            parent_job_id: Some("factory-reset-job".to_string()),
+            execution_state: rms::JobExecutionState::Failed as i32,
+            error_code: rms::JobError::Unauthenticated as i32,
+            error_message: "default login failed".to_string(),
+            node_id: Some("switch-1".to_string()),
+            ..Default::default()
+        };
+
+        let jobs = vec![
+            rms::JobStatus {
+                job_id: "factory-reset-job".to_string(),
+                child_job_ids: vec!["child-1".to_string()],
+                execution_state: rms::JobExecutionState::Failed as i32,
+                ..Default::default()
+            },
+            failed_child,
+        ];
+
+        let status = summarize_rms_switch_factory_reset_jobs("factory-reset-job", &jobs)
+            .expect("a failed job should remain an observed terminal status");
+
+        assert_eq!(status.state, SwitchFactoryResetState::Failed);
+
+        assert!(status.error.as_deref().is_some_and(|error| {
+            error.contains("child-1")
+                && error.contains("switch-1")
+                && error.contains("JOB_ERROR_UNAUTHENTICATED")
+                && error.contains("default login failed")
+        }));
+    }
+
+    #[test]
+    fn factory_reset_job_summary_preserves_unknown_outcomes() {
+        assert!(matches!(
+            summarize_rms_switch_factory_reset_jobs("factory-reset-job", &[]),
+            Err(ComponentManagerError::OperationOutcomeUnknown(_))
+        ));
+
+        let jobs = vec![rms::JobStatus {
+            job_id: "factory-reset-job".to_string(),
+            execution_state: i32::MAX,
+            ..Default::default()
+        }];
+
+        assert!(matches!(
+            summarize_rms_switch_factory_reset_jobs("factory-reset-job", &jobs),
+            Err(ComponentManagerError::OperationOutcomeUnknown(_))
+        ));
     }
 
     #[test]
@@ -4090,6 +4473,221 @@ mod tests {
     }
 
     // ---- NvSwitchManager tests ----
+
+    #[tokio::test]
+    async fn sw_factory_reset_job_status_includes_children_and_returns_domain_status() {
+        let mock = MockRmsApi::new();
+
+        let response = rms::GetJobStatusResponse {
+            job_states: vec![rms::JobStatus {
+                job_id: "factory-reset-job-1".to_string(),
+                child_job_ids: vec!["factory-reset-child-1".to_string()],
+                execution_state: rms::JobExecutionState::Running as i32,
+                ..Default::default()
+            }],
+        };
+
+        mock.enqueue_get_job_status(Ok(response)).await;
+
+        let status = rms_get_switch_factory_reset_job_status(&mock, "factory-reset-job-1")
+            .await
+            .expect("factory-reset job status should be readable");
+
+        assert_eq!(status.state, SwitchFactoryResetState::Pending);
+        assert!(status.error.is_none());
+
+        let calls = mock.get_job_status_calls().await;
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].job_id, "factory-reset-job-1");
+        assert!(calls[0].include_child_job_states);
+    }
+
+    #[tokio::test]
+    async fn sw_factory_reset_job_status_unobservable_states_preserve_unknown_outcome() {
+        let cases = [
+            tonic::Status::not_found("expired factory-reset-job-1"),
+            tonic::Status::invalid_argument("factory-reset-job-1 is not observable"),
+        ];
+
+        for status in cases {
+            let mock = MockRmsApi::new();
+
+            mock.enqueue_get_job_status(Err(RackManagerError::ApiInvocationError(status)))
+                .await;
+
+            let error = rms_get_switch_factory_reset_job_status(&mock, "factory-reset-job-1")
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                error,
+                ComponentManagerError::OperationOutcomeUnknown(_)
+            ));
+
+            assert!(
+                mock.batch_reset_switch_factory_default_calls()
+                    .await
+                    .is_empty()
+            );
+        }
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_batch_reset_switch_factory_default_maps_endpoints_and_returns_job_id(
+        pool: sqlx::PgPool,
+    ) {
+        let (mock, backend, _, _, _, sw1, _) = make_backend(&pool).await;
+
+        let expected_response = rms::BatchResetSwitchFactoryDefaultResponse {
+            response: Some(rms::NodeBatchResponse {
+                status: rms::ReturnCode::Success as i32,
+                job_id: "factory-reset-job-1".to_string(),
+                ..Default::default()
+            }),
+        };
+
+        mock.enqueue_batch_reset_switch_factory_default(Ok(expected_response))
+            .await;
+
+        let endpoint = make_sw_endpoint(SW_MAC_1);
+
+        let tls_server_domain = "switches.example.test";
+
+        let job_id = NvSwitchManager::batch_reset_switch_factory_default(
+            &backend,
+            std::slice::from_ref(&endpoint),
+            Some(tls_server_domain),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(job_id, "factory-reset-job-1");
+
+        let calls = mock.batch_reset_switch_factory_default_calls().await;
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].domain.as_deref(), Some(tls_server_domain));
+
+        let nodes = calls[0]
+            .nodes
+            .as_ref()
+            .expect("the RMS request should include target nodes");
+
+        assert_eq!(nodes.nodes.len(), 1);
+        assert_eq!(nodes.nodes[0].node_id, sw1.to_string());
+    }
+
+    #[tokio::test]
+    async fn sw_batch_reset_switch_factory_default_requires_durable_job_id() {
+        let cases = [
+            (
+                "missing response",
+                rms::BatchResetSwitchFactoryDefaultResponse::default(),
+            ),
+            (
+                "empty job ID",
+                rms::BatchResetSwitchFactoryDefaultResponse {
+                    response: Some(rms::NodeBatchResponse::default()),
+                },
+            ),
+        ];
+
+        for (scenario, response) in cases {
+            let mock = MockRmsApi::new();
+            mock.enqueue_batch_reset_switch_factory_default(Ok(response))
+                .await;
+
+            let error =
+                rms_batch_reset_switch_factory_default(&mock, vec![rms::NodeInfo::default()], None)
+                    .await
+                    .expect_err(scenario);
+
+            assert!(matches!(
+                error,
+                ComponentManagerError::OperationOutcomeUnknown(_)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn sw_batch_reset_switch_factory_default_preserves_ambiguous_transport_failure() {
+        let mock = MockRmsApi::new();
+
+        mock.enqueue_batch_reset_switch_factory_default(Err(RackManagerError::ApiInvocationError(
+            tonic::Status::unavailable("connection lost"),
+        )))
+        .await;
+
+        let error =
+            rms_batch_reset_switch_factory_default(&mock, vec![rms::NodeInfo::default()], None)
+                .await
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ComponentManagerError::OperationOutcomeUnknown(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn sw_batch_reset_switch_factory_default_preserves_unproven_rejections() {
+        let invalid_argument = MockRmsApi::new();
+        invalid_argument
+            .enqueue_batch_reset_switch_factory_default(Err(RackManagerError::ApiInvocationError(
+                tonic::Status::invalid_argument("invalid target"),
+            )))
+            .await;
+
+        let error = rms_batch_reset_switch_factory_default(
+            &invalid_argument,
+            vec![rms::NodeInfo::default()],
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ComponentManagerError::OperationOutcomeUnknown(_)
+        ));
+
+        let unimplemented = MockRmsApi::new();
+        unimplemented
+            .enqueue_batch_reset_switch_factory_default(Err(RackManagerError::ApiInvocationError(
+                tonic::Status::unimplemented("unsupported"),
+            )))
+            .await;
+
+        let error = rms_batch_reset_switch_factory_default(
+            &unimplemented,
+            vec![rms::NodeInfo::default()],
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, ComponentManagerError::Unsupported(_)));
+    }
+
+    #[carbide_macros::sqlx_test]
+    async fn sw_batch_reset_switch_factory_default_rejects_empty_targets_before_dispatch(
+        pool: sqlx::PgPool,
+    ) {
+        let (mock, backend, _, _, _, _, _) = make_backend(&pool).await;
+
+        let error = NvSwitchManager::batch_reset_switch_factory_default(&backend, &[], None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ComponentManagerError::InvalidArgument(_)));
+
+        assert!(
+            mock.batch_reset_switch_factory_default_calls()
+                .await
+                .is_empty()
+        );
+    }
 
     #[carbide_macros::sqlx_test]
     async fn sw_configure_switch_certificate_success(pool: sqlx::PgPool) {

--- a/crates/rack/src/rms_client.rs
+++ b/crates/rack/src/rms_client.rs
@@ -1201,6 +1201,14 @@ pub mod test_support {
                     ..Default::default()
                 }))
         }
+
+        async fn batch_disable_switch_mtls(
+            &self,
+            _cmd: rms::BatchDisableSwitchMtlsRequest,
+        ) -> Result<rms::BatchDisableSwitchMtlsResponse, RackManagerError> {
+            Ok(rms::BatchDisableSwitchMtlsResponse::default())
+        }
+
         async fn get_configure_switch_certificate_job_status(
             &self,
             cmd: rms::GetConfigureSwitchCertificateJobStatusRequest,


### PR DESCRIPTION
Add backend-agnostic component-manager support for resetting switch NVOS to factory defaults, with an RMS backend implementation. Update `librms` to `v0.10.1`.

- When a supporting backend accepts a reset, it returns a job ID that callers can use to observe progress.
- If `tls_server_domain` is provided, it applies to all target switches; otherwise the backend uses its configured default.
- When asked to wait, component-manager polls the parent and per-switch job states until completion, failure, timeout, or a non-retryable error.
- A reset completes only when the parent and every per-switch job complete successfully.
- Unknown observations for a known job are retried. An unknown submission outcome is not automatically resubmitted.
- Backends without factory-reset support return `Unsupported`.


## Related issues

Resolves #4565

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)