### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -573,7 +573,7 @@ jobs:
       # compression-level: 0 because squashfs/bfb/efi payloads are already
       # compressed; re-deflating them burns CPU for a rounding error of savings.
       - name: Upload artifacts
-        if: always()  # Upload artifacts even if build fails (matches GitLab CI 'when: always')
+        if: ${{ !cancelled() }}  # Upload artifacts even if build fails (matches GitLab CI 'when: always')
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.build_type }}-artifacts-${{ inputs.arch }}-${{ github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,10 @@ on:
       - "v[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]*"
       - "v[0-9].[0-9].[0-9]-rc[0-9]*"
 
+concurrency:
+  group: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') && format('core-pr-{0}', github.ref_name) || format('core-run-{0}-{1}', github.run_id, github.run_attempt) }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') }}
+
 env:
   # Build configuration
   CARGO_INCREMENTAL: 0
@@ -47,6 +51,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Check Core CI concurrency policy
+        run: bash scripts/check-ci-concurrency.sh core
 
       - name: Detect non-rest changes
         id: non-rest-changes
@@ -685,7 +692,7 @@ jobs:
   build-release-container-x86_64:
     if: >-
       ${{
-        always()
+        !cancelled()
         && github.event_name != 'schedule'
         && needs.prepare.result == 'success'
         && contains('success,skipped', needs.build-container-x86_64.result)
@@ -719,7 +726,7 @@ jobs:
   build-release-container-aarch64:
     if: >-
       ${{
-        always()
+        !cancelled()
         && github.event_name != 'schedule'
         && needs.prepare.result == 'success'
         && contains('success,skipped', needs.build-container-aarch64.result)
@@ -796,7 +803,7 @@ jobs:
   build-machine-a-tron:
     if: >-
       ${{
-        always()
+        !cancelled()
         && github.event_name != 'schedule'
         && needs.prepare.result == 'success'
         && needs.prepare.outputs.source_files_changed == 'true'
@@ -826,7 +833,7 @@ jobs:
   build-mat-k8s-controller:
     if: >-
       ${{
-        always()
+        !cancelled()
         && github.event_name != 'schedule'
         && needs.prepare.result == 'success'
         && needs.prepare.outputs.source_files_changed == 'true'
@@ -852,7 +859,7 @@ jobs:
   test-release-container-services:
     if: >-
       ${{
-        always()
+        !cancelled()
         && github.event_name != 'schedule'
         && needs.prepare.result == 'success'
         && contains('success,skipped', needs.build-container-x86_64.result)
@@ -945,7 +952,7 @@ jobs:
     needs:
       - prepare
       - build-artifacts-container-x86_64
-    if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
@@ -966,7 +973,7 @@ jobs:
     needs:
       - prepare
       - build-artifacts-container-aarch64
-    if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
@@ -1911,7 +1918,7 @@ jobs:
 
   build-summary:
     runs-on: linux-amd64-cpu4
-    if: ${{ always() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' }}
     needs:
       - prepare
       - build-container-x86_64

--- a/.github/workflows/rest-build-push-docker.yml
+++ b/.github/workflows/rest-build-push-docker.yml
@@ -337,7 +337,7 @@ jobs:
       - build-nico-psm
       - build-nico-nsm
       - build-nico-mcp
-    if: always()
+    if: ${{ !cancelled() }}
     outputs:
       build_artifacts: ${{ steps.aggregate.outputs.artifacts }}
 

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -14,6 +14,10 @@ on:
       - "v[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]*"
       - "v[0-9].[0-9].[0-9]-rc[0-9]*"
 
+concurrency:
+  group: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') && format('rest-pr-{0}', github.ref_name) || format('rest-run-{0}-{1}', github.run_id, github.run_attempt) }}
+  cancel-in-progress: ${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') }}
+
 jobs:
   changes:
     name: Detect REST CI Gate
@@ -28,6 +32,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Check REST CI concurrency policy
+        run: bash scripts/check-ci-concurrency.sh rest
 
       - name: Detect rest-api changes
         id: filter

--- a/scripts/check-ci-concurrency.sh
+++ b/scripts/check-ci-concurrency.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: check-ci-concurrency.sh [all|core|rest]"
+}
+
+if (( $# > 1 )); then
+	usage >&2
+	exit 2
+fi
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+mode="${1:-all}"
+if [[ "${mode}" != "all" && "${mode}" != "core" && "${mode}" != "rest" ]]; then
+	usage >&2
+	exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+assert_concurrency_policy() {
+	local workflow_path="$1"
+	local expected_group="$2"
+	local expected_cancel="$3"
+	local blocks
+	local groups
+	local cancels
+
+	read -r blocks groups cancels < <(
+		awk -v expected_group="${expected_group}" -v expected_cancel="${expected_cancel}" '
+			$0 == "concurrency:" { blocks++; in_concurrency = 1; next }
+			in_concurrency && /^[^[:space:]#]/ { in_concurrency = 0 }
+			in_concurrency && $0 == expected_group { groups++ }
+			in_concurrency && $0 == expected_cancel { cancels++ }
+			END { print blocks + 0, groups + 0, cancels + 0 }
+		' "${workflow_path}"
+	)
+
+	if (( blocks != 1 || groups != 1 || cancels != 1 )); then
+		printf 'Expected one root concurrency policy in %s; found blocks=%d groups=%d cancel-in-progress=%d.\n' \
+			"${workflow_path#"${repo_root}/"}" "${blocks}" "${groups}" "${cancels}" >&2
+		return 1
+	fi
+}
+
+assert_workflow_policy() {
+	local workflow="$1"
+	local workflow_path
+	local expected_group
+	local expected_cancel
+
+	case "${workflow}" in
+	core)
+		workflow_path="${repo_root}/.github/workflows/ci.yaml"
+		expected_group="  group: \${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') && format('core-pr-{0}', github.ref_name) || format('core-run-{0}-{1}', github.run_id, github.run_attempt) }}"
+		;;
+	rest)
+		workflow_path="${repo_root}/.github/workflows/rest-ci.yml"
+		expected_group="  group: \${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') && format('rest-pr-{0}', github.ref_name) || format('rest-run-{0}-{1}', github.run_id, github.run_attempt) }}"
+		;;
+	esac
+
+	expected_cancel="  cancel-in-progress: \${{ github.event_name == 'push' && github.run_attempt == '1' && startsWith(github.ref, 'refs/heads/pull-request/') }}"
+	assert_concurrency_policy "${workflow_path}" "${expected_group}" "${expected_cancel}"
+}
+
+resolve_policy() {
+	local workflow="$1"
+	local event_name="$2"
+	local ref="$3"
+	local run_id="$4"
+	local run_attempt="$5"
+	local ref_name
+
+	resolved_cancel=false
+	if [[ "${event_name}" == "push" && "${run_attempt}" == "1" && "${ref}" == refs/heads/pull-request/* ]]; then
+		ref_name="${ref#refs/heads/}"
+		resolved_group="${workflow}-pr-${ref_name}"
+		resolved_cancel=true
+	else
+		resolved_group="${workflow}-run-${run_id}-${run_attempt}"
+	fi
+}
+
+fixtures=(
+	'core|first Core PR run|push|refs/heads/pull-request/4575|1001|1|core-pr-pull-request/4575|true'
+	'core|newer run for the same Core PR|push|refs/heads/pull-request/4575|1002|1|core-pr-pull-request/4575|true'
+	'core|different Core PR|push|refs/heads/pull-request/4576|1003|1|core-pr-pull-request/4576|true'
+	'core|Core main push|push|refs/heads/main|2001|1|core-run-2001-1|false'
+	'core|Core tag push|push|refs/tags/v2.2.0|2002|1|core-run-2002-1|false'
+	'core|Core merge group|merge_group|refs/heads/gh-readonly-queue/main/pr-4575|2003|1|core-run-2003-1|false'
+	'core|rerun of an older Core PR run|push|refs/heads/pull-request/4575|1001|2|core-run-1001-2|false'
+	'rest|first REST PR run|push|refs/heads/pull-request/4575|3001|1|rest-pr-pull-request/4575|true'
+	'rest|newer run for the same REST PR|push|refs/heads/pull-request/4575|3002|1|rest-pr-pull-request/4575|true'
+	'rest|different REST PR|push|refs/heads/pull-request/4576|3003|1|rest-pr-pull-request/4576|true'
+	'rest|REST main push|push|refs/heads/main|4001|1|rest-run-4001-1|false'
+	'rest|REST tag push|push|refs/tags/v2.2.0|4002|1|rest-run-4002-1|false'
+	'rest|REST manual run on main|workflow_dispatch|refs/heads/main|4003|1|rest-run-4003-1|false'
+	'rest|REST manual run on a PR mirror|workflow_dispatch|refs/heads/pull-request/4575|4004|1|rest-run-4004-1|false'
+	'rest|REST merge group|merge_group|refs/heads/gh-readonly-queue/main/pr-4575|4005|1|rest-run-4005-1|false'
+	'rest|rerun of an older REST PR run|push|refs/heads/pull-request/4575|3001|2|rest-run-3001-2|false'
+)
+
+if [[ "${mode}" == "all" || "${mode}" == "core" ]]; then
+	assert_workflow_policy "core"
+fi
+if [[ "${mode}" == "all" || "${mode}" == "rest" ]]; then
+	assert_workflow_policy "rest"
+fi
+
+failed=0
+checked=0
+for fixture in "${fixtures[@]}"; do
+	IFS='|' read -r fixture_workflow fixture_name event_name ref run_id run_attempt expected_group expected_cancel <<<"${fixture}"
+	if [[ "${mode}" != "all" && "${mode}" != "${fixture_workflow}" ]]; then
+		continue
+	fi
+
+	resolve_policy "${fixture_workflow}" "${event_name}" "${ref}" "${run_id}" "${run_attempt}"
+	checked=$((checked + 1))
+	if [[ "${resolved_group}" != "${expected_group}" || "${resolved_cancel}" != "${expected_cancel}" ]]; then
+		printf '%s failed: expected group=%s cancel=%s, got group=%s cancel=%s\n' \
+			"${fixture_name}" "${expected_group}" "${expected_cancel}" \
+			"${resolved_group}" "${resolved_cancel}" >&2
+		failed=1
+	fi
+done
+
+if (( failed )); then
+	exit 1
+fi
+
+printf 'Checked %d %s CI concurrency fixture(s).\n' "${checked}" "${mode}"


### PR DESCRIPTION
A newer PR update now cancels only the older Core or REST run for the same `pull-request/<n>` mirror. Separate workflow keys protect unrelated work and explicit reruns, while cancellation-safe job conditions make sure long builds, tests, summaries, and large uploads actually stop.

Primary callouts are:

- **Expected green-run effect:** A latest PR update does not become intrinsically faster on an idle runner. It can finish sooner when cancelling an obsolete run frees a runner it would otherwise wait for, but we do not have enough evidence to promise a median wall-clock reduction.
- **What it really buys us:** A superseded Core run stops consuming whatever is left of the roughly `222` runner-minutes observed in the current PR #4513 run, rather than competing with work developers still care about. A full applicable REST run can add another `120.7` runner-minutes of avoidable work.

The workflow policy deliberately isolates Core from REST, one PR from another, and explicit reruns from automatic first attempts. Table-driven fixtures cover 16 PR, rerun, `main`, tag, REST `workflow_dispatch`, and merge-group cases. Jobs that must report a canceled required check remain cancellation-aware; expensive work and large artifact uploads do not.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4575.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Local validation passed:

- all 16 concurrency-policy fixtures
- `bash -n` and ShellCheck for the fixture script
- actionlint for all four changed workflows
- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `git diff --check`

Live cancellation proof passed on this PR:

| Controlled update | Superseded Core run | Superseded REST run |
|---|---|---|
| 1 | [31028861128](https://github.com/NVIDIA/infra-controller/actions/runs/31028861128) ended `cancelled` at age `5m21s`, `54s` after its replacement appeared | [31028861206](https://github.com/NVIDIA/infra-controller/actions/runs/31028861206) ended `cancelled` at age `5m26s`, `59s` after its replacement appeared |
| 2 | [31029216599](https://github.com/NVIDIA/infra-controller/actions/runs/31029216599) ended `cancelled` at age `4m06s`, `1m05s` after its replacement appeared | [31029216606](https://github.com/NVIDIA/infra-controller/actions/runs/31029216606) ended `cancelled` at age `4m03s`, `1m03s` after its replacement appeared |

Those four obsolete runs cancelled 67 jobs. They had consumed `85m39s` of runner-bearing elapsed time; compared with the rounded `222`-minute Core and `120.7`-minute REST baselines, the estimated avoided remainder was about `599.8` runner-minutes, or `87.5%`. That is a comparable-run estimate, not a direct billing measurement or a promise that the newest green run becomes faster.

The final head completed successfully:

- [Core run 31029450442](https://github.com/NVIDIA/infra-controller/actions/runs/31029450442): `49m48s`, with `51` jobs and `225m28s` of summed job elapsed time
- [REST run 31029449446](https://github.com/NVIDIA/infra-controller/actions/runs/31029449446): `13m45s`, with `71` jobs and `121m52s` of summed job elapsed time

One cancelled REST secret scan briefly treated cancellation as a finding in its PR comment. Its own quality gate reported no secret, and the final scan corrected the shared comment to “no secrets found.” CodeRabbit's final review produced no actionable comments, and a human review approved the PR.

Closes #4575
