### PR TITLE
fix(api): make tenant FQDNs + FNN detection IPv6-aware

### DIFF
--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -113,6 +113,32 @@ fn deprecated_deny_prefixes_for_agent(
     }
 }
 
+/// `preferred_physical_ip` chooses a stable address for the fallback tenant
+/// hostname. IPv4 remains the familiar name for a dual-stack interface, while
+/// choosing the lowest address within each family keeps the result independent
+/// of `HashMap` iteration order.
+fn preferred_physical_ip(ip_addresses: impl IntoIterator<Item = IpAddr>) -> Option<IpAddr> {
+    ip_addresses
+        .into_iter()
+        .min_by_key(|ip_address| (!ip_address.is_ipv4(), *ip_address))
+}
+
+/// `tenant_interface_fqdn` keeps the tenant's hostname intact when one was
+/// provided. Otherwise, the physical address becomes a valid DNS label through
+/// the same formatter used by IP-based host naming.
+fn tenant_interface_fqdn(
+    tenant_hostname: Option<&str>,
+    physical_ip: &IpAddr,
+    domain: &str,
+) -> Result<String, DatabaseError> {
+    let hostname = match tenant_hostname {
+        Some(hostname) => hostname.to_string(),
+        None => db::host_naming::address_to_hostname(physical_ip)?,
+    };
+
+    Ok(format!("{hostname}.{domain}"))
+}
+
 async fn get_managed_host_network_config_inner(
     api: &Api,
     dpu_machine_id: MachineId,
@@ -340,7 +366,6 @@ async fn get_managed_host_network_config_inner(
 
             let mut tenant_interfaces = Vec::with_capacity(interfaces.len());
 
-            //Get Physical interface
             let physical_iface = interfaces.iter().find(|x| {
                 rpc::InterfaceFunctionType::from(x.function_id.function_type())
                     == rpc::InterfaceFunctionType::Physical
@@ -353,15 +378,13 @@ async fn get_managed_host_network_config_inner(
                 .into());
             };
 
-            //Get Physical IP
-            let physical_ip: IpAddr = match physical_iface.ip_addrs.iter().next() {
-                Some((_, ip_addr)) => *ip_addr,
-                None => {
-                    return Err(CarbideError::internal(String::from(
-                        "Physical IP address not found",
-                    ))
-                    .into())
-                }
+            let Some(physical_ip) =
+                preferred_physical_ip(physical_iface.ip_addrs.values().copied())
+            else {
+                return Err(CarbideError::internal(String::from(
+                    "physical IP address not found",
+                ))
+                .into());
             };
 
             // All interfaces have the segment id allocated. It is already validated during
@@ -449,16 +472,11 @@ async fn get_managed_host_network_config_inner(
                         .clone(),
                     None => "unknowndomain".to_string(),
                 };
-                let fqdn = if let Some(hostname) = &instance.config.tenant.hostname {
-                    format!("{hostname}.{domain}")
-                } else {
-                    let dashed_ip = physical_ip
-                        .to_string()
-                        .split('.')
-                        .collect::<Vec<_>>()
-                        .join("-");
-                    format!("{dashed_ip}.{domain}")
-                };
+                let fqdn = tenant_interface_fqdn(
+                    instance.config.tenant.hostname.as_deref(),
+                    &physical_ip,
+                    &domain,
+                )?;
 
                 let tenant_interface = ethernet_virtualization::tenant_network(
                     &mut txn,
@@ -1507,6 +1525,78 @@ mod deny_prefix_tests {
                 VpcVirtualizationType::EthernetVirtualizer => ipv4_only.clone(),
                 VpcVirtualizationType::EthernetVirtualizerWithNvue => ipv4_only.clone(),
                 VpcVirtualizationType::Flat => ipv4_only,
+            }
+        );
+    }
+}
+
+#[cfg(test)]
+mod tenant_fqdn_tests {
+    use carbide_test_support::Outcome::Yields;
+    use carbide_test_support::{scenarios, value_scenarios};
+
+    use super::*;
+
+    #[test]
+    fn physical_ip_selection_is_stable_and_prefers_ipv4() {
+        let ipv4_low: IpAddr = "192.0.2.10".parse().unwrap();
+        let ipv4_high: IpAddr = "192.0.2.20".parse().unwrap();
+        let ipv6_low: IpAddr = "2001:db8::10".parse().unwrap();
+        let ipv6_high: IpAddr = "2001:db8::20".parse().unwrap();
+
+        value_scenarios!(
+            run = preferred_physical_ip;
+            "no physical address" {
+                vec![] => None,
+            }
+
+            "one address family" {
+                vec![ipv4_high, ipv4_low] => Some(ipv4_low),
+                vec![ipv6_high, ipv6_low] => Some(ipv6_low),
+            }
+
+            "dual-stack address order" {
+                vec![ipv6_low, ipv4_high, ipv6_high, ipv4_low] => Some(ipv4_low),
+                vec![ipv4_low, ipv6_high, ipv4_high, ipv6_low] => Some(ipv4_low),
+            }
+        );
+    }
+
+    #[test]
+    fn tenant_fqdn_uses_the_configured_name_or_physical_address() {
+        struct FqdnCase {
+            tenant_hostname: Option<&'static str>,
+            physical_ip: IpAddr,
+        }
+
+        let ipv4: IpAddr = "192.0.2.10".parse().unwrap();
+        let ipv6: IpAddr = "2001:db8::10".parse().unwrap();
+
+        scenarios!(
+            run = |FqdnCase {
+                tenant_hostname,
+                physical_ip,
+            }| tenant_interface_fqdn(tenant_hostname, &physical_ip, "tenant.example").map_err(drop);
+            "tenant-supplied hostname" {
+                FqdnCase {
+                    tenant_hostname: Some("customer-host"),
+                    physical_ip: ipv6,
+                } => Yields("customer-host.tenant.example".to_string()),
+            }
+
+            "address-derived hostname" {
+                FqdnCase {
+                    tenant_hostname: None,
+                    physical_ip: ipv4,
+                } => Yields("192-0-2-10.tenant.example".to_string()),
+                FqdnCase {
+                    tenant_hostname: None,
+                    physical_ip: ipv6,
+                } => Yields(concat!(
+                    "2001-0db8-0000-0000-0000-0000-0000-0010",
+                    ".tenant.example"
+                )
+                .to_string()),
             }
         );
     }

--- a/crates/api-db/src/host_naming/mod.rs
+++ b/crates/api-db/src/host_naming/mod.rs
@@ -407,10 +407,10 @@ fn ip_or_dormant(ctx: &NamingContext<'_>) -> DatabaseResult<String> {
     }
 }
 
-/// Builds the IP-derived hostname: IPv4 dotted-quad with dashes (`10.1.2.3` ->
-/// `10-1-2-3`); IPv6 fully-expanded hex segments with dashes. Validates the
-/// result is a legal DNS name.
-pub(crate) fn address_to_hostname(address: &IpAddr) -> DatabaseResult<String> {
+/// `address_to_hostname` builds the IP-derived hostname: IPv4 dotted-quad with
+/// dashes (`10.1.2.3` -> `10-1-2-3`); IPv6 fully-expanded hex segments with
+/// dashes. It validates the result as a legal DNS name before returning it.
+pub fn address_to_hostname(address: &IpAddr) -> DatabaseResult<String> {
     let hostname = match address {
         IpAddr::V4(_) => address.to_string().replace('.', "-"),
         IpAddr::V6(v6) => v6

--- a/crates/api-db/src/ip_allocator.rs
+++ b/crates/api-db/src/ip_allocator.rs
@@ -23,9 +23,7 @@ use carbide_uuid::instance::InstanceId;
 use carbide_uuid::network::NetworkPrefixId;
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use model::address_selection_strategy::AddressSelectionStrategy;
-use model::network_prefix::NetworkPrefix;
 use model::network_segment::NetworkSegment;
-use sqlx::PgConnection;
 
 use crate::db_read::DbReader;
 use crate::{DatabaseError, DatabaseResult};
@@ -295,88 +293,6 @@ impl Iterator for IpAllocator {
                 Err(DhcpError::PrefixExhausted(segment_prefix.prefix.ip()).into()),
             )),
             Some(network) => Some((segment_prefix.id, Ok(network))),
-        }
-    }
-}
-
-/// NOTE(chet): This has been deprecated, but I'm keeping it here for reference
-/// just incase the topic comes up again, and/or we want to revisit a SQL
-/// based allocation fast-path again. The reasons this is being deprecated
-/// are because its introduction actually dropped support for dual-stacking
-/// environments, and because it cannot actually support IPv6 allocation. It
-/// ends up being a little complicated to try to leverage this for IPv4 single
-/// IP allocations amidst IPv6 allocations. BUT, we should definitely always
-/// be looking into more efficient ways of bulk allocation.
-///
-/// next_machine_interface_v4_ip is a SQL fast-path for allocating a single
-/// IPv4 address from a prefix.
-///
-/// This finds the next available IP in a single database query by using
-/// `generate_series()` to enumerate all candidate addresses and LEFT JOIN
-/// against already-allocated addresses. This is much faster than the
-/// Rust-based `IpAllocator` (which loads all used IPs into memory) during
-/// bulk operations like ingestion.
-///
-/// This is permanently IPv4-only for two reasons:
-///
-/// 1. `generate_series()` uses PostgreSQL `bigint` (64-bit). IPv6 addresses
-///    are 128-bit — there is no native 128-bit integer type in PostgreSQL.
-/// 2. `generate_series()` materializes the entire range in memory. Even a
-///    /96 prefix has ~4 billion addresses; a /64 has 2^64. The query would
-///    either OOM or take effectively forever.
-///
-/// IPv6 allocation uses the Rust-based `IpAllocator` instead, which uses
-/// u128 math and steps through candidate subnets without enumerating the
-/// full address space. See `machine_interface::create()` for the fallback.
-pub async fn next_machine_interface_v4_ip(
-    txn: &mut PgConnection,
-    prefix: &NetworkPrefix,
-) -> DatabaseResult<Option<IpAddr>> {
-    if prefix.prefix.is_ipv6() {
-        return Ok(None);
-    }
-    match prefix.gateway {
-        None => {
-            let nr = prefix.num_reserved.max(2); // Reserve network and gateway addresses at least
-            let query = r#"
-SELECT ($1::inet + ip_series.n)::inet AS ip
-FROM generate_series($3, (1 << (32 - $2)) - 2) AS ip_series(n)
-LEFT JOIN machine_interface_addresses AS mia
-  ON mia.address = ($1::inet + ip_series.n)::inet
-WHERE mia.address IS NULL
-ORDER BY ip
-LIMIT 1;
-    "#;
-
-            sqlx::query_scalar(query)
-                .bind(prefix.prefix.ip())
-                .bind(prefix.prefix.prefix() as i32)
-                .bind(nr)
-                .fetch_optional(txn)
-                .await
-                .map_err(|e| DatabaseError::query(query, e))
-        }
-        Some(gw) => {
-            let nr = prefix.num_reserved.max(1); // Reserve network address at least
-            let query = r#"
-SELECT ($1::inet + ip_series.n)::inet AS ip
-FROM generate_series($3, (1 << (32 - $2)) - 2) AS ip_series(n)
-LEFT JOIN machine_interface_addresses AS mia
-  ON mia.address = ($1::inet + ip_series.n)::inet
-WHERE mia.address IS NULL
-  AND ($1::inet + ip_series.n)::inet <> $4::inet
-ORDER BY ip
-LIMIT 1;
-    "#;
-
-            sqlx::query_scalar(query)
-                .bind(prefix.prefix.ip())
-                .bind(prefix.prefix.prefix() as i32)
-                .bind(nr)
-                .bind(gw)
-                .fetch_optional(txn)
-                .await
-                .map_err(|e| DatabaseError::query(query, e))
         }
     }
 }

--- a/crates/api-model/src/network_prefix.rs
+++ b/crates/api-model/src/network_prefix.rs
@@ -80,27 +80,95 @@ impl<'r> FromRow<'r, PgRow> for NetworkPrefix {
 }
 
 impl NetworkPrefix {
+    /// `gateway_cidr` formats the configured gateway with this segment's
+    /// prefix length.
+    ///
+    /// Consumers install the gateway on the segment, so a gateway of
+    /// `192.0.2.1` in `192.0.2.0/24` becomes `192.0.2.1/24`, not the host
+    /// route `192.0.2.1/32`. Returns `None` when no gateway is configured.
     pub fn gateway_cidr(&self) -> Option<String> {
-        // TODO: This was here before, but seems broken
-        // The gateway address should always be a /32
-        // Should we directly return the prefix?
         self.gateway
             .map(|g| format!("{}/{}", g, self.prefix.prefix()))
     }
 
-    // We use this to try to guess whether an associated segment is stretchable
-    // in cases where the database doesn't contain that information.
+    /// `smells_like_fnn` recognizes narrow segment prefixes generated from a
+    /// VPC prefix when the persisted `can_stretch` value is unavailable.
+    ///
+    /// FNN uses `/31` IPv4 and `/127` IPv6 linknets. The heuristic starts one
+    /// bit wider (`/30` or `/126`) to preserve the existing IPv4 tolerance,
+    /// but only matches rows associated with a `VpcPrefixId`.
     pub fn smells_like_fnn(&self) -> bool {
         self.vpc_prefix_id.is_some()
             && match self.prefix {
-                // A 31 network prefix is used for FNN.
                 IpNetwork::V4(v4) => v4.prefix() >= 30,
-                IpNetwork::V6(_) => {
-                    // We don't have any IPv6 segment prefixes at the time of
-                    // writing so we don't really expect this arm to match, but
-                    // let's provide a safe value just in case.
-                    false
-                }
+                IpNetwork::V6(v6) => v6.prefix() >= 126,
             }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    /// Builds the smallest complete prefix needed to exercise model helpers.
+    fn network_prefix(
+        prefix: &str,
+        gateway: Option<&str>,
+        associated_with_vpc_prefix: bool,
+    ) -> NetworkPrefix {
+        NetworkPrefix {
+            id: NetworkPrefixId::new(),
+            segment_id: NetworkSegmentId::new(),
+            prefix: prefix.parse().unwrap(),
+            gateway: gateway.map(|gateway| gateway.parse().unwrap()),
+            dhcpv6_link_address: None,
+            num_reserved: 0,
+            vpc_prefix_id: associated_with_vpc_prefix.then(VpcPrefixId::new),
+            vpc_prefix: None,
+            svi_ip: None,
+            num_free_ips: None,
+        }
+    }
+
+    #[test]
+    fn gateway_cidr_uses_the_segment_prefix_length() {
+        value_scenarios!(run = |prefix: NetworkPrefix| prefix.gateway_cidr();
+            "configured gateways" {
+                network_prefix("192.0.2.0/24", Some("192.0.2.1"), false)
+                    => Some("192.0.2.1/24".to_string()),
+                network_prefix("2001:db8::/64", Some("2001:db8::1"), false)
+                    => Some("2001:db8::1/64".to_string()),
+            }
+
+            "gateway is not configured" {
+                network_prefix("192.0.2.0/24", None, false) => None,
+            }
+        );
+    }
+
+    #[test]
+    fn smells_like_fnn_requires_a_vpc_prefix_and_narrow_linknet() {
+        value_scenarios!(run = |prefix: NetworkPrefix| prefix.smells_like_fnn();
+            "IPv4 cutoff" {
+                network_prefix("192.0.2.0/29", None, true) => false,
+                network_prefix("192.0.2.0/30", None, true) => true,
+                network_prefix("192.0.2.0/31", None, true) => true,
+                network_prefix("192.0.2.1/32", None, true) => true,
+            }
+
+            "IPv6 cutoff" {
+                network_prefix("2001:db8::/125", None, true) => false,
+                network_prefix("2001:db8::/126", None, true) => true,
+                network_prefix("2001:db8::/127", None, true) => true,
+                network_prefix("2001:db8::1/128", None, true) => true,
+            }
+
+            "prefix is not associated with a VPC prefix" {
+                network_prefix("192.0.2.0/31", None, false) => false,
+                network_prefix("2001:db8::/127", None, false) => false,
+            }
+        );
     }
 }


### PR DESCRIPTION
As it stood, the tenant FQDN fallback grabbed whichever physical address happened to come out of a `HashMap`, then only knew how to turn dotted IPv4 into a DNS label. That made IPv6-only names invalid and let a dual-stack name change with map iteration order.

So, this picks IPv4 first for compatibility, uses the lowest address within each family, and runs the fallback through the existing `address_to_hostname` formatter. It also teaches `smells_like_fnn` about `/126` and narrower IPv6 linknets, documents why `gateway_cidr` keeps the segment prefix length, and removes the unused `next_machine_interface_v4_ip` path that could never support IPv6 allocation.

The result is a small cleanup of the remaining IPv4-only assumptions without changing the supported VPC migration model.

## Related issues

- Supports https://github.com/NVIDIA/infra-controller/issues/2406

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

`UpdateVpcVirtualization` is deliberately unchanged. `ETV -> FNN` is the only supported direction, and FNN already accepts every segment type and address family ETV can use; adding guards for reverse transitions would make an unsupported path look intentional.


Closes #2406
