### PR TITLE
docs: pull our failure-boundary guidance into STYLE_GUIDE.md

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -817,26 +817,81 @@ automatic conversions to convert between errors, or `.map_err()` if you have to.
 that are used for tests/mocks, or for toplevel binaries where errors are given to the user for informational purposes,
 and not intended to be inspected by other rust code. (We do not always adhere to this rule.)
 
-Avoid using `let _unused = foo();` to discard errors. This is error-prone: If later `foo()` is refactored to become
-an async function, assigning the result to `_unused` silences the compiler warning telling you forgot to call `.await`.
-If you don't care about the errors a function produces, prefer using `.ok()` to convert the error into a
-(discardable) Option.
+#### Preserve error sources and semantic meaning
+
+Preserve the source error as it moves through the system, and add context at abstraction boundaries. Do not replace an
+error with only its display string while another layer may still need to inspect its type or source. At an external API
+or user-facing boundary, map the failure to a stable semantic variant rather than exposing internal details. Where
+operators need root-cause detail, record the source chain internally, but redact secrets from both user-facing errors
+and operator records.
+
+Use a default only when absence is semantically equivalent to that value. Keep missing, malformed, unavailable, and
+explicitly empty states distinct when callers or operators need to react to them differently. Fallback helpers such as
+`unwrap_or_default()` and `or_default()` are appropriate only when this equivalence is part of the contract; do not use
+them merely to erase an error or simplify control flow. Compatibility defaults must preserve the previous contract;
+document omission behavior and test omitted values separately from explicitly supplied default values.
+
+#### Choose the failure policy before the syntax
+
+For each `Result`, deliberately choose whether to propagate, handle, retry, record and continue, or intentionally
+discard the failure. Avoid using `let _ = foo();` or an underscore-prefixed binding such as `let _unused = foo();` to
+discard errors. This is error-prone: if `foo()` is later refactored to become async, binding its result this way
+silences the compiler warning that `.await` is missing. When intentionally discarding an error, prefer `.ok()` to
+convert it into a discardable `Option`; this makes such an async refactor fail to compile. The use of `.ok()` does not
+itself justify ignoring an operational failure.
 
 ```rust
-fn fails() -> Result<(), Error> {}
+fn fails() -> std::io::Result<()> {
+    Err(std::io::Error::other("example failure"))
+}
 
 fn avoid() {
-    // if somebody makes `fails()` async later, the compiler won't complain, and the future will
-    // never get run
+    // If somebody makes `fails()` async later, the compiler won't complain, and the future will
+    // never get run.
     let _dontcare = fails();
 }
 
-
-fn prefer() {
-    // if somebody makes `fails()` async later, you get a compiler error
+fn intentionally_discard() {
+    // If somebody makes `fails()` async later, this becomes a compiler error.
     fails().ok();
 }
 ```
+
+Best-effort paths should still make repeated operational failures observable. Follow
+[Instrumentation](#instrumentation): use a plain `tracing::` macro when diagnostic text is enough; use a
+`carbide_instrument::Event` when the failure merits a count, rate, or duration.
+
+#### Keep operational failures recoverable
+
+Do not use a panicking operation — including `unwrap()`, `expect()`, `panic!`, `assert!`, or `unreachable!` — when
+failure can be caused by routine or malformed request data, persisted data, configuration, the network, hardware, or a
+recoverable dependency failure. Return a typed error with context so callers retain the option to apply appropriate
+logging, metrics, retry, and API error mapping. Do not leave `todo!` or `unimplemented!` on a reachable production path.
+
+Tests may use panicking assertions and call `unwrap()` on known-good fixture values when a panic is the intended failure
+report. In production, a task- or process-terminating operation is acceptable only for a proven local invariant or an
+intentional fail-fast boundary. Keep the proof or boundary rationale close to the operation, use an `expect()` message
+that explains the invariant where appropriate, and prefer a type or construction API that makes the invalid state
+unrepresentable.
+
+Treating a poisoned `std::sync::Mutex` as fatal can be an intentional fail-fast choice. If a thread panics while holding
+the lock, it may have left the guarded state in a condition where application invariants no longer hold. When the state
+cannot be safely validated or rebuilt, using `expect()` on `lock()` makes the decision to fail fast explicit:
+
+```rust
+let mut state = shared_state
+    .lock()
+    .expect("shared state mutex poisoned; guarded invariants may be broken");
+state.apply_update();
+```
+
+When recovery is safe, handle the `PoisonError` and validate or rebuild the state instead, calling `clear_poison()` only
+after restoring the invariant. Mutex poisoning signals a possible broken invariant; it does not by itself require
+termination.
+
+A supervised task boundary may intentionally propagate a child panic as described in
+[Background tasks](#background-tasks). This is different from panicking on an ordinary operational error inside the
+task.
 
 ### Avoid stringly-typed values
 


### PR DESCRIPTION
This is an attempt to capture the general NICo maintainer design principles and guidance around failure boundaries for the codebase. **This PR is derived from the pre-OSS review corpus as a whole -- years of MRs and tens of thousands of comments and discussions. **As such, it leans into the guiding design decisions and principles used to define and grow the project into the product we have today.****

**The idea is to ensure we capture our core principles** in `STYLE_GUIDE.md`. If any of those principles have changed, we should capture that too, ensuring we don't lose sight of why decisions were made as the codebase evolves with new contributors, human and agentic alike.

**For this PR specifically, I focused on failure handling.** The search surfaced related `panic`/`unwrap` conversations, error cause/context conversations, and discussion around silent defaults throughout the corpus and across multiple participants.

This pulls out the recurring parts:

- Keep the source error.
- Decide whether we're propagating, handling, retrying, recording, or discarding before reaching for `.ok()`.
- Don't turn ordinary operational failures into panics.
- Don't let a convenient default erase a distinction the caller needs.

It also keeps the important exceptions for tests, proven local invariants, intentional fail-fast boundaries, and `JoinSet` child-panic propagation. I don't want to fix one missing rule by accidentally outlawing something NICo does on purpose.

Again, we can always adjust this now or later. The hope is that we don't lose the reasoning behind why we made certain decisions to get us where we are now, and can continue using that reasoning to help drive future decisions.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4607

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Validation passed with `cargo make format-nightly`, `cargo make clippy`, `cargo make carbide-lints`, `rumdl check --config docs/.rumdl.toml STYLE_GUIDE.md`, and Pandoc rendering.

## Additional Notes

Closes #4607
