### PR TITLE
refactor(api-web): adopt style guide rules for pub/module visibility

### DIFF
--- a/crates/api-web/src/action_status.rs
+++ b/crates/api-web/src/action_status.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use itertools::Itertools;
 
 #[derive(PartialEq, Eq)]
-pub(crate) enum Type {
+pub(super) enum Type {
     Power,
     ResetBmc,
     MachineSetup,
@@ -35,7 +35,7 @@ pub(crate) enum Type {
 }
 
 impl Type {
-    pub fn from_query(query: &HashMap<String, String>) -> Option<Self> {
+    fn from_query(query: &HashMap<String, String>) -> Option<Self> {
         query
             .get("action_type")
             .map(String::as_str)
@@ -53,7 +53,7 @@ impl Type {
                 _ => None,
             })
     }
-    pub fn to_query(&self) -> (&'static str, &'static str) {
+    fn to_query(&self) -> (&'static str, &'static str) {
         (
             "action_type",
             match self {
@@ -70,7 +70,7 @@ impl Type {
             },
         )
     }
-    pub fn display_name(&self) -> &'static str {
+    fn display_name(&self) -> &'static str {
         match self {
             Type::Power => "Power Control",
             Type::ResetBmc => "BMC Reset",
@@ -86,14 +86,14 @@ impl Type {
     }
 }
 
-pub(crate) enum Class {
+pub(super) enum Class {
     Success,
     Warning,
     Error,
 }
 
 impl Class {
-    pub fn from_query(query: &HashMap<String, String>) -> Self {
+    fn from_query(query: &HashMap<String, String>) -> Self {
         match query.get("action_class").map(String::as_str) {
             Some("success") => Self::Success,
             Some("error") => Self::Error,
@@ -101,11 +101,11 @@ impl Class {
         }
     }
 
-    pub fn to_query(&self) -> (&'static str, &'static str) {
+    fn to_query(&self) -> (&'static str, &'static str) {
         ("action_class", self.as_str())
     }
 
-    pub fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &'static str {
         match self {
             Self::Success => "success",
             Self::Error => "error",
@@ -114,14 +114,14 @@ impl Class {
     }
 }
 
-pub(crate) struct ActionStatus<'a> {
-    pub action: Type,
-    pub class: Class,
-    pub message: Cow<'a, str>,
+pub(super) struct ActionStatus<'a> {
+    pub(super) action: Type,
+    pub(super) class: Class,
+    pub(super) message: Cow<'a, str>,
 }
 
 impl ActionStatus<'_> {
-    pub fn from_query(query: &HashMap<String, String>) -> Option<ActionStatus<'_>> {
+    pub(super) fn from_query(query: &HashMap<String, String>) -> Option<ActionStatus<'_>> {
         Type::from_query(query).map(|action| {
             let message = query
                 .get("action_message")
@@ -135,7 +135,7 @@ impl ActionStatus<'_> {
         })
     }
 
-    pub fn url_cleanup_script() -> &'static str {
+    fn url_cleanup_script() -> &'static str {
         r#"<script>
 (function() {
   const url = new URL(window.location.href);
@@ -148,7 +148,7 @@ impl ActionStatus<'_> {
 </script>"#
     }
 
-    pub fn action_result_script(&self) -> String {
+    pub(super) fn action_result_script(&self) -> String {
         let cleanup = Self::url_cleanup_script();
         let name = self.action.display_name();
         let escaped_msg = self
@@ -170,7 +170,7 @@ impl ActionStatus<'_> {
         }
     }
 
-    pub fn update_redirect_url(&self, redirect_url: &str) -> String {
+    pub(super) fn update_redirect_url(&self, redirect_url: &str) -> String {
         let (base_url, anchor) = match redirect_url.rfind('#') {
             Some(pos) => (&redirect_url[..pos], &redirect_url[pos..]),
             None => (redirect_url, ""),

--- a/crates/api-web/src/attestation.rs
+++ b/crates/api-web/src/attestation.rs
@@ -87,7 +87,7 @@ struct AttestationPcr {
 }
 
 /// View attestation results
-pub async fn show_attestation_results(
+pub(super) async fn show_attestation_results(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> impl IntoResponse {
@@ -351,7 +351,9 @@ async fn get_latest_journal_for_machine_id(
     Ok(latest_journal)
 }
 
-pub async fn show_attestation_summary(AxumState(state): AxumState<Arc<Api>>) -> impl IntoResponse {
+pub(super) async fn show_attestation_summary(
+    AxumState(state): AxumState<Arc<Api>>,
+) -> impl IntoResponse {
     let request = tonic::Request::new(mbprotos::ListAttestationSummaryRequest {});
 
     let attestation_summary = match state.list_attestation_summary(request).await {
@@ -379,7 +381,7 @@ pub async fn show_attestation_summary(AxumState(state): AxumState<Arc<Api>>) -> 
     (StatusCode::OK, Html(attestation_summary.render().unwrap()))
 }
 
-pub async fn submit_report_promotion(
+pub(super) async fn submit_report_promotion(
     AxumState(state): AxumState<Arc<Api>>,
     Form(params): Form<HashMap<String, String>>,
 ) -> impl IntoResponse {

--- a/crates/api-web/src/auth.rs
+++ b/crates/api-web/src/auth.rs
@@ -49,12 +49,12 @@ const CLIENT_SECRET_HEADER: &str = "client_secret";
 const CLIENT_CREDENTIALS_FLOW_SESSION_EXPIRATION_SECONDS: u32 = 600;
 
 #[derive(Debug, Deserialize)]
-pub struct AuthRequest {
+pub(super) struct AuthRequest {
     code: Option<String>,
     state: Option<String>,
 }
 
-pub async fn callback(
+pub(super) async fn callback(
     AxumState(_state): AxumState<Arc<Api>>,
     request_headers: HeaderMap,
     Query(query): Query<AuthRequest>,
@@ -374,13 +374,13 @@ pub async fn callback(
 ///
 /// Note: Use the Error variant to return INTERNAL_SERVER_ERROR, don't use
 /// (INTERNAL_SERVER_ERROR, "error string"), as the latter will not be logged properly.
-pub enum AuthCallbackResponse {
+pub(super) enum AuthCallbackResponse {
     Response(Response),
     Error(AuthCallbackError),
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum AuthCallbackError {
+pub(super) enum AuthCallbackError {
     #[error("expected oauth2 extension layer is empty")]
     EmptyOauth2Layer,
     #[error(
@@ -470,7 +470,7 @@ impl From<Response> for AuthCallbackResponse {
 /// What's really being parsed in the claims portion
 /// of the JWT, which holds a lot of user-data.
 #[derive(Debug, Deserialize)]
-pub struct OauthUserData {
+struct OauthUserData {
     oid: String,
     name: String,
     unique_name: String,
@@ -479,7 +479,7 @@ pub struct OauthUserData {
 /// A container for the list of groups return in
 /// a graph response to a /transitiveMemberOf call
 #[derive(Debug, Deserialize)]
-pub struct OauthUserGroups {
+struct OauthUserGroups {
     value: Vec<OauthUserGroup>,
 }
 
@@ -487,7 +487,7 @@ pub struct OauthUserGroups {
 /// returned in a graph response to a
 /// /transitiveMemberOf call
 #[derive(Debug, Deserialize)]
-pub struct OauthUserGroup {
+struct OauthUserGroup {
     id: String,
 }
 
@@ -498,7 +498,7 @@ struct AsyncRequestHandlerWithTimeouts<'a> {
 }
 
 impl<'a> AsyncRequestHandlerWithTimeouts<'a> {
-    pub fn new(client: &'a reqwest::Client) -> Self {
+    fn new(client: &'a reqwest::Client) -> Self {
         Self { client }
     }
 }

--- a/crates/api-web/src/compute_allocation.rs
+++ b/crates/api-web/src/compute_allocation.rs
@@ -103,7 +103,7 @@ struct ComputeAllocationDetailDisplay {
 /// Struct for deserializing a request to view
 /// existing ComputeAllocations
 #[derive(Deserialize, Debug)]
-pub struct ShowComputeAllocationParams {
+pub(super) struct ShowComputeAllocationParams {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     limit: Option<usize>,
     #[serde(default, deserialize_with = "empty_string_as_none")]
@@ -111,7 +111,7 @@ pub struct ShowComputeAllocationParams {
 }
 
 /// Handler for displaying all compute allocations.
-pub async fn show(
+pub(super) async fn show(
     AxumState(api): AxumState<Arc<Api>>,
     Query(params): Query<ShowComputeAllocationParams>,
     path: OriginalUri,
@@ -203,7 +203,7 @@ async fn fetch_compute_allocations(
 }
 
 /// Handler for displaying a single compute allocation.
-pub async fn show_detail(
+pub(super) async fn show_detail(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(compute_allocation_id): AxumPath<String>,
 ) -> Response {
@@ -287,7 +287,7 @@ pub async fn show_detail(
 /// Struct for deserializing a request to create
 /// a new ComputeAllocation
 #[derive(Deserialize, Debug)]
-pub struct CreateComputeAllocationForm {
+pub(super) struct CreateComputeAllocationForm {
     id: String,
     tenant_organization_id: String,
     instance_type_id: String,
@@ -298,7 +298,7 @@ pub struct CreateComputeAllocationForm {
 }
 
 /// Handler to create a new ComputeAllocation.
-pub async fn create(
+pub(super) async fn create(
     AxumState(api): AxumState<Arc<Api>>,
     Form(form): Form<CreateComputeAllocationForm>,
 ) -> Response {
@@ -376,7 +376,7 @@ pub async fn create(
 /// Struct for deserializing a request to update
 /// an existing ComputeAllocation
 #[derive(Deserialize, Debug)]
-pub struct UpdateComputeAllocationForm {
+pub(super) struct UpdateComputeAllocationForm {
     tenant_organization_id: String,
     instance_type_id: String,
     count: u32,
@@ -387,7 +387,7 @@ pub struct UpdateComputeAllocationForm {
 }
 
 /// Handler for updating an existing ComputeAllocation.
-pub async fn update(
+pub(super) async fn update(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(compute_allocation_id): AxumPath<String>,
     Form(form): Form<UpdateComputeAllocationForm>,
@@ -464,12 +464,12 @@ pub async fn update(
 /// Struct for deserializing a request to delete
 /// an existing ComputeAllocation
 #[derive(Deserialize, Debug)]
-pub struct DeleteComputeAllocationForm {
+pub(super) struct DeleteComputeAllocationForm {
     tenant_organization_id: String,
 }
 
 /// Handler for deleting an existing ComputeAllocation.
-pub async fn delete(
+pub(super) async fn delete(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(compute_allocation_id): AxumPath<String>,
     Form(form): Form<DeleteComputeAllocationForm>,

--- a/crates/api-web/src/configuration.rs
+++ b/crates/api-web/src/configuration.rs
@@ -42,47 +42,47 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 /// Everything the Configuration page template needs.
-pub(crate) struct ConfigPageView {
-    pub groups: Vec<ConfigGroupView>,
+pub(super) struct ConfigPageView {
+    pub(super) groups: Vec<ConfigGroupView>,
 }
 
-pub(crate) struct ConfigGroupView {
-    pub title: &'static str,
+pub(super) struct ConfigGroupView {
+    pub(super) title: &'static str,
     /// Stable identifier used for the tab's `data-tab` / `id` attributes.
-    pub slug: &'static str,
-    pub sections: Vec<ConfigSectionView>,
+    pub(super) slug: &'static str,
+    pub(super) sections: Vec<ConfigSectionView>,
 }
 
-pub(crate) struct ConfigSectionView {
-    pub title: String,
+pub(super) struct ConfigSectionView {
+    pub(super) title: String,
     /// Dotted TOML path prefix of this section ("" for top-level options).
-    pub path: String,
-    pub rows: Vec<ConfigRowView>,
+    pub(super) path: String,
+    pub(super) rows: Vec<ConfigRowView>,
 }
 
-pub(crate) struct ConfigRowView {
-    pub name: String,
+pub(super) struct ConfigRowView {
+    pub(super) name: String,
     /// Full dotted path, also used by the client-side filter.
-    pub path: String,
-    pub ty: String,
-    pub value: CellValue,
-    pub overridden: bool,
+    pub(super) path: String,
+    pub(super) ty: String,
+    pub(super) value: CellValue,
+    pub(super) overridden: bool,
     /// Source label ("nico-api-config.toml", env, ...) when overridden.
-    pub source: String,
-    pub default: CellValue,
+    pub(super) source: String,
+    pub(super) default: CellValue,
     /// Rendered by [`markdown_lite`]; the template inserts it with `|safe`.
-    pub description_html: String,
+    pub(super) description_html: String,
     /// The value shown is the live, runtime-adjustable value.
-    pub runtime: bool,
+    pub(super) runtime: bool,
     /// Lowercased haystack for the client-side filter: name, path, value,
     /// source, and description — deliberately not the type or the panel's
     /// "Type/Default/Path" labels, which would match on every row.
-    pub search: String,
+    pub(super) search: String,
 }
 
 /// A value or default cell. Rendering (and HTML escaping) is centralized in
 /// [`CellValue::to_html`] — the template inserts its output with `|safe`.
-pub(crate) enum CellValue {
+pub(super) enum CellValue {
     /// The option resolves to null/absent.
     Unset,
     /// The option is set to an empty string, list, or map.
@@ -103,7 +103,7 @@ pub(crate) enum CellValue {
 
 impl CellValue {
     /// The single place cell HTML is produced.
-    pub fn to_html(&self) -> String {
+    pub(super) fn to_html(&self) -> String {
         match self {
             CellValue::Unset => r#"<span class="config-unset">unset</span>"#.to_string(),
             CellValue::Empty => r#"<span class="config-unset">empty</span>"#.to_string(),
@@ -119,7 +119,7 @@ impl CellValue {
     }
 
     /// Used by the template to dim rows whose option isn't set.
-    pub fn is_unset(&self) -> bool {
+    pub(super) fn is_unset(&self) -> bool {
         matches!(self, CellValue::Unset)
     }
 
@@ -137,13 +137,13 @@ impl CellValue {
 /// Live values of the runtime-adjustable settings, folded into the catalog
 /// next to their config options and tagged "runtime". `None` values render
 /// as "unset".
-pub(crate) struct LiveSettings {
-    pub log_filter: String,
-    pub site_explorer_enabled: String,
-    pub create_machines: String,
-    pub bmc_proxy: Option<String>,
-    pub tracing_enabled: String,
-    pub dpu_agent_upgrade_policy: String,
+pub(super) struct LiveSettings {
+    pub(super) log_filter: String,
+    pub(super) site_explorer_enabled: String,
+    pub(super) create_machines: String,
+    pub(super) bmc_proxy: Option<String>,
+    pub(super) tracing_enabled: String,
+    pub(super) dpu_agent_upgrade_policy: String,
 }
 
 /// A dynamic setting joined into the catalog: attached to the config option
@@ -236,7 +236,7 @@ fn group_title(slug: &str) -> &'static str {
 /// Builds the page view from the reference doc, the redacted effective config
 /// (as JSON), the explicitly-set key paths with their source labels, and the
 /// live runtime-adjustable values.
-pub(crate) fn build_config_page(
+pub(super) fn build_config_page(
     reference_md: &str,
     effective: &serde_json::Value,
     explicit_paths: &BTreeMap<String, String>,

--- a/crates/api-web/src/domain.rs
+++ b/crates/api-web/src/domain.rs
@@ -34,7 +34,7 @@ struct DomainShow {
 }
 
 /// List domains
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let domains = match fetch_domains(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -48,7 +48,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let domains = match fetch_domains(state).await {
         Ok(m) => m,
         Err(err) => {

--- a/crates/api-web/src/dpa.rs
+++ b/crates/api-web/src/dpa.rs
@@ -37,7 +37,7 @@ struct DpaShow {
 }
 
 /// List DPAs
-pub async fn show_dpas_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_dpas_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let dpas = match fetch_dpas(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -50,7 +50,7 @@ pub async fn show_dpas_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_dpas_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_dpas_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let dpas = match fetch_dpas(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -112,7 +112,7 @@ impl From<forgerpc::DpaInterface> for DpaDetail {
 }
 
 /// View DPA details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(dpa_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/dpu_versions.rs
+++ b/crates/api-web/src/dpu_versions.rs
@@ -125,7 +125,7 @@ async fn fetch_dpus(api: &Arc<Api>) -> Result<Vec<Row>, tonic::Status> {
     Ok(machines)
 }
 
-pub async fn list_html(
+pub(super) async fn list_html(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<PaginationParams>,
 ) -> impl IntoResponse {
@@ -146,7 +146,7 @@ pub async fn list_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn list_json(AxumState(state): AxumState<Arc<Api>>) -> impl IntoResponse {
+pub(super) async fn list_json(AxumState(state): AxumState<Arc<Api>>) -> impl IntoResponse {
     let machines = match fetch_dpus(&state).await {
         Ok(m) => m,
         Err(err) => {

--- a/crates/api-web/src/expected_machine.rs
+++ b/crates/api-web/src/expected_machine.rs
@@ -150,7 +150,7 @@ impl ExpectedMachineTabs {
     }
 }
 
-pub async fn show_all_html(
+pub(super) async fn show_all_html(
     AxumState(api): AxumState<Arc<Api>>,
     Query(mut params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -277,7 +277,9 @@ pub async fn show_all_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_expected_machine_raw_json(AxumState(api): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_expected_machine_raw_json(
+    AxumState(api): AxumState<Arc<Api>>,
+) -> Response {
     let result = match api
         .get_all_expected_machines(tonic::Request::new(()))
         .await

--- a/crates/api-web/src/expected_power_shelf.rs
+++ b/crates/api-web/src/expected_power_shelf.rs
@@ -43,7 +43,7 @@ struct ExpectedPowerShelfRow {
 }
 
 /// Show all expected power shelves.
-pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let power_shelves = match fetch_expected_power_shelves(&state).await {
         Ok(shelves) => shelves,
         Err((code, msg)) => return (code, msg).into_response(),
@@ -53,7 +53,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
 }
 
 /// Show all expected power shelves as JSON.
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let power_shelves = match fetch_expected_power_shelves(&state).await {
         Ok(shelves) => shelves,
         Err((code, msg)) => return (code, msg).into_response(),

--- a/crates/api-web/src/expected_rack.rs
+++ b/crates/api-web/src/expected_rack.rs
@@ -43,7 +43,7 @@ struct ExpectedRackRow {
 }
 
 /// Show all expected racks.
-pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_expected_racks(&state).await {
         Ok(racks) => racks,
         Err((code, msg)) => return (code, msg).into_response(),
@@ -53,7 +53,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
 }
 
 /// Show all expected racks as JSON.
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_expected_racks(&state).await {
         Ok(racks) => racks,
         Err((code, msg)) => return (code, msg).into_response(),

--- a/crates/api-web/src/expected_switch.rs
+++ b/crates/api-web/src/expected_switch.rs
@@ -43,7 +43,7 @@ struct ExpectedSwitchRow {
 }
 
 /// Show all expected switches.
-pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let switches = match fetch_expected_switches(&state).await {
         Ok(switches) => switches,
         Err((code, msg)) => return (code, msg).into_response(),
@@ -53,7 +53,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
 }
 
 /// Show all expected switches as JSON.
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let switches = match fetch_expected_switches(&state).await {
         Ok(switches) => switches,
         Err((code, msg)) => return (code, msg).into_response(),

--- a/crates/api-web/src/explored_endpoint.rs
+++ b/crates/api-web/src/explored_endpoint.rs
@@ -215,7 +215,7 @@ impl From<&ExploredEndpoint> for ExploredEndpointDisplay {
 }
 
 /// List explored endpoints
-pub async fn show_html_all(
+pub(super) async fn show_html_all(
     AxumState(state): AxumState<Arc<Api>>,
     Query(mut params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -273,7 +273,7 @@ pub async fn show_html_all(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_html_paired(
+pub(super) async fn show_html_paired(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<PaginationParams>,
 ) -> Response {
@@ -301,7 +301,7 @@ pub async fn show_html_paired(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_html_unpaired(
+pub(super) async fn show_html_unpaired(
     AxumState(state): AxumState<Arc<Api>>,
     Query(mut params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -396,7 +396,7 @@ pub async fn show_html_unpaired(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let report = match fetch_explored_endpoints(&state).await {
         Ok(report) => report,
         Err(err) => {
@@ -505,7 +505,7 @@ impl From<ExploredEndpointInfo> for ExploredEndpointDetail<'_> {
 
 /// Fetch a single explored endpoint
 /// TODO: The API is rather inefficient since it loads all of them and filters client side
-pub async fn fetch_explored_endpoint(
+async fn fetch_explored_endpoint(
     api: &Api,
     endpoint_ip: String,
 ) -> Result<ExploredEndpoint, Response> {
@@ -535,7 +535,7 @@ pub async fn fetch_explored_endpoint(
     Ok(endpoint)
 }
 /// View details of an explored endpoint
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Query(params): Query<HashMap<String, String>>,
@@ -646,7 +646,7 @@ pub async fn detail(
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 
-pub async fn re_explore(
+pub(super) async fn re_explore(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Form(form): Form<ReExploreEndpointAction>,
@@ -668,7 +668,7 @@ pub async fn re_explore(
     Redirect::to(&view_url)
 }
 
-pub async fn refresh_endpoint(
+pub(super) async fn refresh_endpoint(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> impl IntoResponse {
@@ -710,7 +710,7 @@ pub async fn refresh_endpoint(
     }
 }
 
-pub async fn pause_remediation(
+pub(super) async fn pause_remediation(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Form(form): Form<PauseRemediationAction>,
@@ -735,12 +735,12 @@ pub async fn pause_remediation(
 }
 
 #[derive(Deserialize, Debug)]
-pub struct ReExploreEndpointAction {
+pub(super) struct ReExploreEndpointAction {
     if_version_match: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct PauseRemediationAction {
+pub(super) struct PauseRemediationAction {
     pause: bool,
 }
 
@@ -777,7 +777,7 @@ fn query_filter_for(
     Box::new(move |x| vf(x) && ef(x))
 }
 
-pub async fn power_control(
+pub(super) async fn power_control(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Form(form): Form<PowerControlEndpointAction>,
@@ -854,12 +854,12 @@ pub async fn power_control(
 }
 
 #[derive(Deserialize, Debug)]
-pub struct PowerControlEndpointAction {
+pub(super) struct PowerControlEndpointAction {
     action: Option<String>,
     redirect_to: Option<String>,
 }
 
-pub async fn bmc_reset(
+pub(super) async fn bmc_reset(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Form(form): Form<BmcResetEndpointAction>,
@@ -909,22 +909,22 @@ pub async fn bmc_reset(
 }
 
 #[derive(Deserialize, Debug)]
-pub struct BmcResetEndpointAction {
+pub(super) struct BmcResetEndpointAction {
     use_ipmi: Option<String>,
     redirect_to: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct MachineSetupAction {
+pub(super) struct MachineSetupAction {
     boot_interface_mac: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct DpuFirstBootOrderAction {
+pub(super) struct DpuFirstBootOrderAction {
     boot_interface_mac: Option<String>,
 }
 
-pub async fn clear_last_exploration_error(
+pub(super) async fn clear_last_exploration_error(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {
@@ -946,7 +946,7 @@ pub async fn clear_last_exploration_error(
     Redirect::to(&view_url).into_response()
 }
 
-pub async fn clear_bmc_credentials(
+pub(super) async fn clear_bmc_credentials(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {
@@ -983,7 +983,7 @@ pub async fn clear_bmc_credentials(
     Redirect::to(&view_url).into_response()
 }
 
-pub async fn disable_secure_boot(
+pub(super) async fn disable_secure_boot(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {
@@ -1017,7 +1017,7 @@ pub async fn disable_secure_boot(
     Redirect::to(&redirect_url).into_response()
 }
 
-pub async fn disable_lockdown(
+pub(super) async fn disable_lockdown(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {
@@ -1055,7 +1055,7 @@ pub async fn disable_lockdown(
     Redirect::to(&redirect_url).into_response()
 }
 
-pub async fn enable_lockdown(
+pub(super) async fn enable_lockdown(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {
@@ -1093,7 +1093,7 @@ pub async fn enable_lockdown(
     Redirect::to(&redirect_url).into_response()
 }
 
-pub async fn machine_setup(
+pub(super) async fn machine_setup(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Form(form): Form<MachineSetupAction>,
@@ -1150,7 +1150,7 @@ pub async fn machine_setup(
     Redirect::to(&redirect_url).into_response()
 }
 
-pub async fn set_dpu_first_boot_order(
+pub(super) async fn set_dpu_first_boot_order(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
     Form(form): Form<DpuFirstBootOrderAction>,
@@ -1220,7 +1220,7 @@ pub async fn set_dpu_first_boot_order(
 /// id) once a machine owns this endpoint, or site-explorer's automatic default
 /// for a not-yet-managed endpoint. Managed hosts persist a fresh generation
 /// for machine-controller; unowned endpoints still apply it directly.
-pub async fn restore_boot_interface(
+pub(super) async fn restore_boot_interface(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {
@@ -1260,7 +1260,7 @@ pub async fn restore_boot_interface(
     Redirect::to(&redirect_url).into_response()
 }
 
-pub async fn delete_endpoint(
+pub(super) async fn delete_endpoint(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(endpoint_ip): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/filters.rs
+++ b/crates/api-web/src/filters.rs
@@ -29,12 +29,15 @@ use carbide_uuid::machine::MachineId;
 
 /// Generates HTML links for Machine IDs
 #[askama::filter_fn]
-pub fn machine_id_link(id: impl Display, _env: &dyn askama::Values) -> ::askama::Result<String> {
+pub(super) fn machine_id_link(
+    id: impl Display,
+    _env: &dyn askama::Values,
+) -> ::askama::Result<String> {
     machine_link(id, "machine")
 }
 
 /// Generates a formatted link for Machine IDs to a predefined path
-pub fn machine_link(id: impl Display, path: impl Display) -> ::askama::Result<String> {
+pub(super) fn machine_link(id: impl Display, path: impl Display) -> ::askama::Result<String> {
     let id = id.to_string();
     let link_path: String = url::form_urlencoded::byte_serialize(id.as_bytes()).collect();
 
@@ -85,12 +88,15 @@ fn escaped_shortened_id_link(id: impl Display, path: impl Display) -> ::askama::
 }
 
 #[askama::filter_fn]
-pub fn rack_id_link(id: impl Display, _env: &dyn askama::Values) -> ::askama::Result<String> {
+pub(super) fn rack_id_link(
+    id: impl Display,
+    _env: &dyn askama::Values,
+) -> ::askama::Result<String> {
     escaped_shortened_id_link(id, "rack")
 }
 
 #[askama::filter_fn]
-pub fn power_shelf_id_link(
+pub(super) fn power_shelf_id_link(
     id: impl Display,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {
@@ -98,13 +104,16 @@ pub fn power_shelf_id_link(
 }
 
 #[askama::filter_fn]
-pub fn switch_id_link(id: impl Display, _env: &dyn askama::Values) -> ::askama::Result<String> {
+pub(super) fn switch_id_link(
+    id: impl Display,
+    _env: &dyn askama::Values,
+) -> ::askama::Result<String> {
     escaped_shortened_id_link(id, "switch")
 }
 
 /// Formats labels into HTML
 #[askama::filter_fn]
-pub fn label_list_fmt(
+pub(super) fn label_list_fmt(
     labels: &[rpc::forge::Label],
     _env: &dyn askama::Values,
     truncate: bool,
@@ -152,7 +161,7 @@ pub fn label_list_fmt(
 /// If there is no alert, generates a green "None" bubble
 /// Generates HTML using the unified bubble system
 #[askama::filter_fn]
-pub fn health_alerts_fmt(
+pub(super) fn health_alerts_fmt(
     alerts: &[health_report::HealthProbeAlert],
     _env: &dyn askama::Values,
     include_message: bool,
@@ -188,7 +197,7 @@ pub fn health_alerts_fmt(
 /// Formats a list of Health Alert Classifications
 /// If there is no alert, the generated String will be empty
 #[askama::filter_fn]
-pub fn health_alert_classifications_fmt(
+pub(super) fn health_alert_classifications_fmt(
     alerts: &Vec<health_report::HealthProbeAlert>,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {
@@ -197,7 +206,7 @@ pub fn health_alert_classifications_fmt(
 
 /// Formats a single Health Alert Classification
 #[askama::filter_fn]
-pub fn health_alert_classification_fmt(
+pub(super) fn health_alert_classification_fmt(
     alert: &health_report::HealthProbeAlert,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {
@@ -234,7 +243,7 @@ where
 /// Renders version strings including timestamps
 /// Also shows the localized timestamp on Mouseover
 #[askama::filter_fn]
-pub fn config_version(
+pub(super) fn config_version(
     version: impl Display,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {
@@ -253,7 +262,7 @@ pub fn config_version(
 
 /// Prints the value of the `Option` in case it's `Some(x)`, and otherwise an empty string
 #[askama::filter_fn]
-pub fn option_fmt(
+pub(super) fn option_fmt(
     value: &Option<impl Display>,
     _env: &dyn askama::Values,
 ) -> askama::Result<String> {
@@ -264,7 +273,7 @@ pub fn option_fmt(
 }
 
 #[askama::filter_fn]
-pub fn option_fmt_or(
+pub(super) fn option_fmt_or(
     value: &Option<impl Display>,
     _env: &dyn askama::Values,
     default: &str,
@@ -280,7 +289,10 @@ pub fn option_fmt_or(
 /// Invalid JSON is returned unchanged so this can also be used for endpoints whose
 /// response bodies are not guaranteed to be JSON.
 #[askama::filter_fn]
-pub fn pretty_json(value: impl Display, _env: &dyn askama::Values) -> ::askama::Result<String> {
+pub(super) fn pretty_json(
+    value: impl Display,
+    _env: &dyn askama::Values,
+) -> ::askama::Result<String> {
     Ok(format_json(value))
 }
 
@@ -303,7 +315,7 @@ fn format_json(value: impl Display) -> String {
     serde_json::to_string_pretty(&json).unwrap_or(input)
 }
 
-pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, String) {
+fn state_and_substate_labels(state_json: impl Display) -> (String, String) {
     let state_json = state_json.to_string();
     let Ok(value) = serde_json::from_str::<serde_json::Value>(&state_json) else {
         return (state_json, String::new());
@@ -331,7 +343,7 @@ pub(crate) fn state_and_substate_labels(state_json: impl Display) -> (String, St
 }
 
 #[askama::filter_fn]
-pub fn state_with_substate_label(
+pub(super) fn state_with_substate_label(
     state: impl Display,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {
@@ -361,7 +373,7 @@ fn capitalize_state(state: &str) -> String {
 
 /// Formats the boot order list
 #[askama::filter_fn]
-pub fn boot_order_fmt(
+pub(super) fn boot_order_fmt(
     boot_order: &Option<rpc::site_explorer::BootOrder>,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {
@@ -377,7 +389,10 @@ pub fn boot_order_fmt(
 }
 
 #[askama::filter_fn]
-pub fn colorize_output(ansi_text: &str, _env: &dyn askama::Values) -> ::askama::Result<String> {
+pub(super) fn colorize_output(
+    ansi_text: &str,
+    _env: &dyn askama::Values,
+) -> ::askama::Result<String> {
     let html = ansi_to_html::Converter::new()
         .convert(ansi_text)
         .unwrap_or_default();
@@ -386,7 +401,7 @@ pub fn colorize_output(ansi_text: &str, _env: &dyn askama::Values) -> ::askama::
 
 /// Formats a state handler outcome
 #[askama::filter_fn]
-pub fn controller_state_reason_fmt(
+pub(super) fn controller_state_reason_fmt(
     reason: &Option<::rpc::forge::ControllerStateReason>,
     _env: &dyn askama::Values,
 ) -> ::askama::Result<String> {

--- a/crates/api-web/src/firmware.rs
+++ b/crates/api-web/src/firmware.rs
@@ -68,7 +68,7 @@ struct DesiredFirmwareRow {
     explicit_update_start_needed: bool,
 }
 
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let desired_firmware = match fetch_desired_firmware(&state).await {
         Ok(rows) => rows,
         Err(err) => {
@@ -87,7 +87,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let desired_firmware = match fetch_desired_firmware(&state).await {
         Ok(rows) => rows,
         Err(err) => {

--- a/crates/api-web/src/health.rs
+++ b/crates/api-web/src/health.rs
@@ -65,17 +65,17 @@ struct HealthPage {
 #[derive(Template)]
 #[template(path = "health_history_table.html")]
 pub(super) struct HealthHistoryTable {
-    pub records: Vec<HealthHistoryRecord>,
+    pub(super) records: Vec<HealthHistoryRecord>,
 }
 
 #[derive(Debug, serde::Serialize)]
 pub(super) struct HealthHistoryRecord {
-    pub timestamp: String,
-    pub health: health_report::HealthReport,
+    timestamp: String,
+    health: health_report::HealthReport,
 }
 
 impl HealthHistoryRecord {
-    pub fn from_rpc_convert_invalid(record: ::rpc::forge::HealthHistoryRecord) -> Self {
+    fn from_rpc_convert_invalid(record: ::rpc::forge::HealthHistoryRecord) -> Self {
         HealthHistoryRecord {
             timestamp: record.time.map(|time| time.to_string()).unwrap_or_default(),
             health: record
@@ -179,7 +179,7 @@ struct MachineHealthSnapshot {
 }
 
 /// View machine health.
-pub async fn machine_health(
+pub(super) async fn machine_health(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> Response {
@@ -196,7 +196,7 @@ pub async fn machine_health(
 }
 
 /// View rack health.
-pub async fn rack_health(
+pub(super) async fn rack_health(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(rack_id): AxumPath<String>,
 ) -> Response {
@@ -213,7 +213,7 @@ pub async fn rack_health(
 }
 
 /// View power shelf health.
-pub async fn power_shelf_health(
+pub(super) async fn power_shelf_health(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(power_shelf_id): AxumPath<String>,
 ) -> Response {
@@ -230,7 +230,7 @@ pub async fn power_shelf_health(
 }
 
 /// View switch health.
-pub async fn switch_health(
+pub(super) async fn switch_health(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(switch_id): AxumPath<String>,
 ) -> Response {
@@ -247,7 +247,7 @@ pub async fn switch_health(
 }
 
 /// View NVLink domain health.
-pub async fn nvlink_domain_health(
+pub(super) async fn nvlink_domain_health(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(domain_id): AxumPath<String>,
 ) -> Response {
@@ -264,7 +264,7 @@ pub async fn nvlink_domain_health(
 }
 
 /// Redirect NVLink domain details to the health page.
-pub async fn nvlink_domain_detail(AxumPath(domain_id): AxumPath<String>) -> Response {
+pub(super) async fn nvlink_domain_detail(AxumPath(domain_id): AxumPath<String>) -> Response {
     let Ok(domain_id) = NvLinkDomainId::from_str(&domain_id) else {
         return (StatusCode::BAD_REQUEST, "invalid NVLink domain id").into_response();
     };
@@ -716,7 +716,7 @@ async fn fetch_switch_aggregate_health(
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
-pub struct HealthReportEntry {
+pub(super) struct HealthReportEntry {
     mode: String,
     health_report: HealthReport,
 }
@@ -763,11 +763,11 @@ impl TryFrom<HealthReportEntry> for ::rpc::forge::HealthReportEntry {
 }
 
 #[derive(serde::Deserialize)]
-pub struct RemoveHealthReport {
+pub(super) struct RemoveHealthReport {
     source: String,
 }
 
-pub async fn add_machine_health_report(
+pub(super) async fn add_machine_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     auth_context: Option<axum::Extension<AuthContext>>,
@@ -787,7 +787,7 @@ pub async fn add_machine_health_report(
     .await
 }
 
-pub async fn add_rack_health_report(
+pub(super) async fn add_rack_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(rack_id): AxumPath<String>,
     auth_context: Option<axum::Extension<AuthContext>>,
@@ -801,7 +801,7 @@ pub async fn add_rack_health_report(
     add_health_report_for(state, HealthObject::Rack(rack_id), auth_context, payload).await
 }
 
-pub async fn add_power_shelf_health_report(
+pub(super) async fn add_power_shelf_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(power_shelf_id): AxumPath<String>,
     auth_context: Option<axum::Extension<AuthContext>>,
@@ -821,7 +821,7 @@ pub async fn add_power_shelf_health_report(
     .await
 }
 
-pub async fn add_switch_health_report(
+pub(super) async fn add_switch_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(switch_id): AxumPath<String>,
     auth_context: Option<axum::Extension<AuthContext>>,
@@ -842,7 +842,7 @@ pub async fn add_switch_health_report(
 }
 
 /// Insert an NVLink domain health report from the admin web UI.
-pub async fn add_nvlink_domain_health_report(
+pub(super) async fn add_nvlink_domain_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(domain_id): AxumPath<String>,
     auth_context: Option<axum::Extension<AuthContext>>,
@@ -955,7 +955,7 @@ async fn add_health_report_for(
     }
 }
 
-pub async fn remove_machine_health_report(
+pub(super) async fn remove_machine_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     extract::Json(payload): extract::Json<RemoveHealthReport>,
@@ -968,7 +968,7 @@ pub async fn remove_machine_health_report(
     remove_health_report_for(state, HealthObject::Machine(machine_id), payload).await
 }
 
-pub async fn remove_rack_health_report(
+pub(super) async fn remove_rack_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(rack_id): AxumPath<String>,
     extract::Json(payload): extract::Json<RemoveHealthReport>,
@@ -981,7 +981,7 @@ pub async fn remove_rack_health_report(
     remove_health_report_for(state, HealthObject::Rack(rack_id), payload).await
 }
 
-pub async fn remove_power_shelf_health_report(
+pub(super) async fn remove_power_shelf_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(power_shelf_id): AxumPath<String>,
     extract::Json(payload): extract::Json<RemoveHealthReport>,
@@ -994,7 +994,7 @@ pub async fn remove_power_shelf_health_report(
     remove_health_report_for(state, HealthObject::PowerShelf(power_shelf_id), payload).await
 }
 
-pub async fn remove_switch_health_report(
+pub(super) async fn remove_switch_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(switch_id): AxumPath<String>,
     extract::Json(payload): extract::Json<RemoveHealthReport>,
@@ -1008,7 +1008,7 @@ pub async fn remove_switch_health_report(
 }
 
 /// Remove an NVLink domain health report from the admin web UI.
-pub async fn remove_nvlink_domain_health_report(
+pub(super) async fn remove_nvlink_domain_health_report(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(domain_id): AxumPath<String>,
     extract::Json(payload): extract::Json<RemoveHealthReport>,

--- a/crates/api-web/src/health_history.rs
+++ b/crates/api-web/src/health_history.rs
@@ -37,7 +37,7 @@ struct MachineHealth {
 }
 
 /// Show the health history for a certain Machine
-pub async fn show_health_history(
+pub(super) async fn show_health_history(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> Response {
@@ -54,7 +54,7 @@ pub async fn show_health_history(
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 
-pub async fn show_health_history_json(
+pub(super) async fn show_health_history_json(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> Response {
@@ -65,7 +65,7 @@ pub async fn show_health_history_json(
     (StatusCode::OK, Json(health_records)).into_response()
 }
 
-pub async fn fetch_health_records(
+async fn fetch_health_records(
     api: &Api,
     machine_id: &str,
 ) -> Result<(MachineId, Vec<HealthHistoryRecord>), (http::StatusCode, String)> {

--- a/crates/api-web/src/ib_fabric.rs
+++ b/crates/api-web/src/ib_fabric.rs
@@ -35,7 +35,7 @@ struct IbFabricShow {
 }
 
 /// List fabrics
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let fabrics = match fetch_ib_fabric_ids(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -52,7 +52,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let fabrics = match fetch_ib_fabric_ids(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -67,7 +67,7 @@ pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Json(fabrics)).into_response()
 }
 
-pub async fn fetch_ib_fabric_ids(api: Arc<Api>) -> Result<Vec<String>, tonic::Status> {
+pub(super) async fn fetch_ib_fabric_ids(api: Arc<Api>) -> Result<Vec<String>, tonic::Status> {
     let request = tonic::Request::new(forgerpc::IbFabricSearchFilter::default());
 
     let ib_fabric_ids = api

--- a/crates/api-web/src/ib_partition.rs
+++ b/crates/api-web/src/ib_partition.rs
@@ -72,7 +72,7 @@ impl From<forgerpc::IbPartition> for IbPartitionRowDisplay {
 }
 
 /// List partitions
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_ib_partitions(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -91,7 +91,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_ib_partitions(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -254,7 +254,7 @@ impl From<forgerpc::IbPartition> for IbPartitionDetail {
 }
 
 /// View partition details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(partition_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/instance.rs
+++ b/crates/api-web/src/instance.rs
@@ -132,7 +132,7 @@ impl From<forgerpc::Instance> for InstanceDisplay {
 }
 
 /// List instances
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_instances(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -146,7 +146,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_instances(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -574,7 +574,7 @@ async fn get_interfaces_for_instance_detail(
 }
 
 /// View instance
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(instance_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/instance_type.rs
+++ b/crates/api-web/src/instance_type.rs
@@ -160,7 +160,7 @@ impl From<forgerpc::InstanceTypeMachineCapabilityFilterAttributes>
 /// Struct for deserializing a request to view
 /// existing instance types
 #[derive(Deserialize, Debug)]
-pub struct ShowInstanceTypeParams {
+pub(super) struct ShowInstanceTypeParams {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     limit: Option<usize>,
     #[serde(default, deserialize_with = "empty_string_as_none")]
@@ -168,7 +168,7 @@ pub struct ShowInstanceTypeParams {
 }
 
 /// Handler for displaying all instance types
-pub async fn show(
+pub(super) async fn show(
     AxumState(api): AxumState<Arc<Api>>,
     Query(params): Query<ShowInstanceTypeParams>,
     path: OriginalUri,
@@ -267,7 +267,7 @@ async fn fetch_instance_types(
 }
 
 /// Handler for displaying a single instance type.
-pub async fn show_detail(
+pub(super) async fn show_detail(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(instance_type_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/interface.rs
+++ b/crates/api-web/src/interface.rs
@@ -151,7 +151,7 @@ impl From<forgerpc::MachineInterface> for InterfaceRowDisplay {
 }
 
 /// List machine interfaces
-pub async fn show_html(
+pub(super) async fn show_html(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<PaginationParams>,
     uri: OriginalUri,
@@ -209,7 +209,7 @@ pub async fn show_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let machine_interfaces = match fetch_machine_interfaces(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -307,7 +307,7 @@ impl From<forgerpc::MachineInterface> for InterfaceDetail {
 }
 
 /// View machine interface details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(interface_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/ipam.rs
+++ b/crates/api-web/src/ipam.rs
@@ -84,7 +84,7 @@ impl DhcpEntryDisplay {
 }
 
 /// DHCP allocations page
-pub async fn dhcp_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn dhcp_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let interfaces = match fetch_interfaces(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -110,7 +110,7 @@ pub async fn dhcp_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn dhcp_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn dhcp_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let interfaces = match fetch_interfaces(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -158,7 +158,7 @@ struct DnsRecordDisplay {
 }
 
 /// DNS records page
-pub async fn dns_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn dns_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     // Fetch domains.
     let domains = match db::dns::domain::find_by(
         &state.database_connection,
@@ -255,7 +255,7 @@ struct UnderlaySegmentDisplay {
 }
 
 /// Underlay Networks top-level.
-pub async fn underlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn underlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let query = r#"
         SELECT ns.id as segment_id, ns.name as segment_name,
                ns.network_segment_type::text as segment_type,
@@ -349,7 +349,7 @@ struct UnderlayAddressDisplay {
 
 /// Underlay segment detail, which includes machine IPs
 /// allocated in a segment.
-pub async fn underlay_segment_html(
+pub(super) async fn underlay_segment_html(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(segment_id): AxumPath<String>,
 ) -> Response {
@@ -475,7 +475,7 @@ struct OverlayVpcPrefixDisplay {
 }
 
 /// Overlay Networks -- lists VNIs and their prefixes.
-pub async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn overlay_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     // Fetch all VPCs.
     let rpc_vpcs = match fetch_vpcs(state.clone()).await {
         Ok(v) => v,
@@ -679,7 +679,7 @@ struct OverlaySegmentDisplay {
 
 /// Overlay prefix detail, which includes segments carved
 /// from a VPC prefix.
-pub async fn overlay_prefix_html(
+pub(super) async fn overlay_prefix_html(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(vpc_prefix_id): AxumPath<String>,
 ) -> Response {
@@ -882,7 +882,7 @@ struct OverlayAddressDisplay {
 }
 
 /// Overlay segment detail (IPs allocated in a segment).
-pub async fn overlay_segment_html(
+pub(super) async fn overlay_segment_html(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(segment_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/ipxe_template.rs
+++ b/crates/api-web/src/ipxe_template.rs
@@ -35,10 +35,10 @@ fn ipxe_template_visibility_fmt(visibility: &i32) -> Cow<'static, str> {
 }
 
 mod filters {
-    pub use super::super::filters::option_fmt;
+    pub(super) use super::super::filters::option_fmt;
 
     #[askama::filter_fn]
-    pub fn ipxe_template_visibility_fmt(
+    pub(super) fn ipxe_template_visibility_fmt(
         visibility: &i32,
         _env: &dyn askama::Values,
     ) -> askama::Result<super::Cow<'static, str>> {
@@ -54,7 +54,7 @@ struct IpxeTemplateShow {
     templates: Vec<forgerpc::IpxeTemplate>,
 }
 
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let templates = match fetch_templates(state).await {
         Ok(t) => t,
         Err(err) => {
@@ -71,7 +71,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let templates = match fetch_templates(state).await {
         Ok(t) => t,
         Err(err) => {
@@ -106,7 +106,7 @@ impl From<forgerpc::IpxeTemplate> for IpxeTemplateDetail {
     }
 }
 
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(id_str): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -59,7 +59,7 @@ use tower_http::normalize_path::NormalizePath;
 /// The tool list itself is owned by `carbide-api-core` (it is derived from the
 /// parsed `CarbideConfig` during API Core configuration loading).
 /// This trait just surfaces it to templates.
-pub trait Base {
+trait Base {
     /// Configured external tool links rendered in the admin UI's
     /// "Tools" sidebar. Empty when no tools are configured or
     /// before API Core configuration loading has initialized them (e.g. unit tests).
@@ -78,24 +78,24 @@ pub trait Base {
 /// in entity detail pages. Render with `{{ metadata_detail|safe }}`.
 #[derive(Template)]
 #[template(path = "metadata_details.html")]
-pub(crate) struct MetadataDetail {
-    pub metadata: rpc::forge::Metadata,
-    pub metadata_version: String,
+struct MetadataDetail {
+    metadata: rpc::forge::Metadata,
+    metadata_version: String,
 }
 
 /// Reusable template for rendering aggregate health details in entity detail
 /// pages. Render with `{{ health_detail|safe }}`.
 #[derive(Template)]
 #[template(path = "health_detail.html")]
-pub(crate) struct HealthDetail {
-    pub health_reports_url: String,
-    pub health_reports_link_text: &'static str,
-    pub health: health_report::HealthReport,
-    pub health_sources: Vec<String>,
+struct HealthDetail {
+    health_reports_url: String,
+    health_reports_link_text: &'static str,
+    health: health_report::HealthReport,
+    health_sources: Vec<String>,
 }
 
 impl HealthDetail {
-    pub(crate) fn new(
+    fn new(
         health_reports_url: String,
         health_reports_link_text: &'static str,
         health: Option<rpc::health::HealthReport>,
@@ -122,13 +122,13 @@ impl HealthDetail {
 /// Render with `{{ state_display|safe }}`.
 #[derive(Debug, Clone, PartialEq, Eq, Template)]
 #[template(path = "state_display.html")]
-pub(crate) struct StateDisplay {
-    pub state: String,
-    pub time_in_state_above_sla: bool,
+struct StateDisplay {
+    state: String,
+    time_in_state_above_sla: bool,
 }
 
 impl StateDisplay {
-    pub fn from_lifecycle(lifecycle: Option<&forgerpc::LifecycleStatus>) -> Self {
+    fn from_lifecycle(lifecycle: Option<&forgerpc::LifecycleStatus>) -> Self {
         let state = lifecycle
             .map(|lifecycle| lifecycle.state.clone())
             .filter(|state| !state.is_empty())
@@ -150,29 +150,29 @@ impl StateDisplay {
 /// Render with `{{ state_sla_detail|safe }}`.
 #[derive(Template)]
 #[template(path = "state_sla_details.html")]
-pub(crate) struct StateSlaDetail {
-    pub state_sla: String,
-    pub time_in_state_above_sla: bool,
-    pub state_reason: Option<rpc::forge::ControllerStateReason>,
+struct StateSlaDetail {
+    state_sla: String,
+    time_in_state_above_sla: bool,
+    state_reason: Option<rpc::forge::ControllerStateReason>,
 }
 
 /// Reusable template for rendering lifecycle fields.
 /// Render with `{{ lifecycle_detail|safe }}`.
 #[derive(Template)]
 #[template(path = "lifecycle_detail.html")]
-pub(crate) struct LifecycleDetail {
-    pub state_display: StateDisplay,
-    pub associated_instance_id: Option<String>,
-    pub json_state: Option<String>,
-    pub version: String,
-    pub time_in_state: String,
-    pub state_sla: String,
-    pub time_in_state_above_sla: bool,
-    pub state_reason: Option<rpc::forge::ControllerStateReason>,
+struct LifecycleDetail {
+    state_display: StateDisplay,
+    associated_instance_id: Option<String>,
+    json_state: Option<String>,
+    version: String,
+    time_in_state: String,
+    state_sla: String,
+    time_in_state_above_sla: bool,
+    state_reason: Option<rpc::forge::ControllerStateReason>,
 }
 
 impl LifecycleDetail {
-    pub fn new(
+    fn new(
         state: String,
         version: String,
         state_reason: Option<forgerpc::ControllerStateReason>,
@@ -230,7 +230,7 @@ fn format_state_sla(sla: Option<&forgerpc::StateSla>) -> String {
 // `#[crate::sqlx_test]` in the admin-UI tests. These tests do not support
 // `fixtures(...)`; use explicit setup helpers instead.
 #[cfg(test)]
-pub(crate) use carbide_macros::sqlx_test;
+use carbide_macros::sqlx_test;
 use carbide_utils::none_if_empty::NoneIfEmpty;
 
 #[cfg(test)]
@@ -263,7 +263,7 @@ mod ipxe_template;
 mod logs;
 mod machine;
 mod machine_validation;
-pub mod managed_host;
+mod managed_host;
 mod network_device;
 mod network_security_group;
 mod network_segment;
@@ -271,7 +271,7 @@ mod network_status;
 mod nmxc_browser;
 mod nvlink;
 mod operating_system;
-pub(crate) mod pagination;
+mod pagination;
 mod power_shelf;
 mod rack;
 mod redfish_actions;
@@ -320,7 +320,7 @@ const TABLE_FILTER_JS: &str = include_str!("../templates/static/table_filter.js"
 // It would appear the oauth2 author read about the typestate pattern and decided making
 // everyone declare 10 type parameters when storing a Client sounds like a great idea.
 // https://github.com/ramosbugs/oauth2-rs/blob/main/UPGRADE.md#add-typestate-generic-types-to-client
-pub(crate) type Oauth2ClientWithPropertiesSet = Client<
+type Oauth2ClientWithPropertiesSet = Client<
     BasicErrorResponse,
     BasicTokenResponse,
     BasicTokenIntrospectionResponse,
@@ -333,7 +333,7 @@ pub(crate) type Oauth2ClientWithPropertiesSet = Client<
     EndpointSet,
 >;
 
-pub(crate) struct Oauth2Layer {
+struct Oauth2Layer {
     client: Oauth2ClientWithPropertiesSet,
     http_client: reqwest::Client,
     private_cookiejar_key: Key,
@@ -905,7 +905,7 @@ fn routes_with_auth_mode(
     ))
 }
 
-pub async fn web_auth_middleware_fn(
+async fn web_auth_middleware_fn(
     headers: HeaderMap,
     mut req: Request<AxumBody>,
     next: Next,
@@ -1228,7 +1228,7 @@ struct Index {
 
 impl Base for Index {}
 
-pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
+async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
     let request = tonic::Request::new(forgerpc::DpuAgentUpgradePolicyRequest { new_policy: None });
     use forgerpc::AgentUpgradePolicy::*;
     let agent_upgrade_policy = match state
@@ -1305,7 +1305,7 @@ pub async fn root(state: AxumState<Arc<Api>>) -> impl IntoResponse {
     (StatusCode::OK, Html(index.render().unwrap()))
 }
 
-pub async fn static_data(
+async fn static_data(
     _state: AxumState<Arc<Api>>,
     AxumPath(filename): AxumPath<String>,
 ) -> Response {
@@ -1334,7 +1334,7 @@ pub async fn static_data(
 }
 
 /// Creates a response that describes that `resource` was not found
-pub(crate) fn not_found_response(resource: String) -> Response {
+fn not_found_response(resource: String) -> Response {
     (
         StatusCode::NOT_FOUND,
         Html(format!("Not found: {resource}")),
@@ -1342,7 +1342,7 @@ pub(crate) fn not_found_response(resource: String) -> Response {
         .into_response()
 }
 
-pub(crate) fn invalid_machine_id() -> String {
+fn invalid_machine_id() -> String {
     "INVALID_MACHINE".to_string()
 }
 

--- a/crates/api-web/src/logs.rs
+++ b/crates/api-web/src/logs.rs
@@ -48,13 +48,13 @@ struct LogsPage {}
 impl Base for LogsPage {}
 
 /// `GET /admin/logs` — the unified live log viewer hub.
-pub async fn page() -> Html<String> {
+pub(super) async fn page() -> Html<String> {
     Html(LogsPage {}.render().unwrap())
 }
 
 /// Handle `GET /admin/logs/{source}/stream`, which opens up
 /// the Server-Sent Events stream of nico-api log lines.
-pub async fn stream(State(state): State<Arc<Api>>, Path(source): Path<String>) -> Response {
+pub(super) async fn stream(State(state): State<Arc<Api>>, Path(source): Path<String>) -> Response {
     if source != "api" {
         return (
             StatusCode::NOT_FOUND,
@@ -96,7 +96,7 @@ pub async fn stream(State(state): State<Arc<Api>>, Path(source): Path<String>) -
 
 /// Query parameters for the scrollback history endpoint.
 #[derive(serde::Deserialize)]
-pub struct HistoryQuery {
+pub(super) struct HistoryQuery {
     /// Return lines older than this `seq` cursor. Absent = newest page.
     before: Option<u64>,
     /// Max lines to return; clamped to `MAX_PAGE_SIZE`. Absent = `DEFAULT_PAGE_SIZE`.
@@ -106,7 +106,7 @@ pub struct HistoryQuery {
 /// `GET /admin/logs/{source}/history?before=<seq>&limit=<n>` — one page of
 /// buffered lines (oldest-first) for scrollback. With `before`, returns the
 /// page just older than that cursor; without it, the newest page.
-pub async fn history(
+pub(super) async fn history(
     State(state): State<Arc<Api>>,
     Path(source): Path<String>,
     Query(query): Query<HistoryQuery>,

--- a/crates/api-web/src/machine.rs
+++ b/crates/api-web/src/machine.rs
@@ -186,7 +186,7 @@ impl MachineRowDisplay {
     }
 }
 
-pub async fn show_hosts_html(
+pub(super) async fn show_hosts_html(
     state: AxumState<Arc<Api>>,
     query: Query<PaginationParams>,
     path: OriginalUri,
@@ -194,7 +194,7 @@ pub async fn show_hosts_html(
     show(state, true, false, query, path).await
 }
 
-pub async fn show_hosts_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_hosts_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let machines = match fetch_machines(state, false, true).await {
         Ok(r) => r,
         Err(err) => {
@@ -205,7 +205,7 @@ pub async fn show_hosts_json(AxumState(state): AxumState<Arc<Api>>) -> Response 
     (StatusCode::OK, Json(machines)).into_response()
 }
 
-pub async fn show_dpus_html(
+pub(super) async fn show_dpus_html(
     state: AxumState<Arc<Api>>,
     query: Query<PaginationParams>,
     path: OriginalUri,
@@ -213,7 +213,7 @@ pub async fn show_dpus_html(
     show(state, false, true, query, path).await
 }
 
-pub async fn show_dpus_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_dpus_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let mut machines = match fetch_machines(state, true, true).await {
         Ok(r) => r,
         Err(err) => {
@@ -228,7 +228,7 @@ pub async fn show_dpus_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
 }
 
 /// List machines
-pub async fn show_all_html(
+pub(super) async fn show_all_html(
     state: AxumState<Arc<Api>>,
     query: Query<PaginationParams>,
     path: OriginalUri,
@@ -236,7 +236,7 @@ pub async fn show_all_html(
     show(state, true, true, query, path).await
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let machines = match fetch_machines(state, true, true).await {
         Ok(r) => r,
         Err(err) => {
@@ -320,7 +320,7 @@ async fn show(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn fetch_machine(
+async fn fetch_machine(
     api: &Api,
     machine_id: MachineId,
 ) -> Result<::rpc::forge::Machine, Response> {
@@ -363,7 +363,7 @@ pub async fn fetch_machine(
 }
 
 /// Fetches Instance Type Names for the given Instance Type IDs
-pub async fn fetch_instance_type_names(
+async fn fetch_instance_type_names(
     api: &Api,
     instance_type_ids: Vec<String>,
 ) -> Result<HashMap<String, String>, Response> {
@@ -397,7 +397,7 @@ pub async fn fetch_instance_type_names(
     Ok(result)
 }
 
-pub async fn fetch_machines(
+pub(super) async fn fetch_machines(
     api: Arc<Api>,
     include_dpus: bool,
     include_history: bool,
@@ -809,13 +809,13 @@ struct MachineNvLinkGpuDisplay {
     guid: u64,
 }
 
-pub struct ValidationRun {
-    pub status: String,
-    pub context: String,
-    pub validation_id: String,
-    pub start_time: String,
-    pub end_time: String,
-    pub machine_id: String,
+pub(super) struct ValidationRun {
+    pub(super) status: String,
+    pub(super) context: String,
+    pub(super) validation_id: String,
+    pub(super) start_time: String,
+    pub(super) end_time: String,
+    pub(super) machine_id: String,
 }
 
 impl From<forgerpc::Machine> for MachineDetail<'_> {
@@ -1082,7 +1082,7 @@ impl From<forgerpc::Machine> for MachineDetail<'_> {
 }
 
 /// View machine
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     Query(params): Query<HashMap<String, String>>,
@@ -1247,20 +1247,20 @@ pub async fn detail(
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 
-pub fn get_machine_type(machine_id: &str) -> String {
+fn get_machine_type(machine_id: &str) -> String {
     MachineType::from_id_string(machine_id)
         .map(|t| t.to_string())
         .unwrap_or_else(|| "Unknown".to_string())
 }
 
 #[derive(Deserialize, Debug)]
-pub struct MaintenanceAction {
+pub(super) struct MaintenanceAction {
     action: String,
     reference: Option<String>,
 }
 
 /// Enter / Exit maintenance mode
-pub async fn maintenance(
+pub(super) async fn maintenance(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     Form(form): Form<MaintenanceAction>,
@@ -1307,14 +1307,14 @@ pub async fn maintenance(
 }
 
 #[derive(Deserialize, Debug)]
-pub struct QuarantineAction {
+pub(super) struct QuarantineAction {
     action: String,
     mode: Option<String>,
     reason: Option<String>,
 }
 
 /// Enter / Exit quarantine
-pub async fn quarantine(
+pub(super) async fn quarantine(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     Form(form): Form<QuarantineAction>,
@@ -1363,14 +1363,14 @@ pub async fn quarantine(
 }
 
 #[derive(Deserialize, Debug)]
-pub struct SkuAction {
+pub(super) struct SkuAction {
     action: String,
     sku_id: Option<String>,
     force: Option<String>,
 }
 
 /// Assign / Remove a SKU on a machine
-pub async fn sku(
+pub(super) async fn sku(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     Form(form): Form<SkuAction>,
@@ -1443,13 +1443,13 @@ pub async fn sku(
 /// Form fields for selecting one exact owned interface as the host's desired
 /// boot interface.
 #[derive(Deserialize, Debug)]
-pub struct SetDesiredBootInterfaceAction {
+pub(super) struct SetDesiredBootInterfaceAction {
     machine_interface_id: MachineInterfaceId,
 }
 
 /// Updates the host's primary and desired boot interface together. The API
 /// records the intent and leaves Redfish convergence to machine-controller.
-pub async fn set_desired_boot_interface(
+pub(super) async fn set_desired_boot_interface(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
     Form(form): Form<SetDesiredBootInterfaceAction>,
@@ -1500,7 +1500,7 @@ pub async fn set_desired_boot_interface(
 
 /// Requests another machine-controller pass for the persisted desired target
 /// without replacing it with the primary interface shown by the page.
-pub async fn reconcile_boot_interface(
+pub(super) async fn reconcile_boot_interface(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/machine_validation.rs
+++ b/crates/api-web/src/machine_validation.rs
@@ -193,7 +193,7 @@ impl From<forgerpc::MachineValidationExternalConfig> for ValidationExternalConfi
         }
     }
 }
-pub async fn results(
+pub(super) async fn results(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(validation_id): AxumPath<String>,
 ) -> Response {
@@ -251,7 +251,7 @@ pub async fn results(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn result_details(
+pub(super) async fn result_details(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath((validation_id, test_id)): AxumPath<(String, String)>,
 ) -> Response {
@@ -314,7 +314,7 @@ pub async fn result_details(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_tests_html(
+pub(super) async fn show_tests_html(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<PaginationParams>,
 ) -> Response {
@@ -341,7 +341,7 @@ pub async fn show_tests_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_tests_details_html(
+pub(super) async fn show_tests_details_html(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(test_id): AxumPath<String>,
 ) -> Response {
@@ -382,7 +382,7 @@ async fn fetch_validation_tests(
         .map(|response| response.into_inner().tests)
 }
 
-pub async fn runs(
+pub(super) async fn runs(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<PaginationParams>,
 ) -> Response {
@@ -429,7 +429,7 @@ pub async fn runs(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn external_configs(
+pub(super) async fn external_configs(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<PaginationParams>,
 ) -> Response {

--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -78,33 +78,32 @@ struct HostGroup {
 }
 
 #[derive(PartialEq, Eq)]
-pub struct ManagedHostRowDisplay {
-    pub machine_id: String,
-    pub state: String,
-    pub time_in_state: String,
-    pub time_in_state_above_sla: bool,
-    pub state_reason: String,
-    pub health_probe_alerts: Vec<health_report::HealthProbeAlert>,
-    pub health_sources: Vec<String>,
-    pub host_admin_ip: String,
-    pub host_admin_mac: String,
-    pub host_bmc_ip: String,
-    pub host_bmc_mac: String,
-    pub vendor: String,
-    pub model: String,
-    pub num_gpus: usize,
-    pub num_ib_ifs: usize,
-    pub host_memory: String,
-    pub is_link_ref: bool, // is maintenance_reference a URL?
-    pub maintenance_reference: String,
-    pub maintenance_start_time: String,
-    pub dpus: Vec<AttachedDpuRowDisplay>,
-    pub dpf_enabled: bool,
-    pub dpf_used_for_ingestion: bool,
+struct ManagedHostRowDisplay {
+    machine_id: String,
+    state: String,
+    time_in_state_above_sla: bool,
+    state_reason: String,
+    health_probe_alerts: Vec<health_report::HealthProbeAlert>,
+    health_sources: Vec<String>,
+    host_admin_ip: String,
+    host_admin_mac: String,
+    host_bmc_ip: String,
+    host_bmc_mac: String,
+    vendor: String,
+    model: String,
+    num_gpus: usize,
+    num_ib_ifs: usize,
+    host_memory: String,
+    is_link_ref: bool, // is maintenance_reference a URL?
+    maintenance_reference: String,
+    maintenance_start_time: String,
+    dpus: Vec<AttachedDpuRowDisplay>,
+    dpf_enabled: bool,
+    dpf_used_for_ingestion: bool,
 }
 
 impl ManagedHostRowDisplay {
-    pub(crate) fn from_snapshot(
+    fn from_snapshot(
         item: ManagedHostStateSnapshot,
         sla_config: &machine::slas::MachineSlaConfig,
     ) -> Self {
@@ -186,7 +185,6 @@ impl ManagedHostRowDisplay {
         Self {
             machine_id: host_snapshot.id.to_string(),
             state: host_snapshot.state.value.to_string(),
-            time_in_state: host_snapshot.state.version.since_state_change_humanized(),
             time_in_state_above_sla: machine::state_sla(
                 &host_snapshot.id,
                 &host_snapshot.state.value,
@@ -269,12 +267,12 @@ impl Ord for ManagedHostRowDisplay {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
-pub struct AttachedDpuRowDisplay {
-    pub machine_id: String,
-    pub bmc_ip: String,
-    pub bmc_mac: String,
-    pub oob_ip: String,
-    pub oob_mac: String,
+struct AttachedDpuRowDisplay {
+    machine_id: String,
+    bmc_ip: String,
+    bmc_mac: String,
+    oob_ip: String,
+    oob_mac: String,
 }
 
 enum DpuProperty {
@@ -411,7 +409,7 @@ impl ManagedHostRowDisplay {
 }
 
 /// List managed hosts
-pub async fn show_html(
+pub(super) async fn show_html(
     state: AxumState<Arc<Api>>,
     Query(mut params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -723,7 +721,7 @@ fn filter_expr(keys: &[GroupingKey], values: &[String]) -> String {
         .join("&")
 }
 
-pub async fn show_all_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(state: AxumState<Arc<Api>>) -> Response {
     let mut managed_hosts = match fetch_managed_hosts_with_metadata(state, true).await {
         Ok(m) => m,
         Err(err) => {
@@ -828,7 +826,7 @@ impl ActiveFilters<'_> {
 }
 
 /// View managed host details. This has been replaced by the Machine details page
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(_state): AxumState<Arc<Api>>,
     AxumPath(machine_id): AxumPath<String>,
 ) -> Response {
@@ -869,3 +867,98 @@ fn short_state(s: &str) -> &str {
 }
 
 impl super::Base for ManagedHostShow {}
+
+#[cfg(test)]
+mod tests {
+    use model::machine::LoadSnapshotOptions;
+
+    use super::ManagedHostRowDisplay;
+    use crate::tests::env::TestEnv;
+
+    // Test the ManagedHostRowDisplay as a proxy for testing that the HTML has what we want in
+    // managed_host::show_html (parsing the HTML string is prohibitive)
+    #[crate::sqlx_test]
+    async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
+        let env = TestEnv::new(pool).await;
+        let (mh, build_data) = env.create_ready_managed_host(2).await;
+        let hardware_info = mh.host.hardware_info();
+        let dpu_1 = mh.dpu(0);
+        let dpu_2 = mh.dpu(1);
+
+        // Get info from the test managed host so we know what to assert on in the
+        // ManagedHostRowDisplay.
+        let machine_id = mh.host.id;
+
+        let snapshots = db::managed_host::load_all(
+            &env.api().database_connection,
+            LoadSnapshotOptions {
+                include_history: false,
+                include_instance_data: false,
+                host_health_config: env.api().runtime_config.host_health,
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            snapshots.len(),
+            1,
+            "Unexpected number of managed host snapshots"
+        );
+
+        let snapshot = snapshots.into_iter().next().unwrap();
+        assert_eq!(snapshot.host_snapshot.id, machine_id);
+
+        let sla_config = model::machine::slas::MachineSlaConfig::new(
+            env.api()
+                .runtime_config
+                .machine_state_controller
+                .failure_retry_time,
+        );
+        let row = ManagedHostRowDisplay::from_snapshot(snapshot.clone(), &sla_config);
+
+        assert!(row.maintenance_start_time.is_empty());
+        assert!(row.maintenance_reference.is_empty());
+        assert_eq!(row.state, "Ready");
+        assert_eq!(row.num_ib_ifs, hardware_info.infiniband_interfaces.len());
+        assert_eq!(row.num_gpus, hardware_info.gpus.len(),);
+        assert!(!row.time_in_state_above_sla);
+        assert_eq!(row.host_bmc_ip, build_data.host_bmc_ip().to_string());
+        assert_eq!(row.host_bmc_mac, mh.host.bmc_mac.to_string());
+        assert_eq!(
+            row.vendor,
+            hardware_info.dmi_data.as_ref().unwrap().sys_vendor
+        );
+        assert_eq!(
+            row.model,
+            hardware_info.dmi_data.as_ref().unwrap().product_name
+        );
+        assert_eq!(row.machine_id, machine_id.to_string());
+        assert!(!row.health_sources.is_empty());
+        assert!(row.health_probe_alerts.is_empty());
+        assert!(!row.host_admin_ip.is_empty());
+        assert_eq!(row.host_admin_mac, mh.host.primary_mac().to_string());
+        assert!(row.state_reason.is_empty());
+
+        assert_eq!(row.dpus.len(), 2);
+
+        assert_eq!(
+            row.dpus[0].machine_id,
+            snapshot.dpu_snapshots[0].id.to_string()
+        );
+        assert_eq!(row.dpus[0].bmc_ip, build_data.dpu_bmc_ip(0).to_string());
+        assert_eq!(row.dpus[0].bmc_mac, dpu_1.bmc_mac.to_string());
+        assert_eq!(row.dpus[0].oob_mac, dpu_1.oob_mac().to_string());
+        assert!(!row.dpus[0].oob_ip.is_empty(), "dpu should show an oob ip");
+
+        assert_eq!(
+            row.dpus[1].machine_id,
+            snapshot.dpu_snapshots[1].id.to_string()
+        );
+        assert_eq!(row.dpus[1].bmc_ip, build_data.dpu_bmc_ip(1).to_string());
+        assert_eq!(row.dpus[1].bmc_mac, dpu_2.bmc_mac.to_string());
+        assert_eq!(row.dpus[1].oob_mac, dpu_2.oob_mac().to_string());
+        assert!(!row.dpus[1].oob_ip.is_empty(), "dpu should show an oob ip");
+
+        Ok(())
+    }
+}

--- a/crates/api-web/src/network_device.rs
+++ b/crates/api-web/src/network_device.rs
@@ -78,7 +78,7 @@ struct ConnectedDPU {
 }
 
 /// List network devices
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let network_devices = match fetch_network_devices(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -98,7 +98,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let network_devices = match fetch_network_devices(state).await {
         Ok(m) => m,
         Err(err) => {

--- a/crates/api-web/src/network_security_group.rs
+++ b/crates/api-web/src/network_security_group.rs
@@ -107,7 +107,7 @@ struct NetworkSecurityGroupDetailDisplay {
 /// Struct for deserializing a request to view
 /// existing NSGs
 #[derive(Deserialize, Debug)]
-pub struct ShowNetworkSecurityGroupParams {
+pub(super) struct ShowNetworkSecurityGroupParams {
     #[serde(default, deserialize_with = "empty_string_as_none")]
     limit: Option<usize>,
     #[serde(default, deserialize_with = "empty_string_as_none")]
@@ -115,7 +115,7 @@ pub struct ShowNetworkSecurityGroupParams {
 }
 
 /// Handler for displaying all network security groups
-pub async fn show(
+pub(super) async fn show(
     AxumState(api): AxumState<Arc<Api>>,
     Query(params): Query<ShowNetworkSecurityGroupParams>,
     path: OriginalUri,
@@ -220,7 +220,7 @@ async fn fetch_network_security_groups(
 /// It will include some extra details like any objects
 /// that are using the NSG and propagation status for those
 /// objects.
-pub async fn show_detail(
+pub(super) async fn show_detail(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(network_security_group_id): AxumPath<String>,
 ) -> Response {
@@ -385,7 +385,7 @@ pub async fn show_detail(
 /// Struct for deserializing a request to create
 /// a new NSG
 #[derive(Deserialize, Debug)]
-pub struct CreateNetworkSecurityGroupForm {
+pub(super) struct CreateNetworkSecurityGroupForm {
     id: String,
     tenant_organization_id: String,
     name: String,
@@ -396,7 +396,7 @@ pub struct CreateNetworkSecurityGroupForm {
 }
 
 // Handler to create a new NSG
-pub async fn create(
+pub(super) async fn create(
     AxumState(api): AxumState<Arc<Api>>,
     Form(form): Form<CreateNetworkSecurityGroupForm>,
 ) -> Response {
@@ -477,7 +477,7 @@ pub async fn create(
 /// Struct for deserializing a request to update
 /// an existing NSG
 #[derive(Deserialize, Debug)]
-pub struct UpdateNetworkSecurityGroupForm {
+pub(super) struct UpdateNetworkSecurityGroupForm {
     tenant_organization_id: String,
     name: String,
     stateful_egress: Option<bool>,
@@ -489,7 +489,7 @@ pub struct UpdateNetworkSecurityGroupForm {
 }
 
 // Handler for updating an existing NSG
-pub async fn update(
+pub(super) async fn update(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(network_security_group_id): AxumPath<String>,
     Form(form): Form<UpdateNetworkSecurityGroupForm>,
@@ -569,12 +569,12 @@ pub async fn update(
 /// Struct for deserializing a request to delete
 /// an existing NSG
 #[derive(Deserialize, Debug)]
-pub struct DeleteNetworkSecurityGroupForm {
+pub(super) struct DeleteNetworkSecurityGroupForm {
     tenant_organization_id: String,
 }
 
 // Handler for deleting an existing NSG
-pub async fn delete(
+pub(super) async fn delete(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(network_security_group_id): AxumPath<String>,
     Form(form): Form<DeleteNetworkSecurityGroupForm>,

--- a/crates/api-web/src/network_segment.rs
+++ b/crates/api-web/src/network_segment.rs
@@ -89,7 +89,7 @@ impl TryFrom<forgerpc::NetworkSegment> for NetworkSegmentRowDisplay {
 }
 
 /// List network segments
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let networks = match fetch_network_segments(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -145,7 +145,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let networks = match fetch_network_segments(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -316,7 +316,7 @@ impl TryFrom<forgerpc::NetworkSegment> for NetworkSegmentDetail {
 }
 
 /// View networks segment details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(segment_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/network_status.rs
+++ b/crates/api-web/src/network_status.rs
@@ -66,7 +66,7 @@ struct NetworkStatusDisplay {
     is_agent_updated: bool,
 }
 
-pub async fn show_html(
+pub(super) async fn show_html(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Response {
@@ -147,7 +147,7 @@ pub async fn show_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(
+pub(super) async fn show_all_json(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Response {

--- a/crates/api-web/src/nmxc_browser.rs
+++ b/crates/api-web/src/nmxc_browser.rs
@@ -46,7 +46,7 @@ struct Header {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct QueryParams {
+pub(super) struct QueryParams {
     chassis_serial: Option<String>,
     operation: Option<String>,
     gpu_uid: Option<String>,
@@ -65,7 +65,7 @@ fn browse_operation_from_query(s: &str) -> i32 {
 }
 
 /// Runs a selected NMX-C browse operation against the endpoint mapped for `chassis_serial`.
-pub async fn query(
+pub(super) async fn query(
     AxumState(state): AxumState<Arc<Api>>,
     AxumQuery(query): AxumQuery<QueryParams>,
 ) -> Response {

--- a/crates/api-web/src/nvlink.rs
+++ b/crates/api-web/src/nvlink.rs
@@ -185,7 +185,7 @@ impl From<ShowLogicalPartition> for LogicalPartitionDetail {
 }
 
 /// List logical partitions
-pub async fn show_nvlink_logical_partitions_html(
+pub(super) async fn show_nvlink_logical_partitions_html(
     AxumState(state): AxumState<Arc<Api>>,
 ) -> Response {
     let partitions = match fetch_logical_partitions(state.clone(), false, None).await {
@@ -206,7 +206,7 @@ pub async fn show_nvlink_logical_partitions_html(
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_nvlink_logical_partitions_json(
+pub(super) async fn show_nvlink_logical_partitions_json(
     AxumState(state): AxumState<Arc<Api>>,
 ) -> impl IntoResponse {
     let partitions = match fetch_logical_partitions(state, false, None).await {
@@ -224,7 +224,7 @@ pub async fn show_nvlink_logical_partitions_json(
 }
 
 /// List NVLink domains with health reports.
-pub async fn show_nvlink_domain_health_html(
+pub(super) async fn show_nvlink_domain_health_html(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<NvLinkDomainHealthParams>,
     uri: OriginalUri,
@@ -268,7 +268,9 @@ pub async fn show_nvlink_domain_health_html(
 }
 
 /// List NVLink domains with health reports as JSON.
-pub async fn show_nvlink_domain_health_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_nvlink_domain_health_json(
+    AxumState(state): AxumState<Arc<Api>>,
+) -> Response {
     let rows = match fetch_nvlink_domain_health_rows(&state).await {
         Ok(rows) => rows,
         Err(err) => {
@@ -285,7 +287,7 @@ pub async fn show_nvlink_domain_health_json(AxumState(state): AxumState<Arc<Api>
 }
 
 /// View Logical Partition details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(partition_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/operating_system.rs
+++ b/crates/api-web/src/operating_system.rs
@@ -73,7 +73,7 @@ impl From<&forgerpc::OperatingSystem> for OsRowDisplay {
     }
 }
 
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let oss = match fetch_operating_systems(state).await {
         Ok(v) => v,
         Err(err) => {
@@ -92,7 +92,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let mut oss = match fetch_operating_systems(state).await {
         Ok(v) => v,
         Err(err) => {
@@ -229,7 +229,7 @@ impl From<forgerpc::OperatingSystem> for OsDetail {
     }
 }
 
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(os_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/pagination.rs
+++ b/crates/api-web/src/pagination.rs
@@ -21,11 +21,11 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, de};
 
-pub const DEFAULT_PAGE_RECORD_LIMIT: usize = 50;
+const DEFAULT_PAGE_RECORD_LIMIT: usize = 50;
 const MAX_PAGE_RECORD_LIMIT: usize = 100;
 
 /// Serde deserialization decorator to map empty Strings to None.
-pub fn empty_string_as_none<'de, D, T>(de: D) -> Result<Option<T>, D::Error>
+pub(super) fn empty_string_as_none<'de, D, T>(de: D) -> Result<Option<T>, D::Error>
 where
     D: Deserializer<'de>,
     T: FromStr,
@@ -39,21 +39,21 @@ where
 }
 
 #[derive(Deserialize, Debug, Default)]
-pub struct PaginationParams {
+pub(super) struct PaginationParams {
     #[serde(default, deserialize_with = "empty_string_as_none")]
-    pub limit: Option<usize>,
+    pub(super) limit: Option<usize>,
     #[serde(default, deserialize_with = "empty_string_as_none")]
-    pub current_page: Option<usize>,
+    pub(super) current_page: Option<usize>,
 }
 
-pub struct PaginationInfo {
-    pub current_page: usize,
-    pub limit: usize,
-    pub total_items: usize,
+pub(super) struct PaginationInfo {
+    current_page: usize,
+    limit: usize,
+    total_items: usize,
 }
 
 impl PaginationInfo {
-    pub fn pages(&self) -> usize {
+    fn pages(&self) -> usize {
         if self.limit == 0 {
             if self.total_items == 0 { 0 } else { 1 }
         } else {
@@ -61,33 +61,33 @@ impl PaginationInfo {
         }
     }
 
-    pub fn previous(&self) -> usize {
+    fn previous(&self) -> usize {
         self.current_page.saturating_sub(1)
     }
 
-    pub fn next(&self) -> usize {
+    fn next(&self) -> usize {
         self.current_page.saturating_add(1)
     }
 
-    pub fn page_range_start(&self) -> usize {
+    fn page_range_start(&self) -> usize {
         self.current_page.saturating_sub(3)
     }
 
-    pub fn page_range_end(&self) -> usize {
+    fn page_range_end(&self) -> usize {
         min(self.current_page.saturating_add(4), self.pages())
     }
 }
 
 /// Shared pagination context for Askama templates. Embeds `PaginationInfo` and
 /// adds the URL path and extra query parameters needed to render page links.
-pub struct PageContext {
+pub(super) struct PageContext {
     info: PaginationInfo,
-    pub path: String,
-    pub extra_query_params: String,
+    pub(super) path: String,
+    pub(super) extra_query_params: String,
 }
 
 impl PageContext {
-    pub fn new(info: PaginationInfo, path: impl Into<String>) -> Self {
+    pub(super) fn new(info: PaginationInfo, path: impl Into<String>) -> Self {
         Self {
             info,
             path: path.into(),
@@ -97,7 +97,7 @@ impl PageContext {
 
     /// Create a PageContext from a pre-computed page count (for handlers that
     /// perform database-level pagination and don't know the total item count).
-    pub fn from_page_count(
+    pub(super) fn from_page_count(
         current_page: usize,
         limit: usize,
         pages: usize,
@@ -117,7 +117,7 @@ impl PageContext {
     /// Create a PageContext representing the "show all" view: a single page
     /// holding every item. Used by handlers that opt into the `limit=0` "All"
     /// pagination option and already know the total item count.
-    pub fn all(total_items: usize, path: impl Into<String>) -> Self {
+    pub(super) fn all(total_items: usize, path: impl Into<String>) -> Self {
         Self {
             info: PaginationInfo {
                 current_page: 0,
@@ -129,40 +129,40 @@ impl PageContext {
         }
     }
 
-    pub fn with_extra_params(mut self, extra: String) -> Self {
+    pub(super) fn with_extra_params(mut self, extra: String) -> Self {
         self.extra_query_params = extra;
         self
     }
 
-    pub fn current_page(&self) -> usize {
+    pub(super) fn current_page(&self) -> usize {
         self.info.current_page
     }
 
-    pub fn limit(&self) -> usize {
+    pub(super) fn limit(&self) -> usize {
         self.info.limit
     }
 
-    pub fn total_items(&self) -> usize {
+    pub(super) fn total_items(&self) -> usize {
         self.info.total_items
     }
 
-    pub fn pages(&self) -> usize {
+    pub(super) fn pages(&self) -> usize {
         self.info.pages()
     }
 
-    pub fn previous(&self) -> usize {
+    pub(super) fn previous(&self) -> usize {
         self.info.previous()
     }
 
-    pub fn next(&self) -> usize {
+    pub(super) fn next(&self) -> usize {
         self.info.next()
     }
 
-    pub fn page_range_start(&self) -> usize {
+    pub(super) fn page_range_start(&self) -> usize {
         self.info.page_range_start()
     }
 
-    pub fn page_range_end(&self) -> usize {
+    pub(super) fn page_range_end(&self) -> usize {
         self.info.page_range_end()
     }
 }
@@ -178,7 +178,10 @@ fn resolve_params(params: &PaginationParams) -> (usize, usize) {
 
 /// Paginate an already-collected Vec (e.g. after in-memory filtering).
 /// Drains elements outside the page window so only the current page remains.
-pub fn paginate_vec<T>(items: Vec<T>, params: &PaginationParams) -> (PaginationInfo, Vec<T>) {
+pub(super) fn paginate_vec<T>(
+    items: Vec<T>,
+    params: &PaginationParams,
+) -> (PaginationInfo, Vec<T>) {
     let (current_page, limit) = resolve_params(params);
     let total_items = items.len();
     let info = PaginationInfo {

--- a/crates/api-web/src/power_shelf.rs
+++ b/crates/api-web/src/power_shelf.rs
@@ -46,7 +46,7 @@ struct PowerShelfRecord {
 }
 
 /// Show all power shelves
-pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let power_shelves = match fetch_power_shelves(&state).await {
         Ok(shelves) => shelves,
         Err(err) => {
@@ -89,7 +89,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
 }
 
 /// Show all power shelves as JSON
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let power_shelves = match fetch_power_shelves(&state).await {
         Ok(shelves) => shelves,
         Err(err) => {
@@ -172,7 +172,7 @@ impl PowerShelfDetail {
 }
 
 /// View details about a Power Shelf.
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(power_shelf_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/rack.rs
+++ b/crates/api-web/src/rack.rs
@@ -70,7 +70,7 @@ struct RackDetail {
 }
 
 /// Show all racks
-pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_racks(&state).await {
         Ok(racks) => racks,
         Err(err) => {
@@ -86,7 +86,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
 }
 
 /// Show all racks as JSON
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let racks = match fetch_racks(&state).await {
         Ok(racks) => racks,
         Err(err) => {
@@ -97,7 +97,7 @@ pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Json(racks)).into_response()
 }
 
-pub async fn fetch_racks(api: &Api) -> Result<rpc::forge::RackList, tonic::Status> {
+async fn fetch_racks(api: &Api) -> Result<rpc::forge::RackList, tonic::Status> {
     let request = tonic::Request::new(rpc::forge::RackSearchFilter::default());
 
     let rack_ids = api.find_rack_ids(request).await?.into_inner().rack_ids;
@@ -122,10 +122,7 @@ pub async fn fetch_racks(api: &Api) -> Result<rpc::forge::RackList, tonic::Statu
     Ok(rpc::forge::RackList { racks })
 }
 
-pub async fn fetch_rack(
-    api: &Api,
-    rack_id: &RackId,
-) -> Result<Option<::rpc::forge::Rack>, Response> {
+async fn fetch_rack(api: &Api, rack_id: &RackId) -> Result<Option<::rpc::forge::Rack>, Response> {
     let request = tonic::Request::new(rpc::forge::RacksByIdsRequest {
         rack_ids: vec![rack_id.clone()],
     });
@@ -159,7 +156,7 @@ pub async fn fetch_rack(
 }
 
 /// View details about a Rack
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(rack_id): AxumPath<String>,
     Query(_params): Query<HashMap<String, String>>,
@@ -264,10 +261,7 @@ pub async fn detail(
     (StatusCode::OK, Html(display.render().unwrap())).into_response()
 }
 
-pub async fn fetch_machine_ids(
-    api: Arc<Api>,
-    rack_id: RackId,
-) -> Result<Vec<String>, tonic::Status> {
+async fn fetch_machine_ids(api: Arc<Api>, rack_id: RackId) -> Result<Vec<String>, tonic::Status> {
     let request = tonic::Request::new(rpc::forge::MachineSearchConfig {
         include_predicted_host: true,
         rack_id: Some(rack_id.clone()),

--- a/crates/api-web/src/redfish_actions.rs
+++ b/crates/api-web/src/redfish_actions.rs
@@ -41,15 +41,15 @@ struct RedfishBrowser {
 
 #[derive(Template)]
 #[template(path = "redfish_actions_table.html")]
-pub struct RedfishActionsTable {
-    pub action_requests: Vec<RedfishAction>,
-    pub required_approvals: usize,
-    pub current_user_name: Option<String>,
+pub(super) struct RedfishActionsTable {
+    pub(super) action_requests: Vec<RedfishAction>,
+    pub(super) required_approvals: usize,
+    pub(super) current_user_name: Option<String>,
 }
 
 /// Queries the redfish endpoint in the query parameter
 /// and displays the result
-pub async fn query(
+pub(super) async fn query(
     AxumState(state): AxumState<Arc<Api>>,
     Extension(oauth2_layer): Extension<Option<Arc<Oauth2Layer>>>,
     request_headers: HeaderMap,
@@ -89,14 +89,14 @@ pub async fn query(
 }
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct ActionRequest {
+pub(super) struct ActionRequest {
     ips: Vec<String>,
     target: String,
     action: String,
     parameters: String,
 }
 
-pub async fn create(
+pub(super) async fn create(
     AxumState(state): AxumState<Arc<Api>>,
     Extension(auth_context): Extension<AuthContext>,
     Json(payload): Json<ActionRequest>,
@@ -120,7 +120,7 @@ pub async fn create(
     (StatusCode::OK, "successfully inserted request").into_response()
 }
 
-pub async fn approve(
+pub(super) async fn approve(
     AxumState(state): AxumState<Arc<Api>>,
     Extension(auth_context): Extension<AuthContext>,
     request_id: String,
@@ -150,7 +150,7 @@ pub async fn approve(
     (StatusCode::OK, "successfully approved request").into_response()
 }
 
-pub async fn apply(
+pub(super) async fn apply(
     AxumState(state): AxumState<Arc<Api>>,
     Extension(auth_context): Extension<AuthContext>,
     request_id: String,
@@ -180,7 +180,7 @@ pub async fn apply(
     (StatusCode::OK, "successfully applied request").into_response()
 }
 
-pub async fn cancel(AxumState(state): AxumState<Arc<Api>>, request_id: String) -> Response {
+pub(super) async fn cancel(AxumState(state): AxumState<Arc<Api>>, request_id: String) -> Response {
     let request = tonic::Request::new(rpc::forge::RedfishActionId {
         request_id: match request_id.parse() {
             Ok(v) => v,
@@ -204,22 +204,25 @@ pub async fn cancel(AxumState(state): AxumState<Arc<Api>>, request_id: String) -
     (StatusCode::OK, "successfully cancelled request").into_response()
 }
 
-pub mod filters {
+mod filters {
     use std::fmt::Write;
 
     use askama_escape::Escaper;
     use itertools::Itertools;
     use rpc::forge::OptionalRedfishActionResult;
 
-    pub use super::super::filters::pretty_json;
+    pub(super) use super::super::filters::pretty_json;
 
     #[askama::filter_fn]
-    pub fn date_fmt(value: &rpc::Timestamp, _env: &dyn askama::Values) -> ::askama::Result<String> {
+    pub(super) fn date_fmt(
+        value: &rpc::Timestamp,
+        _env: &dyn askama::Values,
+    ) -> ::askama::Result<String> {
         super::date_fmt_inner(value)
     }
 
     #[askama::filter_fn]
-    pub fn machine_ips_fmt(
+    pub(super) fn machine_ips_fmt(
         values: &[String],
         _env: &dyn askama::Values,
     ) -> ::askama::Result<String> {
@@ -242,7 +245,7 @@ pub mod filters {
     }
 
     #[askama::filter_fn]
-    pub fn contains_name(
+    pub(super) fn contains_name(
         approvals: &[String],
         _env: &dyn askama::Values,
         name: &str,
@@ -251,7 +254,7 @@ pub mod filters {
     }
 
     #[askama::filter_fn]
-    pub fn to_json(
+    pub(super) fn to_json(
         values: &[OptionalRedfishActionResult],
         _env: &dyn askama::Values,
     ) -> ::askama::Result<Vec<String>> {
@@ -286,7 +289,7 @@ pub mod filters {
     }
 }
 
-pub fn date_fmt_inner(value: &rpc::Timestamp) -> ::askama::Result<String> {
+fn date_fmt_inner(value: &rpc::Timestamp) -> ::askama::Result<String> {
     Ok(to_time::<String>(Some(*value), None).unwrap_or_default())
 }
 

--- a/crates/api-web/src/redfish_browser.rs
+++ b/crates/api-web/src/redfish_browser.rs
@@ -59,7 +59,7 @@ struct Header {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct QueryParams {
+pub(super) struct QueryParams {
     url: Option<String>,
 }
 
@@ -81,7 +81,7 @@ fn bmc_base_url(uri: &http::Uri, bmc_ip: IpAddr) -> Result<String, http::uri::In
 
 /// Queries the redfish endpoint in the query parameter
 /// and displays the result
-pub async fn query(
+pub(super) async fn query(
     AxumState(state): AxumState<Arc<Api>>,
     AxumQuery(query): AxumQuery<QueryParams>,
     Extension(oauth2_layer): Extension<Option<Arc<Oauth2Layer>>>,
@@ -244,8 +244,8 @@ async fn find_machine_id(
     Ok(None)
 }
 
-pub mod filters {
-    pub use super::super::filters::*;
+mod filters {
+    pub(super) use super::super::filters::*;
 }
 
 impl super::Base for RedfishBrowser {}

--- a/crates/api-web/src/resource_pool.rs
+++ b/crates/api-web/src/resource_pool.rs
@@ -29,7 +29,7 @@ use super::Base;
 
 mod filters {
     #[askama::filter_fn]
-    pub fn resource_pool_allocated_fmt(
+    pub(super) fn resource_pool_allocated_fmt(
         pool: &super::forgerpc::ResourcePool,
         _env: &dyn askama::Values,
     ) -> askama::Result<String> {
@@ -50,7 +50,7 @@ struct ResourcePoolShow {
 }
 
 /// List resource pools
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let pools = match fetch_resource_pools(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -66,7 +66,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_resource_pools(state).await {
         Ok(m) => m,
         Err(err) => {

--- a/crates/api-web/src/search.rs
+++ b/crates/api-web/src/search.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 use super::Base;
 
-pub async fn find(
+pub(super) async fn find(
     AxumState(state): AxumState<Arc<Api>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Response {

--- a/crates/api-web/src/site_explorer_run_status.rs
+++ b/crates/api-web/src/site_explorer_run_status.rs
@@ -30,18 +30,18 @@ fn display_error(run: &SiteExplorerLastRun) -> String {
     }
 }
 
-pub(crate) struct SiteExplorerLastRunDisplay {
-    pub(crate) status_label: &'static str,
-    pub(crate) status_class: &'static str,
-    pub(crate) started_at: String,
-    pub(crate) finished_at: String,
-    pub(crate) endpoint_explorations: i64,
-    pub(crate) endpoint_explorations_success: i64,
-    pub(crate) endpoint_explorations_failed: i64,
-    pub(crate) failure_category: String,
-    pub(crate) last_successful_finished_at: String,
-    pub(crate) last_failed_finished_at: String,
-    pub(crate) error: String,
+pub(super) struct SiteExplorerLastRunDisplay {
+    pub(super) status_label: &'static str,
+    pub(super) status_class: &'static str,
+    pub(super) started_at: String,
+    pub(super) finished_at: String,
+    pub(super) endpoint_explorations: i64,
+    pub(super) endpoint_explorations_success: i64,
+    pub(super) endpoint_explorations_failed: i64,
+    pub(super) failure_category: String,
+    pub(super) last_successful_finished_at: String,
+    pub(super) last_failed_finished_at: String,
+    pub(super) error: String,
 }
 
 impl From<&SiteExplorerLastRun> for SiteExplorerLastRunDisplay {

--- a/crates/api-web/src/sku.rs
+++ b/crates/api-web/src/sku.rs
@@ -85,7 +85,7 @@ impl From<forgerpc::Sku> for SkuRowDisplay {
 }
 
 /// List SKUs
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let skus = match fetch_skus(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -100,7 +100,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let skus = match fetch_skus(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -171,7 +171,7 @@ impl From<forgerpc::Sku> for SkuDetail {
 }
 
 /// View SKU details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(sku_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/spx_partition.rs
+++ b/crates/api-web/src/spx_partition.rs
@@ -57,7 +57,7 @@ impl From<forgerpc::SpxPartition> for SpxPartitionRowDisplay {
 }
 
 /// List partitions
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_spx_partitions(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -76,7 +76,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let partitions = match fetch_spx_partitions(state).await {
         Ok(n) => n,
         Err(err) => {

--- a/crates/api-web/src/state_history.rs
+++ b/crates/api-web/src/state_history.rs
@@ -37,26 +37,26 @@ use super::{Base, filters};
 
 #[derive(Template)]
 #[template(path = "state_history.html")]
-pub(super) struct StateHistory {
-    pub id: String,
+struct StateHistory {
+    id: String,
     /// The type of object that the history is for in humand readable
     /// form. E.g. Host, Switch, PowerShelf, etc.
-    pub object_type: String,
+    object_type: String,
     /// The base URL that is used for this type of object. E.g. `machine`
-    pub object_url_path: String,
-    pub history: StateHistoryTable,
+    object_url_path: String,
+    history: StateHistoryTable,
 }
 
 #[derive(Template)]
 #[template(path = "state_history_table.html")]
 pub(super) struct StateHistoryTable {
-    pub records: Vec<StateHistoryRecord>,
+    pub(super) records: Vec<StateHistoryRecord>,
 }
 
 #[derive(Debug, serde::Serialize)]
 pub(super) struct StateHistoryRecord {
-    pub state: String,
-    pub version: String,
+    state: String,
+    version: String,
 }
 
 impl From<::rpc::forge::MachineEvent> for StateHistoryRecord {
@@ -91,7 +91,7 @@ macro_rules! define_show_state_history_handlers {
         // Path segment after "admin/", e.g. "machine" or "power-shelf"
         object_url_path = $object_url_path:literal,
     ) => {
-        pub async fn $fn_name(
+        pub(super) async fn $fn_name(
             AxumState(state): AxumState<Arc<Api>>,
             AxumPath(id): AxumPath<String>,
         ) -> Response {
@@ -112,7 +112,7 @@ macro_rules! define_show_state_history_handlers {
             (StatusCode::OK, Html(display.render().unwrap())).into_response()
         }
 
-        pub async fn $fn_name_json(
+        pub(super) async fn $fn_name_json(
             AxumState(state): AxumState<Arc<Api>>,
             AxumPath(id): AxumPath<String>,
         ) -> Response {
@@ -128,7 +128,7 @@ macro_rules! define_show_state_history_handlers {
 macro_rules! define_fetch_state_history_records {
     (
         // name of the generated function
-        $fn_name:ident,
+        $visibility:vis $fn_name:ident,
         // type of the ID (MachineId, SwitchId, ...)
         id_type = $Id:ty,
         // canonical structured log field for this ID type
@@ -143,7 +143,7 @@ macro_rules! define_fetch_state_history_records {
         record_type = $Record:ty,
     ) => {
         /// Fetches state history records for object with ID `id_str`
-        pub async fn $fn_name(
+        $visibility async fn $fn_name(
             api: &Api,
             id_str: &str,
         ) -> Result<($Id, Vec<$Record>), (http::StatusCode, String)> {
@@ -201,7 +201,7 @@ define_fetch_state_history_records!(
 );
 
 define_fetch_state_history_records!(
-    fetch_power_shelf_state_history_records,
+    pub(super) fetch_power_shelf_state_history_records,
     id_type = PowerShelfId,
     id_log_field = power_shelf_id,
     id_vec_field = power_shelf_ids,
@@ -211,7 +211,7 @@ define_fetch_state_history_records!(
 );
 
 define_fetch_state_history_records!(
-    fetch_rack_state_history_records,
+    pub(super) fetch_rack_state_history_records,
     id_type = RackId,
     id_log_field = rack_id,
     id_vec_field = rack_ids,
@@ -221,7 +221,7 @@ define_fetch_state_history_records!(
 );
 
 define_fetch_state_history_records!(
-    fetch_switch_state_history_records,
+    pub(super) fetch_switch_state_history_records,
     id_type = SwitchId,
     id_log_field = switch_id,
     id_vec_field = switch_ids,

--- a/crates/api-web/src/switch.rs
+++ b/crates/api-web/src/switch.rs
@@ -46,7 +46,7 @@ struct SwitchRecord {
 }
 
 /// Show all switches
-pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(state: AxumState<Arc<Api>>) -> Response {
     let switches = match fetch_switches(&state).await {
         Ok(switches) => switches,
         Err(err) => {
@@ -89,7 +89,7 @@ pub async fn show_html(state: AxumState<Arc<Api>>) -> Response {
 }
 
 /// Show all switches as JSON
-pub async fn show_json(state: AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_json(state: AxumState<Arc<Api>>) -> Response {
     let switches = match fetch_switches(&state).await {
         Ok(switches) => switches,
         Err(err) => {
@@ -206,7 +206,7 @@ impl SwitchDetail {
 }
 
 /// View details about a Switch.
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(api): AxumState<Arc<Api>>,
     AxumPath(switch_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/tenant.rs
+++ b/crates/api-web/src/tenant.rs
@@ -53,7 +53,7 @@ impl From<forgerpc::Tenant> for TenantDisplay {
 }
 
 /// List tenants
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_tenants(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -68,7 +68,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out: forgerpc::TenantList = match fetch_tenants(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -135,7 +135,7 @@ impl From<forgerpc::Tenant> for TenantDetail {
 }
 
 /// View tenant
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(organization_id): AxumPath<String>,
 ) -> Response {

--- a/crates/api-web/src/tenant_keyset.rs
+++ b/crates/api-web/src/tenant_keyset.rs
@@ -68,7 +68,7 @@ impl From<forgerpc::TenantKeyset> for KeysetDisplay {
 }
 
 /// List tenants
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out = match fetch_keysets(state).await {
         Ok(m) => m,
         Err(err) => {
@@ -83,7 +83,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let out: forgerpc::TenantKeySetList = match fetch_keysets(state).await {
         Ok(ks) => ks,
         Err(err) => {
@@ -159,7 +159,7 @@ impl From<forgerpc::TenantKeyset> for TenantKeysetDetail {
 }
 
 /// View keyset
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath((organization_id, keyset_id)): AxumPath<(String, String)>,
 ) -> Response {

--- a/crates/api-web/src/tests/env.rs
+++ b/crates/api-web/src/tests/env.rs
@@ -26,9 +26,9 @@ use carbide_test_harness::network::segment::TestNetworkSegment;
 use carbide_test_harness::prelude::*;
 use model::test_support::ManagedHostConfig;
 
-pub struct TestEnv {
-    pub test_harness: TestHarness,
-    pub redfish_sim: Arc<RedfishSim>,
+pub(crate) struct TestEnv {
+    pub(super) test_harness: TestHarness,
+    pub(super) redfish_sim: Arc<RedfishSim>,
     site_explorer: TestSiteExplorer,
     domain: TestDomain,
     underlay_segment: TestNetworkSegment,
@@ -36,7 +36,7 @@ pub struct TestEnv {
 }
 
 impl TestEnv {
-    pub async fn new(pool: PgPool) -> Self {
+    pub(crate) async fn new(pool: PgPool) -> Self {
         let redfish_sim = Arc::new(RedfishSim::default());
         let redfish_pool = Arc::clone(&redfish_sim);
         let test_harness = TestHarness::builder(pool)
@@ -64,15 +64,15 @@ impl TestEnv {
         }
     }
 
-    pub fn api(&self) -> &Api {
+    pub(crate) fn api(&self) -> &Api {
         self.test_harness.api()
     }
 
-    pub fn domain(&self) -> &TestDomain {
+    pub(super) fn domain(&self) -> &TestDomain {
         &self.domain
     }
 
-    pub async fn create_ready_managed_host(
+    pub(crate) async fn create_ready_managed_host(
         &self,
         dpu_count: usize,
     ) -> (TestManagedHost, TestManagedHostBuildData) {

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -21,17 +21,16 @@ use axum::response::Response;
 use carbide_rpc_utils::ManagedHostOutput;
 use carbide_test_harness::TestMachine as _;
 use carbide_uuid::machine::{MachineId, MachineInterfaceId};
-use db::{machine, managed_host};
+use db::machine;
 use health_report::{
     HealthAlertClassification, HealthProbeAlert, HealthProbeId, HealthReport, HealthReportApplyMode,
 };
 use http_body_util::BodyExt;
 use hyper::http::header::CONTENT_TYPE;
 use hyper::http::{Method, StatusCode};
-use model::machine::{InstanceState, LoadSnapshotOptions, ManagedHostState, RetryInfo};
+use model::machine::{InstanceState, ManagedHostState, RetryInfo};
 use tower::ServiceExt;
 
-use crate::managed_host::ManagedHostRowDisplay;
 use crate::tests::env::TestEnv;
 use crate::tests::{make_test_app, web_request_builder};
 
@@ -418,93 +417,6 @@ async fn test_multi_dpu(pool: sqlx::PgPool) {
             "DPU should not have the same machine ID as the host"
         );
     }
-}
-
-// Test the ManagedHostRowDisplay as a proxy for testing that the HTML has what we want in
-// managed_host::show_html (parsing the HTML string is prohibitive)
-#[crate::sqlx_test]
-async fn test_managed_host_row_display(pool: sqlx::PgPool) -> eyre::Result<()> {
-    let env = TestEnv::new(pool).await;
-    let (mh, build_data) = env.create_ready_managed_host(2).await;
-    let hardware_info = mh.host.hardware_info();
-    let dpu_1 = mh.dpu(0);
-    let dpu_2 = mh.dpu(1);
-
-    // Get info from the test managed host so we know what to assert on in the ManagedHostRowDisplay.
-    let machine_id = mh.host.id;
-
-    let snapshots = managed_host::load_all(
-        &env.api().database_connection,
-        LoadSnapshotOptions {
-            include_history: false,
-            include_instance_data: false,
-            host_health_config: env.api().runtime_config.host_health,
-        },
-    )
-    .await?;
-
-    assert_eq!(
-        snapshots.len(),
-        1,
-        "Unexpected number of managed host snapshots"
-    );
-
-    let snapshot = snapshots.into_iter().next().unwrap();
-    assert_eq!(snapshot.host_snapshot.id, machine_id);
-
-    let sla_config = model::machine::slas::MachineSlaConfig::new(
-        env.api()
-            .runtime_config
-            .machine_state_controller
-            .failure_retry_time,
-    );
-    let row = ManagedHostRowDisplay::from_snapshot(snapshot.clone(), &sla_config);
-
-    assert!(row.maintenance_start_time.is_empty());
-    assert!(row.maintenance_reference.is_empty());
-    assert_eq!(row.state, "Ready");
-    assert_eq!(row.num_ib_ifs, hardware_info.infiniband_interfaces.len());
-    assert_eq!(row.num_gpus, hardware_info.gpus.len(),);
-    assert!(!row.time_in_state_above_sla);
-    assert!(!row.time_in_state.is_empty()); // Should match something like "0 seconds"
-    assert_eq!(row.host_bmc_ip, build_data.host_bmc_ip().to_string());
-    assert_eq!(row.host_bmc_mac, mh.host.bmc_mac.to_string());
-    assert_eq!(
-        row.vendor,
-        hardware_info.dmi_data.as_ref().unwrap().sys_vendor
-    );
-    assert_eq!(
-        row.model,
-        hardware_info.dmi_data.as_ref().unwrap().product_name
-    );
-    assert_eq!(row.machine_id, machine_id.to_string());
-    assert!(!row.health_sources.is_empty());
-    assert!(row.health_probe_alerts.is_empty());
-    assert!(!row.host_admin_ip.is_empty());
-    assert_eq!(row.host_admin_mac, mh.host.primary_mac().to_string());
-    assert!(row.state_reason.is_empty());
-
-    assert_eq!(row.dpus.len(), 2);
-
-    assert_eq!(
-        row.dpus[0].machine_id,
-        snapshot.dpu_snapshots[0].id.to_string()
-    );
-    assert_eq!(row.dpus[0].bmc_ip, build_data.dpu_bmc_ip(0).to_string());
-    assert_eq!(row.dpus[0].bmc_mac, dpu_1.bmc_mac.to_string());
-    assert_eq!(row.dpus[0].oob_mac, dpu_1.oob_mac().to_string());
-    assert!(!row.dpus[0].oob_ip.is_empty(), "dpu should show an oob ip");
-
-    assert_eq!(
-        row.dpus[1].machine_id,
-        snapshot.dpu_snapshots[1].id.to_string()
-    );
-    assert_eq!(row.dpus[1].bmc_ip, build_data.dpu_bmc_ip(1).to_string());
-    assert_eq!(row.dpus[1].bmc_mac, dpu_2.bmc_mac.to_string());
-    assert_eq!(row.dpus[1].oob_mac, dpu_2.oob_mac().to_string());
-    assert!(!row.dpus[1].oob_ip.is_empty(), "dpu should show an oob ip");
-
-    Ok(())
 }
 
 #[crate::sqlx_test]

--- a/crates/api-web/src/tests/mod.rs
+++ b/crates/api-web/src/tests/mod.rs
@@ -22,7 +22,7 @@ use hyper::http::request::Builder;
 use crate::{WebAuthMode, routes_with_auth_mode};
 
 mod component_detail;
-mod env;
+pub(super) mod env;
 mod explored_endpoint;
 mod firmware;
 mod health;

--- a/crates/api-web/src/ufm_browser.rs
+++ b/crates/api-web/src/ufm_browser.rs
@@ -46,14 +46,14 @@ struct Header {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct QueryParams {
+pub(super) struct QueryParams {
     fabric_id: Option<String>,
     path: Option<String>,
 }
 
 /// Queries the redfish endpoint in the query parameter
 /// and displays the result
-pub async fn query(
+pub(super) async fn query(
     AxumState(state): AxumState<Arc<Api>>,
     AxumQuery(query): AxumQuery<QueryParams>,
 ) -> Response {

--- a/crates/api-web/src/vpc.rs
+++ b/crates/api-web/src/vpc.rs
@@ -99,7 +99,7 @@ impl From<forgerpc::Vpc> for VpcRowDisplay {
 }
 
 /// List VPCs
-pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let vpcs = match fetch_vpcs(state.clone()).await {
         Ok(n) => n,
         Err(err) => {
@@ -114,7 +114,7 @@ pub async fn show_html(AxumState(state): AxumState<Arc<Api>>) -> Response {
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }
 
-pub async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
+pub(super) async fn show_all_json(AxumState(state): AxumState<Arc<Api>>) -> Response {
     let vpcs = match fetch_vpcs(state).await {
         Ok(n) => n,
         Err(err) => {
@@ -235,7 +235,7 @@ impl From<forgerpc::Vpc> for VpcDetail {
 }
 
 /// View VPC details
-pub async fn detail(
+pub(super) async fn detail(
     AxumState(state): AxumState<Arc<Api>>,
     AxumPath(vpc_id): AxumPath<String>,
 ) -> Response {


### PR DESCRIPTION
This adopts the new style guide rules around `pub` and module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout API Web.

Primary callouts are:
- Replace unrestricted `pub` throughout `crates/api-web/src/**` with private, `pub(super)`, or test-only `pub(crate)` visibility based on real call sites.
- Keep `carbide_api_web::routes` public as the crate's HTTP integration point while scoping handlers and helpers to their actual parents and siblings.
- Keep managed-host row-display coverage without widening production APIs by colocating that test with its private implementation.
- Remove the unused managed-host `time_in_state` display field exposed during dead-code cleanup.
- Leave HTTP routes, templates, serialized responses, RPC calls, and runtime behavior unchanged.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4548.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

All 59 API Web tests passed during implementation. The focused managed-host row-display test also passed against an isolated PostgreSQL instance after the clean rebase that brought in https://github.com/NVIDIA/infra-controller/pull/4600. I also ran:

```bash
make core/tests TEST_ARGS="-p carbide-api-web test_managed_host_row_display"
cargo check --locked -p carbide-api-web --all-targets --all-features
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
git diff --check
```

## Additional Notes

The initial visibility lint identified 280 overbroad declarations across 51 files. The final 55-file diff also includes the root and test-module boundaries exposed by that cleanup, and the only unrestricted source `pub` left is the intentional `carbide_api_web::routes` crate API. Most hunks are visibility tokens plus the resulting rustfmt reflow.

Local CodeRabbit and read-only Claude reviews completed over the full diff. All applicable findings are incorporated.

Closes #4548
