### PR TITLE
fix(machine-a-tron): Support DevSpace ingestion reports

### DIFF
--- a/helm-prereqs/ingestion-rate-report.sh
+++ b/helm-prereqs/ingestion-rate-report.sh
@@ -25,30 +25,51 @@
 #   * machine_interfaces.created  → interface registration curve
 # Output is plain text; pass --csv for machine-readable per-minute buckets.
 #
-# Environment (defaults match setup-machine-a-tron.sh):
-#   KUBECONFIG, POSTGRES_NS (postgres), NICO_DB (nico_system_nico)
+# Environment:
+#   KUBECONFIG, POSTGRES_NS (postgres), NICO_SYSTEM_NS (nico-system)
+#   NICO_DB overrides the database selected for the discovered target.
 # =============================================================================
 set -euo pipefail
 
 POSTGRES_NS="${POSTGRES_NS:-postgres}"
-NICO_DB="${NICO_DB:-nico_system_nico}"
+NICO_SYSTEM_NS="${NICO_SYSTEM_NS:-nico-system}"
+NICO_DB="${NICO_DB:-}"
 CSV=false
 [[ "${1:-}" == "--csv" ]] && CSV=true
 
-PG="$(kubectl get pods -n "$POSTGRES_NS" -l application=spilo \
+# A Patroni deployment must have a master. Only use the standalone StatefulSet
+# when no Spilo pods exist; this is the database created by DevSpace bootstrap.
+SPILO_PODS="$(kubectl get pods -n "$POSTGRES_NS" -l application=spilo \
     -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.labels.spilo-role}{"\n"}{end}' 2>/dev/null \
-    | awk '$2=="master"{print $1}' | head -1)"
-[[ -n "$PG" ]] || { echo "ERROR: no Patroni primary in $POSTGRES_NS" >&2; exit 1; }
+    || true)"
+PG_TARGET="$(awk '$2=="master"{print $1; exit}' <<< "$SPILO_PODS")"
+if [[ -n "$SPILO_PODS" ]]; then
+    [[ -n "$PG_TARGET" ]] || { echo "ERROR: no Patroni primary in $POSTGRES_NS" >&2; exit 1; }
+    NICO_DB="${NICO_DB:-nico_system_nico}"
+elif kubectl get statefulset postgres -n "$POSTGRES_NS" >/dev/null 2>&1; then
+    PG_TARGET="statefulset/postgres"
+    if [[ -z "$NICO_DB" ]]; then
+        NICO_DB="$(kubectl get configmap nico-system-nico-database-config -n "$NICO_SYSTEM_NS" \
+            -o jsonpath='{.data.DB_NAME}' 2>/dev/null || true)"
+        [[ -n "$NICO_DB" ]] || {
+            echo "ERROR: database name not found in $NICO_SYSTEM_NS/nico-system-nico-database-config; set NICO_DB" >&2
+            exit 1
+        }
+    fi
+else
+    echo "ERROR: no PostgreSQL target found in $POSTGRES_NS" >&2
+    exit 1
+fi
 # Surface query failures rather than returning an empty string that later
 # parses as a zero row.
 q() {
-    local out rc
-    out="$(kubectl exec -n "$POSTGRES_NS" "$PG" -- su postgres -c "psql -d $NICO_DB -v ON_ERROR_STOP=1 -tAc \"$1\"" 2>&1)"; rc=$?
+    local out rc=0
+    out="$(kubectl exec -n "$POSTGRES_NS" "$PG_TARGET" -- su postgres -c "psql -d $NICO_DB -v ON_ERROR_STOP=1 -tAc \"$1\"" 2>&1)" || rc=$?
     if (( rc != 0 )); then
         echo "ERROR: query failed (rc=$rc): ${out}" >&2
         return "$rc"
     fi
-    printf '%s' "$out"
+    printf '%s\n' "$out"
 }
 
 report_curve() {   # $1 = table  $2 = label
@@ -56,8 +77,8 @@ report_curve() {   # $1 = table  $2 = label
     local stats
     stats="$(q "SELECT count(*) || '|' || min(created) || '|' || max(created) || '|' ||
         round(extract(epoch FROM (max(created) - min(created)))) || '|' ||
-        round(extract(epoch FROM (percentile_cont(0.5) WITHIN GROUP (ORDER BY created) - min(created)))) || '|' ||
-        round(extract(epoch FROM (percentile_cont(0.9) WITHIN GROUP (ORDER BY created) - min(created))))
+        round(percentile_cont(0.5) WITHIN GROUP (ORDER BY extract(epoch FROM created)) - extract(epoch FROM min(created))) || '|' ||
+        round(percentile_cont(0.9) WITHIN GROUP (ORDER BY extract(epoch FROM created)) - extract(epoch FROM min(created)))
         FROM ${tbl};")"
     [[ -n "$stats" ]] || { echo "${label}: no rows"; return; }
     IFS='|' read -r n first last span p50 p90 <<< "$stats"
@@ -66,7 +87,9 @@ report_curve() {   # $1 = table  $2 = label
     if $CSV; then
         echo "  per-minute buckets (${label}):"
         q "SELECT date_trunc('minute', created) || ',' || count(*)
-           FROM ${tbl} GROUP BY 1 ORDER BY 1;" | sed 's/^/    /'
+           FROM ${tbl}
+           GROUP BY date_trunc('minute', created)
+           ORDER BY date_trunc('minute', created);" | sed 's/^/    /'
     fi
 }
 
@@ -77,4 +100,6 @@ report_curve machine_interfaces "machine_interfaces.created"
 # pipeline shows up as machines wedged mid-state, not just as a slower rate).
 echo "state distribution:"
 q "SELECT '  ' || coalesce(controller_state->>'state','?') || ': ' || count(*)
-   FROM machines GROUP BY 1 ORDER BY 2 DESC;"
+   FROM machines
+   GROUP BY coalesce(controller_state->>'state','?')
+   ORDER BY count(*) DESC;"


### PR DESCRIPTION
Manual DevSpace verification of the Machine-a-Tron ingestion harness from #4516 showed that the rate report could not find the standalone PostgreSQL StatefulSet and that its PostgreSQL 14 queries failed before producing complete output. This change discovers the DevSpace database while preserving Patroni behavior, surfaces query failures, and makes both report modes compatible with PostgreSQL 14.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The normal and `--csv` report modes were tested through the default DevSpace PostgreSQL interface.
