### PR TITLE
fix(cicd): reject incomplete boot outputs before upload

### DIFF
--- a/.github/ci/test_validate_boot_outputs.py
+++ b/.github/ci/test_validate_boot_outputs.py
@@ -1,0 +1,430 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for Core boot and ephemeral output validation.
+
+Run from the repository root with
+`python3 -m unittest discover -s .github/ci -p 'test_validate_boot_outputs.py'`.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+
+from validate_boot_outputs import (
+    CONTRACTS,
+    ArtifactContract,
+    BuildIdentity,
+    main,
+    validate_outputs,
+)
+
+
+EXPECTED_BUILD_IDENTITIES = {
+    ("boot", "x86_64"): BuildIdentity(
+        cargo_make_task="build-boot-artifacts-x86-host-ci",
+        build_type="boot",
+        arch="x86_64",
+    ),
+    ("boot", "aarch64"): BuildIdentity(
+        cargo_make_task="build-boot-artifacts-bfb-ci",
+        build_type="boot",
+        arch="aarch64",
+    ),
+    ("ephemeral", "x86_64"): BuildIdentity(
+        cargo_make_task="create-ephemeral-image-x86-host-ci",
+        build_type="ephemeral",
+        arch="x86_64",
+    ),
+    ("ephemeral", "aarch64"): BuildIdentity(
+        cargo_make_task="create-ephemeral-image-arm-host-ci",
+        build_type="ephemeral",
+        arch="aarch64",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ValidationCase:
+    """Files and expected error for one table-driven contract fixture.
+
+    Attributes:
+        name: Description shown by `unittest` when the subtest fails.
+        omit: Required pattern whose fixture file should not be written.
+        empty: Required pattern whose fixture file should contain zero bytes.
+        include_optional: Whether to write every optional diagnostic file.
+        include_disabled: Whether to write every deliberately disabled file.
+        expected_error: Error this fixture must report, or `None` when the
+            contract should pass without errors.
+    """
+
+    name: str
+    omit: str | None = None
+    empty: str | None = None
+    include_optional: bool = False
+    include_disabled: bool = False
+    expected_error: str | None = None
+
+
+def concrete_path(pattern: str) -> Path:
+    """Replace each `*` in a contract pattern with a stable fixture name."""
+
+    return Path(pattern.replace("*", "fixture"))
+
+
+def write_output(root: Path, pattern: str, content: bytes = b"artifact") -> None:
+    """Write one fixture file for an exact path or `*` contract pattern.
+
+    Args:
+        root: Temporary repository root for the fixture.
+        pattern: Exact path or glob to turn into one concrete fixture path.
+        content: Bytes written to the fixture file.
+    """
+
+    output = root / concrete_path(pattern)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(content)
+
+
+def populate_contract(
+    root: Path,
+    contract: ArtifactContract,
+    *,
+    omit: str | None = None,
+    empty: str | None = None,
+    include_optional: bool = False,
+    include_disabled: bool = False,
+) -> None:
+    """Write the requested contract fixture under `root`.
+
+    Required files are written by default. `omit` and `empty` select one
+    required pattern to remove or empty, while the two booleans opt into files
+    that are absent from an ordinary successful fixture.
+
+    Args:
+        root: Temporary repository root for the fixture.
+        contract: Paths used to populate the fixture.
+        omit: Required pattern to leave absent.
+        empty: Required pattern to create as a zero-byte file.
+        include_optional: Whether to write optional diagnostic files.
+        include_disabled: Whether to write deliberately disabled files.
+    """
+
+    for pattern in contract.required:
+        if pattern == omit:
+            continue
+        write_output(root, pattern, b"" if pattern == empty else b"artifact")
+
+    if include_optional:
+        for pattern in contract.optional:
+            write_output(root, pattern)
+
+    if include_disabled:
+        for pattern in contract.disabled:
+            write_output(root, pattern)
+
+
+class ValidateBootOutputsTests(unittest.TestCase):
+    """Verify every builder contract and its filesystem failure modes."""
+
+    def test_contracts_classify_every_active_build_once(self) -> None:
+        self.assertEqual(set(CONTRACTS), set(EXPECTED_BUILD_IDENTITIES.values()))
+
+        for build_identity, contract in CONTRACTS.items():
+            with self.subTest(build_identity=build_identity):
+                required = set(contract.required)
+                optional = set(contract.optional)
+                disabled = set(contract.disabled)
+
+                self.assertTrue(required)
+                self.assertEqual(len(contract.required), len(required))
+                self.assertEqual(required & optional, set())
+                self.assertEqual(required & disabled, set())
+                self.assertEqual(optional & disabled, set())
+
+    def test_required_outputs_are_inside_the_uploaded_paths(self) -> None:
+        # This mirrors the `Upload artifacts` path list in
+        # build-boot-artifacts.yml. Update both when that list changes.
+        upload_paths = (
+            "pxe/static/blobs/",
+            "target/debs/",
+            "target/aarch64-unknown-linux-gnu/release/forge-scout",
+        )
+
+        for build_identity, contract in CONTRACTS.items():
+            with self.subTest(build_identity=build_identity):
+                outside_upload = {
+                    pattern
+                    for pattern in contract.required
+                    if not any(pattern.startswith(path) for path in upload_paths)
+                }
+                self.assertEqual(outside_upload, set())
+
+    def test_every_active_contract_accepts_complete_outputs(self) -> None:
+        for build_identity, contract in CONTRACTS.items():
+            with self.subTest(build_identity=build_identity):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    populate_contract(root, contract, include_optional=True)
+
+                    self.assertEqual(validate_outputs(root, contract), [])
+
+    def test_ephemeral_contracts_keep_downloaded_boot_inputs(self) -> None:
+        # Keep this inventory independent from the production constants. A
+        # boot-input change must update this reviewable handoff contract too.
+        expected_boot_inputs = {
+            "x86_64": {
+                "pxe/static/blobs/internal/x86_64/ipxe.efi",
+                "pxe/static/blobs/internal/x86_64/golan.efi",
+                "pxe/static/blobs/internal/apt/dists/focal/Release",
+                "pxe/static/blobs/internal/apt/dists/focal/main/binary-amd64/Packages",
+                "pxe/static/blobs/internal/apt/dists/focal/main/binary-amd64/Release",
+                "pxe/static/blobs/internal/apt/pool/base/f/forge-scout/forge-scout_*_amd64.deb",
+                "target/debs/forge-scout_*_amd64.deb",
+            },
+            "aarch64": {
+                "pxe/static/blobs/internal/aarch64/secure-boot-pk.pem",
+                "pxe/static/blobs/internal/aarch64/ipxe.efi",
+                "pxe/static/blobs/internal/aarch64/carbide.efi",
+                "pxe/static/blobs/internal/aarch64/carbide.root",
+                "pxe/static/blobs/internal/aarch64/preingestion.bfb",
+                "pxe/static/blobs/internal/aarch64/forge.bfb",
+                "pxe/static/blobs/internal/apt/dists/focal/Release",
+                "pxe/static/blobs/internal/apt/dists/focal/main/binary-arm64/Packages",
+                "pxe/static/blobs/internal/apt/dists/focal/main/binary-arm64/Release",
+                "pxe/static/blobs/internal/apt/pool/base/f/forge-dpu/forge-dpu_*_arm64.deb",
+                "pxe/static/blobs/internal/apt/pool/base/f/forge-scout/forge-scout_*_arm64.deb",
+                "target/aarch64-unknown-linux-gnu/release/forge-scout",
+                "target/debs/forge-dpu_*_arm64.deb",
+                "target/debs/forge-scout_*_arm64.deb",
+            },
+        }
+        expected_generated_outputs = {
+            "x86_64": {
+                "pxe/static/blobs/internal/x86_64/scout.efi",
+                "pxe/static/blobs/internal/x86_64/scout.squashfs",
+                "pxe/static/blobs/internal/x86_64/qcow-imager.efi",
+            },
+            "aarch64": {
+                "pxe/static/blobs/internal/aarch64/scout.efi",
+                "pxe/static/blobs/internal/aarch64/scout.squashfs",
+                "pxe/static/blobs/internal/aarch64/qcow-imager.efi",
+            },
+        }
+
+        for arch, boot_inputs in expected_boot_inputs.items():
+            with self.subTest(arch=arch):
+                identity = EXPECTED_BUILD_IDENTITIES[("ephemeral", arch)]
+                ephemeral_outputs = set(CONTRACTS[identity].required)
+                self.assertEqual(
+                    ephemeral_outputs,
+                    boot_inputs | expected_generated_outputs[arch],
+                )
+
+    def test_ephemeral_contracts_reject_missing_boot_inputs(self) -> None:
+        boot_inputs = {
+            "x86_64": "pxe/static/blobs/internal/x86_64/ipxe.efi",
+            "aarch64": "pxe/static/blobs/internal/aarch64/secure-boot-pk.pem",
+        }
+
+        for arch, boot_input in boot_inputs.items():
+            with self.subTest(arch=arch):
+                identity = EXPECTED_BUILD_IDENTITIES[("ephemeral", arch)]
+                contract = CONTRACTS[identity]
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    populate_contract(root, contract, omit=boot_input)
+
+                    self.assertEqual(
+                        validate_outputs(root, contract),
+                        [f"missing required output: {boot_input}"],
+                    )
+
+    def test_required_optional_and_disabled_cases(self) -> None:
+        contract = CONTRACTS[EXPECTED_BUILD_IDENTITIES[("ephemeral", "x86_64")]]
+        required_output = contract.required[0]
+        cases = (
+            ValidationCase("complete outputs", include_optional=True),
+            ValidationCase(
+                "missing required output",
+                omit=required_output,
+                expected_error=f"missing required output: {required_output}",
+            ),
+            ValidationCase(
+                "empty required output",
+                empty=required_output,
+                expected_error=f"required output is empty: {required_output}",
+            ),
+            ValidationCase("optional output absent"),
+            ValidationCase(
+                "disabled output present",
+                include_optional=True,
+                include_disabled=True,
+                expected_error=f"disabled output is present: {contract.disabled[0]}",
+            ),
+        )
+
+        for case in cases:
+            with self.subTest(case=case.name):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    populate_contract(
+                        root,
+                        contract,
+                        omit=case.omit,
+                        empty=case.empty,
+                        include_optional=case.include_optional,
+                        include_disabled=case.include_disabled,
+                    )
+
+                    errors = validate_outputs(root, contract)
+
+                    if case.expected_error is None:
+                        self.assertEqual(errors, [])
+                    else:
+                        self.assertEqual(errors, [case.expected_error])
+
+    def test_required_output_must_be_a_regular_file(self) -> None:
+        contract = CONTRACTS[EXPECTED_BUILD_IDENTITIES[("ephemeral", "x86_64")]]
+        required_output = contract.required[0]
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate_contract(root, contract)
+            output = root / concrete_path(required_output)
+            output.unlink()
+            output.mkdir()
+
+            self.assertEqual(
+                validate_outputs(root, contract),
+                [f"required output is not a regular file: {required_output}"],
+            )
+
+    def test_required_output_must_not_be_a_symlink(self) -> None:
+        contract = CONTRACTS[EXPECTED_BUILD_IDENTITIES[("ephemeral", "x86_64")]]
+        required_output = contract.required[0]
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            populate_contract(root, contract)
+            output = root / concrete_path(required_output)
+            symlink_target = root / "symlink-target"
+            symlink_target.write_bytes(b"artifact")
+            output.unlink()
+            output.symlink_to(symlink_target)
+
+            self.assertEqual(
+                validate_outputs(root, contract),
+                [f"required output is a symlink: {required_output}"],
+            )
+
+    def test_required_output_must_not_have_a_symlinked_parent(self) -> None:
+        required_output = "pxe/static/blobs/internal/x86_64/ipxe.efi"
+        contract = ArtifactContract(required=(required_output,))
+
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = Path(directory)
+            workspace = fixture_root / "workspace"
+            external = fixture_root / "external"
+            workspace.mkdir()
+            write_output(external, required_output)
+            (workspace / "pxe").symlink_to(external / "pxe", target_is_directory=True)
+
+            self.assertEqual(
+                validate_outputs(workspace, contract),
+                [f"required output has a symlinked parent: {required_output}"],
+            )
+
+    def test_every_match_for_a_required_glob_must_be_nonempty(self) -> None:
+        pattern = "target/debs/forge-scout_*.deb"
+        contract = ArtifactContract(required=(pattern,))
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            write_output(root, "target/debs/forge-scout_valid.deb")
+            write_output(root, "target/debs/forge-scout_empty.deb", b"")
+
+            self.assertEqual(
+                validate_outputs(root, contract),
+                ["required output is empty: target/debs/forge-scout_empty.deb"],
+            )
+
+    def test_main_returns_success_and_failure_statuses(self) -> None:
+        identity = EXPECTED_BUILD_IDENTITIES[("ephemeral", "x86_64")]
+        contract = CONTRACTS[identity]
+        cases = (
+            ("complete outputs", True, 0),
+            ("missing outputs", False, 1),
+        )
+
+        for case_name, should_populate, expected_status in cases:
+            with self.subTest(case=case_name):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    if should_populate:
+                        populate_contract(root, contract)
+
+                    stdout = io.StringIO()
+                    stderr = io.StringIO()
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        status = main(
+                            (
+                                "--cargo-make-task",
+                                identity.cargo_make_task,
+                                "--build-type",
+                                identity.build_type,
+                                "--arch",
+                                identity.arch,
+                                "--root",
+                                str(root),
+                            )
+                        )
+
+                    self.assertEqual(status, expected_status)
+                    self.assertIn(
+                        "Output contract: "
+                        f"{identity.cargo_make_task} "
+                        f"({identity.build_type}/{identity.arch})",
+                        stdout.getvalue(),
+                    )
+                    if expected_status == 0:
+                        self.assertIn(
+                            f"Validated {len(contract.required)} required and "
+                            f"{len(contract.disabled)} disabled output pattern(s).",
+                            stdout.getvalue(),
+                        )
+                        self.assertEqual(stderr.getvalue(), "")
+                    else:
+                        self.assertNotIn("Validated ", stdout.getvalue())
+                        self.assertIn(
+                            f"ERROR: missing required output: {contract.required[0]}",
+                            stderr.getvalue(),
+                        )
+
+    def test_main_rejects_a_mismatched_build_identity(self) -> None:
+        identity = EXPECTED_BUILD_IDENTITIES[("boot", "x86_64")]
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            status = main(
+                (
+                    "--cargo-make-task",
+                    identity.cargo_make_task,
+                    "--build-type",
+                    identity.build_type,
+                    "--arch",
+                    "aarch64",
+                )
+            )
+
+        self.assertEqual(status, 2)
+        self.assertIn(
+            "ERROR: no output contract for "
+            f"{identity.cargo_make_task} (boot/aarch64)",
+            stderr.getvalue(),
+        )

--- a/.github/ci/validate_boot_outputs.py
+++ b/.github/ci/validate_boot_outputs.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check files included in Core boot and ephemeral artifact uploads.
+
+Each active build and architecture has an explicit list of files that must be
+present before GitHub Actions uploads the production bundle. That includes
+downloaded boot inputs carried into an ephemeral bundle. Build logs remain
+optional diagnostics, and intermediate files that are never uploaded are
+outside this check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BuildIdentity:
+    """Reusable-workflow inputs that select one artifact builder.
+
+    Attributes:
+        cargo_make_task: Exact cargo-make task executed by the workflow.
+        build_type: Artifact family reported by the workflow.
+        arch: Architecture reported by the workflow.
+    """
+
+    cargo_make_task: str
+    build_type: str
+    arch: str
+
+
+@dataclass(frozen=True)
+class ArtifactContract:
+    """Files one builder must produce, may omit, or must not produce.
+
+    Attributes:
+        required: Repository-relative paths or globs. Each pattern must match
+            at least one nonempty regular file, and every matching path is
+            checked. Neither the file nor any parent below the repository root
+            may be a symlink.
+        optional: Repository-relative diagnostic paths that appear in the
+            printed contract but do not affect validation. These files, such
+            as `build.log`, are not release inputs.
+        disabled: Repository-relative paths or globs that must not match
+            anything. A match means the CI builder performed work that is
+            deliberately outside its scope.
+    """
+
+    required: tuple[str, ...]
+    optional: tuple[str, ...] = ()
+    disabled: tuple[str, ...] = ()
+
+
+# CI boot jobs intentionally omit the admin CLI because no downstream job uses
+# it. The workflow runs in a clean checkout, so its presence means a redundant
+# workspace build was reintroduced into this job.
+UNBUILT_ADMIN_CLI = "target/debug/nico-admin-cli"
+
+
+BOOT_REQUIRED_OUTPUTS: dict[str, tuple[str, ...]] = {
+    "x86_64": (
+        "pxe/static/blobs/internal/x86_64/ipxe.efi",
+        "pxe/static/blobs/internal/x86_64/golan.efi",
+        "pxe/static/blobs/internal/apt/dists/focal/Release",
+        "pxe/static/blobs/internal/apt/dists/focal/main/binary-amd64/Packages",
+        "pxe/static/blobs/internal/apt/dists/focal/main/binary-amd64/Release",
+        "pxe/static/blobs/internal/apt/pool/base/f/forge-scout/forge-scout_*_amd64.deb",
+        "target/debs/forge-scout_*_amd64.deb",
+    ),
+    "aarch64": (
+        "pxe/static/blobs/internal/aarch64/secure-boot-pk.pem",
+        "pxe/static/blobs/internal/aarch64/ipxe.efi",
+        "pxe/static/blobs/internal/aarch64/carbide.efi",
+        "pxe/static/blobs/internal/aarch64/carbide.root",
+        "pxe/static/blobs/internal/aarch64/preingestion.bfb",
+        "pxe/static/blobs/internal/aarch64/forge.bfb",
+        "pxe/static/blobs/internal/apt/dists/focal/Release",
+        "pxe/static/blobs/internal/apt/dists/focal/main/binary-arm64/Packages",
+        "pxe/static/blobs/internal/apt/dists/focal/main/binary-arm64/Release",
+        "pxe/static/blobs/internal/apt/pool/base/f/forge-dpu/forge-dpu_*_arm64.deb",
+        "pxe/static/blobs/internal/apt/pool/base/f/forge-scout/forge-scout_*_arm64.deb",
+        "target/aarch64-unknown-linux-gnu/release/forge-scout",
+        "target/debs/forge-dpu_*_arm64.deb",
+        "target/debs/forge-scout_*_arm64.deb",
+    ),
+}
+
+
+EPHEMERAL_GENERATED_OUTPUTS: dict[str, tuple[str, ...]] = {
+    "x86_64": (
+        "pxe/static/blobs/internal/x86_64/scout.efi",
+        "pxe/static/blobs/internal/x86_64/scout.squashfs",
+        "pxe/static/blobs/internal/x86_64/qcow-imager.efi",
+    ),
+    "aarch64": (
+        "pxe/static/blobs/internal/aarch64/scout.efi",
+        "pxe/static/blobs/internal/aarch64/scout.squashfs",
+        "pxe/static/blobs/internal/aarch64/qcow-imager.efi",
+    ),
+}
+
+
+# These contracts describe the four tasks selected by Core CI:
+# `build-boot-artifacts-x86-host-ci`, `build-boot-artifacts-bfb-ci`,
+# `create-ephemeral-image-x86-host-ci`, and
+# `create-ephemeral-image-arm-host-ci`. Each key also locks the task to its
+# expected build type and architecture. A new caller must use one complete
+# identity below or add a contract that describes its actual outputs.
+CONTRACTS: dict[BuildIdentity, ArtifactContract] = {
+    BuildIdentity(
+        cargo_make_task="build-boot-artifacts-x86-host-ci",
+        build_type="boot",
+        arch="x86_64",
+    ): ArtifactContract(
+        required=BOOT_REQUIRED_OUTPUTS["x86_64"],
+        disabled=(UNBUILT_ADMIN_CLI,),
+    ),
+    BuildIdentity(
+        cargo_make_task="build-boot-artifacts-bfb-ci",
+        build_type="boot",
+        arch="aarch64",
+    ): ArtifactContract(
+        required=BOOT_REQUIRED_OUTPUTS["aarch64"],
+        disabled=(UNBUILT_ADMIN_CLI,),
+    ),
+    BuildIdentity(
+        cargo_make_task="create-ephemeral-image-x86-host-ci",
+        build_type="ephemeral",
+        arch="x86_64",
+    ): ArtifactContract(
+        # The ephemeral upload preserves the downloaded boot bundle beside its
+        # new images, so validate the carried inputs before uploading them too.
+        required=(
+            BOOT_REQUIRED_OUTPUTS["x86_64"]
+            + EPHEMERAL_GENERATED_OUTPUTS["x86_64"]
+        ),
+        optional=("build.log",),
+        disabled=(UNBUILT_ADMIN_CLI,),
+    ),
+    BuildIdentity(
+        cargo_make_task="create-ephemeral-image-arm-host-ci",
+        build_type="ephemeral",
+        arch="aarch64",
+    ): ArtifactContract(
+        required=(
+            BOOT_REQUIRED_OUTPUTS["aarch64"]
+            + EPHEMERAL_GENERATED_OUTPUTS["aarch64"]
+        ),
+        optional=("build.log",),
+        disabled=(UNBUILT_ADMIN_CLI,),
+    ),
+}
+
+
+def output_has_symlinked_parent(root: Path, relative_output: Path) -> bool:
+    """Return whether a parent below `root` is a symlink."""
+
+    current = root
+    for part in relative_output.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return True
+
+    return False
+
+
+def validate_outputs(root: Path, contract: ArtifactContract) -> list[str]:
+    """Check one builder's files against `contract`.
+
+    All contract patterns are relative to `root`, which is the checked-out
+    repository workspace. A required glob may match several files; every match
+    must satisfy the same file checks. Validation collects every error so one
+    expensive builder run reports all of the files that need attention.
+
+    Args:
+        root: Repository workspace containing the built files.
+        contract: Required, optional, and disabled paths for this builder.
+
+    Returns:
+        Every required-output or disabled-output contract error.
+    """
+
+    errors: list[str] = []
+    for pattern in contract.required:
+        matches = sorted(root.glob(pattern))
+        if not matches:
+            errors.append(f"missing required output: {pattern}")
+            continue
+
+        for output in matches:
+            relative_output = output.relative_to(root)
+            # `Path.is_file()` follows a symlink to its target. Reject the
+            # output and its parents first so an indirect file cannot satisfy
+            # this contract.
+            if output_has_symlinked_parent(root, relative_output):
+                errors.append(
+                    f"required output has a symlinked parent: {relative_output}"
+                )
+            elif output.is_symlink():
+                errors.append(f"required output is a symlink: {relative_output}")
+            elif not output.is_file():
+                errors.append(
+                    f"required output is not a regular file: {relative_output}"
+                )
+            elif output.stat().st_size == 0:
+                errors.append(f"required output is empty: {relative_output}")
+
+    for pattern in contract.disabled:
+        for output in sorted(root.glob(pattern)):
+            errors.append(f"disabled output is present: {output.relative_to(root)}")
+
+    return errors
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse the build identity and repository root to validate."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cargo-make-task",
+        choices=sorted({identity.cargo_make_task for identity in CONTRACTS}),
+        required=True,
+        help="cargo-make task run by the reusable workflow.",
+    )
+    parser.add_argument(
+        "--build-type",
+        choices=sorted({identity.build_type for identity in CONTRACTS}),
+        required=True,
+        help="Output family built by the workflow.",
+    )
+    parser.add_argument(
+        "--arch",
+        choices=sorted({identity.arch for identity in CONTRACTS}),
+        required=True,
+        help="Architecture built by the workflow.",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help=(
+            "Repository workspace containing the pxe/ and target/ directories "
+            "(default: current directory)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def print_paths(label: str, paths: tuple[str, ...]) -> None:
+    """Print one contract category in a stable, readable format."""
+
+    print(f"{label} ({len(paths)}):")
+    if not paths:
+        print("  (none)")
+        return
+
+    for path in paths:
+        print(f"  - {path}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate one build and print its complete output classification.
+
+    Returns:
+        Zero when the contract passes, one after printing every file error, or
+        two when the inputs do not identify a supported builder.
+    """
+
+    args = parse_args(argv)
+    build_identity = BuildIdentity(
+        cargo_make_task=args.cargo_make_task,
+        build_type=args.build_type,
+        arch=args.arch,
+    )
+    contract = CONTRACTS.get(build_identity)
+    if contract is None:
+        print(
+            "ERROR: no output contract for "
+            f"{build_identity.cargo_make_task} "
+            f"({build_identity.build_type}/{build_identity.arch})",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"Output contract: {build_identity.cargo_make_task} "
+        f"({build_identity.build_type}/{build_identity.arch})"
+    )
+    print_paths("Required outputs", contract.required)
+    print_paths("Optional outputs", contract.optional)
+    print_paths("Deliberately disabled outputs", contract.disabled)
+
+    errors = validate_outputs(args.root, contract)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Validated {len(contract.required)} required and "
+        f"{len(contract.disabled)} disabled output pattern(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -53,17 +53,11 @@ on:
         required: false
         default: false
         type: string
-    outputs:
-      artifacts_json:
-        description: 'Artifacts paths as JSON array'
-        value: ${{ jobs.build.outputs.artifacts }}
 
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 120
-    outputs:
-      artifacts: ${{ steps.collect-artifacts.outputs.paths }}
 
     steps:
       - name: Checkout code
@@ -72,6 +66,15 @@ jobs:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0  # Full git history needed for git describe
+
+      # Resolve or download validation Python before the long build, so an
+      # unsupported runner fails immediately. Shell-mode mkosi uses packages
+      # installed for the distro interpreter, so keep this runtime off PATH.
+      - name: Prepare Python for output validation
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          update-environment: false
 
       - name: Initialize submodules at pinned commits
         run: |
@@ -466,91 +469,25 @@ jobs:
 
           echo "Build completed!"
 
-      - name: Verify generated artifacts (informational only)
-        continue-on-error: true  # Don't fail build - matches GitLab CI behavior (no verification step)
+      # Activate the runtime prepared above only after both build paths finish.
+      # This exports the matching Python library directory beside its PATH.
+      - name: Activate Python for output validation
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Validate output contract
+        env:
+          ARCH: ${{ inputs.arch }}
+          BUILD_TYPE: ${{ inputs.build_type }}
+          CARGO_MAKE_TASK: ${{ inputs.cargo_make_task }}
+          REPOSITORY_ROOT: ${{ github.workspace }}
         run: |
-          echo "============================================"
-          echo "Checking generated artifacts (informational)"
-          echo "GitLab CI has no verification - uploads whatever exists with 'when: always'"
-          echo "This check provides debug info but won't fail the build"
-          echo "============================================"
-
-          # Expected files match GitLab CI artifact paths
-          if [[ "${{ inputs.build_type }}" == "boot" ]]; then
-            if [[ "${{ inputs.arch }}" == "x86_64" ]]; then
-              EXPECTED_FILES=(
-                "pxe/static/blobs/internal/x86_64/ipxe.efi"
-                "target/debug/nico-admin-cli"
-                # target/debs/* checked separately
-              )
-            else
-              # Full list from GitLab CI lines 608-615
-              EXPECTED_FILES=(
-                "pxe/static/blobs/internal/aarch64/ipxe.efi"
-                "pxe/static/blobs/internal/aarch64/carbide.efi"
-                "pxe/static/blobs/internal/aarch64/carbide.root"
-                "pxe/static/blobs/internal/aarch64/preingestion.bfb"
-                "pxe/static/blobs/internal/aarch64/forge.bfb"
-                "pxe/static/blobs/internal/apt"
-                "target/aarch64-unknown-linux-gnu/release/forge-scout"
-                # target/debs/* checked separately
-              )
-            fi
-          elif [[ "${{ inputs.build_type }}" == "ephemeral" ]]; then
-            if [[ "${{ inputs.arch }}" == "x86_64" ]]; then
-              EXPECTED_FILES=(
-                "pxe/static/blobs/internal/x86_64/scout.efi"
-                "pxe/static/blobs/internal/x86_64/scout.squashfs"
-                "pxe/static/blobs/internal/x86_64/qcow-imager.efi"
-                # target/debs/* checked separately
-              )
-            else
-              EXPECTED_FILES=(
-                "pxe/static/blobs/internal/aarch64/scout.efi"
-                "pxe/static/blobs/internal/aarch64/scout.squashfs"
-                "pxe/static/blobs/internal/aarch64/qcow-imager.efi"
-                # pxe/mkosi.profiles/scout-x86_64/mkosi.extra/build-output/* checked separately
-                # target/debs/* checked separately
-              )
-            fi
-          fi
-
-          echo ""
-          echo "Checking individual files:"
-          MISSING_COUNT=0
-          for file in "${EXPECTED_FILES[@]}"; do
-            if [[ -f "$file" ]] || [[ -d "$file" ]]; then
-              if [[ -f "$file" ]]; then
-                size=$(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null)
-                echo "  ✓ Found: $file (${size} bytes)"
-              else
-                echo "  ✓ Found: $file (directory)"
-              fi
-            else
-              echo "  ⚠️  Missing: $file"
-              MISSING_COUNT=$((MISSING_COUNT + 1))
-            fi
-          done
-
-          # Check for .deb files
-          if ls target/debs/*.deb >/dev/null 2>&1; then
-            DEB_COUNT=$(ls target/debs/*.deb 2>/dev/null | wc -l)
-            echo "  ✓ Found: target/debs/*.deb (${DEB_COUNT} files)"
-          else
-            echo "  ⚠️  Missing: target/debs/*.deb"
-            MISSING_COUNT=$((MISSING_COUNT + 1))
-          fi
-
-          echo ""
-          echo "============================================"
-          if [[ $MISSING_COUNT -eq 0 ]]; then
-            echo "✅ All expected artifacts found"
-          else
-            echo "⚠️  ${MISSING_COUNT} expected artifact(s) missing"
-            echo "Note: Some artifacts may be disabled (e.g., BFB build)"
-            echo "This is informational only - build continues"
-          fi
-          echo "============================================"
+          python3 .github/ci/validate_boot_outputs.py \
+            --cargo-make-task "${CARGO_MAKE_TASK}" \
+            --build-type "${BUILD_TYPE}" \
+            --arch "${ARCH}" \
+            --root "${REPOSITORY_ROOT}"
 
       - name: Verify mnv_cli exists in built scout image
         if: inputs.build_type == 'ephemeral' && inputs.inject_extras == true
@@ -571,53 +508,33 @@ jobs:
             exit 1
           fi
 
-      - name: Collect artifacts metadata
-        id: collect-artifacts
-        run: |
-          # Determine artifacts based on build type and architecture
-          # Note: Lists match GitLab CI artifact paths; upload step uses if-no-files-found: warn
-          # so missing files (like BFB artifacts when disabled) won't fail the build
-          if [[ "${{ inputs.build_type }}" == "boot" ]]; then
-            if [[ "${{ inputs.arch }}" == "x86_64" ]]; then
-              ARTIFACTS='["pxe/static/blobs/internal/x86_64/ipxe.efi", "target/debug/nico-admin-cli", "target/debs/*"]'
-            else
-              # Lists all expected BFB artifacts even though some may not be generated (BFB build is disabled)
-              # This matches GitLab CI behavior where artifact paths are listed but upload succeeds if files don't exist
-              ARTIFACTS='["pxe/static/blobs/internal/aarch64/secure-boot-pk.pem", "pxe/static/blobs/internal/aarch64/ipxe.efi", "pxe/static/blobs/internal/aarch64/carbide.efi", "pxe/static/blobs/internal/aarch64/carbide.root", "pxe/static/blobs/internal/aarch64/preingestion.bfb", "pxe/static/blobs/internal/aarch64/forge.bfb", "pxe/static/blobs/internal/apt", "target/aarch64-unknown-linux-gnu/release/forge-scout", "target/debs/*"]'
-            fi
-          else
-            if [[ "${{ inputs.arch }}" == "x86_64" ]]; then
-              ARTIFACTS='["pxe/static/blobs/internal/x86_64/scout.efi", "pxe/static/blobs/internal/x86_64/scout.squashfs", "pxe/static/blobs/internal/x86_64/qcow-imager.efi", "target/debs/*"]'
-            else
-              ARTIFACTS='["pxe/static/blobs/internal/aarch64/scout.efi", "pxe/static/blobs/internal/aarch64/scout.squashfs", "pxe/static/blobs/internal/aarch64/qcow-imager.efi", "pxe/mkosi.profiles/scout-x86_64/mkosi.extra/build-output/*", "target/debs/*"]'
-            fi
-          fi
-
-          echo "paths=${ARTIFACTS}" >> $GITHUB_OUTPUT
-          echo "Artifacts to upload: ${ARTIFACTS}"
-
-      # Only paths that a downstream job actually consumes are uploaded. The
-      # ephemeral build takes the packaged .deb (see copy-forge-scout-* in
-      # pxe/Makefile.toml) and the release-artifacts carriers only COPY
-      # pxe/static/blobs/internal/, so the cargo target tree and the
-      # mkosi.profiles staging inputs are deliberately excluded -- they added
-      # ~14 GB of upload/download to the critical path for no consumer. The
-      # unstripped forge-scout binary is kept so crashes from the shipped image
-      # can still be symbolicated.
+      # Upload production artifacts only after the validator and every other
+      # applicable check pass. Boot failures remain in the Actions step logs;
+      # ephemeral failures also upload `build.log` through the separate
+      # best-effort step below.
       #
-      # compression-level: 0 because squashfs/bfb/efi payloads are already
-      # compressed; re-deflating them burns CPU for a rounding error of savings.
+      # Upload the files used by later jobs. The package task writes
+      # forge-scout to `target/debs/`; the ephemeral job downloads that boot
+      # bundle, and `copy-forge-scout-*` in `pxe/Makefile.toml` copies the deb
+      # into mkosi staging. `Dockerfile.release-artifacts-*` consumes
+      # `pxe/static/blobs/internal/`. Excluding the rest of the cargo target tree
+      # and `mkosi.profiles` staging inputs removes ~14 GB of upload/download
+      # from the critical path. Keep the unstripped aarch64 forge-scout binary
+      # so crashes from the shipped image can still be symbolicated.
+      #
+      # `compression-level: 0` avoids re-deflating squashfs, BFB, and EFI files
+      # that are already compressed. `if-no-files-found` checks the path list as
+      # a whole; the validator above is what requires each contract entry.
       - name: Upload artifacts
-        if: ${{ !cancelled() }}  # Upload artifacts even if build fails (matches GitLab CI 'when: always')
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.build_type }}-artifacts-${{ inputs.arch }}-${{ github.run_id }}
           path: |
             pxe/static/blobs/
-            target/debug/nico-admin-cli
             target/debs/
             target/aarch64-unknown-linux-gnu/release/forge-scout
-          if-no-files-found: warn
+          if-no-files-found: error
           compression-level: 0
           retention-days: 1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,14 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Set up Python for CI helpers
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Check boot output contracts
+        run: python3 -m unittest discover -s .github/ci -p 'test_validate_boot_outputs.py'
+
       - name: Detect build-container-x86_64 changes
         id: build-container-changes
         uses: dorny/paths-filter@v3

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ helm-prereqs/values/nico-core.yaml.dpf.bak
 # Claude specific
 .claude/
 
+# Python bytecode
+__pycache__/
+*.py[cod]
+
 # Devenv
 .devenv*
 devenv.local.nix


### PR DESCRIPTION
The reusable boot workflow used a warning-only file list, so a missing or empty required output could survive until an ephemeral-image or carrier job downloaded the bundle. This gives each active build and architecture an explicit contract and validates it at the producer before upload.

- **Expected green-run effect:** Approximately neutral, with a small file-validation cost before upload.
- **What it really buys us:** An incomplete boot bundle fails where it was produced, before we spend time and storage uploading it or start a downstream job that cannot succeed.

The four contracts cover x86 boot, ARM/BFB boot, x86 ephemeral, and ARM ephemeral production uploads. Required outputs must be nonempty regular files rather than symlinks, and the ephemeral contracts also require every downloaded boot input they preserve in the re-uploaded bundle. Optional diagnostics stay optional, and the clean CI builders fail if the unused admin CLI appears. That last check catches a redundant full-workspace build that no downstream job needs.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4651

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

```bash
python3 -B -m unittest discover -s .github/ci -p 'test_validate_boot_outputs.py'
python3 -B .github/ci/validate_boot_outputs.py --help
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
```

All 10 focused validator tests pass. `actionlint` also passes locally with the repository's custom runner labels configured.

## Additional Notes

Production upload is now success-only and uses `if-no-files-found: error`; the separate failure-only ephemeral `build.log` upload remains best-effort. Boot failures remain in Actions step logs, and partial production bundles are deliberately not retained. Artifact names, retention, compression, and downstream download paths are unchanged.

Each artifact builder gets an explicit Python 3.13 interpreter for validation. It stays out of the job's `PATH`, and the validator invokes its exact output path, so shell-mode mkosi keeps using the distro interpreter and its apt-installed modules. The hosted ARM jobs are the smoke test for `actions/setup-python` on the `linux-arm64-cpu16` pool and must pass before merge.

The unused `artifacts_json` output and its second hand-maintained path list were removed after a repository-wide and NVIDIA code search found no consumers. #4579 still owns checksums, architecture inspection, realized manifests, and consumer-side verification.

Closes #4651
