### PR TITLE
ci: Reduce image export churn, cache Rust compile, tweak distro timeouts

### DIFF
--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -17,9 +17,53 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # A cold run pulls ~120 packages from the distro mirror, and on arm64 a
+    # single stalled connection there has taken the whole job down: one 140 kB
+    # package burned two minutes of retries and then failed with a connection
+    # timeout. Keeping the .deb files between runs takes the mirror off the
+    # critical path entirely whenever the set of packages is unchanged.
+    - name: Compute apt cache key
+      id: apt-key
+      shell: bash
+      run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+    # The package list lives in this file, so its hash is what should rotate the
+    # cache. The trailing week keeps the contents from ageing indefinitely: a
+    # primary-key hit never re-saves, so without it the archive would drift
+    # further behind the mirror every run.
+    # restore/save rather than actions/cache, whose post step is `post-if:
+    # success()` and so would skip the save on exactly the run that needs it
+    # most -- the one the mirror just failed.
+    - name: Restore apt archives
+      id: apt-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.cache/nico-apt-archives
+        key: apt-mkosi-${{ runner.arch }}-${{ hashFiles('.github/actions/setup-mkosi-environment/action.yml') }}-${{ steps.apt-key.outputs.week }}
+        restore-keys: |
+          apt-mkosi-${{ runner.arch }}-${{ hashFiles('.github/actions/setup-mkosi-environment/action.yml') }}-
+          apt-mkosi-${{ runner.arch }}-
+
     - name: Update package lists
       shell: bash
       run: |
