### PR TITLE
fix(auth): allow site-agent to call REST-proxied admin operations

### DIFF
--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -307,7 +307,7 @@ impl InternalRBACRules {
         x.perm("AdminGrowResourcePool", vec![ForgeAdminCLI]);
         x.perm("SetMaintenance", vec![ForgeAdminCLI, SiteAgent, Flow]);
         x.perm("SetDynamicConfig", vec![ForgeAdminCLI, Machineatron]);
-        x.perm("TriggerDpuReprovisioning", vec![ForgeAdminCLI]);
+        x.perm("TriggerDpuReprovisioning", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("TriggerHostReprovisioning", vec![ForgeAdminCLI, Flow]);
         x.perm("ListDpuWaitingForReprovisioning", vec![ForgeAdminCLI]);
         x.perm("MarkManualFirmwareUpgradeComplete", vec![ForgeAdminCLI]);
@@ -524,7 +524,7 @@ impl InternalRBACRules {
         );
         x.perm("HeartbeatMachineValidationRun", vec![Scout, SiteAgent]);
         x.perm("AdminBmcReset", vec![ForgeAdminCLI]);
-        x.perm("AdminPowerControl", vec![ForgeAdminCLI, Flow]);
+        x.perm("AdminPowerControl", vec![ForgeAdminCLI, SiteAgent, Flow]);
         x.perm("DisableSecureBoot", vec![ForgeAdminCLI]);
         x.perm("MachineSetup", vec![ForgeAdminCLI]);
         x.perm("SetDpuFirstBootOrder", vec![ForgeAdminCLI]);
@@ -1143,6 +1143,27 @@ mod rbac_rule_tests {
                 "elektra-site-agent".to_string()
             )]
         ));
+
+        // REST admin operations proxy to Core as the site agent (issue #4597).
+        for method in ["AdminPowerControl", "TriggerDpuReprovisioning"] {
+            assert!(
+                InternalRBACRules::allowed_from_static(
+                    method,
+                    &[Principal::SpiffeServiceIdentifier(
+                        "elektra-site-agent".to_string()
+                    )]
+                ),
+                "{method} should allow the site agent"
+            );
+            assert!(
+                !InternalRBACRules::allowed_from_static(
+                    method,
+                    &[Principal::SpiffeServiceIdentifier("nico-dns".to_string())]
+                ),
+                "{method} should reject unrelated services"
+            );
+        }
+
         assert!(InternalRBACRules::allowed_from_static(
             "FindNetworkSegmentsByIds",
             &[


### PR DESCRIPTION
REST admin-operation endpoints authenticate and validate the Provider request, then proxy to Core through `ExecuteCoreGRPC`, which reaches Core as the `elektra-site-agent` SPIFFE principal. Core RBAC did not permit that principal for two of the proxied methods, so both returned HTTP 403 before the requested operation began.

This adds `SiteAgent` to the two affected entries:

- `AdminPowerControl` — now `ForgeAdminCLI`, `SiteAgent`, `Flow`
- `TriggerDpuReprovisioning` — now `ForgeAdminCLI`, `SiteAgent`

The permission shape matches the existing `SetMaintenance` rule: `ForgeAdminCLI`, `SiteAgent`, `Flow`. Before this change, 17 of the 28 production methods proxied through `ExecuteCoreGRPC` permitted `SiteAgent`; this change raises that to 19.

No REST-layer change is needed. The REST handlers already call the correct Core methods; the failure was in the Core permission table.

## Related issues

Fixes #4597

## Type of Change

- [ ] Add - New feature or capability
- [ ] Change - Changes in existing functionality
- [x] Fix - Bug fixes
- [ ] Remove - Removed features or deprecated functionality
- [ ] Internal - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Added assertions to the existing RBAC test block covering both methods with the literal `elektra-site-agent` SPIFFE service identifier, plus negative assertions confirming an unrelated service (`nico-dns`) is still denied.

Verified in a Linux container:

- `cargo test --locked -p carbide-api-core --lib auth::internal_rbac_rules`
  - 2 passed; 0 failed; 0 ignored; 0 measured; 1584 filtered out
- `cargo make clippy-flow`
- `cargo make carbide-lints`
- `cargo make lint-error-messages`
- `cargo make check-format-nightly`
- `cargo make check-event-names`
- `cargo make check-workspace-deps`
- `cargo make check-metric-docs`
- `cargo make check-licenses`
- `cargo make check-bans`

The full `cargo make pre-commit-verify-workspace` command could not complete because `generate-rest-core-proto` requires Go, which was unavailable in the Docker image. The change does not modify proto sources or generated output. All nine remaining gate tasks listed above were run individually and passed.

## Additional Notes

**Scope.** An audit of the 28 production methods REST proxies through `ExecuteCoreGRPC` found that 11 did not permit `SiteAgent` before this change. This PR fixes only the two methods confirmed by #4597, leaving nine unchanged. Those methods require separate validation before any additional permissions are granted.

**Known limitation.** This allows REST-proxied admin operations to reach Core as the site agent. It does not make Core distinguish between “a Provider admin requested this through REST” and “the site agent initiated it directly”—the original Provider-admin identity is lost at the `ExecuteCoreGRPC` proxy boundary. Propagating it would be a cross-cutting change across every `ExecuteCoreGRPC` call path and is out of scope here.
