### PR TITLE
backport: minimal SMC GB300 support (#4121) to release/v2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6840,7 +6840,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.2#5bf822b5e7814df67e2b9a8f98f41fb96dea0a3b"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.3#b199e7bebeb8238fe1440f110d06affba5b6b799"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.2" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.3" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 

--- a/crates/bmc-explorer/src/hw/mod.rs
+++ b/crates/bmc-explorer/src/hw/mod.rs
@@ -27,6 +27,7 @@ pub mod lenovo;
 pub mod lenovo_ami;
 pub mod lenovo_gb300;
 pub mod supermicro;
+pub mod supermicro_gb300;
 pub mod vera_rubin;
 pub mod viking;
 

--- a/crates/bmc-explorer/src/hw/supermicro_gb300.rs
+++ b/crates/bmc-explorer/src/hw/supermicro_gb300.rs
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::hw::BiosAttr;
+
+/// Setup attributes exposed by the Supermicro OpenBMC firmware on GB300.
+///
+/// Unlike GB200, this platform does not expose `TPM`, `EmbeddedUefiShell`, or
+/// `SecureBootEnable`. `SecurityDeviceSupport` is its TPM control, while the
+/// PCIe option ROMs must be enabled for the host to expose the DPU boot target.
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 3] = [
+    BiosAttr::new_str("SecurityDeviceSupport", "Enabled"),
+    BiosAttr::new_bool("Socket0Pcie6DisableOptionROM", false),
+    BiosAttr::new_bool("Socket1Pcie6DisableOptionROM", false),
+];

--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -389,9 +389,7 @@ pub(crate) fn hw_type<B: Bmc>(
         {
             return Some(hw::HwType::DgxGb300);
         }
-        // SMC GB300: Supermicro host BMC. The tray scrape shows ServiceRoot vendor "Supermicro"
-        // (Product "GB NVL", no OEM key), so the vendor string carries it -- no chassis helper
-        // needed. See gb300-firmus-ingestion/triangulation-matrix.md.
+        // SMC GB300: Supermicro OpenBMC host.
         if root.vendor() == Some(Vendor::new("Supermicro")) {
             return Some(hw::HwType::SupermicroGb300);
         }
@@ -1058,11 +1056,10 @@ fn machine_setup_status<B: Bmc>(
             }
         }
 
-        hw::HwType::DgxGb300 | hw::HwType::SupermicroGb300 => {
-            // GB300 platforms (DGX on the NVIDIA "GB BMC", SMC on a Supermicro OpenBMC) share
-            // the platform-level setup expectations: secure boot off and boot order by MAC.
-            // TODO(gb300): add per-ODM EXPECTED_BIOS_ATTRS tables once each GB300 tray's
-            // BIOS is characterized; until then no BIOS-attr verification is applied.
+        hw::HwType::DgxGb300 => {
+            // DGX GB300 on the NVIDIA "GB BMC" uses the platform-level setup expectations:
+            // secure boot off and boot order by MAC.
+            // TODO(dgx-gb300): add EXPECTED_BIOS_ATTRS once the tray BIOS is characterized.
             if explored_system
                 .secure_boot_status()
                 .is_ok_and(|s| s.is_enabled)
@@ -1073,6 +1070,31 @@ fn machine_setup_status<B: Bmc>(
                     actual: "true".to_string(),
                 })
             }
