### PR TITLE
ci: Build Go binaries per arch target instead of per REST service

### DIFF
--- a/.github/workflows/rest-build-binaries.yml
+++ b/.github/workflows/rest-build-binaries.yml
@@ -52,9 +52,9 @@ jobs:
             goos: darwin
             goarch: arm64
     env:
-      # `<name> <package>` per line. Single source for both the build loop and
-      # the inventory check, so a command cannot be dropped from one and not
-      # the other.
+      # `<name> <package>` per line, and the declaration of what gets released.
+      # Single source for both the build loop and the verification loop, so the
+      # two cannot drift.
       COMMANDS: |
         api ./api/cmd/api
         migrations ./db/cmd/migrations
@@ -98,9 +98,12 @@ jobs:
           done <<< "${COMMANDS}"
 
       # A per-command job could not silently produce nothing, because the build
-      # step was the job. Looping means a command dropped from the list, or
-      # built for the wrong platform, would leave a short artifact instead of a
-      # red run, so assert the set and the target explicitly.
+      # step was the job. Looping can, so every declared command is checked for a
+      # file that exists and was built for this target.
+      #
+      # What this cannot do is notice a command missing from COMMANDS, because
+      # COMMANDS is the declaration of what to ship. It needs to be maintained
+      # when new packages are added or removed.
       - name: Verify ${{ matrix.target }} inventory and architecture
         env:
           GOOS_WANT: ${{ matrix.goos }}
@@ -108,7 +111,6 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          expected=$(grep -c '[^[:space:]]' <<< "${COMMANDS}")
           binaries=()
           while read -r name _; do
             [ -n "${name}" ] || continue
@@ -126,8 +128,12 @@ jobs:
             done
             binaries+=("${binary}")
           done <<< "${COMMANDS}"
-          [ "${#binaries[@]}" -eq "${expected}" ] \
-            || { echo "::error::expected ${expected} binaries for ${TARGET}, verified ${#binaries[@]}"; exit 1; }
+          # Catches COMMANDS collapsing to nothing -- an easy YAML block-scalar
+          # mistake that would otherwise upload an empty artifact and pass. A
+          # count compared against COMMANDS itself could not catch this, since
+          # both sides would be zero.
+          [ "${#binaries[@]}" -gt 0 ] \
+            || { echo "::error::COMMANDS declared no binaries for ${TARGET}"; exit 1; }
           # Named explicitly rather than globbed, so the checksum file cannot
           # pick itself up on a runner that kept the previous workspace.
           sha256sum "${binaries[@]}" > "dist/SHA256SUMS-${TARGET}"

--- a/.github/workflows/rest-build-binaries.yml
+++ b/.github/workflows/rest-build-binaries.yml
@@ -26,35 +26,47 @@ env:
   GO_VERSION: "1.26.4"
 
 jobs:
+  # One job per target, not per command. A single-command job still compiles
+  # the whole dependency graph behind that command, and pays a minute or more
+  # of queue, checkout and toolchain setup on top of it. Grouping a target's
+  # commands into one job shares that graph through GOCACHE instead: from a
+  # cold cache the first command takes about 14 seconds and the remaining ten
+  # about 17 seconds combined.
   build-binaries:
