### PR TITLE
refactor(component-manager): decouple APIs from backend-specific types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "prost",
  "prost-types",
  "serde",
+ "serde_json",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -3549,7 +3549,9 @@ async fn assert_configure_nmx_cluster_v2_results(
         .ok_or_else(|| eyre::eyre!("configure request should include desired fabric config"))?;
 
     assert_eq!(desired.topology_type, topology_type);
+    assert!(desired.extra_static_configs.is_empty());
     assert_eq!(configure_request.primary_switch_node_id, None);
+    assert_eq!(configure_request.domain, None);
 
     let configure_nodes = &configure_request
         .nodes
@@ -3565,10 +3567,14 @@ async fn assert_configure_nmx_cluster_v2_results(
             .any(|node| node.node_id == switch_id.to_string())
     }));
 
-    assert_eq!(
-        env.rms_sim.submitted_get_job_status_requests().await.len(),
-        1
-    );
+    let job_status_requests = env.rms_sim.submitted_get_job_status_requests().await;
+
+    let [job_status_request] = job_status_requests.as_slice() else {
+        return Err(eyre::eyre!("expected exactly one job status request").into());
+    };
+
+    assert_eq!(job_status_request.job_id, "configure-scale-up-fabric-job");
+    assert!(!job_status_request.include_child_job_states);
 
     let status_requests = env
         .rms_sim
@@ -3578,6 +3584,8 @@ async fn assert_configure_nmx_cluster_v2_results(
     let [status_request] = status_requests.as_slice() else {
         return Err(eyre::eyre!("expected exactly one fabric status request").into());
     };
+
+    assert_eq!(status_request.domain, None);
 
     let status_nodes = &status_request
         .nodes
@@ -3723,6 +3731,106 @@ async fn test_configure_nmx_cluster_v2_delegates_primary_setup_and_persists_obse
         &topology_type,
     )
     .await
+}
+
+#[crate::sqlx_test]
+async fn test_configure_nmx_cluster_v2_completed_job_with_unknown_profile_stops_flow(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = config_with_nmx_cluster_profile();
+    config.rms.scale_up_fabric_manager_api_version = ScaleUpFabricManagerApiVersion::V2;
+
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides {
+            config: Some(config),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let rack_id = new_rack_id();
+    let missing_profile_id = RackProfileId::new("RemovedNmxCluster");
+    let mut txn = pool.acquire().await?;
+
+    db_rack::create(
+        &mut txn,
+        &rack_id,
+        Some(&missing_profile_id),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+
+    drop(txn);
+
+    attach_switches_with_nvos_credentials(&env, &rack_id, 2).await?;
+
+    env.rms_sim
+        .queue_get_job_status_response(Ok(rms::GetJobStatusResponse {
+            job_states: vec![rms::JobStatus {
+                job_id: "configure-scale-up-fabric-job".to_string(),
+                execution_state: rms::JobExecutionState::Completed as i32,
+                state_description: "completed".to_string(),
+                ..Default::default()
+            }],
+        }))
+        .await;
+
+    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    let handler_instance = RackStateHandler::default();
+
+    let mut services = env.rack_state_handler_services();
+    services.rms_client = None;
+    let mut metrics = RackMetrics::default();
+    let mut db_writes = DbWriteBatch::default();
+
+    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
+        services: &mut services,
+        metrics: &mut metrics,
+        pending_db_writes: &mut db_writes,
+    };
+
+    let job_wait = RackState::Maintenance {
+        maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
+            configure_nmx_cluster: ConfigureNmxClusterState::WaitForScaleUpFabricManagerJob {
+                job_id: "configure-scale-up-fabric-job".to_string(),
+            },
+        },
+    };
+
+    let outcome = handler_instance
+        .handle_object_state(&rack_id, &mut rack, &job_wait, &mut ctx)
+        .await?;
+
+    match outcome {
+        StateHandlerOutcome::Transition { next_state, .. } => match next_state {
+            RackState::Error { cause } => {
+                assert!(cause.contains("rack profile is missing or unknown"));
+            }
+            other => panic!("Expected Error state, got {other:?}"),
+        },
+        other => panic!(
+            "Expected Transition, got {:?}",
+            std::mem::discriminant(&other)
+        ),
+    }
+
+    assert!(
+        env.rms_sim
+            .submitted_get_scale_up_fabric_status_requests()
+            .await
+            .is_empty()
+    );
+
+    assert!(
+        env.rms_sim
+            .submitted_batch_get_scale_up_fabric_service_status_requests()
+            .await
+            .is_empty()
+    );
+
+    Ok(())
 }
 
 /// test_configure_nmx_cluster_transitions_to_completed verifies that

--- a/crates/component-manager/Cargo.toml
+++ b/crates/component-manager/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { workspace = true }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -13,10 +13,9 @@ use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
 use db::{ObjectColumnFilter, WithTransaction};
 use librms::RmsApi;
-use librms::protos::{rack_manager as rms, rack_manager_v2 as rms_v2};
 use model::machine::MachineMaintenanceOperation;
 use model::rack::{MaintenanceActivity, MaintenanceScope, RackState};
-use model::rack_type::RackProfileConfig;
+use model::rack_type::{RackHardwareTopology, RackProfileConfig};
 use model::switch::SwitchMaintenanceOperation;
 use sqlx::PgPool;
 
@@ -25,6 +24,7 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     Backend as NvSwitchBackend, ConfigureSwitchCertificateJobStatus, NvSwitchManager,
+    ScaleUpFabricManagerJobStatus, ScaleUpFabricServiceStatuses, ScaleUpFabricStatus,
     SwitchEndpoint, SwitchFactoryResetJobStatus, SwitchFactoryResetState,
     SwitchPasswordRotationState,
 };
@@ -563,41 +563,46 @@ impl ComponentManager {
         })?
     }
 
