### PR TITLE
refactor(dhcp,pxe): adopt style guide rules for pub/module visibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,7 @@ dependencies = [
 name = "carbide-dhcp"
 version = "0.0.0"
 dependencies = [
+ "carbide-dhcp",
  "carbide-dhcp-common",
  "carbide-instrument",
  "carbide-rpc",

--- a/crates/dhcp-server/src/cache.rs
+++ b/crates/dhcp-server/src/cache.rs
@@ -31,14 +31,14 @@ use rpc::forge::DhcpRecord;
 /// Data in cache is only valid this long
 const MACHINE_CACHE_TIMEOUT: Duration = Duration::from_secs(60);
 /// How many entries to keep. After that we evict the entry used the longest ago.
-pub const MACHINE_CACHE_SIZE: usize = 1000;
+pub(super) const MACHINE_CACHE_SIZE: usize = 1000;
 /// If the cache key comes out shorter than this something went wrong, don't use it.
 const MIN_KEY_LEN: usize = 10;
 
 #[derive(Debug, Clone)]
-pub struct CacheEntry {
-    pub dhcp_record: DhcpRecord,
-    pub timestamp: Instant,
+pub(super) struct CacheEntry {
+    pub(super) dhcp_record: DhcpRecord,
+    timestamp: Instant,
 }
 
 /// Fetch an entry from the cache.
@@ -47,7 +47,7 @@ pub struct CacheEntry {
 /// Takes a global lock on the cache.
 /// Returns None if we don't have that item in cache, or if we did but
 /// it's no longer valid (e.g. too old).
-pub fn get(
+pub(super) fn get(
     mac_address: &str,
     link_address: IpAddr,
     circuit_id: &Option<String>,
@@ -72,7 +72,7 @@ pub fn get(
 }
 
 /// Insert or update an item in the cache
-pub fn put(
+pub(super) fn put(
     mac_address: &str,
     link_address: IpAddr,
     circuit_id: Option<String>,

--- a/crates/dhcp-server/src/command_line.rs
+++ b/crates/dhcp-server/src/command_line.rs
@@ -21,81 +21,81 @@ use clap::{Parser, ValueEnum};
 #[derive(Parser, Debug, Clone)]
 #[clap(name = "forge-dhcp-server")]
 #[clap(author = "Slack channel #swngc-forge-dev")]
-pub struct Args {
+pub(super) struct Args {
     #[arg(long, help = "Interface name where to bind this server.")]
-    pub interfaces: Vec<String>,
+    pub(super) interfaces: Vec<String>,
 
     #[arg(
         long,
         help = "UDP address where the DHCP server listens.",
         default_value = "0.0.0.0:67"
     )]
-    pub listen_addr: SocketAddrV4,
+    pub(super) listen_addr: SocketAddrV4,
 
     #[arg(
         long,
         help = "UDP destination port for responses to DHCP relays.",
         default_value_t = 67
     )]
-    pub relay_response_port: u16,
+    pub(super) relay_response_port: u16,
 
     #[arg(
         long,
         help = "DHCP Config file path.",
         default_value = "/var/support/forge-dhcp/conf/dhcp.yaml"
     )]
-    pub dhcp_config: String,
+    pub(super) dhcp_config: String,
 
     #[arg(
         long,
         help = "DPU Agent provided input file path for IP selection. Defaults to \
                 /var/support/forge-dhcp/conf/host.yaml when --grpc-listen-addr is set."
     )]
-    pub host_config: Option<String>,
+    pub(super) host_config: Option<String>,
 
     #[arg(long, help = "Root CA certificate used to connect to the Carbide API.")]
-    pub forge_root_ca_path: Option<String>,
+    pub(super) forge_root_ca_path: Option<String>,
 
     #[arg(
         long,
         requires = "client_key_path",
         help = "Client certificate used to connect to the Carbide API."
     )]
-    pub client_cert_path: Option<String>,
+    pub(super) client_cert_path: Option<String>,
 
     #[arg(
         long,
         requires = "client_cert_path",
         help = "Client private key used to connect to the Carbide API."
     )]
-    pub client_key_path: Option<String>,
+    pub(super) client_key_path: Option<String>,
 
     #[arg(short, long, value_enum, default_value_t=ServerMode::Dpu)]
-    pub mode: ServerMode,
+    pub(super) mode: ServerMode,
 
     #[arg(
         long,
         help = "gRPC server listen address for config hot-reload (e.g. 0.0.0.0:50051). \
                 When omitted the gRPC server is not started and config reload is disabled."
     )]
-    pub grpc_listen_addr: Option<String>,
+    pub(super) grpc_listen_addr: Option<String>,
 
     #[arg(
         long,
         help = "HTTP listen address for the metrics/health endpoint (e.g. 0.0.0.0:9090). \
                 When omitted the endpoint is not served; metrics are still collected."
     )]
-    pub metrics_listen_addr: Option<String>,
+    pub(super) metrics_listen_addr: Option<String>,
 }
 
 #[derive(ValueEnum, Clone, Debug)]
