### PR TITLE
refactor(fabric,dpu): adopt style guide rules for pub/module visibility

### DIFF
--- a/crates/dpa-manager/src/card_handler.rs
+++ b/crates/dpa-manager/src/card_handler.rs
@@ -28,7 +28,7 @@ mod svpc;
 
 /// Per-interface-type state machine handlers for DPA interfaces.
 #[async_trait]
-pub trait DpaInterfaceStateHandler: Sync {
+pub(super) trait DpaInterfaceStateHandler: Sync {
     async fn handle_provisioning(
         &self,
         monitor: &mut DpaMonitor,
@@ -86,7 +86,9 @@ pub trait DpaInterfaceStateHandler: Sync {
     ) -> DpaManagerResult<HandlerResult>;
 }
 
-pub fn handler_for(interface_type: DpaInterfaceType) -> &'static dyn DpaInterfaceStateHandler {
+pub(super) fn handler_for(
+    interface_type: DpaInterfaceType,
+) -> &'static dyn DpaInterfaceStateHandler {
     match interface_type {
         DpaInterfaceType::Svpc => &svpc::SvpcInterfaceHandler,
         DpaInterfaceType::Astra => &astra::AstraInterfaceHandler,

--- a/crates/dpa-manager/src/card_handler/astra.rs
+++ b/crates/dpa-manager/src/card_handler/astra.rs
@@ -24,7 +24,7 @@ use crate::errors::DpaManagerResult;
 use crate::metrics::DpaMonitorMetrics;
 use crate::{DpaMonitor, HandlerResult};
 
-pub struct AstraInterfaceHandler;
+pub(super) struct AstraInterfaceHandler;
 
 #[async_trait]
 impl DpaInterfaceStateHandler for AstraInterfaceHandler {

--- a/crates/dpa-manager/src/card_handler/svpc.rs
+++ b/crates/dpa-manager/src/card_handler/svpc.rs
@@ -36,7 +36,7 @@ use crate::errors::{DpaManagerError, DpaManagerResult};
 use crate::metrics::DpaMonitorMetrics;
 use crate::{DpaMonitor, HandlerResult};
 
-pub struct SvpcInterfaceHandler;
+pub(super) struct SvpcInterfaceHandler;
 
 enum ReconcileAction {
     Noop,

--- a/crates/dpa-manager/src/metrics.rs
+++ b/crates/dpa-manager/src/metrics.rs
@@ -21,23 +21,23 @@ use std::time::Duration;
 
 use ::carbide_utils::metrics::SharedMetricsHolder;
 use carbide_instrument::Event;
-use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::metrics::{Counter, Meter};
 
 /// Metrics that are gathered in a single dpa monitor run
 #[derive(Clone, Debug)]
-pub struct DpaMonitorMetrics {
+pub(super) struct DpaMonitorMetrics {
     /// Start time of metrics gathering
-    pub recording_started_at: std::time::Instant,
-    pub num_machines_scanned: usize,
-    pub num_instances_scanned: usize,
-    pub num_dpa_interfaces_scanned: usize,
-    pub num_heartbeats_sent: usize,
-    pub num_creates: usize,
-    pub num_deletes: usize,
+    pub(super) recording_started_at: std::time::Instant,
+    pub(super) num_machines_scanned: usize,
+    pub(super) num_instances_scanned: usize,
+    pub(super) num_dpa_interfaces_scanned: usize,
+    pub(super) num_heartbeats_sent: usize,
+    pub(super) num_creates: usize,
+    pub(super) num_deletes: usize,
 }
 
 impl DpaMonitorMetrics {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             recording_started_at: std::time::Instant::now(),
             num_machines_scanned: 0,
@@ -63,13 +63,13 @@ impl Display for DpaMonitorMetrics {
 }
 
 /// Stores Metric data shared between the dpa monitor and the OpenTelemetry background task
-pub struct MetricHolder {
+pub(super) struct MetricHolder {
     instruments: DpaMonitorInstruments,
     last_iteration_metrics: SharedMetricsHolder<DpaMonitorMetrics>,
 }
 
 impl MetricHolder {
-    pub fn new(meter: Meter, hold_period: Duration) -> Self {
+    pub(super) fn new(meter: Meter, hold_period: Duration) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         let instruments = DpaMonitorInstruments::new(meter, last_iteration_metrics.clone());
         instruments.init_counters();
@@ -80,7 +80,7 @@ impl MetricHolder {
     }
 
     /// Updates the most recent metrics
-    pub fn update_metrics(&self, metrics: DpaMonitorMetrics) {
+    pub(super) fn update_metrics(&self, metrics: DpaMonitorMetrics) {
         self.instruments.emit_counters(&metrics);
         self.last_iteration_metrics.update(metrics);
     }
@@ -114,21 +114,14 @@ pub(crate) enum DpaMonitorIterationFinished {
 }
 
 /// Instruments that are used by pub struct DpaMonitor
-#[allow(dead_code)]
-pub struct DpaMonitorInstruments {
-    pub dpa_config_apply_latency: Histogram<f64>,
-    pub heartbeats_sent: Counter<u64>,
-    pub creates: Counter<u64>,
-    pub deletes: Counter<u64>,
+struct DpaMonitorInstruments {
+    heartbeats_sent: Counter<u64>,
+    creates: Counter<u64>,
+    deletes: Counter<u64>,
 }
 
 impl DpaMonitorInstruments {
-    pub fn new(meter: Meter, shared_metrics: SharedMetricsHolder<DpaMonitorMetrics>) -> Self {
-        let dpa_config_apply_latency = meter
-            .f64_histogram("carbide_dpa_monitor_dpa_config_apply_latency")
-            .with_description("Time since dpa config was requested for this instance")
-            .with_unit("ms")
-            .build();
+    fn new(meter: Meter, shared_metrics: SharedMetricsHolder<DpaMonitorMetrics>) -> Self {
         let heartbeats_sent = meter
             .u64_counter("carbide_dpa_monitor_heartbeats_sent")
             .with_description("Number of heartbeats sent to DPA interfaces")
@@ -153,7 +146,6 @@ impl DpaMonitorInstruments {
             .build();
 
         Self {
-            dpa_config_apply_latency,
             heartbeats_sent,
             creates,
             deletes,

--- a/crates/dpf/src/test/helpers.rs
+++ b/crates/dpf/src/test/helpers.rs
@@ -34,8 +34,8 @@ use crate::crds::dpus_generated::*;
 use crate::error::DpfError;
 use crate::repository::{DpfOperatorConfigRepository, DpuRepository, K8sConfigRepository};
 
-pub(crate) struct Collector<T> {
-    pub items: Mutex<Vec<T>>,
+pub(super) struct Collector<T> {
+    pub(super) items: Mutex<Vec<T>>,
     notify: Notify,
 }
 
@@ -49,24 +49,24 @@ impl<T> Default for Collector<T> {
 }
 
 impl<T: Clone> Collector<T> {
-    pub fn push(&self, item: T) {
+    pub(super) fn push(&self, item: T) {
         self.items.lock().unwrap().push(item);
         self.notify.notify_waiters();
     }
 
-    pub fn len(&self) -> usize {
+    pub(super) fn len(&self) -> usize {
         self.items.lock().unwrap().len()
     }
 
-    pub fn get(&self, i: usize) -> Option<T> {
+    pub(super) fn get(&self, i: usize) -> Option<T> {
         self.items.lock().unwrap().get(i).cloned()
     }
 
-    pub fn all(&self) -> Vec<T> {
+    pub(super) fn all(&self) -> Vec<T> {
         self.items.lock().unwrap().clone()
     }
 
-    pub async fn wait_for(&self, n: usize) {
+    pub(super) async fn wait_for(&self, n: usize) {
         let res = timeout(Duration::from_secs(5), async {
             loop {
                 if self.len() >= n {
@@ -84,15 +84,15 @@ impl<T: Clone> Collector<T> {
 
 /// Minimal DpuRepository mock that emits DPUs via broadcast channel.
 #[derive(Clone)]
-pub(crate) struct WatcherMock {
-    pub dpu_tx: broadcast::Sender<DPU>,
+pub(super) struct WatcherMock {
+    dpu_tx: broadcast::Sender<DPU>,
     cancel: CancellationToken,
     watch_count: Arc<AtomicUsize>,
     watch_notify: Arc<Notify>,
 }
 
 impl WatcherMock {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         let (dpu_tx, _) = broadcast::channel(100);
         Self {
             dpu_tx,
@@ -102,11 +102,11 @@ impl WatcherMock {
         }
     }
 
-    pub fn emit_dpu(&self, dpu: DPU) {
+    pub(super) fn emit_dpu(&self, dpu: DPU) {
         let _ = self.dpu_tx.send(dpu);
     }
 
-    pub async fn wait_for_watchers(&self, n: usize) {
+    pub(super) async fn wait_for_watchers(&self, n: usize) {
         let res = timeout(Duration::from_secs(5), async {
             loop {
                 if self.watch_count.load(Ordering::SeqCst) >= n {
@@ -125,7 +125,7 @@ impl WatcherMock {
         }
     }
 
-    pub async fn wait_for_receivers(&self, n: usize) {
+    pub(super) async fn wait_for_receivers(&self, n: usize) {
         let res = timeout(Duration::from_secs(5), async {
             loop {
                 if self.dpu_tx.receiver_count() == n {
@@ -190,7 +190,7 @@ impl DpuRepository for WatcherMock {
     }
 }
 
-pub(crate) fn make_status(phase: DpuStatusPhase) -> DpuStatus {
+pub(super) fn make_status(phase: DpuStatusPhase) -> DpuStatus {
     DpuStatus {
         addresses: None,
         bf_cfg_file: None,
@@ -221,7 +221,7 @@ pub(crate) fn make_status(phase: DpuStatusPhase) -> DpuStatus {
     }
 }
 
-pub(crate) fn make_dpu(
+pub(super) fn make_dpu(
     ns: &str,
     name: &str,
     device: &str,
@@ -262,11 +262,11 @@ pub(crate) fn make_dpu(
     }
 }
 
-pub(crate) fn make_dpu_reboot(ns: &str, name: &str, device: &str, node: &str) -> DPU {
+pub(super) fn make_dpu_reboot(ns: &str, name: &str, device: &str, node: &str) -> DPU {
     make_dpu(ns, name, device, node, DpuStatusPhase::Rebooting)
 }
 
-pub(crate) fn make_dpu_labeled(
+pub(super) fn make_dpu_labeled(
     ns: &str,
     name: &str,
     device: &str,
@@ -281,7 +281,7 @@ pub(crate) fn make_dpu_labeled(
 
 /// Minimal K8sConfigRepository mock for tests that only need
 /// `build_without_resources` / `initialize` (BMC secret creation).
-pub(crate) struct ConfigMock;
+pub(super) struct ConfigMock;
 
 #[async_trait]
 impl K8sConfigRepository for ConfigMock {

--- a/crates/ib-fabric/src/ib/disable.rs
+++ b/crates/ib-fabric/src/ib/disable.rs
@@ -24,7 +24,7 @@ use super::iface::{Filter, GetPartitionOptions, IBFabricRawResponse};
 use super::{IBFabric, IBFabricConfig, IBFabricVersions};
 use crate::errors::IbError;
 
-pub struct DisableIBFabric {}
+pub(super) struct DisableIBFabric {}
 
 #[async_trait]
 impl IBFabric for DisableIBFabric {

--- a/crates/ib-fabric/src/ib/rest.rs
+++ b/crates/ib-fabric/src/ib/rest.rs
@@ -32,7 +32,7 @@ use super::ufmclient::{
 use super::{IBFabric, IBFabricConfig, IBFabricVersions};
 use crate::errors::IbError;
 
-pub struct RestIBFabric {
+pub(super) struct RestIBFabric {
     ufm: Ufm,
 }
 
@@ -68,7 +68,7 @@ pub(super) fn auth_method(auth: &str) -> (Option<String>, Option<UFMCert>) {
     }
 }
 
-pub fn new_client(addr: &str, auth: &str) -> Result<Arc<dyn IBFabric>, IbError> {
+pub(super) fn new_client(addr: &str, auth: &str) -> Result<Arc<dyn IBFabric>, IbError> {
     let (token, cert) = auth_method(auth);
 
     let conf = UFMConfig {

--- a/crates/ib-fabric/src/ib/ufmclient/mod.rs
+++ b/crates/ib-fabric/src/ib/ufmclient/mod.rs
@@ -29,101 +29,101 @@ use crate::ib::ufmclient::rest::ResponseDetails;
 mod rest;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SmConfig {
+pub(super) struct SmConfig {
     /// The subnet_prefix of openSM
-    pub subnet_prefix: String,
+    pub(super) subnet_prefix: String,
     /// The m_key of openSM
-    pub m_key: String,
+    pub(super) m_key: String,
     /// The sm_key of openSM
-    pub sm_key: String,
+    pub(super) sm_key: String,
     /// The sa_key of openSM
-    pub sa_key: String,
+    pub(super) sa_key: String,
     /// The m_key_per_port of openSM
-    pub m_key_per_port: bool,
+    pub(super) m_key_per_port: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct PartitionQoS {
+pub(super) struct PartitionQoS {
     // Default 2k; one of 2k or 4k; the MTU of the services.
-    pub mtu_limit: u16,
+    pub(super) mtu_limit: u16,
     // Default is None, value can be range from 0-15
-    pub service_level: u8,
+    pub(super) service_level: u8,
     /// Supported values: 10, 30, 5, 20, 40, 60, 80, 120, 14, 56, 112, 168, 25, 100, 200, or 300.
     /// 2 is also valid but is used internally to represent rate limit 2.5 that is possible in UFM for lagecy hardware.
     /// It is done to avoid floating point data type usage for rate limit w/o obvious benefits.
     /// 2 to 2.5 and back conversion is done just on REST API operations.
-    pub rate_limit: f32,
+    pub(super) rate_limit: f32,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum PortMembership {
+pub(super) enum PortMembership {
     Limited,
     Full,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct PortConfig {
+pub(super) struct PortConfig {
     /// The GUID of Port.
-    pub guid: String,
+    pub(super) guid: String,
     /// Default false; store the PKey at index 0 of the PKey table of the GUID.
-    pub index0: bool,
+    pub(super) index0: bool,
     /// Default is full:
     ///   "full"    - members with full membership can communicate with all hosts (members) within the network/partition
     ///   "limited" - members with limited membership cannot communicate with other members with limited membership.
     ///               However, communication is allowed between every other combination of membership types.
-    pub membership: PortMembership,
+    pub(super) membership: PortMembership,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct PartitionKey(u16);
+pub(super) struct PartitionKey(u16);
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Partition {
+pub(super) struct Partition {
     /// The name of Partition.
-    pub name: String,
+    pub(super) name: String,
     /// The pkey of Partition.
-    pub pkey: PartitionKey,
+    pub(super) pkey: PartitionKey,
     /// Default false
-    pub ipoib: bool,
+    pub(super) ipoib: bool,
     /// The QoS of Partition.
-    pub qos: Option<PartitionQoS>,
+    pub(super) qos: Option<PartitionQoS>,
     /// GUIDS attached to the Partition. Only available if explictly queried for
-    pub guids: Option<HashSet<String>>,
+    pub(super) guids: Option<HashSet<String>>,
     /// The default membership status of ports on this partition
     /// The value is only available if all of these things are true:
     /// - The partition is the default partition
     /// - associated ports/guid are queried
     /// - UFM version is 6.19 or newer
-    pub membership: Option<PortMembership>,
+    pub(super) membership: Option<PortMembership>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
-pub struct Port {
-    pub guid: String,
-    pub name: String,
+pub(super) struct Port {
+    pub(super) guid: String,
+    pub(super) name: String,
     #[serde(rename = "systemID")]
-    pub system_id: String,
-    pub lid: i32,
-    pub dname: String,
-    pub system_name: String,
-    pub physical_state: String,
-    pub logical_state: String,
+    pub(super) system_id: String,
+    pub(super) lid: i32,
+    pub(super) dname: String,
+    pub(super) system_name: String,
+    pub(super) physical_state: String,
+    pub(super) logical_state: String,
 }
 
 #[derive(Default)]
-pub struct Filter {
-    pub guids: Option<HashSet<String>>,
-    pub pkey: Option<PartitionKey>,
-    pub logical_state: Option<String>,
+pub(super) struct Filter {
+    pub(super) guids: Option<HashSet<String>>,
+    pub(super) pkey: Option<PartitionKey>,
+    pub(super) logical_state: Option<String>,
 }
 
 #[derive(Default, Debug, Copy, Clone)]
-pub struct GetPartitionOptions {
+pub(super) struct GetPartitionOptions {
     /// Whether to include `guids` associated with each partition in the response
-    pub include_guids_data: bool,
+    pub(super) include_guids_data: bool,
     /// Whether the response should contain the `qos_conf` and `ip_over_ib` parameters
-    pub include_qos_conf: bool,
+    pub(super) include_qos_conf: bool,
 }
 
 /// Partition data with extra options as presented by UFM
@@ -141,7 +141,7 @@ struct PartitionData {
     /// - The partition is the default partition
     /// - associated ports/guid are queried with `guids_data==true`
     /// - UFM version is 6.19 or newer
-    pub membership: Option<PortMembership>,
+    membership: Option<PortMembership>,
 }
 
 const HEX_PRE: &str = "0x";
@@ -202,12 +202,12 @@ impl From<PartitionKey> for u16 {
     }
 }
 
-pub struct Ufm {
+pub(super) struct Ufm {
     client: RestClient,
 }
 
 #[derive(Error, Debug)]
-pub enum UFMError {
+pub(super) enum UFMError {
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
     #[error("invalid pkey '{0}'")]
@@ -280,21 +280,21 @@ impl From<RestError> for UFMError {
 }
 
 #[derive(Clone, Debug)]
-pub struct UFMCert {
-    pub ca_crt: String,
-    pub tls_key: String,
-    pub tls_crt: String,
+pub(super) struct UFMCert {
+    pub(super) ca_crt: String,
+    pub(super) tls_key: String,
+    pub(super) tls_crt: String,
 }
 
-pub struct UFMConfig {
-    pub address: String,
-    pub username: Option<String>,
-    pub password: Option<String>,
-    pub token: Option<String>,
-    pub cert: Option<UFMCert>,
+pub(super) struct UFMConfig {
+    pub(super) address: String,
+    pub(super) username: Option<String>,
+    pub(super) password: Option<String>,
+    pub(super) token: Option<String>,
+    pub(super) cert: Option<UFMCert>,
 }
 
-pub fn new_client(conf: UFMConfig) -> Result<Ufm, UFMError> {
+pub(super) fn new_client(conf: UFMConfig) -> Result<Ufm, UFMError> {
     let addr = Url::parse(&conf.address)
         .map_err(|_| UFMError::InvalidConfig(format!("invalid UFM url: {}", conf.address)))?;
     let address = addr.host_str().ok_or(UFMError::InvalidConfig(format!(
@@ -342,14 +342,14 @@ pub fn new_client(conf: UFMConfig) -> Result<Ufm, UFMError> {
 }
 
 impl Ufm {
-    pub async fn get_sm_config(&self) -> Result<SmConfig, UFMError> {
+    pub(super) async fn get_sm_config(&self) -> Result<SmConfig, UFMError> {
         let path = String::from("/app/smconf");
         let sm_config: SmConfig = self.client.get(&path).await?.0;
 
         Ok(sm_config)
     }
 
-    pub async fn update_partition_qos(
+    pub(super) async fn update_partition_qos(
         &self,
         pkey: PartitionKey,
         qos: PartitionQoS,
@@ -377,7 +377,11 @@ impl Ufm {
         Ok(())
     }
 
-    pub async fn bind_ports(&self, p: Partition, ports: Vec<PortConfig>) -> Result<(), UFMError> {
+    pub(super) async fn bind_ports(
+        &self,
+        p: Partition,
+        ports: Vec<PortConfig>,
+    ) -> Result<(), UFMError> {
         let path = String::from("/resources/pkeys");
 
         let mut membership = PortMembership::Full;
@@ -415,7 +419,7 @@ impl Ufm {
         Ok(())
     }
 
-    pub async fn unbind_ports(
+    pub(super) async fn unbind_ports(
         &self,
         pkey: PartitionKey,
         guids: Vec<String>,
@@ -441,7 +445,7 @@ impl Ufm {
         Ok(())
     }
 
-    pub async fn list_partitions(
+    pub(super) async fn list_partitions(
         &self,
         options: GetPartitionOptions,
     ) -> Result<HashMap<PartitionKey, Partition>, UFMError> {
@@ -480,7 +484,7 @@ impl Ufm {
         Ok(results)
     }
 
-    pub async fn get_partition(
+    pub(super) async fn get_partition(
         &self,
         pkey: PartitionKey,
         options: GetPartitionOptions,
@@ -512,7 +516,7 @@ impl Ufm {
         })
     }
 
-    pub async fn list_port(&self, filter: Option<Filter>) -> Result<Vec<Port>, UFMError> {
+    pub(super) async fn list_port(&self, filter: Option<Filter>) -> Result<Vec<Port>, UFMError> {
         let path = String::from("/resources/ports?sys_type=Computer");
         let ports: Vec<Port> = self.client.list(&path).await?.0;
 
@@ -582,7 +586,7 @@ impl Ufm {
         }
     }
 
-    pub async fn version(&self) -> Result<String, UFMError> {
+    pub(super) async fn version(&self) -> Result<String, UFMError> {
         #[derive(Serialize, Deserialize, Debug)]
         struct Version {
             ufm_release_version: String,
@@ -594,7 +598,7 @@ impl Ufm {
         Ok(v.ufm_release_version)
     }
 
-    pub async fn raw_get(&self, path: &str) -> Result<(String, ResponseDetails), UFMError> {
+    pub(super) async fn raw_get(&self, path: &str) -> Result<(String, ResponseDetails), UFMError> {
         let (body, details) = self.client.get_raw(path).await?;
 
         Ok((body, details))

--- a/crates/ib-fabric/src/ib/ufmclient/rest.rs
+++ b/crates/ib-fabric/src/ib/ufmclient/rest.rs
@@ -36,7 +36,7 @@ use thiserror::Error;
 use crate::ib::ufmclient::UFMCert;
 
 #[derive(Error, Debug)]
-pub enum RestError {
+pub(super) enum RestError {
     #[error("invalid configuration: '{0}'")]
     InvalidConfig(String),
     #[error("response body can not be deserialized: {body}")]
@@ -75,7 +75,7 @@ impl From<hyper::Error> for RestError {
 const REST_TIME_OUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Debug)]
-pub enum RestScheme {
+pub(super) enum RestScheme {
     Http,
     Https,
 }
@@ -99,15 +99,15 @@ impl Display for RestScheme {
     }
 }
 
-pub struct RestClientConfig {
-    pub address: String,
-    pub port: Option<u16>,
-    pub scheme: RestScheme,
-    pub auth_info: String,
-    pub base_path: String,
+pub(super) struct RestClientConfig {
+    pub(super) address: String,
+    pub(super) port: Option<u16>,
+    pub(super) scheme: RestScheme,
+    pub(super) auth_info: String,
+    pub(super) base_path: String,
 }
 
-pub struct RestClient {
+pub(super) struct RestClient {
     base_url: String,
     auth_info: String,
     scheme: RestScheme,
@@ -116,7 +116,7 @@ pub struct RestClient {
 }
 
 impl RestClient {
-    pub fn new(conf: &RestClientConfig) -> Result<RestClient, RestError> {
+    pub(super) fn new(conf: &RestClientConfig) -> Result<RestClient, RestError> {
         let mut auth_info = conf.auth_info.clone().trim().to_string();
         let mut auto_cert: Option<UFMCert> = None;
 
@@ -292,7 +292,7 @@ impl RestClient {
         })
     }
 
-    pub async fn get<'a, T: serde::de::DeserializeOwned>(
+    pub(super) async fn get<'a, T: serde::de::DeserializeOwned>(
         &'a self,
         path: &'a str,
     ) -> Result<(T, ResponseDetails), RestError> {
@@ -322,7 +322,7 @@ impl RestClient {
     }
 
     /// Performs a HTTP GET request anad returns the response directly without trying to deserialize it
-    pub async fn get_raw<'a>(
+    pub(super) async fn get_raw<'a>(
         &'a self,
         path: &'a str,
     ) -> Result<(String, ResponseDetails), RestError> {
@@ -330,7 +330,7 @@ impl RestClient {
         Ok((resp.body, resp.details))
     }
 
-    pub async fn list<'a, T: serde::de::DeserializeOwned>(
+    pub(super) async fn list<'a, T: serde::de::DeserializeOwned>(
         &'a self,
         path: &'a str,
     ) -> Result<(T, ResponseDetails), RestError> {
@@ -350,13 +350,17 @@ impl RestClient {
         Ok((data, resp.details))
     }
 
-    pub async fn post(&self, path: &str, data: String) -> Result<ResponseDetails, RestError> {
+    pub(super) async fn post(
+        &self,
+        path: &str,
+        data: String,
+    ) -> Result<ResponseDetails, RestError> {
         let resp = self.execute_request(Method::POST, path, Some(data)).await?;
 
         Ok(resp.details)
     }
 
-    pub async fn put(&self, path: &str, data: String) -> Result<ResponseDetails, RestError> {
+    pub(super) async fn put(&self, path: &str, data: String) -> Result<ResponseDetails, RestError> {
         let resp = self.execute_request(Method::PUT, path, Some(data)).await?;
 
         Ok(resp.details)
@@ -415,14 +419,14 @@ impl RestClient {
     }
 }
 
-pub struct ResponseDetails {
-    pub status_code: u16,
-    pub headers: http::HeaderMap,
+pub(in crate::ib) struct ResponseDetails {
+    pub(in crate::ib) status_code: u16,
+    pub(in crate::ib) headers: http::HeaderMap,
 }
 
 struct ExecuteRequestResult {
-    pub body: String,
-    pub details: ResponseDetails,
+    body: String,
+    details: ResponseDetails,
 }
 
 // Wrap ClientConfig::builder_with_provider() with defaults

--- a/crates/ib-fabric/src/lib.rs
+++ b/crates/ib-fabric/src/lib.rs
@@ -510,7 +510,7 @@ struct FabricData {
 }
 
 impl FabricData {
-    pub fn derive_partitions_by_guid(&mut self) {
+    fn derive_partitions_by_guid(&mut self) {
         let Some(partitions) = self.partitions.as_ref() else {
             self.partition_ids_by_guid = None;
             return;

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -30,70 +30,70 @@ use crate::errors::IbResult;
 
 /// Metrics that are gathered in one a single `IbFabricMonitor` run
 #[derive(Clone, Debug)]
-pub struct IbFabricMonitorMetrics {
+pub(super) struct IbFabricMonitorMetrics {
     /// When we started recording these metrics
-    pub recording_started_at: std::time::Instant,
+    pub(super) recording_started_at: std::time::Instant,
     /// The amount of fabrics that are monitored
-    pub num_fabrics: usize,
+    pub(super) num_fabrics: usize,
     /// Per fabric metrics
-    pub fabrics: HashMap<String, FabricMetrics>,
+    pub(super) fabrics: HashMap<String, FabricMetrics>,
     /// The amount of Machines where the IB status observation got updated
-    pub num_machine_ib_status_updates: usize,
+    pub(super) num_machine_ib_status_updates: usize,
     /// The amount of Machines with a certain port state
     /// Key: Tuple of total and active amount of IB ports on the Machines
     /// Value: Amount of Machines with that amount of total and active ports
-    pub num_machines_by_port_states: HashMap<(usize, usize), usize>,
+    pub(super) num_machines_by_port_states: HashMap<(usize, usize), usize>,
     /// The amount of Machines with a certain amount of associated partitions
     /// Key: The amount of associated partitions
     /// Value: Amount of Machines with that amount of associated partitions
-    pub num_machines_by_ports_with_partitions: HashMap<usize, usize>,
+    pub(super) num_machines_by_ports_with_partitions: HashMap<usize, usize>,
     /// The amount of machines where at least one port is not assigned to the
     /// expected pkey on UFM
-    pub num_machines_with_missing_pkeys: usize,
+    pub(super) num_machines_with_missing_pkeys: usize,
     /// The amount of machines where at least one port is assigned to an unexpected
     /// pkey on UFM
-    pub num_machines_with_unexpected_pkeys: usize,
+    pub(super) num_machines_with_unexpected_pkeys: usize,
     /// The amount of machines where at least one port is assigned to a pkey value
     /// that is not associated with any partition ID
-    pub num_machines_with_unknown_pkeys: usize,
+    pub(super) num_machines_with_unknown_pkeys: usize,
 }
 
 /// Metrics collected for a single fabric
 #[derive(Clone, Debug, Default, Serialize)]
-pub struct FabricMetrics {
+pub(super) struct FabricMetrics {
     /// The endpoint that we use to interact with the fabric
-    pub endpoints: Vec<String>,
+    pub(super) endpoints: Vec<String>,
     /// Error when trying to connect to the fabric
     ///
     /// TODO: Replace raw UFM errors with a bounded classification so distinct
     /// error strings do not create separate dimensions.
-    pub fabric_error: String,
+    pub(super) fabric_error: String,
     /// UFM version
-    pub ufm_version: String,
+    pub(super) ufm_version: String,
     /// The subnet_prefix of UFM
-    pub subnet_prefix: String,
+    pub(super) subnet_prefix: String,
     /// The m_key of UFM
-    pub m_key: String,
+    pub(super) m_key: String,
     /// The sm_key of UFM
-    pub sm_key: String,
+    pub(super) sm_key: String,
     /// The sa_key of UFM
-    pub sa_key: String,
+    pub(super) sa_key: String,
     /// The m_key_per_port of UFM
-    pub m_key_per_port: bool,
+    pub(super) m_key_per_port: bool,
     /// Default partition membership
-    pub default_partition_membership: Option<String>,
+    pub(super) default_partition_membership: Option<String>,
     /// The amount of partitions visible at UFM
-    pub num_partitions: Option<usize>,
+    pub(super) num_partitions: Option<usize>,
     /// The amount of ports visible at UFM - indexed by state
-    pub ports_by_state: Option<HashMap<String, usize>>,
+    pub(super) ports_by_state: Option<HashMap<String, usize>>,
     /// Whether the fabric not configured to protect tenants and infrastructure
-    pub insecure_fabric_configuration: bool,
+    pub(super) insecure_fabric_configuration: bool,
     /// Whether an insecure fabric configuration is allowed
-    pub allow_insecure_fabric_configuration: bool,
+    pub(super) allow_insecure_fabric_configuration: bool,
 }
 
 impl IbFabricMonitorMetrics {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             recording_started_at: std::time::Instant::now(),
             num_fabrics: 0,
@@ -620,20 +620,20 @@ impl IbFabricMonitorInstruments {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, LabelValue)]
 #[allow(clippy::enum_variant_names)]
-pub enum UfmOperation {
+pub(super) enum UfmOperation {
     BindGuidToPkey,
     UnbindGuidFromPkey,
     // If you add anything here, adjust the values function below
 }
 
 impl UfmOperation {
-    pub fn values() -> impl Iterator<Item = Self> {
+    fn values() -> impl Iterator<Item = Self> {
         [Self::BindGuidToPkey, Self::UnbindGuidFromPkey].into_iter()
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, LabelValue)]
-pub enum UfmOperationStatus {
+enum UfmOperationStatus {
     Ok,
     Error,
     // If you add anything here, adjust the values function below
@@ -644,7 +644,7 @@ impl UfmOperationStatus {
     /// enumerate the (operation, status) space directly, so this survives to
     /// pin the vocabulary in tests.
     #[cfg(test)]
-    pub fn values() -> impl Iterator<Item = Self> {
+    fn values() -> impl Iterator<Item = Self> {
         [Self::Ok, Self::Error].into_iter()
     }
 }
@@ -792,13 +792,13 @@ impl UfmGuidPkeyChangeFinished {
 }
 
 /// Stores Metric data shared between the Fabric Monitor and the OpenTelemetry background task
-pub struct MetricHolder {
+pub(super) struct MetricHolder {
     _instruments: IbFabricMonitorInstruments,
     last_iteration_metrics: SharedMetricsHolder<IbFabricMonitorMetrics>,
 }
 
 impl MetricHolder {
-    pub fn new(meter: Meter, hold_period: Duration, fabric_ids: &[&str]) -> Self {
+    pub(super) fn new(meter: Meter, hold_period: Duration, fabric_ids: &[&str]) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         let instruments = IbFabricMonitorInstruments::new(meter, last_iteration_metrics.clone());
         UfmGuidPkeyChangeFinished::initialize_counter_series(fabric_ids);
@@ -809,7 +809,7 @@ impl MetricHolder {
     }
 
     /// Updates the most recent metrics
-    pub fn update_metrics(&self, metrics: IbFabricMonitorMetrics) {
+    pub(super) fn update_metrics(&self, metrics: IbFabricMonitorMetrics) {
         self.last_iteration_metrics.update(metrics);
     }
 }

--- a/crates/nvlink-manager/src/errors.rs
+++ b/crates/nvlink-manager/src/errors.rs
@@ -35,4 +35,4 @@ impl NvLinkManagerError {
     }
 }
 
-pub type NvLinkManagerResult<T> = Result<T, NvLinkManagerError>;
+pub(super) type NvLinkManagerResult<T> = Result<T, NvLinkManagerError>;

--- a/crates/nvlink-manager/src/metrics.rs
+++ b/crates/nvlink-manager/src/metrics.rs
@@ -29,36 +29,36 @@ use crate::NmxcPartitionOperationType;
 
 /// Metrics that are gathered in a single nvl partition monitor run
 #[derive(Clone, Debug)]
-pub struct NvlPartitionMonitorMetrics {
+pub(super) struct NvlPartitionMonitorMetrics {
     /// Start time of metrics gathering
-    pub recording_started_at: std::time::Instant,
-    pub nmxc: NmxcMetrics,
-    pub num_machines_scanned: usize,
-    pub num_instances_scanned: usize,
-    pub num_gpus_scanned: usize,
+    pub(super) recording_started_at: std::time::Instant,
+    pub(super) nmxc: NmxcMetrics,
+    pub(super) num_machines_scanned: usize,
+    pub(super) num_instances_scanned: usize,
+    pub(super) num_gpus_scanned: usize,
     /// Number of machines where NVLink status observation got updated
-    pub num_machine_nvl_status_updates: usize,
+    pub(super) num_machine_nvl_status_updates: usize,
     /// Number of logical partitions
-    pub num_logical_partitions: usize,
+    pub(super) num_logical_partitions: usize,
     /// Number of physical partitions
-    pub num_physical_partitions: usize,
+    pub(super) num_physical_partitions: usize,
     /// Number of completed operations in this run
-    pub num_completed_operations: usize,
+    pub(super) num_completed_operations: usize,
     /// Number of NVLink GPU partition ID mismatches between DB and NMX-C
-    pub num_nvlink_info_mismatches: usize,
+    pub(super) num_nvlink_info_mismatches: usize,
     /// Number of stale partitions deleted from DB (not found in NMX-C)
-    pub num_stale_partitions_deleted: usize,
-    pub applied_changes: HashMap<AppliedChange, usize>,
+    pub(super) num_stale_partitions_deleted: usize,
+    pub(super) applied_changes: HashMap<AppliedChange, usize>,
     /// Time from nvlink_config_version for instances currently in Pending (time spent in Pending), in milliseconds
-    pub nvlink_config_apply_durations_ms: Vec<f64>,
+    pub(super) nvlink_config_apply_durations_ms: Vec<f64>,
     /// Chassis- or rack-level NMX-C connectivity failures that caused null nvlink status observations.
     /// Counted per machine group; the OTEL gauge name remains `..._unreachable_chassis_count` for continuity.
-    pub num_nmx_c_unreachable_chassis: HashMap<ChassisNmxCUnreachableReason, usize>,
+    pub(super) num_nmx_c_unreachable_chassis: HashMap<ChassisNmxCUnreachableReason, usize>,
 }
 
 /// Why the partition monitor could not use NMX-C for a machine group during an iteration.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ChassisNmxCUnreachableReason {
+pub(super) enum ChassisNmxCUnreachableReason {
     /// No rack-switch NVOS IP or `nvlink_nmxc_endpoints` row resolved an endpoint URL.
     NoEndpoint,
     /// The resolved endpoint URL could not be parsed as a valid NMX-C client URI.
@@ -74,7 +74,7 @@ pub enum ChassisNmxCUnreachableReason {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, LabelValue)]
-pub enum NmxcMetricOperation {
+pub(super) enum NmxcMetricOperation {
     Create,
     Remove,
     RemoveDefaultPartition,
@@ -82,26 +82,25 @@ pub enum NmxcMetricOperation {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, LabelValue)]
-pub enum NmxcMetricOperationStatus {
+pub(super) enum NmxcMetricOperationStatus {
     Completed,
     Failed,
     Timedout,
-    Cancelled,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct AppliedChange {
+pub(super) struct AppliedChange {
     /// The operation that has been issued
-    pub operation: NmxcMetricOperation,
+    pub(super) operation: NmxcMetricOperation,
     /// Whether the operation succeeded or failed
-    pub status: NmxcMetricOperationStatus,
+    pub(super) status: NmxcMetricOperationStatus,
 }
 
 /// The NMX-C call that failed inside one partition operation. This stays in
 /// log context rather than becoming another latency label; its only other job
 /// is selecting the diagnostic operators already see for that call.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum NmxcOperationFailureStage {
+pub(super) enum NmxcOperationFailureStage {
     None,
     CreatePartitionRetry,
     CreatePartition,
@@ -112,7 +111,7 @@ pub(crate) enum NmxcOperationFailureStage {
     AddGpus,
 }
 
-pub(crate) const DELETE_DEFAULT_PARTITION_FAILED_MESSAGE: &str =
+pub(super) const DELETE_DEFAULT_PARTITION_FAILED_MESSAGE: &str =
     "Failed to delete default partition";
 
 impl Display for NmxcOperationFailureStage {
@@ -144,32 +143,32 @@ impl Display for NmxcOperationFailureStage {
     message = dynamic,
     describe = "Time consumed for one NMX-C operation"
 )]
-pub(crate) struct NmxcOperationFinished {
+pub(super) struct NmxcOperationFinished {
     #[label]
-    pub operation: NmxcMetricOperation,
+    pub(super) operation: NmxcMetricOperation,
     #[label]
-    pub status: NmxcMetricOperationStatus,
+    pub(super) status: NmxcMetricOperationStatus,
     #[observation]
-    pub latency: Duration,
+    pub(super) latency: Duration,
     #[context]
-    pub failure_stage: NmxcOperationFailureStage,
+    pub(super) failure_stage: NmxcOperationFailureStage,
     #[context]
-    pub nvlink_logical_partition_id: String,
+    pub(super) nvlink_logical_partition_id: String,
     #[context]
-    pub nmx_c_partition_id: String,
+    pub(super) nmx_c_partition_id: String,
     #[context]
-    pub create_partition_request: String,
+    pub(super) create_partition_request: String,
     #[context]
-    pub error: String,
+    pub(super) error: String,
 }
 
 impl DynamicLog for NmxcOperationFinished {
     fn log_at(&self) -> LogAt {
         match self.status {
             NmxcMetricOperationStatus::Completed => LogAt::Off,
-            NmxcMetricOperationStatus::Failed
-            | NmxcMetricOperationStatus::Timedout
-            | NmxcMetricOperationStatus::Cancelled => LogAt::Level(tracing::Level::WARN),
+            NmxcMetricOperationStatus::Failed | NmxcMetricOperationStatus::Timedout => {
+                LogAt::Level(tracing::Level::WARN)
+            }
         }
     }
 }
@@ -203,23 +202,23 @@ impl DynamicMessage for NmxcOperationFinished {
 
 /// Metrics collected for NMX-C data
 #[derive(Clone, Debug, Default)]
-pub struct NmxcMetrics {
+pub(super) struct NmxcMetrics {
     /// The endpoint that we use to interact with NMX-C
-    pub endpoint: String,
+    pub(super) endpoint: String,
     /// connection errors
-    pub connect_error: String,
+    pub(super) connect_error: String,
     /// Version of NMX-C
-    pub version: String,
+    pub(super) version: String,
     /// Partition count per (nvlink_domain_uuid, health).
-    pub partition_health: HashMap<(String, &'static str), usize>,
+    pub(super) partition_health: HashMap<(String, &'static str), usize>,
     /// GPU count per (nvlink_domain_uuid, health).
-    pub gpu_health: HashMap<(String, &'static str), usize>,
+    pub(super) gpu_health: HashMap<(String, &'static str), usize>,
     /// Compute-node count per (nvlink_domain_uuid, health).
-    pub compute_node_health: HashMap<(String, &'static str), usize>,
+    pub(super) compute_node_health: HashMap<(String, &'static str), usize>,
 }
 
 impl NvlPartitionMonitorMetrics {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             recording_started_at: std::time::Instant::now(),
             num_machines_scanned: 0,
@@ -280,7 +279,7 @@ impl Display for NvlPartitionMonitorMetrics {
     metric = histogram,
     describe = "Time consumed for one monitor iteration"
 )]
-pub(crate) enum NvlPartitionMonitorIterationFinished {
+pub(super) enum NvlPartitionMonitorIterationFinished {
     /// A clean pass: sampled, never logged.
     #[event(log = off)]
     Succeeded {
@@ -298,16 +297,13 @@ pub(crate) enum NvlPartitionMonitorIterationFinished {
 }
 
 /// Instruments that are used by pub struct NvlPartitionMonitor
-pub struct NvlPartitionMonitorInstruments {
-    pub nmxc_changes_applied: Counter<u64>,
-    pub nvlink_config_apply_latency: Histogram<f64>,
+struct NvlPartitionMonitorInstruments {
+    nmxc_changes_applied: Counter<u64>,
+    nvlink_config_apply_latency: Histogram<f64>,
 }
 
 impl NvlPartitionMonitorInstruments {
-    pub fn new(
-        meter: Meter,
-        shared_metrics: SharedMetricsHolder<NvlPartitionMonitorMetrics>,
-    ) -> Self {
+    fn new(meter: Meter, shared_metrics: SharedMetricsHolder<NvlPartitionMonitorMetrics>) -> Self {
         let nvlink_config_apply_latency = meter
             .f64_histogram("carbide_nvlink_partition_monitor_nvlink_config_apply_latency")
             .with_description("Time since nvlink config was requested for this instance")
@@ -556,7 +552,7 @@ impl NvlPartitionMonitorInstruments {
 }
 
 impl NmxcMetricOperation {
-    pub fn values() -> impl Iterator<Item = Self> {
+    fn values() -> impl Iterator<Item = Self> {
         [
             Self::Create,
             Self::Update,
@@ -604,7 +600,7 @@ impl From<NmxcPartitionOperationType> for NmxcMetricOperation {
 }
 
 impl NmxcMetricOperationStatus {
-    pub fn values() -> impl Iterator<Item = Self> {
+    fn values() -> impl Iterator<Item = Self> {
         [Self::Completed, Self::Failed, Self::Timedout].into_iter()
     }
 }
@@ -616,13 +612,13 @@ impl From<NmxcMetricOperationStatus> for opentelemetry::Value {
 }
 
 /// Stores Metric data shared between the nvl partition monitor and the OpenTelemetry background task
-pub struct MetricHolder {
+pub(super) struct MetricHolder {
     instruments: NvlPartitionMonitorInstruments,
     last_iteration_metrics: SharedMetricsHolder<NvlPartitionMonitorMetrics>,
 }
 
 impl MetricHolder {
-    pub fn new(meter: Meter, hold_period: Duration) -> Self {
+    pub(super) fn new(meter: Meter, hold_period: Duration) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         let instruments =
             NvlPartitionMonitorInstruments::new(meter, last_iteration_metrics.clone());
@@ -634,7 +630,7 @@ impl MetricHolder {
     }
 
     /// Updates the most recent metrics
-    pub fn update_metrics(&self, metrics: NvlPartitionMonitorMetrics) {
+    pub(super) fn update_metrics(&self, metrics: NvlPartitionMonitorMetrics) {
         self.instruments.emit_counters_and_histograms(&metrics);
         self.last_iteration_metrics.update(metrics);
     }

--- a/crates/nvlink-manager/src/switch_cert_monitor.rs
+++ b/crates/nvlink-manager/src/switch_cert_monitor.rs
@@ -351,12 +351,12 @@ impl SwitchCertMonitorInstruments {
     }
 }
 
-pub struct MetricHolder {
+struct MetricHolder {
     last_iteration_metrics: SharedMetricsHolder<SwitchCertMonitorMetrics>,
 }
 
 impl MetricHolder {
-    pub fn new(meter: Meter, hold_period: Duration) -> Self {
+    fn new(meter: Meter, hold_period: Duration) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         SwitchCertMonitorInstruments::register(meter, last_iteration_metrics.clone());
         Self {

--- a/crates/rack-controller/src/lib.rs
+++ b/crates/rack-controller/src/lib.rs
@@ -42,7 +42,7 @@ pub mod maintenance;
 pub mod metrics;
 pub mod nmx_certificate;
 pub mod ready;
-pub mod validating;
+mod validating;
 
 /// Loads all machines associated with the given rack via their `rack_id` FK.
 pub(crate) async fn get_machines_from_rack(

--- a/crates/rack-controller/src/validating.rs
+++ b/crates/rack-controller/src/validating.rs
@@ -48,22 +48,22 @@ pub(super) fn strip_rv_labels(metadata: &mut Metadata) -> bool {
 /// Aggregated summary of all partition validation statuses in a rack.
 /// Used by the state handler to determine state transitions.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct RackPartitionSummary {
+struct RackPartitionSummary {
     /// Total number of partitions in the rack
-    pub total_partitions: usize,
+    total_partitions: usize,
     /// Number of partitions that haven't started validation
-    pub pending: usize,
+    pending: usize,
     /// Number of partitions currently being validated
-    pub in_progress: usize,
+    in_progress: usize,
     /// Number of partitions that passed validation
-    pub validated: usize,
+    validated: usize,
     /// Number of partitions that failed validation
-    pub failed: usize,
+    failed: usize,
 }
 
 /// Per-machine rack-validation state, derived from machine metadata labels.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) enum MachineRvState {
+enum MachineRvState {
     Idle,
     Inp,
     Pass,
@@ -107,20 +107,20 @@ impl TryFrom<Metadata> for MachineRvState {
 /// validation participants. Machines without it are silently skipped.
 /// Machines whose `rv.run-id` label is missing or doesn't match the
 /// provided `run_id` are also skipped (stale labels from previous runs).
-pub(super) struct RvPartitions {
-    pub(super) inner: HashMap<String, Vec<MachineRvState>>,
+struct RvPartitions {
+    inner: HashMap<String, Vec<MachineRvState>>,
 }
 
 impl RvPartitions {
     /// Build from a vec of machines, filtering by run ID.
-    pub fn from_machines(machines: Vec<Machine>, run_id: &str) -> Result<Self, StateHandlerError> {
+    fn from_machines(machines: Vec<Machine>, run_id: &str) -> Result<Self, StateHandlerError> {
         Self::from_meta_iter(machines.into_iter().map(|m| m.metadata), run_id)
     }
 
     /// Core grouping logic over any iterator of Metadata.
     /// Extracted so unit tests can feed plain metadata without constructing
     /// full Machine values.
-    pub fn from_meta_iter(
+    fn from_meta_iter(
         iter: impl Iterator<Item = Metadata>,
         run_id: &str,
     ) -> Result<Self, StateHandlerError> {
@@ -158,7 +158,7 @@ impl RvPartitions {
     /// - Failed      else if any node is `Fail`
     /// - InProgress  else if any node is `Inp`
     /// - Pending     otherwise (all `Idle`, or a mix of `Idle`/`Pass`)
-    pub fn summarize(&self) -> RackPartitionSummary {
+    fn summarize(&self) -> RackPartitionSummary {
         let mut summary = RackPartitionSummary {
             total_partitions: self.inner.len(),
             ..Default::default()
@@ -187,7 +187,7 @@ impl RvPartitions {
 ///
 /// Queries all machines belonging to the rack, reads their validation metadata
 /// labels, and aggregates the status by partition.
-pub(super) async fn load_partition_summary(
+async fn load_partition_summary(
     rack_id: &RackId,
     rack: &Rack,
     run_id: &str,
@@ -209,7 +209,7 @@ pub(super) async fn load_partition_summary(
 
 /// Scans the rack's machines for an `rv.run-id` label set by RVS.
 /// Returns the first run ID found, or `None` if RVS has not started a run yet.
-pub(super) async fn find_rv_run_id(
+async fn find_rv_run_id(
     rack_id: &RackId,
     rack: &Rack,
     ctx: &mut StateHandlerContext<'_, RackStateHandlerContextObjects>,
@@ -237,7 +237,7 @@ pub(super) async fn find_rv_run_id(
 ///
 /// Pure function encoding the validation state machine transitions.
 /// Returns `None` if no transition should occur.
-pub(crate) fn compute_validation_transition(
+fn compute_validation_transition(
     current: &RackValidationState,
     summary: &RackPartitionSummary,
 ) -> Option<RackValidationState> {
@@ -321,7 +321,7 @@ pub(crate) fn compute_validation_transition(
 //------------------------------------------------------------------------------
 // State handler
 
-pub async fn handle_validating(
+pub(super) async fn handle_validating(
     id: &RackId,
     state: &mut Rack,
     validating_state: &RackValidationState,


### PR DESCRIPTION
This adopts the new style guide rules around module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout IB Fabric, NVLink Manager, DPA Manager, DPF, and Rack Controller.

Primary callouts are:
- Replace unrestricted `pub` throughout `crates/ib-fabric/src/**`, `crates/nvlink-manager/src/**`, `crates/dpa-manager/src/**`, `crates/dpf/src/**`, and `crates/rack-controller/src/**` with private, `pub(super)`, or `pub(in crate::ib)` visibility based on actual callers.
- Keep the UFM REST adapter's sibling-only details within `crate::ib`, while leaving intentional cross-crate IB/NVLink test-support APIs public.
- Narrow monitor metrics, DPA handlers, DPF test fixtures, and rack-validation internals to the modules that use them.
- Remove the never-recorded DPA histogram and callerless NVLink `Cancelled` metric status exposed by the tighter boundaries.
- Leave generated DPF CRD declarations to https://github.com/NVIDIA/infra-controller/issues/4547, and keep controller behavior and the supported public API unchanged.

Tests pass!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4555.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

All 207 tests across IB Fabric, NVLink Manager, DPA Manager, DPF, and Rack Controller pass. I also ran:

```bash
cargo test --locked -p carbide-ib-fabric -p carbide-nvlink-manager -p carbide-dpa-manager -p carbide-dpf -p carbide-rack-controller --all-targets --all-features
cargo clippy --locked -p carbide-ib-fabric -p carbide-nvlink-manager -p carbide-dpa-manager -p carbide-dpf -p carbide-rack-controller --all-targets --all-features -- --force-warn unreachable-pub
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
git diff --check
```

## Additional Notes

The initial compiler inventory found 75 overbroad declarations: 40 in IB Fabric, 12 in NVLink Manager, 11 in DPA Manager, nine hand-authored DPF findings, and three in Rack Controller. The final 16-file diff also narrows adjacent fields and module boundaries exposed by that cleanup. No `unreachable_pub` warning remains in the owned source trees.

DPF's 143 generated CRD warnings are unchanged and reserved for https://github.com/NVIDIA/infra-controller/issues/4547.

Local CodeRabbit returned zero findings. The independent read-only Claude review found four applicable follow-through items around the unused DPA histogram, NVLink metric internals, one DPF test field, and Rack Controller's module boundary; all are incorporated. The resulting compile also exposed and removed the callerless NVLink `Cancelled` metric status.


Closes #4555
