### PR TITLE
fix(cicd): make the Core gate cover every Core job

### DIFF
--- a/.github/ci/check_core_ci_gate.py
+++ b/.github/ci/check_core_ci_gate.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep every Core CI job accounted for by the final required check.
+
+GitHub Actions makes `needs` a static list: it waits for the jobs named there,
+but adding a new top-level job does not update `core-ci-pass` or warn us that
+the job was omitted. The `inventory` command reads the small part of the
+workflow used by the gate and requires every job to be gated or explicitly
+exempted. It also protects the gate's `if: always()` condition so a failed
+dependency cannot skip the required check.
+
+The `results` command evaluates `${{ toJson(needs) }}` from `NEEDS_JSON`.
+`success` and `skipped` pass because conditional jobs legitimately omit work.
+Every gated top-level job is listed independently, so an upstream failure stays
+visible even when it makes downstream jobs skip. Any other or malformed result
+fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+GATE_JOB = "core-ci-pass"
+EXEMPT_JOBS = {
+    "build-summary": (
+        "This reporting-only job writes the Actions summary and does not validate "
+        "build output."
+    ),
+    "notify-build-status": (
+        "This administrative job reports the completed build to Slack on protected refs."
+    ),
+    GATE_JOB: "A job cannot depend on itself.",
+}
+
+# We only need the root job IDs plus `core-ci-pass.if` and
+# `core-ci-pass.needs`. Keep this grammar deliberately narrow and reject
+# unfamiliar formatting: silently skipping a line could let a job escape the
+# required check.
+JOB_KEY = re.compile(r"^  (?P<job>[A-Za-z_][A-Za-z0-9_-]*):(?:\s*#.*)?$")
+NEEDS_ITEM = re.compile(r"^      - (?P<job>[A-Za-z_][A-Za-z0-9_-]*)(?:\s*#.*)?$")
+GATE_IF = re.compile(r"^    if:\s*(?P<condition>.*)$")
+PASSING_RESULTS = frozenset({"success", "skipped"})
+
+
+class WorkflowFormatError(ValueError):
+    """The workflow does not use the job layout this checker can verify."""
+
+
+@dataclass(frozen=True)
+class WorkflowInventory:
+    """The gate policy extracted from one workflow.
+
+    `jobs` keeps every top-level job ID in declaration order. `gate_needs`
+    keeps the gate's direct dependencies in their written order, including
+    duplicates, so the inventory check can report invalid entries instead of
+    normalizing them.
+    """
+
+    jobs: tuple[str, ...]
+    gate_needs: tuple[str, ...]
+
+
+def _leading_spaces(line: str) -> int:
+    """Return the number of literal spaces at the start of `line`."""
+
+    return len(line) - len(line.lstrip(" "))
+
+
+def _find_jobs(lines: list[str]) -> tuple[list[str], dict[str, int]]:
+    """Return every top-level job and its first line in the workflow."""
+
+    jobs_blocks = [index for index, line in enumerate(lines) if line == "jobs:"]
+    if len(jobs_blocks) != 1:
+        raise WorkflowFormatError(
+            f"expected one root `jobs` block, found {len(jobs_blocks)}"
+        )
+
+    jobs: list[str] = []
+    positions: dict[str, int] = {}
+    for index in range(jobs_blocks[0] + 1, len(lines)):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+
+        indentation = _leading_spaces(line)
+        if indentation == 0:
+            break
+        if indentation != 2:
+            continue
+
+        match = JOB_KEY.fullmatch(line)
+        if match is None:
+            raise WorkflowFormatError(
+                f"line {index + 1} is not a supported top-level job declaration: {line!r}"
+            )
+
+        job = match.group("job")
+        if job in positions:
+            raise WorkflowFormatError(f"top-level job `{job}` is declared more than once")
+        jobs.append(job)
+        positions[job] = index
+
+    if not jobs:
+        raise WorkflowFormatError("the root `jobs` block contains no top-level jobs")
+
+    return jobs, positions
+
+
+def _parse_gate(
+    lines: list[str], jobs: list[str], positions: Mapping[str, int]
+) -> list[str]:
+    """Protect the gate condition and read its complete block-style `needs` list."""
+
+    gate_start = positions.get(GATE_JOB)
+    if gate_start is None:
+        raise WorkflowFormatError(f"the workflow does not define `{GATE_JOB}`")
+
+    gate_index = jobs.index(GATE_JOB)
+    gate_end = (
+        positions[jobs[gate_index + 1]] if gate_index + 1 < len(jobs) else len(lines)
+    )
+
+    gate_conditions = [
+        match.group("condition")
+        for index in range(gate_start + 1, gate_end)
+        if (match := GATE_IF.fullmatch(lines[index])) is not None
+    ]
+    if len(gate_conditions) != 1:
+        raise WorkflowFormatError(
+            f"expected one gate-level `if` on `{GATE_JOB}`, "
+            f"found {len(gate_conditions)}"
+        )
+    if gate_conditions[0] != "always()":
+        raise WorkflowFormatError(
+            f"`{GATE_JOB}.if` must be `always()`, found {gate_conditions[0]!r}"
+        )
+
+    needs_lines = [
+        index
+        for index in range(gate_start + 1, gate_end)
+        if lines[index] == "    needs:"
+    ]
+    if len(needs_lines) != 1:
+        raise WorkflowFormatError(
+            f"expected one block-style `needs` list on `{GATE_JOB}`, found {len(needs_lines)}"
+        )
+
+    needs: list[str] = []
+    for index in range(needs_lines[0] + 1, gate_end):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indentation = _leading_spaces(line)
+        if indentation == 4 and line.startswith("    - "):
+            raise WorkflowFormatError(
+                f"line {index + 1} must indent `{GATE_JOB}.needs` items "
+                f"by six spaces: {line!r}"
+            )
+        if indentation <= 4:
+            break
+
+        match = NEEDS_ITEM.fullmatch(line)
+        if match is None:
+            raise WorkflowFormatError(
+                f"line {index + 1} is not a supported `{GATE_JOB}.needs` item: {line!r}"
+            )
+        needs.append(match.group("job"))
+
+    if not needs:
+        raise WorkflowFormatError(f"`{GATE_JOB}.needs` contains no jobs")
+
+    return needs
+
+
+def parse_workflow(workflow_text: str) -> WorkflowInventory:
+    """Parse the small part of a GitHub Actions workflow the gate relies on."""
+
+    lines = workflow_text.splitlines()
+    jobs, positions = _find_jobs(lines)
+    gate_needs = _parse_gate(lines, jobs, positions)
+    return WorkflowInventory(jobs=tuple(jobs), gate_needs=tuple(gate_needs))
+
+
+def _inventory_errors(
+    inventory: WorkflowInventory, exemptions: Mapping[str, str]
+) -> list[str]:
+    """Explain invalid classifications in an already parsed inventory."""
+
+    errors: list[str] = []
+    jobs = set(inventory.jobs)
+    gated_jobs = set(inventory.gate_needs)
+    exempt_jobs = set(exemptions)
+
+    duplicate_needs = sorted(
+        job for job, count in Counter(inventory.gate_needs).items() if count > 1
+    )
+    if duplicate_needs:
+        errors.append(
+            "gate dependencies are listed more than once: " + ", ".join(duplicate_needs)
+        )
+
+    unknown_needs = sorted(gated_jobs - jobs)
+    if unknown_needs:
+        errors.append(
+            "gate dependencies are not top-level jobs: " + ", ".join(unknown_needs)
+        )
+
+    unknown_exemptions = sorted(exempt_jobs - jobs)
+    if unknown_exemptions:
+        errors.append(
+            "exemptions are not top-level jobs: " + ", ".join(unknown_exemptions)
+        )
+
+    empty_reasons = sorted(job for job, reason in exemptions.items() if not reason.strip())
+    if empty_reasons:
+        errors.append("exemptions need a reason: " + ", ".join(empty_reasons))
+
+    duplicate_classifications = sorted(gated_jobs & exempt_jobs)
+    if duplicate_classifications:
+        errors.append(
+            "jobs cannot be both gated and exempt: "
+            + ", ".join(duplicate_classifications)
+        )
+
+    missing_jobs = sorted(jobs - gated_jobs - exempt_jobs)
+    if missing_jobs:
+        errors.append("top-level jobs are not gated or exempt: " + ", ".join(missing_jobs))
+
+    return errors
+
+
+def inventory_errors(
+    workflow_text: str, exemptions: Mapping[str, str] = EXEMPT_JOBS
+) -> list[str]:
+    """Parse the workflow and explain every invalid gate classification."""
+
+    try:
+        inventory = parse_workflow(workflow_text)
+    except WorkflowFormatError as error:
+        return [str(error)]
+
+    return _inventory_errors(inventory, exemptions)
+
+
+def result_errors(needs_context: Mapping[str, object]) -> list[str]:
+    """Return an error for every non-passing result in `needs_context`.
+
+    The accepted status values are `success` and `skipped`. An empty context,
+    malformed job entry, or any other status fails closed.
+    """
+
+    if not needs_context:
+        return ["the gate received no job results"]
+
+    errors: list[str] = []
+    for job, details in sorted(needs_context.items()):
+        if not isinstance(details, Mapping):
+            errors.append(f"`{job}` did not provide a job result object")
+            continue
+
+        result = details.get("result")
+        if result == "failure":
+            errors.append(f"`{job}` failed")
+        elif result == "cancelled":
+            errors.append(f"`{job}` was cancelled")
+        elif result not in PASSING_RESULTS:
+            errors.append(f"`{job}` returned unsupported result {result!r}")
+
+    return errors
+
+
+def _print_annotations(errors: list[str]) -> None:
+    """Write each error using GitHub Actions' workflow-command format."""
+
+    for error in errors:
+        print(f"::error::{error}")
+
+
+def _check_inventory(workflow_path: Path) -> int:
+    """Check one workflow file and report inventory errors as annotations.
+
+    Returns zero only when the file is readable, uses the supported layout,
+    protects the gate condition, and classifies every top-level job.
+    """
+
+    try:
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+    except OSError as error:
+        _print_annotations([f"could not read `{workflow_path}`: {error}"])
+        return 1
+
+    try:
+        inventory = parse_workflow(workflow_text)
+    except WorkflowFormatError as error:
+        _print_annotations([str(error)])
+        return 1
+
+    errors = _inventory_errors(inventory, EXEMPT_JOBS)
+    if errors:
+        _print_annotations(errors)
+        return 1
+
+    print(
+        f"Core CI gate accounts for {len(inventory.jobs)} top-level jobs "
+        f"({len(inventory.gate_needs)} gated, {len(EXEMPT_JOBS)} exempt)."
+    )
+    return 0
+
+
+def _check_results() -> int:
+    """Check `NEEDS_JSON` and report invalid job results as annotations.
+
+    Each dependency is printed for the Actions log. Returns zero only when the
+    input is valid and every dependency passes `result_errors`.
+    """
+
+    needs_json = os.environ.get("NEEDS_JSON")
+    if needs_json is None:
+        _print_annotations(["`NEEDS_JSON` is not set"])
+        return 1
+
+    try:
+        needs_context = json.loads(needs_json)
+    except json.JSONDecodeError as error:
+        _print_annotations([f"`NEEDS_JSON` is not valid JSON: {error}"])
+        return 1
+    if not isinstance(needs_context, Mapping):
+        _print_annotations(["`NEEDS_JSON` must contain a JSON object"])
+        return 1
+
+    for job, details in sorted(needs_context.items()):
+        result = details.get("result") if isinstance(details, Mapping) else None
+        print(f"{job}: {result}")
+
+    errors = result_errors(needs_context)
+    if errors:
+        _print_annotations(errors)
+        return 1
+
+    print("All required jobs succeeded or were intentionally skipped.")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse the selected check and its command-specific arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Check the Core CI final gate inventory and job results."
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    inventory = commands.add_parser(
+        "inventory", help="verify that every top-level job is gated or exempt"
+    )
+    inventory.add_argument("workflow", type=Path)
+    commands.add_parser("results", help="evaluate the job results in `NEEDS_JSON`")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the requested gate check."""
+
+    args = _parse_args()
+    if args.command == "inventory":
+        return _check_inventory(args.workflow)
+    return _check_results()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/ci/test_check_core_ci_gate.py
+++ b/.github/ci/test_check_core_ci_gate.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Core CI final-gate inventory and result checks."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import textwrap
+import unittest
+from unittest import mock
+
+from check_core_ci_gate import _check_results, inventory_errors, result_errors
+
+
+COMPLETE_WORKFLOW = textwrap.dedent(
+    """\
+    name: Core fixture
+
+    jobs:
+      changes:
+        runs-on: ubuntu-latest
+      build:
+        runs-on: ubuntu-latest
+      build-summary:
+        runs-on: ubuntu-latest
+      notify-build-status:
+        runs-on: ubuntu-latest
+      core-ci-pass:
+        runs-on: ubuntu-latest
+        if: always()
+        needs:
+          - changes
+          - build
+        steps:
+          - run: true
+    """
+)
+
+EXEMPTIONS = {
+    "build-summary": "Reports the completed build.",
+    "notify-build-status": "Sends the administrative notification.",
+    "core-ci-pass": "A job cannot depend on itself.",
+}
+
+
+class InventoryTests(unittest.TestCase):
+    """Verify that every workflow job has exactly one gate classification."""
+
+    def test_inventory_classification(self) -> None:
+        cases = (
+            {
+                "name": "complete inventory",
+                "workflow": COMPLETE_WORKFLOW,
+                "exemptions": EXEMPTIONS,
+                "expected": [],
+            },
+            {
+                "name": "missing gate dependency",
+                "workflow": COMPLETE_WORKFLOW.replace("      - build\n", ""),
+                "exemptions": EXEMPTIONS,
+                "expected": ["top-level jobs are not gated or exempt: build"],
+            },
+            {
+                "name": "unknown exemption",
+                "workflow": COMPLETE_WORKFLOW,
+                "exemptions": {**EXEMPTIONS, "retired-job": "No longer used."},
+                "expected": ["exemptions are not top-level jobs: retired-job"],
+            },
+            {
+                "name": "unknown gate dependency",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "      - build\n", "      - build\n      - retired-job\n"
+                ),
+                "exemptions": EXEMPTIONS,
+                "expected": [
+                    "gate dependencies are not top-level jobs: retired-job"
+                ],
+            },
+            {
+                "name": "duplicate classification",
+                "workflow": COMPLETE_WORKFLOW,
+                "exemptions": {**EXEMPTIONS, "build": "Fixture duplicate."},
+                "expected": ["jobs cannot be both gated and exempt: build"],
+            },
+            {
+                "name": "duplicate gate dependency",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "      - build\n", "      - build\n      - build\n"
+                ),
+                "exemptions": EXEMPTIONS,
+                "expected": ["gate dependencies are listed more than once: build"],
+            },
+            {
+                "name": "empty exemption reason",
+                "workflow": COMPLETE_WORKFLOW,
+                "exemptions": {**EXEMPTIONS, "build-summary": ""},
+                "expected": ["exemptions need a reason: build-summary"],
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                self.assertEqual(
+                    inventory_errors(case["workflow"], case["exemptions"]),
+                    case["expected"],
+                )
+
+    def test_required_workflow_sections(self) -> None:
+        cases = (
+            {
+                "name": "missing jobs block",
+                "workflow": COMPLETE_WORKFLOW.replace("jobs:\n", "pipelines:\n"),
+                "expected": "expected one root `jobs` block, found 0",
+            },
+            {
+                "name": "missing gate job",
+                "workflow": COMPLETE_WORKFLOW.replace("core-ci-pass:", "retired-gate:"),
+                "expected": "the workflow does not define `core-ci-pass`",
+            },
+            {
+                "name": "missing gate needs",
+                "workflow": COMPLETE_WORKFLOW.replace("    needs:\n", "    dependencies:\n"),
+                "expected": (
+                    "expected one block-style `needs` list on `core-ci-pass`, found 0"
+                ),
+            },
+            {
+                "name": "missing gate condition",
+                "workflow": COMPLETE_WORKFLOW.replace("    if: always()\n", ""),
+                "expected": (
+                    "expected one gate-level `if` on `core-ci-pass`, found 0"
+                ),
+            },
+            {
+                "name": "wrong gate condition",
+                "workflow": COMPLETE_WORKFLOW.replace("if: always()", "if: success()"),
+                "expected": "`core-ci-pass.if` must be `always()`, found 'success()'",
+            },
+            {
+                "name": "duplicate gate condition",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "    if: always()\n",
+                    "    if: always()\n    if: always()\n",
+                ),
+                "expected": (
+                    "expected one gate-level `if` on `core-ci-pass`, found 2"
+                ),
+            },
+            {
+                "name": "duplicate top-level job",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "  build:\n    runs-on: ubuntu-latest\n",
+                    "  build:\n    runs-on: ubuntu-latest\n"
+                    "  build:\n    runs-on: ubuntu-latest\n",
+                ),
+                "expected": "top-level job `build` is declared more than once",
+            },
+            {
+                "name": "malformed top-level job",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "  build:\n    runs-on: ubuntu-latest\n",
+                    "  build: {runs-on: ubuntu-latest}\n",
+                ),
+                "expected": (
+                    "line 6 is not a supported top-level job declaration: "
+                    "'  build: {runs-on: ubuntu-latest}'"
+                ),
+            },
+            {
+                "name": "malformed gate dependency",
+                "workflow": COMPLETE_WORKFLOW.replace("      - build\n", "      - [build]\n"),
+                "expected": (
+                    "line 17 is not a supported `core-ci-pass.needs` item: "
+                    "'      - [build]'"
+                ),
+            },
+            {
+                "name": "empty gate dependencies",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "      - changes\n      - build\n", ""
+                ),
+                "expected": "`core-ci-pass.needs` contains no jobs",
+            },
+            {
+                "name": "under-indented gate dependency",
+                "workflow": COMPLETE_WORKFLOW.replace(
+                    "      - changes\n", "    - changes\n"
+                ),
+                "expected": (
+                    "line 16 must indent `core-ci-pass.needs` items by six spaces: "
+                    "'    - changes'"
+                ),
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                self.assertEqual(inventory_errors(case["workflow"]), [case["expected"]])
+
+
+class ResultTests(unittest.TestCase):
+    """Verify the final gate's success, skip, and fail-closed result policy."""
+
+    def test_gate_result_policy(self) -> None:
+        cases = (
+            {
+                "name": "success",
+                "result": "success",
+                "expected": [],
+            },
+            {
+                "name": "intentional skip",
+                "result": "skipped",
+                "expected": [],
+            },
+            {
+                "name": "failure",
+                "result": "failure",
+                "expected": ["`fixture-job` failed"],
+            },
+            {
+                "name": "cancellation",
+                "result": "cancelled",
+                "expected": ["`fixture-job` was cancelled"],
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                needs_context = {"fixture-job": {"result": case["result"]}}
+                self.assertEqual(result_errors(needs_context), case["expected"])
+
+    def test_non_mapping_job_result_is_rejected(self) -> None:
+        self.assertEqual(
+            result_errors({"fixture-job": "success"}),
+            ["`fixture-job` did not provide a job result object"],
+        )
+
+    def test_result_command_accepts_healthy_context(self) -> None:
+        needs_json = (
+            '{"successful-job":{"result":"success"},'
+            '"skipped-job":{"result":"skipped"}}'
+        )
+        output = io.StringIO()
+        with mock.patch.dict(os.environ, {"NEEDS_JSON": needs_json}):
+            with contextlib.redirect_stdout(output):
+                return_code = _check_results()
+
+        self.assertEqual(return_code, 0)
+        self.assertNotIn("::error::", output.getvalue())
+        self.assertIn(
+            "All required jobs succeeded or were intentionally skipped.",
+            output.getvalue(),
+        )
+
+    def test_result_command_rejects_invalid_context(self) -> None:
+        cases = (
+            {
+                "name": "malformed JSON",
+                "needs_json": "{",
+                "expected": "::error::`NEEDS_JSON` is not valid JSON:",
+            },
+            {
+                "name": "empty context",
+                "needs_json": "{}",
+                "expected": "::error::the gate received no job results",
+            },
+            {
+                "name": "non-mapping JSON",
+                "needs_json": "[]",
+                "expected": "::error::`NEEDS_JSON` must contain a JSON object",
+            },
+            {
+                "name": "unsupported result",
+                "needs_json": '{"fixture-job":{"result":"waiting"}}',
+                "expected": (
+                    "::error::`fixture-job` returned unsupported result 'waiting'"
+                ),
+            },
+            {
+                "name": "missing result",
+                "needs_json": '{"fixture-job":{}}',
+                "expected": (
+                    "::error::`fixture-job` returned unsupported result None"
+                ),
+            },
+            {
+                "name": "null result",
+                "needs_json": '{"fixture-job":{"result":null}}',
+                "expected": (
+                    "::error::`fixture-job` returned unsupported result None"
+                ),
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                output = io.StringIO()
+                with mock.patch.dict(os.environ, {"NEEDS_JSON": case["needs_json"]}):
+                    with contextlib.redirect_stdout(output):
+                        return_code = _check_results()
+
+                self.assertEqual(return_code, 1)
+                self.assertIn(case["expected"], output.getvalue())
+
+    def test_result_command_rejects_missing_context(self) -> None:
+        output = io.StringIO()
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with contextlib.redirect_stdout(output):
+                return_code = _check_results()
+
+        self.assertEqual(return_code, 1)
+        self.assertIn("::error::`NEEDS_JSON` is not set", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,12 @@ jobs:
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 
+      - name: Test Core CI final-gate checker
+        run: python3 -B .github/ci/test_check_core_ci_gate.py
+
+      - name: Check Core CI final-gate inventory
+        run: python3 -B .github/ci/check_core_ci_gate.py inventory .github/workflows/ci.yaml
+
       - name: Detect non-rest changes
         id: non-rest-changes
         if: startsWith(github.ref, 'refs/heads/pull-request/')
@@ -1458,6 +1464,9 @@ jobs:
 
   proto-breaking-changes:
     name: Proto Breaking Changes Check
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.run_core_ci == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -2128,61 +2137,100 @@ jobs:
       slack-bot-token: ${{ secrets.CDS_SLACK_BOT_OAUTH_TOKEN }}
 
   # ============================================================================
-  # AGGREGATOR — single required check for branch protection
+  # FINAL CORE CI GATE
   # ============================================================================
-  # Fails iff any required job listed in `needs` is `failure` or `cancelled`.
+  # Passes only when every required job reports `success` or `skipped`.
   # `skipped` counts as pass — that's how rest-only PRs unblock when the
   # `changes` gate intentionally skips the core pipeline.
-  # Every stage of each gated release chain is listed so an upstream failure
-  # cannot be hidden when its downstream jobs become SKIPPED.
-  # `changes` + `prepare` are also included so a gate or prepare failure doesn't
-  # silently pass.
-  # Branch protection ruleset should require ONLY this aggregator + rest-ci-pass.
+  # Any other result, plus missing or malformed data, fails closed.
+  # Every job that can determine Core CI health is listed so an upstream
+  # failure cannot be hidden when its downstream jobs become `skipped`.
+  # Reporting-only jobs are explicitly exempted, and the checker in `changes`
+  # rejects every job that is neither gated nor exempted.
+  # The checker also protects `if: always()` so a failed dependency cannot skip
+  # this required check.
+  # Branch protection should require only this gate and `rest-ci-pass`.
   core-ci-pass:
     name: core-ci-pass
     runs-on: ubuntu-latest
     if: always()
     needs:
+      # Detection and preparation
       - changes
       - prepare
-      # x86_64 release-container chain
+
+      # Build, runtime, and artifact base images
       - build-container-x86_64
-      - build-runtime-container-x86_64
-      - build-release-container-x86_64
-      # aarch64 release-container chain
       - build-container-aarch64
+      - build-runtime-container-x86_64
       - build-runtime-container-aarch64
-      - build-release-container-aarch64
-      - test-release-container-services
-      # x86_64 release-artifact chain
       - build-artifacts-container-x86_64
-      - build-boot-artifacts-x86
-      - build-boot-artifacts-ephemeral-image-x86-host
-      - build-release-artifacts-x86-host
-      # aarch64 release-artifact chain
       - build-artifacts-container-aarch64
-      - build-boot-artifacts-bfb
-      - build-boot-artifacts-ephemeral-image-arm-host
-      - build-release-artifacts-arm-host
-      - security-secret-scan
-      - lint-police
-      - migration-police
-      - check-rest-core-proto-sync
+
+      # Release containers and service builds
+      - build-release-container-x86_64
+      - build-release-container-aarch64
+      - merge-manifests-nvmetal-carbide
       - build-machine-a-tron
       - build-mat-k8s-controller
+      - test-release-container-services
+
+      # CLI images
+      - build-forge-cli-x86_64
+      - build-forge-cli-aarch64
+      - merge-manifests-forge-cli
+
+      # Boot and release artifacts
+      - build-boot-artifacts-x86
+      - build-boot-artifacts-bfb
+      - build-boot-artifacts-ephemeral-image-x86-host
+      - build-boot-artifacts-ephemeral-image-arm-host
+      - build-release-artifacts-x86-host
+      - build-release-artifacts-arm-host
+
+      # Security checks
+      - security-secret-scan
+      - security-codeql-scan
+
+      # Machine validation images
+      - build-release-machine-validation-runner
+      - build-release-machine-validation-artifacts-x86-host
+      - build-release-machine-validation-artifacts-arm-host
+      - merge-manifests-machine-validation
+
+      # Source and repository policy checks
+      - proto-police
+      - lint-police
+      - migration-police
+      - proto-breaking-changes
+      - check-rest-core-proto-sync
+
+      # Core Helm charts
+      - build-validate-helm-chart
+      - build-push-helm-chart
+      - build-validate-helm-prereqs-chart
+      - build-push-helm-prereqs-chart
+
+      # BlueField binaries, images, and charts
+      - build-bluefield-binaries
+      - build-bluefield-otelcol-contrib
+      - build-bluefield-transceiver-exporter
+      - download-mft-aarch64
+      - build-bluefield-forge-dpu-agent
+      - build-bluefield-forge-dhcp-server
+      - build-bluefield-carbide-fmds
+      - build-validate-bluefield-helm-charts
+      - build-push-bluefield-helm-charts
+
+      # Post-build publication
+      - promote-to-be-scanned-image
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Decide pass/fail
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
-        run: |
-          set -euo pipefail
-          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
-          if echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | map(select(.value.result == "failure" or .value.result == "cancelled"))
-            | length > 0
-          ' >/dev/null; then
-            echo "::error::One or more required jobs failed or were cancelled"
-            exit 1
-          fi
-          echo "All required jobs OK (success or skipped)"
+        run: python3 -B .github/ci/check_core_ci_gate.py results


### PR DESCRIPTION
`core-ci-pass` was only waiting on part of the workflow, which meant an unlisted build could fail while the protected check still reported green. This makes it wait on every current substantive Core job and checks that inventory before the expensive work starts.

- **Expected green-run effect:** No speedup. The final gate may finish later because it now waits for every job it represents.
- **What it really buys us:** `core-ci-pass` cannot report green while a known Core job is red, and a future top-level job cannot quietly sit outside the gate.

Intentional skips remain accepted, while failures, cancellations, malformed results, and unknown inventory entries stop the gate. The inventory check also requires `if: always()` on the gate, because otherwise a failing dependency could skip the protected check entirely. `proto-breaking-changes` now uses the Core classifier as well, so REST-only PRs do not pick up a Core-only check just because the final gate became complete.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4649

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

```bash
python3 -B .github/ci/test_check_core_ci_gate.py
python3 -B .github/ci/check_core_ci_gate.py inventory .github/workflows/ci.yaml
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
```

## Additional Notes

The gate intentionally does not exempt a job because it has been flaky or depends on the network -- a red Core job needs to make the protected Core result red. Reliability work for those jobs can stay separate from the question of whether the gate reports them.

`core-ci-pass` inherits the workflow-wide `contents: read` token baseline from #4656. Merge #4656 first so the permission policy stays centralized and checked instead of being duplicated on this one job.

This does not change the repository ruleset itself. It makes the existing `core-ci-pass` check accurately represent the workflow the ruleset already relies on; #4586 still owns the later classifier-aware selected/full policy and timing report.


Closes #4649