-    name: Build Binaries (${{ matrix.name }}, ${{ matrix.path }})
+    name: Build Binaries (${{ matrix.target }})
+    # All three targets build on the amd64 runner, as they did when this was
+    # keyed by command. That keeps the existing CGO behaviour: linux-amd64 is
+    # native so cgo is on, and the two cross-compiled targets have it off.
     runs-on: ${{ inputs.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: api
-            path: ./api/cmd/api
-          - name: migrations
-            path: ./db/cmd/migrations
-          - name: sitemgr
-            path: ./site-manager/cmd/sitemgr
-          - name: workflow
-            path: ./workflow/cmd/workflow
-          - name: site-agent
-            path: ./site-agent/cmd/site-agent
-          - name: mock-core
-            path: ./site-agent/cmd/mock-core
-          - name: mock-flow
-            path: ./site-agent/cmd/mock-flow
-          - name: credsmgr
-            path: ./cert-manager/cmd/credsmgr
-          - name: flow
-            path: ./flow
-          - name: psm
-            path: ./powershelf-manager
-          - name: nsm
-            path: ./nvswitch-manager
+          - target: linux-amd64
+            goos: linux
+            goarch: amd64
+          - target: linux-arm64
+            goos: linux
+            goarch: arm64
+          - target: darwin-arm64
+            goos: darwin
+            goarch: arm64
+    env:
+      # `<name> <package>` per line. Single source for both the build loop and
+      # the inventory check, so a command cannot be dropped from one and not
+      # the other.
+      COMMANDS: |
+        api ./api/cmd/api
+        migrations ./db/cmd/migrations
+        sitemgr ./site-manager/cmd/sitemgr
+        workflow ./workflow/cmd/workflow
+        site-agent ./site-agent/cmd/site-agent
+        mock-core ./site-agent/cmd/mock-core
+        mock-flow ./site-agent/cmd/mock-flow
+        credsmgr ./cert-manager/cmd/credsmgr
+        flow ./flow
+        psm ./powershelf-manager
+        nsm ./nvswitch-manager
 
     steps:
       - name: Checkout code
@@ -72,23 +84,60 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Build ${{ matrix.name }} (linux/amd64)
+      - name: Build commands for ${{ matrix.target }}
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          TARGET: ${{ matrix.target }}
         run: |
+          set -euo pipefail
           mkdir -p dist
-          GOOS=linux GOARCH=amd64 go build -o dist/${{ matrix.name }}-linux-amd64 ${{ matrix.path }}
+          while read -r name package; do
+            [ -n "${name}" ] || continue
+            go build -o "dist/${name}-${TARGET}" "${package}"
+          done <<< "${COMMANDS}"
 
-      - name: Build ${{ matrix.name }} (linux/arm64)
+      # A per-command job could not silently produce nothing, because the build
+      # step was the job. Looping means a command dropped from the list, or
+      # built for the wrong platform, would leave a short artifact instead of a
+      # red run, so assert the set and the target explicitly.
+      - name: Verify ${{ matrix.target }} inventory and architecture
+        env:
+          GOOS_WANT: ${{ matrix.goos }}
+          GOARCH_WANT: ${{ matrix.goarch }}
+          TARGET: ${{ matrix.target }}
         run: |
-          GOOS=linux GOARCH=arm64 go build -o dist/${{ matrix.name }}-linux-arm64 ${{ matrix.path }}
+          set -euo pipefail
+          expected=$(grep -c '[^[:space:]]' <<< "${COMMANDS}")
+          binaries=()
+          while read -r name _; do
+            [ -n "${name}" ] || continue
+            binary="dist/${name}-${TARGET}"
+            [ -f "${binary}" ] || { echo "::error::${binary} was not produced"; exit 1; }
+            # `go version -m` reports the settings the toolchain recorded, so
+            # this reads Mach-O and ELF alike and does not depend on how the
+            # runner's `file` database happens to word things. CGO_ENABLED is
+            # deliberately not asserted: it is on for the native target and off
+            # for the cross-compiled ones, which is the pre-existing behaviour.
+            settings=$(go version -m "${binary}")
+            for want in "GOOS=${GOOS_WANT}" "GOARCH=${GOARCH_WANT}"; do
+              grep -qE "^[[:space:]]*build[[:space:]]+${want}$" <<< "${settings}" \
+                || { echo "::error::${binary} was not built for ${want}"; exit 1; }
+            done
+            binaries+=("${binary}")
+          done <<< "${COMMANDS}"
+          [ "${#binaries[@]}" -eq "${expected}" ] \
+            || { echo "::error::expected ${expected} binaries for ${TARGET}, verified ${#binaries[@]}"; exit 1; }
+          # Named explicitly rather than globbed, so the checksum file cannot
+          # pick itself up on a runner that kept the previous workspace.
+          sha256sum "${binaries[@]}" > "dist/SHA256SUMS-${TARGET}"
+          echo "verified ${#binaries[@]} ${TARGET} binaries"
 
-      - name: Build ${{ matrix.name }} (darwin/arm64)
-        run: |
-          GOOS=darwin GOARCH=arm64 go build -o dist/${{ matrix.name }}-darwin-arm64 ${{ matrix.path }}
-
-      - name: Upload ${{ matrix.name }} binaries
+      - name: Upload ${{ matrix.target }} binaries
         if: inputs.upload_artifact == true
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.name }}-binaries
-          path: rest-api/dist/${{ matrix.name }}-*
+          name: ${{ matrix.target }}-binaries
+          # Also picks up SHA256SUMS-<target>, which matches the same suffix.
+          path: rest-api/dist/*-${{ matrix.target }}
           retention-days: 7


### PR DESCRIPTION
Optimize Go binary build CI job by consolidating them per architecture.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4581

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)