### PR TITLE
fix(mat-k8s-ctrl): cache mat api clients and propagate delete errors

### DIFF
--- a/dev/k8s/machine-a-tron-controller/pkg/controller/controller.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/controller/controller.go
@@ -412,6 +412,11 @@ type StatusFetcher interface {
 // StatusFetcherFunc is a function type for creating StatusFetchers per URL.
 type StatusFetcherFunc func(url string) (StatusFetcher, error)
 
+// Closeable is an optional interface for StatusFetchers that need cleanup.
+type Closeable interface {
+	Close() error
+}
+
 // Reconciler reconciles Kubernetes Services with machine-a-tron machine status.
 type Reconciler struct {
 	discovery        Discovery
@@ -422,6 +427,10 @@ type Reconciler struct {
 	statusFetcher    StatusFetcherFunc // Optional, for testing. If nil, uses matclient.
 	logger           zerolog.Logger
 	concurrency      int
+
+	// clientCache caches StatusFetcher instances by URL for connection reuse.
+	// Entries are evicted when their URLs are absent from discovery.
+	clientCache map[string]StatusFetcher
 }
 
 // DeploymentClient is an interface for fetching Deployments.
@@ -446,6 +455,7 @@ func NewReconciler(
 		clientOpts:       clientOpts,
 		logger:           logger,
 		concurrency:      DefaultConcurrency,
+		clientCache:      make(map[string]StatusFetcher),
 	}
 }
 
@@ -454,6 +464,27 @@ func (r *Reconciler) SetConcurrency(n int) {
 	if n > 0 {
 		r.concurrency = n
 	}
+}
+
+// getOrCreateClient returns a cached StatusFetcher or creates a new one.
+func (r *Reconciler) getOrCreateClient(url string) (StatusFetcher, error) {
+	if fetcher, ok := r.clientCache[url]; ok {
+		return fetcher, nil
+	}
+
+	var fetcher StatusFetcher
+	var err error
+	if r.statusFetcher != nil {
+		fetcher, err = r.statusFetcher(url)
+	} else {
+		fetcher, err = matclient.NewClient(url, r.clientOpts...)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	r.clientCache[url] = fetcher
+	return fetcher, nil
 }
 
 // Reconcile performs a full reconciliation cycle.
@@ -465,6 +496,22 @@ func (r *Reconciler) Reconcile(ctx context.Context) ReconcileResult {
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Errorf("discovering instances: %w", err))
 		return result
+	}
+
+	// Build set of discovered URLs for cache eviction (even if empty)
+	discoveredURLs := make(map[string]struct{}, len(instances))
+	for _, instance := range instances {
+		discoveredURLs[instance.URL] = struct{}{}
+	}
+
+	// Evict cached clients whose URLs are no longer discovered
+	for url, fetcher := range r.clientCache {
+		if _, found := discoveredURLs[url]; !found {
+			if c, ok := fetcher.(Closeable); ok {
+				_ = c.Close()
+			}
+			delete(r.clientCache, url)
+		}
 	}
 
 	if len(instances) == 0 {
@@ -506,14 +553,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) ReconcileResult {
 	fetchFailed := false
 
 	for _, instance := range instances {
-		var fetcher StatusFetcher
-		var err error
-
-		if r.statusFetcher != nil {
-			fetcher, err = r.statusFetcher(instance.URL)
-		} else {
-			fetcher, err = matclient.NewClient(instance.URL, r.clientOpts...)
-		}
+		fetcher, err := r.getOrCreateClient(instance.URL)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("creating client for %s: %w", instance.URL, err))
 			fetchFailed = true
@@ -571,7 +611,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) ReconcileResult {
 
 	// Process deletes concurrently
 	if !fetchFailed && len(diff.Delete) > 0 {
-		deleted := r.processDeletesConcurrently(ctx, diff.Delete)
+		deleted := r.processDeletesConcurrently(ctx, diff.Delete, &result)
 		result.Deleted = deleted
 	}
 
@@ -598,9 +638,10 @@ func (r *Reconciler) Reconcile(ctx context.Context) ReconcileResult {
 }
 
 // processDeletesConcurrently deletes services using a worker pool.
-func (r *Reconciler) processDeletesConcurrently(ctx context.Context, names []string) int {
+func (r *Reconciler) processDeletesConcurrently(ctx context.Context, names []string, result *ReconcileResult) int {
 	var deleted int64
 	var wg sync.WaitGroup
+	var errMu sync.Mutex
 	sem := make(chan struct{}, r.concurrency)
 
 	for i, name := range names {
@@ -620,6 +661,9 @@ func (r *Reconciler) processDeletesConcurrently(ctx context.Context, names []str
 
 			if err := r.k8sClient.Delete(ctx, r.serviceBuilder.Namespace, name); err != nil {
 				r.logger.Error().Err(err).Str("service", name).Msg("failed to delete service")
+				errMu.Lock()
+				result.Errors = append(result.Errors, fmt.Errorf("deleting service %s: %w", name, err))
+				errMu.Unlock()
 			} else {
 				atomic.AddInt64(&deleted, 1)
 			}

--- a/dev/k8s/machine-a-tron-controller/pkg/controller/controller_test.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/controller/controller_test.go
@@ -701,7 +701,15 @@ func ptr[T any](v T) *T {
 	return &v
 }
 
-func ptrString(s string) *string { return &s }
+func testMachineStatus() *matclient.MachinesStatusResponse {
+	return &matclient.MachinesStatusResponse{
+		Machines: []matclient.MachineStatus{{
+			MatID:    "mat-id-1",
+			APIState: "Ready",
+			BMC:      matclient.BMCStatus{IP: ptr("10.0.0.1"), Redfish: matclient.EndpointStatus{ReachablePort: 443, ListenPort: 1266}},
+		}},
+	}
+}
 
 func TestProcessRecreatesConcurrently_RecordsErrors(t *testing.T) {
 	tests := []struct {
@@ -908,4 +916,110 @@ func TestReconciler_OwnerReferences(t *testing.T) {
 			}
 		})
 	}
+}
+
+// trackingStatusFetcher implements StatusFetcher and tracks calls for testing.
+type trackingStatusFetcher struct {
+	status     *matclient.MachinesStatusResponse
+	err        error
+	closed     bool
+	fetchCount int
+}
+
+func (m *trackingStatusFetcher) GetMachinesStatus(ctx context.Context) (*matclient.MachinesStatusResponse, error) {
+	m.fetchCount++
+	return m.status, m.err
+}
+
+func (m *trackingStatusFetcher) Close() error {
+	m.closed = true
+	return nil
+}
+
+func TestReconciler_ClientCaching(t *testing.T) {
+	const url1, url2 = "https://mat-1.ns.svc:8443", "https://mat-2.ns.svc:8443"
+
+	setup := func(urls ...string) (*Reconciler, *mockDiscovery, map[string]*trackingStatusFetcher, *int) {
+		instances := make([]DiscoveredInstance, len(urls))
+		for i, u := range urls {
+			instances[i] = DiscoveredInstance{URL: u, ServiceName: "mat-bmc-mock"}
+		}
+		discovery := &mockDiscovery{instances: instances}
+		fetchers := make(map[string]*trackingStatusFetcher)
+		createCount := 0
+
+		r := NewReconciler(discovery, &ServiceBuilder{
+			Namespace:    "ns",
+			BaseSelector: map[string]string{"app": "mat"},
+		}, &trackingK8sClient{services: make(map[string]*corev1.Service)}, nil, nil, zerolog.Nop())
+
+		r.statusFetcher = func(url string) (StatusFetcher, error) {
+			createCount++
+			f := &trackingStatusFetcher{status: testMachineStatus()}
+			fetchers[url] = f
+			return f, nil
+		}
+		return r, discovery, fetchers, &createCount
+	}
+
+	t.Run("reuses cached client", func(t *testing.T) {
+		r, _, fetchers, createCount := setup(url1)
+
+		r.Reconcile(context.Background())
+		assert.Equal(t, 1, *createCount)
+		assert.Equal(t, 1, fetchers[url1].fetchCount)
+
+		r.Reconcile(context.Background())
+		assert.Equal(t, 1, *createCount, "should reuse cached client")
+		assert.Equal(t, 2, fetchers[url1].fetchCount)
+	})
+
+	t.Run("evicts and closes stale client", func(t *testing.T) {
+		r, discovery, fetchers, _ := setup(url1, url2)
+
+		r.Reconcile(context.Background())
+		require.False(t, fetchers[url2].closed)
+
+		discovery.instances = discovery.instances[:1] // remove url2
+		r.Reconcile(context.Background())
+
+		assert.False(t, fetchers[url1].closed)
+		assert.True(t, fetchers[url2].closed, "evicted client should be closed")
+		assert.NotContains(t, r.clientCache, url2)
+	})
+
+	t.Run("evicts all clients when discovery returns zero instances", func(t *testing.T) {
+		r, discovery, fetchers, _ := setup(url1)
+
+		r.Reconcile(context.Background())
+		require.Contains(t, r.clientCache, url1)
+		require.False(t, fetchers[url1].closed)
+
+		discovery.instances = nil // all instances gone
+		r.Reconcile(context.Background())
+
+		assert.True(t, fetchers[url1].closed, "client should be closed when all instances disappear")
+		assert.Empty(t, r.clientCache)
+	})
+}
+
+func TestProcessDeletesConcurrently_PropagatesErrors(t *testing.T) {
+	deleteErr := fmt.Errorf("delete failed")
+
+	reconciler := &Reconciler{
+		serviceBuilder: &ServiceBuilder{Namespace: "test-ns"},
+		k8sClient: &trackingK8sClient{
+			services:  map[string]*corev1.Service{"svc-1": makeTestService("svc-1", "mat-id-1")},
+			deleteErr: deleteErr,
+		},
+		logger:      zerolog.Nop(),
+		concurrency: 1,
+	}
+
+	result := ReconcileResult{}
+	deleted := reconciler.processDeletesConcurrently(context.Background(), []string{"svc-1"}, &result)
+
+	assert.Equal(t, 0, deleted, "should not count failed deletes as deleted")
+	require.Len(t, result.Errors, 1, "should propagate delete error to result")
+	assert.Contains(t, result.Errors[0].Error(), "deleting service svc-1")
 }

--- a/dev/k8s/machine-a-tron-controller/pkg/matclient/client.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/matclient/client.go
@@ -126,6 +126,13 @@ func (c *Client) applyInsecureTLS() {
 	c.httpClient.Transport = transport
 }
 
+// Close releases resources associated with the client.
+// It closes idle connections on the underlying HTTP transport.
+func (c *Client) Close() error {
+	c.httpClient.CloseIdleConnections()
+	return nil
+}
+
 // GetMachinesStatus fetches the current machine status from machine-a-tron.
 func (c *Client) GetMachinesStatus(ctx context.Context) (*MachinesStatusResponse, error) {
 	reqURL := c.baseURL + "/machines/status"

--- a/dev/k8s/machine-a-tron-controller/pkg/matclient/client_test.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/matclient/client_test.go
@@ -186,3 +186,12 @@ func TestClient_GetMachinesStatus_InvalidBodies(t *testing.T) {
 func ptr[T any](v T) *T {
 	return &v
 }
+
+func TestClient_Close(t *testing.T) {
+	client, err := NewClient("https://example.com")
+	require.NoError(t, err)
+
+	// Close should not error and should be idempotent
+	require.NoError(t, client.Close())
+	require.NoError(t, client.Close())
+}

--- a/helm/charts/nico-machine-a-tron/charts/mat-k8s-controller/values.yaml
+++ b/helm/charts/nico-machine-a-tron/charts/mat-k8s-controller/values.yaml
@@ -6,6 +6,23 @@
 ## Enable/disable the controller
 enabled: false
 
+## Container image configuration.
+##
+## IMPORTANT: Production deployments must override these defaults.
+## The default repository has no registry prefix and will not resolve in real clusters.
+##
+## Example install/upgrade command:
+##   helm install nico-machine-a-tron ./helm/charts/nico-machine-a-tron \
+##     --set mat-k8s-controller.enabled=true \
+##     --set mat-k8s-controller.image.repository=<registry>/mat-k8s-controller \
+##     --set mat-k8s-controller.image.tag=<version>
+##
+## Or in values override file:
+##   mat-k8s-controller:
+##     enabled: true
+##     image:
+##       repository: nvcr.io/nvidia/infra-controller/mat-k8s-controller
+##       tag: "1.0.0"
 image:
   repository: mat-k8s-controller
   tag: "0.1.0"


### PR DESCRIPTION
Addresses three issues from PR #3955 review:

1. Client caching - Reconciler caches MAT API clients by URL, creating new clients only on cache miss. Stale entries are evicted and closed when URLs disappear from discovery, including when all instances disappear.
2. Delete error propagation - Delete failures are now appended to`ReconcileResult.Errors` instead of only being logged.
3. Deployment documentation - Added comments to Helm values.yaml explaining production deployments must override the default image repository/tag.

## Related issues
Fixes #4410

## Type of Change
- [x] **Fix** - Bug fixes

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Test Results
```
ok  .../pkg/controller   0.702s  (22 tests)
ok  .../pkg/matclient    0.904s  (5 tests)
```