-    /// Routes ScaleUp Fabric Manager V2 configuration through the switch backend.
-    pub async fn configure_scale_up_fabric_manager_v2(
+    /// Submits ScaleUp Fabric Manager configuration through the switch backend
+    /// and returns its non-empty, opaque job ID. A submission without a durable
+    /// job ID returns [`ComponentManagerError::OperationOutcomeUnknown`].
+    pub async fn configure_scale_up_fabric_manager(
         &self,
-        request: rms_v2::ConfigureScaleUpFabricManagerRequest,
-    ) -> Result<rms_v2::ConfigureScaleUpFabricManagerResponse, ComponentManagerError> {
+        endpoints: &[SwitchEndpoint],
+        topology: RackHardwareTopology,
+    ) -> Result<String, ComponentManagerError> {
         self.nv_switch
-            .configure_scale_up_fabric_manager_v2(request)
+            .configure_scale_up_fabric_manager(endpoints, topology)
             .await
     }
 
-    /// Routes V2 configuration job observation through the switch backend.
+    /// Returns the latest configuration job observation from the switch backend.
+    ///
+    /// Returns `None` when the backend cannot find the requested job.
     pub async fn get_scale_up_fabric_manager_job_status(
         &self,
-        request: rms::GetJobStatusRequest,
-    ) -> Result<rms::GetJobStatusResponse, ComponentManagerError> {
+        job_id: &str,
+    ) -> Result<Option<ScaleUpFabricManagerJobStatus>, ComponentManagerError> {
         self.nv_switch
-            .get_scale_up_fabric_manager_job_status(request)
+            .get_scale_up_fabric_manager_job_status(job_id)
             .await
     }
 
     /// Routes observed ScaleUp Fabric status reads through the switch backend.
     pub async fn get_scale_up_fabric_status(
         &self,
-        request: rms::GetScaleUpFabricStatusRequest,
-    ) -> Result<rms::GetScaleUpFabricStatusResponse, ComponentManagerError> {
-        self.nv_switch.get_scale_up_fabric_status(request).await
+        endpoints: &[SwitchEndpoint],
+    ) -> Result<ScaleUpFabricStatus, ComponentManagerError> {
+        self.nv_switch.get_scale_up_fabric_status(endpoints).await
     }
 
     /// Routes per-switch Fabric Manager status reads through the switch backend.
     pub async fn batch_get_scale_up_fabric_service_status(
         &self,
-        request: rms::BatchGetScaleUpFabricServiceStatusRequest,
-    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, ComponentManagerError> {
+        endpoints: &[SwitchEndpoint],
+    ) -> Result<ScaleUpFabricServiceStatuses, ComponentManagerError> {
         self.nv_switch
-            .batch_get_scale_up_fabric_service_status(request)
+            .batch_get_scale_up_fabric_service_status(endpoints)
             .await
     }
 

--- a/crates/component-manager/src/nv_switch_manager.rs
+++ b/crates/component-manager/src/nv_switch_manager.rs
@@ -1,15 +1,17 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::IpAddr;
 
 use carbide_secrets::credentials::Credentials;
-use librms::protos::{rack_manager as rms, rack_manager_v2 as rms_v2};
 use mac_address::MacAddress;
 use model::component_manager::{
     ConfigureSwitchCertificateState, FirmwareState, NvSwitchComponent, PowerAction,
 };
+use model::rack_type::RackHardwareTopology;
+use model::switch::FabricManagerStatus;
 
 use crate::error::ComponentManagerError;
 use crate::types::FirmwareUpdateOptions;
@@ -61,7 +63,7 @@ pub enum SwitchPasswordRotationState {
 }
 
 /// Physical network identifiers for an NV-Switch, used to register with and
-/// operate against the backend service (NSM).
+/// operate against the configured backend service.
 #[derive(Debug, Clone)]
 pub struct SwitchEndpoint {
     pub bmc_ip: IpAddr,
@@ -118,6 +120,71 @@ impl crate::component_common::ComponentPowerStateResult for SwitchPowerStateResu
 pub struct ConfigureSwitchCertificateJobStatus {
     pub state: ConfigureSwitchCertificateState,
     pub error: Option<String>,
+}
+
+/// Backend observation of a ScaleUp Fabric Manager configuration job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScaleUpFabricManagerJobStatus {
+    /// The job remains queued or running.
+    Pending { description: String },
+
+    /// The desired fabric configuration completed successfully.
+    Completed,
+
+    /// The job terminated unsuccessfully.
+    Failed { error: Option<String> },
+
+    /// The backend returned an execution state that cannot be classified.
+    Unknown { execution_state: i32 },
+}
+
+/// Application-level result reported by a ScaleUp Fabric status operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScaleUpFabricResponseStatus {
+    /// The backend completed the operation successfully.
+    Success,
+
+    /// The backend completed the operation with a failure result.
+    Failure,
+
+    /// The backend returned an unspecified or unrecognized result code.
+    Unknown(i32),
+}
+
+/// Observed ScaleUp Fabric state for one switch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaleUpFabricSwitchStatus {
+    /// Backend node identifier for the switch.
+    pub node_id: String,
+
+    /// Whether the ScaleUp Fabric cluster is enabled on this switch.
+    pub enabled: bool,
+
+    /// Backend-provided inspection failure details.
+    pub error_message: String,
+}
+
+/// Result of inspecting the ScaleUp Fabric configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaleUpFabricStatus {
+    /// Application-level result of the inspection.
+    pub status: ScaleUpFabricResponseStatus,
+
+    /// Per-switch observations, absent when the backend returned no fabric status.
+    pub switches: Option<Vec<ScaleUpFabricSwitchStatus>>,
+
+    /// Backend-provided operation failure details.
+    pub error_message: String,
+}
+
+/// Result of reading per-switch Fabric Manager service status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaleUpFabricServiceStatuses {
+    /// Application-level result of the batch operation.
+    pub status: ScaleUpFabricResponseStatus,
+
+    /// Normalized per-switch observations keyed by backend node identifier.
+    pub service_statuses: HashMap<String, FabricManagerStatus>,
 }
 
 /// Aggregate lifecycle state for a switch factory-reset job.
@@ -263,24 +330,31 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
         )))
     }
 
-    /// Submits rack-level ScaleUp Fabric Manager configuration.
+    /// Submits the desired rack-level ScaleUp Fabric Manager configuration.
     ///