+            if let Some(mac) = boot_interface_mac {
+                let actual = explored_system.boot_order_first_option();
+                let mac_str = format!("/MAC({},", mac.to_string().replace(":", ""));
+                let expected = explored_system.boot_options.iter().find(|option| {
+                    option.uefi_device_path().is_some_and(|path| {
+                        path.inner().contains(&mac_str)
+                            && path.inner().contains("/IPv4(")
+                            && path.inner().ends_with("/Uri()")
+                    })
+                });
+                if let Some(diff) = compare_boot_options(expected, actual) {
+                    diffs.push(diff)
+                }
+            }
+        }
+
+        hw::HwType::SupermicroGb300 => {
+            // Supermicro GB300 uses the GBx00 OpenBMC flow, but its firmware does not expose
+            // SecureBootEnable or EmbeddedUefiShell. Verify only the controls present in the
+            // real tray: TPM support and the DPU-facing PCIe option ROMs.
+            diffs.extend(
+                hw::supermicro_gb300::EXPECTED_BIOS_ATTRS
+                    .iter()
+                    .flat_map(|expected| explored_system.verify_bios_attr(expected)),
+            );
             if let Some(mac) = boot_interface_mac {
                 let actual = explored_system.boot_order_first_option();
                 let mac_str = format!("/MAC({},", mac.to_string().replace(":", ""));

--- a/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
+++ b/crates/bmc-explorer/tests/integration/supermicro_gb300_explore.rs
@@ -54,4 +54,26 @@ async fn explore_supermicro_gb300() {
     );
     assert!(!report.systems.is_empty(), "systems must be present");
     assert!(!report.chassis.is_empty(), "chassis must be present");
+
+    let setup = report
+        .machine_setup_status
+        .expect("SMC GB300 must report machine setup status");
+    assert!(!setup.is_done);
+    assert_eq!(
+        setup
+            .diffs
+            .iter()
+            .map(|diff| {
+                (
+                    diff.key.as_str(),
+                    diff.expected.as_str(),
+                    diff.actual.as_str(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        [
+            ("Socket0Pcie6DisableOptionROM", "false", "true"),
+            ("Socket1Pcie6DisableOptionROM", "false", "true"),
+        ]
+    );
 }

--- a/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
+++ b/crates/bmc-mock/src/hw/supermicro_gb300_nvl.rs
@@ -124,7 +124,7 @@ impl SupermicroGB300Nvl<'_> {
         let system_id = "System_0";
         let boot_options = std::iter::once(
             redfish::boot_option::builder(
-                &redfish::boot_option::resource(system_id, "0002"),
+                &redfish::boot_option::resource(system_id, "Boot0002"),
                 BootOptionKind::Disk,
             )
             .boot_option_reference("Boot0002")
@@ -136,21 +136,20 @@ impl SupermicroGB300Nvl<'_> {
                 .into_iter()
                 .enumerate()
                 .map(|(n, nic)| {
-                    let id = format!("{:04X}", n + 3); // Starting with 0003
+                    let id = format!("Boot{:04X}", n + 3); // Starting with Boot0003
                     let pci_path = "PciRoot(0x0)/Pci(0x10,0x0)/Pci(0x0,0x0)";
                     redfish::boot_option::builder(
                         &redfish::boot_option::resource(system_id, &id),
                         BootOptionKind::Network,
                     )
-                    .boot_option_reference(&format!("Boot{id}"))
+                    .boot_option_reference(&id)
                     .display_name(&format!(
-                        "UEFI HTTP IPv4 Nvidia Network Adapter - {} - {}",
-                        nic.mac_address,
+                        "UEFI HTTPv4 (MAC:{})",
                         nic.mac_address.to_string().replace(":", "")
                     ))
                     .uefi_device_path(&format!(
                         "{pci_path}/MAC({},0x1)\
-                             /IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
+                         /IPv4(0.0.0.0,0x0,DHCP,0.0.0.0,0.0.0.0,0.0.0.0)/Uri()",
                         nic.mac_address.to_string().replace(":", "")
                     ))
                     .build()
@@ -183,7 +182,7 @@ impl SupermicroGB300Nvl<'_> {
                     base_bios: Some(base_bios(system_id)),
                     bios_mode: redfish::computer_system::BiosMode::Generic,
                     boot_options: Some(boot_options),
-                    boot_order_mode: redfish::computer_system::BootOrderMode::OrderedCollection,
+                    boot_order_mode: redfish::computer_system::BootOrderMode::ViaSettings,
                     chassis: vec!["Chassis_0".into()],
                     eth_interfaces: None,
                     id: system_id.into(),
@@ -193,7 +192,9 @@ impl SupermicroGB300Nvl<'_> {
                     model: Some("GB NVL".into()),
                     oem: redfish::computer_system::Oem::Generic,
                     callbacks: Some(callbacks),
-                    secure_boot_available: true,
+                    // This firmware exposes the SecureBoot resource but omits
+                    // SecureBootEnable, so there is no usable status to report.
+                    secure_boot_available: false,
                     serial_console: Some(
                         redfish::serial_console::builder()
                             .max_concurrent_sessions(1)
@@ -299,12 +300,13 @@ impl SupermicroGB300Nvl<'_> {
 }
 
 fn base_bios(system_id: &str) -> serde_json::Value {
-    // libredfish uses this attribute to detect whether this BMC spells the
-    // enabled TPM state as "Enable" or "Enabled" before building its setup
-    // request. The suffixed key and value mirror a real Supermicro fixture.
+    // Security device support is already enabled; the DPU-facing option ROMs
+    // still need to be enabled by clearing their DisableOptionROM controls.
     redfish::bios::builder(&redfish::bios::resource(system_id))
         .attributes(json!({
-            "SecurityDeviceSupport_005A": "Enable",
+            "SecurityDeviceSupport": "Enabled",
+            "Socket0Pcie6DisableOptionROM": true,
+            "Socket1Pcie6DisableOptionROM": true,
         }))
         .build()
 }

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -196,6 +196,7 @@ dependencies = [
 dependencies = [
   "mkdir-static",
   { name = "package-scout-aarch64-release-cross", path = "${REPO_ROOT}" },
+  "create-ephemeral-image-arm-host",
   "bfb-aarch64-sa",
   "ipxe-aarch64-sa",
   "setup-apt-repo-arm64",

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -108,10 +108,16 @@ dependencies = [
 ]
 
 [tasks.stage-scout-loader-rclocal]
-description = "Copies the rc.local script to the scout loader profile directories"
+description = "Copies the Scout loader helpers to the scout loader profile directories"
 script = '''
   cp ${REPO_ROOT}/pxe/common_files/scout-loader-rclocal ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/etc/rc.local
   cp ${REPO_ROOT}/pxe/common_files/scout-loader-rclocal ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/etc/rc.local
+
+  mkdir -p ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/opt/forge/
+  cp ${REPO_ROOT}/pxe/common_files/forge-scout-network.sh ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.extra/opt/forge/
+
+  mkdir -p ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/opt/forge/
+  cp ${REPO_ROOT}/pxe/common_files/forge-scout-network.sh ${REPO_ROOT}/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.extra/opt/forge/
 '''
 
 [tasks.stage-scout-update-check]

--- a/pxe/common_files/forge-scout-network.sh
+++ b/pxe/common_files/forge-scout-network.sh
@@ -24,6 +24,16 @@ ip_command=${SCOUT_IP_COMMAND:-ip}
 networkctl_command=${SCOUT_NETWORKCTL_COMMAND:-networkctl}
 networkd_runtime_dir=${SCOUT_NETWORKD_RUNTIME_DIR:-/run/systemd/network}
 networkd_dhcp_file=${SCOUT_NETWORKD_DHCP_FILE:-/etc/systemd/network/dhcp.network}
+# The boot NIC is frequently not usable yet when this script first runs. The kernel
+# probes PCI devices in domain order, so the interface named by `mac=` can appear
+# tens of seconds into boot -- on a GB300 compute tray the BlueField-3 boot NIC sits
+# on domain 0016 and is probed *after* four ConnectX-8s, ~24s in, while the loader
+# invokes this script at ~9s. Waiting for the interface to appear, gain carrier and
+# lease an address is therefore required for correctness, not just robustness:
+# without it the readiness checks below simply find nothing and the whole filter
+# silently no-ops on exactly the multi-NIC hosts it exists to serve.
+network_wait_seconds=${SCOUT_NETWORK_WAIT_SECONDS:-60}
+network_poll_interval=${SCOUT_NETWORK_POLL_INTERVAL:-1}
 
 if ! cmdline=$(cat "$cmdline_file"); then
 	echo "Skipping Scout network configuration: reason=cmdline_unreadable" >&2
@@ -58,41 +68,62 @@ case "$preferred_mac" in
 esac
 preferred_mac=$(printf '%s\n' "$preferred_mac" | tr '[:upper:]' '[:lower:]')
 
+probe_attempts=0
+probe_max_attempts=$((network_wait_seconds / network_poll_interval))
+[ "$probe_max_attempts" -lt 1 ] && probe_max_attempts=1
+
 preferred_interface=
-preferred_interface_count=0
-for net_path in "$sys_class_net"/*
+while :
 do
-	[ -e "$net_path" ] || continue
-	[ -r "$net_path/address" ] || continue
+	preferred_interface=
+	preferred_interface_count=0
+	for net_path in "$sys_class_net"/*
+	do
+		[ -e "$net_path" ] || continue
+		[ -r "$net_path/address" ] || continue
 
-	interface_mac=$(cat "$net_path/address") || continue
-	interface_mac=$(printf '%s\n' "$interface_mac" | tr '[:upper:]' '[:lower:]')
-	if [ "$interface_mac" = "$preferred_mac" ]; then
-		preferred_interface=${net_path##*/}
-		preferred_interface_count=$((preferred_interface_count + 1))
-	fi
-done
+		interface_mac=$(cat "$net_path/address") || continue
+		interface_mac=$(printf '%s\n' "$interface_mac" | tr '[:upper:]' '[:lower:]')
+		if [ "$interface_mac" = "$preferred_mac" ]; then
+			preferred_interface=${net_path##*/}
+			preferred_interface_count=$((preferred_interface_count + 1))
+		fi
+	done
 
-if [ "$preferred_interface_count" -ne 1 ]; then
-	echo "Skipping Scout network configuration: reason=preferred_interface_count count=$preferred_interface_count" >&2
-	exit 0
-fi
-
-carrier_file="$sys_class_net/$preferred_interface/carrier"
-if [ ! -r "$carrier_file" ] || [ "$(cat "$carrier_file")" != 1 ]; then
-	echo "Skipping Scout network configuration: interface=$preferred_interface reason=no_carrier" >&2
-	exit 0
-fi
-
-if global_addresses=$("$ip_command" -o address show dev "$preferred_interface" scope global); then
-	if [ -z "$global_addresses" ]; then
-		echo "Skipping Scout network configuration: interface=$preferred_interface reason=no_global_address" >&2
+	# More than one interface owning the same MAC is a configuration fault, not a
+	# timing one -- waiting cannot resolve it, so give up immediately.
+	if [ "$preferred_interface_count" -gt 1 ]; then
+		echo "Skipping Scout network configuration: reason=preferred_interface_count count=$preferred_interface_count" >&2
 		exit 0
 	fi
-else
-	echo "Skipping Scout network configuration: interface=$preferred_interface reason=address_inspection_failed" >&2
-	exit 0
-fi
+
+	not_ready=
+	if [ "$preferred_interface_count" -ne 1 ]; then
+		not_ready=no_interface
+	else
+		carrier_file="$sys_class_net/$preferred_interface/carrier"
+		# Reading `carrier` fails with EINVAL while the link is administratively
+		# down, so treat an unreadable value the same as "no carrier yet".
+		if [ ! -r "$carrier_file" ] || [ "$(cat "$carrier_file" 2>/dev/null)" != 1 ]; then
+			not_ready=no_carrier
+		elif ! global_addresses=$("$ip_command" -o address show dev "$preferred_interface" scope global); then
+			not_ready=address_inspection_failed
+		elif [ -z "$global_addresses" ]; then
+			not_ready=no_global_address
+		fi
+	fi
+
+	[ -z "$not_ready" ] && break
+
+	probe_attempts=$((probe_attempts + 1))
+	if [ "$probe_attempts" -ge "$probe_max_attempts" ]; then
+		# Non-zero: the caller retries and reports. Exiting 0 here would mask a
+		# real failure as success and leave every NIC running DHCP.
+		echo "Scout network configuration timed out: interface=${preferred_interface:-<none>} mac=$preferred_mac reason=$not_ready waited=${network_wait_seconds}s" >&2
+		exit 1
+	fi
+	sleep "$network_poll_interval"
+done
 
 runtime_network_file="$networkd_runtime_dir/00-forge-scout-nonpreferred.network"
 

--- a/pxe/common_files/scout-loader-rclocal
+++ b/pxe/common_files/scout-loader-rclocal
@@ -205,6 +205,12 @@ then
 
     DONE=0
     send_msg "LOADER: Downloading ${newrootfsurl}"
+    if [ -x /opt/forge/forge-scout-network.sh ]
+    then
+        send_msg "LOADER: Selecting boot NIC from kernel mac= parameter"
+        /opt/forge/forge-scout-network.sh || send_msg "LOADER: Scout NIC filtering failed; continuing startup"
+    fi
+
     while (( ${DONE} != 1 ))
     do
       # We store the HTTP HEAD info for the script which will check for updates later.

--- a/pxe/common_files/scout-loader-rclocal
+++ b/pxe/common_files/scout-loader-rclocal
@@ -204,15 +204,26 @@ then
     detect_pcr_hash
 
     DONE=0
+    NIC_FILTERED=0
     send_msg "LOADER: Downloading ${newrootfsurl}"
-    if [ -x /opt/forge/forge-scout-network.sh ]
-    then
-        send_msg "LOADER: Selecting boot NIC from kernel mac= parameter"
-        /opt/forge/forge-scout-network.sh || send_msg "LOADER: Scout NIC filtering failed; continuing startup"
-    fi
 
     while (( ${DONE} != 1 ))
     do
+      # Retried until it succeeds rather than attempted once: the boot NIC may not
+      # have been probed yet on the first pass (see forge-scout-network.sh), and a
+      # single early no-op leaves every NIC running DHCP -- which on a multi-homed
+      # host means competing default routes and an unreachable provisioning server.
+      if (( ${NIC_FILTERED} != 1 )) && [ -x /opt/forge/forge-scout-network.sh ]
+      then
+        send_msg "LOADER: Selecting boot NIC from kernel mac= parameter"
+        if /opt/forge/forge-scout-network.sh
+        then
+          NIC_FILTERED=1
+        else
+          send_msg "LOADER: Scout NIC filtering incomplete; retrying"
+        fi
+      fi
+
       # We store the HTTP HEAD info for the script which will check for updates later.
       curl -sSf --head "${newrootfsurl}" 2> "${CURL_ERR}" | sed 's/\r//g' > "${ROOTFS_INFO_TMP}"
       if (( $? == 0 ))

--- a/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.conf
@@ -24,6 +24,7 @@ Packages=
          dbus
          file
          isc-dhcp-client
+         iproute2
          kmod
          linux-nvidia-64k-hwe-24.04
          net-tools

--- a/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-loader-x86_64/mkosi.conf
@@ -22,6 +22,7 @@ Packages=
          curl
          dbus
          isc-dhcp-client
+         iproute2
          kmod
          linux-image-6.8.0-111-generic
          net-tools

--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
@@ -40,6 +40,7 @@ Packages=
      ipmitool
      iproute2
      iputils-ping
+     iproute2
      keyboard-configuration
      isc-dhcp-client
      lldpd

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.conf
@@ -39,6 +39,7 @@ Packages=
      ipmitool
      iproute2
      iputils-ping
+     iproute2
      keyboard-configuration
      isc-dhcp-client
      lldpd


### PR DESCRIPTION
Backport of SMC GB300 support onto `release/v2.1` to build a v2.1 image for onboarding the GB300 trays.

## Commits
1. **#4121** (`bb7ff72f`) — minimal SMC GB300 support: libredfish v0.46.2→v0.46.3 (OpenBMC vendor routing, libredfish #111) + bmc-explorer GB300 handling. Cherry-picked from `main` (`556bdd89`).
2. **`4354b769`** — include ARM host boot artifacts in BFB image (fork `41a957228`): packages `scout.efi` for aarch64 so Grace/ARM GB300 can HTTP-boot scout.
3. **`11f862a1`** — prefer boot NIC during Scout startup (fork `8d7ae4c80`): adds `forge-scout-network.sh` boot-NIC selection.
4. **`32d4ae24`** — wait for boot NIC before filtering Scout DHCP (fork `241af6089`).

Commits 2–4 are cherry-picked from `martinraumann/smcgb300/v2.0-controller-backport` (never upstreamed to main; only #4121 was). They apply cleanly onto v2.1.

## Intentionally NOT included (already in v2.1)
- fork `02c0f6ffd` "use DHCP link address for prediction promotion" + test `4403a8256` — **redundant**: v2.1 `crates/api-core/src/dhcp/discover.rs` already selects `link_address` over the relay/giaddr (`address_to_use_for_dhcp = link_address.as_ref().unwrap_or(&relay_address)`).
- `#4145` setup-status correlation, `#3454` host-boot-interface convergence — already on `release/v2.1`.

cc @martinraumann — please sanity-check the v2.0→v2.1 adaptation of commits 2–4 (they applied clean, but they're your patches).