-pub enum ServerMode {
+pub(super) enum ServerMode {
     Dpu,
     Controller,
 }
 
 impl Args {
-    pub fn load() -> Self {
+    pub(super) fn load() -> Self {
         Self::parse()
     }
 }

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -27,7 +27,7 @@ use carbide_uuid::machine::MachineInterfaceId;
 use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
-pub mod proto {
+mod proto {
     tonic::include_proto!("dhcp_server_control");
 }
 
@@ -40,10 +40,10 @@ use proto::{
 use crate::errors::DhcpError;
 use crate::metrics::DhcpTimestampFileFailed;
 
-// ── Public control channel types ─────────────────────────────────────────────
+// ── Control channel types ────────────────────────────────────────────────────
 
 /// Messages sent from the gRPC handlers to the main restart loop.
-pub enum ControlRequest {
+pub(super) enum ControlRequest {
     /// Write new config YAML and immediately restart the DHCP server.
     /// The restart loop skips the restart if the config is unchanged.
     UpdateAndReload {
@@ -236,7 +236,7 @@ impl DhcpServerControl for DhcpServerControlService {
 // ── Server entry point ────────────────────────────────────────────────────────
 
 /// Start the plain (no-TLS) gRPC control server and block until it exits.
-pub async fn run_grpc_server(addr: SocketAddr, ctrl_tx: mpsc::Sender<ControlRequest>) {
+pub(super) async fn run_grpc_server(addr: SocketAddr, ctrl_tx: mpsc::Sender<ControlRequest>) {
     let service = DhcpServerControlService { ctrl_tx };
     tracing::info!(listen_address = %addr, "gRPC config-reload server listening");
 

--- a/crates/dhcp-server/src/main.rs
+++ b/crates/dhcp-server/src/main.rs
@@ -29,6 +29,7 @@ use std::error::Error;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+#[cfg(test)]
 use ::rpc::forge::{DhcpDiscovery, DhcpRecord};
 use ::rpc::forge_tls_client::ForgeClientConfig;
 use cache::CacheEntry;
@@ -49,6 +50,7 @@ use modes::dpu::{Dpu, get_host_config};
 use tokio::net::UdpSocket;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+#[cfg(test)]
 use tonic::async_trait;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -56,7 +58,7 @@ use tracing_subscriber::prelude::*;
 
 use crate::util::get_socket;
 
-pub struct Server {
+struct Server {
     socket: Arc<UdpSocket>,
 }
 
@@ -561,7 +563,7 @@ fn get_mode(args_mode: &ServerMode) -> Box<dyn DhcpMode> {
 }
 
 #[derive(Debug, Clone)]
-pub struct Config {
+struct Config {
     dhcp_config: DhcpConfig,
     host_config: Option<HostConfig>, // Valid only for Dpu mode.
     relay_response_port: u16,
@@ -612,9 +614,11 @@ fn forge_client_config(args: &Args) -> Result<ForgeClientConfig, DhcpError> {
     Ok(ForgeClientConfig::new(root_ca_path, Some(client_cert)))
 }
 
+#[cfg(test)]
 #[derive(Debug)]
-pub struct TestArm {}
+struct TestArm {}
 
+#[cfg(test)]
 #[async_trait]
 impl DhcpMode for TestArm {
     async fn discover_dhcp(
@@ -632,11 +636,13 @@ impl DhcpMode for TestArm {
     }
 }
 
+#[cfg(test)]
 #[derive(Debug)]
-pub struct Test {}
+struct Test {}
 
+#[cfg(test)]
 impl Test {
-    pub fn dhcp_record() -> Result<DhcpRecord, DhcpError> {
+    fn dhcp_record() -> Result<DhcpRecord, DhcpError> {
         Ok(DhcpRecord {
             machine_id: Some(
                 "fm100dsbiu5ckus880v8407u0mkcensa39cule26im5gnpvmuufckacguc0"
@@ -659,6 +665,7 @@ impl Test {
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl DhcpMode for Test {
     async fn discover_dhcp(
@@ -1494,7 +1501,7 @@ mod test {
         // The reply type the send path counts lease grants under matches the
         // encoded reply.
         assert_eq!(
-            encoded_packet.message_type,
+            encoded_packet.message_type(),
             crate::metrics::MessageTypeLabel::Ack
         );
 
@@ -1528,7 +1535,7 @@ mod test {
 
         // The nak_packet branch reports the refusal, not the request's type.
         assert_eq!(
-            encoded_packet.message_type,
+            encoded_packet.message_type(),
             crate::metrics::MessageTypeLabel::Nak
         );
 

--- a/crates/dhcp-server/src/metrics.rs
+++ b/crates/dhcp-server/src/metrics.rs
@@ -35,7 +35,7 @@ use crate::errors::DhcpError;
 /// (lease-query extensions, unknown codes, a missing message-type option)
 /// counts as `other`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
-pub enum MessageTypeLabel {
+pub(super) enum MessageTypeLabel {
     Discover,
     Request,
     Offer,
@@ -68,7 +68,7 @@ impl From<MessageType> for MessageTypeLabel {
 /// `DhcpError` -- rate limiting, undersized packets, non-IPv4 sources, and
 /// send failures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
-pub enum DropReason {
+pub(super) enum DropReason {
     RateLimited,
     TooShort,
     NotIpv4,
@@ -346,27 +346,27 @@ impl DhcpInterfaceBindFailed {
     message = "Decoded DHCP packet",
     describe = "Number of DHCP packets received and decoded, by DHCP message type."
 )]
-pub struct DhcpRequestReceived {
+pub(super) struct DhcpRequestReceived {
     #[label]
-    pub message_type: MessageTypeLabel,
+    pub(super) message_type: MessageTypeLabel,
     #[context(value)]
-    pub bootp_op: i64,
+    pub(super) bootp_op: i64,
     #[context]
-    pub source_address: SocketAddr,
+    pub(super) source_address: SocketAddr,
     #[context(value)]
-    pub xid: i64,
+    pub(super) xid: i64,
     #[context(value)]
-    pub broadcast_flag: bool,
+    pub(super) broadcast_flag: bool,
     #[context]
-    pub ciaddr: Ipv4Addr,
+    pub(super) ciaddr: Ipv4Addr,
     #[context]
-    pub yiaddr: Ipv4Addr,
+    pub(super) yiaddr: Ipv4Addr,
     #[context]
-    pub siaddr: Ipv4Addr,
+    pub(super) siaddr: Ipv4Addr,
     #[context]
-    pub giaddr: Ipv4Addr,
+    pub(super) giaddr: Ipv4Addr,
     #[context(value)]
-    pub chaddr: String,
+    pub(super) chaddr: String,
 }
 
 /// A packet was dropped without a reply reaching the client -- anywhere from
@@ -382,13 +382,13 @@ pub struct DhcpRequestReceived {
     metric = counter,
     describe = "Number of DHCP packets dropped without a reply, by drop reason."
 )]
-pub struct DhcpPacketDropped {
+pub(super) struct DhcpPacketDropped {
     #[label]
-    pub reason: DropReason,
+    pub(super) reason: DropReason,
     /// The detail behind the drop (an error's Display text where one exists).
     /// Log-line-only by construction; never a metric label.
     #[context]
-    pub error: String,
+    pub(super) error: String,
 }
 
 /// A DHCP reply was sent, labelled by the reply's message type: an `offer` is
@@ -405,25 +405,25 @@ pub struct DhcpPacketDropped {
     message = "Sent DHCP reply",
     describe = "Number of DHCP replies sent, by reply message type."
 )]
-pub struct DhcpReplySent {
+pub(super) struct DhcpReplySent {
     #[label]
-    pub message_type: MessageTypeLabel,
+    pub(super) message_type: MessageTypeLabel,
     #[context]
-    pub destination_address: SocketAddrV4,
+    pub(super) destination_address: SocketAddrV4,
     #[context(value)]
-    pub xid: i64,
+    pub(super) xid: i64,
     #[context(value)]
-    pub broadcast_flag: bool,
+    pub(super) broadcast_flag: bool,
     #[context]
-    pub ciaddr: Ipv4Addr,
+    pub(super) ciaddr: Ipv4Addr,
     #[context]
-    pub yiaddr: Ipv4Addr,
+    pub(super) yiaddr: Ipv4Addr,
     #[context]
-    pub siaddr: Ipv4Addr,
+    pub(super) siaddr: Ipv4Addr,
     #[context]
-    pub giaddr: Ipv4Addr,
+    pub(super) giaddr: Ipv4Addr,
     #[context(value)]
-    pub chaddr: String,
+    pub(super) chaddr: String,
 }
 
 /// A DHCP timestamp-file operation failed. Each variant is one operation, and

--- a/crates/dhcp-server/src/modes/controller.rs
+++ b/crates/dhcp-server/src/modes/controller.rs
@@ -31,7 +31,7 @@ use crate::errors::DhcpError;
 use crate::rpc::client::discover_dhcp;
 
 #[derive(Debug)]
-pub struct Controller {}
+pub(crate) struct Controller {}
 
 #[async_trait]
 impl DhcpMode for Controller {

--- a/crates/dhcp-server/src/modes/dpu.rs
+++ b/crates/dhcp-server/src/modes/dpu.rs
@@ -27,7 +27,7 @@ use crate::packet_handler::DecodedPacket;
 use crate::{Config, HostConfig};
 
 #[derive(Debug)]
-pub struct Dpu {}
+pub(crate) struct Dpu {}
 
 fn from_host_conf(value: &InterfaceInfo, interface_id: MachineInterfaceId) -> DhcpRecord {
     // Fill only needed fields. Rest are left empty or none.
@@ -93,7 +93,7 @@ impl DhcpMode for Dpu {
 
 /// This config is fetched by dpu-agent from controller periodically. In case of any change in
 /// this configuration, dpu-agent MUST restart dhcp-server.
-pub async fn get_host_config(
+pub(crate) async fn get_host_config(
     host_config_path: Option<String>,
 ) -> Result<Option<HostConfig>, DhcpError> {
     let Some(host_config) = host_config_path else {

--- a/crates/dhcp-server/src/modes/mod.rs
+++ b/crates/dhcp-server/src/modes/mod.rs
@@ -27,11 +27,11 @@ use crate::cache::CacheEntry;
 use crate::errors::DhcpError;
 use crate::packet_handler::{DecodedPacket, Packet};
 
-pub mod controller;
-pub mod dpu;
+pub(super) mod controller;
+pub(super) mod dpu;
 
 #[async_trait]
-pub trait DhcpMode: Send + Sync + std::fmt::Debug {
+pub(super) trait DhcpMode: Send + Sync + std::fmt::Debug {
     /// Method to determine IP address to be returned to client.
     async fn discover_dhcp(
         &self,

--- a/crates/dhcp-server/src/packet_handler.rs
+++ b/crates/dhcp-server/src/packet_handler.rs
@@ -38,7 +38,7 @@ use crate::{Config, DhcpMode, util};
 const PKT_TYPE_OP_REQUEST: u8 = 1;
 const BOOTP_CHADDR_LEN: u8 = 16;
 
-pub struct DecodedPacket {
+pub(super) struct DecodedPacket {
     packet: Message,
 }
 
@@ -155,7 +155,7 @@ impl DecodedPacket {
         .ok()
     }
 
-    pub fn get_circuit_id(&self) -> Option<String> {
+    pub(super) fn get_circuit_id(&self) -> Option<String> {
         self.get_option_val(
             OptionCode::RelayAgentInformation,
             Some(RelayCode::AgentCircuitId),
@@ -163,7 +163,7 @@ impl DecodedPacket {
         .ok()
     }
 
-    pub fn get_remote_id(&self) -> Option<String> {
+    fn get_remote_id(&self) -> Option<String> {
         self.get_option_val(
             OptionCode::RelayAgentInformation,
             Some(RelayCode::AgentRemoteId),
@@ -209,28 +209,34 @@ impl DecodedPacket {
     }
 }
 
-pub struct Packet {
+pub(super) struct Packet {
     encoded_packet: Vec<u8>,
     sent_packet: Message,
-    pub dst_address: Ipv4Addr,
-    pub dst_port: u16,
+    dst_address: Ipv4Addr,
+    dst_port: u16,
     /// The reply's DHCP message type (an Offer, an Ack, a Nak), as the
     /// bounded label the send path counts lease grants under.
-    pub message_type: MessageTypeLabel,
+    message_type: MessageTypeLabel,
 }
 
 impl Packet {
     #[cfg(test)]
-    pub fn encoded_packet(&self) -> &Vec<u8> {
+    pub(super) fn encoded_packet(&self) -> &Vec<u8> {
         &self.encoded_packet
     }
-    pub fn dst_address(&self) -> SocketAddrV4 {
+
+    #[cfg(test)]
+    pub(super) fn message_type(&self) -> MessageTypeLabel {
+        self.message_type
+    }
+
+    pub(super) fn dst_address(&self) -> SocketAddrV4 {
         SocketAddrV4::new(self.dst_address, self.dst_port)
     }
 }
 
 impl Packet {
-    pub async fn send(
+    pub(super) async fn send(
         &self,
         dst_address: SocketAddrV4,
         socket: Arc<UdpSocket>,
@@ -262,7 +268,7 @@ impl Packet {
     }
 }
 
-pub async fn process_packet(
+pub(super) async fn process_packet(
     buf: &[u8],
     source_address: SocketAddr,
     config: &Config,

--- a/crates/dhcp-server/src/rpc/client.rs
+++ b/crates/dhcp-server/src/rpc/client.rs
@@ -20,7 +20,7 @@ use rpc::forge_tls_client::{ApiConfig, ForgeTlsClient};
 use crate::Config;
 use crate::errors::DhcpError;
 
-pub async fn discover_dhcp(
+pub(crate) async fn discover_dhcp(
     discovery_request: DhcpDiscovery,
     config: &Config,
 ) -> Result<DhcpRecord, DhcpError> {

--- a/crates/dhcp-server/src/rpc/mod.rs
+++ b/crates/dhcp-server/src/rpc/mod.rs
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-pub mod client;
+pub(super) mod client;

--- a/crates/dhcp-server/src/util.rs
+++ b/crates/dhcp-server/src/util.rs
@@ -71,18 +71,18 @@ fn interface_bind_next_action(retries_left: i32) -> SocketSetupNextAction {
     }
 }
 
-pub fn u8_to_mac(data: &[u8]) -> String {
+pub(super) fn u8_to_mac(data: &[u8]) -> String {
     data.iter()
         .map(|x| format!("{x:02x}"))
         .collect::<Vec<String>>()
         .join(":")
 }
 
-pub fn u8_to_hex_string(data: &[u8]) -> Result<String, DhcpError> {
+pub(super) fn u8_to_hex_string(data: &[u8]) -> Result<String, DhcpError> {
     Ok(std::str::from_utf8(data)?.to_string())
 }
 
-pub fn machine_get_filename(
+pub(super) fn machine_get_filename(
     dhcp_response: &DhcpRecord,
     vendor_class: &VendorClass,
     config: &Config,
@@ -122,7 +122,10 @@ pub fn machine_get_filename(
 }
 
 /// Create a UDP socket and set non_blocking, broadcast and other options flag on it.
-pub async fn get_socket(listen_address: core::net::SocketAddrV4, interface: String) -> UdpSocket {
+pub(super) async fn get_socket(
+    listen_address: core::net::SocketAddrV4,
+    interface: String,
+) -> UdpSocket {
     for retry in 0..SOCKET_SETUP_ATTEMPTS {
         // Create a socket2 socket because std and Tokio sockets do not expose
         // the options that must be set before binding.

--- a/crates/dhcp/Cargo.toml
+++ b/crates/dhcp/Cargo.toml
@@ -15,9 +15,9 @@ chrono = { workspace = true }
 derive_builder = { workspace = true }
 dhcproto = { workspace = true }
 eyre = { workspace = true }
-hyper = { workspace = true, features = ["http2"] }
-hyper-util = { workspace = true, features = ["tokio"] }
-http-body-util = { workspace = true }
+hyper = { workspace = true, features = ["http2"], optional = true }
+hyper-util = { workspace = true, features = ["tokio"], optional = true }
+http-body-util = { workspace = true, optional = true }
 ipnetwork = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
@@ -26,7 +26,7 @@ lru = { workspace = true }
 mac_address = { workspace = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true }
-prost = { workspace = true }
+prost = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
@@ -38,11 +38,22 @@ carbide-rpc = { path = "../rpc" }
 carbide-tls = { path = "../tls" }
 metrics-endpoint = { path = "../metrics-endpoint" }
 
+[features]
+default = []
+test-support = [
+  "dep:http-body-util",
+  "dep:hyper",
+  "dep:hyper-util",
+  "dep:prost",
+]
+
 [dev-dependencies]
 eyre = { workspace = true }
 serde_json = { workspace = true }
 test-cdylib = { workspace = true }
 tempfile = { workspace = true }
+# Self-dependency so the crate's own integration tests see the `test-support` helpers.
+carbide-dhcp = { path = ".", features = ["test-support"] }
 carbide-instrument = { path = "../instrument", features = ["test-support"] }
 carbide-rpc = { path = "../rpc" }
 carbide-test-support = { path = "../test-support" }

--- a/crates/dhcp/src/cache.rs
+++ b/crates/dhcp/src/cache.rs
@@ -39,8 +39,9 @@ use crate::machine::Machine;
 const MACHINE_CACHE_TIMEOUT: Duration = Duration::from_secs(60);
 // For negative caching, the TTL should be longer
 const MACHINE_DISC_FAILED_CACHE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
-// Max allowed discovery failures before an error is returned to the machine without calling carbide-api. Public so unit tests can access it.
-pub const MAX_DISCOVERY_FAILS: u32 = 5;
+// After this many discovery failures, negative caching stops calling the
+// Carbide API and returns `TooManyFailuresError` to Kea.
+pub(super) const MAX_DISCOVERY_FAILS: u32 = 5;
 /// How many entries to keep. After that we evict the entry used the longest ago.
 const MACHINE_CACHE_SIZE: usize = 1000;
 /// If the cache key comes out shorter than this something went wrong, don't use it.
@@ -56,29 +57,29 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone)]
-pub struct CacheEntry {
-    pub timestamp: Instant,
-    pub status: CacheEntryStatus,
+pub(super) struct CacheEntry {
+    timestamp: Instant,
+    pub(super) status: CacheEntryStatus,
 }
 
 #[derive(Debug, Clone)]
-pub enum CacheEntryStatus {
+pub(super) enum CacheEntryStatus {
     ValidEntry(Box<Machine>),
     DiscoveryFailing(u32),
     DiscoveryFailed,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum CacheClass {
+pub(super) enum CacheClass {
     Lease,
     OptionsOnly,
 }
 
 /// Cache namespace for entries that share identity fields but differ by protocol behavior.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct CacheScope {
-    pub address_family: rpc::AddressFamily,
-    pub cache_class: CacheClass,
+pub(super) struct CacheScope {
+    pub(super) address_family: rpc::AddressFamily,
+    pub(super) cache_class: CacheClass,
 }
 
 /// Fetch an entry from the cache.
@@ -87,7 +88,7 @@ pub struct CacheScope {
 /// Takes a global lock on the cache.
 /// Returns None if we don't have that item in cache, or if we did but
 /// it's no longer valid (e.g. too old).
-pub fn get(
+pub(super) fn get(
     address_family: rpc::AddressFamily,
     mac_address: MacAddress,
     link_address: IpAddr,
@@ -107,7 +108,7 @@ pub fn get(
 }
 
 /// Fetch an entry from the cache with a protocol-specific cache class.
-pub fn get_classed(
+pub(super) fn get_classed(
     address_family: rpc::AddressFamily,
     cache_class: CacheClass,
     mac_address: MacAddress,
@@ -157,7 +158,7 @@ pub fn get_classed(
 ///
 /// This also performs opportunistic cache cleanup for expired or invalidated
 /// entries found while scanning matching vendor variants.
-pub fn get_classed_any_vendor(
+pub(super) fn get_classed_any_vendor(
     address_family: rpc::AddressFamily,
     cache_class: CacheClass,
     mac_address: MacAddress,
@@ -200,7 +201,7 @@ pub fn get_classed_any_vendor(
 }
 
 /// Insert or update an item in the cache
-pub fn put(
+pub(super) fn put(
     address_family: rpc::AddressFamily,
     mac_address: MacAddress,
     link_address: IpAddr,       // relay address
@@ -224,7 +225,7 @@ pub fn put(
 }
 
 /// Insert or update an item in the cache with a protocol-specific cache class.
-pub fn put_classed(
+pub(super) fn put_classed(
     scope: CacheScope,
     mac_address: MacAddress,
     link_address: IpAddr,
@@ -263,7 +264,7 @@ pub fn put_classed(
 }
 
 /// Mark and remove cached DHCPv6 lease entries matching an expired API allocation.
-pub fn invalidate_v6_lease(address: Ipv6Addr, mac_address: MacAddress) -> usize {
+pub(super) fn invalidate_v6_lease(address: Ipv6Addr, mac_address: MacAddress) -> usize {
     INVALIDATED_V6_LEASES.lock().unwrap().put(
         invalidated_v6_lease_key(address, mac_address),
         Instant::now(),
@@ -299,7 +300,7 @@ pub fn invalidate_v6_lease(address: Ipv6Addr, mac_address: MacAddress) -> usize 
 }
 
 /// Clear the recent-expiry tombstone for a DHCPv6 lease.
-pub fn clear_v6_lease_invalidation(address: Ipv6Addr, mac_address: MacAddress) -> bool {
+pub(super) fn clear_v6_lease_invalidation(address: Ipv6Addr, mac_address: MacAddress) -> bool {
     INVALIDATED_V6_LEASES
         .lock()
         .unwrap()
@@ -308,7 +309,7 @@ pub fn clear_v6_lease_invalidation(address: Ipv6Addr, mac_address: MacAddress) -
 }
 
 /// Return whether a Machine points at a recently expired DHCPv6 lease.
-pub fn machine_matches_invalidated_v6_lease(machine: &Machine) -> bool {
+pub(super) fn machine_matches_invalidated_v6_lease(machine: &Machine) -> bool {
     match machine.inner.address.parse::<IpAddr>() {
         Ok(IpAddr::V6(address)) => {
             is_v6_lease_invalidated(address, machine.discovery_info.mac_address)
@@ -408,7 +409,7 @@ impl CacheEntry {
 }
 
 impl CacheEntryStatus {
-    pub fn increment_fails(&self) -> CacheEntryStatus {
+    pub(super) fn increment_fails(&self) -> CacheEntryStatus {
         match self {
             CacheEntryStatus::ValidEntry(_machine) => CacheEntryStatus::DiscoveryFailing(1),
             CacheEntryStatus::DiscoveryFailing(count) => {

--- a/crates/dhcp/src/discovery.rs
+++ b/crates/dhcp/src/discovery.rs
@@ -68,7 +68,7 @@ pub extern "C" fn discovery_builder_result_as_str(result: DiscoveryBuilderResult
 }
 
 #[derive(Debug, Clone, Builder)]
-pub struct Discovery {
+pub(super) struct Discovery {
     pub(crate) relay_address: Ipv4Addr,
     pub(crate) mac_address: MacAddress,
 

--- a/crates/dhcp/src/discovery_v6.rs
+++ b/crates/dhcp/src/discovery_v6.rs
@@ -46,35 +46,35 @@ const DUID_UUID_LEN: usize = 18;
 
 /// Supplemental relay metadata from Kea when it has already unwrapped the relay envelope.
 #[derive(Debug, Default, Clone)]
-pub struct RelayContext {
-    pub relay_count: usize,
-    pub hop_count: u8,
-    pub link_address: Option<Ipv6Addr>,
-    pub interface_id: Option<Vec<u8>>,
-    pub remote_id: Option<Vec<u8>>,
-    pub client_link_layer: Option<Vec<u8>>,
+pub(super) struct RelayContext {
+    pub(super) relay_count: usize,
+    pub(super) hop_count: u8,
+    pub(super) link_address: Option<Ipv6Addr>,
+    pub(super) interface_id: Option<Vec<u8>>,
+    pub(super) remote_id: Option<Vec<u8>>,
+    pub(super) client_link_layer: Option<Vec<u8>>,
 }
 
 /// DHCPv6 discovery data selected by the hook before calling Carbide.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct V6Discovery {
-    pub selected_mac: MacAddress,
-    pub duid_mac: Option<MacAddress>,
-    pub duid: Vec<u8>,
-    pub message_type: MessageType,
-    pub relay_link: Option<Ipv6Addr>,
-    pub vendor_class: Option<String>,
-    pub interface_id: Option<Vec<u8>>,
-    pub remote_id: Option<Vec<u8>>,
-    pub desired_addr: Option<Ipv6Addr>,
-    pub ia_addrs: Vec<Ipv6Addr>,
-    pub has_ia_na: bool,
-    pub client_link_layer: Option<MacAddress>,
+pub(super) struct V6Discovery {
+    pub(super) selected_mac: MacAddress,
+    pub(super) duid_mac: Option<MacAddress>,
+    pub(super) duid: Vec<u8>,
+    pub(super) message_type: MessageType,
+    pub(super) relay_link: Option<Ipv6Addr>,
+    pub(super) vendor_class: Option<String>,
+    pub(super) interface_id: Option<Vec<u8>>,
+    pub(super) remote_id: Option<Vec<u8>>,
+    pub(super) desired_addr: Option<Ipv6Addr>,
+    pub(super) ia_addrs: Vec<Ipv6Addr>,
+    pub(super) has_ia_na: bool,
+    pub(super) client_link_layer: Option<MacAddress>,
 }
 
 /// Reasons a DHCPv6 packet cannot be decoded or served by this hook.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum V6DecodeError {
+pub(super) enum V6DecodeError {
     MalformedPacket,
     NestedRelay,
     RelayHopCountExceeded(u8),
@@ -86,13 +86,13 @@ pub enum V6DecodeError {
 
 /// Result of parsing a DUID for a link-layer identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DuidMac {
+enum DuidMac {
     Mac(MacAddress),
     NoLinkLayerMac,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DuidError {
+enum DuidError {
     Malformed,
     UnsupportedType,
 }
@@ -105,12 +105,12 @@ struct RawOption<'a> {
 
 /// Decode a DHCPv6 packet without any Kea-provided relay fallback metadata.
 #[cfg(test)]
-pub fn decode(packet: &[u8]) -> Result<V6Discovery, V6DecodeError> {
+fn decode(packet: &[u8]) -> Result<V6Discovery, V6DecodeError> {
     decode_with_relay_context(packet, &RelayContext::default())
 }
 
 /// Decode a DHCPv6 packet and select the client identity for the Carbide API call.
-pub fn decode_with_relay_context(
+pub(super) fn decode_with_relay_context(
     packet: &[u8],
     relay_context: &RelayContext,
 ) -> Result<V6Discovery, V6DecodeError> {
@@ -131,7 +131,7 @@ pub fn decode_with_relay_context(
 }
 
 /// Extract an Ethernet MAC from a DUID-LL or DUID-LLT byte string.
-pub fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
+fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
     // Kea caps DUIDs at RFC 8415's 128-byte maximum.
     if duid.len() < 2 || duid.len() > DUID_MAX_LEN {
         return Err(DuidError::Malformed);
@@ -149,7 +149,7 @@ pub fn extract_mac_from_duid(duid: &[u8]) -> Result<DuidMac, DuidError> {
 }
 
 /// Parse RFC 6939 option 79 and return an Ethernet MAC when it carries one.
-pub fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
+fn extract_mac_from_option79(payload: &[u8]) -> Option<MacAddress> {
     if payload.len() != 2 + ETHERNET_MAC_LEN {
         return None;
     }
@@ -374,7 +374,10 @@ fn select_identity(decoded: DecodedV6) -> Result<V6Discovery, V6DecodeError> {
 }
 
 /// Map DHCPv6 transport message type to the existing Carbide API message kind.
-pub fn message_kind_for(message_type: MessageType, has_ia_na: bool) -> Option<rpc::MessageKind> {
+pub(super) fn message_kind_for(
+    message_type: MessageType,
+    has_ia_na: bool,
+) -> Option<rpc::MessageKind> {
     match message_type {
         // Stateless SOLICIT is an information-only observation; stateful
         // SOLICIT starts address allocation.

--- a/crates/dhcp/src/kea/ffi.rs
+++ b/crates/dhcp/src/kea/ffi.rs
@@ -17,10 +17,10 @@
 use log::LevelFilter;
 
 unsafe extern "C" {
-    pub fn shim_version() -> libc::c_int;
-    pub fn shim_load(_: *mut libc::c_void) -> libc::c_int;
-    pub fn shim_unload() -> libc::c_int;
-    pub fn shim_multi_threading_compatible() -> libc::c_int;
+    fn shim_version() -> libc::c_int;
+    fn shim_load(_: *mut libc::c_void) -> libc::c_int;
+    fn shim_unload() -> libc::c_int;
+    fn shim_multi_threading_compatible() -> libc::c_int;
 }
 
 #[unsafe(no_mangle)]

--- a/crates/dhcp/src/kea_logger.rs
+++ b/crates/dhcp/src/kea_logger.rs
@@ -19,7 +19,7 @@ use std::ffi::CString;
 use libc::{c_char, c_int};
 use log::{Level, Metadata, Record};
 
-pub struct KeaLogger;
+pub(super) struct KeaLogger;
 
 // Kea stops at level DEBUG, but splits that into 100 'debuglevel' values, so arbitrarity assign
 // one to Log::Debug and one to Log::Trace.

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -42,9 +42,8 @@ mod kea_logger;
 mod lease_expiration;
 mod machine;
 mod machine_v6;
-
-// Should be #[cfg(test)] but tests/integration_test.rs also uses it
 mod metrics;
+#[cfg(any(test, feature = "test-support"))]
 pub mod mock_api_server;
 mod tls;
 
@@ -54,7 +53,7 @@ static CONFIG: Lazy<RwLock<CarbideDhcpContext>> =
 static LOGGER: kea_logger::KeaLogger = kea_logger::KeaLogger;
 
 #[derive(Debug)]
-pub struct CarbideDhcpContext {
+struct CarbideDhcpContext {
     api_endpoint: String,
     nameservers: Vec<Ipv4Addr>,
     dns_servers_ipv6: Vec<Ipv6Addr>,
@@ -77,7 +76,7 @@ pub struct CarbideDhcpContext {
 // `metrics.rs` and resolve from the global meter; this struct holds only the
 // state the certificate-expiry gauge reports.
 #[derive(Debug, Clone)]
-pub struct CarbideDhcpMetrics {
+struct CarbideDhcpMetrics {
     forge_client_config: ForgeClientConfig,
     certificate_expiration_value: Arc<AtomicI64>,
 }
@@ -158,7 +157,7 @@ impl Default for CarbideDhcpContext {
     }
 }
 
-pub(crate) fn parse_ipv4_list(addresses: &str) -> Result<Vec<Ipv4Addr>, std::net::AddrParseError> {
+fn parse_ipv4_list(addresses: &str) -> Result<Vec<Ipv4Addr>, std::net::AddrParseError> {
     addresses
         .split(',')
         .map(str::trim)
@@ -167,7 +166,7 @@ pub(crate) fn parse_ipv4_list(addresses: &str) -> Result<Vec<Ipv4Addr>, std::net
         .collect()
 }
 
-pub(crate) fn format_ipv4_list(addresses: &[Ipv4Addr]) -> String {
+fn format_ipv4_list(addresses: &[Ipv4Addr]) -> String {
     addresses
         .iter()
         .map(ToString::to_string)
@@ -176,7 +175,7 @@ pub(crate) fn format_ipv4_list(addresses: &[Ipv4Addr]) -> String {
 }
 
 /// Parse a comma-separated list of IPv6 addresses from hook configuration.
-pub(crate) fn parse_ipv6_list(addresses: &str) -> Result<Vec<Ipv6Addr>, std::net::AddrParseError> {
+fn parse_ipv6_list(addresses: &str) -> Result<Vec<Ipv6Addr>, std::net::AddrParseError> {
     addresses
         .split(',')
         .map(str::trim)
@@ -186,7 +185,7 @@ pub(crate) fn parse_ipv6_list(addresses: &str) -> Result<Vec<Ipv6Addr>, std::net
 }
 
 impl CarbideDhcpContext {
-    pub fn get_tokio_runtime() -> &'static Runtime {
+    fn get_tokio_runtime() -> &'static Runtime {
         static TOKIO: Lazy<Runtime> = Lazy::new(|| {
             Builder::new_current_thread()
                 .enable_all()

--- a/crates/dhcp/src/machine.rs
+++ b/crates/dhcp/src/machine.rs
@@ -64,13 +64,13 @@ impl DhcpByteBuffer {
 /// additional constraints (options) to and from the client.
 #[derive(Debug, Clone)]
 pub struct Machine {
-    pub inner: rpc::DhcpRecord,
-    pub discovery_info: Discovery,
-    pub vendor_class: Option<VendorClass>,
+    pub(super) inner: rpc::DhcpRecord,
+    pub(super) discovery_info: Discovery,
+    pub(super) vendor_class: Option<VendorClass>,
 }
 
 impl Machine {
-    pub async fn try_fetch(
+    pub(super) async fn try_fetch(
         discovery: Discovery,
         carbide_api_url: &str,
         vendor_class: Option<VendorClass>,
@@ -106,7 +106,7 @@ impl Machine {
         }
     }
 
-    pub fn booturl(&self) -> Option<&str> {
+    fn booturl(&self) -> Option<&str> {
         self.inner.booturl.as_deref()
     }
 }
@@ -552,17 +552,6 @@ pub extern "C" fn machine_free_nameservers(nameservers: *mut libc::c_char) {
         }
 
         drop(CString::from_raw(nameservers))
-    };
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn machine_free_ntpservers(ntpservers: *mut libc::c_char) {
-    unsafe {
-        if ntpservers.is_null() {
-            return;
-        }
-
-        drop(CString::from_raw(ntpservers))
     };
 }
 

--- a/crates/dhcp/src/machine_v6.rs
+++ b/crates/dhcp/src/machine_v6.rs
@@ -68,7 +68,7 @@ pub extern "C" fn carbide_v6_hook_result_as_str(result: V6HookResult) -> *const 
 }
 
 /// Build the Carbide DHCP discovery request for a decoded DHCPv6 packet.
-pub fn build_discovery(v6: &V6Discovery) -> rpc::DhcpDiscovery {
+fn build_discovery(v6: &V6Discovery) -> rpc::DhcpDiscovery {
     rpc::DhcpDiscovery {
         mac_address: v6.selected_mac.to_string(),
         relay_address: v6
@@ -88,7 +88,7 @@ pub fn build_discovery(v6: &V6Discovery) -> rpc::DhcpDiscovery {
 
 impl Machine {
     /// Fetch a DHCPv6 machine record from Carbide using the decoded v6 discovery.
-    pub async fn try_fetch_v6(
+    async fn try_fetch_v6(
         discovery: V6Discovery,
         carbide_api_url: &str,
         client_config: &ForgeClientConfig,

--- a/crates/dhcp/src/metrics.rs
+++ b/crates/dhcp/src/metrics.rs
@@ -55,7 +55,7 @@ const READINESS_CHECK_FREQUENCY: Duration = Duration::from_secs(30);
 /// are the only types a DHCPv4 server sends, so any other code counts as
 /// `other`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
-pub enum ReplyMessageType {
+pub(super) enum ReplyMessageType {
     Offer,
     Ack,
     Nak,
@@ -79,7 +79,7 @@ impl From<u8> for ReplyMessageType {
 /// (`Pkt6::getType()`). Kea represents relay envelopes separately, so this
 /// label intentionally describes the inner response type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, LabelValue)]
-pub enum V6ReplyMessageType {
+pub(super) enum V6ReplyMessageType {
     Advertise,
     Reply,
     Reconfigure,
@@ -108,7 +108,7 @@ impl From<u8> for V6ReplyMessageType {
 /// [`DropReason::Unknown`] closes the domain: a reason string outside this
 /// taxonomy buckets there instead of minting a new time series.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DropReason {
+pub(super) enum DropReason {
     /// `pkt4_receive` refuses packets that did not arrive through a relay.
     NonRelayedPacket,
     /// `pkt4_receive` drops packets whose machine carries no usable IPv4
@@ -220,7 +220,7 @@ impl From<&str> for DropReason {
 /// These labels intentionally follow the existing DHCPv6 snake_case contract,
 /// except `NonRelayedPacket`, which is shared with the v4 drop path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum V6DropReason {
+pub(super) enum V6DropReason {
     NonRelayedPacket,
     Success,
     Ignore,
@@ -302,7 +302,7 @@ impl From<&str> for V6DropReason {
     metric = counter,
     describe = "Number of DHCP requests received."
 )]
-pub struct DhcpRequestReceived;
+struct DhcpRequestReceived;
 
 /// The hook dropped or refused a DHCP request. This counts refusal events,
 /// not packets: an exchange that fails at more than one callout (a refused
@@ -316,9 +316,9 @@ pub struct DhcpRequestReceived;
     metric = counter,
     describe = "Number of DHCP requests dropped or refused, by reason."
 )]
-pub struct DhcpRequestDropped {
+struct DhcpRequestDropped {
     #[label]
-    pub reason: DropReason,
+    reason: DropReason,
 }
 
 /// The DHCPv6 hook dropped a packet before Kea could safely answer it.
@@ -331,9 +331,9 @@ pub struct DhcpRequestDropped {
     metric = counter,
     describe = "Number of dropped DHCPv6 requests, by reason."
 )]
-pub struct DhcpV6RequestDropped {
+struct DhcpV6RequestDropped {
     #[label]
-    pub reason: V6DropReason,
+    reason: V6DropReason,
 }
 
 /// A fully assembled DHCP reply left `pkt4_send` for transmission: an `offer`
@@ -350,9 +350,9 @@ pub struct DhcpV6RequestDropped {
     metric = counter,
     describe = "Number of DHCP replies sent, by reply message type."
 )]
-pub struct DhcpReplySent {
+struct DhcpReplySent {
     #[label]
-    pub message_type: ReplyMessageType,
+    message_type: ReplyMessageType,
 }
 
 /// A fully assembled DHCPv6 response left `pkt6_send` for transmission.
@@ -365,12 +365,12 @@ pub struct DhcpReplySent {
     metric = counter,
     describe = "Number of DHCPv6 replies sent, by response message type."
 )]
-pub struct DhcpV6ReplySent {
+struct DhcpV6ReplySent {
     #[label]
-    pub message_type: V6ReplyMessageType,
+    message_type: V6ReplyMessageType,
 }
 
-pub async fn certificate_loop() {
+async fn certificate_loop() {
     let mut interval = tokio::time::interval(METRICS_CAPTURE_FREQUENCY);
     loop {
         interval.tick().await;
@@ -412,7 +412,7 @@ fn initialize_metrics(mconf: &MetricsSetup) -> CarbideDhcpMetrics {
     metrics
 }
 
-pub fn metrics_server() {
+pub(super) fn metrics_server() {
     let metrics_endpoint = CONFIG
         .read()
         .expect("config lock poisoned?")
@@ -488,7 +488,7 @@ async fn check_api_connectivity(carbide_api_url: &str, client_config: &ForgeClie
     }
 }
 
-pub async fn start_readiness_monitoring() {
+async fn start_readiness_monitoring() {
     let mut readiness_interval = interval(READINESS_CHECK_FREQUENCY);
     let forge_client_config = tls::build_forge_client_config();
 
@@ -526,39 +526,39 @@ fn metrics_initialized() -> bool {
         .is_some()
 }
 
-pub fn increment_total_requests() {
+pub(super) fn increment_total_requests() {
     if metrics_initialized() {
         emit(DhcpRequestReceived);
     }
 }
 
-pub fn increment_dropped_requests(reason: DropReason) {
+pub(super) fn increment_dropped_requests(reason: DropReason) {
     if metrics_initialized() {
         emit(DhcpRequestDropped { reason });
     }
 }
 
-pub fn increment_reply_sent(message_type: ReplyMessageType) {
+pub(super) fn increment_reply_sent(message_type: ReplyMessageType) {
     if metrics_initialized() {
         emit(DhcpReplySent { message_type });
     }
 }
 
 /// Increment the DHCPv6 reply-sent counter for an outgoing response type.
-pub fn increment_v6_reply_sent(message_type: V6ReplyMessageType) {
+pub(super) fn increment_v6_reply_sent(message_type: V6ReplyMessageType) {
     if metrics_initialized() {
         emit(DhcpV6ReplySent { message_type });
     }
 }
 
 /// Increment the DHCPv6-specific dropped-request counter for a reason label.
-pub fn increment_dropped_v6_requests(reason: V6DropReason) {
+pub(super) fn increment_dropped_v6_requests(reason: V6DropReason) {
     if metrics_initialized() {
         emit(DhcpV6RequestDropped { reason });
     }
 }
 
-pub fn set_service_ready(ready: bool) {
+fn set_service_ready(ready: bool) {
     if let Some(health_controller) = &CONFIG
         .read()
         .expect("config lock poisoned")
@@ -569,7 +569,7 @@ pub fn set_service_ready(ready: bool) {
     }
 }
 
-pub fn set_service_healthy(healthy: bool) {
+pub(super) fn set_service_healthy(healthy: bool) {
     if let Some(health_controller) = &CONFIG
         .read()
         .expect("config lock poisoned")

--- a/crates/dhcp/src/mock_api_server.rs
+++ b/crates/dhcp/src/mock_api_server.rs
@@ -19,7 +19,7 @@
 /// It responds to DHCP_DISCOVERY messages with a DHCP_OFFER of 172.20.0.{x}/32, where x is the
 /// last byte of the MAC address sent in the DISCOVERY packet.
 ///
-/// Module only included if #cfg(test)
+/// Included for unit tests or when the `test-support` feature is enabled.
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
@@ -40,6 +40,7 @@ use prost::Message;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
+#[cfg(test)]
 use crate::machine::Machine;
 
 pub const ENDPOINT_DISCOVER_DHCP: &str = ::rpc::service_path!("DiscoverDhcp");
@@ -49,13 +50,9 @@ pub const ENDPOINT_EXPIRE_DHCP_LEASE: &str = ::rpc::service_path!("ExpireDhcpLea
 pub const DHCP_RESPONSE_FQDN: &str = "december-nitrogen.forge.local";
 const DHCP_RESPONSE_ADDR_PREFIX: &str = "172.20.0";
 const DHCP_V6_RESPONSE_PREFIX: &str = "2001:db8::";
-pub const DHCP_V6_RESPONSE_NTP_SERVERS: [&str; 2] = ["2001:db8::124", "2001:db8::125"];
+const DHCP_V6_RESPONSE_NTP_SERVERS: [&str; 2] = ["2001:db8::124", "2001:db8::125"];
 
-pub fn base_dhcp_response(mac_address: MacAddress) -> rpc::DhcpRecord {
-    base_dhcp_response_for_family(mac_address, rpc::AddressFamily::V4)
-}
-
-pub fn base_dhcp_response_for_family(
+fn base_dhcp_response_for_family(
     mac_address: MacAddress,
     address_family: rpc::AddressFamily,
 ) -> rpc::DhcpRecord {
@@ -94,16 +91,7 @@ pub fn base_dhcp_response_for_family(
     }
 }
 
-// Encode a DhcpRecord to match gRPC HTTP/2 DATA frame that API server (via hyper) produces.
-pub fn dhcp_response(mac_address_str: &str) -> Vec<u8> {
-    dhcp_response_with_override(mac_address_str, None, None, rpc::AddressFamily::V4)
-}
-
-/// Same as `dhcp_response` but allows selected response fields to be overridden.
-///
-/// `Some("")` is meaningful for `address_override`: it simulates a Machine that
-/// has no address binding.
-pub fn dhcp_response_with_override(
+fn dhcp_response_with_override(
     mac_address_str: &str,
     address_override: Option<String>,
     fqdn_override: Option<String>,
@@ -234,8 +222,9 @@ fn address_to_offer_v6(mac: MacAddress) -> String {
     format!("{}{:x}", DHCP_V6_RESPONSE_PREFIX, mac.bytes()[5])
 }
 
-// Does this Machine the result we expected?
-pub fn matches_mock_response(machine: &Machine) -> bool {
+// Does this Machine match the result we expected?
+#[cfg(test)]
+pub(super) fn matches_mock_response(machine: &Machine) -> bool {
     machine.inner.fqdn == DHCP_RESPONSE_FQDN
         && machine.inner.address == address_to_offer(machine.discovery_info.mac_address)
 }
@@ -245,6 +234,7 @@ pub struct MockAPIServer {
     handle: JoinHandle<Result<(), hyper::Error>>,
     tx: Option<tokio::sync::oneshot::Sender<()>>,
     local_addr: String,
+    #[cfg(test)]
     inject_failure: Arc<Mutex<bool>>,
     discoveries: Arc<Mutex<Vec<rpc::DhcpDiscovery>>>,
     expired_leases: Arc<Mutex<Vec<rpc::ExpireDhcpLeaseRequest>>>,
@@ -276,8 +266,13 @@ impl MockAPIServer {
         // Gitlab CI (or some part of our config of it) does not support IPv6
         let addr = SocketAddr::V4(SocketAddrV4::from_str("127.0.0.1:0").unwrap());
 
+        #[cfg(test)]
         let inject_failure = Arc::new(Mutex::new(false));
-        let i2 = inject_failure.clone();
+        #[cfg(test)]
+        let failure_injector = Some(inject_failure.clone());
+        #[cfg(not(test))]
+        let failure_injector: Option<Arc<Mutex<bool>>> = None;
+        let i2 = failure_injector;
         let calls = Arc::new(Mutex::new(HashMap::new()));
         let c2 = calls.clone();
         let discoveries = Arc::new(Mutex::new(Vec::new()));
@@ -329,6 +324,7 @@ impl MockAPIServer {
             handle,
             local_addr: format!("http://{local_addr}"),
             tx: Some(tx),
+            #[cfg(test)]
             inject_failure,
             discoveries,
             expired_leases,
@@ -361,7 +357,8 @@ impl MockAPIServer {
         &self.local_addr
     }
 
-    pub fn set_inject_failure(&mut self, fail: bool) {
+    #[cfg(test)]
+    pub(super) fn set_inject_failure(&mut self, fail: bool) {
         *self.inject_failure.lock().unwrap() = fail;
     }
 
@@ -386,7 +383,7 @@ impl MockAPIServer {
     async fn handler(
         req: Request<Incoming>,
         calls: Arc<Mutex<HashMap<String, usize>>>,
-        fail: Arc<Mutex<bool>>,
+        fail: Option<Arc<Mutex<bool>>>,
         discoveries: Arc<Mutex<Vec<rpc::DhcpDiscovery>>>,
         expired_leases: Arc<Mutex<Vec<rpc::ExpireDhcpLeaseRequest>>>,
         address_overrides: Arc<Mutex<HashMap<String, String>>>,
@@ -402,7 +399,7 @@ impl MockAPIServer {
         match path {
             // Add the endpoints you need here
             ENDPOINT_DISCOVER_DHCP => {
-                let inject_failure = *fail.lock().unwrap();
+                let inject_failure = fail.as_ref().is_some_and(|fail| *fail.lock().unwrap());
                 if inject_failure {
                     Err(MockAPIServerError::MockAPIFetchMachineError)
                 } else {

--- a/crates/dhcp/src/tls.rs
+++ b/crates/dhcp/src/tls.rs
@@ -20,7 +20,7 @@ use rpc::forge_tls_client::ForgeClientConfig;
 
 use crate::CONFIG;
 
-pub fn build_forge_client_config() -> ForgeClientConfig {
+pub(super) fn build_forge_client_config() -> ForgeClientConfig {
     let forge_root_ca_path = &CONFIG
         .read()
         .unwrap() // safety: the only way this will panic is if the lock is poisoned,

--- a/crates/dhcp/tests/common/dhcp_factory.rs
+++ b/crates/dhcp/tests/common/dhcp_factory.rs
@@ -20,12 +20,12 @@ use dhcproto::v4::relay::RelayInfo;
 use dhcproto::v4::{Message, relay};
 use dhcproto::{Encodable, Encoder, v4};
 
-pub const RELAY_IP: &str = "127.1.2.3";
+pub(super) const RELAY_IP: &str = "127.1.2.3";
 
-pub struct DHCPFactory {}
+pub(crate) struct DHCPFactory {}
 
 impl DHCPFactory {
-    pub fn encode(msg: Message) -> Result<Vec<u8>, eyre::Report> {
+    pub(crate) fn encode(msg: Message) -> Result<Vec<u8>, eyre::Report> {
         let mut buf = Vec::with_capacity(300); // msg is 279 bytes
         let mut e = Encoder::new(&mut buf);
         msg.encode(&mut e)?;
@@ -34,7 +34,7 @@ impl DHCPFactory {
 
     // Make and encode a relayed DHCP_DISCOVER packet
     // The idx is used as the last byte of the MAC and Link addresses to make them unique.
-    pub fn discover(idx: u8) -> Message {
+    pub(crate) fn discover(idx: u8) -> Message {
         Self::base_relayed_message(idx, v4::MessageType::Discover)
     }
 
@@ -42,7 +42,7 @@ impl DHCPFactory {
     /// standard MAC, vendor class, and relay options. Callers can mutate the
     /// returned `Message` further (e.g. set ciaddr, insert option 50/54) to
     /// shape it into REQUEST sub-states.
-    pub fn base_relayed_message(idx: u8, msg_type: v4::MessageType) -> Message {
+    pub(crate) fn base_relayed_message(idx: u8, msg_type: v4::MessageType) -> Message {
         // 0x02 prefix is a 'locally administered address'
         let mac = vec![0x02, 0x00, 0x00, 0x00, 0x00, idx];
 

--- a/crates/dhcp/tests/common/dhcpv6_factory.rs
+++ b/crates/dhcp/tests/common/dhcpv6_factory.rs
@@ -21,41 +21,41 @@ use dhcproto::v6::{
 };
 use dhcproto::{Decodable, Decoder, Encodable, Encoder};
 
-pub const RELAY_ADDR: &str = "::1";
+pub(super) const RELAY_ADDR: &str = "::1";
 
 const RELAY_FORW: u8 = 12;
 const RELAY_REPL: u8 = 13;
 const HTYPE_ETHERNET: u16 = 1;
 
-pub struct DHCPv6Factory {}
+pub(crate) struct DHCPv6Factory {}
 
 impl DHCPv6Factory {
     /// Relay link-address used by generated Relay-Forward packets.
-    pub const RELAY_LINK_ADDR: &str = "2001:db8::1";
+    pub(crate) const RELAY_LINK_ADDR: &str = "2001:db8::1";
 
     /// Hex-encoded relay interface-id expected by the API.
-    pub const RELAY_INTERFACE_ID_HEX: &str = "65746830";
+    pub(crate) const RELAY_INTERFACE_ID_HEX: &str = "65746830";
 
     /// Hex-encoded relay remote-id expected by the API.
-    pub const RELAY_REMOTE_ID_HEX: &str = "7261636b2d61";
+    pub(crate) const RELAY_REMOTE_ID_HEX: &str = "7261636b2d61";
 
     /// Return the stable locally-administered MAC used for one test client.
-    pub fn mac(idx: u8) -> [u8; 6] {
+    fn mac(idx: u8) -> [u8; 6] {
         [0x02, 0x00, 0x00, 0x00, 0x00, idx]
     }
 
     /// Return the mock API address for a client index.
-    pub fn mock_addr(idx: u8) -> Ipv6Addr {
+    pub(crate) fn mock_addr(idx: u8) -> Ipv6Addr {
         Ipv6Addr::from(0x20010db8000000000000000000000000u128 + idx as u128)
     }
 
     /// Return the colon-separated MAC string used by the mock API.
-    pub fn mac_string(idx: u8) -> String {
+    pub(crate) fn mac_string(idx: u8) -> String {
         format!("02:00:00:00:00:{idx:02x}")
     }
 
     /// Return a raw RFC 4704 client-FQDN payload with non-zero flags.
-    pub fn client_fqdn_payload() -> Vec<u8> {
+    pub(crate) fn client_fqdn_payload() -> Vec<u8> {
         let mut payload = vec![0x01];
         payload.extend_from_slice(&[
             9, b't', b'e', b's', b't', b'-', b'h', b'o', b's', b't', 5, b'f', b'o', b'r', b'g',
@@ -65,7 +65,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a DUID-LL identity for one test client.
-    pub fn duid_ll(idx: u8) -> Vec<u8> {
+    pub(crate) fn duid_ll(idx: u8) -> Vec<u8> {
         let mut duid = vec![0, 3];
         duid.extend_from_slice(&HTYPE_ETHERNET.to_be_bytes());
         duid.extend_from_slice(&Self::mac(idx));
@@ -73,17 +73,17 @@ impl DHCPv6Factory {
     }
 
     /// Return the hex-encoded DUID-LL identity for one test client.
-    pub fn duid_ll_hex(idx: u8) -> String {
+    pub(crate) fn duid_ll_hex(idx: u8) -> String {
         Self::duid_hex(&Self::duid_ll(idx))
     }
 
     /// Return the hex-encoded representation of a raw DUID.
-    pub fn duid_hex(duid: &[u8]) -> String {
+    pub(crate) fn duid_hex(duid: &[u8]) -> String {
         duid.iter().map(|byte| format!("{byte:02x}")).collect()
     }
 
     /// Build a DUID-LLT identity for one test client.
-    pub fn duid_llt(idx: u8) -> Vec<u8> {
+    pub(crate) fn duid_llt(idx: u8) -> Vec<u8> {
         let mut duid = vec![0, 1];
         duid.extend_from_slice(&HTYPE_ETHERNET.to_be_bytes());
         duid.extend_from_slice(&1u32.to_be_bytes());
@@ -92,7 +92,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a DUID-EN identity with the requested total byte length.
-    pub fn duid_en(len: usize) -> Vec<u8> {
+    pub(crate) fn duid_en(len: usize) -> Vec<u8> {
         // Type 2 plus enterprise-number form the minimum DUID-EN prefix.
         let mut duid = vec![0, 2, 0, 0, 0, 1];
         duid.resize(len, 0xaa);
@@ -100,45 +100,45 @@ impl DHCPv6Factory {
     }
 
     /// Build a valid DUID-UUID identity with no embedded MAC.
-    pub fn duid_uuid(idx: u8) -> Vec<u8> {
+    pub(crate) fn duid_uuid(idx: u8) -> Vec<u8> {
         vec![0, 4, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, idx]
     }
 
     /// Build a malformed UUID DUID that should be rejected before option 79.
-    pub fn truncated_duid_uuid() -> Vec<u8> {
+    pub(crate) fn truncated_duid_uuid() -> Vec<u8> {
         vec![0, 4, 0, 1, 2, 3]
     }
 
     /// Build a stateful SOLICIT with IA_NA.
-    pub fn solicit(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit(idx: u8) -> Vec<u8> {
         Self::relay_wrap(Self::stateful_solicit_message(idx), true)
     }
 
     /// Build a stateful SOLICIT with a caller-supplied relay hop count.
-    pub fn solicit_with_hop_count(idx: u8, hop_count: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_hop_count(idx: u8, hop_count: u8) -> Vec<u8> {
         Self::relay_wrap_with_hop_count(Self::stateful_solicit_message(idx), true, hop_count)
     }
 
     /// Build a SOLICIT wrapped by two Relay-Forward envelopes.
-    pub fn solicit_with_nested_relay(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_nested_relay(idx: u8) -> Vec<u8> {
         let inner = Self::relay_wrap(Self::stateful_solicit_message(idx), true);
         Self::relay_wrap_payload(&inner, idx, true, 0)
     }
 
     /// Build a stateful SOLICIT without relay option 79.
-    pub fn solicit_without_relay_option79(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_without_relay_option79(idx: u8) -> Vec<u8> {
         Self::relay_wrap(Self::stateful_solicit_message(idx), false)
     }
 
     /// Build a stateful SOLICIT carrying vendor-class option 16.
-    pub fn solicit_with_vendor_class(idx: u8, vendor_class: &[u8]) -> Vec<u8> {
+    pub(crate) fn solicit_with_vendor_class(idx: u8, vendor_class: &[u8]) -> Vec<u8> {
         let mut message = Self::stateful_solicit_message(idx);
         Self::add_vendor_class(&mut message, vendor_class);
         Self::relay_wrap(message, true)
     }
 
     /// Build a SOLICIT using a caller-supplied DUID and relay option-79 policy.
-    pub fn solicit_with_duid(idx: u8, duid: Vec<u8>, relay_option79: bool) -> Vec<u8> {
+    pub(crate) fn solicit_with_duid(idx: u8, duid: Vec<u8>, relay_option79: bool) -> Vec<u8> {
         Self::relay_wrap(
             Self::client_message(idx, MessageType::Solicit, duid, None, true, false),
             relay_option79,
@@ -146,7 +146,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a SOLICIT with a spoofed client-supplied option 79 only.
-    pub fn solicit_with_inner_option79(idx: u8, duid: Vec<u8>) -> Vec<u8> {
+    pub(crate) fn solicit_with_inner_option79(idx: u8, duid: Vec<u8>) -> Vec<u8> {
         let mut message = Self::client_message(idx, MessageType::Solicit, duid, None, true, false);
         message
             .opts_mut()
@@ -158,7 +158,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a SOLICIT carrying rapid-commit.
-    pub fn rapid_commit_solicit(idx: u8) -> Vec<u8> {
+    pub(crate) fn rapid_commit_solicit(idx: u8) -> Vec<u8> {
         Self::relay_wrap(
             Self::client_message(
                 idx,
@@ -173,12 +173,12 @@ impl DHCPv6Factory {
     }
 
     /// Build a stateless SOLICIT with no IA_NA.
-    pub fn stateless_solicit(idx: u8) -> Vec<u8> {
+    pub(crate) fn stateless_solicit(idx: u8) -> Vec<u8> {
         Self::relay_wrap(Self::stateless_solicit_message(idx), true)
     }
 
     /// Build a SOLICIT carrying unsupported IA_TA.
-    pub fn solicit_with_ia_ta(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_ia_ta(idx: u8) -> Vec<u8> {
         // Omit IA_NA so the packet only exercises the unsupported IA_TA path.
         let mut message = Self::stateless_solicit_message(idx);
         Self::add_ia_ta(&mut message, idx);
@@ -186,7 +186,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a SOLICIT carrying supported IA_NA plus unsupported IA_TA.
-    pub fn solicit_with_ia_na_and_ia_ta(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_ia_na_and_ia_ta(idx: u8) -> Vec<u8> {
         // Keep IA_NA present to exercise mixed-container rejection.
         let mut message = Self::stateful_solicit_message(idx);
         Self::add_ia_ta(&mut message, idx);
@@ -194,7 +194,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a SOLICIT carrying unsupported IA_PD.
-    pub fn solicit_with_ia_pd(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_ia_pd(idx: u8) -> Vec<u8> {
         // Omit IA_NA so the packet only exercises the unsupported IA_PD path.
         let mut message = Self::stateless_solicit_message(idx);
         Self::add_ia_pd(&mut message, idx);
@@ -202,7 +202,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a SOLICIT carrying supported IA_NA plus unsupported IA_PD.
-    pub fn solicit_with_ia_na_and_ia_pd(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_ia_na_and_ia_pd(idx: u8) -> Vec<u8> {
         // Keep IA_NA present to exercise mixed-container rejection.
         let mut message = Self::stateful_solicit_message(idx);
         Self::add_ia_pd(&mut message, idx);
@@ -210,7 +210,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a SOLICIT carrying more than one IA_NA container.
-    pub fn solicit_with_multiple_ia_na(idx: u8) -> Vec<u8> {
+    pub(crate) fn solicit_with_multiple_ia_na(idx: u8) -> Vec<u8> {
         // The API contract has one selected address, so multiple IA_NA
         // containers must be rejected before lease override.
         let mut message = Self::stateful_solicit_message(idx);
@@ -224,19 +224,19 @@ impl DHCPv6Factory {
     }
 
     /// Build an INFORMATION-REQUEST.
-    pub fn information_request(idx: u8) -> Vec<u8> {
+    pub(crate) fn information_request(idx: u8) -> Vec<u8> {
         Self::relay_wrap(Self::information_request_message(idx), true)
     }
 
     /// Build an INFORMATION-REQUEST carrying client option 39.
-    pub fn information_request_with_client_fqdn(idx: u8) -> Vec<u8> {
+    pub(crate) fn information_request_with_client_fqdn(idx: u8) -> Vec<u8> {
         let mut message = Self::information_request_message(idx);
         Self::add_client_fqdn(&mut message);
         Self::relay_wrap(message, true)
     }
 
     /// Build a REQUEST selecting the advertised server and address.
-    pub fn request(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+    pub(crate) fn request(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
         Self::relay_wrap(
             Self::message_with_server_and_address(idx, MessageType::Request, server_id, address),
             true,
@@ -244,7 +244,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a REQUEST with no IA_NA.
-    pub fn request_without_ia_na(idx: u8) -> Vec<u8> {
+    pub(crate) fn request_without_ia_na(idx: u8) -> Vec<u8> {
         // REQUEST is stateful; this intentionally omits IA_NA to verify drop behavior.
         Self::relay_wrap(
             Self::client_message(
@@ -260,7 +260,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a REQUEST without relay option 79.
-    pub fn request_without_relay_option79(
+    pub(crate) fn request_without_relay_option79(
         idx: u8,
         server_id: Vec<u8>,
         address: Ipv6Addr,
@@ -272,7 +272,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a REQUEST using a caller-supplied DUID and relay option-79 policy.
-    pub fn request_with_duid(
+    pub(crate) fn request_with_duid(
         idx: u8,
         server_id: Vec<u8>,
         address: Ipv6Addr,
@@ -293,7 +293,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a REQUEST carrying vendor-class option 16.
-    pub fn request_with_vendor_class(
+    pub(crate) fn request_with_vendor_class(
         idx: u8,
         server_id: Vec<u8>,
         address: Ipv6Addr,
@@ -306,7 +306,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a RENEW for an existing lease.
-    pub fn renew(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+    pub(crate) fn renew(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
         Self::relay_wrap(
             Self::message_with_server_and_address(idx, MessageType::Renew, server_id, address),
             true,
@@ -314,7 +314,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a RENEW using a caller-supplied DUID and relay option-79 policy.
-    pub fn renew_with_duid(
+    pub(crate) fn renew_with_duid(
         idx: u8,
         server_id: Vec<u8>,
         address: Ipv6Addr,
@@ -335,23 +335,15 @@ impl DHCPv6Factory {
     }
 
     /// Build a REBIND for an existing lease.
-    pub fn rebind(idx: u8, address: Ipv6Addr) -> Vec<u8> {
+    pub(crate) fn rebind(idx: u8, address: Ipv6Addr) -> Vec<u8> {
         Self::relay_wrap(
             Self::client_message_with_address(idx, MessageType::Rebind, address, None),
             true,
         )
     }
 
-    /// Build a RELEASE for an existing lease.
-    pub fn release(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
-        Self::relay_wrap(
-            Self::message_with_server_and_address(idx, MessageType::Release, server_id, address),
-            true,
-        )
-    }
-
     /// Build a RELEASE with a caller-supplied relay hop count.
-    pub fn release_with_hop_count(
+    pub(crate) fn release_with_hop_count(
         idx: u8,
         server_id: Vec<u8>,
         address: Ipv6Addr,
@@ -365,7 +357,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a RELEASE carrying unsupported IA_TA alongside the released IA_NA.
-    pub fn release_with_ia_ta(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+    pub(crate) fn release_with_ia_ta(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
         // Lease-end messages are Kea protocol handling; extra IA_TA must not
         // make the Carbide hook call discovery or drop before Kea responds.
         let mut message =
@@ -374,16 +366,8 @@ impl DHCPv6Factory {
         Self::relay_wrap(message, true)
     }
 
-    /// Build a DECLINE for an unusable offered lease.
-    pub fn decline(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
-        Self::relay_wrap(
-            Self::message_with_server_and_address(idx, MessageType::Decline, server_id, address),
-            true,
-        )
-    }
-
     /// Build a DECLINE carrying unsupported IA_PD alongside the declined IA_NA.
-    pub fn decline_with_ia_pd(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
+    pub(crate) fn decline_with_ia_pd(idx: u8, server_id: Vec<u8>, address: Ipv6Addr) -> Vec<u8> {
         // Lease-end messages are Kea protocol handling; extra IA_PD must not
         // make the Carbide hook call discovery or drop before Kea responds.
         let mut message =
@@ -393,7 +377,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a DECLINE with a caller-supplied relay hop count.
-    pub fn decline_with_hop_count(
+    pub(crate) fn decline_with_hop_count(
         idx: u8,
         server_id: Vec<u8>,
         address: Ipv6Addr,
@@ -407,7 +391,7 @@ impl DHCPv6Factory {
     }
 
     /// Build a CONFIRM for an address the client wants to keep using.
-    pub fn confirm(idx: u8, address: Ipv6Addr) -> Vec<u8> {
+    pub(crate) fn confirm(idx: u8, address: Ipv6Addr) -> Vec<u8> {
         Self::relay_wrap(
             Self::client_message_with_address(idx, MessageType::Confirm, address, None),
             true,
@@ -538,7 +522,7 @@ impl DHCPv6Factory {
     }
 
     /// Decode Kea's Relay-Reply and return the inner DHCPv6 message.
-    pub fn decode_reply(packet: &[u8]) -> Result<Message, eyre::Report> {
+    pub(crate) fn decode_reply(packet: &[u8]) -> Result<Message, eyre::Report> {
         match packet.first().copied() {
             Some(RELAY_REPL) => {
                 let relay_msg = Self::relay_msg_payload(packet)
@@ -553,7 +537,7 @@ impl DHCPv6Factory {
     }
 
     /// Extract the IAADDR from the first IA_NA option.
-    pub fn ia_addr(message: &Message) -> Option<Ipv6Addr> {
+    pub(crate) fn ia_addr(message: &Message) -> Option<Ipv6Addr> {
         match message.opts().get(OptionCode::IANA) {
             Some(DhcpOption::IANA(ia_na)) => match ia_na.opts.get(OptionCode::IAAddr) {
                 Some(DhcpOption::IAAddr(addr)) => Some(addr.addr),
@@ -564,7 +548,7 @@ impl DHCPv6Factory {
     }
 
     /// Extract the server-id option needed for REQUEST/RENEW/RELEASE.
-    pub fn server_id(message: &Message) -> Vec<u8> {
+    pub(crate) fn server_id(message: &Message) -> Vec<u8> {
         match message.opts().get(OptionCode::ServerId) {
             Some(DhcpOption::ServerId(server_id)) => server_id.clone(),
             other => panic!("DHCPv6 response did not include server-id: {other:?}"),

--- a/crates/dhcp/tests/common/kea.rs
+++ b/crates/dhcp/tests/common/kea.rs
@@ -93,7 +93,7 @@ impl Drop for KeaRunPermit {
     }
 }
 
-pub struct Kea {
+pub(crate) struct Kea {
     temp_conf_file: PathBuf,
 
     dhcp_in_port: u16,
@@ -111,7 +111,7 @@ impl Kea {
     /// Reserve dynamic DHCP ports, start Kea, and return it with a connected
     /// relay socket. The Kea process is stopped when the harness drops. Tests
     /// that inspect Kea's memfile can pass an externally-owned lease path.
-    pub fn start(
+    pub(crate) fn start(
         api_server_url: &str,
         lease_file: Option<&Path>,
     ) -> Result<(Kea, UdpSocket), eyre::Report> {

--- a/crates/dhcp/tests/common/kea_v6.rs
+++ b/crates/dhcp/tests/common/kea_v6.rs
@@ -35,9 +35,9 @@ const KEA_SHUTDOWN_GRACE: Duration = Duration::from_secs(2);
 const KEA_SHUTDOWN_POLL: Duration = Duration::from_millis(50);
 const METRICS_READY_CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
 /// DHCPv6 DNS servers configured through hook context.
-pub const HOOK_DNS_SERVERS_IPV6: [&str; 1] = ["2001:db8::53"];
+pub(super) const HOOK_DNS_SERVERS_IPV6: [&str; 1] = ["2001:db8::53"];
 /// DHCPv6 NTP servers configured through hook context.
-pub const HOOK_NTP_SERVERS_IPV6: [&str; 1] = ["2001:db8::123"];
+pub(super) const HOOK_NTP_SERVERS_IPV6: [&str; 1] = ["2001:db8::123"];
 
 // Real Kea children share process-global hook/logger/metrics state through the
 // loaded cdylib, so serialize them instead of running multiple daemons at once.
@@ -45,24 +45,24 @@ static KEA6_RUN_GATE: OnceLock<Kea6RunGate> = OnceLock::new();
 
 /// Kea expired-lease processing knobs used by tests that force quick reclamation.
 #[derive(Debug, Clone, Copy)]
-pub struct Kea6ExpiredLeasesProcessing {
-    pub reclaim_timer_wait_time: u16,
-    pub flush_reclaimed_timer_wait_time: u16,
-    pub hold_reclaimed_time: u32,
-    pub max_reclaim_leases: u32,
-    pub max_reclaim_time: u16,
-    pub unwarned_reclaim_cycles: u16,
+pub(crate) struct Kea6ExpiredLeasesProcessing {
+    pub(crate) reclaim_timer_wait_time: u16,
+    pub(crate) flush_reclaimed_timer_wait_time: u16,
+    pub(crate) hold_reclaimed_time: u32,
+    pub(crate) max_reclaim_leases: u32,
+    pub(crate) max_reclaim_time: u16,
+    pub(crate) unwarned_reclaim_cycles: u16,
 }
 
 /// Runtime configuration overrides for the DHCPv6 integration-test Kea process.
 #[derive(Debug, Clone, Copy)]
-pub struct Kea6Config {
-    pub preferred_lifetime: u32,
-    pub valid_lifetime: u32,
-    pub renew_timer: u32,
-    pub rebind_timer: u32,
-    pub mac_sources: Option<&'static [&'static str]>,
-    pub expired_leases_processing: Option<Kea6ExpiredLeasesProcessing>,
+pub(crate) struct Kea6Config {
+    pub(crate) preferred_lifetime: u32,
+    pub(crate) valid_lifetime: u32,
+    pub(crate) renew_timer: u32,
+    pub(crate) rebind_timer: u32,
+    pub(crate) mac_sources: Option<&'static [&'static str]>,
+    pub(crate) expired_leases_processing: Option<Kea6ExpiredLeasesProcessing>,
 }
 
 impl Default for Kea6Config {
@@ -132,7 +132,7 @@ impl Drop for Kea6RunPermit {
     }
 }
 
-pub struct Kea6 {
+pub(crate) struct Kea6 {
     temp_conf_file: PathBuf,
     dhcp_in_port: u16,
     dhcp_out_port: u16,
@@ -152,7 +152,7 @@ struct Kea6Ports {
 
 impl Kea6 {
     /// Reserve dynamic DHCPv6 ports, start Kea, and return a connected relay socket.
-    pub fn start(
+    pub(crate) fn start(
         api_server_url: &str,
         lease_file: Option<&Path>,
     ) -> Result<(Kea6, UdpSocket), eyre::Report> {
@@ -160,7 +160,7 @@ impl Kea6 {
     }
 
     /// Start Kea with launch-time overrides such as lifetimes, mac-sources, and expiry processing.
-    pub fn start_with_config(
+    pub(crate) fn start_with_config(
         api_server_url: &str,
         lease_file: Option<&Path>,
         config: Kea6Config,
@@ -411,7 +411,7 @@ impl Kea6 {
         }
     }
 
-    pub fn wait_for_log(&self, needle: &str, timeout: Duration) -> bool {
+    pub(crate) fn wait_for_log(&self, needle: &str, timeout: Duration) -> bool {
         let deadline = Instant::now() + timeout;
         loop {
             if self
@@ -430,12 +430,12 @@ impl Kea6 {
         }
     }
 
-    pub fn metrics_endpoint(&self) -> SocketAddr {
+    pub(crate) fn metrics_endpoint(&self) -> SocketAddr {
         self.metrics_endpoint
     }
 
     /// Restart the same Kea6 config and memfile, clearing process-local hook cache.
-    pub fn restart(&mut self) -> Result<(), eyre::Report> {
+    pub(crate) fn restart(&mut self) -> Result<(), eyre::Report> {
         let run_permit = self
             ._run_permit
             .take()

--- a/crates/dhcp/tests/common/mod.rs
+++ b/crates/dhcp/tests/common/mod.rs
@@ -19,9 +19,9 @@ mod dhcp_factory;
 #[allow(dead_code)]
 mod dhcpv6_factory;
 #[allow(dead_code)]
-pub(crate) mod kea;
+mod kea;
 #[allow(dead_code)]
-pub(crate) mod kea_v6;
+mod kea_v6;
 
 use std::io::{Read, Write};
 use std::net::{Ipv6Addr, SocketAddr, TcpStream};
@@ -29,23 +29,22 @@ use std::time::{Duration, Instant};
 
 use dhcp::mock_api_server::DHCP_RESPONSE_FQDN;
 #[allow(unused_imports)]
-pub use dhcp_factory::DHCPFactory;
+pub(super) use dhcp_factory::DHCPFactory;
 use dhcproto::v6::{DhcpOption, Message, NtpSuboption, OptionCode};
 #[allow(unused_imports)]
-pub use dhcpv6_factory::DHCPv6Factory;
+pub(super) use dhcpv6_factory::DHCPv6Factory;
 #[allow(unused_imports)]
-pub use kea::Kea;
+pub(super) use kea::Kea;
+use kea_v6::{HOOK_DNS_SERVERS_IPV6, HOOK_NTP_SERVERS_IPV6};
 #[allow(unused_imports)]
-pub use kea_v6::{
-    HOOK_DNS_SERVERS_IPV6, HOOK_NTP_SERVERS_IPV6, Kea6, Kea6Config, Kea6ExpiredLeasesProcessing,
-};
+pub(super) use kea_v6::{Kea6, Kea6Config, Kea6ExpiredLeasesProcessing};
 
 #[allow(dead_code)]
 const METRICS_READ_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Return the DHCPv6 dropped-request counter value for a reason label.
 #[allow(dead_code)]
-pub fn v6_drop_metric_value(endpoint: SocketAddr, reason: &str) -> f64 {
+pub(super) fn v6_drop_metric_value(endpoint: SocketAddr, reason: &str) -> f64 {
     scrape_metrics(endpoint)
         .map(|metrics| drop_counter_value(&metrics, reason))
         .unwrap_or(0.0)
@@ -53,7 +52,7 @@ pub fn v6_drop_metric_value(endpoint: SocketAddr, reason: &str) -> f64 {
 
 /// Wait until the DHCPv6 dropped-request counter reaches the expected value.
 #[allow(dead_code)]
-pub fn wait_for_v6_drop_metric_at_least(
+pub(super) fn wait_for_v6_drop_metric_at_least(
     endpoint: SocketAddr,
     reason: &str,
     minimum: f64,
@@ -99,7 +98,7 @@ fn drop_counter_value(metrics: &str, reason: &str) -> f64 {
 
 /// Assert that the DHCPv6 response carries hook-configured DNS servers.
 #[allow(dead_code)]
-pub fn assert_hook_v6_dns_servers(response: &Message) {
+pub(super) fn assert_hook_v6_dns_servers(response: &Message) {
     // Keep the expected value tied to the Kea test config, not mock API data.
     let expected = HOOK_DNS_SERVERS_IPV6
         .into_iter()
@@ -114,7 +113,7 @@ pub fn assert_hook_v6_dns_servers(response: &Message) {
 
 /// Assert that the DHCPv6 response carries the API-owned parent domain.
 #[allow(dead_code)]
-pub fn assert_api_v6_domain_search(response: &Message) {
+pub(super) fn assert_api_v6_domain_search(response: &Message) {
     // DHCPv6 domain-search uses the trusted parent domain from the API FQDN.
     let expected = DHCP_RESPONSE_FQDN
         .split_once('.')
@@ -132,7 +131,7 @@ pub fn assert_api_v6_domain_search(response: &Message) {
 
 /// Assert that the DHCPv6 response carries hook-configured NTP servers.
 #[allow(dead_code)]
-pub fn assert_hook_v6_ntp_servers(response: &Message) {
+pub(super) fn assert_hook_v6_ntp_servers(response: &Message) {
     // Keep the expected value tied to the Kea test config, not API mock data.
     let expected = HOOK_NTP_SERVERS_IPV6
         .into_iter()

--- a/crates/pxe/src/common.rs
+++ b/crates/pxe/src/common.rs
@@ -28,32 +28,32 @@ use crate::extractors::machine_architecture;
 
 #[derive(Debug)]
 pub(crate) struct Machine {
-    pub instructions: CloudInitInstructions,
+    pub(super) instructions: CloudInitInstructions,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct MachineInterface {
-    pub architecture: Option<machine_architecture::MachineArchitecture>,
+    pub(super) architecture: Option<machine_architecture::MachineArchitecture>,
     /// IP carbide-pxe observed for the booting machine: Does not support `X-Forwarded-For` for
     /// proxying, it is the real IP of the connecting client.
-    pub client_ip: IpAddr,
-    pub platform: Option<String>,
-    pub manufacturer: Option<String>,
-    pub product: Option<String>,
-    pub serial: Option<String>,
-    pub asset: Option<String>,
+    pub(super) client_ip: IpAddr,
+    pub(super) platform: Option<String>,
+    pub(super) manufacturer: Option<String>,
+    pub(super) product: Option<String>,
+    pub(super) serial: Option<String>,
+    pub(super) asset: Option<String>,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct AppState {
-    pub engine: Engine<Tera>,
+    pub(super) engine: Engine<Tera>,
     // pub request_metrics: RequestMetrics,
-    pub runtime_config: RuntimeConfig,
-    pub prometheus_handle: PrometheusHandle,
+    pub(super) runtime_config: RuntimeConfig,
+    pub(super) prometheus_handle: PrometheusHandle,
     /// The registry behind the global OTel meter, where the instrumentation
     /// framework's events record; `/metrics` renders it alongside the
     /// `metrics-exporter-prometheus` recorder above.
-    pub otel_registry: prometheus::Registry,
+    pub(super) otel_registry: prometheus::Registry,
 }
 
 /// An [`AppState`] for handler tests: an empty template engine, a local

--- a/crates/pxe/src/config.rs
+++ b/crates/pxe/src/config.rs
@@ -19,19 +19,19 @@ use std::net::IpAddr;
 
 #[derive(Clone, Debug)]
 pub(crate) struct RuntimeConfig {
-    pub internal_api_url: String,
-    pub client_facing_api_url: String,
-    pub pxe_url: String,
-    pub static_pxe_url: String,
+    pub(super) internal_api_url: String,
+    pub(super) client_facing_api_url: String,
+    pub(super) pxe_url: String,
+    pub(super) static_pxe_url: String,
     /// CA bundle served to bootstrapping clients. When no dedicated bundle is
     /// configured, this remains the same file used for outbound API trust.
-    pub bootstrap_root_ca_path: String,
-    pub forge_root_ca_path: String,
-    pub server_cert_path: String,
-    pub server_key_path: String,
-    pub bind_address: IpAddr,
-    pub bind_port: u16,
-    pub template_directory: String,
+    pub(super) bootstrap_root_ca_path: String,
+    pub(super) forge_root_ca_path: String,
+    pub(super) server_cert_path: String,
+    pub(super) server_key_path: String,
+    pub(super) bind_address: IpAddr,
+    pub(super) bind_port: u16,
+    pub(super) template_directory: String,
 }
 
 impl RuntimeConfig {

--- a/crates/pxe/src/extractors/machine_architecture.rs
+++ b/crates/pxe/src/extractors/machine_architecture.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::rpc_error::PxeRequestError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum MachineArchitecture {
+pub(crate) enum MachineArchitecture {
     Arm = 0,
     X86 = 1,
 }

--- a/crates/pxe/src/extractors/mod.rs
+++ b/crates/pxe/src/extractors/mod.rs
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 
-pub mod machine;
-pub mod machine_architecture;
-pub mod machine_interface;
+mod machine;
+pub(super) mod machine_architecture;
+mod machine_interface;

--- a/crates/pxe/src/main.rs
+++ b/crates/pxe/src/main.rs
@@ -43,7 +43,7 @@ mod rpc_error;
 #[derive(Parser, Debug)]
 struct Args {
     #[clap(long, default_value = "false", help = "Print version number and exit")]
-    pub version: bool,
+    version: bool,
 
     #[clap(short, long, default_value = "static")]
     static_dir: String,

--- a/crates/pxe/src/metrics.rs
+++ b/crates/pxe/src/metrics.rs
@@ -122,9 +122,9 @@ pub(crate) struct PxeBootOutcomes {
 )]
 pub(crate) struct PxeBootOutcome {
     #[label]
-    pub endpoint: BootEndpoint,
+    pub(super) endpoint: BootEndpoint,
     #[label]
-    pub reason: OutcomeReason,
+    pub(super) reason: OutcomeReason,
 }
 
 // Both failure Events write the same counter as `PxeBootOutcome`. Keep the
@@ -142,11 +142,11 @@ pub(crate) struct PxeBootOutcome {
 )]
 pub(crate) struct PxeCloudInitRequestFailed {
     #[label]
-    pub endpoint: BootEndpoint,
+    pub(super) endpoint: BootEndpoint,
     #[label]
-    pub reason: OutcomeReason,
+    pub(super) reason: OutcomeReason,
     #[context]
-    pub error: String,
+    pub(super) error: String,
 }
 
 /// `PxeCustomIpxeFetchFailed` records a custom iPXE lookup that fell back to
@@ -160,11 +160,11 @@ pub(crate) struct PxeCloudInitRequestFailed {
 )]
 pub(crate) struct PxeCustomIpxeFetchFailed {
     #[label]
-    pub endpoint: BootEndpoint,
+    pub(super) endpoint: BootEndpoint,
     #[label]
-    pub reason: OutcomeReason,
+    pub(super) reason: OutcomeReason,
     #[context]
-    pub error: String,
+    pub(super) error: String,
 }
 
 #[cfg(test)]

--- a/crates/pxe/src/middleware/metrics.rs
+++ b/crates/pxe/src/middleware/metrics.rs
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-// Completely forked from the `axum-metrics` crate, but changed the one line that doesn't allow req-uri
-// as a fallback because we need it.
+// Completely forked from the `axum-metrics` crate, with PXE-specific adjustments.
 
 //! Minimalist exporter-agnostic [`metrics`] instrumentation middleware for [`axum`].
 //!
@@ -74,8 +73,6 @@
 //! - `endpoint`: the matched route template ([`MatchedPath`]), or `unknown` otherwise.
 //! - `method`: the request method.
 //! - `code`: the response status code.
-//! - Additional labels from [`ExtraMetricLabels`] extension of [`Request`] or [`Response`],
-//!   if exists.
 use std::borrow::Cow;
 use std::future::Future;
 use std::num::Saturating;
@@ -92,16 +89,9 @@ use pin_project_lite::pin_project;
 use tower_layer::Layer;
 use tower_service::Service;
 
-/// An [http extension][axum::http::Extensions] to add extra metric labels.
-///
-/// Setting this extension for [`Request`] or [`Response`] to add additional labels to the relavent
-/// metrics.
-#[derive(Debug, Clone)]
-pub struct ExtraMetricLabels(pub Vec<Label>);
-
 /// Layer for applying [`Metric`].
 #[derive(Default, Clone)]
-pub struct MetricLayer {
+pub(crate) struct MetricLayer {
     _priv: (),
 }
 
@@ -115,7 +105,7 @@ impl<S> Layer<S> for MetricLayer {
 
 /// Middleware that instrument metrics on all requests and responses.
 #[derive(Debug, Clone)]
-pub struct Metric<S> {
+pub(crate) struct Metric<S> {
     inner: S,
 }
 
@@ -160,33 +150,21 @@ where
         let method = req.method().clone();
         let endpoint = match req.extensions().get::<MatchedPath>() {
             Some(path) => Cow::Owned(path.as_str().to_owned()),
-            // The original code here punts on this, we want the req.uri() as a backup explicitly
-            None => Cow::Owned(req.uri().path().to_string()),
+            None => Cow::Borrowed("unknown"),
         };
-        // endpoint, method, code, (reserved)
-        let mut labels = Vec::with_capacity(4);
+        let mut labels = Vec::with_capacity(3);
         labels.extend([
             Label::new("endpoint", endpoint),
             Label::new("method", method_to_str(&method)),
         ]);
 
-        let req = {
-            let req_labels = match req.extensions().get::<ExtraMetricLabels>() {
-                None => labels.clone(),
-                Some(extra_labels) => labels
-                    .iter()
-                    .chain(extra_labels.0.iter())
-                    .cloned()
-                    .collect(),
-            };
-            req.map(|inner| RequestBody {
-                inner,
-                metric: ReqMetric {
-                    body_size: Saturating(0),
-                    labels: req_labels,
-                },
-            })
-        };
+        let req = req.map(|inner| RequestBody {
+            inner,
+            metric: ReqMetric {
+                body_size: Saturating(0),
+                labels: labels.clone(),
+            },
+        });
 
         inflight_gauge.increment(1);
         let resp_metric = RespMetric {
@@ -222,7 +200,7 @@ pin_project! {
     /// Response body for [`Metric`].
     // Keep order.
     #[repr(C)]
-    pub struct ResponseBody<B> {
+    pub(crate) struct ResponseBody<B> {
         #[pin]
         inner: B,
         metric: RespMetric,
@@ -260,7 +238,7 @@ pin_project! {
     /// Request body for [`Metric`].
     // Keep order.
     #[repr(C)]
-    pub struct RequestBody<B> {
+    pub(crate) struct RequestBody<B> {
         #[pin]
         inner: B,
         metric: ReqMetric,
@@ -312,7 +290,7 @@ pin_project! {
     /// Response future for [`Metric`].
     // Keep order.
     #[repr(C)]
-    pub struct ResponseFuture<Fut> {
+    pub(crate) struct ResponseFuture<Fut> {
         #[pin]
         fut: Fut,
         metric: Option<RespMetric>,
@@ -333,9 +311,6 @@ where
         metric
             .labels
             .push(Label::new("code", code_to_str(resp.status())));
-        if let Some(extra_labels) = resp.extensions().get::<ExtraMetricLabels>() {
-            metric.labels.extend(extra_labels.0.iter().cloned());
-        }
         histogram!("http_response_duration_seconds", metric.labels.iter())
             .record(metric.start_inst.elapsed());
 
@@ -384,4 +359,63 @@ fn code_to_str(code: StatusCode) -> &'static str {
     assert!((MIN..=MAX).contains(&code));
     let pos = 3 * (code - MIN) as usize;
     &TABLE[pos..pos + 3]
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use metrics_exporter_prometheus::PrometheusBuilder;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn missing_matched_paths_use_bounded_unknown_endpoint() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+        let app = Router::new()
+            .route("/known", get(|| async { StatusCode::NO_CONTENT }))
+            .nest_service(
+                "/nested",
+                Router::new().route("/{id}", get(|| async { StatusCode::NO_CONTENT })),
+            )
+            .layer(MetricLayer::default());
+
+        for (uri, expected_status) in [
+            ("/unmatched/user-controlled", StatusCode::NOT_FOUND),
+            ("/nested/user-controlled", StatusCode::NO_CONTENT),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .body(Body::empty())
+                        .expect("build request"),
+                )
+                .await
+                .expect("serve request");
+            assert_eq!(response.status(), expected_status);
+        }
+
+        let exposition = handle.render();
+        for code in ["204", "404"] {
+            assert!(
+                exposition.lines().any(|line| {
+                    line.starts_with("http_requests_total{")
+                        && line.contains(&format!("code=\"{code}\""))
+                        && line.contains("endpoint=\"unknown\"")
+                }),
+                "missing MatchedPath must use the bounded unknown endpoint label, got:\n{exposition}"
+            );
+        }
+        assert!(
+            !exposition.contains("user-controlled"),
+            "raw request paths must not appear in metric labels, got:\n{exposition}"
+        );
+    }
 }

--- a/crates/pxe/src/middleware/mod.rs
+++ b/crates/pxe/src/middleware/mod.rs
@@ -20,10 +20,10 @@ use axum::http::uri::PathAndQuery;
 use axum::http::{Request, Uri};
 use axum::response::Response;
 
-pub mod logging;
-pub mod metrics;
+pub(super) mod logging;
+pub(super) mod metrics;
 
-pub async fn normalize_url<B>(mut request: Request<B>) -> Request<B> {
+pub(super) async fn normalize_url<B>(mut request: Request<B>) -> Request<B> {
     let uri = request.uri_mut();
     if let Some(p_q) = uri.path_and_query() {
         let path_and_query = p_q.to_string();
@@ -38,7 +38,7 @@ pub async fn normalize_url<B>(mut request: Request<B>) -> Request<B> {
 }
 
 // Converts content-length -> Content-Length to work with BMC http-download FW 24.07
-pub async fn fix_content_length_header<B>(mut response: Response<B>) -> Response<B> {
+pub(super) async fn fix_content_length_header<B>(mut response: Response<B>) -> Response<B> {
     if let Some(value) = response.headers_mut().remove("content-length") {
         response.headers_mut().insert("Content-Length", value);
     }
@@ -60,7 +60,7 @@ mod test {
 
     use super::*;
     #[tokio::test]
-    pub async fn test_url_normalize() {
+    async fn test_url_normalize() {
         let request = Request::builder()
             .uri("http://localhost:8080/api/v0/cloud-init//user-data")
             .body(())

--- a/crates/pxe/src/routes/cloud_init.rs
+++ b/crates/pxe/src/routes/cloud_init.rs
@@ -173,7 +173,7 @@ fn user_data_handler(
     ("user-data".to_string(), context)
 }
 
-pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoResponse {
+async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoResponse {
     let (template_key, template_data) = match (
         machine.instructions.custom_cloud_init,
         machine.instructions.discovery_instructions,
@@ -246,7 +246,7 @@ pub async fn user_data(machine: Machine, state: State<AppState>) -> impl IntoRes
     axum_template::Render(template_key, state.engine.clone(), template_data)
 }
 
-pub async fn meta_data(machine: Machine, state: State<AppState>) -> impl IntoResponse {
+async fn meta_data(machine: Machine, state: State<AppState>) -> impl IntoResponse {
     let (template_key, template_data) = match machine.instructions.metadata {
         None => log_and_generate_generic_error(
             format!("No metadata was found for machine {machine:?}"),
@@ -318,14 +318,14 @@ fn resolve_network_config(custom_cloud_init: Option<&str>) -> Cow<'static, str> 
 /// DEFAULT_NETWORK_CONFIG instead of an empty document, so hosts get
 /// DHCP on every interface by default rather than cloud-init's own
 /// first-interface-only behavior.
-pub async fn network_config(machine: Machine, state: State<AppState>) -> impl IntoResponse {
+async fn network_config(machine: Machine, state: State<AppState>) -> impl IntoResponse {
     let network_config_yaml =
         resolve_network_config(machine.instructions.custom_cloud_init.as_deref());
     let template_data = HashMap::from([("network_config", network_config_yaml)]);
     axum_template::Render("network-config", state.engine.clone(), template_data)
 }
 
-pub async fn vendor_data(state: State<AppState>) -> impl IntoResponse {
+async fn vendor_data(state: State<AppState>) -> impl IntoResponse {
     emit(PxeBootOutcome {
         endpoint: BootEndpoint::CloudInit,
         reason: OutcomeReason::Ok,
@@ -340,7 +340,7 @@ pub async fn vendor_data(state: State<AppState>) -> impl IntoResponse {
 /// Builds the PXE service's route table for the cloud-init-related
 /// endpoints served under `path_prefix`: `user-data`, `meta-data`,
 /// `vendor-data`, and `network-config`.
-pub fn get_router(path_prefix: &str) -> Router<AppState> {
+pub(crate) fn get_router(path_prefix: &str) -> Router<AppState> {
     Router::new()
         .route(
             format!("{}/{}", path_prefix, "user-data").as_str(),

--- a/crates/pxe/src/routes/ipxe.rs
+++ b/crates/pxe/src/routes/ipxe.rs
@@ -30,7 +30,7 @@ use crate::common::{AppState, Machine, MachineInterface};
 use crate::metrics::{BootEndpoint, OutcomeReason, PxeBootOutcome, PxeCustomIpxeFetchFailed};
 use crate::routes::RpcContext;
 
-pub enum PxeErrorCode {
+enum PxeErrorCode {
     ArchitectureNotFound = 105,
     InterfaceNotFound = 106,
     InstructionsEmpty = 107,
@@ -52,7 +52,7 @@ exit {error_code} ||
     )])
 }
 
-pub async fn whoami(machine: Machine, state: State<AppState>) -> impl IntoResponse {
+async fn whoami(machine: Machine, state: State<AppState>) -> impl IntoResponse {
     let (template_key, template_data) =
         if let Some(instructions) = machine.instructions.discovery_instructions {
             match (instructions.machine_interface, instructions.domain) {
@@ -98,7 +98,7 @@ pub async fn whoami(machine: Machine, state: State<AppState>) -> impl IntoRespon
     axum_template::Render(template_key, state.engine.clone(), template_data)
 }
 
-pub async fn boot(contents: MachineInterface, state: State<AppState>) -> impl IntoResponse {
+async fn boot(contents: MachineInterface, state: State<AppState>) -> impl IntoResponse {
     let (template_key, template_data) = match contents.architecture {
         Some(arch) => {
             // The wrapping `pxe` Tera template (pxe/templates/pxe) consumes:
@@ -206,7 +206,7 @@ exit 101 ||
     axum_template::Render(template_key, state.engine.clone(), template_data)
 }
 
-pub fn get_router(path_prefix: &str) -> Router<AppState> {
+pub(crate) fn get_router(path_prefix: &str) -> Router<AppState> {
     Router::new()
         .route(
             format!("{}/{}", path_prefix, "whoami").as_str(),

--- a/crates/pxe/src/routes/metrics.rs
+++ b/crates/pxe/src/routes/metrics.rs
@@ -52,7 +52,7 @@ async fn metrics(state: State<AppState>) -> ([(axum::http::HeaderName, &'static 
     )
 }
 
-pub fn get_router(path_prefix: &str) -> Router<AppState> {
+pub(crate) fn get_router(path_prefix: &str) -> Router<AppState> {
     Router::new().route(path_prefix, get(metrics))
 }
 

--- a/crates/pxe/src/routes/mod.rs
+++ b/crates/pxe/src/routes/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod ipxe;
 pub(crate) mod metrics;
 pub(crate) mod tls;
 
-pub struct RpcContext;
+struct RpcContext;
 
 impl RpcContext {
     async fn get_pxe_instructions(

--- a/crates/pxe/src/routes/tls.rs
+++ b/crates/pxe/src/routes/tls.rs
@@ -51,7 +51,7 @@ async fn root_ca(headers: HeaderMap, state: State<AppState>) -> impl IntoRespons
     }
 }
 
-pub fn get_router(path_prefix: &str) -> Router<AppState> {
+pub(crate) fn get_router(path_prefix: &str) -> Router<AppState> {
     Router::new().route(
         format!("{}/{}", path_prefix, "root_ca").as_str(),
         get(root_ca),

--- a/crates/pxe/src/rpc_error.rs
+++ b/crates/pxe/src/rpc_error.rs
@@ -19,19 +19,13 @@ use std::fmt::{Debug, Display};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum_client_ip::Rejection;
-use carbide_uuid::UuidConversionError;
-use rpc::errors::RpcDataConversionError;
 
-pub enum PxeRequestError {
+pub(super) enum PxeRequestError {
     CarbideApiError(tonic::Status),
     MissingClientConfig,
-    MissingMachineId,
     MissingIp(Rejection),
     InvalidBuildArch,
-    MalformedMachineId(String),
     MalformedBuildArch(String),
-    RpcConversion(RpcDataConversionError),
-    UuidConversion(UuidConversionError),
 }
 
 impl IntoResponse for PxeRequestError {
@@ -59,15 +53,10 @@ impl Display for PxeRequestError {
                 Self::MissingClientConfig =>
                     "Missing client configuration from server config (should not reach this case)"
                         .to_string(),
-                Self::MissingMachineId =>
-                    "Missing Machine Identifier (UUID) specified in URI parameter uuid".to_string(),
                 Self::InvalidBuildArch =>
                     "Invalid build arch specified in URI parameter buildarch".to_string(),
-                Self::MalformedMachineId(err) => format!("Malformed Machine UUID: {err}"),
                 Self::MalformedBuildArch(err) => format!("Malformed build arch: {err}"),
                 Self::MissingIp(err) => format!("Source IP is missing. Error: {err:?}"),
-                Self::RpcConversion(err) => format!("Error converting RPC data: {err:?}"),
-                Self::UuidConversion(err) => format!("Error converting RPC UUID data: {err:?}"),
             }
         )
     }
@@ -82,20 +71,14 @@ mod tests {
     #[derive(Clone, Copy, Debug)]
     enum ErrorCase {
         MissingClientConfig,
-        MissingMachineId,
         InvalidBuildArch,
-        MalformedMachineId,
         MalformedBuildArch,
     }
 
     fn error_for(case: ErrorCase) -> PxeRequestError {
         match case {
             ErrorCase::MissingClientConfig => PxeRequestError::MissingClientConfig,
-            ErrorCase::MissingMachineId => PxeRequestError::MissingMachineId,
             ErrorCase::InvalidBuildArch => PxeRequestError::InvalidBuildArch,
-            ErrorCase::MalformedMachineId => {
-                PxeRequestError::MalformedMachineId("bad uuid".to_string())
-            }
             ErrorCase::MalformedBuildArch => {
                 PxeRequestError::MalformedBuildArch("bad arch".to_string())
             }
@@ -120,12 +103,10 @@ mod tests {
         value_scenarios!(display_error:
             "missing inputs" {
                 ErrorCase::MissingClientConfig => "Missing client configuration from server config (should not reach this case)".to_string(),
-                ErrorCase::MissingMachineId => "Missing Machine Identifier (UUID) specified in URI parameter uuid".to_string(),
                 ErrorCase::InvalidBuildArch => "Invalid build arch specified in URI parameter buildarch".to_string(),
             }
 
             "malformed inputs" {
-                ErrorCase::MalformedMachineId => "Malformed Machine UUID: bad uuid".to_string(),
                 ErrorCase::MalformedBuildArch => "Malformed build arch: bad arch".to_string(),
             }
         );
@@ -136,9 +117,7 @@ mod tests {
         value_scenarios!(debug_matches_display:
             "debug" {
                 ErrorCase::MissingClientConfig => true,
-                ErrorCase::MissingMachineId => true,
                 ErrorCase::InvalidBuildArch => true,
-                ErrorCase::MalformedMachineId => true,
                 ErrorCase::MalformedBuildArch => true,
             }
         );
@@ -149,9 +128,7 @@ mod tests {
         value_scenarios!(response_status:
             "response status" {
                 ErrorCase::MissingClientConfig => StatusCode::BAD_REQUEST,
-                ErrorCase::MissingMachineId => StatusCode::BAD_REQUEST,
                 ErrorCase::InvalidBuildArch => StatusCode::BAD_REQUEST,
-                ErrorCase::MalformedMachineId => StatusCode::BAD_REQUEST,
                 ErrorCase::MalformedBuildArch => StatusCode::BAD_REQUEST,
             }
         );


### PR DESCRIPTION
This adopts the new style guide rules around module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout DHCP, DHCP Server, and PXE.

Primary callouts are:
- Replace unrestricted `pub` throughout `crates/dhcp/**`, `crates/dhcp-server/src/**`, and `crates/pxe/src/**` with private, `pub(super)`, or `pub(crate)` visibility based on actual callers.
- Keep the cbindgen-declared Kea hook ABI public and leave generated tonic declarations untouched behind a private module boundary.
- Gate cross-crate `mock_api_server` support behind an explicit `test-support` feature, with its mock-only dependency edges enabled by that feature and failure injection kept unit-only.
- Narrow DHCP integration-test fixtures under `tests/common/**` to the test crates and parent modules that actually use them.
- Remove callerless DHCP response/factory helpers, the redundant `machine_free_ntpservers` symbol, PXE's unused `ExtraMetricLabels` extension, and unused PXE error variants.
- Leave the cbindgen-declared Kea hook ABI, gRPC contract, DHCP/PXE protocol behavior, and metric names unchanged.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4552.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

All 59 DHCP unit tests, 38 DHCP integration tests, 29 DHCP Server tests, and 28 PXE tests pass. I also ran:

```bash
cargo test --locked -p carbide-dhcp --all-targets --all-features
cargo test --locked -p carbide-dhcp-server -p carbide-pxe --all-targets --all-features
cargo test --locked -p carbide-dhcp --no-default-features --all-targets --no-run
cargo check --locked -p carbide-dhcp --lib --no-default-features
cargo clippy --locked -p carbide-dhcp -p carbide-dhcp-server -p carbide-pxe --all-targets --all-features -- -D warnings
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
cargo make check-licenses
cargo make check-bans
cargo make check-workspace-deps
taplo fmt --check crates/dhcp/Cargo.toml
git diff --check
```

## Additional Notes

The initial compiler inventory found 242 overbroad declarations: 184 in DHCP, 35 in DHCP Server, and 23 in PXE. The final 44-file diff also includes the integration-test boundaries and callerless code exposed by that cleanup. The remaining unrestricted `pub` declarations are limited to the cbindgen-declared C ABI, explicit feature-gated integration-test support, and generated tonic declarations behind a private module.

Ubuntu's path-specific AppArmor profiles for `/usr/sbin/kea-dhcp4` and `/usr/sbin/kea-dhcp6` denied the test harness's temporary PID and lock paths. I ran the complete DHCP integration suite against SHA-256-identical executable copies outside those profiles, then restored the two temporary launch-path edits byte-for-byte; no temporary path remains in this diff.

Local CodeRabbit and the independent fresh-eyes review returned zero findings. The applicable read-only Claude findings around optional mock dependencies, private cache state, stale comments, and scope-equivalent visibility edits are incorporated. I declined one suggestion to expose unit-only failure injection through the integration-test feature because no integration caller needs that API.


Closes #4552
