### PR TITLE
fix: claim machine interface addresses before publishing hostnames

### DIFF
--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2094,7 +2094,7 @@ async fn create_without_addresses(
         txn,
         &segment.id,
         macaddr,
-        hostname,
+        &hostname,
         segment.config.subdomain_id,
         primary_interface,
         interface_type,
@@ -2116,13 +2116,18 @@ async fn create_without_addresses(
     Ok(snapshot)
 }
 
-/// Create the actual machine interface once we know what addresses we want.
+/// `create_inner` creates an addressed interface once allocation has selected
+/// its addresses.
+///
+/// The row starts outside `target_domain_id`, claims its address rows in a
+/// deterministic order, and then joins the domain. This keeps creates and
+/// existing-interface replacements on the same address-before-FQDN lock order.
 #[allow(clippy::too_many_arguments)]
 async fn create_inner(
     txn: &mut PgConnection,
     segment: &NetworkSegment,
     macaddr: &MacAddress,
-    domain_id: Option<DomainId>,
+    target_domain_id: Option<DomainId>,
     primary_interface: bool,
     allocated_addresses: &[IpAddr],
     allocation_type: AllocationType,
@@ -2153,24 +2158,36 @@ async fn create_inner(
         interface_type,
         // The row doesn't exist yet.
         interface_id: None,
-        domain_id,
+        domain_id: target_domain_id,
     };
     let hostname = host_naming::hostname_for(txn, &ctx).await?;
 
+    // Address rows need this parent ID, but `domain_id` can wait. Keeping it
+    // `NULL` means this transaction does not claim `fqdn_must_be_unique` until
+    // after it has claimed every address key. Existing-interface replacements
+    // already use that order, so #4150 cannot leave the two paths waiting on
+    // one another's unique keys.
     let interface_id = insert_machine_interface(
         txn,
         &segment.id,
         macaddr,
-        hostname,
-        domain_id,
+        &hostname,
+        None,
         primary_interface,
         interface_type,
     )
     .await?;
 
-    for address in allocated_addresses {
+    // A dual-stack create claims two address keys. Sort them so concurrent
+    // creates cannot take those keys in reverse.
+    let mut sorted_addresses = allocated_addresses.to_vec();
+    sorted_addresses.sort_unstable();
+    for address in &sorted_addresses {
         insert_machine_interface_address(txn, &interface_id, address, allocation_type).await?;
     }
+
+    // The address keys are in place now, so publish the target FQDN.
+    update_hostname_and_domain(txn, interface_id, &hostname, target_domain_id).await?;
 
     Ok(interface_id)
 }
@@ -2470,7 +2487,7 @@ async fn insert_machine_interface(
     txn: &mut PgConnection,
     segment_id: &NetworkSegmentId,
     mac_address: &MacAddress,
-    hostname: String,
+    hostname: &str,
     domain_id: Option<DomainId>,
     is_primary_interface: bool,
     interface_type: InterfaceType,

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -128,6 +128,113 @@ async fn create_managed_segment(
     Ok(segment_id)
 }
 
+/// `create_inner` claims addresses in a deterministic order before the new
+/// interface joins its configured DNS domain. The trigger inspects earlier
+/// writes in the same transaction, so an ordering regression fails without
+/// relying on a race.
+#[crate::sqlx_test]
+async fn create_inner_claims_addresses_before_publishing_fqdn(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_name = "address-before-hostname";
+    let segment_id = create_managed_segment(
+        &pool,
+        segment_name,
+        "192.0.2.0/29",
+        NetworkSegmentType::Admin,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+
+    let mut txn = db::Transaction::begin(&pool).await?;
+    let domain = db::dns::domain::persist(
+        model::dns::NewDomain::new("address-order.example"),
+        txn.as_pgconn(),
+    )
+    .await?;
+    sqlx::query("UPDATE network_segments SET subdomain_id = $1 WHERE id = $2")
+        .bind(domain.id)
+        .bind(segment_id)
+        .execute(txn.as_pgconn())
+        .await?;
+    // Use one prefix from each family so the trigger can also reject a
+    // reversed dual-stack insert.
+    db::network_prefix::create_for(
+        txn.as_pgconn(),
+        &segment_id,
+        &[NewNetworkPrefix {
+            prefix: "2001:db8::/126".parse()?,
+            gateway: None,
+            dhcpv6_link_address: None,
+            num_reserved: 0,
+        }],
+    )
+    .await?;
+    let segment = db::network_segment::find_by_name(txn.as_pgconn(), segment_name).await?;
+
+    sqlx::raw_sql(
+        r#"
+        CREATE FUNCTION test_assert_create_inner_address_order()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM machine_interfaces
+                WHERE id = NEW.interface_id
+                  AND domain_id IS NOT NULL
+            ) THEN
+                RAISE EXCEPTION 'machine interface entered its DNS domain before address insertion';
+            END IF;
+            IF EXISTS (
+                SELECT 1
+                FROM machine_interface_addresses
+                WHERE interface_id = NEW.interface_id
+                  AND address > NEW.address
+            ) THEN
+                RAISE EXCEPTION 'machine interface addresses were not inserted in address order';
+            END IF;
+            RETURN NEW;
+        END;
+        $$;
+
+        CREATE TRIGGER test_assert_create_inner_address_order
+        BEFORE INSERT ON machine_interface_addresses
+        FOR EACH ROW
+        EXECUTE FUNCTION test_assert_create_inner_address_order();
+        "#,
+    )
+    .execute(txn.as_pgconn())
+    .await?;
+
+    let mac_address: MacAddress = "02:00:00:20:04:01".parse()?;
+    let allocated_addresses: [IpAddr; 2] = ["2001:db8::2".parse()?, "192.0.2.2".parse()?];
+    let interface_id = create_inner(
+        txn.as_pgconn(),
+        &segment,
+        &mac_address,
+        segment.config.subdomain_id,
+        false,
+        &allocated_addresses,
+        AllocationType::Dhcp,
+        InterfaceType::Data,
+    )
+    .await?;
+    let mut interface = find_one(txn.as_pgconn(), interface_id).await?;
+    txn.commit().await?;
+
+    interface.addresses.sort_unstable();
+    assert_eq!(
+        interface.addresses,
+        vec![allocated_addresses[1], allocated_addresses[0]]
+    );
+    assert_eq!(interface.hostname, "192-0-2-2");
+    assert_eq!(interface.domain_id, Some(domain.id));
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 #[allow(txn_held_across_await)] // Intentionally hold interface locks while testing another writer.
 async fn find_by_machine_id_for_update_locks_non_bmc_interfaces_in_id_order(


### PR DESCRIPTION
New-interface creation and existing-interface replacement used opposite write orders. `create_inner` published a new interface's `(domain_id, hostname)` before inserting its address rows. The replacement path claimed the address first, then updated `(domain_id, hostname)`.

That was fine with the existing database constraints, but #4150 will add site-wide uniqueness to `machine_interface_addresses.address` alongside `fqdn_must_be_unique`. With both constraints in place, a create could hold the FQDN while waiting for the address, while a replacement could hold the address and wait for the FQDN.

So, this makes new-interface creation follow the same address-before-FQDN order. `create_inner` now inserts the interface with its final hostname and `domain_id = NULL`, sorts and inserts its addresses, and then calls `update_hostname_and_domain` to publish the FQDN. `domain_id` used to receive its configured value in the initial `INSERT`; the helper now applies that value after the address rows exist.

For callers, this is a noop. There are no API, config, or database schema changes, successful creates store the same interface data as before, and the surrounding transaction still rolls everything back on failure. This just gives #4150 one lock order to build on.

And, there's a PostgreSQL regression test that uses a test-only trigger to make the intermediate writes visible. It verifies that the interface stays outside its DNS domain until its addresses are claimed, and that dual-stack addresses are inserted in a deterministic order.

## Related issues

- Supports #4654.
- Prerequisite for #4150.
- Part of #3491.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

- This PR only establishes the shared write order. The address cleanup and site-wide uniqueness constraint remain in #4150.