### PR TITLE
fix: Validate that both DPF and VMAAS are not enabled at the same time. (backport #4477)

### DIFF
--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -203,6 +203,14 @@ pub(crate) async fn start_runtime(
     cancel_token: CancellationToken,
     ready_channel: Sender<()>,
 ) -> eyre::Result<()> {
+    eyre::ensure!(
+        !matches!(
+            (carbide_config.dpf.enabled, &carbide_config.vmaas_config),
+            (true, Some(_))
+        ),
+        "cannot enable both VMaaS and DPF; disable one in the configuration"
+    );
+
     let shared_redfish_pool = create_redfish_pool(&carbide_config, credential_manager.clone())?;
     let shared_nv_redfish_pool =
         carbide_redfish::nv_redfish::new_pool(carbide_config.site_explorer.bmc_proxy.clone());


### PR DESCRIPTION
Backport of #4477 to `release/v2.1`.

Validate that both DPF and VMAAS are not enabled at the same time.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Backport of #4477.