### PR TITLE
docs: pull our type-boundary guidance into STYLE_GUIDE.md

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -159,6 +159,57 @@ See [`crates/test-support/src/lib.rs`](crates/test-support/src/lib.rs) for the f
 
 ## gRPC API definitions
 
+**Choose presence by meaning.** Keep protobuf, Rust, database, and update semantics aligned. For proto3, use:
+
+| Meaning | Representation |
+| --- | --- |
+| Unset differs from zero or the default for a scalar or enum | `optional` |
+| Zero or one structured value | A singular message |
+| Unset differs from empty for a collection | A wrapper message containing a repeated field |
+| Mutually exclusive alternatives | `oneof` |
+
+A `oneof` can be unset. If one member is required, reject an unset `oneof` with a documented validation error;
+otherwise, document whether omission is valid. Do not use a repeated field for zero-or-one data or wrap a scalar when
+`optional` is enough.
+
+Use `Option<T>` in Rust while unset matters. Store `NULL` only when absence is a valid database state. Omitting an
+update field does not require nullable storage.
+
+**Define create and update semantics.**
+
+- **Create:** state whether omission infers, defaults, or rejects the value. Document explicit zero or default values
+  and errors.
+- **Update:** state whether the request is a complete replacement or a patch. Replacements require callers to resubmit
+  unchanged fields and selector variants, and define whether missing values default or fail. Patches preserve omitted
+  fields and document how each supported operation maps from the wire to Rust and storage.
+- **Preserve, set, and clear:** when a patch supports these operations, use a field mask plus values and a clear
+  convention; an operation enum plus its value; or an update `oneof` whose omission means preserve and whose variants
+  mean set and clear. Represent all three in Rust with a nested `Option` or dedicated enum; plain `Option<T>` is not
+  enough.
+- **Field masks:** define how path selection and value presence interact, including whether a selected path with an
+  omitted value preserves, defaults, clears, or fails validation. Define precedence or rejection for overlapping parent
+  and child paths.
+
+For replacements and patches, document operation precedence, fallback behavior, explicit zero or default values,
+invalid field combinations, and errors.
+
+**Make modes explicit.** Use `oneof` or a separate request type when each mode accepts different fields. If an enum
+selects the mode while sibling fields remain, document the valid combinations and reject the rest. Prefer distinct
+methods or a semantic enum over a boolean that selects different operations. When a boolean is clearest, use a positive
+name with obvious `true` and `false` behavior. An implicit proto3 `bool` treats omission as `false`. Use it only when
+both states have the same meaning. If presence matters, use `optional bool` and document the omitted case, including
+any validation error.
+
+**Roll out required fields in order.**
+
+1. Deploy readers that accept omitted and present forms, with documented fallback and error behavior.
+2. Update all writers and backfill existing data.
+3. Verify mixed-version clients and rollback behavior.
+4. Enforce requiredness.
+
+If omission has no safe fallback, add a versioned boundary instead of making a wire or persisted field mandatory in
+place.
+
 - APIs to list resources and retrieve resource state should be paginated in order to scale to a high amount of managed
   resources. Pagination should be achieved in the following fashion:
   - An API call with the format `FindResourceNameIds` (e.g. `FindMachineIds`) should be used to list the IDs of all
@@ -903,6 +954,15 @@ and can't be exhaustively checked by the compiler. See
 [`ErrorCode`](crates/api-model/src/errors.rs) for the pattern: typed
 `ErrorSystem`/`ErrorSubsystem` parts plus a `code`, rendered to the wire string
 in one place. Reserve raw strings for genuinely open-ended values.
+
+**Parse once at the boundary.** Parse and validate structured values at an untyped interface, then keep the domain type
+internally. Prefer `IpAddr`, `Uri`, typed identifiers or enums, and typed serde structures over repeatedly parsing
+strings or generic JSON. Convert only at the interface that requires a string, bytes, number, or structured message.
+
+**Use a newtype only when it adds safety.** It should enforce an invariant or prevent values with the same representation
+from being confused. Otherwise, avoid it. Document the invariant and how invalid input is reported, or state that every
+underlying value is valid and the wrapper exists only to separate types. Test accepted and rejected values when
+applicable, plus each wire, serde, or database representation the type uses.
 
 ### Prefer methods over free functions
 


### PR DESCRIPTION
This is an attempt to capture the general NICo maintainer design principles and guidance around API presence and strong domain types for the codebase. This PR is derived from the pre-OSS review corpus as a whole -- years of MRs and tens of thousands of comments and discussions. As such, it leans into the guiding design decisions and principles used to define and grow the project into the product we have today.

The idea is to ensure we capture our core principles in `STYLE_GUIDE.md`. If any of those principles have changed, we should capture that too, ensuring we don't lose sight of why decisions were made as the codebase evolves with new contributors, human and agentic alike.

For this PR specifically, I focused on making API and internal types describe the real contract. The search surfaced related optionality, zero-value presence, mode-specific field, boolean-operation, identifier, address, and parse-once conversations throughout the corpus and across multiple participants.

This pulls out the recurring parts:

- Make optionality describe semantic absence across every layer.
- Use explicit presence when zero is valid and unset means something different.
- Use semantic operations and types when a boolean or group of optional fields hides distinct modes.
- Treat new mandatory wire or persisted fields as compatibility migrations.
- Parse and validate at the untyped boundary, then keep the domain type internally.

It also keeps the important exception that not every primitive needs a wrapper. A newtype should enforce an invariant or prevent a real mix-up, and each boundary representation it crosses should remain deliberate and tested.

Again, we can always adjust this now or later. The hope is that we don't lose the reasoning behind why we made certain decisions to get us where we are now, and can continue using that reasoning to help drive future decisions.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4625

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Validation passed with `cargo make format-nightly`, `cargo make clippy`, `cargo make carbide-lints`, `rumdl check --config docs/.rumdl.toml STYLE_GUIDE.md`, `git diff --check`, and Pandoc rendering. No tests were run because this is documentation-only.

## Additional Notes

This deliberately does not recommend wrapping every primitive. A newtype should add safety, and representation tests are expected only for the boundaries that type actually crosses.

Closes #4625
