### PR TITLE
refactor(bmc-mock): adopt style guide rules for pub/module visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,6 +877,7 @@ dependencies = [
  "axum-server",
  "bmc-vendor",
  "bytes",
+ "carbide-test-support",
  "chrono",
  "clap",
  "duration-str",

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -63,6 +63,7 @@ tracing-subscriber = { features = ["env-filter"], workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+carbide-test-support = { path = "../test-support" }
 tokio = { features = ["test-util"], workspace = true }
 
 [lints]

--- a/crates/bmc-mock/src/auth_router.rs
+++ b/crates/bmc-mock/src/auth_router.rs
@@ -37,7 +37,7 @@ use crate::redfish::{account_service, service_root, session_service};
 const WWW_AUTHENTICATE_VALUE: HeaderValue = HeaderValue::from_static("Basic realm=\"bmc-mock\"");
 const X_AUTH_TOKEN_HEADER: &str = "x-auth-token";
 
-pub fn append(router: Router, authorizer: Authorizer) -> Router {
+pub(super) fn append(router: Router, authorizer: Authorizer) -> Router {
     let service_root_path = service_root::resource().odata_id.to_string();
     let service_root_path_with_trailing_slash = format!("{service_root_path}/");
     let account_service_path = account_service::resource().odata_id.to_string();
@@ -162,7 +162,7 @@ impl AuthMiddleware {
 }
 
 #[derive(Clone)]
-pub struct Authorizer {
+pub(super) struct Authorizer {
     account_service_state: Arc<AccountServiceState>,
     session_service_state: Arc<SessionServiceState>,
     forbid_factory_default_password: bool,
@@ -170,7 +170,7 @@ pub struct Authorizer {
 
 impl Authorizer {
     /// Builds the factory-default authorizer for a mock BMC state.
-    pub fn new(
+    pub(super) fn new(
         account_service_state: Arc<AccountServiceState>,
         session_service_state: Arc<SessionServiceState>,
     ) -> Self {
@@ -181,7 +181,7 @@ impl Authorizer {
         }
     }
 
-    pub fn permit_factory_default_password(mut self) -> Self {
+    pub(super) fn permit_factory_default_password(mut self) -> Self {
         self.forbid_factory_default_password = false;
         self
     }

--- a/crates/bmc-mock/src/bmc_state.rs
+++ b/crates/bmc-mock/src/bmc_state.rs
@@ -27,23 +27,23 @@ use crate::redfish::update_service::UpdateServiceState;
 
 #[derive(Clone)]
 pub struct BmcState {
-    pub bmc_vendor: redfish::oem::BmcVendor,
-    pub bmc_product: Option<&'static str>,
-    pub bmc_redfish_version: &'static str,
-    pub oem_state: redfish::oem::State,
+    pub(crate) bmc_vendor: redfish::oem::BmcVendor,
+    pub(crate) bmc_product: Option<&'static str>,
+    pub(crate) bmc_redfish_version: &'static str,
+    pub(crate) oem_state: redfish::oem::State,
     pub manager: Arc<ManagerState>,
     pub system_state: Arc<SystemState>,
-    pub chassis_state: Arc<ChassisState>,
-    pub update_service_state: Arc<UpdateServiceState>,
+    pub(crate) chassis_state: Arc<ChassisState>,
+    pub(crate) update_service_state: Arc<UpdateServiceState>,
     pub account_service_state: Arc<AccountServiceState>,
-    pub session_service_state: Arc<SessionServiceState>,
+    pub(crate) session_service_state: Arc<SessionServiceState>,
     pub injection: Arc<InjectionStore>,
-    pub callbacks: Option<Arc<dyn crate::Callbacks>>,
+    pub(crate) callbacks: Option<Arc<dyn crate::Callbacks>>,
     /// Whether this BMC advertises and serves the `/redfish/v1/Systems`
     /// collection. Delta power shelves expose no `ComputerSystem` collection,
     /// so the service root omits the `Systems` link and the collection endpoint
     /// returns 404.
-    pub exposes_computer_systems: bool,
+    pub(crate) exposes_computer_systems: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -65,7 +65,7 @@ impl BmcState {
         }
     }
 
-    pub fn complete_all_bios_jobs(&self) {
+    fn complete_all_bios_jobs(&self) {
         if let redfish::oem::State::DellIdrac(v) = &self.oem_state {
             v.complete_all_bios_jobs()
         }

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -21,13 +21,13 @@ use bmc_mock::HardwareType;
 use clap::{Parser, ValueEnum};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-pub enum MachineRole {
+pub(super) enum MachineRole {
     Host,
     Dpu,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
-pub enum StateBackend {
+pub(super) enum StateBackend {
     Internal,
     Libvirt,
 }
@@ -47,9 +47,9 @@ fn parse_hardware_profile(value: &str) -> Result<HardwareType, String> {
 }
 
 #[derive(Clone, Parser, Debug)]
-pub struct IpRouterPair {
-    pub ip_address: String,
-    pub targz: std::path::PathBuf,
+pub(super) struct IpRouterPair {
+    pub(super) ip_address: String,
+    pub(super) targz: std::path::PathBuf,
 }
 
 impl From<String> for IpRouterPair {
@@ -67,77 +67,77 @@ impl From<String> for IpRouterPair {
 }
 
 #[derive(Clone, Parser, Debug)]
-pub struct Args {
+pub(super) struct Args {
     #[clap(short, long)]
-    pub cert_path: Option<String>,
+    pub(super) cert_path: Option<String>,
 
     #[clap(short, long)]
-    pub port: Option<u16>,
+    pub(super) port: Option<u16>,
 
     #[clap(
         long,
         help = "Path to .tar.gz file of redfish data to output. Create it from libredfish tests/mockups/<vendor>"
     )]
-    pub targz: Option<std::path::PathBuf>,
+    pub(super) targz: Option<std::path::PathBuf>,
 
     #[clap(
         long,
         help = "An ip_address and .tar.gz file pair (comma separated).\nThe file is an archive of redfish data when the request is forwarded to a specific IP address.\nRepeat for different machines"
     )]
-    pub ip_router: Option<Vec<IpRouterPair>>,
+    pub(super) ip_router: Option<Vec<IpRouterPair>>,
 
     #[clap(long, help = "Start an IPMI/SOL simulator for the generated BMC mock")]
-    pub enable_ipmi_simulation: bool,
+    pub(super) enable_ipmi_simulation: bool,
 
     #[clap(long, help = "Back the generated BMC with the named libvirt domain")]
-    pub libvirt_domain: Option<String>,
+    pub(super) libvirt_domain: Option<String>,
 
     #[clap(
         long,
         value_parser = parse_hardware_profile,
         help = "Redfish hardware profile for an explicitly configured host or DPU, using its existing snake_case name"
     )]
-    pub hardware_profile: Option<HardwareType>,
+    pub(super) hardware_profile: Option<HardwareType>,
 
     #[clap(long, value_enum, help = "Expose a host BMC or one DPU BMC")]
-    pub machine_role: Option<MachineRole>,
+    pub(super) machine_role: Option<MachineRole>,
 
     #[clap(
         long,
         value_enum,
         help = "Use an in-process power-state simulator or a libvirt domain"
     )]
-    pub state_backend: Option<StateBackend>,
+    pub(super) state_backend: Option<StateBackend>,
 
     #[clap(
         long,
         requires = "hardware_profile",
         help = "DPU count for a variable-count profile, or an assertion for a fixed-count profile"
     )]
-    pub dpu_count: Option<u8>,
+    pub(super) dpu_count: Option<u8>,
 
     #[clap(
         long,
         requires = "hardware_profile",
         help = "Zero-based DPU index when --machine-role=dpu"
     )]
-    pub dpu_index: Option<usize>,
+    pub(super) dpu_index: Option<usize>,
 
     #[clap(
         long,
         default_value_t = 0,
         help = "Stable instance number used to make generated identities unique"
     )]
-    pub instance_index: u8,
+    pub(super) instance_index: u8,
 
     #[clap(long, default_value = "qemu:///system", requires = "libvirt_domain")]
-    pub libvirt_uri: String,
+    pub(super) libvirt_uri: String,
 
     #[clap(long, default_value = "virsh", requires = "libvirt_domain")]
-    pub virsh_path: PathBuf,
+    pub(super) virsh_path: PathBuf,
 }
 
-pub fn parse_args() -> Args {
+pub(super) fn parse_args() -> Args {
     Args::parse()
 }
 

--- a/crates/bmc-mock/src/hw/bluefield3.rs
+++ b/crates/bmc-mock/src/hw/bluefield3.rs
@@ -23,27 +23,27 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
 
-pub struct Bluefield3<'a> {
-    pub product_serial_number: Cow<'a, str>,
-    pub host_mac_address: MacAddress,
-    pub bmc_mac_address: MacAddress,
-    pub oob_mac_address: Option<MacAddress>,
-    pub mode: Mode,
-    pub firmware_versions: FirmwareVersions,
+pub(crate) struct Bluefield3<'a> {
+    pub(crate) product_serial_number: Cow<'a, str>,
+    pub(crate) host_mac_address: MacAddress,
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) oob_mac_address: Option<MacAddress>,
+    pub(crate) mode: Mode,
+    pub(crate) firmware_versions: FirmwareVersions,
 }
 
-pub enum Mode {
+pub(crate) enum Mode {
     // P/N 900-9D3B6-00CN-PA0. Installed on WIWYNN GB200s / Lenovo GB300s.
     B3240ColdAisle,
     // P/N 900-9D3B4-00CC-EA0 & 900-9D3B6-00CV-AA0
     SuperNIC { nic_mode: bool },
 }
 
-pub struct FirmwareVersions {
-    pub bmc: String,
-    pub uefi: String,
-    pub dpu_nic: String,
-    pub erot: String,
+pub(crate) struct FirmwareVersions {
+    pub(crate) bmc: String,
+    pub(crate) uefi: String,
+    pub(crate) dpu_nic: String,
+    pub(crate) erot: String,
 }
 
 impl Bluefield3<'_> {
@@ -57,7 +57,7 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         redfish::chassis::ChassisConfig {
             chassis: vec![
                 redfish::chassis::SingleChassisConfig {
@@ -108,7 +108,10 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "Bluefield";
         let boot_opt_builder = |id: &str, kind| {
             redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
@@ -188,7 +191,7 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "Bluefield_BMC",
@@ -208,7 +211,7 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         let base_mac = self.base_mac().to_string().replace(':', "");
         let sys_image = format!(
             "{}:{}00:00{}:{}",
@@ -237,7 +240,7 @@ impl Bluefield3<'_> {
         }
     }
 
-    pub fn host_nic(&self) -> hw::nic::Nic<'static> {
+    pub(crate) fn host_nic(&self) -> hw::nic::Nic<'static> {
         hw::nic::Nic {
             mac_address: self.host_mac_address,
             // This how it represented on host with number of trailing
@@ -250,11 +253,10 @@ impl Bluefield3<'_> {
             ),
             part_number: Some(self.part_number().into()),
             firmware_version: Some(self.firmware_versions.dpu_nic.clone().into()),
-            is_mat_dpu: true,
         }
     }
 
-    pub fn host_nic_h100_variant(&self) -> hw::nic::Nic<'static> {
+    pub(super) fn host_nic_h100_variant(&self) -> hw::nic::Nic<'static> {
         hw::nic::Nic {
             mac_address: self.host_mac_address,
             // This how it represented on host with number of trailing
@@ -265,7 +267,6 @@ impl Bluefield3<'_> {
             description: None,
             part_number: Some(format!("{}       ", self.part_number()).into()),
             firmware_version: Some(self.firmware_versions.dpu_nic.clone().into()),
-            is_mat_dpu: true,
         }
     }
 

--- a/crates/bmc-mock/src/hw/bluefield4.rs
+++ b/crates/bmc-mock/src/hw/bluefield4.rs
@@ -24,19 +24,19 @@ use serde_json::json;
 use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
 
 #[derive(Clone, Copy, Debug)]
-pub enum Mode {
+pub(crate) enum Mode {
     // B4240V installed on VR NVL.
     B4240V,
     // Air Cooled Bluefield-4 DPU
     B4240,
 }
 
-pub struct Bluefield4<'a> {
-    pub product_serial_number: Cow<'a, str>,
-    pub host_mac_address: MacAddress,
-    pub oob_mac_address: MacAddress,
-    pub bmc_mac_address: MacAddress,
-    pub mode: Mode,
+pub(crate) struct Bluefield4<'a> {
+    pub(crate) product_serial_number: Cow<'a, str>,
+    pub(crate) host_mac_address: MacAddress,
+    pub(crate) oob_mac_address: MacAddress,
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) mode: Mode,
 }
 
 impl Bluefield4<'_> {
@@ -62,7 +62,7 @@ impl Bluefield4<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         redfish::chassis::ChassisConfig {
             chassis: vec![
                 redfish::chassis::SingleChassisConfig {
@@ -164,7 +164,10 @@ impl Bluefield4<'_> {
         MacAddress::new([bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7]])
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = Self::SYSTEM_ID;
         let boot_opt_builder = |id: &str, kind| {
             redfish::boot_option::builder(&redfish::boot_option::resource(system_id, id), kind)
@@ -395,7 +398,7 @@ impl Bluefield4<'_> {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: Self::MANAGER_ID,
@@ -415,13 +418,13 @@ impl Bluefield4<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }
     }
 
-    pub fn host_nic(&self) -> hw::nic::Nic<'static> {
+    pub(crate) fn host_nic(&self) -> hw::nic::Nic<'static> {
         match self.mode {
             Mode::B4240 => hw::nic::Nic {
                 mac_address: self.host_mac_address,
@@ -431,7 +434,6 @@ impl Bluefield4<'_> {
                 description: Some("CX9 Family [ConnectX-9]".into()),
                 part_number: Some(self.part_number().into()),
                 firmware_version: Some("82.48.0802".into()),
-                is_mat_dpu: true,
             },
             Mode::B4240V => hw::nic::Nic {
                 mac_address: self.host_mac_address,
@@ -441,12 +443,11 @@ impl Bluefield4<'_> {
                 description: None,
                 part_number: Some(self.part_number().into()),
                 firmware_version: None,
-                is_mat_dpu: true,
             },
         }
     }
 
-    pub fn model(&self) -> &'static str {
+    pub(super) fn model(&self) -> &'static str {
         match self.mode {
             Mode::B4240V => "B4240V",
             Mode::B4240 => "B4240",

--- a/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r750.rs
@@ -23,16 +23,16 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, LogService, LogServices, hw, redfish};
 
-pub struct DellPowerEdgeR750<'a> {
-    pub bmc_mac_address: MacAddress,
-    pub product_serial_number: Cow<'a, str>,
-    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
-    pub embedded_nic: EmbeddedNic,
+pub(crate) struct DellPowerEdgeR750<'a> {
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) product_serial_number: Cow<'a, str>,
+    pub(crate) nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
+    pub(crate) embedded_nic: EmbeddedNic,
 }
 
-pub struct EmbeddedNic {
-    pub port_1: MacAddress,
-    pub port_2: MacAddress,
+pub(crate) struct EmbeddedNic {
+    pub(crate) port_1: MacAddress,
+    pub(crate) port_2: MacAddress,
 }
 
 struct DellEventLog {
@@ -82,7 +82,7 @@ impl DellPowerEdgeR750<'_> {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "iDRAC.Embedded.1",
@@ -109,7 +109,10 @@ impl DellPowerEdgeR750<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let callbacks = Some(callbacks);
         let serial_number = Some(self.product_serial_number.to_string().into());
         let system_id = "System.Embedded.1";
@@ -216,7 +219,7 @@ impl DellPowerEdgeR750<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let chassis_id = "System.Embedded.1";
         let net_adapter_builder = |id: &str| {
             redfish::network_adapter::builder(&redfish::network_adapter::chassis_resource(
@@ -295,7 +298,7 @@ impl DellPowerEdgeR750<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/dell_poweredge_r760_bf4.rs
+++ b/crates/bmc-mock/src/hw/dell_poweredge_r760_bf4.rs
@@ -23,10 +23,10 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-pub struct DellPowerEdgeR760Bf4<'a> {
-    pub bmc_mac_address: MacAddress,
-    pub product_serial_number: Cow<'a, str>,
-    pub bf4: hw::nic::Nic<'a>,
+pub(crate) struct DellPowerEdgeR760Bf4<'a> {
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) product_serial_number: Cow<'a, str>,
+    pub(crate) bf4: hw::nic::Nic<'a>,
 }
 
 const BF4_SLOT: hw::nic::SlotNumber = 2;
@@ -46,7 +46,7 @@ impl DellPowerEdgeR760Bf4<'_> {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "iDRAC.Embedded.1",
@@ -73,7 +73,10 @@ impl DellPowerEdgeR760Bf4<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let callbacks = Some(callbacks);
         let serial_number = Some(self.product_serial_number.to_string().into());
         let system_id = "System.Embedded.1";
@@ -151,7 +154,7 @@ impl DellPowerEdgeR760Bf4<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let chassis_id = "System.Embedded.1";
         let network_adapter_id = format!("NIC.Slot.{BF4_SLOT}");
         let function_id = format!("NIC.Slot.{BF4_SLOT}-1");
@@ -217,7 +220,7 @@ impl DellPowerEdgeR760Bf4<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/delta_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/delta_power_shelf.rs
@@ -40,18 +40,18 @@ const CHASSIS_ID: &str = "chassis";
 
 /// Default per-PSU power states: the six-bay shelf the real scrape reports,
 /// all outputting power.
-pub const DEFAULT_PSU_POWER: &[bool] = &[true; 6];
+pub(crate) const DEFAULT_PSU_POWER: &[bool] = &[true; 6];
 
-pub struct DeltaPowerShelf<'a> {
-    pub bmc_mac_address: MacAddress,
-    pub product_serial_number: Cow<'a, str>,
+pub(crate) struct DeltaPowerShelf<'a> {
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) product_serial_number: Cow<'a, str>,
     /// Commanded on/off state per PSU bay, reported under
     /// `Oem.deltaenergysystems.Power`. One entry per `PowerSupplyUnit`.
-    pub psu_power: Cow<'a, [bool]>,
+    pub(crate) psu_power: Cow<'a, [bool]>,
 }
 
 impl DeltaPowerShelf<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "SMC",
@@ -74,11 +74,11 @@ impl DeltaPowerShelf<'_> {
     /// Delta power shelves expose no `ComputerSystem`; the collection is empty
     /// and (via the `exposes_computer_systems` gate) is not advertised or
     /// served. Site-explorer synthesizes a system from the chassis instead.
-    pub fn system_config(&self) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(&self) -> redfish::computer_system::Config {
         redfish::computer_system::Config { systems: vec![] }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         redfish::chassis::ChassisConfig {
             chassis: vec![redfish::chassis::SingleChassisConfig {
                 id: CHASSIS_ID.into(),
@@ -110,7 +110,7 @@ impl DeltaPowerShelf<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/dgx_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/dgx_gb300_nvl.rs
@@ -28,25 +28,24 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-#[allow(dead_code)]
-pub struct DgxGB300Nvl<'a> {
-    pub system_0_serial_number: Cow<'a, str>,
-    pub chassis_0_serial_number: Cow<'a, str>,
-    pub dpu: hw::bluefield3::Bluefield3<'a>,
-    pub embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
-    pub bmc_mac_address_eth0: MacAddress,
-    pub bmc_mac_address_eth1: MacAddress,
-    pub bmc_mac_address_usb0: MacAddress,
-    pub hgx_bmc_mac_address_usb0: MacAddress,
-    pub hgx_serial_number: Cow<'a, str>,
-    pub topology: hw::nvidia_gbx00::Topology,
-    pub cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
-    pub gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
-    pub io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
+pub(crate) struct DgxGB300Nvl<'a> {
+    pub(crate) system_0_serial_number: Cow<'a, str>,
+    pub(crate) chassis_0_serial_number: Cow<'a, str>,
+    pub(crate) dpu: hw::bluefield3::Bluefield3<'a>,
+    pub(crate) embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
+    pub(crate) bmc_mac_address_eth0: MacAddress,
+    pub(crate) bmc_mac_address_eth1: MacAddress,
+    pub(crate) bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_serial_number: Cow<'a, str>,
+    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
+    pub(crate) gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
+    pub(crate) io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
 }
 
 impl DgxGB300Nvl<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let bmc_manager_id = "BMC_0";
         let bmc_eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -104,7 +103,10 @@ impl DgxGB300Nvl<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "System_0";
         let boot_options = std::iter::once(
             redfish::boot_option::builder(
@@ -200,7 +202,7 @@ impl DgxGB300Nvl<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let dpu_chassis = |chassis_id: &'static str, bf3: &hw::bluefield3::Bluefield3<'_>| {
             let nic = bf3.host_nic();
             redfish::chassis::SingleChassisConfig {
@@ -266,7 +268,7 @@ impl DgxGB300Nvl<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/dgx_vr_nvl.rs
+++ b/crates/bmc-mock/src/hw/dgx_vr_nvl.rs
@@ -25,11 +25,11 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-pub struct DgxVrNvl<'a> {
-    pub system_0_serial_number: Cow<'a, str>,
-    pub chassis_0_serial_number: Cow<'a, str>,
-    pub dpu: hw::bluefield4::Bluefield4<'a>,
-    pub bmc_mac_address_eth0: MacAddress,
+pub(crate) struct DgxVrNvl<'a> {
+    pub(crate) system_0_serial_number: Cow<'a, str>,
+    pub(crate) chassis_0_serial_number: Cow<'a, str>,
+    pub(crate) dpu: hw::bluefield4::Bluefield4<'a>,
+    pub(crate) bmc_mac_address_eth0: MacAddress,
 }
 
 impl DgxVrNvl<'_> {
@@ -37,7 +37,7 @@ impl DgxVrNvl<'_> {
     const BLUEFIELD_NIC_ID: &'static str = "BlueField_NIC_0";
     const BLUEFIELD_PCIE_DEVICE_ID: &'static str = "BlueField_0";
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let bmc_manager_id = "BMC_0";
         let bmc_eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -62,7 +62,10 @@ impl DgxVrNvl<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "System_0";
         let boot_options = std::iter::once(
             redfish::boot_option::builder(
@@ -143,7 +146,7 @@ impl DgxVrNvl<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         redfish::chassis::ChassisConfig {
             chassis: vec![
                 redfish::chassis::SingleChassisConfig {
@@ -230,7 +233,7 @@ impl DgxVrNvl<'_> {
         .build()
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/generic_ami.rs
+++ b/crates/bmc-mock/src/hw/generic_ami.rs
@@ -22,13 +22,13 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-pub struct GenericAmi<'a> {
-    pub product_serial_number: Cow<'a, str>,
-    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
+pub(crate) struct GenericAmi<'a> {
+    pub(crate) product_serial_number: Cow<'a, str>,
+    pub(crate) nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
 }
 
 impl GenericAmi<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let bmc_manager_id = "Self";
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
@@ -49,7 +49,10 @@ impl GenericAmi<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "Self";
 
         let boot_opt_builder = |id: &str, kind| {
@@ -106,7 +109,7 @@ impl GenericAmi<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let chassis_id = "Self";
 
         let pcie_devices = self
@@ -133,7 +136,7 @@ impl GenericAmi<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
+++ b/crates/bmc-mock/src/hw/hpe_proliant_dl380a_gen11.rs
@@ -25,17 +25,17 @@ use crate::{BootOptionKind, Callbacks, hw, redfish};
 
 /// Values are taken from a Redfish dump of a real ProLiant DL380a Gen11
 /// (iLO 6 v1.58, BIOS U58 v2.22) with a BlueField-3 SuperNIC installed.
-pub struct HpeProliantDl380aGen11<'a> {
-    pub bmc_mac_address: MacAddress,
-    pub product_serial_number: Cow<'a, str>,
-    pub nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
+pub(crate) struct HpeProliantDl380aGen11<'a> {
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) product_serial_number: Cow<'a, str>,
+    pub(crate) nics: Vec<(hw::nic::SlotNumber, hw::nic::Nic<'a>)>,
 }
 
 const MODEL: &str = "ProLiant DL380a Gen11";
 const SKU: &str = "P54903-B21";
 
 impl HpeProliantDl380aGen11<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "1",
@@ -56,7 +56,10 @@ impl HpeProliantDl380aGen11<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "1";
 
         let eth_interfaces = self
@@ -145,7 +148,7 @@ impl HpeProliantDl380aGen11<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let chassis_id = "1";
 
         let network_adapters = self
@@ -193,7 +196,7 @@ impl HpeProliantDl380aGen11<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/lenovo_gb300_nvl.rs
@@ -23,26 +23,24 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-#[allow(dead_code)]
-pub struct LenovoGB300Nvl<'a> {
-    pub system_0_serial_number: Cow<'a, str>,
-    pub chassis_0_serial_number: Cow<'a, str>,
-    pub dpu: hw::bluefield3::Bluefield3<'a>,
-    pub cx8_mac_addresses: [MacAddress; 10],
-    pub embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
-    pub bmc_mac_address_eth0: MacAddress,
-    pub bmc_mac_address_eth1: MacAddress,
-    pub bmc_mac_address_usb0: MacAddress,
-    pub hgx_bmc_mac_address_usb0: MacAddress,
-    pub hgx_serial_number: Cow<'a, str>,
-    pub topology: hw::nvidia_gbx00::Topology,
-    pub cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
-    pub gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
-    pub io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
+pub(crate) struct LenovoGB300Nvl<'a> {
+    pub(crate) system_0_serial_number: Cow<'a, str>,
+    pub(crate) chassis_0_serial_number: Cow<'a, str>,
+    pub(crate) dpu: hw::bluefield3::Bluefield3<'a>,
+    pub(crate) embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
+    pub(crate) bmc_mac_address_eth0: MacAddress,
+    pub(crate) bmc_mac_address_eth1: MacAddress,
+    pub(crate) bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_serial_number: Cow<'a, str>,
+    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
+    pub(crate) gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
+    pub(crate) io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
 }
 
 impl LenovoGB300Nvl<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let bmc_manager_id = "BMC_0";
         let bmc_eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -101,7 +99,10 @@ impl LenovoGB300Nvl<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "System_0";
         // TODO: It is PXE but apparently if enable HTTP in bios HTTP
         // (Uefi) boot options will show up here...
@@ -206,7 +207,7 @@ impl LenovoGB300Nvl<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let dpu_chassis = |chassis_id: &'static str, bf3: &hw::bluefield3::Bluefield3<'_>| {
             let nic = bf3.host_nic();
             redfish::chassis::SingleChassisConfig {
@@ -273,7 +274,7 @@ impl LenovoGB300Nvl<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/liteon_power_shelf.rs
+++ b/crates/bmc-mock/src/hw/liteon_power_shelf.rs
@@ -21,9 +21,9 @@ use mac_address::MacAddress;
 
 use crate::redfish;
 
-pub struct LiteOnPowerShelf<'a> {
-    pub bmc_mac_address: MacAddress,
-    pub product_serial_number: Cow<'a, str>,
+pub(crate) struct LiteOnPowerShelf<'a> {
+    pub(crate) bmc_mac_address: MacAddress,
+    pub(crate) product_serial_number: Cow<'a, str>,
 }
 
 impl LiteOnPowerShelf<'_> {
@@ -37,7 +37,7 @@ impl LiteOnPowerShelf<'_> {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![redfish::manager::SingleConfig {
                 id: "bmc",
@@ -63,7 +63,7 @@ impl LiteOnPowerShelf<'_> {
         }
     }
 
-    pub fn system_config(&self) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(&self) -> redfish::computer_system::Config {
         let system_id = "system";
 
         redfish::computer_system::Config {
@@ -91,7 +91,7 @@ impl LiteOnPowerShelf<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let chassis_id = "powershelf";
 
         redfish::chassis::ChassisConfig {
@@ -126,7 +126,7 @@ impl LiteOnPowerShelf<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/mod.rs
+++ b/crates/bmc-mock/src/hw/mod.rs
@@ -19,79 +19,79 @@
 //! (i.e. how this hardware is represented via Redfish).
 
 /// Description of NIC card.
-pub mod nic;
+pub(super) mod nic;
 
 /// Support of NVIDIA Bluefield3 DPU.
-pub mod bluefield3;
+pub(super) mod bluefield3;
 
 /// Support of NVIDIA Bluefield4 DPU.
-pub mod bluefield4;
+pub(super) mod bluefield4;
 
 /// Generic AMI server.
-pub mod generic_ami;
+pub(super) mod generic_ami;
 
 /// Support of HPE ProLiant DL380a Gen11 servers (iLO 6).
-pub mod hpe_proliant_dl380a_gen11;
+pub(super) mod hpe_proliant_dl380a_gen11;
 
 /// Support of Dell PowerEdge R750 servers.
-pub mod dell_poweredge_r750;
+pub(super) mod dell_poweredge_r750;
 
 /// Support of Dell PowerEdge R760 server with Bluefield4 installed.
-pub mod dell_poweredge_r760_bf4;
+pub(super) mod dell_poweredge_r760_bf4;
 
 /// Support of Wiwynn GB200 NVL servers.
-pub mod wiwynn_gb200_nvl;
+pub(super) mod wiwynn_gb200_nvl;
 
 /// Rack hardware layouts.
-pub mod rack;
+pub(super) mod rack;
 
 /// WIWYNN GB200 NVL72 rack.
-pub mod wiwynn_gb200_nvl72_rack;
+pub(super) mod wiwynn_gb200_nvl72_rack;
 
 /// Support of Lenovo GB300 NVL servers.
-pub mod lenovo_gb300_nvl;
+pub(super) mod lenovo_gb300_nvl;
 
 /// Support of DGX GB300 NVL servers (NVIDIA "GB BMC" host).
-pub mod dgx_gb300_nvl;
+pub(super) mod dgx_gb300_nvl;
 
 /// Support of Supermicro (SMC) GB300 NVL servers (Supermicro OpenBMC host).
-pub mod supermicro_gb300_nvl;
+pub(super) mod supermicro_gb300_nvl;
 
 /// Support of DGX VR NVL servers.
-pub mod dgx_vr_nvl;
+pub(super) mod dgx_vr_nvl;
 
 /// Support of LiteOn Power Shelf.
-pub mod liteon_power_shelf;
+pub(super) mod liteon_power_shelf;
 
 /// Support of Delta Energy Systems Power Shelf.
-pub mod delta_power_shelf;
+pub(super) mod delta_power_shelf;
 
 /// Support of NVIDIA Switch ND5200_LD.
-pub mod nvidia_switch_nd5200_ld;
+pub(super) mod nvidia_switch_nd5200_ld;
 
 /// Support of NVIDIA Switch N5700_LD.
-pub mod nvidia_switch_n5700_ld;
+pub(super) mod nvidia_switch_n5700_ld;
 
 /// Support of NVIDIA DGX H100.
-pub mod nvidia_dgx_h100;
+pub(super) mod nvidia_dgx_h100;
 
 /// Common support of GB200 and GB300
-pub mod nvidia_gbx00;
+pub(super) mod nvidia_gbx00;
 
 /// GB200 CPU/GPU
-pub mod nvidia_gb200;
+pub(super) mod nvidia_gb200;
 
 /// GB300 CPU/GPU
-pub mod nvidia_gb300;
+pub(super) mod nvidia_gb300;
 
 /// Intel E810 NIC.
-pub mod nic_intel_e810;
+pub(super) mod nic_intel_e810;
 
 /// Intel X550 NIC.
-pub mod nic_intel_x550;
+pub(super) mod nic_intel_x550;
 
 /// Intel I210 NIC.
-pub mod nic_intel_i210;
+pub(super) mod nic_intel_i210;
 
 /// NVIDIA ConnectX-7.
-pub mod nic_nvidia_cx7;
+pub(super) mod nic_nvidia_cx7;

--- a/crates/bmc-mock/src/hw/nic.rs
+++ b/crates/bmc-mock/src/hw/nic.rs
@@ -18,21 +18,20 @@
 use std::borrow::Cow;
 
 use mac_address::MacAddress;
-pub type SlotNumber = usize;
+pub(crate) type SlotNumber = usize;
 
-pub struct Nic<'a> {
-    pub mac_address: MacAddress,
-    pub serial_number: Option<Cow<'a, str>>,
-    pub manufacturer: Option<Cow<'a, str>>,
-    pub model: Option<Cow<'a, str>>,
-    pub description: Option<Cow<'a, str>>,
-    pub part_number: Option<Cow<'a, str>>,
-    pub firmware_version: Option<Cow<'a, str>>,
-    pub is_mat_dpu: bool,
+pub(crate) struct Nic<'a> {
+    pub(crate) mac_address: MacAddress,
+    pub(crate) serial_number: Option<Cow<'a, str>>,
+    pub(crate) manufacturer: Option<Cow<'a, str>>,
+    pub(crate) model: Option<Cow<'a, str>>,
+    pub(crate) description: Option<Cow<'a, str>>,
+    pub(crate) part_number: Option<Cow<'a, str>>,
+    pub(crate) firmware_version: Option<Cow<'a, str>>,
 }
 
 impl Nic<'_> {
-    pub fn rooftop(mac: MacAddress) -> Nic<'static> {
+    pub(crate) fn rooftop(mac: MacAddress) -> Nic<'static> {
         let serial_number = Some(format!("RT{}", mac.to_string().replace(':', "")).into());
         Nic {
             manufacturer: Some("Rooftop Technologies".into()),
@@ -42,7 +41,6 @@ impl Nic<'_> {
             description: None,
             firmware_version: None,
             mac_address: mac,
-            is_mat_dpu: false,
         }
     }
 }

--- a/crates/bmc-mock/src/hw/nic_intel_e810.rs
+++ b/crates/bmc-mock/src/hw/nic_intel_e810.rs
@@ -20,12 +20,12 @@ use mac_address::MacAddress;
 use crate::hw;
 
 // This type describes Intel® Ethernet Network Adapter E810.
-pub struct NicIntelE810 {
-    pub mac_addresses: [MacAddress; 2],
+pub(crate) struct NicIntelE810 {
+    pub(crate) mac_addresses: [MacAddress; 2],
 }
 
 impl NicIntelE810 {
-    pub fn ethernet_nics(&self) -> [hw::nic::Nic<'static>; 2] {
+    pub(super) fn ethernet_nics(&self) -> [hw::nic::Nic<'static>; 2] {
         // Real serial numbers are MAC address of port0 without ':'.
         let serial_number = self.mac_addresses[0].to_string().replace(":", "");
         self.mac_addresses.map(|mac| hw::nic::Nic {
@@ -36,7 +36,6 @@ impl NicIntelE810 {
             description: None,
             part_number: Some("K91258-010".into()),
             firmware_version: None,
-            is_mat_dpu: false,
         })
     }
 }

--- a/crates/bmc-mock/src/hw/nic_intel_i210.rs
+++ b/crates/bmc-mock/src/hw/nic_intel_i210.rs
@@ -20,12 +20,12 @@ use mac_address::MacAddress;
 use crate::hw;
 
 // This type describes Intel® Ethernet Network Adapter I210.
-pub struct NicIntelI210 {
-    pub mac_address: MacAddress,
+pub(crate) struct NicIntelI210 {
+    pub(crate) mac_address: MacAddress,
 }
 
 impl NicIntelI210 {
-    pub fn ethernet_nic(&self) -> hw::nic::Nic<'static> {
+    pub(super) fn ethernet_nic(&self) -> hw::nic::Nic<'static> {
         hw::nic::Nic {
             mac_address: self.mac_address,
             serial_number: None,
@@ -34,7 +34,6 @@ impl NicIntelI210 {
             description: None,
             part_number: None,
             firmware_version: None,
-            is_mat_dpu: false,
         }
     }
 }

--- a/crates/bmc-mock/src/hw/nic_intel_x550.rs
+++ b/crates/bmc-mock/src/hw/nic_intel_x550.rs
@@ -20,12 +20,12 @@ use mac_address::MacAddress;
 use crate::hw;
 
 // This type describes Intel® Ethernet Network Adapter E810.
-pub struct NicIntelX550 {
-    pub mac_address: MacAddress,
+pub(crate) struct NicIntelX550 {
+    pub(crate) mac_address: MacAddress,
 }
 
 impl NicIntelX550 {
-    pub fn to_nic(&self) -> hw::nic::Nic<'static> {
+    pub(super) fn to_nic(&self) -> hw::nic::Nic<'static> {
         hw::nic::Nic {
             mac_address: self.mac_address,
             serial_number: None,
@@ -34,7 +34,6 @@ impl NicIntelX550 {
             description: None,
             part_number: None,
             firmware_version: None,
-            is_mat_dpu: false,
         }
     }
 }

--- a/crates/bmc-mock/src/hw/nic_nvidia_cx7.rs
+++ b/crates/bmc-mock/src/hw/nic_nvidia_cx7.rs
@@ -22,13 +22,13 @@ use mac_address::MacAddress;
 use crate::hw;
 
 // This type describes NVIDIA ConnectX-7A Dual Port NIC.
-pub struct NicNvidiaCx7A<'a> {
-    pub serial_number: Cow<'a, str>,
-    pub mac_addresses: [MacAddress; 2],
+pub(crate) struct NicNvidiaCx7A<'a> {
+    pub(crate) serial_number: Cow<'a, str>,
+    pub(crate) mac_addresses: [MacAddress; 2],
 }
 
 impl NicNvidiaCx7A<'_> {
-    pub fn ethernet_nics(&self) -> [hw::nic::Nic<'_>; 2] {
+    pub(super) fn ethernet_nics(&self) -> [hw::nic::Nic<'_>; 2] {
         self.mac_addresses.map(|mac| hw::nic::Nic {
             mac_address: mac,
             serial_number: Some(self.serial_number.clone()),
@@ -37,19 +37,18 @@ impl NicNvidiaCx7A<'_> {
             description: None,
             part_number: Some("CX755206A      ".into()),
             firmware_version: None,
-            is_mat_dpu: false,
         })
     }
 }
 
 // This type describes NVIDIA ConnectX-7B 4x port NIC Ethernet/IB.
-pub struct NicNvidiaCx7B<'a> {
-    pub serial_number: Cow<'a, str>,
-    pub mac_addresses: [MacAddress; 4],
+pub(crate) struct NicNvidiaCx7B<'a> {
+    pub(crate) serial_number: Cow<'a, str>,
+    pub(crate) mac_addresses: [MacAddress; 4],
 }
 
 impl NicNvidiaCx7B<'_> {
-    pub fn ib_nics(&self) -> [hw::nic::Nic<'_>; 4] {
+    pub(super) fn ib_nics(&self) -> [hw::nic::Nic<'_>; 4] {
         self.mac_addresses.map(|mac_address| hw::nic::Nic {
             mac_address,
             serial_number: Some(self.serial_number.clone()),
@@ -58,7 +57,6 @@ impl NicNvidiaCx7B<'_> {
             description: None,
             part_number: Some("MCX750500B-692".into()),
             firmware_version: None,
-            is_mat_dpu: false,
         })
     }
 }

--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -24,22 +24,22 @@ use serde_json::json;
 use crate::json::JsonExt;
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-pub struct NvidiaDgxH100<'a> {
-    pub dgx_system_serial_number: Cow<'a, str>,
-    pub dgx_chassis_serial_number: Cow<'a, str>,
-    pub ib_nics: [hw::nic_nvidia_cx7::NicNvidiaCx7B<'a>; 2],
-    pub mgmt_nic: hw::nic_intel_x550::NicIntelX550,
-    pub dpu: hw::bluefield3::Bluefield3<'a>,
-    pub storage_nic0: hw::nic_nvidia_cx7::NicNvidiaCx7A<'a>,
-    pub storage_nic1: hw::nic_intel_e810::NicIntelE810,
-    pub gpu_serial: [Cow<'a, str>; 8],
-    pub bmc_mac_address_eth0: MacAddress,
-    pub bmc_mac_address_usb0: MacAddress,
-    pub hgx_bmc_mac_address_usb0: MacAddress,
+pub(crate) struct NvidiaDgxH100<'a> {
+    pub(crate) dgx_system_serial_number: Cow<'a, str>,
+    pub(crate) dgx_chassis_serial_number: Cow<'a, str>,
+    pub(crate) ib_nics: [hw::nic_nvidia_cx7::NicNvidiaCx7B<'a>; 2],
+    pub(crate) mgmt_nic: hw::nic_intel_x550::NicIntelX550,
+    pub(crate) dpu: hw::bluefield3::Bluefield3<'a>,
+    pub(crate) storage_nic0: hw::nic_nvidia_cx7::NicNvidiaCx7A<'a>,
+    pub(crate) storage_nic1: hw::nic_intel_e810::NicIntelE810,
+    pub(crate) gpu_serial: [Cow<'a, str>; 8],
+    pub(crate) bmc_mac_address_eth0: MacAddress,
+    pub(crate) bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
 }
 
 impl NvidiaDgxH100<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let bmc_manager_id = "BMC";
         let bmc_eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -99,7 +99,10 @@ impl NvidiaDgxH100<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "DGX";
         let callbacks = Some(callbacks);
         let storage_nic0_ports = self.storage_nic0.ethernet_nics();
@@ -212,7 +215,7 @@ impl NvidiaDgxH100<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let dgx_chassis_id = "DGX";
         let net_adapter_builder = |id: &str| {
             redfish::network_adapter::builder(&redfish::network_adapter::chassis_resource(
@@ -337,7 +340,7 @@ impl NvidiaDgxH100<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: [
                 // version required carbide to pass ingestion test in site explorer.

--- a/crates/bmc-mock/src/hw/nvidia_gb200.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb200.rs
@@ -46,7 +46,7 @@ pub(crate) fn nvl72_rack_elevation(
 }
 
 #[derive(Clone, Copy)]
-pub enum BoardIndex {
+pub(crate) enum BoardIndex {
     Board0,
     Board1,
 }
@@ -61,19 +61,22 @@ impl fmt::Display for BoardIndex {
     }
 }
 
-pub struct BiancaBoard<'a> {
-    pub index: BoardIndex,
-    pub cpu_serial_number: Cow<'a, str>,
-    pub gpu_serial_number: Cow<'a, str>,
+pub(crate) struct BiancaBoard<'a> {
+    pub(crate) index: BoardIndex,
+    pub(crate) cpu_serial_number: Cow<'a, str>,
+    pub(crate) gpu_serial_number: Cow<'a, str>,
 }
 
-pub struct GpuChassisIds {
-    pub chassis_id: Cow<'static, str>,
-    pub pcie_device_id: Cow<'static, str>,
+struct GpuChassisIds {
+    chassis_id: Cow<'static, str>,
+    pcie_device_id: Cow<'static, str>,
 }
 
 impl BiancaBoard<'_> {
-    pub fn hgx_cpu_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+    pub(super) fn hgx_cpu_chassis(
+        &self,
+        id: Cow<'static, str>,
+    ) -> redfish::chassis::SingleChassisConfig {
         let sensors = redfish::sensor::generate_chassis_sensors(
             &id,
             redfish::sensor::Layout {
@@ -106,7 +109,7 @@ impl BiancaBoard<'_> {
         }
     }
 
-    pub fn gpu_chassis_ids(&self) -> [GpuChassisIds; 2] {
+    fn gpu_chassis_ids(&self) -> [GpuChassisIds; 2] {
         let base = self.gpu_base_index();
         [0, 1].map(|local| {
             let n = base + local;
@@ -117,7 +120,7 @@ impl BiancaBoard<'_> {
         })
     }
 
-    pub fn hgx_gpu_processors(&self, system_id: &str) -> [redfish::processor::Processor; 2] {
+    pub(super) fn hgx_gpu_processors(&self, system_id: &str) -> [redfish::processor::Processor; 2] {
         self.gpu_chassis_ids().map(|ids| {
             let voltage_sensor_id =
                 redfish::sensor::sensor_id(redfish::sensor::SensorKind::Voltage, 1);
@@ -131,7 +134,7 @@ impl BiancaBoard<'_> {
         })
     }
 
-    pub fn hgx_gpu_chassis(&self) -> [redfish::chassis::SingleChassisConfig; 2] {
+    pub(super) fn hgx_gpu_chassis(&self) -> [redfish::chassis::SingleChassisConfig; 2] {
         self.gpu_chassis_ids().map(|ids| {
             let sensors = redfish::sensor::generate_chassis_sensors(
                 &ids.chassis_id,
@@ -169,12 +172,15 @@ impl BiancaBoard<'_> {
     }
 }
 
-pub struct IoBoard<'a> {
-    pub serial_number: Cow<'a, str>,
+pub(crate) struct IoBoard<'a> {
+    pub(crate) serial_number: Cow<'a, str>,
 }
 
 impl IoBoard<'_> {
-    pub fn as_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+    pub(super) fn as_chassis(
+        &self,
+        id: Cow<'static, str>,
+    ) -> redfish::chassis::SingleChassisConfig {
         let sensors = redfish::sensor::generate_chassis_sensors(
             &id,
             redfish::sensor::Layout {

--- a/crates/bmc-mock/src/hw/nvidia_gb300.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb300.rs
@@ -19,12 +19,15 @@ use std::borrow::Cow;
 
 use crate::redfish;
 
-pub struct NvidiaGB300Gpu<'a> {
-    pub serial_number: Cow<'a, str>,
+pub(crate) struct NvidiaGB300Gpu<'a> {
+    pub(crate) serial_number: Cow<'a, str>,
 }
 
 impl NvidiaGB300Gpu<'_> {
-    pub fn as_hgx_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+    pub(super) fn as_hgx_chassis(
+        &self,
+        id: Cow<'static, str>,
+    ) -> redfish::chassis::SingleChassisConfig {
         let sensors = redfish::sensor::generate_chassis_sensors(
             &id,
             redfish::sensor::Layout {
@@ -49,12 +52,15 @@ impl NvidiaGB300Gpu<'_> {
     }
 }
 
-pub struct NvidiaGB300Cpu<'a> {
-    pub serial_number: Cow<'a, str>,
+pub(crate) struct NvidiaGB300Cpu<'a> {
+    pub(crate) serial_number: Cow<'a, str>,
 }
 
 impl NvidiaGB300Cpu<'_> {
-    pub fn as_hgx_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+    pub(super) fn as_hgx_chassis(
+        &self,
+        id: Cow<'static, str>,
+    ) -> redfish::chassis::SingleChassisConfig {
         let sensors = redfish::sensor::generate_chassis_sensors(
             &id,
             redfish::sensor::Layout {
@@ -81,12 +87,15 @@ impl NvidiaGB300Cpu<'_> {
     }
 }
 
-pub struct NvidiaGB300IoBoard<'a> {
-    pub serial_number: Cow<'a, str>,
+pub(crate) struct NvidiaGB300IoBoard<'a> {
+    pub(crate) serial_number: Cow<'a, str>,
 }
 
 impl NvidiaGB300IoBoard<'_> {
-    pub fn as_chassis(&self, id: Cow<'static, str>) -> redfish::chassis::SingleChassisConfig {
+    pub(super) fn as_chassis(
+        &self,
+        id: Cow<'static, str>,
+    ) -> redfish::chassis::SingleChassisConfig {
         let sensors = redfish::sensor::generate_chassis_sensors(
             &id,
             redfish::sensor::Layout {

--- a/crates/bmc-mock/src/hw/nvidia_gbx00.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gbx00.rs
@@ -23,15 +23,15 @@ use serde_json::json;
 
 use crate::redfish;
 
-pub struct Topology {
-    pub chassis_physical_slot_number: u32,
-    pub compute_tray_index: u32,
-    pub revision_id: u32,
-    pub topology_id: u32,
+pub(crate) struct Topology {
+    pub(crate) chassis_physical_slot_number: u32,
+    pub(crate) compute_tray_index: u32,
+    pub(crate) revision_id: u32,
+    pub(crate) topology_id: u32,
 }
 
 // CBC chassis definition.
-pub fn cbc_chassis(
+pub(super) fn cbc_chassis(
     chassis_id: Cow<'static, str>,
     topology: &Topology,
 ) -> redfish::chassis::SingleChassisConfig {

--- a/crates/bmc-mock/src/hw/nvidia_switch_n5700_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_n5700_ld.rs
@@ -27,16 +27,16 @@ const BMC_FIRMWARE_VERSION: &str = "88.0002.1978";
 const SWITCH_MODEL: &str = "N5700_LD";
 const SWITCH_PART_NUMBER: &str = "920-9K33D-00MV-GS0";
 
-pub struct NvidiaSwitchN5700Ld<'a> {
-    pub bmc_mac_address_eth0: MacAddress,
-    pub bmc_mac_address_eth1: MacAddress,
-    pub bmc_mac_address_usb0: MacAddress,
-    pub bmc_serial_number: Cow<'a, str>,
-    pub switch_serial_number: Cow<'a, str>,
+pub(crate) struct NvidiaSwitchN5700Ld<'a> {
+    pub(crate) bmc_mac_address_eth0: MacAddress,
+    pub(crate) bmc_mac_address_eth1: MacAddress,
+    pub(crate) bmc_mac_address_usb0: MacAddress,
+    pub(crate) bmc_serial_number: Cow<'a, str>,
+    pub(crate) switch_serial_number: Cow<'a, str>,
 }
 
 impl NvidiaSwitchN5700Ld<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let manager_id = "BMC_0";
         let eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -68,7 +68,7 @@ impl NvidiaSwitchN5700Ld<'_> {
         }
     }
 
-    pub fn system_config(&self) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(&self) -> redfish::computer_system::Config {
         redfish::computer_system::Config {
             systems: vec![redfish::computer_system::SingleSystemConfig {
                 id: Cow::Borrowed("System_0"),
@@ -92,7 +92,7 @@ impl NvidiaSwitchN5700Ld<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let mut chassis = vec![
             self.bmc_eeprom_chassis(),
             self.cpld_chassis(),
@@ -129,7 +129,7 @@ impl NvidiaSwitchN5700Ld<'_> {
         redfish::chassis::ChassisConfig { chassis }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         let fw_inv_builder = |id: &str| {
             redfish::software_inventory::builder(
                 &redfish::software_inventory::firmware_inventory_resource(id),

--- a/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
+++ b/crates/bmc-mock/src/hw/nvidia_switch_nd5200_ld.rs
@@ -21,16 +21,16 @@ use mac_address::MacAddress;
 
 use crate::redfish;
 
-pub struct NvidiaSwitchNd5200Ld<'a> {
-    pub bmc_mac_address_eth0: MacAddress,
-    pub bmc_mac_address_eth1: MacAddress,
-    pub bmc_mac_address_usb0: MacAddress,
-    pub bmc_serial_number: Cow<'a, str>,
-    pub switch_serial_number: Cow<'a, str>,
+pub(crate) struct NvidiaSwitchNd5200Ld<'a> {
+    pub(crate) bmc_mac_address_eth0: MacAddress,
+    pub(crate) bmc_mac_address_eth1: MacAddress,
+    pub(crate) bmc_mac_address_usb0: MacAddress,
+    pub(crate) bmc_serial_number: Cow<'a, str>,
+    pub(crate) switch_serial_number: Cow<'a, str>,
 }
 
 impl NvidiaSwitchNd5200Ld<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let manager_id = "BMC_0";
         let eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -62,7 +62,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
         }
     }
 
-    pub fn system_config(&self) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(&self) -> redfish::computer_system::Config {
         let system_id = "System_0";
 
         redfish::computer_system::Config {
@@ -88,7 +88,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         redfish::chassis::ChassisConfig {
             chassis: [
                 redfish::chassis::SingleChassisConfig {
@@ -181,7 +181,7 @@ impl NvidiaSwitchNd5200Ld<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -29,25 +29,24 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-#[allow(dead_code)]
-pub struct SupermicroGB300Nvl<'a> {
-    pub system_0_serial_number: Cow<'a, str>,
-    pub chassis_0_serial_number: Cow<'a, str>,
-    pub dpu: hw::bluefield3::Bluefield3<'a>,
-    pub embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
-    pub bmc_mac_address_eth0: MacAddress,
-    pub bmc_mac_address_eth1: MacAddress,
-    pub bmc_mac_address_usb0: MacAddress,
-    pub hgx_bmc_mac_address_usb0: MacAddress,
-    pub hgx_serial_number: Cow<'a, str>,
-    pub topology: hw::nvidia_gbx00::Topology,
-    pub cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
-    pub gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
-    pub io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
+pub(crate) struct SupermicroGB300Nvl<'a> {
+    pub(crate) system_0_serial_number: Cow<'a, str>,
+    pub(crate) chassis_0_serial_number: Cow<'a, str>,
+    pub(crate) dpu: hw::bluefield3::Bluefield3<'a>,
+    pub(crate) embedded_1g_nic: hw::nic_intel_i210::NicIntelI210,
+    pub(crate) bmc_mac_address_eth0: MacAddress,
+    pub(crate) bmc_mac_address_eth1: MacAddress,
+    pub(crate) bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_bmc_mac_address_usb0: MacAddress,
+    pub(crate) hgx_serial_number: Cow<'a, str>,
+    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) cpu: [hw::nvidia_gb300::NvidiaGB300Cpu<'a>; 2],
+    pub(crate) gpu: [hw::nvidia_gb300::NvidiaGB300Gpu<'a>; 4],
+    pub(crate) io_board: [hw::nvidia_gb300::NvidiaGB300IoBoard<'a>; 2],
 }
 
 impl SupermicroGB300Nvl<'_> {
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         let bmc_manager_id = "BMC_0";
         let bmc_eth_builder = |eth| {
             redfish::ethernet_interface::builder(&redfish::ethernet_interface::manager_resource(
@@ -120,7 +119,10 @@ impl SupermicroGB300Nvl<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "System_0";
         let boot_options = std::iter::once(
             redfish::boot_option::builder(
@@ -226,7 +228,7 @@ impl SupermicroGB300Nvl<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let dpu_chassis = |chassis_id: &'static str, bf3: &hw::bluefield3::Bluefield3<'_>| {
             let nic = bf3.host_nic();
             redfish::chassis::SingleChassisConfig {
@@ -292,7 +294,7 @@ impl SupermicroGB300Nvl<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         redfish::update_service::UpdateServiceConfig {
             firmware_inventory: vec![],
         }

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -22,14 +22,14 @@ use serde_json::json;
 
 use crate::{BootOptionKind, Callbacks, hw, redfish};
 
-pub struct WiwynnGB200Nvl<'a> {
-    pub system_serial_number: Cow<'a, str>,
-    pub chassis_serial_number: Cow<'a, str>,
-    pub compute_board: [hw::nvidia_gb200::BiancaBoard<'a>; 2],
-    pub dpu1: hw::bluefield3::Bluefield3<'a>,
-    pub dpu2: hw::bluefield3::Bluefield3<'a>,
-    pub topology: hw::nvidia_gbx00::Topology,
-    pub io_board: [hw::nvidia_gb200::IoBoard<'a>; 2],
+pub(crate) struct WiwynnGB200Nvl<'a> {
+    pub(crate) system_serial_number: Cow<'a, str>,
+    pub(crate) chassis_serial_number: Cow<'a, str>,
+    pub(crate) compute_board: [hw::nvidia_gb200::BiancaBoard<'a>; 2],
+    pub(crate) dpu1: hw::bluefield3::Bluefield3<'a>,
+    pub(crate) dpu2: hw::bluefield3::Bluefield3<'a>,
+    pub(crate) topology: hw::nvidia_gbx00::Topology,
+    pub(crate) io_board: [hw::nvidia_gb200::IoBoard<'a>; 2],
 }
 
 impl WiwynnGB200Nvl<'_> {
@@ -43,7 +43,7 @@ impl WiwynnGB200Nvl<'_> {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(crate) fn manager_config(&self) -> redfish::manager::Config {
         redfish::manager::Config {
             managers: vec![
                 redfish::manager::SingleConfig {
@@ -72,7 +72,10 @@ impl WiwynnGB200Nvl<'_> {
         }
     }
 
-    pub fn system_config(&self, callbacks: Arc<dyn Callbacks>) -> redfish::computer_system::Config {
+    pub(crate) fn system_config(
+        &self,
+        callbacks: Arc<dyn Callbacks>,
+    ) -> redfish::computer_system::Config {
         let system_id = "System_0";
         let callbacks = Some(callbacks);
         let serial_number = Some(self.system_serial_number.to_string().into());
@@ -151,7 +154,7 @@ impl WiwynnGB200Nvl<'_> {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         let dpu_chassis = |chassis_id: &'static str, bf3: &hw::bluefield3::Bluefield3<'_>| {
             let nic = bf3.host_nic();
             let network_adapters = Some(vec![
@@ -236,7 +239,7 @@ impl WiwynnGB200Nvl<'_> {
         }
     }
 
-    pub fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
+    pub(crate) fn update_service_config(&self) -> redfish::update_service::UpdateServiceConfig {
         let fw_inv_builder = |id: &str| {
             redfish::software_inventory::builder(
                 &redfish::software_inventory::firmware_inventory_resource(id),

--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl72_rack.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl72_rack.rs
@@ -18,10 +18,10 @@
 use crate::hw::rack::RackElevation;
 use crate::{HardwareType, hw};
 
-pub struct WiwynnGB200Nvl72Rack;
+pub(crate) struct WiwynnGB200Nvl72Rack;
 
 impl WiwynnGB200Nvl72Rack {
-    pub fn rack_elevation(&self) -> RackElevation {
+    pub(crate) fn rack_elevation(&self) -> RackElevation {
         hw::nvidia_gb200::nvl72_rack_elevation(
             HardwareType::WiwynnGB200Nvl,
             HardwareType::LiteOnPowerShelf,

--- a/crates/bmc-mock/src/injection/mod.rs
+++ b/crates/bmc-mock/src/injection/mod.rs
@@ -22,11 +22,11 @@
 //! the response body, replace it wholesale, slow it down, or short-circuit
 //! it with a status code).
 //!
-//! At HTTP request time the middleware calls [`InjectionStore::pre_handle`]
+//! At HTTP request time the middleware calls `InjectionStore::pre_handle`
 //! before invoking the inner Redfish router; if that returns `Some(response)`
 //! the inner handler is skipped (`Status` short-circuit) or its execution is
 //! delayed (`Latency`). After the inner handler runs the middleware calls
-//! [`InjectionStore::post_handle`] to apply `Replace` / `JsonMerge` actions
+//! `InjectionStore::post_handle` to apply `Replace` / `JsonMerge` actions
 //! on the response body.
 //!
 //! Globbing follows the [`glob`] crate (filesystem-style):
@@ -54,10 +54,11 @@ pub use store::InjectionStore;
 use crate::BmcState;
 use crate::json::JsonExt;
 
-pub mod presets;
-pub mod store;
+#[cfg(test)]
+mod presets;
+mod store;
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(super) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(
         "/Injection/rules",
         get(list_rules)
@@ -107,7 +108,7 @@ fn rules_response(store: &InjectionStore) -> Response {
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct RuleId(pub String);
+pub struct RuleId(String);
 
 impl From<&str> for RuleId {
     fn from(s: &str) -> Self {
@@ -174,11 +175,11 @@ mod duration_str_serde {
 
     use serde::{Deserializer, Serializer};
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
         duration_str::deserialize_duration(d)
     }
 
-    pub fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(d: &Duration, s: S) -> Result<S::Ok, S::Error> {
         s.serialize_str(&format!("{}ms", d.as_millis()))
     }
 }

--- a/crates/bmc-mock/src/injection/presets.rs
+++ b/crates/bmc-mock/src/injection/presets.rs
@@ -21,7 +21,7 @@ use super::{Action, Rule, Selector};
 
 /// BlueField PCIe devices vanish from the chassis collections (and 404 on direct GET)
 /// NetworkAdapter resources report blank vendor strings with no NetworkDeviceFunctions
-pub fn all_dpu_lost_on_host() -> Vec<Rule> {
+pub(super) fn all_dpu_lost_on_host() -> Vec<Rule> {
     vec![
         Rule {
             id: "all_dpu_lost__pcie_hide".into(),

--- a/crates/bmc-mock/src/injection/store.rs
+++ b/crates/bmc-mock/src/injection/store.rs
@@ -77,12 +77,8 @@ impl InjectionStore {
         })
     }
 
-    pub fn clear(&self) {
+    pub(super) fn clear(&self) {
         self.rules.store(Arc::new(Vec::new()));
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.rules.load().is_empty()
     }
 
     fn rcu_with<R: Default>(
@@ -99,7 +95,7 @@ impl InjectionStore {
     }
 
     /// Used to modify HTTP response and inject latency.
-    pub async fn pre_handle(&self, method: &Method, path: &str) -> Option<Response> {
+    pub(crate) async fn pre_handle(&self, method: &Method, path: &str) -> Option<Response> {
         let snapshot = self.rules.load_full();
         if snapshot.is_empty() {
             return None;
@@ -170,7 +166,7 @@ impl InjectionStore {
     }
 
     /// Modify response body
-    pub async fn post_handle(&self, path: &str, response: Response) -> Response {
+    pub(crate) async fn post_handle(&self, path: &str, response: Response) -> Response {
         let snapshot = self.rules.load_full();
         if snapshot.is_empty() {
             return response;

--- a/crates/bmc-mock/src/ipmi.rs
+++ b/crates/bmc-mock/src/ipmi.rs
@@ -29,13 +29,13 @@ use crate::bmc_state::BmcState;
 
 /// Request body for IPMI mock endpoint.
 #[derive(Debug, Deserialize)]
-pub struct IpmiRequest {
+struct IpmiRequest {
     action: String,
 }
 
 /// Response body for IPMI mock endpoint.
 #[derive(Debug, Serialize)]
-pub struct IpmiResponse {
+struct IpmiResponse {
     success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
@@ -58,7 +58,7 @@ impl IpmiResponse {
 }
 
 /// Add IPMI routes to the router.
-pub fn add_routes(router: Router<BmcState>) -> Router<BmcState> {
+pub(super) fn add_routes(router: Router<BmcState>) -> Router<BmcState> {
     router.route("/ipmi", post(handle_ipmi))
 }
 

--- a/crates/bmc-mock/src/ipmi_sim.rs
+++ b/crates/bmc-mock/src/ipmi_sim.rs
@@ -41,7 +41,6 @@ const START_ATTEMPTS: usize = 5;
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const PASSWORD_UPDATE_TIMEOUT: Duration = Duration::from_secs(10);
-pub const STANDARD_IPMI_PORT: u16 = 623;
 const IPMI_SIM_EXECUTABLE: &str = "ipmi_sim";
 const CHASSIS_CONTROL_FIFO: &str = "chassis-control.fifo";
 

--- a/crates/bmc-mock/src/json.rs
+++ b/crates/bmc-mock/src/json.rs
@@ -19,7 +19,7 @@ use axum::body::Body;
 use axum::http::{HeaderValue, StatusCode};
 use axum::response::Response;
 
-pub trait JsonExt {
+pub(super) trait JsonExt {
     fn patch(self, patch: impl JsonPatch) -> serde_json::Value
     where
         Self: Sized;
@@ -76,7 +76,7 @@ impl JsonExt for serde_json::Value {
     }
 }
 
-pub trait JsonPatch {
+pub(super) trait JsonPatch {
     fn json_patch(&self) -> serde_json::Value;
 }
 
@@ -86,7 +86,7 @@ impl JsonPatch for serde_json::Value {
     }
 }
 
-pub fn json_patch(target: &mut serde_json::Value, patch: serde_json::Value) {
+pub(super) fn json_patch(target: &mut serde_json::Value, patch: serde_json::Value) {
     match (target, patch) {
         (serde_json::Value::Object(target_obj), serde_json::Value::Object(patch_obj)) => {
             for (k, v_patch) in patch_obj {

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tokio::time::Instant;
-pub mod ipmi;
+mod ipmi;
 pub mod ipmi_sim;
 pub mod libvirt;
 pub mod simulated;
@@ -30,7 +30,7 @@ mod bmc_state;
 mod combined_server;
 mod combined_service;
 mod http;
-pub mod hw;
+mod hw;
 pub mod injection;
 mod json;
 pub mod mac_address_pool;
@@ -45,6 +45,7 @@ pub mod tls;
 pub use bmc_state::{BmcEvent, BmcState};
 pub use combined_server::{CombinedServer, ListenerOrAddress};
 pub use combined_service::combined_router;
+pub use hw::rack::{RackElevation, RackUnit};
 pub use machine_info::{
     DpuFirmwareVersions, DpuMachineInfo, DpuSettings, HostMachineInfo, MachineInfo,
 };
@@ -57,7 +58,6 @@ pub use redfish::virtual_media::DeviceConfig as VirtualMediaDeviceConfig;
 
 pub const DUMMY_FACTORY_USERNAME: &str = "root";
 pub const DUMMY_FACTORY_PASSWORD: &str = "factory_password";
-pub const DUMMY_FACTORY_DPU_PASSWORD: &str = "0penBmc";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
 pub enum RackType {
@@ -258,7 +258,7 @@ pub enum SystemPowerControl {
     Resume,
 }
 
-pub trait LogServices: Send + Sync {
+trait LogServices: Send + Sync {
     fn services(&self) -> Vec<&(dyn LogService + '_)>;
 
     fn find(&self, id: &str) -> Option<&(dyn LogService + '_)> {
@@ -269,7 +269,7 @@ pub trait LogServices: Send + Sync {
     }
 }
 
-pub trait LogService: Send + Sync {
+trait LogService: Send + Sync {
     fn id(&self) -> &str;
 
     fn entries(&self, collection: &redfish::Collection<'_>) -> Vec<serde_json::Value>;

--- a/crates/bmc-mock/src/mac_address_pool.rs
+++ b/crates/bmc-mock/src/mac_address_pool.rs
@@ -289,17 +289,6 @@ impl MacAddressPool {
         Ok(())
     }
 
-    /// Allocate MAC address subrange from ranges pool.
-    pub fn allocate_range(&mut self) -> Result<Self, Error> {
-        self.allocate_range_config().map(|pool| {
-            Self::new(Config {
-                // Returned pool should not have subranges.
-                ranges: None,
-                pool: Some(pool),
-            })
-        })
-    }
-
     fn maybe_reserve_range(&mut self, addr: MacAddress) {
         if let Some(range_base) = self.config.range_base_for(addr) {
             self.allocated_ranges.insert(range_base);
@@ -355,6 +344,14 @@ impl MacAddressExt for MacAddress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    impl MacAddressPool {
+        /// Build a child pool for tests that exercise allocations within a
+        /// range returned by the production range-allocation API.
+        fn allocate_range(&mut self) -> Result<Self, Error> {
+            self.allocate_range_config().map(Self::new_pool)
+        }
+    }
 
     fn mac(v: u64) -> MacAddress {
         MacAddress::from_u64(v)

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -45,8 +45,8 @@ pub struct HostMachineInfo {
     pub hw_mac_addr_pool: MacAddressPoolConfig,
     /// Per-PSU commanded on/off states for a Delta power shelf, reported under
     /// `Oem.deltaenergysystems.Power`. `None` uses the default all-on shelf;
-    /// set it (e.g. via [`HostMachineInfo::with_delta_psu_power`]) to model
-    /// off/mixed shelves. Ignored for non-Delta hardware.
+    /// [`crate::test_support::delta_powershelf_bmc_with_psu_power`] sets it to
+    /// model off/mixed shelves. Ignored for non-Delta hardware.
     pub delta_psu_power: Option<Vec<bool>>,
 }
 
@@ -209,21 +209,21 @@ impl DpuMachineInfo {
         }
     }
 
-    pub fn bmc_product(&self) -> Option<&'static str> {
+    fn bmc_product(&self) -> Option<&'static str> {
         match self.dpu_type() {
             DpuType::Bluefield3 => Some("BlueField-3 DPU"),
             DpuType::Bluefield4 => Some("BlueField-4"),
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    fn manager_config(&self) -> redfish::manager::Config {
         match self.dpu_type() {
             DpuType::Bluefield3 => self.bluefield3().manager_config(),
             DpuType::Bluefield4 => self.bluefield4().manager_config(),
         }
     }
 
-    pub fn system_config(
+    fn system_config(
         &self,
         callbacks: Arc<dyn crate::Callbacks>,
     ) -> redfish::computer_system::Config {
@@ -233,21 +233,21 @@ impl DpuMachineInfo {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         match self.dpu_type() {
             DpuType::Bluefield3 => self.bluefield3().chassis_config(),
             DpuType::Bluefield4 => self.bluefield4().chassis_config(),
         }
     }
 
-    pub fn update_service_config(&self) -> UpdateServiceConfig {
+    fn update_service_config(&self) -> UpdateServiceConfig {
         match self.dpu_type() {
             DpuType::Bluefield3 => self.bluefield3().update_service_config(),
             DpuType::Bluefield4 => self.bluefield4().update_service_config(),
         }
     }
 
-    pub fn oem_state(&self) -> redfish::oem::State {
+    fn oem_state(&self) -> redfish::oem::State {
         match self.dpu_type() {
             DpuType::Bluefield3 => redfish::oem::State::NvidiaBluefield(
                 redfish::oem::nvidia::bluefield::BluefieldState::new_bf3(
@@ -310,12 +310,12 @@ impl HostMachineInfo {
     /// PSU bay). Used by tests to model off/mixed shelves; the default is an
     /// all-on six-bay shelf.
     #[must_use]
-    pub fn with_delta_psu_power(mut self, states: Vec<bool>) -> Self {
+    pub(super) fn with_delta_psu_power(mut self, states: Vec<bool>) -> Self {
         self.delta_psu_power = Some(states);
         self
     }
 
-    pub fn primary_dpu(&self) -> Option<&DpuMachineInfo> {
+    fn primary_dpu(&self) -> Option<&DpuMachineInfo> {
         self.dpus.first()
     }
 
@@ -325,7 +325,7 @@ impl HostMachineInfo {
             .or(self.non_dpu_mac_address)
     }
 
-    pub fn oem_state(&self) -> redfish::oem::State {
+    fn oem_state(&self) -> redfish::oem::State {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => {
                 redfish::oem::State::DellIdrac(redfish::oem::dell::idrac::IdracState::default())
@@ -348,7 +348,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
+    fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => {
                 redfish::oem::BmcVendor::Dell
@@ -377,7 +377,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn bmc_product(&self) -> Option<&'static str> {
+    fn bmc_product(&self) -> Option<&'static str> {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 => None,
             HardwareType::DellPowerEdgeR760Bf4 => Some("Integrated Dell Remote Access Controller"),
@@ -397,7 +397,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn bmc_redfish_version(&self) -> &'static str {
+    fn bmc_redfish_version(&self) -> &'static str {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 | HardwareType::DellPowerEdgeR760Bf4 => "1.18.0",
             HardwareType::WiwynnGB200Nvl => "1.17.0",
@@ -416,7 +416,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    fn manager_config(&self) -> redfish::manager::Config {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().manager_config(),
             HardwareType::DellPowerEdgeR760Bf4 => self.dell_poweredge_r760_bf4().manager_config(),
@@ -439,7 +439,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn system_config(
+    fn system_config(
         &self,
         callbacks: Arc<dyn crate::Callbacks>,
     ) -> redfish::computer_system::Config {
@@ -469,7 +469,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().chassis_config(),
             HardwareType::DellPowerEdgeR760Bf4 => self.dell_poweredge_r760_bf4().chassis_config(),
@@ -492,7 +492,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn update_service_config(&self) -> UpdateServiceConfig {
+    fn update_service_config(&self) -> UpdateServiceConfig {
         match self.hw_type {
             HardwareType::DellPowerEdgeR750 => self.dell_poweredge_r750().update_service_config(),
             HardwareType::DellPowerEdgeR760Bf4 => {
@@ -521,7 +521,7 @@ impl HostMachineInfo {
         }
     }
 
-    pub fn factory_default_account(&self) -> redfish::account_service::Account {
+    fn factory_default_account(&self) -> redfish::account_service::Account {
         // TODO: need to be updated for each individual system.
         let id = match self.hw_type {
             HardwareType::NvidiaDgxH100 | HardwareType::GenericAmi => "2",
@@ -714,7 +714,12 @@ impl HostMachineInfo {
         let io_board1_sn = "MT2524000002";
         let mut pool = MacAddressPool::new_pool(self.hw_mac_addr_pool);
         let mut next_mac = || pool.allocate().expect("MAC address must be allocated");
-        let cx8_mac_addresses = std::array::from_fn(|_| next_mac());
+        // Machine-a-tron's `lenovo_network_interfaces` assigns the first ten
+        // addresses to the CX-8s. Reserve the same slots here so the embedded
+        // NIC and BMC interfaces report matching addresses.
+        for _ in 0..10 {
+            next_mac();
+        }
         hw::lenovo_gb300_nvl::LenovoGB300Nvl {
             system_0_serial_number: Cow::Borrowed(&self.serial),
             chassis_0_serial_number: Cow::Borrowed(&self.serial),
@@ -722,7 +727,6 @@ impl HostMachineInfo {
                 .next()
                 .expect("One DPU must present for GB300 NVL")
                 .bluefield3(),
-            cx8_mac_addresses,
             embedded_1g_nic: hw::nic_intel_i210::NicIntelI210 {
                 mac_address: next_mac(),
             },
@@ -803,7 +807,7 @@ impl HostMachineInfo {
 
     /// Whether this host advertises and serves a `/redfish/v1/Systems`
     /// collection. Delta power shelves do not.
-    pub fn exposes_computer_systems(&self) -> bool {
+    fn exposes_computer_systems(&self) -> bool {
         !matches!(self.hw_type, HardwareType::DeltaPowerShelf)
     }
 
@@ -939,21 +943,21 @@ impl MachineInfo {
         )
     }
 
-    pub fn oem_state(&self) -> redfish::oem::State {
+    pub(super) fn oem_state(&self) -> redfish::oem::State {
         match self {
             MachineInfo::Host(host) => host.oem_state(),
             MachineInfo::Dpu(dpu) => dpu.oem_state(),
         }
     }
 
-    pub fn manager_config(&self) -> redfish::manager::Config {
+    pub(super) fn manager_config(&self) -> redfish::manager::Config {
         match self {
             MachineInfo::Host(host) => host.manager_config(),
             MachineInfo::Dpu(dpu) => dpu.manager_config(),
         }
     }
 
-    pub fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
+    pub(super) fn bmc_vendor(&self) -> redfish::oem::BmcVendor {
         match self {
             MachineInfo::Host(h) => h.bmc_vendor(),
             MachineInfo::Dpu(_) => {
@@ -962,21 +966,21 @@ impl MachineInfo {
         }
     }
 
-    pub fn bmc_redfish_version(&self) -> &'static str {
+    pub(super) fn bmc_redfish_version(&self) -> &'static str {
         match self {
             MachineInfo::Host(h) => h.bmc_redfish_version(),
             MachineInfo::Dpu(_) => "1.17.0",
         }
     }
 
-    pub fn bmc_product(&self) -> Option<&'static str> {
+    pub(super) fn bmc_product(&self) -> Option<&'static str> {
         match self {
             MachineInfo::Host(h) => h.bmc_product(),
             MachineInfo::Dpu(d) => d.bmc_product(),
         }
     }
 
-    pub fn system_config(
+    pub(super) fn system_config(
         &self,
         callbacks: Arc<dyn crate::Callbacks>,
     ) -> redfish::computer_system::Config {
@@ -986,14 +990,14 @@ impl MachineInfo {
         }
     }
 
-    pub fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
+    pub(super) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
         match self {
             Self::Host(h) => h.chassis_config(),
             Self::Dpu(dpu) => dpu.chassis_config(),
         }
     }
 
-    pub fn update_service_config(&self) -> UpdateServiceConfig {
+    pub(super) fn update_service_config(&self) -> UpdateServiceConfig {
         match self {
             Self::Host(h) => h.update_service_config(),
             Self::Dpu(dpu) => dpu.update_service_config(),
@@ -1002,17 +1006,10 @@ impl MachineInfo {
 
     /// Whether this machine advertises and serves a `/redfish/v1/Systems`
     /// collection. Only Delta power shelves omit it.
-    pub fn exposes_computer_systems(&self) -> bool {
+    pub(super) fn exposes_computer_systems(&self) -> bool {
         match self {
             Self::Host(h) => h.exposes_computer_systems(),
             Self::Dpu(_) => true,
-        }
-    }
-
-    pub fn product_serial(&self) -> &String {
-        match self {
-            Self::Host(h) => &h.serial,
-            Self::Dpu(d) => &d.serial,
         }
     }
 
@@ -1046,7 +1043,7 @@ impl MachineInfo {
         }
     }
 
-    pub fn factory_default_account(&self) -> redfish::account_service::Account {
+    pub(super) fn factory_default_account(&self) -> redfish::account_service::Account {
         match self {
             MachineInfo::Host(h) => h.factory_default_account(),
             MachineInfo::Dpu(d) => {

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -28,7 +28,7 @@ use crate::Callbacks;
 use crate::http::call_router_with_new_request;
 use crate::injection::InjectionStore;
 
-pub fn append(
+pub(super) fn append(
     mat_host_id: String,
     router: Router,
     injection: Arc<InjectionStore>,

--- a/crates/bmc-mock/src/redfish/account_service.rs
+++ b/crates/bmc-mock/src/redfish/account_service.rs
@@ -31,7 +31,7 @@ use crate::bmc_state::BmcState;
 use crate::json::JsonExt;
 use crate::{http, redfish};
 
-pub fn resource() -> redfish::Resource<'static> {
+pub(crate) fn resource() -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Borrowed("/redfish/v1/AccountService"),
         odata_type: Cow::Borrowed("#AccountService.v1_9_0.AccountService"),
@@ -40,7 +40,7 @@ pub fn resource() -> redfish::Resource<'static> {
     }
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(&resource().odata_id, get(get_root).patch(patch_root))
         .route(
             &ACCOUNTS_COLLECTION_RESOURCE.odata_id,
@@ -75,7 +75,7 @@ pub(crate) trait PasswordUpdater: Send + Sync {
 }
 
 impl AccountServiceState {
-    pub fn new(factory_default_account: Account) -> Self {
+    pub(crate) fn new(factory_default_account: Account) -> Self {
         Self {
             accounts: Mutex::new(vec![factory_default_account]),
             password_updater: Mutex::new(None),
@@ -86,11 +86,11 @@ impl AccountServiceState {
         *self.password_updater.lock().expect("mutex poisoned") = Some(Arc::downgrade(updater));
     }
 
-    pub fn accounts(&self) -> Vec<Account> {
+    pub(crate) fn accounts(&self) -> Vec<Account> {
         self.accounts.lock().expect("mutex poisoned").clone()
     }
 
-    pub fn find(&self, account_id: &str) -> Option<Account> {
+    pub(crate) fn find(&self, account_id: &str) -> Option<Account> {
         self.accounts
             .lock()
             .expect("mutex poisoned")
@@ -108,7 +108,7 @@ impl AccountServiceState {
             .map(|account| (account.username.clone(), account.password.clone()))
     }
 
-    pub fn is_authorized(&self, username: &str, password: &str) -> bool {
+    pub(crate) fn is_authorized(&self, username: &str, password: &str) -> bool {
         self.accounts
             .lock()
             .expect("mutex poisoned")
@@ -116,7 +116,7 @@ impl AccountServiceState {
             .any(|account| account.matches(username, password))
     }
 
-    pub fn is_factory_default_password(&self, username: &str, password: &str) -> bool {
+    pub(crate) fn is_factory_default_password(&self, username: &str, password: &str) -> bool {
         self.accounts
             .lock()
             .expect("mutex poisoned")
@@ -124,7 +124,7 @@ impl AccountServiceState {
             .any(|account| account.matches_factory_default_password(username, password))
     }
 
-    pub async fn update_password(
+    pub(crate) async fn update_password(
         &self,
         account_id: &str,
         password: impl Into<String>,
@@ -168,7 +168,7 @@ impl AccountServiceState {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Account {
+pub(crate) struct Account {
     id: String,
     username: String,
     password: String,
@@ -177,7 +177,7 @@ pub struct Account {
 }
 
 impl Account {
-    pub fn administrator(
+    pub(crate) fn administrator(
         id: impl Into<String>,
         username: impl Into<String>,
         password: impl Into<String>,
@@ -210,7 +210,7 @@ impl Account {
     }
 }
 
-pub async fn get_root() -> Response {
+async fn get_root() -> Response {
     let service_attrs = json!({
         "AccountLockoutCounterResetAfter": 0,
         "AccountLockoutDuration": 0,
@@ -226,11 +226,11 @@ pub async fn get_root() -> Response {
         .into_ok_response()
 }
 
-pub async fn patch_root() -> Response {
+async fn patch_root() -> Response {
     http::ok_no_content()
 }
 
-pub fn account_resource(id: impl Display) -> redfish::Resource<'static> {
+fn account_resource(id: impl Display) -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Owned(format!("{}/{id}", ACCOUNTS_COLLECTION_RESOURCE.odata_id)),
         odata_type: Cow::Borrowed("#ManagerAccount.v1_8_0.ManagerAccount"),
@@ -239,7 +239,7 @@ pub fn account_resource(id: impl Display) -> redfish::Resource<'static> {
     }
 }
 
-pub async fn get_accounts(State(state): State<BmcState>) -> Response {
+async fn get_accounts(State(state): State<BmcState>) -> Response {
     let members = state
         .account_service_state
         .accounts()
@@ -251,11 +251,11 @@ pub async fn get_accounts(State(state): State<BmcState>) -> Response {
         .into_ok_response()
 }
 
-pub async fn create_account() -> Response {
+async fn create_account() -> Response {
     json!({}).into_ok_response()
 }
 
-pub async fn patch_account(
+async fn patch_account(
     State(state): State<BmcState>,
     Path(account_id): Path<String>,
     Json(patch_account): Json<serde_json::Value>,
@@ -282,10 +282,7 @@ pub async fn patch_account(
     }
 }
 
-pub async fn get_account(
-    State(state): State<BmcState>,
-    Path(account_id): Path<String>,
-) -> Response {
+async fn get_account(State(state): State<BmcState>, Path(account_id): Path<String>) -> Response {
     state
         .account_service_state
         .find(&account_id)

--- a/crates/bmc-mock/src/redfish/assembly.rs
+++ b/crates/bmc-mock/src/redfish/assembly.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn chassis_resource(chassis_id: &str) -> redfish::Resource<'static> {
+pub(crate) fn chassis_resource(chassis_id: &str) -> redfish::Resource<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/Assembly");
     redfish::Resource {
         odata_id: odata_id.into(),
@@ -33,7 +33,7 @@ pub fn chassis_resource(chassis_id: &str) -> redfish::Resource<'static> {
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> AssemblyBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> AssemblyBuilder {
     AssemblyBuilder {
         odata_id: resource.odata_id.to_string(),
         assemblies: vec![],
@@ -41,14 +41,14 @@ pub fn builder(resource: &redfish::Resource) -> AssemblyBuilder {
     }
 }
 
-pub fn data_builder(member_id: Cow<'static, str>) -> AssemblyData {
+pub(crate) fn data_builder(member_id: Cow<'static, str>) -> AssemblyData {
     AssemblyData {
         member_id,
         value: json!({}),
     }
 }
 
-pub struct AssemblyBuilder {
+pub(crate) struct AssemblyBuilder {
     odata_id: String,
     assemblies: Vec<AssemblyData>,
     value: serde_json::Value,
@@ -65,12 +65,12 @@ impl Builder for AssemblyBuilder {
 }
 
 impl AssemblyBuilder {
-    pub fn add_data(mut self, data: AssemblyData) -> Self {
+    pub(crate) fn add_data(mut self, data: AssemblyData) -> Self {
         self.assemblies.push(data);
         self
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(crate) fn build(self) -> serde_json::Value {
         json!({
             "Assemblies":
             self.assemblies.into_iter().map(|assembly| {
@@ -84,7 +84,7 @@ impl AssemblyBuilder {
     }
 }
 
-pub struct AssemblyData {
+pub(crate) struct AssemblyData {
     member_id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -99,11 +99,11 @@ impl Builder for AssemblyData {
 }
 
 impl AssemblyData {
-    pub fn serial_number(self, v: &str) -> Self {
+    pub(crate) fn serial_number(self, v: &str) -> Self {
         self.add_str_field("SerialNumber", v)
     }
 
-    pub fn build(self) -> Self {
+    pub(crate) fn build(self) -> Self {
         self
     }
 }

--- a/crates/bmc-mock/src/redfish/bios.rs
+++ b/crates/bmc-mock/src/redfish/bios.rs
@@ -21,7 +21,7 @@ use serde_json::json;
 use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 
-pub fn resource<'a>(system_id: &str) -> redfish::Resource<'a> {
+pub(crate) fn resource<'a>(system_id: &str) -> redfish::Resource<'a> {
     let odata_id = format!(
         "{}/Bios",
         redfish::computer_system::resource(system_id).odata_id
@@ -34,33 +34,33 @@ pub fn resource<'a>(system_id: &str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn change_password_target(resource: &redfish::Resource<'_>) -> String {
+pub(super) fn change_password_target(resource: &redfish::Resource<'_>) -> String {
     format!("{}/Actions/Bios.ChangePassword", resource.odata_id)
 }
 
-pub fn builder(resource: &redfish::Resource) -> BiosBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> BiosBuilder {
     BiosBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub struct BiosBuilder {
+pub(crate) struct BiosBuilder {
     value: serde_json::Value,
 }
 
 impl BiosBuilder {
-    pub fn attributes(self, value: serde_json::Value) -> Self {
+    pub(crate) fn attributes(self, value: serde_json::Value) -> Self {
         self.apply_patch(json!({"Attributes": value}))
     }
 
     /// libredfish's HPE `Bios` model requires `@odata.context` (real iLOs
     /// always send it); without it the machine controller's lockdown check
     /// fails to deserialize the response.
-    pub fn odata_context(self, value: &str) -> Self {
+    pub(crate) fn odata_context(self, value: &str) -> Self {
         self.apply_patch(json!({"@odata.context": value}))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(crate) fn build(self) -> serde_json::Value {
         self.value
     }
 

--- a/crates/bmc-mock/src/redfish/boot_option.rs
+++ b/crates/bmc-mock/src/redfish/boot_option.rs
@@ -21,7 +21,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish::Builder;
 use crate::{BootOptionKind, redfish};
 
-pub fn collection(system_id: &str) -> redfish::Collection<'static> {
+pub(super) fn collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!(
         "{}/BootOptions",
         redfish::computer_system::resource(system_id).odata_id
@@ -33,7 +33,7 @@ pub fn collection(system_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn resource<'a>(system_id: &str, boot_option_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn resource<'a>(system_id: &str, boot_option_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("{}/{boot_option_id}", collection(system_id).odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -43,7 +43,7 @@ pub fn resource<'a>(system_id: &str, boot_option_id: &'a str) -> redfish::Resour
     }
 }
 
-pub fn builder(resource: &redfish::Resource, kind: BootOptionKind) -> BootOptionBuilder {
+pub(crate) fn builder(resource: &redfish::Resource, kind: BootOptionKind) -> BootOptionBuilder {
     BootOptionBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
@@ -52,23 +52,23 @@ pub fn builder(resource: &redfish::Resource, kind: BootOptionKind) -> BootOption
     }
 }
 
-pub struct BootOption {
-    pub id: Cow<'static, str>,
-    pub reference: Option<String>,
-    pub kind: BootOptionKind,
+pub(crate) struct BootOption {
+    pub(crate) id: Cow<'static, str>,
+    pub(crate) reference: Option<String>,
+    pub(crate) kind: BootOptionKind,
     value: serde_json::Value,
 }
 
 impl BootOption {
-    pub fn boot_reference(&self) -> &str {
+    pub(crate) fn boot_reference(&self) -> &str {
         self.reference.as_deref().unwrap_or(&self.id)
     }
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub struct BootOptionBuilder {
+pub(crate) struct BootOptionBuilder {
     id: Cow<'static, str>,
     reference: Option<String>,
     value: serde_json::Value,
@@ -87,29 +87,29 @@ impl Builder for BootOptionBuilder {
 }
 
 impl BootOptionBuilder {
-    pub fn display_name(self, value: &str) -> Self {
+    pub(crate) fn display_name(self, value: &str) -> Self {
         self.add_str_field("DisplayName", value)
     }
 
-    pub fn boot_option_reference(self, value: &str) -> Self {
+    pub(crate) fn boot_option_reference(self, value: &str) -> Self {
         let mut result = self.add_str_field("BootOptionReference", value);
         result.reference = Some(value.to_string());
         result
     }
 
-    pub fn uefi_device_path(self, value: &str) -> Self {
+    pub(crate) fn uefi_device_path(self, value: &str) -> Self {
         self.add_str_field("UefiDevicePath", value)
     }
 
-    pub fn alias(self, value: &str) -> Self {
+    pub(crate) fn alias(self, value: &str) -> Self {
         self.add_str_field("Alias", value)
     }
 
-    pub fn odata_etag(self, value: &str) -> Self {
+    pub(crate) fn odata_etag(self, value: &str) -> Self {
         self.add_str_field("@odata.etag", value)
     }
 
-    pub fn build(self) -> BootOption {
+    pub(crate) fn build(self) -> BootOption {
         BootOption {
             id: self.id,
             reference: self.reference,

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -28,7 +28,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish::Builder;
 use crate::{http, redfish};
 
-pub fn resource<'a>(chassis_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn resource<'a>(chassis_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("{}/{chassis_id}", collection().odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -38,7 +38,7 @@ pub fn resource<'a>(chassis_id: &'a str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn collection() -> redfish::Collection<'static> {
+pub(super) fn collection() -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Borrowed("/redfish/v1/Chassis"),
         odata_type: Cow::Borrowed("#ChassisCollection.ChassisCollection"),
@@ -46,13 +46,13 @@ pub fn collection() -> redfish::Collection<'static> {
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> ChassisBuilder {
+fn builder(resource: &redfish::Resource) -> ChassisBuilder {
     ChassisBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const CHASSIS_ID: &str = "{chassis_id}";
     const NET_ADAPTER_ID: &str = "{network_adapter_id}";
     const NET_FUNC_ID: &str = "{function_id}";
@@ -134,27 +134,27 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
         )
 }
 
-pub struct SingleChassisConfig {
-    pub id: Cow<'static, str>,
-    pub serial_number: Option<Cow<'static, str>>,
-    pub manufacturer: Option<Cow<'static, str>>,
-    pub model: Option<Cow<'static, str>>,
-    pub part_number: Option<Cow<'static, str>>,
-    pub sku: Option<Cow<'static, str>>,
-    pub network_adapters: Option<Vec<redfish::network_adapter::NetworkAdapter>>,
-    pub pcie_devices: Option<Vec<redfish::pcie_device::PCIeDevice>>,
-    pub sensors: Option<Vec<redfish::sensor::Sensor>>,
-    pub leak_detectors: Option<Vec<redfish::leak_detector::LeakDetector>>,
-    pub chassis_type: Cow<'static, str>,
-    pub assembly: Option<serde_json::Value>,
-    pub power_supplies: Option<Vec<redfish::power_supply::PowerSupply>>,
-    pub oem: Option<serde_json::Value>,
+pub(crate) struct SingleChassisConfig {
+    pub(crate) id: Cow<'static, str>,
+    pub(crate) serial_number: Option<Cow<'static, str>>,
+    pub(crate) manufacturer: Option<Cow<'static, str>>,
+    pub(crate) model: Option<Cow<'static, str>>,
+    pub(crate) part_number: Option<Cow<'static, str>>,
+    pub(crate) sku: Option<Cow<'static, str>>,
+    pub(crate) network_adapters: Option<Vec<redfish::network_adapter::NetworkAdapter>>,
+    pub(crate) pcie_devices: Option<Vec<redfish::pcie_device::PCIeDevice>>,
+    pub(crate) sensors: Option<Vec<redfish::sensor::Sensor>>,
+    pub(crate) leak_detectors: Option<Vec<redfish::leak_detector::LeakDetector>>,
+    pub(crate) chassis_type: Cow<'static, str>,
+    pub(crate) assembly: Option<serde_json::Value>,
+    pub(crate) power_supplies: Option<Vec<redfish::power_supply::PowerSupply>>,
+    pub(crate) oem: Option<serde_json::Value>,
 }
 
 impl SingleChassisConfig {
     // To use with ..SingleChassisConfig::defaults() to fill config
     // with defaults.
-    pub fn defaults() -> SingleChassisConfig {
+    pub(crate) fn defaults() -> SingleChassisConfig {
         Self {
             id: "".into(),
             chassis_type: "".into(),
@@ -174,16 +174,16 @@ impl SingleChassisConfig {
     }
 }
 
-pub struct ChassisConfig {
-    pub chassis: Vec<SingleChassisConfig>,
+pub(crate) struct ChassisConfig {
+    pub(crate) chassis: Vec<SingleChassisConfig>,
 }
 
-pub struct ChassisState {
+pub(crate) struct ChassisState {
     chassis: Vec<SingleChassisState>,
 }
 
 impl ChassisState {
-    pub fn from_config(config: ChassisConfig) -> Self {
+    pub(crate) fn from_config(config: ChassisConfig) -> Self {
         let chassis = config
             .chassis
             .into_iter()
@@ -192,19 +192,19 @@ impl ChassisState {
         Self { chassis }
     }
 
-    pub fn find(&self, chassis_id: &str) -> Option<&SingleChassisState> {
+    pub(crate) fn find(&self, chassis_id: &str) -> Option<&SingleChassisState> {
         self.chassis
             .iter()
             .find(|c| c.config.id.as_ref() == chassis_id)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &SingleChassisState> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &SingleChassisState> {
         self.chassis.iter()
     }
 }
 
-pub struct SingleChassisState {
-    pub config: SingleChassisConfig,
+pub(crate) struct SingleChassisState {
+    pub(crate) config: SingleChassisConfig,
 }
 
 impl SingleChassisState {
@@ -212,7 +212,7 @@ impl SingleChassisState {
         Self { config }
     }
 
-    pub fn pcie_devices_resources(&self) -> Vec<redfish::Resource<'static>> {
+    pub(crate) fn pcie_devices_resources(&self) -> Vec<redfish::Resource<'static>> {
         self.config
             .pcie_devices
             .iter()
@@ -616,7 +616,7 @@ async fn get_chassis_leak_detector(
         .unwrap_or_else(http::not_found)
 }
 
-pub struct ChassisBuilder {
+struct ChassisBuilder {
     value: serde_json::Value,
 }
 
@@ -629,59 +629,59 @@ impl Builder for ChassisBuilder {
 }
 
 impl ChassisBuilder {
-    pub fn serial_number(self, v: &str) -> Self {
+    fn serial_number(self, v: &str) -> Self {
         self.add_str_field("SerialNumber", v)
     }
 
-    pub fn chassis_type(self, v: &str) -> Self {
+    fn chassis_type(self, v: &str) -> Self {
         self.add_str_field("ChassisType", v)
     }
 
-    pub fn manufacturer(self, v: &str) -> Self {
+    fn manufacturer(self, v: &str) -> Self {
         self.add_str_field("Manufacturer", v)
     }
 
-    pub fn part_number(self, v: &str) -> Self {
+    fn part_number(self, v: &str) -> Self {
         self.add_str_field("PartNumber", v)
     }
 
-    pub fn model(self, v: &str) -> Self {
+    fn model(self, v: &str) -> Self {
         self.add_str_field("Model", v)
     }
 
-    pub fn sku(self, v: &str) -> Self {
+    fn sku(self, v: &str) -> Self {
         self.add_str_field("SKU", v)
     }
 
-    pub fn assembly(self, v: &redfish::Resource<'_>) -> Self {
+    fn assembly(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("Assembly"))
     }
 
-    pub fn network_adapters(self, v: &redfish::Collection<'_>) -> Self {
+    fn network_adapters(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("NetworkAdapters"))
     }
 
-    pub fn pcie_devices(self, v: &redfish::Collection<'_>) -> Self {
+    fn pcie_devices(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("PCIeDevices"))
     }
 
-    pub fn sensors(self, v: &redfish::Collection<'_>) -> Self {
+    fn sensors(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("Sensors"))
     }
 
-    pub fn power_subsystem(self, v: &redfish::Resource<'_>) -> Self {
+    fn power_subsystem(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("PowerSubsystem"))
     }
 
-    pub fn thermal_subsystem(self, v: &redfish::Resource<'_>) -> Self {
+    fn thermal_subsystem(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("ThermalSubsystem"))
     }
 
-    pub fn oem(self, v: &serde_json::Value) -> Self {
+    fn oem(self, v: &serde_json::Value) -> Self {
         self.apply_patch(json!({"Oem": v}))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/collection.rs
+++ b/crates/bmc-mock/src/redfish/collection.rs
@@ -22,14 +22,14 @@ use serde_json::json;
 use crate::json::{JsonExt, JsonPatch};
 
 /// Defines minimal set of Redfish resource attributes.
-pub struct Collection<'a> {
-    pub odata_id: Cow<'a, str>,
-    pub odata_type: Cow<'a, str>,
-    pub name: Cow<'a, str>,
+pub(crate) struct Collection<'a> {
+    pub(crate) odata_id: Cow<'a, str>,
+    pub(crate) odata_type: Cow<'a, str>,
+    pub(crate) name: Cow<'a, str>,
 }
 
 impl Collection<'_> {
-    pub fn nav_property(&self, name: &str) -> serde_json::Value {
+    pub(crate) fn nav_property(&self, name: &str) -> serde_json::Value {
         json!({
             name: {
                 "@odata.id": self.odata_id
@@ -37,7 +37,7 @@ impl Collection<'_> {
         })
     }
 
-    pub fn with_members(&self, members: &[impl serde::Serialize]) -> serde_json::Value {
+    pub(crate) fn with_members(&self, members: &[impl serde::Serialize]) -> serde_json::Value {
         let count = members.len();
         self.json_patch().patch(json!({
             "Members": members,

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -35,7 +35,7 @@ use crate::{
     POWER_CYCLE_DELAY, SetSystemPowerError, http, redfish,
 };
 
-pub fn collection() -> redfish::Collection<'static> {
+pub(super) fn collection() -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Borrowed("/redfish/v1/Systems"),
         odata_type: Cow::Borrowed("#ComputerSystemCollection.ComputerSystemCollection"),
@@ -43,7 +43,7 @@ pub fn collection() -> redfish::Collection<'static> {
     }
 }
 
-pub fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -53,7 +53,7 @@ pub fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn reset_target(system_id: &str) -> String {
+pub(super) fn reset_target(system_id: &str) -> String {
     format!(
         "{}/Actions/ComputerSystem.Reset",
         resource(system_id).odata_id
@@ -79,7 +79,10 @@ struct HpeBootSettingsPatch {
     persistent_boot_config_order: Vec<String>,
 }
 
-pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> Router<BmcState> {
+pub(crate) fn add_routes(
+    r: Router<BmcState>,
+    bmc_vendor: redfish::oem::BmcVendor,
+) -> Router<BmcState> {
     const SYSTEM_ID: &str = "{system_id}";
     const ETH_ID: &str = "{eth_id}";
     const BOOT_OPTION_ID: &str = "{boot_option_id}";
@@ -183,28 +186,28 @@ pub fn add_routes(r: Router<BmcState>, bmc_vendor: redfish::oem::BmcVendor) -> R
     }
 }
 
-pub struct SingleSystemConfig {
-    pub id: Cow<'static, str>,
-    pub eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
-    pub serial_number: Option<Cow<'static, str>>,
-    pub manufacturer: Option<Cow<'static, str>>,
-    pub model: Option<Cow<'static, str>>,
-    pub boot_order_mode: BootOrderMode,
-    pub callbacks: Option<Arc<dyn Callbacks>>,
-    pub chassis: Vec<Cow<'static, str>>,
-    pub boot_options: Option<Vec<redfish::boot_option::BootOption>>,
-    pub bios_mode: BiosMode,
-    pub base_bios: Option<serde_json::Value>,
-    pub log_services: Option<Arc<dyn LogServices>>,
-    pub storage: Option<Vec<redfish::storage::Storage>>,
-    pub processors: Option<Vec<redfish::processor::Processor>>,
-    pub secure_boot_available: bool,
-    pub serial_console: Option<redfish::serial_console::SerialConsole>,
-    pub oem: Oem,
+pub(crate) struct SingleSystemConfig {
+    pub(crate) id: Cow<'static, str>,
+    pub(crate) eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
+    pub(crate) serial_number: Option<Cow<'static, str>>,
+    pub(crate) manufacturer: Option<Cow<'static, str>>,
+    pub(crate) model: Option<Cow<'static, str>>,
+    pub(crate) boot_order_mode: BootOrderMode,
+    pub(crate) callbacks: Option<Arc<dyn Callbacks>>,
+    pub(crate) chassis: Vec<Cow<'static, str>>,
+    pub(crate) boot_options: Option<Vec<redfish::boot_option::BootOption>>,
+    pub(crate) bios_mode: BiosMode,
+    pub(crate) base_bios: Option<serde_json::Value>,
+    pub(crate) log_services: Option<Arc<dyn LogServices>>,
+    pub(crate) storage: Option<Vec<redfish::storage::Storage>>,
+    pub(crate) processors: Option<Vec<redfish::processor::Processor>>,
+    pub(crate) secure_boot_available: bool,
+    pub(crate) serial_console: Option<redfish::serial_console::SerialConsole>,
+    pub(crate) oem: Oem,
 }
 
-pub struct Config {
-    pub systems: Vec<SingleSystemConfig>,
+pub(crate) struct Config {
+    pub(crate) systems: Vec<SingleSystemConfig>,
 }
 
 pub struct SystemState {
@@ -212,13 +215,13 @@ pub struct SystemState {
 }
 
 #[derive(Default)]
-pub struct BootSourceOverride {
+struct BootSourceOverride {
     mode: Option<String>,
     enabled: Option<String>,
     target: Option<String>,
 }
 
-pub struct SingleSystemState {
+pub(crate) struct SingleSystemState {
     config: SingleSystemConfig,
     virtual_media: Option<redfish::virtual_media::VirtualMediaState>,
     boot_order_override: Mutex<Option<Vec<String>>>,
@@ -232,34 +235,34 @@ pub struct SingleSystemState {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum BootOrderMode {
+pub(crate) enum BootOrderMode {
     Generic,
     OrderedCollection,
     ViaSettings, // Set boot order using /Settings resource
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum BiosMode {
+pub(crate) enum BiosMode {
     DellOem,
     Generic,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Oem {
+pub(crate) enum Oem {
     NvidiaBluefield,
     Generic,
 }
 
 impl SystemState {
-    pub fn from_config(config: Config, options: &MachineRouterOptions) -> Self {
+    pub(crate) fn from_config(config: Config, options: &MachineRouterOptions) -> Self {
         Self::from_configs(config.systems, options.virtual_media_devices.clone())
     }
 
-    pub fn systems(&self) -> &[SingleSystemState] {
+    pub(crate) fn systems(&self) -> &[SingleSystemState] {
         &self.systems
     }
 
-    pub fn find(&self, system_id: &str) -> Option<&SingleSystemState> {
+    pub(crate) fn find(&self, system_id: &str) -> Option<&SingleSystemState> {
         self.systems
             .iter()
             .find(|system| system.config.id.as_ref() == system_id)
@@ -297,7 +300,7 @@ impl SystemState {
             .find_map(|system| system.resolve_current_boot_selection())
     }
 
-    pub fn on_boot_completed(&self) {
+    pub(crate) fn on_boot_completed(&self) {
         self.systems.iter().for_each(|s| s.on_boot_completed())
     }
 }
@@ -319,7 +322,7 @@ impl SingleSystemState {
         }
     }
 
-    pub fn on_boot_completed(&self) {
+    pub(crate) fn on_boot_completed(&self) {
         let mut src = self.boot_source_override.lock().unwrap();
         if src.enabled.as_ref().is_some_and(|v| v == "Once") {
             src.enabled = Some("Disabled".into())
@@ -334,7 +337,10 @@ impl SingleSystemState {
             .find(|processor| processor.id == processor_id)
     }
 
-    pub fn find_boot_option(&self, option_id: &str) -> Option<&redfish::boot_option::BootOption> {
+    pub(crate) fn find_boot_option(
+        &self,
+        option_id: &str,
+    ) -> Option<&redfish::boot_option::BootOption> {
         self.config
             .boot_options
             .iter()
@@ -1122,13 +1128,13 @@ async fn change_bios_password_action(Path(_system_id): Path<String>) -> Response
     json!({}).into_ok_response()
 }
 
-pub fn builder(resource: &redfish::Resource) -> SystemBuilder {
+fn builder(resource: &redfish::Resource) -> SystemBuilder {
     SystemBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub struct SystemBuilder {
+struct SystemBuilder {
     value: serde_json::Value,
 }
 
@@ -1141,56 +1147,56 @@ impl Builder for SystemBuilder {
 }
 
 impl SystemBuilder {
-    pub fn serial_console(self, value: &redfish::serial_console::SerialConsole) -> Self {
+    fn serial_console(self, value: &redfish::serial_console::SerialConsole) -> Self {
         self.apply_patch(json!({ "SerialConsole": value.to_json() }))
     }
 
-    pub fn serial_number(self, v: &str) -> Self {
+    fn serial_number(self, v: &str) -> Self {
         self.add_str_field("SerialNumber", v)
     }
 
-    pub fn manufacturer(self, v: &str) -> Self {
+    fn manufacturer(self, v: &str) -> Self {
         self.add_str_field("Manufacturer", v)
     }
 
-    pub fn model(self, v: &str) -> Self {
+    fn model(self, v: &str) -> Self {
         self.add_str_field("Model", v)
     }
 
-    pub fn ethernet_interfaces(self, v: &redfish::Collection<'_>) -> Self {
+    fn ethernet_interfaces(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("EthernetInterfaces"))
     }
 
-    pub fn boot_order(self, boot_order: &[&str]) -> Self {
+    fn boot_order(self, boot_order: &[&str]) -> Self {
         self.apply_patch(json!({"Boot": {"BootOrder": boot_order}}))
     }
 
-    pub fn boot_options(self, boot_options: &redfish::Collection<'_>) -> Self {
+    fn boot_options(self, boot_options: &redfish::Collection<'_>) -> Self {
         self.apply_patch(json!({"Boot": boot_options.nav_property("BootOptions")}))
     }
 
-    pub fn boot_source_override(self, value: serde_json::Value) -> Self {
+    fn boot_source_override(self, value: serde_json::Value) -> Self {
         self.apply_patch(json!({"Boot": value}))
     }
 
-    pub fn virtual_media(self, value: &redfish::Collection<'_>) -> Self {
+    fn virtual_media(self, value: &redfish::Collection<'_>) -> Self {
         self.apply_patch(value.nav_property("VirtualMedia"))
     }
 
-    pub fn secure_boot(self, secure_boot: &redfish::Resource<'_>) -> Self {
+    fn secure_boot(self, secure_boot: &redfish::Resource<'_>) -> Self {
         self.apply_patch(secure_boot.nav_property("SecureBoot"))
     }
 
-    pub fn pcie_devices(self, devices: &[redfish::Resource<'_>]) -> Self {
+    fn pcie_devices(self, devices: &[redfish::Resource<'_>]) -> Self {
         let devices = devices.iter().map(|r| r.entity_ref()).collect::<Vec<_>>();
         self.apply_patch(json!({"PCIeDevices": devices}))
     }
 
-    pub fn bios(self, resource: &redfish::Resource<'_>) -> Self {
+    fn bios(self, resource: &redfish::Resource<'_>) -> Self {
         self.apply_patch(resource.nav_property("Bios"))
     }
 
-    pub fn power_state(self, state: MockPowerState) -> Self {
+    fn power_state(self, state: MockPowerState) -> Self {
         let power_state = match state {
             MockPowerState::On => "On",
             MockPowerState::Off => "Off",
@@ -1205,19 +1211,19 @@ impl SystemBuilder {
         self.add_str_field("PowerState", power_state)
     }
 
-    pub fn log_services(self, log_services: &redfish::Collection<'_>) -> Self {
+    fn log_services(self, log_services: &redfish::Collection<'_>) -> Self {
         self.apply_patch(log_services.nav_property("LogServices"))
     }
 
-    pub fn storage(self, storage: &redfish::Collection<'_>) -> Self {
+    fn storage(self, storage: &redfish::Collection<'_>) -> Self {
         self.apply_patch(storage.nav_property("Storage"))
     }
 
-    pub fn processors(self, processors: &redfish::Collection<'_>) -> Self {
+    fn processors(self, processors: &redfish::Collection<'_>) -> Self {
         self.apply_patch(processors.nav_property("Processors"))
     }
 
-    pub fn link_chassis(self, ids: &[Cow<'static, str>]) -> Self {
+    fn link_chassis(self, ids: &[Cow<'static, str>]) -> Self {
         let chassis = ids
             .iter()
             .map(|id| redfish::chassis::resource(id).entity_ref())
@@ -1225,11 +1231,11 @@ impl SystemBuilder {
         self.apply_patch(json!({"Links": {"Chassis": chassis}}))
     }
 
-    pub fn oem_nvidia(self, resource: &redfish::Resource<'_>) -> Self {
+    fn oem_nvidia(self, resource: &redfish::Resource<'_>) -> Self {
         self.apply_patch(json!({"Oem": {"Nvidia": resource.entity_ref()}}))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/ethernet_interface.rs
+++ b/crates/bmc-mock/src/redfish/ethernet_interface.rs
@@ -24,7 +24,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
+pub(super) fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/EthernetInterfaces");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -33,7 +33,10 @@ pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn manager_resource<'a>(manager_id: &'a str, iface_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn manager_resource<'a>(
+    manager_id: &'a str,
+    iface_id: &'a str,
+) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/EthernetInterfaces/{iface_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -43,7 +46,7 @@ pub fn manager_resource<'a>(manager_id: &'a str, iface_id: &'a str) -> redfish::
     }
 }
 
-pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+pub(super) fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/EthernetInterfaces");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -52,7 +55,7 @@ pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn system_resource<'a>(system_id: &str, iface_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn system_resource<'a>(system_id: &str, iface_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/EthernetInterfaces/{iface_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -62,7 +65,7 @@ pub fn system_resource<'a>(system_id: &str, iface_id: &'a str) -> redfish::Resou
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> EthernetInterfaceBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> EthernetInterfaceBuilder {
     EthernetInterfaceBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
@@ -70,18 +73,18 @@ pub fn builder(resource: &redfish::Resource) -> EthernetInterfaceBuilder {
 }
 
 #[derive(Clone)]
-pub struct EthernetInterface {
-    pub id: Cow<'static, str>,
+pub(crate) struct EthernetInterface {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl EthernetInterface {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub struct EthernetInterfaceBuilder {
+pub(crate) struct EthernetInterfaceBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -96,19 +99,19 @@ impl Builder for EthernetInterfaceBuilder {
 }
 
 impl EthernetInterfaceBuilder {
-    pub fn mac_address(self, addr: MacAddress) -> Self {
+    pub(crate) fn mac_address(self, addr: MacAddress) -> Self {
         self.add_str_field("MACAddress", &addr.to_string())
     }
 
-    pub fn interface_enabled(self, v: bool) -> Self {
+    pub(crate) fn interface_enabled(self, v: bool) -> Self {
         self.apply_patch(json!({ "InterfaceEnabled": v }))
     }
 
-    pub fn description(self, v: &str) -> Self {
+    pub(crate) fn description(self, v: &str) -> Self {
         self.add_str_field("Description", v)
     }
 
-    pub fn build(self) -> EthernetInterface {
+    pub(crate) fn build(self) -> EthernetInterface {
         EthernetInterface {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -32,7 +32,7 @@ use crate::http::call_router_with_new_request;
 // Add support of `$expand=.($levels=N)` per the redfish spec
 //
 // https://www.dmtf.org/sites/default/files/standards/documents/DSP0268_2024.2.pdf
-pub fn append(router: Router) -> Router {
+pub(crate) fn append(router: Router) -> Router {
     Router::new()
         .route("/{*all}", get(process).fallback(fallback))
         .with_state(Expander { inner: router })

--- a/crates/bmc-mock/src/redfish/host_interface.rs
+++ b/crates/bmc-mock/src/redfish/host_interface.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
+pub(super) fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/HostInterfaces");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -32,7 +32,10 @@ pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn manager_resource<'a>(manager_id: &'a str, iface_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn manager_resource<'a>(
+    manager_id: &'a str,
+    iface_id: &'a str,
+) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/HostInterfaces/{iface_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -42,7 +45,7 @@ pub fn manager_resource<'a>(manager_id: &'a str, iface_id: &'a str) -> redfish::
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> HostInterfaceBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> HostInterfaceBuilder {
     HostInterfaceBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
@@ -50,18 +53,18 @@ pub fn builder(resource: &redfish::Resource) -> HostInterfaceBuilder {
 }
 
 #[derive(Clone)]
-pub struct HostInterface {
-    pub id: Cow<'static, str>,
+pub(crate) struct HostInterface {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl HostInterface {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub struct HostInterfaceBuilder {
+pub(crate) struct HostInterfaceBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -76,11 +79,11 @@ impl Builder for HostInterfaceBuilder {
 }
 
 impl HostInterfaceBuilder {
-    pub fn interface_enabled(self, v: bool) -> Self {
+    pub(crate) fn interface_enabled(self, v: bool) -> Self {
         self.apply_patch(json!({ "InterfaceEnabled": v }))
     }
 
-    pub fn build(self) -> HostInterface {
+    pub(crate) fn build(self) -> HostInterface {
         HostInterface {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/leak_detector.rs
+++ b/crates/bmc-mock/src/redfish/leak_detector.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn collection(chassis_id: &str) -> redfish::Collection<'static> {
+pub(super) fn collection(chassis_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!(
         "{}/LeakDetectors",
         redfish::thermal_subsystem::leak_detection_resource(chassis_id).odata_id
@@ -35,7 +35,7 @@ pub fn collection(chassis_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn resource<'a>(chassis_id: &str, leak_detector_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn resource<'a>(chassis_id: &str, leak_detector_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("{}/{leak_detector_id}", collection(chassis_id).odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -46,14 +46,14 @@ pub fn resource<'a>(chassis_id: &str, leak_detector_id: &'a str) -> redfish::Res
 }
 
 #[derive(Debug, Clone)]
-pub struct LeakDetector {
-    pub id: Cow<'static, str>,
-    pub user_label: Option<Cow<'static, str>>,
-    pub detector_state: DetectorState,
+pub(crate) struct LeakDetector {
+    pub(crate) id: Cow<'static, str>,
+    pub(crate) user_label: Option<Cow<'static, str>>,
+    pub(crate) detector_state: redfish::resource::Status,
 }
 
 impl LeakDetector {
-    pub fn to_json(&self, chassis_id: &str) -> serde_json::Value {
+    pub(crate) fn to_json(&self, chassis_id: &str) -> serde_json::Value {
         let mut builder = builder(&resource(chassis_id, &self.id))
             .detector_state(self.detector_state)
             .leak_detector_type("Moisture");
@@ -64,34 +64,17 @@ impl LeakDetector {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum DetectorState {
-    Ok,
-    Warning,
-    Critical,
-}
-
-impl DetectorState {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Ok => "OK",
-            Self::Warning => "Warning",
-            Self::Critical => "Critical",
-        }
-    }
-}
-
-pub fn builder(resource: &redfish::Resource) -> LeakDetectorBuilder {
+fn builder(resource: &redfish::Resource) -> LeakDetectorBuilder {
     LeakDetectorBuilder {
         value: resource.json_patch().patch(json!({
             "Status": redfish::resource::Status::Ok.into_json(),
-            "DetectorState": DetectorState::Ok.as_str(),
+            "DetectorState": "OK",
             "LeakDetectorType": "Moisture",
         })),
     }
 }
 
-pub struct LeakDetectorBuilder {
+struct LeakDetectorBuilder {
     value: serde_json::Value,
 }
 
@@ -104,37 +87,95 @@ impl Builder for LeakDetectorBuilder {
 }
 
 impl LeakDetectorBuilder {
-    pub fn detector_state(self, detector_state: DetectorState) -> Self {
-        let status = match detector_state {
-            DetectorState::Ok => redfish::resource::Status::Ok,
-            DetectorState::Warning => redfish::resource::Status::Warning,
-            DetectorState::Critical => redfish::resource::Status::Critical,
-        };
+    fn detector_state(self, detector_state: redfish::resource::Status) -> Self {
         self.apply_patch(json!({
             "DetectorState": detector_state.as_str(),
-            "Status": status.into_json(),
+            "Status": detector_state.into_json(),
         }))
     }
 
-    pub fn leak_detector_type(self, value: &str) -> Self {
+    fn leak_detector_type(self, value: &str) -> Self {
         self.add_str_field("LeakDetectorType", value)
     }
 
-    pub fn user_label(self, value: &str) -> Self {
+    fn user_label(self, value: &str) -> Self {
         self.add_str_field("UserLabel", value)
     }
 
-    pub fn build(self) -> serde_json::Value {
+    fn build(self) -> serde_json::Value {
         self.value
     }
 }
 
-pub fn generate_chassis_leak_detectors(count: usize) -> Vec<LeakDetector> {
+pub(crate) fn generate_chassis_leak_detectors(count: usize) -> Vec<LeakDetector> {
     (1..=count)
         .map(|index| LeakDetector {
             id: Cow::Owned(format!("LeakDetector_{index}")),
             user_label: Some(Cow::Owned(format!("Leak Detector {index}"))),
-            detector_state: DetectorState::Ok,
+            detector_state: redfish::resource::Status::Ok,
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::{Check, check_values};
+
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    struct SerializedState {
+        detector_state: String,
+        health: String,
+        state: String,
+    }
+
+    #[test]
+    fn detector_state_sets_detector_and_health_status() {
+        check_values(
+            [
+                Check {
+                    scenario: "OK detector keeps healthy Redfish status",
+                    input: redfish::resource::Status::Ok,
+                    expect: SerializedState {
+                        detector_state: "OK".to_string(),
+                        health: "OK".to_string(),
+                        state: "Enabled".to_string(),
+                    },
+                },
+                Check {
+                    scenario: "warning detector reports warning Redfish status",
+                    input: redfish::resource::Status::Warning,
+                    expect: SerializedState {
+                        detector_state: "Warning".to_string(),
+                        health: "Warning".to_string(),
+                        state: "Enabled".to_string(),
+                    },
+                },
+                Check {
+                    scenario: "critical detector reports critical Redfish status",
+                    input: redfish::resource::Status::Critical,
+                    expect: SerializedState {
+                        detector_state: "Critical".to_string(),
+                        health: "Critical".to_string(),
+                        state: "Enabled".to_string(),
+                    },
+                },
+            ],
+            |detector_state| {
+                let value = LeakDetector {
+                    id: Cow::Borrowed("LeakDetector_1"),
+                    user_label: None,
+                    detector_state,
+                }
+                .to_json("Chassis_1");
+
+                SerializedState {
+                    detector_state: value["DetectorState"].as_str().unwrap().to_string(),
+                    health: value["Status"]["Health"].as_str().unwrap().to_string(),
+                    state: value["Status"]["State"].as_str().unwrap().to_string(),
+                }
+            },
+        );
+    }
 }

--- a/crates/bmc-mock/src/redfish/log_service.rs
+++ b/crates/bmc-mock/src/redfish/log_service.rs
@@ -21,7 +21,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
+pub(super) fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/LogServices");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -30,7 +30,7 @@ pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+pub(super) fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/LogServices");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -39,7 +39,7 @@ pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn system_resource<'a>(system_id: &str, service_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn system_resource<'a>(system_id: &str, service_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/LogServices/{service_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -49,7 +49,7 @@ pub fn system_resource<'a>(system_id: &str, service_id: &'a str) -> redfish::Res
     }
 }
 
-pub fn system_entries_collection<'a>(
+pub(super) fn system_entries_collection<'a>(
     system_id: &str,
     service_id: &'a str,
 ) -> redfish::Collection<'a> {
@@ -61,13 +61,13 @@ pub fn system_entries_collection<'a>(
     }
 }
 
-pub fn builder(resource: &redfish::Resource<'_>) -> LogServiceBuilder {
+pub(super) fn builder(resource: &redfish::Resource<'_>) -> LogServiceBuilder {
     LogServiceBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub fn event_entry(collection: &redfish::Collection<'_>, id: &str) -> EntryBuilder {
+pub(crate) fn event_entry(collection: &redfish::Collection<'_>, id: &str) -> EntryBuilder {
     let odata_id = format!("{}/{}", collection.odata_id, id);
     EntryBuilder {
         value: redfish::Resource {
@@ -81,7 +81,7 @@ pub fn event_entry(collection: &redfish::Collection<'_>, id: &str) -> EntryBuild
     .entry_type("Event")
 }
 
-pub struct LogServiceBuilder {
+pub(super) struct LogServiceBuilder {
     value: serde_json::Value,
 }
 
@@ -94,16 +94,16 @@ impl Builder for LogServiceBuilder {
 }
 
 impl LogServiceBuilder {
-    pub fn entries(self, v: &redfish::Collection<'_>) -> Self {
+    pub(super) fn entries(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("Entries"))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(super) fn build(self) -> serde_json::Value {
         self.value
     }
 }
 
-pub struct EntryBuilder {
+pub(crate) struct EntryBuilder {
     value: serde_json::Value,
 }
 
@@ -116,23 +116,23 @@ impl Builder for EntryBuilder {
 }
 
 impl EntryBuilder {
-    pub fn entry_type(self, v: &str) -> Self {
+    fn entry_type(self, v: &str) -> Self {
         self.add_str_field("EntryType", v)
     }
 
-    pub fn message(self, v: &str) -> Self {
+    pub(crate) fn message(self, v: &str) -> Self {
         self.add_str_field("Message", v)
     }
 
-    pub fn severity(self, v: &str) -> Self {
+    pub(crate) fn severity(self, v: &str) -> Self {
         self.add_str_field("Severity", v)
     }
 
-    pub fn created(self, v: &str) -> Self {
+    pub(crate) fn created(self, v: &str) -> Self {
         self.add_str_field("Created", v)
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(crate) fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/manager.rs
+++ b/crates/bmc-mock/src/redfish/manager.rs
@@ -32,7 +32,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish::Builder;
 use crate::{http, redfish};
 
-pub fn collection() -> redfish::Collection<'static> {
+pub(super) fn collection() -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Borrowed("/redfish/v1/Managers"),
         odata_type: Cow::Borrowed("#ManagerCollection.ManagerCollection"),
@@ -40,7 +40,7 @@ pub fn collection() -> redfish::Collection<'static> {
     }
 }
 
-pub fn resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
+fn resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -50,11 +50,11 @@ pub fn resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn reset_target(manager_id: &str) -> String {
+pub(super) fn reset_target(manager_id: &str) -> String {
     format!("{}/Actions/Manager.Reset", resource(manager_id).odata_id)
 }
 
-pub fn builder(resource: &redfish::Resource<'_>) -> ManagerBuilder {
+fn builder(resource: &redfish::Resource<'_>) -> ManagerBuilder {
     let reset_target = reset_target(&resource.id);
     ManagerBuilder {
         manager_id: resource.id.to_string(),
@@ -63,7 +63,7 @@ pub fn builder(resource: &redfish::Resource<'_>) -> ManagerBuilder {
     }
 }
 
-pub struct ManagerBuilder {
+struct ManagerBuilder {
     manager_id: String,
     reset_target: String,
     value: serde_json::Value,
@@ -80,19 +80,19 @@ impl Builder for ManagerBuilder {
 }
 
 impl ManagerBuilder {
-    pub fn ethernet_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
+    fn ethernet_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
         self.apply_patch(collection.nav_property("EthernetInterfaces"))
     }
 
-    pub fn host_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
+    fn host_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
         self.apply_patch(collection.nav_property("HostInterfaces"))
     }
 
-    pub fn serial_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
+    fn serial_interfaces(self, collection: &redfish::Collection<'_>) -> Self {
         self.apply_patch(collection.nav_property("SerialInterfaces"))
     }
 
-    pub fn enable_reset_action(self) -> Self {
+    fn enable_reset_action(self) -> Self {
         let patch = json!({
             "Actions": {
                 "#Manager.Reset": {
@@ -103,23 +103,23 @@ impl ManagerBuilder {
         self.apply_patch(patch)
     }
 
-    pub fn log_services(self, collection: redfish::Collection<'_>) -> Self {
+    fn log_services(self, collection: redfish::Collection<'_>) -> Self {
         self.apply_patch(collection.nav_property("LogServices"))
     }
 
-    pub fn firmware_version(self, v: &str) -> Self {
+    fn firmware_version(self, v: &str) -> Self {
         self.add_str_field("FirmwareVersion", v)
     }
 
-    pub fn manager_type(self, v: &str) -> Self {
+    fn manager_type(self, v: &str) -> Self {
         self.add_str_field("ManagerType", v)
     }
 
-    pub fn network_protocol(self, resource: redfish::Resource<'_>) -> Self {
+    fn network_protocol(self, resource: redfish::Resource<'_>) -> Self {
         self.apply_patch(resource.nav_property("NetworkProtocol"))
     }
 
-    pub fn oem(self, oem: &Oem) -> Self {
+    fn oem(self, oem: &Oem) -> Self {
         match oem {
             Oem::Dell => self.apply_patch(json!({
                 "Oem": {
@@ -162,25 +162,25 @@ impl ManagerBuilder {
     // TODO: we can use typed UUID here, but all these fields are
     // really not used it just requirements of libredfish model added
     // "just in case"...
-    pub fn uuid(self, v: &str) -> Self {
+    fn uuid(self, v: &str) -> Self {
         self.add_str_field("UUID", v)
     }
 
-    pub fn date_time(self, v: DateTime<Utc>) -> Self {
+    fn date_time(self, v: DateTime<Utc>) -> Self {
         let current_time = v.format("%Y-%m-%dT%H:%M:%S+00:00").to_string();
         self.add_str_field("DateTime", &current_time)
     }
 
-    pub fn status(self, status: redfish::resource::Status) -> Self {
+    fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({"Status": status.into_json()}))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    fn build(self) -> serde_json::Value {
         self.value
     }
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const MGR_ID: &str = "{manager_id}";
     const ETH_ID: &str = "{ethernet_id}";
     const HOST_IF_ID: &str = "{hostif_id}";
@@ -225,7 +225,7 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
 }
 
 #[derive(Clone, Copy)]
-pub enum Oem {
+pub(crate) enum Oem {
     Dell,
     Hpe,
     Supermicro,
@@ -237,18 +237,18 @@ impl AsRef<Oem> for Oem {
     }
 }
 
-pub struct Config {
-    pub managers: Vec<SingleConfig>,
+pub(crate) struct Config {
+    pub(crate) managers: Vec<SingleConfig>,
 }
 
 #[derive(Clone)]
-pub struct SingleConfig {
-    pub id: &'static str,
-    pub eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
-    pub host_interfaces: Option<Vec<redfish::host_interface::HostInterface>>,
-    pub serial_interfaces: Option<Vec<redfish::serial_interface::SerialInterface>>,
-    pub firmware_version: Option<&'static str>,
-    pub oem: Option<Oem>,
+pub(crate) struct SingleConfig {
+    pub(crate) id: &'static str,
+    pub(crate) eth_interfaces: Option<Vec<redfish::ethernet_interface::EthernetInterface>>,
+    pub(crate) host_interfaces: Option<Vec<redfish::host_interface::HostInterface>>,
+    pub(crate) serial_interfaces: Option<Vec<redfish::serial_interface::SerialInterface>>,
+    pub(crate) firmware_version: Option<&'static str>,
+    pub(crate) oem: Option<Oem>,
 }
 
 pub struct ManagerState {
@@ -256,7 +256,7 @@ pub struct ManagerState {
 }
 
 impl ManagerState {
-    pub fn new(config: &Config) -> Self {
+    pub(crate) fn new(config: &Config) -> Self {
         Self {
             managers: config
                 .managers
@@ -266,7 +266,7 @@ impl ManagerState {
         }
     }
 
-    pub fn find(&self, manager_id: &str) -> Option<&SingleManagerState> {
+    pub(crate) fn find(&self, manager_id: &str) -> Option<&SingleManagerState> {
         self.managers.iter().find(|c| c.id == manager_id)
     }
 
@@ -277,7 +277,7 @@ impl ManagerState {
     }
 }
 
-pub struct SingleManagerState {
+pub(crate) struct SingleManagerState {
     id: &'static str,
     ipmi_enabled: Arc<atomic::AtomicBool>,
     ipmi_port: Mutex<Option<u16>>,
@@ -327,7 +327,7 @@ impl NtpState {
 }
 
 impl SingleManagerState {
-    pub fn new(config: &SingleConfig) -> Self {
+    pub(crate) fn new(config: &SingleConfig) -> Self {
         Self {
             id: config.id,
             config: config.clone(),

--- a/crates/bmc-mock/src/redfish/manager_network_protocol.rs
+++ b/crates/bmc-mock/src/redfish/manager_network_protocol.rs
@@ -22,7 +22,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn manager_resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn manager_resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Managers/{manager_id}/NetworkProtocol");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -33,13 +33,13 @@ pub fn manager_resource<'a>(manager_id: &'a str) -> redfish::Resource<'a> {
 }
 
 /// Get builder of the network adapter.
-pub fn builder(resource: &redfish::Resource) -> ManagerNetworkProtocolBuilder {
+pub(super) fn builder(resource: &redfish::Resource) -> ManagerNetworkProtocolBuilder {
     ManagerNetworkProtocolBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub struct ManagerNetworkProtocolBuilder {
+pub(super) struct ManagerNetworkProtocolBuilder {
     value: serde_json::Value,
 }
 
@@ -52,7 +52,7 @@ impl Builder for ManagerNetworkProtocolBuilder {
 }
 
 impl ManagerNetworkProtocolBuilder {
-    pub fn ipmi(self, enabled: bool, port: Option<u16>) -> Self {
+    pub(super) fn ipmi(self, enabled: bool, port: Option<u16>) -> Self {
         let value = self.apply_patch(json!({"IPMI": { "ProtocolEnabled": enabled }}));
         match port {
             Some(port) => value.apply_patch(json!({"IPMI": { "Port": port }})),
@@ -60,7 +60,7 @@ impl ManagerNetworkProtocolBuilder {
         }
     }
 
-    pub fn ntp(self, protocol_enabled: bool, servers: &[impl AsRef<str>]) -> Self {
+    pub(super) fn ntp(self, protocol_enabled: bool, servers: &[impl AsRef<str>]) -> Self {
         let servers = servers.iter().map(AsRef::as_ref).collect::<Vec<_>>();
         self.apply_patch(json!({
             "NTP": {
@@ -70,7 +70,7 @@ impl ManagerNetworkProtocolBuilder {
         }))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(super) fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/mod.rs
+++ b/crates/bmc-mock/src/redfish/mod.rs
@@ -15,45 +15,45 @@
  * limitations under the License.
  */
 
-pub mod account_service;
-pub mod assembly;
-pub mod bios;
-pub mod boot_option;
-pub mod chassis;
-pub mod collection;
-pub mod computer_system;
-pub mod ethernet_interface;
-pub mod host_interface;
-pub mod leak_detector;
-pub mod log_service;
-pub mod manager;
-pub mod manager_network_protocol;
-pub mod network_adapter;
-pub mod network_device_function;
-pub mod oem;
-pub mod pcie_device;
-pub mod power_subsystem;
-pub mod power_supply;
-pub mod processor;
-pub mod resource;
-pub mod secure_boot;
-pub mod sensor;
-pub mod serial_console;
-pub mod serial_interface;
-pub mod service_root;
-pub mod session_service;
-pub mod software_inventory;
-pub mod storage;
-pub mod task_service;
-pub mod telemetry_service;
-pub mod thermal_subsystem;
-pub mod update_service;
-pub mod virtual_media;
+pub(crate) mod account_service;
+pub(crate) mod assembly;
+pub(crate) mod bios;
+pub(crate) mod boot_option;
+pub(crate) mod chassis;
+mod collection;
+pub(crate) mod computer_system;
+pub(crate) mod ethernet_interface;
+pub(crate) mod host_interface;
+pub(crate) mod leak_detector;
+pub(crate) mod log_service;
+pub(crate) mod manager;
+mod manager_network_protocol;
+pub(crate) mod network_adapter;
+pub(crate) mod network_device_function;
+pub(crate) mod oem;
+pub(crate) mod pcie_device;
+mod power_subsystem;
+pub(crate) mod power_supply;
+pub(crate) mod processor;
+pub(crate) mod resource;
+mod secure_boot;
+pub(crate) mod sensor;
+pub(crate) mod serial_console;
+pub(crate) mod serial_interface;
+pub(crate) mod service_root;
+pub(crate) mod session_service;
+pub(crate) mod software_inventory;
+mod storage;
+pub(crate) mod task_service;
+pub(crate) mod telemetry_service;
+mod thermal_subsystem;
+pub(crate) mod update_service;
+pub(crate) mod virtual_media;
 
-pub mod expander_router;
+pub(crate) mod expander_router;
 
-pub use collection::Collection;
-pub use resource::Resource;
+pub(super) use collection::Collection;
+use resource::Resource;
 
 trait Builder {
     fn maybe_with<T, V>(self, f: fn(Self, &V) -> Self, v: &Option<T>) -> Self

--- a/crates/bmc-mock/src/redfish/network_adapter.rs
+++ b/crates/bmc-mock/src/redfish/network_adapter.rs
@@ -26,7 +26,7 @@ use crate::{hw, redfish};
 const NETWORK_ADAPTER_TYPE: &str = "#NetworkAdapter.v1_7_0.NetworkAdapter";
 const NETWORK_ADAPTER_NAME: &str = "Network Adapter";
 
-pub fn chassis_resource(chassis_id: &str, adapter_id: &str) -> redfish::Resource<'static> {
+pub(crate) fn chassis_resource(chassis_id: &str, adapter_id: &str) -> redfish::Resource<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters/{adapter_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -36,7 +36,7 @@ pub fn chassis_resource(chassis_id: &str, adapter_id: &str) -> redfish::Resource
     }
 }
 
-pub fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
+pub(super) fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/NetworkAdapters");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -45,17 +45,17 @@ pub fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub struct NetworkAdapter {
-    pub id: Cow<'static, str>,
+pub(crate) struct NetworkAdapter {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
-    pub functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
+    pub(crate) functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
 }
 
 impl NetworkAdapter {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
-    pub fn find_function(
+    pub(crate) fn find_function(
         &self,
         function_id: &str,
     ) -> Option<&redfish::network_device_function::NetworkDeviceFunction> {
@@ -64,7 +64,7 @@ impl NetworkAdapter {
 }
 
 /// Get builder of the network adapter.
-pub fn builder(resource: &redfish::Resource) -> NetworkAdapterBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> NetworkAdapterBuilder {
     NetworkAdapterBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
@@ -72,7 +72,10 @@ pub fn builder(resource: &redfish::Resource) -> NetworkAdapterBuilder {
     }
 }
 
-pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> NetworkAdapterBuilder {
+pub(crate) fn builder_from_nic(
+    resource: &redfish::Resource,
+    nic: &hw::nic::Nic,
+) -> NetworkAdapterBuilder {
     builder(resource)
         .maybe_with(NetworkAdapterBuilder::serial_number, &nic.serial_number)
         .maybe_with(NetworkAdapterBuilder::description, &nic.description)
@@ -81,7 +84,7 @@ pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> Net
         .maybe_with(NetworkAdapterBuilder::part_number, &nic.part_number)
 }
 
-pub struct NetworkAdapterBuilder {
+pub(crate) struct NetworkAdapterBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
     functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
@@ -98,27 +101,27 @@ impl Builder for NetworkAdapterBuilder {
 }
 
 impl NetworkAdapterBuilder {
-    pub fn manufacturer(self, value: &str) -> Self {
+    pub(crate) fn manufacturer(self, value: &str) -> Self {
         self.add_str_field("Manufacturer", value)
     }
 
-    pub fn model(self, value: &str) -> Self {
+    pub(crate) fn model(self, value: &str) -> Self {
         self.add_str_field("Model", value)
     }
 
-    pub fn part_number(self, value: &str) -> Self {
+    pub(crate) fn part_number(self, value: &str) -> Self {
         self.add_str_field("PartNumber", value)
     }
 
-    pub fn serial_number(self, value: &str) -> Self {
+    pub(crate) fn serial_number(self, value: &str) -> Self {
         self.add_str_field("SerialNumber", value)
     }
 
-    pub fn description(self, value: &str) -> Self {
+    pub(crate) fn description(self, value: &str) -> Self {
         self.add_str_field("Description", value)
     }
 
-    pub fn network_device_functions(
+    pub(crate) fn network_device_functions(
         self,
         collection: &redfish::Collection<'_>,
         functions: Vec<redfish::network_device_function::NetworkDeviceFunction>,
@@ -128,13 +131,13 @@ impl NetworkAdapterBuilder {
         v
     }
 
-    pub fn status(self, status: redfish::resource::Status) -> Self {
+    pub(crate) fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({
             "Status": status.into_json()
         }))
     }
 
-    pub fn build(self) -> NetworkAdapter {
+    pub(crate) fn build(self) -> NetworkAdapter {
         NetworkAdapter {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/network_device_function.rs
+++ b/crates/bmc-mock/src/redfish/network_device_function.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn chassis_collection(
+pub(crate) fn chassis_collection(
     chassis_id: &str,
     network_adapter_id: &str,
 ) -> redfish::Collection<'static> {
@@ -39,7 +39,7 @@ pub fn chassis_collection(
     }
 }
 
-pub fn chassis_resource<'a>(
+pub(crate) fn chassis_resource<'a>(
     chassis_id: &'a str,
     network_adapter_id: &'a str,
     function_id: &'a str,
@@ -56,25 +56,25 @@ pub fn chassis_resource<'a>(
 }
 
 /// Get builder of the network device function.
-pub fn builder(resource: &redfish::Resource) -> NetworkDeviceFunctionBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> NetworkDeviceFunctionBuilder {
     NetworkDeviceFunctionBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
     }
 }
 
-pub struct NetworkDeviceFunction {
-    pub id: Cow<'static, str>,
+pub(crate) struct NetworkDeviceFunction {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl NetworkDeviceFunction {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub struct NetworkDeviceFunctionBuilder {
+pub(crate) struct NetworkDeviceFunctionBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -89,15 +89,15 @@ impl Builder for NetworkDeviceFunctionBuilder {
 }
 
 impl NetworkDeviceFunctionBuilder {
-    pub fn ethernet(self, v: serde_json::Value) -> Self {
+    pub(crate) fn ethernet(self, v: serde_json::Value) -> Self {
         self.apply_patch(json!({ "Ethernet": v }))
     }
 
-    pub fn oem(self, v: serde_json::Value) -> Self {
+    pub(crate) fn oem(self, v: serde_json::Value) -> Self {
         self.apply_patch(json!({ "Oem": v }))
     }
 
-    pub fn build(self) -> NetworkDeviceFunction {
+    pub(crate) fn build(self) -> NetworkDeviceFunction {
         NetworkDeviceFunction {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/idrac.rs
@@ -32,7 +32,7 @@ use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch, json_patch};
 use crate::{http, redfish};
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(
         "/redfish/v1/Managers/iDRAC.Embedded.1/Attributes",
         get(get_managers_oem_dell_attributes).patch(patch_managers_oem_dell_attributes),
@@ -107,7 +107,7 @@ async fn patch_managers_oem_dell_attributes(
 }
 
 #[derive(Debug, Clone)]
-pub enum JobState {
+pub(crate) enum JobState {
     Scheduled,
     Completed,
 }
@@ -150,7 +150,7 @@ async fn get_dell_job(State(state): State<BmcState>, Path(job_id): Path<String>)
     .into_ok_response()
 }
 
-pub fn create_job_with_location(state: BmcState) -> Response {
+pub(in crate::redfish) fn create_job_with_location(state: BmcState) -> Response {
     let redfish::oem::State::DellIdrac(state) = state.oem_state else {
         return http::not_found();
     };
@@ -180,20 +180,20 @@ async fn post_import_sys_configuration(State(state): State<BmcState>) -> Respons
 const DELL_JOB_TYPE: &str = "DellConfiguration";
 
 #[derive(Debug, Clone)]
-pub struct Job {
-    pub job_id: String,
-    pub job_state: JobState,
-    pub job_type: String,
-    pub start_time: chrono::DateTime<chrono::Utc>,
-    pub end_time: Option<chrono::DateTime<chrono::Utc>>,
+pub(crate) struct Job {
+    pub(crate) job_id: String,
+    pub(crate) job_state: JobState,
+    pub(crate) job_type: String,
+    pub(crate) start_time: chrono::DateTime<chrono::Utc>,
+    pub(crate) end_time: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl Job {
-    pub fn is_dell_job(&self) -> bool {
+    pub(crate) fn is_dell_job(&self) -> bool {
         matches!(self.job_type.as_str(), DELL_JOB_TYPE)
     }
 
-    pub fn percent_complete(&self) -> i32 {
+    pub(crate) fn percent_complete(&self) -> i32 {
         match &self.job_state {
             JobState::Completed => 100,
             _ => 0,
@@ -202,9 +202,9 @@ impl Job {
 }
 
 #[derive(Clone)]
-pub struct IdracState {
-    pub jobs: Arc<Mutex<HashMap<String, Job>>>,
-    pub dell_attrs: Arc<Mutex<serde_json::Value>>,
+pub(crate) struct IdracState {
+    pub(crate) jobs: Arc<Mutex<HashMap<String, Job>>>,
+    pub(crate) dell_attrs: Arc<Mutex<serde_json::Value>>,
 }
 
 impl Default for IdracState {
@@ -217,11 +217,11 @@ impl Default for IdracState {
 }
 
 impl IdracState {
-    pub fn get_job(&self, job_id: &String) -> Option<Job> {
+    pub(crate) fn get_job(&self, job_id: &String) -> Option<Job> {
         self.jobs.lock().unwrap().get(job_id).cloned()
     }
 
-    pub fn add_job(&self) -> Result<String, Box<dyn std::error::Error>> {
+    pub(crate) fn add_job(&self) -> Result<String, Box<dyn std::error::Error>> {
         let mut jobs = self.jobs.lock().unwrap();
 
         let job_id = rand::rng()
@@ -242,7 +242,7 @@ impl IdracState {
         Ok(job_id)
     }
 
-    pub fn complete_all_bios_jobs(&self) {
+    pub(crate) fn complete_all_bios_jobs(&self) {
         let mut jobs = self.jobs.lock().unwrap();
 
         let bios_jobs: Vec<Job> = jobs
@@ -257,12 +257,12 @@ impl IdracState {
         }
     }
 
-    pub fn update_attrs(&self, v: serde_json::Value) {
+    pub(crate) fn update_attrs(&self, v: serde_json::Value) {
         let mut dell_attrs = self.dell_attrs.lock().unwrap();
         json_patch(&mut dell_attrs, v);
     }
 
-    pub fn get_attrs(&self, mut base: serde_json::Value) -> serde_json::Value {
+    pub(crate) fn get_attrs(&self, mut base: serde_json::Value) -> serde_json::Value {
         let dell_attrs = self.dell_attrs.lock().unwrap();
         json_patch(&mut base, dell_attrs.clone());
         base

--- a/crates/bmc-mock/src/redfish/oem/dell/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/mod.rs
@@ -15,5 +15,5 @@
  * limitations under the License.
  */
 
-pub mod idrac;
-pub mod network_device_function;
+pub(crate) mod idrac;
+pub(crate) mod network_device_function;

--- a/crates/bmc-mock/src/redfish/oem/dell/network_device_function.rs
+++ b/crates/bmc-mock/src/redfish/oem/dell/network_device_function.rs
@@ -17,7 +17,11 @@
 
 use serde_json::json;
 
-pub fn dell_nic_info(function_id: &str, slot: usize, serial_number: &str) -> serde_json::Value {
+pub(crate) fn dell_nic_info(
+    function_id: &str,
+    slot: usize,
+    serial_number: &str,
+) -> serde_json::Value {
     json!({
         "Dell": {
             "@odata.type": "#DellOem.v1_3_0.DellOemResources",

--- a/crates/bmc-mock/src/redfish/oem/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/mod.rs
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-pub mod dell;
-pub mod nvidia;
-pub mod supermicro;
+pub(crate) mod dell;
+pub(crate) mod nvidia;
+pub(crate) mod supermicro;
 
 use crate::redfish::Resource;
 
 #[derive(Clone, Copy, Debug)]
-pub enum BmcVendor {
+pub(crate) enum BmcVendor {
     Dell,
     Nvidia(NvidiaNamestyle),
     Wiwynn,
@@ -34,13 +34,13 @@ pub enum BmcVendor {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum NvidiaNamestyle {
+pub(crate) enum NvidiaNamestyle {
     Uppercase,
     Capitalized,
 }
 
 impl BmcVendor {
-    pub fn service_root_value(&self) -> Option<&'static str> {
+    pub(crate) fn service_root_value(&self) -> Option<&'static str> {
         match self {
             BmcVendor::Nvidia(NvidiaNamestyle::Capitalized) => Some("Nvidia"),
             BmcVendor::Nvidia(NvidiaNamestyle::Uppercase) => Some("NVIDIA"),
@@ -57,7 +57,7 @@ impl BmcVendor {
     }
     // This function creates settings of the resource from the resource
     // id. Real identifier is different for different BMC vendors.
-    pub fn make_settings_odata_id(&self, resource: &Resource<'_>) -> String {
+    pub(crate) fn make_settings_odata_id(&self, resource: &Resource<'_>) -> String {
         match self {
             // Supermicro uses `{odata_id}/Settings` per the SMC GB300 tray scrape
             // (`/Systems/System_0/Settings`, `/Bios/Settings`). Other Supermicro models
@@ -81,7 +81,7 @@ impl BmcVendor {
 }
 
 #[derive(Clone)]
-pub enum State {
+pub(crate) enum State {
     NvidiaBluefield(nvidia::bluefield::BluefieldState),
     DellIdrac(dell::idrac::IdracState),
     Supermicro(supermicro::manager::SupermicroState),

--- a/crates/bmc-mock/src/redfish/oem/nvidia/bluefield.rs
+++ b/crates/bmc-mock/src/redfish/oem/nvidia/bluefield.rs
@@ -30,7 +30,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::{http, redfish};
 
 #[derive(Clone)]
-pub enum BluefieldState {
+pub(crate) enum BluefieldState {
     Bluefield3 {
         mode: Arc<Mutex<ModeState>>,
         base_mac: MacAddress,
@@ -38,7 +38,7 @@ pub enum BluefieldState {
     Bluefield4,
 }
 
-pub struct ModeState {
+pub(crate) struct ModeState {
     nic_mode: bool,
     /// A `Mode.Set` queues the requested mode here. A real BlueField applies it
     /// only after the host power-cycles, so it lands on `nic_mode` on the next
@@ -47,7 +47,7 @@ pub struct ModeState {
 }
 
 impl BluefieldState {
-    pub fn new_bf3(nic_mode: bool, base_mac: MacAddress) -> Self {
+    pub(crate) fn new_bf3(nic_mode: bool, base_mac: MacAddress) -> Self {
         Self::Bluefield3 {
             mode: Arc::new(Mutex::new(ModeState {
                 nic_mode,
@@ -57,12 +57,12 @@ impl BluefieldState {
         }
     }
 
-    pub fn new_bf4() -> Self {
+    pub(crate) fn new_bf4() -> Self {
         Self::Bluefield4
     }
 
     /// Whether the BlueField currently reports NIC mode.
-    pub fn nic_mode(&self) -> bool {
+    pub(crate) fn nic_mode(&self) -> bool {
         match self {
             Self::Bluefield3 { mode, .. } => mode.lock().unwrap().nic_mode,
             Self::Bluefield4 => false,
@@ -81,7 +81,7 @@ impl BluefieldState {
 
     /// Apply a queued `Mode.Set`, if any -- called on power-on, the point at
     /// which a real BlueField picks up a staged mode change.
-    pub fn apply_pending_mode(&self) {
+    pub(crate) fn apply_pending_mode(&self) {
         match self {
             Self::Bluefield3 { mode, .. } => {
                 let mut mode = mode.lock().unwrap();
@@ -94,7 +94,7 @@ impl BluefieldState {
     }
 }
 
-pub fn resource(system_id: &str) -> redfish::Resource<'static> {
+pub(in crate::redfish) fn resource(system_id: &str) -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Owned(format!("/redfish/v1/Systems/{system_id}/Oem/Nvidia")),
         odata_type: Cow::Borrowed("#NvidiaComputerSystem.v1_0_0.NvidiaComputerSystem"),
@@ -107,7 +107,7 @@ pub fn resource(system_id: &str) -> redfish::Resource<'static> {
 
 const SYSTEMS_OEM_RESOURCE_DELETE_FIELDS: &[&str] = &["Id", "Name"];
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(
         "/redfish/v1/Systems/{system_id}/Oem/Nvidia",
         get(get_oem_nvidia),

--- a/crates/bmc-mock/src/redfish/oem/nvidia/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/nvidia/mod.rs
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-pub mod bluefield;
+pub(crate) mod bluefield;

--- a/crates/bmc-mock/src/redfish/oem/supermicro/manager.rs
+++ b/crates/bmc-mock/src/redfish/oem/supermicro/manager.rs
@@ -29,7 +29,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::{http, redfish};
 
 #[derive(Clone)]
-pub struct SupermicroState {
+pub(crate) struct SupermicroState {
     kcs_interface: Arc<Mutex<serde_json::Value>>,
     sys_lockdown: Arc<Mutex<serde_json::Value>>,
 }
@@ -67,7 +67,7 @@ impl SupermicroState {
     }
 }
 
-pub fn kcs_interface_resource(manager_id: &str) -> redfish::Resource<'static> {
+fn kcs_interface_resource(manager_id: &str) -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Owned(format!(
             "/redfish/v1/Managers/{manager_id}/Oem/Supermicro/KCSInterface"
@@ -78,7 +78,7 @@ pub fn kcs_interface_resource(manager_id: &str) -> redfish::Resource<'static> {
     }
 }
 
-pub fn sys_lockdown_resource(manager_id: &str) -> redfish::Resource<'static> {
+fn sys_lockdown_resource(manager_id: &str) -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Owned(format!(
             "/redfish/v1/Managers/{manager_id}/Oem/Supermicro/SysLockdown"
@@ -89,7 +89,7 @@ pub fn sys_lockdown_resource(manager_id: &str) -> redfish::Resource<'static> {
     }
 }
 
-pub fn manager_oem_patch(manager_id: &str) -> serde_json::Value {
+pub(in crate::redfish) fn manager_oem_patch(manager_id: &str) -> serde_json::Value {
     json!({
         "Oem": {
             "Supermicro": {
@@ -100,7 +100,7 @@ pub fn manager_oem_patch(manager_id: &str) -> serde_json::Value {
     })
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(
         "/redfish/v1/Managers/{manager_id}/Oem/Supermicro/KCSInterface",
         get(get_kcs_interface).patch(patch_kcs_interface),

--- a/crates/bmc-mock/src/redfish/oem/supermicro/mod.rs
+++ b/crates/bmc-mock/src/redfish/oem/supermicro/mod.rs
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-pub mod manager;
+pub(crate) mod manager;

--- a/crates/bmc-mock/src/redfish/pcie_device.rs
+++ b/crates/bmc-mock/src/redfish/pcie_device.rs
@@ -25,7 +25,7 @@ use crate::{hw, redfish};
 
 const PCIE_DEVICE_TYPE: &str = "#PCIeDevice.v1_5_0.PCIeDevice";
 
-pub fn chassis_resource(chassis_id: &str, dev_id: &str) -> redfish::Resource<'static> {
+pub(crate) fn chassis_resource(chassis_id: &str, dev_id: &str) -> redfish::Resource<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/PCIeDevices/{dev_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -35,7 +35,7 @@ pub fn chassis_resource(chassis_id: &str, dev_id: &str) -> redfish::Resource<'st
     }
 }
 
-pub fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
+pub(super) fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/PCIeDevices");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -45,18 +45,19 @@ pub fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
 }
 
 /// Generate resource bound to chassis.
-pub fn builder(resource: &redfish::Resource) -> PcieDeviceBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> PcieDeviceBuilder {
     PcieDeviceBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
-        mat_dpu: false,
     }
 }
 
-pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> PcieDeviceBuilder {
-    let b = builder(resource);
-    let b = if nic.is_mat_dpu { b.mat_dpu() } else { b };
-    b.maybe_with(PcieDeviceBuilder::serial_number, &nic.serial_number)
+pub(crate) fn builder_from_nic(
+    resource: &redfish::Resource,
+    nic: &hw::nic::Nic,
+) -> PcieDeviceBuilder {
+    builder(resource)
+        .maybe_with(PcieDeviceBuilder::serial_number, &nic.serial_number)
         .maybe_with(PcieDeviceBuilder::description, &nic.description)
         .maybe_with(PcieDeviceBuilder::manufacturer, &nic.manufacturer)
         .maybe_with(PcieDeviceBuilder::model, &nic.model)
@@ -64,22 +65,20 @@ pub fn builder_from_nic(resource: &redfish::Resource, nic: &hw::nic::Nic) -> Pci
         .maybe_with(PcieDeviceBuilder::firmware_version, &nic.firmware_version)
 }
 
-pub struct PCIeDevice {
-    pub id: Cow<'static, str>,
-    pub is_mat_dpu: bool,
+pub(crate) struct PCIeDevice {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl PCIeDevice {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub struct PcieDeviceBuilder {
+pub(crate) struct PcieDeviceBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
-    mat_dpu: bool,
 }
 
 impl Builder for PcieDeviceBuilder {
@@ -87,52 +86,45 @@ impl Builder for PcieDeviceBuilder {
         Self {
             value: self.value.patch(patch),
             id: self.id,
-            mat_dpu: self.mat_dpu,
         }
     }
 }
 
 impl PcieDeviceBuilder {
-    pub fn description(self, value: &str) -> Self {
+    pub(crate) fn description(self, value: &str) -> Self {
         self.add_str_field("Description", value)
     }
 
-    pub fn manufacturer(self, value: &str) -> Self {
+    pub(crate) fn manufacturer(self, value: &str) -> Self {
         self.add_str_field("Manufacturer", value)
     }
 
-    pub fn model(self, value: &str) -> Self {
+    pub(crate) fn model(self, value: &str) -> Self {
         self.add_str_field("Model", value)
     }
 
-    pub fn part_number(self, value: &str) -> Self {
+    pub(crate) fn part_number(self, value: &str) -> Self {
         self.add_str_field("PartNumber", value)
     }
 
-    pub fn serial_number(self, value: &str) -> Self {
+    pub(crate) fn serial_number(self, value: &str) -> Self {
         self.add_str_field("SerialNumber", value)
     }
 
-    pub fn firmware_version(self, value: &str) -> Self {
+    fn firmware_version(self, value: &str) -> Self {
         self.add_str_field("FirmwareVersion", value)
     }
 
-    pub fn mat_dpu(mut self) -> Self {
-        self.mat_dpu = true;
-        self
-    }
-
-    pub fn status(self, status: redfish::resource::Status) -> Self {
+    pub(crate) fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({
             "Status": status.into_json()
         }))
     }
 
-    pub fn build(self) -> PCIeDevice {
+    pub(crate) fn build(self) -> PCIeDevice {
         PCIeDevice {
             id: self.id,
             value: self.value,
-            is_mat_dpu: self.mat_dpu,
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/power_subsystem.rs
+++ b/crates/bmc-mock/src/redfish/power_subsystem.rs
@@ -21,7 +21,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn resource(chassis_id: &str) -> redfish::Resource<'static> {
+pub(super) fn resource(chassis_id: &str) -> redfish::Resource<'static> {
     let odata_id = format!(
         "{}/PowerSubsystem",
         redfish::chassis::resource(chassis_id).odata_id
@@ -34,13 +34,13 @@ pub fn resource(chassis_id: &str) -> redfish::Resource<'static> {
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> PowerSubsystemBuilder {
+pub(super) fn builder(resource: &redfish::Resource) -> PowerSubsystemBuilder {
     PowerSubsystemBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub struct PowerSubsystemBuilder {
+pub(super) struct PowerSubsystemBuilder {
     value: serde_json::Value,
 }
 
@@ -53,11 +53,11 @@ impl Builder for PowerSubsystemBuilder {
 }
 
 impl PowerSubsystemBuilder {
-    pub fn power_supplies(self, v: redfish::Collection) -> Self {
+    pub(super) fn power_supplies(self, v: redfish::Collection) -> Self {
         self.apply_patch(v.nav_property("PowerSupplies"))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(super) fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/power_supply.rs
+++ b/crates/bmc-mock/src/redfish/power_supply.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn resource<'a>(chassis_id: &str, supply_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn resource<'a>(chassis_id: &str, supply_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!(
         "{}/PowerSubsystem/PowerSupplies/{supply_id}",
         redfish::chassis::resource(chassis_id).odata_id
@@ -36,7 +36,7 @@ pub fn resource<'a>(chassis_id: &str, supply_id: &'a str) -> redfish::Resource<'
     }
 }
 
-pub fn collection(chassis_id: &str) -> redfish::Collection<'static> {
+pub(super) fn collection(chassis_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!(
         "{}/PowerSubsystem/PowerSupplies",
         redfish::chassis::resource(chassis_id).odata_id
@@ -48,25 +48,25 @@ pub fn collection(chassis_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub struct PowerSupply {
-    pub id: Cow<'static, str>,
+pub(crate) struct PowerSupply {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl PowerSupply {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> PowerSupplyBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> PowerSupplyBuilder {
     PowerSupplyBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
     }
 }
 
-pub struct PowerSupplyBuilder {
+pub(crate) struct PowerSupplyBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -81,7 +81,7 @@ impl Builder for PowerSupplyBuilder {
 }
 
 impl PowerSupplyBuilder {
-    pub fn oem_liteon_power_state(self, v: bool) -> Self {
+    pub(crate) fn oem_liteon_power_state(self, v: bool) -> Self {
         self.apply_patch(json!({"PowerState": v}))
     }
 
@@ -89,7 +89,7 @@ impl PowerSupplyBuilder {
     /// `Oem.deltaenergysystems.Power` (not the standard `PowerState` field),
     /// alongside a `FanSpeedTarget`. Mirrors the shape served by real Delta
     /// power shelves.
-    pub fn oem_delta_power_state(self, v: bool) -> Self {
+    pub(crate) fn oem_delta_power_state(self, v: bool) -> Self {
         self.apply_patch(json!({
             "Oem": {
                 "deltaenergysystems": {
@@ -101,13 +101,13 @@ impl PowerSupplyBuilder {
         }))
     }
 
-    pub fn status(self, status: redfish::resource::Status) -> Self {
+    pub(crate) fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({
             "Status": status.into_json()
         }))
     }
 
-    pub fn build(self) -> PowerSupply {
+    pub(crate) fn build(self) -> PowerSupply {
         PowerSupply {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/processor.rs
+++ b/crates/bmc-mock/src/redfish/processor.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+pub(super) fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/Processors");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -32,7 +32,7 @@ pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn system_resource<'a>(system_id: &str, processor_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn system_resource<'a>(system_id: &str, processor_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/Processors/{processor_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -42,7 +42,7 @@ pub fn system_resource<'a>(system_id: &str, processor_id: &'a str) -> redfish::R
     }
 }
 
-pub fn metrics_resource(system_id: &str, processor_id: &str) -> redfish::Resource<'static> {
+pub(super) fn metrics_resource(system_id: &str, processor_id: &str) -> redfish::Resource<'static> {
     let odata_id =
         format!("/redfish/v1/Systems/{system_id}/Processors/{processor_id}/ProcessorMetrics");
     redfish::Resource {
@@ -54,30 +54,30 @@ pub fn metrics_resource(system_id: &str, processor_id: &str) -> redfish::Resourc
 }
 
 /// A mock Redfish `Processor` plus its associated `ProcessorMetrics` resource.
-pub struct Processor {
-    pub id: Cow<'static, str>,
+pub(crate) struct Processor {
+    pub(crate) id: Cow<'static, str>,
     resource: serde_json::Value,
     metrics: serde_json::Value,
 }
 
 impl Processor {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.resource.clone()
     }
 
-    pub fn metrics_json(&self) -> serde_json::Value {
+    pub(crate) fn metrics_json(&self) -> serde_json::Value {
         self.metrics.clone()
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> ProcessorBuilder {
+fn builder(resource: &redfish::Resource) -> ProcessorBuilder {
     ProcessorBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
     }
 }
 
-pub struct ProcessorBuilder {
+struct ProcessorBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -92,15 +92,15 @@ impl Builder for ProcessorBuilder {
 }
 
 impl ProcessorBuilder {
-    pub fn processor_type(self, value: &str) -> Self {
+    fn processor_type(self, value: &str) -> Self {
         self.add_str_field("ProcessorType", value)
     }
 
-    pub fn metrics(self, metrics: &redfish::Resource<'_>) -> Self {
+    fn metrics(self, metrics: &redfish::Resource<'_>) -> Self {
         self.apply_patch(metrics.nav_property("Metrics"))
     }
 
-    pub fn status(self, status: redfish::resource::Status) -> Self {
+    fn status(self, status: redfish::resource::Status) -> Self {
         self.apply_patch(json!({ "Status": status.into_json() }))
     }
 
@@ -113,7 +113,7 @@ impl ProcessorBuilder {
     }
 }
 
-pub fn gpu(system_id: &str, processor_id: &str, core_voltage_sensor_uri: &str) -> Processor {
+pub(crate) fn gpu(system_id: &str, processor_id: &str, core_voltage_sensor_uri: &str) -> Processor {
     let metrics = metrics_resource(system_id, processor_id);
     let metrics_json = nvidia_gpu_metrics(&metrics, processor_id, core_voltage_sensor_uri);
     builder(&system_resource(system_id, processor_id))

--- a/crates/bmc-mock/src/redfish/resource.rs
+++ b/crates/bmc-mock/src/redfish/resource.rs
@@ -22,29 +22,25 @@ use serde_json::json;
 use crate::json::JsonPatch;
 
 /// Defines minimal set of Redfish resource attributes.
-pub struct Resource<'a> {
-    pub odata_id: Cow<'a, str>,
-    pub odata_type: Cow<'a, str>,
-    pub id: Cow<'a, str>,
-    pub name: Cow<'a, str>,
+pub(crate) struct Resource<'a> {
+    pub(crate) odata_id: Cow<'a, str>,
+    pub(crate) odata_type: Cow<'a, str>,
+    pub(crate) id: Cow<'a, str>,
+    pub(crate) name: Cow<'a, str>,
 }
 
 impl<'a> Resource<'a> {
-    pub fn entity_ref(&self) -> serde_json::Value {
+    pub(crate) fn entity_ref(&self) -> serde_json::Value {
         json!({
             "@odata.id": self.odata_id
         })
     }
-    pub fn nav_property(&self, name: &str) -> serde_json::Value {
+    pub(crate) fn nav_property(&self, name: &str) -> serde_json::Value {
         json!({
             name: {
                 "@odata.id": self.odata_id
             }
         })
-    }
-    pub fn with_name(mut self, name: &'a str) -> Self {
-        self.name = Cow::Borrowed(name);
-        self
     }
 }
 
@@ -65,22 +61,26 @@ impl JsonPatch for Resource<'_> {
     }
 }
 
-pub enum Status {
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Status {
     Ok,
     Warning,
     Critical,
 }
 
 impl Status {
-    pub fn into_json(self) -> serde_json::Value {
-        let health = match self {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
             Self::Ok => "OK",
             Self::Warning => "Warning",
             Self::Critical => "Critical",
-        };
+        }
+    }
+
+    pub(super) fn into_json(self) -> serde_json::Value {
         json!({
             "State": "Enabled",
-            "Health": health,
+            "Health": self.as_str(),
         })
     }
 }

--- a/crates/bmc-mock/src/redfish/secure_boot.rs
+++ b/crates/bmc-mock/src/redfish/secure_boot.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!(
         "{}/SecureBoot",
         redfish::computer_system::resource(system_id).odata_id
@@ -36,13 +36,13 @@ pub fn resource<'a>(system_id: &'a str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> SecureBootBuilder {
+pub(super) fn builder(resource: &redfish::Resource) -> SecureBootBuilder {
     SecureBootBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub struct SecureBootBuilder {
+pub(super) struct SecureBootBuilder {
     value: serde_json::Value,
 }
 
@@ -55,11 +55,11 @@ impl Builder for SecureBootBuilder {
 }
 
 impl SecureBootBuilder {
-    pub fn secure_boot_enable(self, v: bool) -> Self {
+    pub(super) fn secure_boot_enable(self, v: bool) -> Self {
         self.apply_patch(json!({"SecureBootEnable": v}))
     }
 
-    pub fn secure_boot_current_boot(self, enabled: bool) -> Self {
+    pub(super) fn secure_boot_current_boot(self, enabled: bool) -> Self {
         if enabled {
             self.add_str_field("SecureBootCurrentBoot", "Enabled")
         } else {
@@ -67,7 +67,7 @@ impl SecureBootBuilder {
         }
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(super) fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/sensor.rs
+++ b/crates/bmc-mock/src/redfish/sensor.rs
@@ -24,7 +24,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
+pub(super) fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Chassis/{chassis_id}/Sensors");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -33,7 +33,7 @@ pub fn chassis_collection(chassis_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn chassis_resource<'a>(chassis_id: &str, sensor_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn chassis_resource<'a>(chassis_id: &str, sensor_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("{}/{sensor_id}", chassis_collection(chassis_id).odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -43,7 +43,7 @@ pub fn chassis_resource<'a>(chassis_id: &str, sensor_id: &'a str) -> redfish::Re
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> SensorBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> SensorBuilder {
     SensorBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch().patch(json!({
@@ -53,28 +53,28 @@ pub fn builder(resource: &redfish::Resource) -> SensorBuilder {
 }
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct Layout {
-    pub temperature: usize,
-    pub fan: usize,
-    pub power: usize,
-    pub current: usize,
-    pub voltage: usize,
+pub(crate) struct Layout {
+    pub(crate) temperature: usize,
+    pub(crate) fan: usize,
+    pub(crate) power: usize,
+    pub(crate) current: usize,
+    pub(crate) voltage: usize,
 }
 
 impl Layout {
-    pub const fn total(&self) -> usize {
+    const fn total(&self) -> usize {
         self.temperature + self.fan + self.power + self.current + self.voltage
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct Sensor {
-    pub id: Cow<'static, str>,
+pub(crate) struct Sensor {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl Sensor {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         let Some(reading_type) = self
             .value
             .get("ReadingType")
@@ -101,19 +101,19 @@ impl Sensor {
     }
 }
 
-pub struct SensorBuilder {
+pub(crate) struct SensorBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Thresholds {
-    pub lower_fatal: Option<f64>,
-    pub lower_critical: Option<f64>,
-    pub lower_caution: Option<f64>,
-    pub upper_caution: Option<f64>,
-    pub upper_critical: Option<f64>,
-    pub upper_fatal: Option<f64>,
+struct Thresholds {
+    lower_fatal: Option<f64>,
+    lower_critical: Option<f64>,
+    lower_caution: Option<f64>,
+    upper_caution: Option<f64>,
+    upper_critical: Option<f64>,
+    upper_fatal: Option<f64>,
 }
 
 impl Builder for SensorBuilder {
@@ -184,31 +184,31 @@ impl SensorBuilder {
         redfish::resource::Status::Ok
     }
 
-    pub fn name(self, value: &str) -> Self {
+    pub(crate) fn name(self, value: &str) -> Self {
         self.add_str_field("Name", value)
     }
 
-    pub fn reading_f64(self, value: f64) -> Self {
+    pub(crate) fn reading_f64(self, value: f64) -> Self {
         self.apply_patch(json!({ "Reading": value }))
     }
 
-    pub fn reading_u32(self, value: u32) -> Self {
+    fn reading_u32(self, value: u32) -> Self {
         self.apply_patch(json!({ "Reading": value }))
     }
 
-    pub fn reading_type(self, value: &str) -> Self {
+    pub(crate) fn reading_type(self, value: &str) -> Self {
         self.add_str_field("ReadingType", value)
     }
 
-    pub fn reading_units(self, value: &str) -> Self {
+    pub(crate) fn reading_units(self, value: &str) -> Self {
         self.add_str_field("ReadingUnits", value)
     }
 
-    pub fn physical_context(self, value: &str) -> Self {
+    fn physical_context(self, value: &str) -> Self {
         self.add_str_field("PhysicalContext", value)
     }
 
-    pub fn threshold_lower_critical(self, value: f64) -> Self {
+    fn threshold_lower_critical(self, value: f64) -> Self {
         self.apply_patch(json!({
             "Thresholds": {
                 "LowerCritical": {
@@ -218,7 +218,7 @@ impl SensorBuilder {
         }))
     }
 
-    pub fn threshold_lower_fatal(self, value: f64) -> Self {
+    fn threshold_lower_fatal(self, value: f64) -> Self {
         self.apply_patch(json!({
             "Thresholds": {
                 "LowerFatal": {
@@ -228,7 +228,7 @@ impl SensorBuilder {
         }))
     }
 
-    pub fn threshold_lower_caution(self, value: f64) -> Self {
+    pub(crate) fn threshold_lower_caution(self, value: f64) -> Self {
         self.apply_patch(json!({
             "Thresholds": {
                 "LowerCaution": {
@@ -238,7 +238,7 @@ impl SensorBuilder {
         }))
     }
 
-    pub fn threshold_upper_caution(self, value: f64) -> Self {
+    pub(crate) fn threshold_upper_caution(self, value: f64) -> Self {
         self.apply_patch(json!({
             "Thresholds": {
                 "UpperCaution": {
@@ -248,7 +248,7 @@ impl SensorBuilder {
         }))
     }
 
-    pub fn threshold_upper_critical(self, value: f64) -> Self {
+    pub(crate) fn threshold_upper_critical(self, value: f64) -> Self {
         self.apply_patch(json!({
             "Thresholds": {
                 "UpperCritical": {
@@ -258,7 +258,7 @@ impl SensorBuilder {
         }))
     }
 
-    pub fn threshold_upper_fatal(self, value: f64) -> Self {
+    fn threshold_upper_fatal(self, value: f64) -> Self {
         self.apply_patch(json!({
             "Thresholds": {
                 "UpperFatal": {
@@ -268,7 +268,7 @@ impl SensorBuilder {
         }))
     }
 
-    pub fn thresholds(mut self, thresholds: Thresholds) -> Self {
+    fn thresholds(mut self, thresholds: Thresholds) -> Self {
         if let Some(value) = thresholds.lower_fatal {
             self = self.threshold_lower_fatal(value);
         }
@@ -290,7 +290,7 @@ impl SensorBuilder {
         self
     }
 
-    pub fn build(self) -> Sensor {
+    pub(crate) fn build(self) -> Sensor {
         let status = self.health_status();
         Sensor {
             id: self.id,
@@ -302,7 +302,7 @@ impl SensorBuilder {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum SensorKind {
+pub(crate) enum SensorKind {
     Temperature,
     Fan,
     Power,
@@ -434,7 +434,7 @@ impl SensorKind {
     }
 }
 
-pub fn generate_chassis_sensors(chassis_id: &str, layout: Layout) -> Vec<Sensor> {
+pub(crate) fn generate_chassis_sensors(chassis_id: &str, layout: Layout) -> Vec<Sensor> {
     let mut rng = rand::rng();
     let mut sensors = Vec::with_capacity(layout.total());
     append_sensors(
@@ -475,7 +475,7 @@ pub fn generate_chassis_sensors(chassis_id: &str, layout: Layout) -> Vec<Sensor>
     sensors
 }
 
-pub fn sensor_id(kind: SensorKind, index: usize) -> String {
+pub(crate) fn sensor_id(kind: SensorKind, index: usize) -> String {
     format!("{}_{}", kind.id_prefix(), index)
 }
 

--- a/crates/bmc-mock/src/redfish/serial_console.rs
+++ b/crates/bmc-mock/src/redfish/serial_console.rs
@@ -21,21 +21,21 @@ use crate::json::JsonExt;
 use crate::redfish::Builder;
 
 #[derive(Clone)]
-pub struct SerialConsole {
+pub(crate) struct SerialConsole {
     value: serde_json::Value,
 }
 
 impl SerialConsole {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub fn builder() -> SerialConsoleBuilder {
+pub(crate) fn builder() -> SerialConsoleBuilder {
     SerialConsoleBuilder { value: json!({}) }
 }
 
-pub struct SerialConsoleBuilder {
+pub(crate) struct SerialConsoleBuilder {
     value: serde_json::Value,
 }
 
@@ -48,25 +48,25 @@ impl Builder for SerialConsoleBuilder {
 }
 
 impl SerialConsoleBuilder {
-    pub fn max_concurrent_sessions(self, value: u64) -> Self {
+    pub(crate) fn max_concurrent_sessions(self, value: u64) -> Self {
         self.apply_patch(json!({ "MaxConcurrentSessions": value }))
     }
 
-    pub fn ssh(self, value: &SerialConsoleProtocol) -> Self {
+    pub(crate) fn ssh(self, value: &SerialConsoleProtocol) -> Self {
         self.apply_patch(json!({ "SSH": value.to_json() }))
     }
 
-    pub fn ipmi(self, value: &SerialConsoleProtocol) -> Self {
+    pub(crate) fn ipmi(self, value: &SerialConsoleProtocol) -> Self {
         self.apply_patch(json!({ "IPMI": value.to_json() }))
     }
 
-    pub fn build(self) -> SerialConsole {
+    pub(crate) fn build(self) -> SerialConsole {
         SerialConsole { value: self.value }
     }
 }
 
 #[derive(Clone)]
-pub struct SerialConsoleProtocol {
+pub(crate) struct SerialConsoleProtocol {
     value: serde_json::Value,
 }
 
@@ -76,11 +76,11 @@ impl SerialConsoleProtocol {
     }
 }
 
-pub fn protocol_builder() -> SerialConsoleProtocolBuilder {
+pub(crate) fn protocol_builder() -> SerialConsoleProtocolBuilder {
     SerialConsoleProtocolBuilder { value: json!({}) }
 }
 
-pub struct SerialConsoleProtocolBuilder {
+pub(crate) struct SerialConsoleProtocolBuilder {
     value: serde_json::Value,
 }
 
@@ -93,27 +93,27 @@ impl Builder for SerialConsoleProtocolBuilder {
 }
 
 impl SerialConsoleProtocolBuilder {
-    pub fn service_enabled(self, value: bool) -> Self {
+    pub(crate) fn service_enabled(self, value: bool) -> Self {
         self.apply_patch(json!({ "ServiceEnabled": value }))
     }
 
-    pub fn port(self, value: u16) -> Self {
+    pub(crate) fn port(self, value: u16) -> Self {
         self.apply_patch(json!({ "Port": value }))
     }
 
-    pub fn shared_with_manager_cli(self, value: bool) -> Self {
+    pub(crate) fn shared_with_manager_cli(self, value: bool) -> Self {
         self.apply_patch(json!({ "SharedWithManagerCLI": value }))
     }
 
-    pub fn console_entry_command(self, value: &str) -> Self {
+    pub(crate) fn console_entry_command(self, value: &str) -> Self {
         self.add_str_field("ConsoleEntryCommand", value)
     }
 
-    pub fn hot_key_sequence_display(self, value: &str) -> Self {
+    pub(crate) fn hot_key_sequence_display(self, value: &str) -> Self {
         self.add_str_field("HotKeySequenceDisplay", value)
     }
 
-    pub fn build(self) -> SerialConsoleProtocol {
+    pub(crate) fn build(self) -> SerialConsoleProtocol {
         SerialConsoleProtocol { value: self.value }
     }
 }

--- a/crates/bmc-mock/src/redfish/serial_interface.rs
+++ b/crates/bmc-mock/src/redfish/serial_interface.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
+pub(super) fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Owned(format!(
             "/redfish/v1/Managers/{manager_id}/SerialInterfaces"
@@ -33,7 +33,10 @@ pub fn manager_collection(manager_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn manager_resource<'a>(manager_id: &'a str, interface_id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn manager_resource<'a>(
+    manager_id: &'a str,
+    interface_id: &'a str,
+) -> redfish::Resource<'a> {
     redfish::Resource {
         odata_id: Cow::Owned(format!(
             "/redfish/v1/Managers/{manager_id}/SerialInterfaces/{interface_id}"
@@ -45,25 +48,25 @@ pub fn manager_resource<'a>(manager_id: &'a str, interface_id: &'a str) -> redfi
 }
 
 #[derive(Clone)]
-pub struct SerialInterface {
-    pub id: Cow<'static, str>,
+pub(crate) struct SerialInterface {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl SerialInterface {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> SerialInterfaceBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> SerialInterfaceBuilder {
     SerialInterfaceBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
     }
 }
 
-pub struct SerialInterfaceBuilder {
+pub(crate) struct SerialInterfaceBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -78,47 +81,47 @@ impl Builder for SerialInterfaceBuilder {
 }
 
 impl SerialInterfaceBuilder {
-    pub fn description(self, value: &str) -> Self {
+    pub(crate) fn description(self, value: &str) -> Self {
         self.add_str_field("Description", value)
     }
 
-    pub fn interface_enabled(self, value: bool) -> Self {
+    pub(crate) fn interface_enabled(self, value: bool) -> Self {
         self.apply_patch(json!({ "InterfaceEnabled": value }))
     }
 
-    pub fn signal_type(self, value: &str) -> Self {
+    pub(crate) fn signal_type(self, value: &str) -> Self {
         self.add_str_field("SignalType", value)
     }
 
-    pub fn bit_rate(self, value: &str) -> Self {
+    pub(crate) fn bit_rate(self, value: &str) -> Self {
         self.add_str_field("BitRate", value)
     }
 
-    pub fn parity(self, value: &str) -> Self {
+    pub(crate) fn parity(self, value: &str) -> Self {
         self.add_str_field("Parity", value)
     }
 
-    pub fn data_bits(self, value: &str) -> Self {
+    pub(crate) fn data_bits(self, value: &str) -> Self {
         self.add_str_field("DataBits", value)
     }
 
-    pub fn stop_bits(self, value: &str) -> Self {
+    pub(crate) fn stop_bits(self, value: &str) -> Self {
         self.add_str_field("StopBits", value)
     }
 
-    pub fn flow_control(self, value: &str) -> Self {
+    pub(crate) fn flow_control(self, value: &str) -> Self {
         self.add_str_field("FlowControl", value)
     }
 
-    pub fn connector_type(self, value: &str) -> Self {
+    pub(crate) fn connector_type(self, value: &str) -> Self {
         self.add_str_field("ConnectorType", value)
     }
 
-    pub fn pin_out(self, value: &str) -> Self {
+    pub(crate) fn pin_out(self, value: &str) -> Self {
         self.add_str_field("PinOut", value)
     }
 
-    pub fn build(self) -> SerialInterface {
+    pub(crate) fn build(self) -> SerialInterface {
         SerialInterface {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/service_root.rs
+++ b/crates/bmc-mock/src/redfish/service_root.rs
@@ -28,7 +28,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn resource<'a>() -> redfish::Resource<'a> {
+pub(crate) fn resource<'a>() -> redfish::Resource<'a> {
     redfish::Resource {
         odata_id: Cow::Borrowed("/redfish/v1"),
         odata_type: Cow::Borrowed("#ServiceRoot.v1_10_0.ServiceRoot"),
@@ -37,11 +37,11 @@ pub fn resource<'a>() -> redfish::Resource<'a> {
     }
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(&resource().odata_id, get(get_service_root))
 }
 
-pub fn builder(resource: &redfish::Resource) -> ServiceRootBuilder {
+fn builder(resource: &redfish::Resource) -> ServiceRootBuilder {
     ServiceRootBuilder {
         value: resource.json_patch().patch(json!({
             "Links": {
@@ -78,7 +78,7 @@ async fn get_service_root(State(state): State<BmcState>) -> Response {
         .into_ok_response()
 }
 
-pub struct ServiceRootBuilder {
+struct ServiceRootBuilder {
     value: serde_json::Value,
 }
 
@@ -91,47 +91,47 @@ impl Builder for ServiceRootBuilder {
 }
 
 impl ServiceRootBuilder {
-    pub fn build(self) -> serde_json::Value {
+    fn build(self) -> serde_json::Value {
         self.value
     }
 
-    pub fn redfish_version(self, v: &str) -> Self {
+    fn redfish_version(self, v: &str) -> Self {
         self.add_str_field("RedfishVersion", v)
     }
 
-    pub fn vendor(self, v: &str) -> Self {
+    fn vendor(self, v: &str) -> Self {
         self.add_str_field("Vendor", v)
     }
 
-    pub fn product(self, v: &str) -> Self {
+    fn product(self, v: &str) -> Self {
         self.add_str_field("Product", v)
     }
 
-    pub fn account_service(self, v: &redfish::Resource<'_>) -> Self {
+    fn account_service(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("AccountService"))
     }
 
-    pub fn session_service(self, v: &redfish::Resource<'_>) -> Self {
+    fn session_service(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("SessionService"))
     }
 
-    pub fn chassis_collection(self, v: &redfish::Collection<'_>) -> Self {
+    fn chassis_collection(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("Chassis"))
     }
 
-    pub fn system_collection(self, v: &redfish::Collection<'_>) -> Self {
+    fn system_collection(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("Systems"))
     }
 
-    pub fn manager_collection(self, v: &redfish::Collection<'_>) -> Self {
+    fn manager_collection(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("Managers"))
     }
 
-    pub fn update_service(self, v: &redfish::Resource<'_>) -> Self {
+    fn update_service(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("UpdateService"))
     }
 
-    pub fn telemetry_service(self, v: &redfish::Resource<'_>) -> Self {
+    fn telemetry_service(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("TelemetryService"))
     }
 }

--- a/crates/bmc-mock/src/redfish/session_service.rs
+++ b/crates/bmc-mock/src/redfish/session_service.rs
@@ -39,7 +39,7 @@ use crate::{http, redfish};
 const X_AUTH_TOKEN: HeaderName = HeaderName::from_static("x-auth-token");
 const SESSION_TOKEN_TTL: Duration = Duration::from_secs(120);
 
-pub fn service_resource() -> redfish::Resource<'static> {
+pub(super) fn service_resource() -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Borrowed("/redfish/v1/SessionService"),
         odata_type: Cow::Borrowed("#SessionService.v1_1_9.SessionService"),
@@ -48,7 +48,7 @@ pub fn service_resource() -> redfish::Resource<'static> {
     }
 }
 
-pub fn sessions_collection() -> redfish::Collection<'static> {
+pub(crate) fn sessions_collection() -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Borrowed("/redfish/v1/SessionService/Sessions"),
         odata_type: Cow::Borrowed("#SessionCollection.SessionCollection"),
@@ -56,7 +56,7 @@ pub fn sessions_collection() -> redfish::Collection<'static> {
     }
 }
 
-pub fn session_resource(id: impl Display) -> redfish::Resource<'static> {
+fn session_resource(id: impl Display) -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Owned(format!("/redfish/v1/SessionService/Sessions/{id}")),
         odata_type: Cow::Borrowed("#Session.v1_7_0.Session"),
@@ -65,7 +65,7 @@ pub fn session_resource(id: impl Display) -> redfish::Resource<'static> {
     }
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route(&service_resource().odata_id, get(get_service))
         .route(
             &sessions_collection().odata_id,
@@ -78,11 +78,11 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
 }
 
 #[derive(Clone, Debug)]
-pub struct SessionRecord {
-    pub id: String,
-    pub username: String,
-    pub token: String,
-    pub expires_at: Instant,
+pub(crate) struct SessionRecord {
+    pub(crate) id: String,
+    pub(crate) username: String,
+    pub(crate) token: String,
+    pub(crate) expires_at: Instant,
 }
 
 impl SessionRecord {
@@ -100,23 +100,23 @@ impl SessionRecord {
 }
 
 #[derive(Debug, Default)]
-pub struct SessionServiceState {
+pub(crate) struct SessionServiceState {
     next_id: Mutex<u64>,
     sessions: Mutex<HashMap<String, SessionRecord>>,
 }
 
 impl SessionServiceState {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn is_token_valid(&self, token: &str) -> bool {
+    pub(crate) fn is_token_valid(&self, token: &str) -> bool {
         let mut sessions = self.sessions.lock().expect("mutex poisoned");
         Self::prune_expired(&mut sessions, Instant::now());
         sessions.contains_key(token)
     }
 
-    pub fn create(&self, username: impl Into<String>) -> SessionRecord {
+    pub(crate) fn create(&self, username: impl Into<String>) -> SessionRecord {
         let id = {
             let mut next_id = self.next_id.lock().expect("mutex poisoned");
             *next_id += 1;
@@ -136,19 +136,19 @@ impl SessionServiceState {
         record
     }
 
-    pub fn list(&self) -> Vec<SessionRecord> {
+    pub(crate) fn list(&self) -> Vec<SessionRecord> {
         let mut sessions = self.sessions.lock().expect("mutex poisoned");
         Self::prune_expired(&mut sessions, Instant::now());
         sessions.values().cloned().collect()
     }
 
-    pub fn find_by_id(&self, id: &str) -> Option<SessionRecord> {
+    pub(crate) fn find_by_id(&self, id: &str) -> Option<SessionRecord> {
         let mut sessions = self.sessions.lock().expect("mutex poisoned");
         Self::prune_expired(&mut sessions, Instant::now());
         sessions.values().find(|rec| rec.id == id).cloned()
     }
 
-    pub fn delete_by_id(&self, id: &str) -> bool {
+    pub(crate) fn delete_by_id(&self, id: &str) -> bool {
         let mut sessions = self.sessions.lock().expect("mutex poisoned");
         Self::prune_expired(&mut sessions, Instant::now());
         let Some(token) = sessions

--- a/crates/bmc-mock/src/redfish/software_inventory.rs
+++ b/crates/bmc-mock/src/redfish/software_inventory.rs
@@ -23,7 +23,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn firmware_inventory_collection() -> redfish::Collection<'static> {
+pub(super) fn firmware_inventory_collection() -> redfish::Collection<'static> {
     let odata_id = format!(
         "{}/FirmwareInventory",
         redfish::update_service::resource().odata_id
@@ -35,7 +35,7 @@ pub fn firmware_inventory_collection() -> redfish::Collection<'static> {
     }
 }
 
-pub fn firmware_inventory_resource<'a>(id: &'a str) -> redfish::Resource<'a> {
+pub(crate) fn firmware_inventory_resource<'a>(id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("{}/{id}", firmware_inventory_collection().odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -46,25 +46,25 @@ pub fn firmware_inventory_resource<'a>(id: &'a str) -> redfish::Resource<'a> {
 }
 
 /// Generate resource bound to chassis.
-pub fn builder(resource: &redfish::Resource) -> SoftwareInventoryBuilder {
+pub(crate) fn builder(resource: &redfish::Resource) -> SoftwareInventoryBuilder {
     SoftwareInventoryBuilder {
         id: Cow::Owned(resource.id.to_string()),
         value: resource.json_patch(),
     }
 }
 
-pub struct SoftwareInventory {
-    pub id: Cow<'static, str>,
+pub(crate) struct SoftwareInventory {
+    pub(crate) id: Cow<'static, str>,
     value: serde_json::Value,
 }
 
 impl SoftwareInventory {
-    pub fn to_json(&self) -> serde_json::Value {
+    pub(crate) fn to_json(&self) -> serde_json::Value {
         self.value.clone()
     }
 }
 
-pub struct SoftwareInventoryBuilder {
+pub(crate) struct SoftwareInventoryBuilder {
     id: Cow<'static, str>,
     value: serde_json::Value,
 }
@@ -79,31 +79,31 @@ impl Builder for SoftwareInventoryBuilder {
 }
 
 impl SoftwareInventoryBuilder {
-    pub fn name(self, value: &str) -> Self {
+    pub(crate) fn name(self, value: &str) -> Self {
         self.add_str_field("Name", value)
     }
 
-    pub fn manufacturer(self, value: &str) -> Self {
+    pub(crate) fn manufacturer(self, value: &str) -> Self {
         self.add_str_field("Manufacturer", value)
     }
 
-    pub fn software_id(self, value: &str) -> Self {
+    pub(crate) fn software_id(self, value: &str) -> Self {
         self.add_str_field("SoftwareId", value)
     }
 
-    pub fn version(self, value: &str) -> Self {
+    pub(crate) fn version(self, value: &str) -> Self {
         self.add_str_field("Version", value)
     }
 
-    pub fn status(self, value: redfish::resource::Status) -> Self {
+    pub(crate) fn status(self, value: redfish::resource::Status) -> Self {
         self.apply_patch(json!({ "Status": value.into_json() }))
     }
 
-    pub fn updateable(self, value: bool) -> Self {
+    pub(crate) fn updateable(self, value: bool) -> Self {
         self.apply_patch(json!({ "Updateable": value }))
     }
 
-    pub fn related_items(self, odata_ids: &[&str]) -> Self {
+    pub(crate) fn related_items(self, odata_ids: &[&str]) -> Self {
         let items = odata_ids
             .iter()
             .map(|odata_id| json!({ "@odata.id": odata_id }))
@@ -114,7 +114,7 @@ impl SoftwareInventoryBuilder {
         }))
     }
 
-    pub fn build(self) -> SoftwareInventory {
+    pub(crate) fn build(self) -> SoftwareInventory {
         SoftwareInventory {
             id: self.id,
             value: self.value,

--- a/crates/bmc-mock/src/redfish/storage.rs
+++ b/crates/bmc-mock/src/redfish/storage.rs
@@ -18,7 +18,7 @@ use std::borrow::Cow;
 
 use crate::redfish;
 
-pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
+pub(super) fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/Storage");
     redfish::Collection {
         odata_id: Cow::Owned(odata_id),
@@ -27,7 +27,7 @@ pub fn system_collection(system_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn system_resource<'a>(system_id: &str, storage_id: &'a str) -> redfish::Resource<'a> {
+pub(super) fn system_resource<'a>(system_id: &str, storage_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("/redfish/v1/Systems/{system_id}/Storage/{storage_id}");
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -37,7 +37,6 @@ pub fn system_resource<'a>(system_id: &str, storage_id: &'a str) -> redfish::Res
     }
 }
 
-pub struct Storage {
-    pub id: Cow<'static, str>,
-    pub value: serde_json::Value,
+pub(crate) struct Storage {
+    pub(crate) id: Cow<'static, str>,
 }

--- a/crates/bmc-mock/src/redfish/task_service.rs
+++ b/crates/bmc-mock/src/redfish/task_service.rs
@@ -23,7 +23,7 @@ use serde_json::json;
 use crate::bmc_state::BmcState;
 use crate::json::JsonExt;
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     r.route("/redfish/v1/TaskService/Tasks/{task_id}", get(get_task))
 }
 
@@ -41,7 +41,7 @@ async fn get_task() -> Response {
     .into_ok_response()
 }
 
-pub fn update_firmware_simple_update_task() -> Response {
+pub(super) fn update_firmware_simple_update_task() -> Response {
     json!({
         "@odata.id": "/redfish/v1/TaskService/Tasks/0",
         "@odata.type": "#Task.v1_4_3.Task",

--- a/crates/bmc-mock/src/redfish/telemetry_service.rs
+++ b/crates/bmc-mock/src/redfish/telemetry_service.rs
@@ -28,9 +28,9 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::{http, redfish};
 
 /// Id of the single aggregated report the mock publishes.
-pub const REPORT_ID: &str = "PlatformEnvironmentMetrics";
+const REPORT_ID: &str = "PlatformEnvironmentMetrics";
 
-pub fn resource() -> redfish::Resource<'static> {
+pub(super) fn resource() -> redfish::Resource<'static> {
     redfish::Resource {
         odata_id: Cow::Borrowed("/redfish/v1/TelemetryService"),
         odata_type: Cow::Borrowed("#TelemetryService.v1_3_1.TelemetryService"),
@@ -39,7 +39,7 @@ pub fn resource() -> redfish::Resource<'static> {
     }
 }
 
-pub fn metric_reports_collection() -> redfish::Collection<'static> {
+fn metric_reports_collection() -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Borrowed("/redfish/v1/TelemetryService/MetricReports"),
         odata_type: Cow::Borrowed("#MetricReportCollection.MetricReportCollection"),
@@ -47,7 +47,7 @@ pub fn metric_reports_collection() -> redfish::Collection<'static> {
     }
 }
 
-pub fn metric_report_resource<'a>(report_id: &'a str) -> redfish::Resource<'a> {
+fn metric_report_resource<'a>(report_id: &'a str) -> redfish::Resource<'a> {
     let odata_id = format!("{}/{report_id}", metric_reports_collection().odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -57,7 +57,7 @@ pub fn metric_report_resource<'a>(report_id: &'a str) -> redfish::Resource<'a> {
     }
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const REPORT_ID_PARAM: &str = "{report_id}";
     r.route(&resource().odata_id, get(get_telemetry_service))
         .route(

--- a/crates/bmc-mock/src/redfish/thermal_subsystem.rs
+++ b/crates/bmc-mock/src/redfish/thermal_subsystem.rs
@@ -21,7 +21,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish;
 use crate::redfish::Builder;
 
-pub fn resource(chassis_id: &str) -> redfish::Resource<'static> {
+pub(super) fn resource(chassis_id: &str) -> redfish::Resource<'static> {
     let odata_id = format!(
         "{}/ThermalSubsystem",
         redfish::chassis::resource(chassis_id).odata_id
@@ -34,7 +34,7 @@ pub fn resource(chassis_id: &str) -> redfish::Resource<'static> {
     }
 }
 
-pub fn leak_detection_resource(chassis_id: &str) -> redfish::Resource<'static> {
+pub(super) fn leak_detection_resource(chassis_id: &str) -> redfish::Resource<'static> {
     let odata_id = format!("{}/LeakDetection", resource(chassis_id).odata_id);
     redfish::Resource {
         odata_id: Cow::Owned(odata_id),
@@ -44,19 +44,19 @@ pub fn leak_detection_resource(chassis_id: &str) -> redfish::Resource<'static> {
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> ThermalSubsystemBuilder {
+pub(super) fn builder(resource: &redfish::Resource) -> ThermalSubsystemBuilder {
     ThermalSubsystemBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub fn leak_detection_builder(resource: &redfish::Resource) -> LeakDetectionBuilder {
+pub(super) fn leak_detection_builder(resource: &redfish::Resource) -> LeakDetectionBuilder {
     LeakDetectionBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub struct ThermalSubsystemBuilder {
+pub(super) struct ThermalSubsystemBuilder {
     value: serde_json::Value,
 }
 
@@ -69,16 +69,16 @@ impl Builder for ThermalSubsystemBuilder {
 }
 
 impl ThermalSubsystemBuilder {
-    pub fn leak_detection(self, v: &redfish::Resource<'_>) -> Self {
+    pub(super) fn leak_detection(self, v: &redfish::Resource<'_>) -> Self {
         self.apply_patch(v.nav_property("LeakDetection"))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(super) fn build(self) -> serde_json::Value {
         self.value
     }
 }
 
-pub struct LeakDetectionBuilder {
+pub(super) struct LeakDetectionBuilder {
     value: serde_json::Value,
 }
 
@@ -91,11 +91,11 @@ impl Builder for LeakDetectionBuilder {
 }
 
 impl LeakDetectionBuilder {
-    pub fn leak_detectors(self, v: &redfish::Collection<'_>) -> Self {
+    pub(super) fn leak_detectors(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("LeakDetectors"))
     }
 
-    pub fn build(self) -> serde_json::Value {
+    pub(super) fn build(self) -> serde_json::Value {
         self.value
     }
 }

--- a/crates/bmc-mock/src/redfish/update_service.rs
+++ b/crates/bmc-mock/src/redfish/update_service.rs
@@ -27,7 +27,7 @@ use crate::json::{JsonExt, JsonPatch};
 use crate::redfish::Builder;
 use crate::{http, redfish};
 
-pub fn resource<'a>() -> redfish::Resource<'a> {
+pub(super) fn resource<'a>() -> redfish::Resource<'a> {
     redfish::Resource {
         odata_id: Cow::Borrowed("/redfish/v1/UpdateService"),
         odata_type: Cow::Borrowed("#UpdateService.v1_9_0.UpdateService"),
@@ -36,17 +36,17 @@ pub fn resource<'a>() -> redfish::Resource<'a> {
     }
 }
 
-pub fn builder(resource: &redfish::Resource) -> UpdateServiceBuilder {
+fn builder(resource: &redfish::Resource) -> UpdateServiceBuilder {
     UpdateServiceBuilder {
         value: resource.json_patch(),
     }
 }
 
-pub fn simple_update_target() -> String {
+fn simple_update_target() -> String {
     format!("{}/Actions/UpdateService.SimpleUpdate", resource().odata_id)
 }
 
-pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
     const FW_INVENTORY_ID: &str = "{fw_inventory_id}";
     r.route(&resource().odata_id, get(get_update_service))
         .route(&simple_update_target(), post(update_firmware_simple_update))
@@ -60,22 +60,22 @@ pub fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
         )
 }
 
-pub struct UpdateServiceConfig {
-    pub firmware_inventory: Vec<redfish::software_inventory::SoftwareInventory>,
+pub(crate) struct UpdateServiceConfig {
+    pub(crate) firmware_inventory: Vec<redfish::software_inventory::SoftwareInventory>,
 }
 
-pub struct UpdateServiceState {
+pub(crate) struct UpdateServiceState {
     firmware_inventory: Vec<redfish::software_inventory::SoftwareInventory>,
 }
 
 impl UpdateServiceState {
-    pub fn from_config(config: UpdateServiceConfig) -> Self {
+    pub(crate) fn from_config(config: UpdateServiceConfig) -> Self {
         Self {
             firmware_inventory: config.firmware_inventory,
         }
     }
 
-    pub fn find_firmware_inventory(
+    pub(crate) fn find_firmware_inventory(
         &self,
         id: &str,
     ) -> Option<&redfish::software_inventory::SoftwareInventory> {
@@ -117,7 +117,7 @@ async fn get_firmware_inventory_resource(
         .unwrap_or_else(http::not_found)
 }
 
-pub struct UpdateServiceBuilder {
+struct UpdateServiceBuilder {
     value: serde_json::Value,
 }
 
@@ -130,11 +130,11 @@ impl Builder for UpdateServiceBuilder {
 }
 
 impl UpdateServiceBuilder {
-    pub fn build(self) -> serde_json::Value {
+    fn build(self) -> serde_json::Value {
         self.value
     }
 
-    pub fn firmware_inventory(self, v: &redfish::Collection<'_>) -> Self {
+    fn firmware_inventory(self, v: &redfish::Collection<'_>) -> Self {
         self.apply_patch(v.nav_property("FirmwareInventory"))
     }
 }

--- a/crates/bmc-mock/src/redfish/virtual_media.rs
+++ b/crates/bmc-mock/src/redfish/virtual_media.rs
@@ -47,12 +47,12 @@ struct DeviceState {
     media: Mutex<Media>,
 }
 
-pub struct VirtualMediaState {
+pub(crate) struct VirtualMediaState {
     devices: Vec<DeviceState>,
 }
 
 impl VirtualMediaState {
-    pub fn new(devices: Vec<DeviceConfig>) -> Self {
+    pub(super) fn new(devices: Vec<DeviceConfig>) -> Self {
         Self {
             devices: devices
                 .into_iter()
@@ -78,7 +78,7 @@ impl VirtualMediaState {
     }
 }
 
-pub fn collection(system_id: &str) -> redfish::Collection<'static> {
+pub(super) fn collection(system_id: &str) -> redfish::Collection<'static> {
     redfish::Collection {
         odata_id: Cow::Owned(format!(
             "{}/VirtualMedia",
@@ -89,7 +89,7 @@ pub fn collection(system_id: &str) -> redfish::Collection<'static> {
     }
 }
 
-pub fn resource<'a>(system_id: &str, device_id: &'a str) -> redfish::Resource<'a> {
+fn resource<'a>(system_id: &str, device_id: &'a str) -> redfish::Resource<'a> {
     redfish::Resource {
         odata_id: Cow::Owned(format!("{}/{device_id}", collection(system_id).odata_id)),
         odata_type: Cow::Borrowed("#VirtualMedia.v1_3_2.VirtualMedia"),
@@ -112,7 +112,7 @@ fn eject_media_target(system_id: &str, device_id: &str) -> String {
     )
 }
 
-pub fn add_routes(router: Router<BmcState>) -> Router<BmcState> {
+pub(crate) fn add_routes(router: Router<BmcState>) -> Router<BmcState> {
     const SYSTEM_ID: &str = "{system_id}";
     const DEVICE_ID: &str = "{device_id}";
     router

--- a/crates/bmc-mock/src/tar_router.rs
+++ b/crates/bmc-mock/src/tar_router.rs
@@ -36,7 +36,7 @@ use eyre::Context;
 use flate2::read::GzDecoder;
 use regex::Regex;
 
-pub type EntryMap = Arc<Mutex<HashMap<String, String>>>;
+pub(super) type EntryMap = Arc<Mutex<HashMap<String, String>>>;
 
 #[derive(Clone, Default)]
 struct TarRouterCache {
@@ -45,7 +45,7 @@ struct TarRouterCache {
 
 /// Allows callers to specify an in-memory tar (like via include_bytes!()) or a path to one on the
 /// filesystem.
-pub enum TarGzOption<'a> {
+pub(super) enum TarGzOption<'a> {
     Disk(&'a PathBuf),
 }
 
@@ -58,7 +58,7 @@ impl TarGzOption<'_> {
 }
 
 /// Create a mock of
-pub fn tar_router(
+pub(super) fn tar_router(
     targz: TarGzOption,
     existing_tars: Option<&mut HashMap<std::path::PathBuf, EntryMap>>,
 ) -> eyre::Result<Router> {

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 pub mod axum_http_client;
 
 #[derive(Debug)]
-pub struct NoopCallbacks;
+pub(super) struct NoopCallbacks;
 
 impl Callbacks for NoopCallbacks {
     fn get_power_state(&self) -> MockPowerState {
@@ -55,9 +55,6 @@ impl Callbacks for NoopCallbacks {
 pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
 
 lazy_static::lazy_static! {
-    pub static ref TEST_HW_MAC_POOL_CONFIG: MacAddressPoolConfig =
-        MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).unwrap();
-
     pub static ref TEST_MAC_POOL: Arc<Mutex<MacAddressPool>> =
         Arc::new(Mutex::new(MacAddressPool::new(MacAddressConfig {
             pool: Some(MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 32).unwrap()),
@@ -102,7 +99,7 @@ pub async fn bmc_for_machine(machine_info: MachineInfo) -> TestBmcHandle {
     .await
 }
 
-pub(crate) fn host_info(hw_type: HardwareType) -> MachineInfo {
+pub(super) fn host_info(hw_type: HardwareType) -> MachineInfo {
     let ndpu = hw_type.fixed_number_of_dpu().unwrap_or(0);
     let mut pool = TEST_MAC_POOL.lock().unwrap();
     let ranges_config = pool.allocate_range_config().unwrap();

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -371,8 +371,8 @@ pub struct MachineATronConfig {
     #[serde(default)]
     pub host_bmc_password: Option<String>,
 
-    /// Same as `host_bmc_password`, for DPU BMC mocks
-    /// (factory default `DUMMY_FACTORY_DPU_PASSWORD`).
+    /// Same as `host_bmc_password`, for DPU BMC mocks. When unset, each DPU
+    /// model uses its factory-default password.
     #[serde(default)]
     pub dpu_bmc_password: Option<String>,
 


### PR DESCRIPTION
This adopts the new style guide rules around module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout BMC Mock.

Primary callouts are:
- Replace unrestricted `pub` throughout `crates/bmc-mock/src/**` with private, `pub(super)`, or `pub(crate)` visibility based on actual callers.
- Keep the mock server/router, `MachineInfo`, injection controls, IPMI simulator, MAC pools, callback backends, and integration-test support public where they cross crate boundaries.
- Make the hardware and Redfish implementation trees internal while keeping `RackElevation` and `RackUnit` available through intentional root re-exports.
- Remove unused exports, helpers, and nonserialized state, including stale blanket dead-code allowances.
- Preserve HTTP routes, serialized Redfish responses, supported test fixtures, deterministic MAC allocation, and runtime behavior.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4550.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

The corresponding Machine-a-tron deployment-guide and setup-script credential-source corrections are tracked in https://github.com/NVIDIA/infra-controller/issues/4633 so they can stay together behind the required reviewer boundary.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

All 84 BMC Mock tests passed. I also checked every direct workspace consumer and ran:

```bash
cargo test --locked -p bmc-mock --all-targets --all-features
cargo check --locked -p bmc-mock --all-targets --all-features
cargo clippy --locked -p bmc-mock --all-targets --all-features -- -D unreachable-pub
RUSTDOCFLAGS='-D rustdoc::private_intra_doc_links -D rustdoc::broken_intra_doc_links' cargo doc --locked -p bmc-mock --no-deps --all-features
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
git diff --check
```

## Additional Notes

The initial visibility lint identified 397 overbroad declarations across 48 files. Narrowing the crate's root gateways exposed an additional internal Redfish frontier; the final 85-file diff includes that follow-through plus the directly related Machine-a-tron rustdoc correction. The only unrestricted public surfaces left are backed by cross-crate callers, integration-test consumers, or intentional root re-exports.

Local CodeRabbit and read-only Claude reviews completed over the full diff. All applicable findings are incorporated.

Closes #4550
