### PR TITLE
fix: lint police simulated merge base branch used

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1485,12 +1485,20 @@ jobs:
           persist-credentials: false
 
       - name: Build pull request merge result
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch --no-tags origin "$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
+          PR_NUMBER="${GITHUB_REF_NAME##pull-request/}"
+          TARGET=$(curl -sf \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+            | jq -r '.base.ref')
+          git fetch --no-tags origin "${TARGET}:refs/remotes/origin/${TARGET}"
           git -c user.name="CI merge validation" \
             -c user.email=ci@example.invalid \
-            merge --no-commit --no-ff "origin/$GITHUB_BASE_REF"
+            merge --no-commit --no-ff "origin/${TARGET}"
 
       - name: Validate Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1 >/dev/null

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1487,10 +1487,10 @@ jobs:
       - name: Build pull request merge result
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git fetch --no-tags origin main:refs/remotes/origin/main
+          git fetch --no-tags origin "$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
           git -c user.name="CI merge validation" \
             -c user.email=ci@example.invalid \
-            merge --no-commit --no-ff origin/main
+            merge --no-commit --no-ff "origin/$GITHUB_BASE_REF"
 
       - name: Validate Cargo metadata
         run: cargo metadata --locked --no-deps --format-version 1 >/dev/null


### PR DESCRIPTION
The lint police job was failing on release branch PRs: https://github.com/NVIDIA/infra-controller/actions/runs/31021360041/job/92359688163

The `Build pull request merge result` step was hardcoded to always merge against `origin/main`:

```yaml
git fetch --no-tags origin main:refs/remotes/origin/main
git merge --no-commit --no-ff origin/main
```

This fails when a PR targets a release branch because the simulated merge is against the wrong base.

`GITHUB_BASE_REF` can't be used here since the workflow triggers on `push` events (to `pull-request/N` branches), not `pull_request` events — so that variable is never populated. Instead, the PR number is extracted from `GITHUB_REF_NAME` and used to query the GitHub API for the actual target branch:

```yaml
# calculate target branch
PR_NUMBER="${GITHUB_REF_NAME##pull-request/}"
TARGET=$(curl -sf \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  -H "Accept: application/vnd.github+json" \
  "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
  | jq -r '.base.ref')

# simulate merge
git fetch --no-tags origin "${TARGET}:refs/remotes/origin/${TARGET}"
git merge --no-commit --no-ff "origin/${TARGET}"
```

This makes the simulated merge match the branch the PR will actually land on.


## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