-    /// This operation is currently supported only by the RMS switch backend.
-    async fn configure_scale_up_fabric_manager_v2(
+    /// A successful submission returns a non-empty, opaque job ID. If the backend may
+    /// have accepted the request but does not return a durable job ID, the
+    /// implementation returns [`ComponentManagerError::OperationOutcomeUnknown`]. The
+    /// default implementation returns [`ComponentManagerError::Unsupported`].
+    async fn configure_scale_up_fabric_manager(
         &self,
-        _request: rms_v2::ConfigureScaleUpFabricManagerRequest,
-    ) -> Result<rms_v2::ConfigureScaleUpFabricManagerResponse, ComponentManagerError> {
+        _endpoints: &[SwitchEndpoint],
+        _topology: RackHardwareTopology,
+    ) -> Result<String, ComponentManagerError> {
         Err(ComponentManagerError::Unsupported(format!(
-            "scale-up fabric manager V2 configuration is not supported by the {} backend",
+            "scale-up fabric manager configuration is not supported by the {} backend",
             self.name()
         )))
     }
 
-    /// Reads the RMS job created by ScaleUp Fabric Manager V2 configuration.
+    /// Returns the latest observation for a ScaleUp Fabric Manager job.
+    ///
+    /// `None` means the backend cannot find the requested job. The default
+    /// implementation returns [`ComponentManagerError::Unsupported`].
     async fn get_scale_up_fabric_manager_job_status(
         &self,
-        _request: rms::GetJobStatusRequest,
-    ) -> Result<rms::GetJobStatusResponse, ComponentManagerError> {
+        _job_id: &str,
+    ) -> Result<Option<ScaleUpFabricManagerJobStatus>, ComponentManagerError> {
         Err(ComponentManagerError::Unsupported(format!(
             "scale-up fabric manager job status is not supported by the {} backend",
             self.name()
@@ -288,10 +362,12 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
     }
 
     /// Reads the primary and enabled state observed for the submitted fabric.
+    ///
+    /// The default implementation returns [`ComponentManagerError::Unsupported`].
     async fn get_scale_up_fabric_status(
         &self,
-        _request: rms::GetScaleUpFabricStatusRequest,
-    ) -> Result<rms::GetScaleUpFabricStatusResponse, ComponentManagerError> {
+        _endpoints: &[SwitchEndpoint],
+    ) -> Result<ScaleUpFabricStatus, ComponentManagerError> {
         Err(ComponentManagerError::Unsupported(format!(
             "scale-up fabric status is not supported by the {} backend",
             self.name()
@@ -299,10 +375,12 @@ pub trait NvSwitchManager: Send + Sync + Debug + 'static {
     }
 
     /// Reads per-switch Fabric Manager service status for persistence by NICo.
+    ///
+    /// The default implementation returns [`ComponentManagerError::Unsupported`].
     async fn batch_get_scale_up_fabric_service_status(
         &self,
-        _request: rms::BatchGetScaleUpFabricServiceStatusRequest,
-    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, ComponentManagerError> {
+        _endpoints: &[SwitchEndpoint],
+    ) -> Result<ScaleUpFabricServiceStatuses, ComponentManagerError> {
         Err(ComponentManagerError::Unsupported(format!(
             "scale-up fabric manager service status is not supported by the {} backend",
             self.name()

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -35,7 +35,9 @@ use model::component_manager::{
     ComputeTrayComponent, ConfigureSwitchCertificateState, FirmwareState, NvSwitchComponent,
     PowerAction, PowerShelfComponent,
 };
-use model::rack_type::{RackProfile, RackProfileConfig};
+use model::rack_type::{RackHardwareTopology, RackProfile, RackProfileConfig};
+use model::switch::{FabricManagerState, FabricManagerStatus};
+use serde::Deserialize;
 use sqlx::PgPool;
 use tracing::instrument;
 
@@ -47,9 +49,10 @@ use crate::config::ComponentManagerConfig;
 use crate::error::ComponentManagerError;
 use crate::nv_switch_manager::{
     Backend as NvSwitchBackend, ConfigureSwitchCertificateJobStatus, NvSwitchManager,
-    SwitchComponentResult, SwitchEndpoint, SwitchFactoryResetJobStatus, SwitchFactoryResetState,
-    SwitchFirmwareUpdateStatus, SwitchPasswordRotationState, SwitchPowerStateResult,
-    SwitchSlotAndTrayResult,
+    ScaleUpFabricManagerJobStatus, ScaleUpFabricResponseStatus, ScaleUpFabricServiceStatuses,
+    ScaleUpFabricStatus, ScaleUpFabricSwitchStatus, SwitchComponentResult, SwitchEndpoint,
+    SwitchFactoryResetJobStatus, SwitchFactoryResetState, SwitchFirmwareUpdateStatus,
+    SwitchPasswordRotationState, SwitchPowerStateResult, SwitchSlotAndTrayResult,
 };
 use crate::power_shelf_manager::{
     Backend as PowerShelfBackend, PowerShelfComponentResult, PowerShelfEndpoint,
@@ -268,6 +271,34 @@ impl RmsBackend {
             identity: &identity.identity,
             node_identity,
         })
+    }
+
+    async fn resolve_scale_up_fabric_nodes(
+        &self,
+        endpoints: &[SwitchEndpoint],
+    ) -> Result<Vec<rms::NodeInfo>, ComponentManagerError> {
+        let macs: Vec<MacAddress> = endpoints.iter().map(|endpoint| endpoint.bmc_mac).collect();
+        let identities = resolve_switch_identities(&self.db, &macs).await?;
+        let hostnames = resolve_switch_machine_interface_hostnames(&self.db, endpoints).await?;
+        let mut nodes = Vec::with_capacity(endpoints.len());
+
+        for endpoint in endpoints {
+            let resolved = self
+                .resolve_switch_or_power_shelf_node(
+                    &identities,
+                    endpoint.bmc_mac,
+                    SwitchOrPowerShelfRole::Switch,
+                )
+                .map_err(ComponentManagerError::Internal)?;
+
+            nodes.push(build_switch_node_info(
+                endpoint,
+                &resolved,
+                hostnames.get(&endpoint.nvos_mac).cloned(),
+            ));
+        }
+
+        Ok(nodes)
     }
 }
 
@@ -1445,6 +1476,161 @@ fn classify_rms_switch_slot_and_tray(
     }
 }
 
+fn scale_up_fabric_response_status_from_rms(status: i32) -> ScaleUpFabricResponseStatus {
+    match rms::ReturnCode::try_from(status) {
+        Ok(rms::ReturnCode::Success) => ScaleUpFabricResponseStatus::Success,
+        Ok(rms::ReturnCode::Failure) => ScaleUpFabricResponseStatus::Failure,
+        Ok(rms::ReturnCode::Unspecified) | Err(_) => ScaleUpFabricResponseStatus::Unknown(status),
+    }
+}
+
+fn scale_up_fabric_job_status_from_rms(
+    job_id: &str,
+    response: rms::GetJobStatusResponse,
+) -> Option<ScaleUpFabricManagerJobStatus> {
+    let job = response
+        .job_states
+        .into_iter()
+        .find(|job| job.job_id == job_id)?;
+
+    Some(
+        match rms::JobExecutionState::try_from(job.execution_state) {
+            Ok(rms::JobExecutionState::Queued | rms::JobExecutionState::Running) => {
+                ScaleUpFabricManagerJobStatus::Pending {
+                    description: job.state_description,
+                }
+            }
+            Ok(rms::JobExecutionState::Completed) => ScaleUpFabricManagerJobStatus::Completed,
+            Ok(rms::JobExecutionState::Failed) => ScaleUpFabricManagerJobStatus::Failed {
+                error: (!job.error_message.trim().is_empty()).then_some(job.error_message),
+            },
+            Ok(rms::JobExecutionState::Unspecified) | Err(_) => {
+                ScaleUpFabricManagerJobStatus::Unknown {
+                    execution_state: job.execution_state,
+                }
+            }
+        },
+    )
+}
+
+fn scale_up_fabric_status_from_rms(
+    response: rms::GetScaleUpFabricStatusResponse,
+) -> ScaleUpFabricStatus {
+    ScaleUpFabricStatus {
+        status: scale_up_fabric_response_status_from_rms(response.status),
+        switches: response.fabric_status.map(|status| {
+            status
+                .switches
+                .into_iter()
+                .map(|switch| ScaleUpFabricSwitchStatus {
+                    node_id: switch.node_id,
+                    enabled: switch.enabled,
+                    error_message: switch.error_message,
+                })
+                .collect()
+        }),
+        error_message: response.error_message,
+    }
+}
+
+fn scale_up_fabric_manager_job_id_from_rms(
+    response: rms_v2::ConfigureScaleUpFabricManagerResponse,
+) -> Result<String, ComponentManagerError> {
+    if response.job_id.trim().is_empty() {
+        return Err(ComponentManagerError::OperationOutcomeUnknown(
+            "RMS ConfigureScaleUpFabricManagerV2 returned an empty job ID".to_string(),
+        ));
+    }
+
+    Ok(response.job_id)
+}
+
+#[derive(Debug, Deserialize)]
+struct RmsFabricManagerStatusPayload {
+    status: Option<String>,
+    #[serde(rename = "addition-info")]
+    addition_info: Option<String>,
+    reason: Option<String>,
+}
+
+fn fabric_manager_status_from_rms(
+    node_id: &str,
+    entry: rms::ScaleUpFabricServiceStatusEntry,
+) -> FabricManagerStatus {
+    // A per-switch RMS error is authoritative; its JSON may be absent or stale.
+    if !entry.error_message.trim().is_empty() {
+        return FabricManagerStatus {
+            fabric_manager_state: FabricManagerState::Unknown,
+            addition_info: None,
+            reason: None,
+            error_message: Some(entry.error_message),
+        };
+    }
+
+    if entry.status_json.trim().is_empty() {
+        return FabricManagerStatus {
+            fabric_manager_state: FabricManagerState::Unknown,
+            addition_info: None,
+            reason: None,
+            error_message: None,
+        };
+    }
+
+    let status_json =
+        match serde_json::from_str::<RmsFabricManagerStatusPayload>(&entry.status_json) {
+            Ok(status_json) => status_json,
+            Err(error) => {
+                tracing::warn!(
+                    switch_id = %node_id,
+                    %error,
+                    status_json = %entry.status_json,
+                    "Failed to parse RMS fabric-manager status JSON"
+                );
+
+                return FabricManagerStatus {
+                    fabric_manager_state: FabricManagerState::Unknown,
+                    addition_info: None,
+                    reason: None,
+                    error_message: None,
+                };
+            }
+        };
+
+    let fabric_manager_state = match status_json.status.as_deref().unwrap_or_default() {
+        "ok" => FabricManagerState::Ok,
+        "not ok" => FabricManagerState::NotOk,
+        _ => FabricManagerState::Unknown,
+    };
+
+    FabricManagerStatus {
+        fabric_manager_state,
+        addition_info: status_json.addition_info,
+        reason: status_json.reason,
+        error_message: None,
+    }
+}
+
+/// Converts an RMS Fabric Manager service response into typed controller observations.
+///
+/// The RMS-backed V1 and V2 workflows share this conversion so both persist
+/// identical service state. Aggregate statistics are not used by the controller
+/// and are discarded.
+pub fn scale_up_fabric_service_statuses_from_rms(
+    response: rms::BatchGetScaleUpFabricServiceStatusResponse,
+) -> ScaleUpFabricServiceStatuses {
+    ScaleUpFabricServiceStatuses {
+        status: scale_up_fabric_response_status_from_rms(response.status),
+        service_statuses: response
+            .service_statuses
+            .into_iter()
+            .map(|(node_id, status)| {
+                let observation = fabric_manager_status_from_rms(&node_id, status);
+                (node_id, observation)
+            })
+            .collect(),
+    }
+}
+
 #[async_trait::async_trait]
 impl NvSwitchManager for RmsBackend {
     fn name(&self) -> &str {
@@ -1988,65 +2174,101 @@ impl NvSwitchManager for RmsBackend {
         rms_get_switch_factory_reset_job_status(self.client.as_ref(), job_id).await
     }
 
-    #[instrument(skip(self, request), fields(backend = "rms"))]
-    async fn configure_scale_up_fabric_manager_v2(
+    #[instrument(skip(self, endpoints, topology), fields(backend = "rms"))]
+    async fn configure_scale_up_fabric_manager(
         &self,
-        request: rms_v2::ConfigureScaleUpFabricManagerRequest,
-    ) -> Result<rms_v2::ConfigureScaleUpFabricManagerResponse, ComponentManagerError> {
-        red::instrumented(
+        endpoints: &[SwitchEndpoint],
+        topology: RackHardwareTopology,
+    ) -> Result<String, ComponentManagerError> {
+        let nodes = self.resolve_scale_up_fabric_nodes(endpoints).await?;
+
+        let response = red::instrumented(
             "rms",
             "configure_scale_up_fabric_manager_v2",
-            self.client.configure_scale_up_fabric_manager_v2(request),
+            self.client.configure_scale_up_fabric_manager_v2(
+                rms_v2::ConfigureScaleUpFabricManagerRequest {
+                    nodes: Some(rms::NodeSet { nodes }),
+                    // RMS selects the V2 primary across the supplied fabric.
+                    primary_switch_node_id: None,
+                    domain: None,
+                    config: Some(rms_v2::ScaleUpFabricConfig {
+                        topology_type: topology.to_string(),
+                        extra_static_configs: Vec::new(),
+                    }),
+                },
+            ),
         )
-        .await
-        .map_err(Into::into)
+        .await?;
+
+        scale_up_fabric_manager_job_id_from_rms(response)
     }
 
-    #[instrument(skip(self, request), fields(backend = "rms"))]
+    #[instrument(skip(self), fields(backend = "rms", job_id))]
     async fn get_scale_up_fabric_manager_job_status(
         &self,
-        request: rms::GetJobStatusRequest,
-    ) -> Result<rms::GetJobStatusResponse, ComponentManagerError> {
-        match red::instrumented("rms", "get_job_status", self.client.get_job_status(request)).await
+        job_id: &str,
+    ) -> Result<Option<ScaleUpFabricManagerJobStatus>, ComponentManagerError> {
+        let response = match red::instrumented(
+            "rms",
+            "get_job_status",
+            self.client.get_job_status(rms::GetJobStatusRequest {
+                job_id: job_id.to_string(),
+                include_child_job_states: false,
+            }),
+        )
+        .await
         {
             Err(RackManagerError::ApiInvocationError(status))
                 if status.code() == tonic::Code::NotFound =>
             {
-                Err(ComponentManagerError::NotFound(
-                    "scale-up fabric manager job was not found".to_string(),
-                ))
+                return Ok(None);
             }
-            result => result.map_err(Into::into),
-        }
+            result => result?,
+        };
+
+        Ok(scale_up_fabric_job_status_from_rms(job_id, response))
     }
 
-    #[instrument(skip(self, request), fields(backend = "rms"))]
+    #[instrument(skip(self, endpoints), fields(backend = "rms"))]
     async fn get_scale_up_fabric_status(
         &self,
-        request: rms::GetScaleUpFabricStatusRequest,
-    ) -> Result<rms::GetScaleUpFabricStatusResponse, ComponentManagerError> {
-        red::instrumented(
+        endpoints: &[SwitchEndpoint],
+    ) -> Result<ScaleUpFabricStatus, ComponentManagerError> {
+        let nodes = self.resolve_scale_up_fabric_nodes(endpoints).await?;
+
+        let response = red::instrumented(
             "rms",
             "get_scale_up_fabric_status",
-            self.client.get_scale_up_fabric_status(request),
+            self.client
+                .get_scale_up_fabric_status(rms::GetScaleUpFabricStatusRequest {
+                    nodes: Some(rms::NodeSet { nodes }),
+                    domain: None,
+                }),
         )
-        .await
-        .map_err(Into::into)
+        .await?;
+
+        Ok(scale_up_fabric_status_from_rms(response))
     }
 
-    #[instrument(skip(self, request), fields(backend = "rms"))]
+    #[instrument(skip(self, endpoints), fields(backend = "rms"))]
     async fn batch_get_scale_up_fabric_service_status(
         &self,
-        request: rms::BatchGetScaleUpFabricServiceStatusRequest,
-    ) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, ComponentManagerError> {
-        red::instrumented(
+        endpoints: &[SwitchEndpoint],
+    ) -> Result<ScaleUpFabricServiceStatuses, ComponentManagerError> {
+        let nodes = self.resolve_scale_up_fabric_nodes(endpoints).await?;
+
+        let response = red::instrumented(
             "rms",
             "batch_get_scale_up_fabric_service_status",
-            self.client
-                .batch_get_scale_up_fabric_service_status(request),
+            self.client.batch_get_scale_up_fabric_service_status(
+                rms::BatchGetScaleUpFabricServiceStatusRequest {
+                    nodes: Some(rms::NodeSet { nodes }),
+                },
+            ),
         )
-        .await
-        .map_err(Into::into)
+        .await?;
+
+        Ok(scale_up_fabric_service_statuses_from_rms(response))
     }
 
     #[instrument(skip(self, endpoint, next_password), fields(backend = "rms", bmc_mac = %endpoint.bmc_mac))]
@@ -3129,6 +3351,219 @@ mod tests {
             ],
             |details| classify_rms_switch_slot_and_tray(details.as_ref()),
         );
+    }
+
+    #[test]
+    fn scale_up_fabric_response_status_preserves_unknown_codes() {
+        value_scenarios!(scale_up_fabric_response_status_from_rms:
+            "known codes" {
+                rms::ReturnCode::Success as i32 => ScaleUpFabricResponseStatus::Success,
+                rms::ReturnCode::Failure as i32 => ScaleUpFabricResponseStatus::Failure,
+            }
+
+            "unknown codes" {
+                rms::ReturnCode::Unspecified as i32 => ScaleUpFabricResponseStatus::Unknown(
+                    rms::ReturnCode::Unspecified as i32,
+                ),
+                17 => ScaleUpFabricResponseStatus::Unknown(17),
+            }
+        );
+    }
+
+    #[test]
+    fn scale_up_fabric_job_status_maps_lifecycle_and_visibility() {
+        let response = |job_id: &str,
+                        execution_state: i32,
+                        description: &str,
+                        error_message: &str| rms::GetJobStatusResponse {
+            job_states: vec![rms::JobStatus {
+                job_id: job_id.to_string(),
+                execution_state,
+                state_description: description.to_string(),
+                error_message: error_message.to_string(),
+                ..Default::default()
+            }],
+        };
+
+        value_scenarios!(run = |response| scale_up_fabric_job_status_from_rms("job-1", response);
+            "job visibility" {
+                rms::GetJobStatusResponse::default() => None,
+                response("other-job", rms::JobExecutionState::Completed as i32, "", "") => None,
+            }
+
+            "pending jobs" {
+                response("job-1", rms::JobExecutionState::Queued as i32, "queued", "")
+                    => Some(ScaleUpFabricManagerJobStatus::Pending {
+                        description: "queued".to_string(),
+                    }),
+                response("job-1", rms::JobExecutionState::Running as i32, "reconciling", "")
+                    => Some(ScaleUpFabricManagerJobStatus::Pending {
+                        description: "reconciling".to_string(),
+                    }),
+            }
+
+            "terminal jobs" {
+                response("job-1", rms::JobExecutionState::Completed as i32, "", "")
+                    => Some(ScaleUpFabricManagerJobStatus::Completed),
+                response("job-1", rms::JobExecutionState::Failed as i32, "", "")
+                    => Some(ScaleUpFabricManagerJobStatus::Failed { error: None }),
+                response("job-1", rms::JobExecutionState::Failed as i32, "", "fabric rejected")
+                    => Some(ScaleUpFabricManagerJobStatus::Failed {
+                        error: Some("fabric rejected".to_string()),
+                    }),
+            }
+
+            "unknown states" {
+                response("job-1", rms::JobExecutionState::Unspecified as i32, "", "")
+                    => Some(ScaleUpFabricManagerJobStatus::Unknown {
+                        execution_state: rms::JobExecutionState::Unspecified as i32,
+                    }),
+                response("job-1", 17, "", "")
+                    => Some(ScaleUpFabricManagerJobStatus::Unknown { execution_state: 17 }),
+            }
+        );
+    }
+
+    #[test]
+    fn scale_up_fabric_status_conversion_keeps_required_controller_data() {
+        let status = scale_up_fabric_status_from_rms(rms::GetScaleUpFabricStatusResponse {
+            status: rms::ReturnCode::Success as i32,
+            fabric_status: Some(rms::ScaleUpFabricStatus {
+                switches: vec![rms::ScaleUpFabricSwitchStatus {
+                    node_id: "switch-1".to_string(),
+                    enabled: true,
+                    error_message: "inspection warning".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            error_message: "response warning".to_string(),
+        });
+
+        assert_eq!(
+            status,
+            ScaleUpFabricStatus {
+                status: ScaleUpFabricResponseStatus::Success,
+                switches: Some(vec![ScaleUpFabricSwitchStatus {
+                    node_id: "switch-1".to_string(),
+                    enabled: true,
+                    error_message: "inspection warning".to_string(),
+                }]),
+                error_message: "response warning".to_string(),
+            }
+        );
+
+        assert_eq!(
+            scale_up_fabric_status_from_rms(rms::GetScaleUpFabricStatusResponse {
+                status: rms::ReturnCode::Success as i32,
+                fabric_status: None,
+                error_message: String::new(),
+            })
+            .switches,
+            None
+        );
+    }
+
+    #[test]
+    fn scale_up_fabric_service_status_conversion_normalizes_rms_payloads() {
+        let entry = |status_json: &str, error_message: &str| rms::ScaleUpFabricServiceStatusEntry {
+            status_json: status_json.to_string(),
+            error_message: error_message.to_string(),
+        };
+
+        let status = |fabric_manager_state,
+                      addition_info: Option<&str>,
+                      reason: Option<&str>,
+                      error_message: Option<&str>| FabricManagerStatus {
+            fabric_manager_state,
+            addition_info: addition_info.map(str::to_string),
+            reason: reason.map(str::to_string),
+            error_message: error_message.map(str::to_string),
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "ok preserves service details",
+                    input: entry(
+                        r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","reason":"","status":"ok"}"#,
+                        "",
+                    ),
+                    expect: status(
+                        FabricManagerState::Ok,
+                        Some("CONTROL_PLANE_STATE_CONFIGURED"),
+                        Some(""),
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "not ok preserves service details",
+                    input: entry(
+                        r#"{"addition-info":"","reason":"stopped by user","status":"not ok"}"#,
+                        "",
+                    ),
+                    expect: status(
+                        FabricManagerState::NotOk,
+                        Some(""),
+                        Some("stopped by user"),
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "unknown status keeps available details",
+                    input: entry(
+                        r#"{"addition-info":"pending","reason":"new RMS state","status":"unexpected"}"#,
+                        "",
+                    ),
+                    expect: status(
+                        FabricManagerState::Unknown,
+                        Some("pending"),
+                        Some("new RMS state"),
+                        None,
+                    ),
+                },
+                Check {
+                    scenario: "empty status json is unknown",
+                    input: entry("", ""),
+                    expect: status(FabricManagerState::Unknown, None, None, None),
+                },
+                Check {
+                    scenario: "error message takes precedence over status json",
+                    input: entry(
+                        r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","status":"ok"}"#,
+                        "nmx-controller not started",
+                    ),
+                    expect: status(
+                        FabricManagerState::Unknown,
+                        None,
+                        None,
+                        Some("nmx-controller not started"),
+                    ),
+                },
+                Check {
+                    scenario: "malformed json is unknown",
+                    input: entry("{not-json", ""),
+                    expect: status(FabricManagerState::Unknown, None, None, None),
+                },
+            ],
+            |entry| fabric_manager_status_from_rms("switch-1", entry),
+        );
+    }
+
+    #[test]
+    fn scale_up_fabric_configuration_requires_durable_job_id() {
+        for job_id in ["", " \t"] {
+            let result = scale_up_fabric_manager_job_id_from_rms(
+                rms_v2::ConfigureScaleUpFabricManagerResponse {
+                    job_id: job_id.to_string(),
+                },
+            );
+
+            assert!(matches!(
+                result,
+                Err(ComponentManagerError::OperationOutcomeUnknown(_))
+            ));
+        }
     }
 
     #[test]

--- a/crates/rack-controller/src/fabric_manager.rs
+++ b/crates/rack-controller/src/fabric_manager.rs
@@ -23,13 +23,13 @@ use carbide_rack_controller::config::RmsConfig;
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::rack::RackId;
 use carbide_uuid::switch::SwitchId;
-use component_manager::component_manager::ComponentManager;
-use component_manager::error::ComponentManagerError;
+use component_manager::nv_switch_manager::{
+    ScaleUpFabricResponseStatus, ScaleUpFabricServiceStatuses, ScaleUpFabricStatus,
+};
+use component_manager::rms::scale_up_fabric_service_statuses_from_rms;
 use db::switch as db_switch;
 use librms::protos::rack_manager as rms;
 use model::rack::FirmwareUpgradeDeviceInfo;
-use model::switch::{FabricManagerState, FabricManagerStatus};
-use serde::Deserialize;
 use sqlx::PgConnection;
 
 use crate as carbide_rack_controller;
@@ -77,7 +77,7 @@ pub(super) async fn batch_get_scale_up_fabric_service_status(
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
     node_identity: &RmsNodeIdentity,
-) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, String> {
+) -> Result<ScaleUpFabricServiceStatuses, String> {
     let Some(url) = rms_config.api_url.as_deref().none_if_empty() else {
         return Err("RMS client not configured".to_string());
     };
@@ -92,106 +92,37 @@ pub(super) async fn batch_get_scale_up_fabric_service_status(
     let rms_api_config = librms::client::RmsApiConfig::new(url, &rms_client_config);
     let rms_client = librms::RackManagerApi::new(&rms_api_config);
 
-    rms_client
-        .client
-        .batch_get_scale_up_fabric_service_status(build_scale_up_fabric_services_status_request(
-            rack_id,
-            switches,
-            node_identity,
-        ))
-        .await
-        .map_err(|error| format!("RMS BatchGetScaleUpFabricServiceStatus failed: {}", error))
-}
+    let response =
+        rms_client
+            .client
+            .batch_get_scale_up_fabric_service_status(
+                build_scale_up_fabric_services_status_request(rack_id, switches, node_identity),
+            )
+            .await
+            .map_err(|error| format!("RMS BatchGetScaleUpFabricServiceStatus failed: {}", error))?;
 
-pub(super) async fn batch_get_scale_up_fabric_service_status_via_component_manager(
-    component_manager: &ComponentManager,
-    rack_id: &RackId,
-    switches: &[FirmwareUpgradeDeviceInfo],
-    node_identity: &RmsNodeIdentity,
-) -> Result<rms::BatchGetScaleUpFabricServiceStatusResponse, ComponentManagerError> {
-    component_manager
-        .batch_get_scale_up_fabric_service_status(build_scale_up_fabric_services_status_request(
-            rack_id,
-            switches,
-            node_identity,
-        ))
-        .await
-}
-
-#[derive(Debug, Deserialize)]
-struct RmsFabricManagerStatusPayload {
-    status: Option<String>,
-    #[serde(rename = "addition-info")]
-    addition_info: Option<String>,
-    reason: Option<String>,
-}
-
-fn fabric_manager_status_from_entry(
-    node_id: &str,
-    entry: &rms::ScaleUpFabricServiceStatusEntry,
-) -> FabricManagerStatus {
-    if !entry.error_message.trim().is_empty() {
-        return FabricManagerStatus {
-            fabric_manager_state: FabricManagerState::Unknown,
-            addition_info: None,
-            reason: None,
-            error_message: Some(entry.error_message.clone()),
-        };
-    }
-
-    if entry.status_json.trim().is_empty() {
-        return FabricManagerStatus {
-            fabric_manager_state: FabricManagerState::Unknown,
-            addition_info: None,
-            reason: None,
-            error_message: None,
-        };
-    }
-
-    let status_json =
-        match serde_json::from_str::<RmsFabricManagerStatusPayload>(&entry.status_json) {
-            Ok(status_json) => status_json,
-            Err(error) => {
-                tracing::warn!(
-                    switch_id = %node_id,
-                    %error,
-                    status_json = %entry.status_json,
-                    "Failed to parse RMS fabric-manager status JSON"
-                );
-                return FabricManagerStatus {
-                    fabric_manager_state: FabricManagerState::Unknown,
-                    addition_info: None,
-                    reason: None,
-                    error_message: None,
-                };
-            }
-        };
-
-    let fabric_manager_state = match status_json.status.as_deref().unwrap_or_default() {
-        "ok" => FabricManagerState::Ok,
-        "not ok" => FabricManagerState::NotOk,
-        _ => FabricManagerState::Unknown,
-    };
-
-    FabricManagerStatus {
-        fabric_manager_state,
-        addition_info: status_json.addition_info,
-        reason: status_json.reason,
-        error_message: None,
-    }
+    Ok(scale_up_fabric_service_statuses_from_rms(response))
 }
 
 pub(super) async fn persist_fabric_manager_statuses(
     txn: &mut PgConnection,
     rack_id: &RackId,
     switches: &[FirmwareUpgradeDeviceInfo],
-    response: &rms::BatchGetScaleUpFabricServiceStatusResponse,
+    response: &ScaleUpFabricServiceStatuses,
 ) -> Result<(), String> {
-    if response.status != rms::ReturnCode::Success as i32 {
-        return Err(
-            "RMS BatchGetScaleUpFabricServiceStatus returned failure for ConfigureNmxCluster"
-                .to_string(),
-        );
+    match response.status {
+        ScaleUpFabricResponseStatus::Success => {}
+        ScaleUpFabricResponseStatus::Failure => {
+            return Err(
+                "RMS BatchGetScaleUpFabricServiceStatus returned failure for ConfigureNmxCluster"
+                    .to_string(),
+            );
+        }
+        ScaleUpFabricResponseStatus::Unknown(code) => {
+            return Err(format!(
+                "RMS BatchGetScaleUpFabricServiceStatus returned unknown status code {code} for ConfigureNmxCluster"
+            ));
+        }
     }
 
     for switch in switches {
@@ -207,9 +138,8 @@ pub(super) async fn persist_fabric_manager_statuses(
                 switch.node_id, error
             )
         })?;
-        let fabric_manager_status = fabric_manager_status_from_entry(&switch.node_id, entry);
 
-        db_switch::update_fabric_manager_status(txn, switch_id, Some(&fabric_manager_status))
+        db_switch::update_fabric_manager_status(txn, switch_id, Some(entry))
             .await
             .map_err(|error| {
                 format!(
@@ -221,9 +151,9 @@ pub(super) async fn persist_fabric_manager_statuses(
         tracing::info!(
             rack_id = %rack_id,
             switch_id = %switch.node_id,
-            fabric_manager_status = %fabric_manager_status.display_status(),
-            raw_fabric_manager_state = ?fabric_manager_status.fabric_manager_state,
-            error_message = %fabric_manager_status.error_message.as_deref().unwrap_or_default(),
+            fabric_manager_status = %entry.display_status(),
+            raw_fabric_manager_state = ?entry.fabric_manager_state,
+            error_message = %entry.error_message.as_deref().unwrap_or_default(),
             "Persisted FabricManager status for switch"
         );
     }
@@ -331,11 +261,11 @@ pub(super) fn select_primary_switch(
 /// Returns an error when RMS does not report one valid primary.
 pub(super) fn observed_primary_switch(
     switches: &[FirmwareUpgradeDeviceInfo],
-    response: &rms::GetScaleUpFabricStatusResponse,
+    response: &ScaleUpFabricStatus,
 ) -> Result<SwitchId, String> {
-    match rms::ReturnCode::try_from(response.status) {
-        Ok(rms::ReturnCode::Success) => {}
-        Ok(rms::ReturnCode::Failure) => {
+    match response.status {
+        ScaleUpFabricResponseStatus::Success => {}
+        ScaleUpFabricResponseStatus::Failure => {
             let details = if response.error_message.trim().is_empty() {
                 "no error details provided"
             } else {
@@ -344,22 +274,19 @@ pub(super) fn observed_primary_switch(
 
             return Err(format!("RMS GetScaleUpFabricStatus failed: {details}"));
         }
-        Ok(rms::ReturnCode::Unspecified) | Err(_) => {
+        ScaleUpFabricResponseStatus::Unknown(status) => {
             return Err(format!(
                 "RMS GetScaleUpFabricStatus returned invalid status {}",
-                response.status
+                status
             ));
         }
     }
 
-    let Some(fabric_status) = response.fabric_status.as_ref() else {
+    let Some(switch_statuses) = response.switches.as_ref() else {
         return Err("RMS GetScaleUpFabricStatus returned no fabric status".to_string());
     };
 
-    let mut enabled_switches = fabric_status
-        .switches
-        .iter()
-        .filter(|switch| switch.enabled);
+    let mut enabled_switches = switch_statuses.iter().filter(|switch| switch.enabled);
 
     let Some(enabled_switch) = enabled_switches.next() else {
         return Err("RMS GetScaleUpFabricStatus reported no primary switch".to_string());
@@ -430,6 +357,7 @@ mod tests {
     use carbide_rack::rms_node_type::switch_node_identity_for_profile;
     use carbide_test_support::{Check, check_values};
     use carbide_uuid::switch::{SwitchIdSource, SwitchType};
+    use component_manager::nv_switch_manager::ScaleUpFabricSwitchStatus;
     use model::rack_type::{RackProductFamily, RackProfile};
 
     use super::*;
@@ -546,30 +474,24 @@ mod tests {
         let second_id = SwitchId::new(SwitchIdSource::Tpm, [2; 32], SwitchType::NvLink).to_string();
         let expected_switches = vec![switch(&first_id), switch(&second_id)];
 
-        let switch_status = |node_id: &str, enabled| rms::ScaleUpFabricSwitchStatus {
+        let switch_status = |node_id: &str, enabled| ScaleUpFabricSwitchStatus {
             node_id: node_id.to_string(),
             enabled,
-            ..Default::default()
+            error_message: String::new(),
         };
 
-        let response =
-            |status: rms::ReturnCode, switches: Option<Vec<rms::ScaleUpFabricSwitchStatus>>| {
-                rms::GetScaleUpFabricStatusResponse {
-                    status: status as i32,
-                    fabric_status: switches.map(|switches| rms::ScaleUpFabricStatus {
-                        switches,
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                }
-            };
+        let response = |status, switches| ScaleUpFabricStatus {
+            status,
+            switches,
+            error_message: String::new(),
+        };
 
         check_values(
             [
                 Check {
                     scenario: "one enabled submitted switch",
                     input: response(
-                        rms::ReturnCode::Success,
+                        ScaleUpFabricResponseStatus::Success,
                         Some(vec![
                             switch_status(&first_id, false),
                             switch_status(&second_id, true),
@@ -579,18 +501,23 @@ mod tests {
                 },
                 Check {
                     scenario: "RMS failure",
-                    input: response(rms::ReturnCode::Failure, Some(Vec::new())),
+                    input: response(ScaleUpFabricResponseStatus::Failure, Some(Vec::new())),
+                    expect: None,
+                },
+                Check {
+                    scenario: "unknown response status",
+                    input: response(ScaleUpFabricResponseStatus::Unknown(17), Some(Vec::new())),
                     expect: None,
                 },
                 Check {
                     scenario: "missing fabric status",
-                    input: response(rms::ReturnCode::Success, None),
+                    input: response(ScaleUpFabricResponseStatus::Success, None),
                     expect: None,
                 },
                 Check {
                     scenario: "no enabled switch",
                     input: response(
-                        rms::ReturnCode::Success,
+                        ScaleUpFabricResponseStatus::Success,
                         Some(vec![switch_status(&first_id, false)]),
                     ),
                     expect: None,
@@ -598,7 +525,7 @@ mod tests {
                 Check {
                     scenario: "multiple enabled switches",
                     input: response(
-                        rms::ReturnCode::Success,
+                        ScaleUpFabricResponseStatus::Success,
                         Some(vec![
                             switch_status(&first_id, true),
                             switch_status(&second_id, true),
@@ -609,7 +536,7 @@ mod tests {
                 Check {
                     scenario: "enabled switch outside submitted rack",
                     input: response(
-                        rms::ReturnCode::Success,
+                        ScaleUpFabricResponseStatus::Success,
                         Some(vec![switch_status(
                             &SwitchId::new(SwitchIdSource::Tpm, [3; 32], SwitchType::NvLink)
                                 .to_string(),
@@ -624,111 +551,6 @@ mod tests {
                     .ok()
                     .map(|primary| primary.to_string())
             },
-        );
-    }
-
-    fn entry(status_json: &str, error_message: &str) -> rms::ScaleUpFabricServiceStatusEntry {
-        rms::ScaleUpFabricServiceStatusEntry {
-            status_json: status_json.to_string(),
-            error_message: error_message.to_string(),
-        }
-    }
-
-    /// The full derived status plus its product-facing display string, so a
-    /// table row asserts both the parsed fields and the "running"/"not_running"
-    /// outcome the caller acts on.
-    #[derive(Debug, PartialEq)]
-    struct Observed {
-        status: FabricManagerStatus,
-        display: &'static str,
-    }
-
-    fn observe(entry: rms::ScaleUpFabricServiceStatusEntry) -> Observed {
-        let status = fabric_manager_status_from_entry("sw-1", &entry);
-        let display = status.display_status();
-        Observed { status, display }
-    }
-
-    #[test]
-    fn test_fabric_manager_status_from_entry() {
-        check_values(
-            [
-                Check {
-                    scenario: "ok with control-plane configured -> running",
-                    input: entry(
-                        r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","reason":"","status":"ok"}"#,
-                        "",
-                    ),
-                    expect: Observed {
-                        status: FabricManagerStatus {
-                            fabric_manager_state: FabricManagerState::Ok,
-                            addition_info: Some("CONTROL_PLANE_STATE_CONFIGURED".to_string()),
-                            reason: Some(String::new()),
-                            error_message: None,
-                        },
-                        display: "running",
-                    },
-                },
-                Check {
-                    scenario: "not ok -> not_running",
-                    input: entry(
-                        r#"{"addition-info":"","reason":"stopped by user","status":"not ok"}"#,
-                        "",
-                    ),
-                    expect: Observed {
-                        status: FabricManagerStatus {
-                            fabric_manager_state: FabricManagerState::NotOk,
-                            addition_info: Some(String::new()),
-                            reason: Some("stopped by user".to_string()),
-                            error_message: None,
-                        },
-                        display: "not_running",
-                    },
-                },
-                Check {
-                    scenario: "empty status json -> unknown, not_running",
-                    input: entry("", ""),
-                    expect: Observed {
-                        status: FabricManagerStatus {
-                            fabric_manager_state: FabricManagerState::Unknown,
-                            addition_info: None,
-                            reason: None,
-                            error_message: None,
-                        },
-                        display: "not_running",
-                    },
-                },
-                Check {
-                    scenario: "error message surfaces -> unknown, not_running",
-                    input: entry(
-                        r#"{"addition-info":"CONTROL_PLANE_STATE_CONFIGURED","status":"ok"}"#,
-                        "nmx-controller not started",
-                    ),
-                    expect: Observed {
-                        status: FabricManagerStatus {
-                            fabric_manager_state: FabricManagerState::Unknown,
-                            addition_info: None,
-                            reason: None,
-                            error_message: Some("nmx-controller not started".to_string()),
-                        },
-                        display: "not_running",
-                    },
-                },
-                Check {
-                    scenario: "malformed json -> unknown, not_running",
-                    input: entry("{not-json", ""),
-                    expect: Observed {
-                        status: FabricManagerStatus {
-                            fabric_manager_state: FabricManagerState::Unknown,
-                            addition_info: None,
-                            reason: None,
-                            error_message: None,
-                        },
-                        display: "not_running",
-                    },
-                },
-            ],
-            observe,
         );
     }
 }

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -35,8 +35,7 @@ use carbide_rack::rms_node_type::{
 use carbide_rack_controller::config::{RmsConfig, ScaleUpFabricManagerApiVersion};
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
-    batch_get_scale_up_fabric_service_status,
-    batch_get_scale_up_fabric_service_status_via_component_manager, observed_primary_switch,
+    batch_get_scale_up_fabric_service_status, observed_primary_switch,
     persist_fabric_manager_statuses, persist_primary_switch, select_primary_switch,
     validate_switch_inventory_for_nmx_cluster,
 };
@@ -46,12 +45,13 @@ use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use component_manager::component_manager::ComponentManager;
 use component_manager::error::ComponentManagerError;
+use component_manager::nv_switch_manager::ScaleUpFabricManagerJobStatus;
 use db::{
     host_machine_update as db_host_machine_update, machine as db_machine,
     machine_topology as db_machine_topology, power_shelf as db_power_shelf, rack as db_rack,
     switch as db_switch,
 };
-use librms::protos::{rack_manager as rms, rack_manager_v2 as rms_v2};
+use librms::protos::rack_manager as rms;
 use model::rack::{
     ConfigureNmxClusterCertificateState, ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo,
     FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope,
@@ -67,7 +67,7 @@ use state_controller::state_handler::{
 use crate as carbide_rack_controller;
 use crate::nmx_certificate::{
     ConfigureNmxClusterCertificatePollOutcome, poll_configure_nmx_cluster_certificate_jobs,
-    start_configure_nmx_cluster_certificate,
+    start_configure_nmx_cluster_certificate, switch_endpoint_from_firmware_device,
 };
 
 /// Strips all `rv.*` metadata labels from every machine in the rack.
@@ -1846,11 +1846,14 @@ async fn configure_scale_up_fabric_manager_v2(
         .await;
     };
 
-    let switch_node_identity = match switch_node_identity_for_profile(profile) {
-        Ok(identity) => identity,
-        Err(error) => {
-            return transition_to_rack_error(id, state, error.to_string(), ctx).await;
-        }
+    let endpoints = match switch_inventory
+        .switches
+        .iter()
+        .map(switch_endpoint_from_firmware_device)
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(endpoints) => endpoints,
+        Err(cause) => return transition_to_rack_error(id, state, cause, ctx).await,
     };
 
     let topology_type = rack_hardware_topology.to_string();
@@ -1862,26 +1865,11 @@ async fn configure_scale_up_fabric_manager_v2(
         "Submitting RMS v2 NMX cluster configuration"
     );
 
-    let response = match component_manager
-        .configure_scale_up_fabric_manager_v2(rms_v2::ConfigureScaleUpFabricManagerRequest {
-            nodes: Some(rms::NodeSet {
-                nodes: switch_inventory
-                    .switches
-                    .iter()
-                    .map(|switch| build_new_node_info(id, switch, &switch_node_identity))
-                    .collect(),
-            }),
-            // No override: RMS owns V2 primary selection.
-            primary_switch_node_id: None,
-            domain: None,
-            config: Some(rms_v2::ScaleUpFabricConfig {
-                topology_type: topology_type.clone(),
-                extra_static_configs: Vec::new(),
-            }),
-        })
+    let job_id = match component_manager
+        .configure_scale_up_fabric_manager(&endpoints, rack_hardware_topology)
         .await
     {
-        Ok(response) => response,
+        Ok(job_id) => job_id,
         Err(error @ ComponentManagerError::Unsupported(_)) => {
             return transition_to_rack_error(id, state, error.to_string(), ctx).await;
         }
@@ -1900,21 +1888,11 @@ async fn configure_scale_up_fabric_manager_v2(
         }
     };
 
-    if response.job_id.trim().is_empty() {
-        return transition_to_rack_error(
-            id,
-            state,
-            "RMS ConfigureScaleUpFabricManagerV2 returned an empty job ID",
-            ctx,
-        )
-        .await;
-    }
-
     tracing::info!(
         rack_id = %id,
         topology_type = %topology_type,
         switch_count = switch_inventory.switches.len(),
-        job_id = %response.job_id,
+        job_id,
         "V2 ConfigureScaleUpFabricManager submitted; waiting for RMS job"
     );
 
@@ -1923,7 +1901,7 @@ async fn configure_scale_up_fabric_manager_v2(
     Ok(StateHandlerOutcome::transition(RackState::Maintenance {
         maintenance_state: RackMaintenanceState::ConfigureNmxCluster {
             configure_nmx_cluster: ConfigureNmxClusterState::WaitForScaleUpFabricManagerJob {
-                job_id: response.job_id,
+                job_id,
             },
         },
     }))
@@ -1947,21 +1925,10 @@ async fn wait_for_scale_up_fabric_manager_job(
     };
 
     let job = match component_manager
-        .get_scale_up_fabric_manager_job_status(rms::GetJobStatusRequest {
-            job_id: job_id.to_string(),
-            include_child_job_states: false,
-        })
+        .get_scale_up_fabric_manager_job_status(job_id)
         .await
     {
-        Ok(response) => response
-            .job_states
-            .into_iter()
-            .find(|job| job.job_id == job_id),
-        Err(ComponentManagerError::NotFound(_)) => {
-            // V2 submission is idempotent, so losing RMS job state
-            // is recovered by submitting the same desired state.
-            None
-        }
+        Ok(job) => job,
         Err(error @ ComponentManagerError::Unsupported(_)) => {
             return transition_to_rack_error(id, state, error.to_string(), ctx).await;
         }
@@ -1992,14 +1959,14 @@ async fn wait_for_scale_up_fabric_manager_job(
 
     // Job completion proves RMS reconciliation finished, but NICo still reads
     // observed state to discover and persist the RMS-selected primary.
-    match rms::JobExecutionState::try_from(job.execution_state) {
-        Ok(rms::JobExecutionState::Queued | rms::JobExecutionState::Running) => {
+    match job {
+        ScaleUpFabricManagerJobStatus::Pending { description } => {
             Ok(StateHandlerOutcome::wait(format!(
                 "ConfigureScaleUpFabricManager job {job_id} is {}",
-                job.state_description
+                description
             )))
         }
-        Ok(rms::JobExecutionState::Completed) => {
+        ScaleUpFabricManagerJobStatus::Completed => {
             tracing::info!(
                 rack_id = %id,
                 job_id,
@@ -2016,24 +1983,20 @@ async fn wait_for_scale_up_fabric_manager_job(
             )
             .await
         }
-        Ok(rms::JobExecutionState::Failed) => {
-            let cause = if job.error_message.trim().is_empty() {
-                format!("ConfigureScaleUpFabricManager job {job_id} failed")
-            } else {
-                format!(
-                    "ConfigureScaleUpFabricManager job {job_id} failed: {}",
-                    job.error_message
-                )
-            };
+        ScaleUpFabricManagerJobStatus::Failed { error } => {
+            let cause = error.map_or_else(
+                || format!("ConfigureScaleUpFabricManager job {job_id} failed"),
+                |error| format!("ConfigureScaleUpFabricManager job {job_id} failed: {error}"),
+            );
 
             transition_to_rack_error(id, state, cause, ctx).await
         }
-        Ok(rms::JobExecutionState::Unspecified) | Err(_) => transition_to_rack_error(
+        ScaleUpFabricManagerJobStatus::Unknown { execution_state } => transition_to_rack_error(
             id,
             state,
             format!(
                 "ConfigureScaleUpFabricManager job {job_id} returned invalid execution state {}",
-                job.execution_state
+                execution_state
             ),
             ctx,
         )
@@ -2044,8 +2007,10 @@ async fn wait_for_scale_up_fabric_manager_job(
 /// Verifies and persists the primary switch and per-switch Fabric Manager
 /// status from RMS V2.
 ///
-/// Read failures retain the completed-job state for retry. Primary selection
-/// and Fabric Manager status are committed together before maintenance advances.
+/// Transient read failures retain the completed-job state for retry. A missing
+/// rack profile is terminal because the backend cannot reconstruct the submitted
+/// switch identities. Primary selection and Fabric Manager status are committed
+/// together before maintenance advances.
 async fn verify_scale_up_fabric_manager_v2(
     id: &RackId,
     state: &mut Rack,
@@ -2076,36 +2041,30 @@ async fn verify_scale_up_fabric_manager_v2(
         return transition_to_rack_error(id, state, cause, ctx).await;
     }
 
-    let Some(profile) = super::resolve_profile(id, rack_profile_id, ctx) else {
+    if super::resolve_profile(id, rack_profile_id, ctx).is_none() {
         return transition_to_rack_error(
             id,
             state,
-            "rack profile is missing or unknown; cannot build RMS switch node descriptor",
+            "rack profile is missing or unknown; cannot verify RMS ScaleUp Fabric status",
             ctx,
         )
         .await;
-    };
+    }
 
-    let switch_node_identity = match switch_node_identity_for_profile(profile) {
-        Ok(identity) => identity,
-        Err(error) => {
-            return transition_to_rack_error(id, state, error.to_string(), ctx).await;
-        }
+    let endpoints = match switch_inventory
+        .switches
+        .iter()
+        .map(switch_endpoint_from_firmware_device)
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(endpoints) => endpoints,
+        Err(cause) => return transition_to_rack_error(id, state, cause, ctx).await,
     };
 
     // RMS owns primary selection in V2. Read the observed switch state instead
     // of reproducing RMS tray-selection policy in NICo.
     let response = match component_manager
-        .get_scale_up_fabric_status(rms::GetScaleUpFabricStatusRequest {
-            nodes: Some(rms::NodeSet {
-                nodes: switch_inventory
-                    .switches
-                    .iter()
-                    .map(|switch| build_new_node_info(id, switch, &switch_node_identity))
-                    .collect(),
-            }),
-            domain: None,
-        })
+        .get_scale_up_fabric_status(&endpoints)
         .await
     {
         Ok(response) => response,
@@ -2140,30 +2099,26 @@ async fn verify_scale_up_fabric_manager_v2(
 
     // GetScaleUpFabricStatus identifies the primary, while existing NICo
     // consumers require the richer per-switch Fabric Manager status payload.
-    let fabric_manager_status_response =
-        match batch_get_scale_up_fabric_service_status_via_component_manager(
-            component_manager,
-            id,
-            &switch_inventory.switches,
-            &switch_node_identity,
-        )
+    let fabric_manager_status_response = match component_manager
+        .batch_get_scale_up_fabric_service_status(&endpoints)
         .await
-        {
-            Ok(response) => response,
-            Err(error @ ComponentManagerError::Unsupported(_)) => {
-                return transition_to_rack_error(id, state, error.to_string(), ctx).await;
-            }
-            Err(error) => {
-                let cause = error.to_string();
-                tracing::warn!(
-                    rack_id = %id,
-                    cause,
-                    "Unable to read RMS Fabric Manager status; retrying"
-                );
+    {
+        Ok(response) => response,
+        Err(error @ ComponentManagerError::Unsupported(_)) => {
+            return transition_to_rack_error(id, state, error.to_string(), ctx).await;
+        }
+        Err(error) => {
+            let cause = error.to_string();
 
-                return Ok(StateHandlerOutcome::wait(cause));
-            }
-        };
+            tracing::warn!(
+                rack_id = %id,
+                cause,
+                "Unable to read RMS Fabric Manager status; retrying"
+            );
+
+            return Ok(StateHandlerOutcome::wait(cause));
+        }
+    };
 
     let observed_primary_node_id = observed_primary.to_string();
     let mut txn = ctx.services.db_pool.begin().await?;


### PR DESCRIPTION
Several methods on `ComponentManager` and `NvSwitchManager` directly use RMS protobuf types. This leaks RMS wire details into rack-controller and introduces type coupling for other switch backends. This refactor introduces backend-agnostic types and solves the coupling problem.

## Related issues

Resolves #4602

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)