### PR TITLE
ci: Disable non-performative Rust image caching to prevent churn

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -710,6 +710,13 @@ jobs:
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-container-x86_64
       context_path: .
+      # No layer cache: the Dockerfile does `COPY . ./` before the compile, so
+      # any new commit invalidates the builder layer and the expensive cargo
+      # step can never be restored. Exporting it anyway measured 7m32s on a main
+      # run and bought two cached layers, while its multi-GB blobs were the bulk
+      # of what pushed the 50 GB Actions quota to its ceiling and evicted the
+      # sccache entries. sccache is what carries reuse across commits here.
+      cache: false
       build_args: ${{ needs.prepare.outputs.release_build_args }}
       image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -744,6 +751,10 @@ jobs:
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-container-aarch64
       context_path: .
+      # Off for the same reason as the x86_64 release container above, and this
+      # is the worst of the four: 8m21s of cache export on a main run for two
+      # cached layers.
+      cache: false
       build_args: ${{ needs.prepare.outputs.release_build_args_aarch64 }}
       image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -977,6 +988,9 @@ jobs:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
+      # Off for the same reason as the release containers above: 2m00s of cache
+      # export on a main run for a single cached layer.
+      cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-x86_64:${{ needs.prepare.outputs.major_minor_version }}-latest
@@ -998,6 +1012,9 @@ jobs:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-forge-cli
+      # Off for the same reason as the release containers above: 3m27s of cache
+      # export on a main run for two cached layers.
+      cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}
       additional_tags: ${{ needs.prepare.outputs.image_registry }}/forge-admin-cli-aarch64:${{ needs.prepare.outputs.major_minor_version }}-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -230,19 +230,24 @@ jobs:
       # steps. github-script is first-party, so we use it to re-export the two
       # values instead of taking on a third-party action for this.
       #
+      # Deliberately not tied to `inputs.cache`. That input turns off the
+      # BuildKit layer cache, which is a different mechanism: sccache caches
+      # individual compilations, so it still pays off for an image whose layers
+      # are worthless because `COPY . ./` invalidates everything after it. When
+      # the two shared one input, turning the layer cache off for the Rust
+      # images also dropped sccache to the local mount and cost
+      # build-release-container-x86_64 its 347 hits and 2m11s.
+      #
       # Runs unconditionally and always exports a non-empty value. buildx
       # rejects a secret whose value is empty, so a skipped step or an unset
       # token would fail the build outright instead of merely disabling the
       # cache. The sentinel is what the Dockerfiles detect.
       - name: Expose Actions cache credentials to the build
         uses: actions/github-script@v7
-        env:
-          CACHE_ENABLED: ${{ inputs.cache }}
         with:
           script: |
-            const enabled = process.env.CACHE_ENABLED === 'true';
-            const token = enabled ? (process.env.ACTIONS_RUNTIME_TOKEN || '') : '';
-            const url = enabled ? (process.env.ACTIONS_RESULTS_URL || '') : '';
+            const token = process.env.ACTIONS_RUNTIME_TOKEN || '';
+            const url = process.env.ACTIONS_RESULTS_URL || '';
             if (token) core.setSecret(token);
             core.exportVariable('BUILD_ACTIONS_RUNTIME_TOKEN', token || 'unavailable');
             core.exportVariable('BUILD_ACTIONS_RESULTS_URL', url || 'unavailable');


### PR DESCRIPTION
Updating cached items based on latest CI runs.

The four Rust image builds export a BuildKit layer cache that nothing can reuse. Their Dockerfiles `COPY . ./` before the compile, so any new commit invalidates the builder layer and the expensive cargo step is never restored. A main run
spends `21m` exporting those layers and gets seven cached layers back across all four, and they are using up most of the `50 GB` cache.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4572

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

## Additional Notes
* sccache is not affected, its secrets are passed independently of this input so compiler level reuse stays in place
* The bluefield and smaller images keep their layer cache, they restore many layers for a negligible export, so only the four Rust images change here

This supports https://github.com/NVIDIA/infra-controller/issues/4778

Closes #4778