+        set -euo pipefail
+
+        # apt defaults to three tries against a 120s timeout, so one unhealthy
+        # mirror IP stalls for minutes before it gives up on a package. Failing
+        # faster and trying more often lands on a healthy IP sooner.
+        sudo tee /etc/apt/apt.conf.d/99-nico-acquire >/dev/null <<'EOF'
+        Acquire::Retries "5";
+        Acquire::http::Timeout "20";
+        Acquire::https::Timeout "20";
+        Binary::apt-get::APT::Keep-Downloaded-Packages "true";
+        EOF
+
+        # apt only skips a download when the .deb is already in its own cache
+        # directory, so the restored archives have to be seeded into it.
+        mkdir -p ~/.cache/nico-apt-archives
+        sudo cp -n ~/.cache/nico-apt-archives/*.deb /var/cache/apt/archives/ 2>/dev/null || true
+
         sudo apt-get update
 
     - name: Install system dependencies
@@ -88,6 +132,25 @@ runs:
           protobuf-compiler
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_unconfined=0
         sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+    # Runs after a failed install too: apt keeps every .deb it did fetch before
+    # giving up, so banking them shrinks what the retry has to ask the mirror
+    # for. Owned by the runner user so the save step can read them back.
+    - name: Collect apt archives
+      if: always()
+      shell: bash
+      run: |
+        mkdir -p ~/.cache/nico-apt-archives
+        sudo cp -u /var/cache/apt/archives/*.deb ~/.cache/nico-apt-archives/ 2>/dev/null || true
+        sudo chown -R "$(id -u):$(id -g)" ~/.cache/nico-apt-archives
+        echo "apt archives held: $(find ~/.cache/nico-apt-archives -name '*.deb' | wc -l) packages ($(du -sh ~/.cache/nico-apt-archives | cut -f1))"
+
+    - name: Save apt archives
+      if: always() && steps.apt-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.cache/nico-apt-archives
+        key: ${{ steps.apt-cache.outputs.cache-primary-key }}
 
     - name: Install Rust toolchain
       shell: bash

--- a/.github/actions/setup-mkosi-environment/action.yml
+++ b/.github/actions/setup-mkosi-environment/action.yml
@@ -136,8 +136,12 @@ runs:
     # Runs after a failed install too: apt keeps every .deb it did fetch before
     # giving up, so banking them shrinks what the retry has to ask the mirror
     # for. Owned by the runner user so the save step can read them back.
+    #
+    # !cancelled() rather than always(), so a superseded run that CI just
+    # cancelled stops promptly instead of lingering to bank a cache nobody
+    # asked for. An ordinary failure still saves.
     - name: Collect apt archives
-      if: always()
+      if: ${{ !cancelled() }}
       shell: bash
       run: |
         mkdir -p ~/.cache/nico-apt-archives
@@ -146,7 +150,7 @@ runs:
         echo "apt archives held: $(find ~/.cache/nico-apt-archives -name '*.deb' | wc -l) packages ($(du -sh ~/.cache/nico-apt-archives | cut -f1))"
 
     - name: Save apt archives
-      if: always() && steps.apt-cache.outputs.cache-hit != 'true'
+      if: ${{ !cancelled() && steps.apt-cache.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v4
       with:
         path: ~/.cache/nico-apt-archives

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -375,6 +375,9 @@ jobs:
           # files here lets the container reuse that script rather than carry a
           # second copy of the backend-selection logic.
           SCCACHE_SECRETS="$(mktemp -d)"
+          # These runners are not guaranteed to be ephemeral, so the token must
+          # not outlive the step that needs it.
+          trap 'rm -rf "${SCCACHE_SECRETS}"' EXIT
           printf '%s' "${BUILD_ACTIONS_RESULTS_URL}" > "${SCCACHE_SECRETS}/actions_results_url"
           printf '%s' "${BUILD_ACTIONS_RUNTIME_TOKEN}" > "${SCCACHE_SECRETS}/actions_runtime_token"
           printf '%s' "${SCCACHE_GHA_RW_MODE}" > "${SCCACHE_SECRETS}/sccache_gha_rw_mode"

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -346,13 +346,45 @@ jobs:
             exit 1
           fi
 
+      # The build-artifacts containers ship sccache but never point it anywhere,
+      # so the Rust compile inside them started cold on every run -- 3m36s of the
+      # bfb critical path. These are the same credentials the release image
+      # builds hand to BuildKit. The sentinel keeps the value non-empty so the
+      # in-container check can tell "no backend" from "malformed endpoint".
+      - name: Expose Actions cache credentials to the container build
+        if: inputs.use_container == true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const token = process.env.ACTIONS_RUNTIME_TOKEN || '';
+            const url = process.env.ACTIONS_RESULTS_URL || '';
+            if (token) core.setSecret(token);
+            core.exportVariable('BUILD_ACTIONS_RUNTIME_TOKEN', token || 'unavailable');
+            core.exportVariable('BUILD_ACTIONS_RESULTS_URL', url || 'unavailable');
+            core.info(`In-container sccache backend: ${token && url ? 'enabled' : 'disabled'}`);
+
       # Run build in container mode (for boot artifacts)
       - name: Run cargo make task (container mode)
         if: inputs.use_container == true
+        env:
+          # Only main publishes; every other ref reads what main left behind.
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
         run: |
+          # dev/docker/sccache-cache.sh reads its credentials from /run/secrets
+          # because that is where BuildKit puts them. Staging the same three
+          # files here lets the container reuse that script rather than carry a
+          # second copy of the backend-selection logic.
+          SCCACHE_SECRETS="$(mktemp -d)"
+          printf '%s' "${BUILD_ACTIONS_RESULTS_URL}" > "${SCCACHE_SECRETS}/actions_results_url"
+          printf '%s' "${BUILD_ACTIONS_RUNTIME_TOKEN}" > "${SCCACHE_SECRETS}/actions_runtime_token"
+          printf '%s' "${SCCACHE_GHA_RW_MODE}" > "${SCCACHE_SECRETS}/sccache_gha_rw_mode"
+          chmod 600 "${SCCACHE_SECRETS}"/*
+
           # Set up environment variables for container (matches GitLab CI global variables)
           ENV_ARGS="-e CARGO_HOME=/workspace/cargo"
           ENV_ARGS="$ENV_ARGS -e CARGO_INCREMENTAL=0"
+          ENV_ARGS="$ENV_ARGS -e RUSTC_WRAPPER=sccache"
+          ENV_ARGS="$ENV_ARGS -e SCCACHE_DIR=/workspace/cache/sccache"
           ENV_ARGS="$ENV_ARGS -e CACHE_DIRECTORY=/workspace/cache"
           ENV_ARGS="$ENV_ARGS -e APT_CACHE_DIR=/workspace/apt"
           ENV_ARGS="$ENV_ARGS -e LOGNAME=root"
@@ -368,7 +400,7 @@ jobs:
           echo "FORGE_CA=prod"
           echo "============================================"
 
-          EXTRA_DOCKER_ARGS=""
+          EXTRA_DOCKER_ARGS="-v ${SCCACHE_SECRETS}:/run/secrets:ro"
           if [[ "${{ inputs.cargo_make_task }}" == "build-boot-artifacts-bfb-ci" ]]; then
             # bfb build runs `docker pull/save` (see pxe/Makefile.toml tasks.bfb-hbn-pull/export).
             # Allow docker CLI inside the build container to talk to the host Docker daemon.
@@ -400,7 +432,7 @@ jobs:
             -w /workspace \
             ${ENV_ARGS} \
             ${{ inputs.build_container }} \
-            bash -c "git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/pxe/ipxe/upstream && echo 'VERSION in container: '\${VERSION} && cargo make --cwd pxe ${SA_ENABLEMENT_ARG} ${{ inputs.cargo_make_task }}"
+            bash -c ". /workspace/dev/docker/sccache-cache.sh && sccache_setup && git config --global --add safe.directory /workspace && git config --global --add safe.directory /workspace/pxe/ipxe/upstream && echo 'VERSION in container: '\${VERSION} && cargo make --cwd pxe ${SA_ENABLEMENT_ARG} ${{ inputs.cargo_make_task }} && sccache_report"
 
       # Run build directly on runner (for ephemeral images with mkosi)
       - name: Run cargo make task (shell mode)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -895,13 +895,13 @@ jobs:
           username: ${{ secrets.NICO_TARGET_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
           token: ${{ secrets.NICO_TARGET_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
 
-      # This job already mounts a host sccache directory into the build
-      # container, but nothing ever persisted it, so every run started from an
-      # empty cache and recompiled the whole workspace. Cargo.lock keys the
-      # entry; restore-keys let a lockfile bump start from the previous cache
-      # instead of from nothing.
+      # The build container mounts this directory as its sccache store, so a
+      # miss here means recompiling the whole workspace before the first test
+      # runs. restore-keys let a lockfile bump start from the previous entry
+      # rather than from an empty cache.
       - name: Restore sccache
-        uses: actions/cache@v4
+        id: sccache
+        uses: actions/cache/restore@v4
         with:
           path: .sccache
           key: sccache-test-release-x86_64-${{ hashFiles('Cargo.lock') }}
@@ -931,16 +931,35 @@ jobs:
             -e CI_COMMIT_SHORT_SHA="${CI_COMMIT_SHORT_SHA}" \
             -e VERSION="${VERSION}" \
             -e CONTAINER_REPO_ROOT=/carbide \
+            -e HOST_OWNER="$(id -u):$(id -g)" \
             "${BUILD_CONTAINER}" \
             bash -c '
               set -euo pipefail
+              # Everything in here runs as root, so sccache leaves /sccache
+              # owned by root and the post-job archive step cannot read it back.
+              # Hand the directory to the runner user on the way out, including
+              # when the tests fail.
+              trap "chown -R ${HOST_OWNER} /sccache 2>/dev/null || true" EXIT
               git config --global --add safe.directory /carbide
               /etc/init.d/postgresql start
               sudo -u postgres psql -c "ALTER USER root WITH SUPERUSER;"
               createdb root
               cargo make test-release-container-services
               sccache --show-stats || true
+              echo "sccache directory holds $(du -sh /sccache | cut -f1)"
             '
+
+      # Worth saving even when the tests failed: the entry holds the dependency
+      # compilation, which is no less valid after a red run and is most of the
+      # eight minutes spent before the first test starts. Cargo.lock keys it, so
+      # a run that changes no dependencies hits the primary key and skips the
+      # upload rather than rewriting an equivalent entry.
+      - name: Save sccache
+        if: ${{ !cancelled() && steps.sccache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: .sccache
+          key: ${{ steps.sccache.outputs.cache-primary-key }}
 
       - name: Final repository clean check
         run: bash scripts/check-repo-clean.sh "release-container service tests"
@@ -1236,7 +1255,10 @@ jobs:
     name: CodeQL Security Analysis
     needs: prepare
     runs-on: linux-amd64-cpu4
-    timeout-minutes: 360
+    # The scan runs in about two minutes. It was inheriting the 360-minute
+    # default, so the one run in twenty that wedges holds a runner for six hours
+    # and leaves the workflow open long after every other job has finished.
+    timeout-minutes: 20
     permissions:
       actions: read
       contents: read
@@ -1250,6 +1272,10 @@ jobs:
           persist-credentials: false
 
       - name: Run CodeQL Scan
+        # Bounded separately from the job so a hang fails this step by name and
+        # still lets the post steps run, rather than the runner being killed
+        # mid-flight with no attribution.
+        timeout-minutes: 15
         uses: NVIDIA/dsx-github-actions/.github/actions/codeql-scan@20dc10dda4fa9f8f0380a47cd9a7800d3da3dcf3
         with:
           languages: 'rust'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -275,7 +275,12 @@ jobs:
           # images cannot be loaded into the classic store, so they always push
           # directly.
           push: ${{ inputs.push && (contains(inputs.platforms, ',') || github.repository == 'NVIDIA/infra-controller') }}
-          load: ${{ (inputs.load && !inputs.push) || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller') }}
+          # Loading means exporting the whole image to the daemon, so it is only
+          # worth doing when a later step reads it back: the deferred push on
+          # mirrors, or the main-branch Grype scan. A pull request runs neither,
+          # yet the 8 GB boot-artifacts carrier still spent a measured 5m20s on
+          # the export before every step that could have used it was skipped.
+          load: ${{ (inputs.load && !inputs.push && inputs.scan && github.ref == 'refs/heads/main') || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller') }}
           # mirrors: the docker exporter cannot attach attestations, and
           # provenance would embed private downstream repo refs into artifacts
           provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -262,6 +262,19 @@ jobs:
             echo "build_args=" >> $GITHUB_OUTPUT
           fi
 
+      # Loading means exporting the whole image to the daemon, so it is only
+      # worth doing when a later step reads it back: the deferred push on
+      # mirrors, or the main-branch Grype scan, which inspects the local
+      # daemon. A pull request runs neither, yet the 8 GB boot-artifacts
+      # carrier still spent a measured 5m20s on the export before every step
+      # that could have used it was skipped. Decided once here so the build and
+      # the summary cannot disagree about what happened.
+      - name: Decide whether to load the image locally
+        id: loadgate
+        env:
+          NEEDED: ${{ (inputs.load && !inputs.push && inputs.scan && github.ref == 'refs/heads/main') || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller') }}
+        run: printf 'load=%s\n' "${NEEDED}" >> "$GITHUB_OUTPUT"
+
       - name: Build image
         id: build
         uses: docker/build-push-action@v5
@@ -275,12 +288,7 @@ jobs:
           # images cannot be loaded into the classic store, so they always push
           # directly.
           push: ${{ inputs.push && (contains(inputs.platforms, ',') || github.repository == 'NVIDIA/infra-controller') }}
-          # Loading means exporting the whole image to the daemon, so it is only
-          # worth doing when a later step reads it back: the deferred push on
-          # mirrors, or the main-branch Grype scan. A pull request runs neither,
-          # yet the 8 GB boot-artifacts carrier still spent a measured 5m20s on
-          # the export before every step that could have used it was skipped.
-          load: ${{ (inputs.load && !inputs.push && inputs.scan && github.ref == 'refs/heads/main') || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller') }}
+          load: ${{ steps.loadgate.outputs.load == 'true' }}
           # mirrors: the docker exporter cannot attach attestations, and
           # provenance would embed private downstream repo refs into artifacts
           provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
@@ -340,6 +348,23 @@ jobs:
           key="$(basename -- "$IMAGE_NAME")"
           printf 'key=%s\n' "$key" >> "$GITHUB_OUTPUT"
 
+      # security-container-scan inspects the local Docker daemon and never pulls
+      # for itself. On this repo main pushes straight from buildx and loads
+      # nothing, so the scan's precheck reported "local docker image not found"
+      # and both the SBOM and Grype steps recorded outcome=skipped -- invisible,
+      # because continue-on-error and fail-build=false turn that into a green
+      # check. Fetching the image we just pushed is what makes the mainline scan
+      # actually scan. A warning rather than a failure: this must not be able to
+      # break publishing, but it must stop being silent.
+      - name: Fetch pushed image for the scan
+        if: ${{ inputs.scan && github.ref == 'refs/heads/main' && steps.build.outcome == 'success' && steps.loadgate.outputs.load != 'true' }}
+        env:
+          IMAGE: ${{ steps.tag_list.outputs.primary }}
+        run: |
+          if ! docker pull "${IMAGE}"; then
+            echo "::warning::could not pull ${IMAGE}; the Grype scan will find no local image and skip"
+          fi
+
       - name: Grype vulnerability scan
         if: ${{ inputs.scan && github.ref == 'refs/heads/main' && steps.build.outcome == 'success' }}
         continue-on-error: true
@@ -359,4 +384,4 @@ jobs:
           echo "  Digest: ${{ steps.build.outputs.digest }}"
           echo "  Platforms: ${{ inputs.platforms }}"
           echo "  Pushed: ${{ inputs.push }}"
-          echo "  Loaded locally: ${{ inputs.load && !inputs.push }}"
+          echo "  Loaded locally: ${{ steps.loadgate.outputs.load }}"

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -174,7 +174,12 @@ jobs:
             CARBIDE_BUILD_HELM_VERSION=${{ inputs.helm_version }}
           tags: ${{ steps.docker-tags.outputs.arch_tag }}
           cache-from: type=gha,scope=${{ inputs.service_name }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.service_name }}-${{ matrix.arch }}
+          # Export only from main, matching docker-build.yml. Ten services on two
+          # architectures exporting mode=max from every PR push wrote ~10 GiB of
+          # layer blobs per branch into a quota that is already over budget, and
+          # the resulting eviction was costing us the caches that actually get
+          # reused. Pull requests still read main's cache through cache-from.
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=max,scope={0}-{1}', inputs.service_name, matrix.arch) || '' }}
           labels: |
             org.opencontainers.image.title=${{ inputs.service_name }}
             org.opencontainers.image.version=${{ inputs.semantic_version }}


### PR DESCRIPTION
PR: https://github.com/NVIDIA/infra-controller/pull/4513 brought Core CI runtime down from `1hr` to `46m`. `46m` is still quite long, this PR implements a few more CI improvements to reduce build time to `35m` range.

- **Stopped exporting images nothing reads** (docker-build.yml). `load` is currently set to true whenever a build isn't pushing, so every PR exported the finished image to the local Docker daemon and then skips every step that could have used it — about 5m20s on the 8 GB `build-release-artifacts-arm-host` alone. The image is now only loaded when a later step actually reads it back: the deferred push on mirrors, or the main-branch Grype scan
- **Added cache support for bfb Rust compile** (build-boot-artifacts.yml). Dockerfile.build-artifacts-container-aarch64 is installing sccache but never sets `RUSTC_WRAPPER` or a backend, so roughly ~3m30s compile ran with the wrapper inert. The job now exports the Actions cache credentials the same way the release image builds do
- **Distro mirror is off the critical path** (setup-mkosi-environment). Prevent failures like [this](https://github.com/NVIDIA/infra-controller/actions/runs/31024214964/job/92377398001#step:6:346) - one 140 kB libevent package stalling against us-east-2.ec2.ports.ubuntu.com, not general slow bandwidth. Downloaded .deb files are now cached between runs and seeded back into apt's own cache directory. apt is configured to fail faster and retry more (Retries 5, 20s timeout instead of the 120s default)

## Related Issues
https://github.com/NVIDIA/infra-controller/issues/4574

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
- Also updated the Go image caching path to match the core path — both cache-to sites in the repo are gated to main, and pull requests keep reading main's cache through cache-from


This supports https://github.com/NVIDIA/infra-controller/issues/4605

Closes #4605