### PR TITLE
refactor(bmc/console): adopt style guide rules for pub/module visibility

### DIFF
--- a/crates/bmc-explorer/src/chassis.rs
+++ b/crates/bmc-explorer/src/chassis.rs
@@ -37,18 +37,18 @@ use crate::{Error, network_adapter};
 
 type AssemblyModelFilterFn = fn(Option<AssemblyModel<&str>>) -> bool;
 const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
-pub struct Config {
-    pub network_adapter: network_adapter::Config,
-    pub need_assembly_sn: fn(ResourceIdRef) -> Option<AssemblyModelFilterFn>,
-    pub lazy_fetch: Option<fn(&ODataId) -> bool>,
+pub(crate) struct Config {
+    pub(crate) network_adapter: network_adapter::Config,
+    pub(crate) need_assembly_sn: fn(ResourceIdRef) -> Option<AssemblyModelFilterFn>,
+    pub(crate) lazy_fetch: Option<fn(&ODataId) -> bool>,
 }
 
-pub struct ExploredChassisCollection<B: Bmc> {
-    pub members: Vec<ExploredChassis<B>>,
+pub(crate) struct ExploredChassisCollection<B: Bmc> {
+    pub(super) members: Vec<ExploredChassis<B>>,
 }
 
 impl<B: Bmc> ExploredChassisCollection<B> {
-    pub async fn explore(root: &ServiceRoot<B>, config: &Config) -> Result<Self, Error<B>> {
+    pub(crate) async fn explore(root: &ServiceRoot<B>, config: &Config) -> Result<Self, Error<B>> {
         let mut members = Vec::new();
         for m in Self::fetch_members(root, config).await? {
             members.push(ExploredChassis::explore(m, config).await?);
@@ -88,11 +88,11 @@ impl<B: Bmc> ExploredChassisCollection<B> {
         }
     }
 
-    pub fn to_model(&self) -> Vec<Chassis> {
+    pub(crate) fn to_model(&self) -> Vec<Chassis> {
         self.members.iter().map(|v| v.to_model()).collect()
     }
 
-    pub fn is_liteon_powershelf(&self) -> bool {
+    pub(crate) fn is_liteon_powershelf(&self) -> bool {
         self.members.iter().any(|m| {
             m.chassis.id().into_inner() == "powershelf"
                 || (m.chassis.id().into_inner() == "chassis"
@@ -104,7 +104,7 @@ impl<B: Bmc> ExploredChassisCollection<B> {
         })
     }
 
-    pub fn liteon_power_state(&self) -> Option<LiteOnSuppliesState<'_>> {
+    pub(crate) fn liteon_power_state(&self) -> Option<LiteOnSuppliesState<'_>> {
         self.members.iter().find_map(|m| {
             m.oem_liteon_power_supplies
                 .as_ref()
@@ -118,7 +118,7 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     /// or "powershelf"). The manufacturer gate is what distinguishes Delta from
     /// the Lite-On power shelf, which shares the generic "powershelf" chassis
     /// id.
-    pub fn is_delta_powershelf(&self) -> bool {
+    pub(crate) fn is_delta_powershelf(&self) -> bool {
         self.members.iter().any(|m| {
             is_delta_powershelf_chassis(
                 m.chassis.id().into_inner(),
@@ -134,7 +134,7 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     /// Aggregate power state across all Delta PSUs found on the chassis members.
     /// Delta reports commanded PSU on/off state under
     /// `Oem.deltaenergysystems.Power`.
-    pub fn delta_power_state(&self) -> ModelPowerState {
+    fn delta_power_state(&self) -> ModelPowerState {
         let supplies: Vec<&DeltaPowerSupply> = self
             .members
             .iter()
@@ -159,7 +159,7 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     /// Synthesizes a [`ModelComputerSystem`] for a power shelf that does not
     /// expose a Redfish `ComputerSystem`. Identity is taken from the primary
     /// power-shelf chassis member (mirrors the libredfish Delta path).
-    pub fn synthesized_powershelf_system(&self) -> ModelComputerSystem {
+    pub(crate) fn synthesized_powershelf_system(&self) -> ModelComputerSystem {
         let member = self
             .members
             .iter()
@@ -193,14 +193,14 @@ impl<B: Bmc> ExploredChassisCollection<B> {
         }
     }
 
-    pub fn is_gb300(&self) -> bool {
+    pub(crate) fn is_gb300(&self) -> bool {
         self.members.iter().any(|m| {
             m.chassis.hardware_id().manufacturer == Some(Manufacturer::new("NVIDIA"))
                 && m.chassis.hardware_id().model == Some(Model::new("NVIDIA GB300"))
         })
     }
 
-    pub fn is_mgx_c2(&self) -> bool {
+    pub(crate) fn is_mgx_c2(&self) -> bool {
         self.members.iter().any(|m| {
             let hardware_id = m.chassis.hardware_id();
             is_mgx_c2_processor_module(
@@ -211,13 +211,13 @@ impl<B: Bmc> ExploredChassisCollection<B> {
         })
     }
 
-    pub fn is_lenovo(&self) -> bool {
+    pub(crate) fn is_lenovo(&self) -> bool {
         self.members
             .iter()
             .any(|m| m.chassis.hardware_id().manufacturer == Some(Manufacturer::new("Lenovo")))
     }
 
-    pub fn is_bluefield2(&self) -> bool {
+    pub(crate) fn is_bluefield2(&self) -> bool {
         self.members
             .iter()
             .find(|c| c.chassis.id().into_inner() == "Card1")
@@ -228,14 +228,14 @@ impl<B: Bmc> ExploredChassisCollection<B> {
             })
     }
 
-    pub fn is_bluefield4(&self) -> bool {
+    pub(crate) fn is_bluefield4(&self) -> bool {
         self.members.iter().any(|c| {
             c.chassis.hardware_id().model == Some(Model::new("B4240"))
                 || c.chassis.hardware_id().model == Some(Model::new("B4240V"))
         })
     }
 
-    pub fn dpu_card1_serial_number(&self) -> Result<Option<&str>, Error<B>> {
+    pub(crate) fn dpu_card1_serial_number(&self) -> Result<Option<&str>, Error<B>> {
         let maybe_sn = self
             .members
             .iter()
@@ -252,7 +252,7 @@ impl<B: Bmc> ExploredChassisCollection<B> {
     // read NDF0 PermanentMACAddress from known BF4 Redfish topology paths and
     // derive PF0 base MAC as (NDF0 - 0x10).
     // Remove callers once BF4 BMC exposes PF0 base MAC in ComputerSystem BaseMAC.
-    pub fn dpu_bf4_ndf0_permanent_mac(&self) -> Option<BaseMac> {
+    pub(crate) fn dpu_bf4_ndf0_permanent_mac(&self) -> Option<BaseMac> {
         const BF4_NDF0_PATHS: [(&str, &str, &str); 2] = [
             // /redfish/v1/Chassis/BlueField_0/NetworkAdapters/BlueField_NIC_0/NetworkDeviceFunctions/0
             ("BlueField_0", "BlueField_NIC_0", "0"),
@@ -289,7 +289,7 @@ impl<B: Bmc> ExploredChassisCollection<B> {
         None
     }
 
-    pub async fn pcie_devices(
+    pub(crate) async fn pcie_devices(
         &self,
         chassis_filter: impl Fn(&ExploredChassis<B>) -> bool,
     ) -> Result<Vec<PcieDevice<B>>, Error<B>> {
@@ -324,12 +324,12 @@ fn u64_to_mac(value: u64) -> MacAddress {
     MacAddress::new([b[2], b[3], b[4], b[5], b[6], b[7]])
 }
 
-pub struct ExploredChassis<B: Bmc> {
-    pub chassis: NvChassis<B>,
-    pub network_adapters: ExploredNetworkAdapterCollection<B>,
-    pub assembly_sn: Option<String>,
-    pub oem_liteon_power_supplies: Option<Vec<LiteOnPowerSupply>>,
-    pub oem_delta_power_supplies: Option<Vec<DeltaPowerSupply>>,
+pub(crate) struct ExploredChassis<B: Bmc> {
+    pub(crate) chassis: NvChassis<B>,
+    pub(crate) network_adapters: ExploredNetworkAdapterCollection<B>,
+    assembly_sn: Option<String>,
+    oem_liteon_power_supplies: Option<Vec<LiteOnPowerSupply>>,
+    oem_delta_power_supplies: Option<Vec<DeltaPowerSupply>>,
 }
 
 impl<B: Bmc> ExploredChassis<B> {
@@ -462,15 +462,15 @@ impl<B: Bmc> ExploredChassis<B> {
     }
 }
 
-pub struct LiteOnPowerSupply {
-    pub id: String,
-    pub serial_number: Option<String>,
-    pub power_state: Option<bool>,
+struct LiteOnPowerSupply {
+    id: String,
+    serial_number: Option<String>,
+    power_state: Option<bool>,
 }
 
-pub struct DeltaPowerSupply {
-    pub id: String,
-    pub power_state: Option<bool>,
+struct DeltaPowerSupply {
+    id: String,
+    power_state: Option<bool>,
 }
 
 /// Reads a Delta PSU's commanded on/off state from its OEM extension.
@@ -528,7 +528,7 @@ fn powershelf_power_state(states: impl Iterator<Item = Option<bool>>) -> ModelPo
     }
 }
 
-pub struct LiteOnSuppliesState<'a>(&'a [LiteOnPowerSupply]);
+pub(crate) struct LiteOnSuppliesState<'a>(&'a [LiteOnPowerSupply]);
 
 impl fmt::Display for LiteOnSuppliesState<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -541,7 +541,7 @@ impl fmt::Display for LiteOnSuppliesState<'_> {
 }
 
 impl LiteOnSuppliesState<'_> {
-    pub fn to_model(&self) -> ModelPowerState {
+    pub(crate) fn to_model(&self) -> ModelPowerState {
         if self.0.is_empty() {
             return ModelPowerState::Unknown;
         }

--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -46,30 +46,30 @@ lazy_static::lazy_static! {
     static ref UEFI_MAC_PATTERN: Regex = Regex::new(&format!(r"MAC\((?<{UEFI_MAC_PATTERN_CAPTURE}>[[:alnum:]]+)\,")).unwrap();
 }
 
-pub struct Config<'a, B: Bmc> {
-    pub need_oem_nvidia_bluefield: bool,
+pub(crate) struct Config<'a, B: Bmc> {
+    pub(crate) need_oem_nvidia_bluefield: bool,
     // Temporary workaround for BlueField DPU BMCs that intermittently return
     // HTTP 500 for the BIOS resource while the DPU is in NIC mode.
-    pub ignore_500_on_bios_fetch: bool,
+    pub(crate) ignore_500_on_bios_fetch: bool,
     // Temporary workaround for BlueField DPU BMCs that intermittently return
     // HTTP 404 for the OOB interface or the full EthernetInterfaces collection.
     // This is expected to be fixed in BMC firmware 24.10-39, which adds
     // internal retries.
-    pub retry_404_on_eth_interfaces: bool,
-    pub explore: &'a ExploreConfig<'a, B>,
+    pub(crate) retry_404_on_eth_interfaces: bool,
+    pub(crate) explore: &'a ExploreConfig<'a, B>,
 }
 
-pub struct ExploredComputerSystem<B: Bmc> {
-    pub system: ComputerSystem<B>,
-    pub bios: Option<Bios<B>>,
-    pub boot_options: Vec<BootOption<B>>,
-    pub ethernet_interfaces: Vec<EthernetInterface<B>>,
-    pub oem_nvidia_bluefield: Option<NvidiaComputerSystem<B>>,
-    pub secure_boot: Option<SecureBoot<B>>,
+pub(crate) struct ExploredComputerSystem<B: Bmc> {
+    pub(crate) system: ComputerSystem<B>,
+    pub(crate) bios: Option<Bios<B>>,
+    pub(crate) boot_options: Vec<BootOption<B>>,
+    ethernet_interfaces: Vec<EthernetInterface<B>>,
+    oem_nvidia_bluefield: Option<NvidiaComputerSystem<B>>,
+    secure_boot: Option<SecureBoot<B>>,
 }
 
 impl<B: Bmc> ExploredComputerSystem<B> {
-    pub async fn explore(
+    pub(crate) async fn explore(
         system: ComputerSystem<B>,
         config: &Config<'_, B>,
     ) -> Result<Self, Error<B>> {
@@ -171,7 +171,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             }
         }
     }
-    pub fn to_model(
+    pub(crate) fn to_model(
         &self,
         hw_type: Option<hw::HwType>,
         chassis: &ExploredChassisCollection<B>,
@@ -287,7 +287,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         })
     }
 
-    pub fn secure_boot_status(&self) -> Result<SecureBootStatus, Error<B>> {
+    pub(crate) fn secure_boot_status(&self) -> Result<SecureBootStatus, Error<B>> {
         let secure_boot = self
             .secure_boot
             .as_ref()
@@ -308,7 +308,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         })
     }
 
-    pub fn boot_order_first_option(&self) -> Option<&BootOption<B>> {
+    pub(crate) fn boot_order_first_option(&self) -> Option<&BootOption<B>> {
         self.system
             .boot_order()
             .as_ref()
@@ -320,7 +320,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             })
     }
 
-    pub fn check_boot_by_uefi_prefix(
+    pub(crate) fn check_boot_by_uefi_prefix(
         &self,
         boot_interface_mac: MacAddress,
     ) -> Option<MachineSetupDiff> {
@@ -331,7 +331,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         compare_boot_options(expected, actual)
     }
 
-    pub fn check_boot_option_enabled_by_uefi_prefix(
+    pub(crate) fn check_boot_option_enabled_by_uefi_prefix(
         &self,
         boot_interface_mac: MacAddress,
     ) -> Option<MachineSetupDiff> {
@@ -526,7 +526,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         }
     }
 
-    pub fn bios_attr_eq(&self, expected: &hw::BiosAttr) -> Option<bool> {
+    fn bios_attr_eq(&self, expected: &hw::BiosAttr) -> Option<bool> {
         self.bios
             .as_ref()
             .and_then(|bios| bios.attribute(expected.key))
@@ -538,7 +538,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             })
     }
 
-    pub fn verify_bios_attr(&self, expected: &hw::BiosAttr<'_>) -> Option<MachineSetupDiff> {
+    pub(crate) fn verify_bios_attr(&self, expected: &hw::BiosAttr<'_>) -> Option<MachineSetupDiff> {
         if let Some(actual) = self
             .bios
             .as_ref()

--- a/crates/bmc-explorer/src/inventories.rs
+++ b/crates/bmc-explorer/src/inventories.rs
@@ -21,12 +21,12 @@ use nv_redfish::{Bmc, Resource, ServiceRoot};
 
 use crate::{Error, hw};
 
-pub struct ExploredInventories<B: Bmc> {
+pub(crate) struct ExploredInventories<B: Bmc> {
     members: Vec<SoftwareInventory<B>>,
 }
 
 impl<B: Bmc> ExploredInventories<B> {
-    pub async fn explore(root: &ServiceRoot<B>) -> Result<Self, Error<B>> {
+    pub(crate) async fn explore(root: &ServiceRoot<B>) -> Result<Self, Error<B>> {
         Ok(Self {
             members: root
                 .update_service()
@@ -40,7 +40,7 @@ impl<B: Bmc> ExploredInventories<B> {
         })
     }
 
-    pub fn to_model(&self, hw_type: Option<hw::HwType>) -> Vec<ModelService> {
+    pub(crate) fn to_model(&self, hw_type: Option<hw::HwType>) -> Vec<ModelService> {
         let fw_inventories = ModelService {
             id: "FirmwareInventory".to_string(),
             inventories: self

--- a/crates/bmc-explorer/src/manager.rs
+++ b/crates/bmc-explorer/src/manager.rs
@@ -45,29 +45,29 @@ fn enabled_ipmi_port(
 }
 
 #[derive(Default)]
-pub struct Config {
-    pub need_host_interfaces: bool,
-    pub need_oem_dell_attributes: bool,
-    pub need_oem_lenovo_security_service: bool,
-    pub need_oem_supermicro_kcs_interface: bool,
-    pub need_oem_supermicro_sys_lockdown: bool,
-    pub need_oem_ami_config_bmc: bool,
+pub(crate) struct Config {
+    pub(crate) need_host_interfaces: bool,
+    pub(crate) need_oem_dell_attributes: bool,
+    pub(crate) need_oem_lenovo_security_service: bool,
+    pub(crate) need_oem_supermicro_kcs_interface: bool,
+    pub(crate) need_oem_supermicro_sys_lockdown: bool,
+    pub(crate) need_oem_ami_config_bmc: bool,
 }
 
-pub struct ExploredManager<B: Bmc> {
-    pub manager: Manager<B>,
-    pub eth_interfaces: Vec<EthernetInterface<B>>,
-    pub ipmi_port: Option<u16>,
-    pub host_interfaces: Option<Vec<HostInterface<B>>>,
-    pub oem_dell_attributes: Option<DellAttributes<B>>,
-    pub oem_lenovo_security_service: Option<LenovoSecurityService<B>>,
-    pub oem_supermicro_kcs_interface: Option<KcsInterface<B>>,
-    pub oem_supermicro_sys_lockdown: Option<SysLockdown<B>>,
-    pub oem_ami_config_bmc: Option<ConfigBmc<B>>,
+pub(crate) struct ExploredManager<B: Bmc> {
+    pub(crate) manager: Manager<B>,
+    pub(crate) eth_interfaces: Vec<EthernetInterface<B>>,
+    ipmi_port: Option<u16>,
+    pub(crate) host_interfaces: Option<Vec<HostInterface<B>>>,
+    pub(crate) oem_dell_attributes: Option<DellAttributes<B>>,
+    pub(crate) oem_lenovo_security_service: Option<LenovoSecurityService<B>>,
+    pub(crate) oem_supermicro_kcs_interface: Option<KcsInterface<B>>,
+    pub(crate) oem_supermicro_sys_lockdown: Option<SysLockdown<B>>,
+    pub(crate) oem_ami_config_bmc: Option<ConfigBmc<B>>,
 }
 
 impl<B: Bmc> ExploredManager<B> {
-    pub async fn explore(manager: Manager<B>, config: &Config) -> Result<Self, Error<B>> {
+    pub(crate) async fn explore(manager: Manager<B>, config: &Config) -> Result<Self, Error<B>> {
         let eth_interfaces = manager
             .ethernet_interfaces()
             .await
@@ -185,7 +185,7 @@ impl<B: Bmc> ExploredManager<B> {
         })
     }
 
-    pub fn to_model(&self) -> Result<ModelManager, Error<B>> {
+    pub(crate) fn to_model(&self) -> Result<ModelManager, Error<B>> {
         let ethernet_interfaces = self
             .eth_interfaces
             .iter()

--- a/crates/bmc-explorer/src/network_adapter.rs
+++ b/crates/bmc-explorer/src/network_adapter.rs
@@ -23,16 +23,16 @@ use nv_redfish::{Bmc, Resource};
 
 use crate::Error;
 
-pub struct Config {
-    pub need_network_device_fns: bool,
+pub(crate) struct Config {
+    pub(crate) need_network_device_fns: bool,
 }
 
-pub struct ExploredNetworkAdapterCollection<B: Bmc> {
+pub(crate) struct ExploredNetworkAdapterCollection<B: Bmc> {
     members: Vec<ExploredNetworkAdapter<B>>,
 }
 
 impl<B: Bmc> ExploredNetworkAdapterCollection<B> {
-    pub async fn explore(chassis: &Chassis<B>, config: &Config) -> Result<Self, Error<B>> {
+    pub(crate) async fn explore(chassis: &Chassis<B>, config: &Config) -> Result<Self, Error<B>> {
         match chassis.network_adapters().await {
             Ok(Some(network_adapters)) => {
                 let mut members = Vec::new();
@@ -51,7 +51,7 @@ impl<B: Bmc> ExploredNetworkAdapterCollection<B> {
 
     // Find adapater by MAC address. To make it work network adapters
     // must be explored with need_network_device_fns set to true.
-    pub fn find_by_mac(
+    pub(crate) fn find_by_mac(
         &self,
         mac: MacAddress,
     ) -> Option<(&ExploredNetworkAdapter<B>, &NetworkDeviceFunction<B>)> {
@@ -60,22 +60,22 @@ impl<B: Bmc> ExploredNetworkAdapterCollection<B> {
             .find_map(|a| a.find_by_mac(mac).map(|f| (a, f)))
     }
 
-    pub fn to_model(&self) -> Vec<ModelNetworkAdapter> {
+    pub(crate) fn to_model(&self) -> Vec<ModelNetworkAdapter> {
         self.members.iter().map(|v| v.to_model()).collect()
     }
 
-    pub fn members(&self) -> &[ExploredNetworkAdapter<B>] {
+    pub(crate) fn members(&self) -> &[ExploredNetworkAdapter<B>] {
         &self.members
     }
 }
 
-pub struct ExploredNetworkAdapter<B: Bmc> {
-    pub adapter: NetworkAdapter<B>,
-    pub functions: Option<Vec<NetworkDeviceFunction<B>>>,
+pub(crate) struct ExploredNetworkAdapter<B: Bmc> {
+    pub(crate) adapter: NetworkAdapter<B>,
+    pub(crate) functions: Option<Vec<NetworkDeviceFunction<B>>>,
 }
 
 impl<B: Bmc> ExploredNetworkAdapter<B> {
-    pub async fn explore(adapter: NetworkAdapter<B>, config: &Config) -> Result<Self, Error<B>> {
+    async fn explore(adapter: NetworkAdapter<B>, config: &Config) -> Result<Self, Error<B>> {
         let functions = if config.need_network_device_fns {
             if let Some(collection) = adapter
                 .network_device_functions()
@@ -94,7 +94,7 @@ impl<B: Bmc> ExploredNetworkAdapter<B> {
         Ok(Self { adapter, functions })
     }
 
-    pub fn find_by_mac(&self, mac: MacAddress) -> Option<&NetworkDeviceFunction<B>> {
+    fn find_by_mac(&self, mac: MacAddress) -> Option<&NetworkDeviceFunction<B>> {
         self.functions.iter().flatten().find(|f| {
             f.ethernet_permanent_mac_address()
                 .and_then(|mac| mac.as_str().parse::<MacAddress>().ok())
@@ -102,7 +102,7 @@ impl<B: Bmc> ExploredNetworkAdapter<B> {
         })
     }
 
-    pub fn to_model(&self) -> ModelNetworkAdapter {
+    fn to_model(&self) -> ModelNetworkAdapter {
         let hw_id = self.adapter.hardware_id();
         ModelNetworkAdapter {
             id: self.adapter.id().to_string(),

--- a/crates/bmc-explorer/tests/integration/common.rs
+++ b/crates/bmc-explorer/tests/integration/common.rs
@@ -24,7 +24,7 @@ use bmc_explorer::ErrorClass;
 use bmc_mock::test_support::TestBmc;
 use bmc_mock::test_support::axum_http_client::Error as TestBmcError;
 
-pub fn error_classifier(err: &<TestBmc as nv_redfish::Bmc>::Error) -> Option<ErrorClass> {
+pub(crate) fn error_classifier(err: &<TestBmc as nv_redfish::Bmc>::Error) -> Option<ErrorClass> {
     match err {
         TestBmcError::InvalidResponse { status, .. } => match *status {
             StatusCode::NOT_FOUND => Some(ErrorClass::NotFound),
@@ -35,7 +35,7 @@ pub fn error_classifier(err: &<TestBmc as nv_redfish::Bmc>::Error) -> Option<Err
     }
 }
 
-pub fn explorer_config() -> bmc_explorer::Config<'static, TestBmc> {
+pub(crate) fn explorer_config() -> bmc_explorer::Config<'static, TestBmc> {
     bmc_explorer::Config {
         boot_interface_mac: None,
         error_classifier: &error_classifier,

--- a/crates/bmc-proxy/src/acl.rs
+++ b/crates/bmc-proxy/src/acl.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Deserializer};
 /// evaluated in order, and the first matching entry determines the outcome of
 /// the request.
 #[derive(Clone, Default)]
-pub struct AclConfig {
+pub(crate) struct AclConfig {
     // Keys are "users" (ie. service principals), values are a list of AclEntries for authenticating them.
     config: BTreeMap<String, Vec<AclEntry>>,
 }
@@ -49,7 +49,7 @@ impl AclConfig {
     /// The principal's ACL entries are evaluated in order. The first matching
     /// entry wins. If the principal is unknown or no entry matches, this
     /// returns `false`.
-    pub fn allows(&self, principal: &str, method: &http::Method, path: &str) -> bool {
+    pub(crate) fn allows(&self, principal: &str, method: &http::Method, path: &str) -> bool {
         let Some(entries) = self.config.get(principal) else {
             return false;
         };
@@ -179,7 +179,7 @@ impl AclEntry {
 
 #[derive(thiserror::Error, Debug)]
 #[error("error parsing ACL path {orig}: {err}")]
-pub struct AclPathParseError {
+struct AclPathParseError {
     orig: String,
     err: String,
 }

--- a/crates/bmc-proxy/src/bmc_proxy.rs
+++ b/crates/bmc-proxy/src/bmc_proxy.rs
@@ -65,7 +65,7 @@ const TLS_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const MAX_BODY_SIZE: usize = 8 * 1024 * 1024; // 8MiB body size limit (matches nginx ingress controller defaults)
 
 #[derive(thiserror::Error, Debug)]
-pub enum BmcProxyError {
+pub(crate) enum BmcProxyError {
     #[error("error resolving BMC information through carbide API: {0}")]
     Api(String),
     #[error("invalid configuration: {0}")]
@@ -80,8 +80,8 @@ pub enum BmcProxyError {
     TlsConfig(String),
 }
 
-pub struct BmcProxyParams {
-    pub config: Arc<crate::Config>,
+pub(crate) struct BmcProxyParams {
+    pub(crate) config: Arc<crate::Config>,
 }
 
 #[derive(Clone)]
@@ -141,7 +141,7 @@ impl BmcProxyState {
     }
 }
 
-pub async fn start(
+pub(crate) async fn start(
     params: BmcProxyParams,
     cancel_token: CancellationToken,
     join_set: &mut JoinSet<()>,
@@ -544,7 +544,7 @@ fn get_tls_acceptor(tls_config: &TlsConfig) -> Result<RefreshableTlsAcceptor, Bm
     })
 }
 
-pub fn cert_description_layer<AZ: Authorization>(
+fn cert_description_layer<AZ: Authorization>(
     auth_config: &AuthConfig,
 ) -> Result<CertDescriptionMiddleware<AZ>, BmcProxyError> {
     tracing::info!(trust_config = ?auth_config.trust, "TrustConfig rendered from config");
@@ -977,10 +977,10 @@ impl From<(StatusCode, &'static str)> for ProxyError {
 }
 
 struct BmcClientInfo {
-    pub http_client: reqwest_middleware::ClientWithMiddleware,
-    pub header_map: HeaderMap,
-    pub credentials: BmcCredentials,
-    pub base_upstream_uri: Uri,
+    http_client: reqwest_middleware::ClientWithMiddleware,
+    header_map: HeaderMap,
+    credentials: BmcCredentials,
+    base_upstream_uri: Uri,
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/crates/bmc-proxy/src/config.rs
+++ b/crates/bmc-proxy/src/config.rs
@@ -29,7 +29,7 @@ use url::Url;
 use crate::acl::AclConfig;
 
 #[derive(thiserror::Error, Debug)]
-pub enum ConfigError {
+pub(crate) enum ConfigError {
     #[error("{0}")]
     Read(String),
     #[error(transparent)]
@@ -43,33 +43,33 @@ impl From<figment::Error> for ConfigError {
 }
 
 #[derive(Deserialize)]
-pub struct Config {
+pub(crate) struct Config {
     #[serde(default = "Defaults::listen")]
-    pub listen: SocketAddr,
+    pub(crate) listen: SocketAddr,
     #[serde(default = "Defaults::metrics_endpoint")]
-    pub metrics_endpoint: SocketAddr,
+    pub(crate) metrics_endpoint: SocketAddr,
     #[serde(default)]
-    pub allowed_principals: HashSet<String>,
-    pub tls: TlsConfig,
-    pub auth: AuthConfig,
+    pub(crate) allowed_principals: HashSet<String>,
+    pub(crate) tls: TlsConfig,
+    pub(crate) auth: AuthConfig,
     #[serde(default)]
-    pub carbide_api: CarbideApiConfig,
-    pub bmc_proxy: Option<HostPortPair>,
+    pub(crate) carbide_api: CarbideApiConfig,
+    pub(crate) bmc_proxy: Option<HostPortPair>,
     #[serde(default)]
-    pub tracing: TracingConfig,
+    pub(crate) tracing: TracingConfig,
 }
 
 /// OpenTelemetry trace export settings for proxied BMC requests.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct TracingConfig {
+pub(crate) struct TracingConfig {
     /// Whether to record and export OTLP spans. Default: false.
     #[serde(default)]
-    pub enabled: bool,
+    pub(crate) enabled: bool,
     /// Collector endpoint for OTLP/gRPC traces. Overridden by the standard
     /// `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_ENDPOINT`
     /// variables when either is set.
     #[serde(default)]
-    pub otlp_endpoint: Option<String>,
+    pub(crate) otlp_endpoint: Option<String>,
 }
 
 struct Defaults;
@@ -97,11 +97,11 @@ impl Defaults {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-pub struct TlsConfig {
-    pub identity_pemfile_path: String,
-    pub identity_keyfile_path: String,
-    pub root_cafile_path: String,
-    pub admin_root_cafile_path: String,
+pub(crate) struct TlsConfig {
+    pub(crate) identity_pemfile_path: String,
+    pub(crate) identity_keyfile_path: String,
+    pub(crate) root_cafile_path: String,
+    pub(crate) admin_root_cafile_path: String,
 }
 
 impl Default for TlsConfig {
@@ -117,11 +117,11 @@ impl Default for TlsConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-pub struct CarbideApiConfig {
-    pub root_ca: String,
-    pub client_cert: String,
-    pub client_key: String,
-    pub api_url: Url,
+pub(crate) struct CarbideApiConfig {
+    pub(crate) root_ca: String,
+    pub(crate) client_cert: String,
+    pub(crate) client_key: String,
+    pub(crate) api_url: Url,
 }
 
 impl Default for CarbideApiConfig {
@@ -137,21 +137,21 @@ impl Default for CarbideApiConfig {
 
 /// Authentication related configuration
 #[derive(Clone, Deserialize)]
-pub struct AuthConfig {
+pub(crate) struct AuthConfig {
     /// Additional nico-admin-cli certs allowed.  This does not include actually allowing the cert to connect, just that certs that can be verified which match these criteria can do GRPC requests.
     #[serde(default)]
-    pub cli_certs: Option<AllowedCertCriteria>,
+    pub(crate) cli_certs: Option<AllowedCertCriteria>,
 
     /// Configuration for the root of trust for client cert auth
     #[serde(default = "Defaults::trust_config")]
-    pub trust: TrustConfig,
+    pub(crate) trust: TrustConfig,
 
     #[serde(default)]
-    pub acls: AclConfig,
+    pub(crate) acls: AclConfig,
 }
 
 impl Config {
-    pub fn parse(s: &str) -> Result<Config, ConfigError> {
+    pub(crate) fn parse(s: &str) -> Result<Config, ConfigError> {
         Figment::new()
             .merge(Toml::string(s))
             .merge(Env::prefixed("CARBIDE_BMC_PROXY_"))

--- a/crates/bmc-proxy/src/main.rs
+++ b/crates/bmc-proxy/src/main.rs
@@ -33,15 +33,15 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Parser)]
 #[clap(name = "carbide-bmc-proxy")]
-pub struct Args {
+struct Args {
     #[clap(long, default_value = "false", help = "Print version number and exit")]
-    pub version: bool,
+    version: bool,
 
     #[clap(short, long)]
-    pub debug: bool,
+    debug: bool,
 
     #[clap(long)]
-    pub config_path: String,
+    config_path: String,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -29,7 +29,7 @@ use metrics_endpoint::{MetricsEndpointConfig, MetricsSetup};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
-pub async fn start(
+pub(crate) async fn start(
     address: SocketAddr,
     metrics_setup: MetricsSetup,
     cancellation_token: CancellationToken,
@@ -276,11 +276,11 @@ impl UpstreamStatus {
 )]
 pub(crate) struct UpstreamRequestCompleted {
     #[label]
-    pub method: MethodLabel,
+    pub(crate) method: MethodLabel,
     #[label]
-    pub status: UpstreamStatus,
+    pub(crate) status: UpstreamStatus,
     #[observation]
-    pub took: Duration,
+    pub(crate) took: Duration,
 }
 
 #[cfg(test)]

--- a/crates/bmc-proxy/src/net.rs
+++ b/crates/bmc-proxy/src/net.rs
@@ -39,7 +39,7 @@ fn should_retry_as_ipv4(address: &SocketAddr, err: &io::Error) -> bool {
         && err.raw_os_error() == Some(libc::EAFNOSUPPORT)
 }
 
-pub async fn bind_with_ipv4_fallback(address: SocketAddr) -> io::Result<TcpListener> {
+pub(crate) async fn bind_with_ipv4_fallback(address: SocketAddr) -> io::Result<TcpListener> {
     match TcpListener::bind(address).await {
         Ok(listener) => Ok(listener),
         Err(e) if should_retry_as_ipv4(&address, &e) => {

--- a/crates/bmc-proxy/src/setup.rs
+++ b/crates/bmc-proxy/src/setup.rs
@@ -29,7 +29,7 @@ use tracing_subscriber::{Layer, filter};
 use crate::config::TracingConfig;
 
 #[derive(thiserror::Error, Debug)]
-pub enum SetupError {
+pub(crate) enum SetupError {
     #[error("error configuring logging from environment variables: {0}")]
     EnvFilter(#[from] tracing_subscriber::filter::FromEnvError),
     #[error("error initializing tracing subscriber: {0}")]
@@ -38,18 +38,18 @@ pub enum SetupError {
     Metrics(String),
 }
 
-pub type SetupResult<T> = Result<T, SetupError>;
+pub(crate) type SetupResult<T> = Result<T, SetupError>;
 
 /// Owns the OTLP tracer provider for the lifetime of the process. The batch
 /// span processor only exports on its own schedule, so the provider has to be
 /// shut down explicitly at exit or the final batch is dropped.
-pub struct TracingGuard(Option<opentelemetry_sdk::trace::SdkTracerProvider>);
+pub(crate) struct TracingGuard(Option<opentelemetry_sdk::trace::SdkTracerProvider>);
 
 impl TracingGuard {
     /// Flushes and shuts down the OTLP exporter. `SdkTracerProvider::shutdown`
     /// blocks the calling thread for up to five seconds waiting on the batch
     /// processor's worker, so it must not run on a runtime worker.
-    pub async fn shutdown(self) {
+    pub(crate) async fn shutdown(self) {
         let Some(provider) = self.0 else {
             return;
         };
@@ -66,7 +66,10 @@ impl TracingGuard {
     }
 }
 
-pub fn setup_logging(debug: bool, tracing_config: &TracingConfig) -> SetupResult<TracingGuard> {
+pub(crate) fn setup_logging(
+    debug: bool,
+    tracing_config: &TracingConfig,
+) -> SetupResult<TracingGuard> {
     // W3C propagation must be installed before any inbound extract or outbound inject (#2438).
     // Without it, OpenTelemetry's default propagator is a no-op.
     global::set_text_map_propagator(TraceContextPropagator::new());
@@ -202,12 +205,12 @@ fn should_accept_span_or_event(metadata: &tracing::Metadata<'_>) -> bool {
         .is_some_and(|path| path.starts_with("tokio"))
 }
 
-pub fn setup_metrics() -> SetupResult<MetricsSetup> {
+pub(crate) fn setup_metrics() -> SetupResult<MetricsSetup> {
     metrics_endpoint::new_metrics_setup("carbide-bmc-proxy", "carbide-system", true)
         .map_err(|e| SetupError::Metrics(e.to_string()))
 }
 
-pub fn dep_log_filter(env_filter: EnvFilter) -> EnvFilter {
+fn dep_log_filter(env_filter: EnvFilter) -> EnvFilter {
     [
         "hyper=error",
         "rustls=warn",

--- a/crates/host-support/src/hardware_enumeration/gpu.rs
+++ b/crates/host-support/src/hardware_enumeration/gpu.rs
@@ -22,7 +22,7 @@ use super::HardwareEnumerationResult;
 /// Retrieve nvidia-smi data about a machine.
 ///
 /// It is assumed that the machine should have the nvidia kernel module loaded, or this call will fail.
-pub fn get_nvidia_smi_data() -> HardwareEnumerationResult<Vec<RpcGpu>> {
+pub(super) fn get_nvidia_smi_data() -> HardwareEnumerationResult<Vec<RpcGpu>> {
     let cmd = Cmd::new("timeout")
         .args(vec![
             "--kill-after=120s",

--- a/crates/host-support/src/hardware_enumeration/tpm.rs
+++ b/crates/host-support/src/hardware_enumeration/tpm.rs
@@ -54,7 +54,7 @@ const TPM_EK_CERT_NV_INDICES: &[EkCertNvIndex] = &[
 
 /// Enumerates errors for TPM related operations
 #[derive(Debug, thiserror::Error)]
-pub enum TpmError {
+pub(super) enum TpmError {
     #[error("unable to invoke subprocess {0}: {1}")]
     Subprocess(&'static str, std::io::Error),
     #[error("subprocess exited with exit code {0:?}. stderr: {1}")]
@@ -69,11 +69,11 @@ pub enum TpmError {
 }
 
 /// Returns the TPM's endorsement key certificate in binary format
-pub fn get_ek_certificate() -> Result<Vec<u8>, TpmError> {
+pub(super) fn get_ek_certificate() -> Result<Vec<u8>, TpmError> {
     get_ek_certificate_with_runner(&StdCommandRunner)
 }
 
-pub fn is_tpm_present() -> bool {
+pub(super) fn is_tpm_present() -> bool {
     std::path::Path::new("/dev/tpmrm0").exists() || std::path::Path::new("/dev/tpm0").exists()
 }
 

--- a/crates/host-support/src/registration.rs
+++ b/crates/host-support/src/registration.rs
@@ -149,7 +149,7 @@ impl<'a, 'c> RegistrationClient<'a, 'c> {
 
     // discover_machine is a retrying wrapper around making
     // discover_machine gRPC calls to the Carbide API.
-    pub async fn discover_machine(
+    async fn discover_machine(
         &mut self,
         info: MachineDiscoveryInfo,
     ) -> Result<rpc::MachineDiscoveryResult, RegistrationError> {

--- a/crates/ipmi/src/bmc_mock.rs
+++ b/crates/ipmi/src/bmc_mock.rs
@@ -30,13 +30,13 @@ use crate::metrics::{IpmiCommand, count_ipmi_command};
 
 /// HTTP-based IPMI implementation for testing with bmc-mock.
 /// Sends JSON requests to bmc_proxy which routes to appropriate machine.
-pub struct IPMIToolHttpImpl {
+pub(super) struct IPMIToolHttpImpl {
     bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
     credential_reader: Arc<dyn CredentialReader>,
 }
 
 impl IPMIToolHttpImpl {
-    pub fn new(
+    pub(super) fn new(
         bmc_proxy: Arc<ArcSwap<Option<HostPortPair>>>,
         credential_reader: Arc<dyn CredentialReader>,
     ) -> Self {

--- a/crates/ipmi/src/test_support.rs
+++ b/crates/ipmi/src/test_support.rs
@@ -23,7 +23,7 @@ use carbide_uuid::machine::MachineId;
 
 use crate::IPMITool;
 
-pub struct IPMIToolTestImpl {}
+pub(super) struct IPMIToolTestImpl {}
 
 #[async_trait]
 impl IPMITool for IPMIToolTestImpl {

--- a/crates/ipmi/src/tool.rs
+++ b/crates/ipmi/src/tool.rs
@@ -27,13 +27,13 @@ use eyre::eyre;
 use crate::IPMITool;
 use crate::metrics::{IpmiCommand, count_ipmi_command};
 
-pub struct IPMIToolImpl {
+pub(super) struct IPMIToolImpl {
     credential_reader: Arc<dyn CredentialReader>,
     attempts: u32,
 }
 
 impl IPMIToolImpl {
-    pub fn new(credential_reader: Arc<dyn CredentialReader>, attempts: Option<u32>) -> Self {
+    pub(super) fn new(credential_reader: Arc<dyn CredentialReader>, attempts: Option<u32>) -> Self {
         IPMIToolImpl {
             credential_reader,
             attempts: attempts.unwrap_or(3),
@@ -177,7 +177,7 @@ mod test {
     use carbide_secrets::test_support::credentials::TestCredentialManager;
 
     #[test]
-    pub fn test_ipmitool_new() {
+    fn test_ipmitool_new() {
         let cp = Arc::new(TestCredentialManager::new(Credentials::UsernamePassword {
             username: "user".to_string(),
             password: "password".to_string(),

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -251,7 +251,7 @@ struct NvueApplyData {
 }
 
 impl NvueApplyData {
-    pub fn force_apply() -> Self {
+    fn force_apply() -> Self {
         let state = "apply".into();
         let auto_prompt = NvueAutoPrompt::ays_yes();
         Self { state, auto_prompt }
@@ -266,7 +266,7 @@ struct NvueAutoPrompt {
 }
 
 impl NvueAutoPrompt {
-    pub fn ays_yes() -> Self {
+    fn ays_yes() -> Self {
         let ays = "ays_yes".into();
         Self { ays }
     }

--- a/crates/redfish/src/libredfish/implementation.rs
+++ b/crates/redfish/src/libredfish/implementation.rs
@@ -45,14 +45,14 @@ fn libredfish_endpoint_host(host: &str) -> Cow<'_, str> {
     }
 }
 
-pub struct RedfishClientPoolImpl {
+pub(super) struct RedfishClientPoolImpl {
     pool: libredfish::RedfishClientPool,
     credential_reader: Arc<dyn CredentialReader>,
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
 }
 
 impl RedfishClientPoolImpl {
-    pub fn new(
+    pub(super) fn new(
         credential_reader: Arc<dyn CredentialReader>,
         pool: libredfish::RedfishClientPool,
         proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,

--- a/crates/ssh-console/src/bmc/client.rs
+++ b/crates/ssh-console/src/bmc/client.rs
@@ -43,7 +43,7 @@ use crate::ssh_server::ServerMetrics;
 /// Spawn a connection to the given BMC in the background, returning a handle. Connections will
 /// be retried indefinitely, with exponential backoff, until a shutdown is signaled (ie. by dropping
 /// the ClientHandle.)
-pub fn spawn(
+pub(super) fn spawn(
     connection_details: ConnectionDetails,
     config: Arc<Config>,
     metrics: Arc<BmcPoolMetrics>,
@@ -511,7 +511,7 @@ fn next_retry_backoff(config: &Config, prev: Duration) -> Duration {
     duration
 }
 
-pub struct ClientHandle {
+pub(super) struct ClientHandle {
     machine_id: MachineId,
     kind: connection::Kind,
     /// Writer to send messages (including data) to BMC
@@ -521,7 +521,8 @@ pub struct ClientHandle {
     broadcast_to_frontend_tx: broadcast::Sender<ToFrontendMessage>,
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
-    pub connection_state: Arc<AtomicConnectionState>, // pub for metrics gathering
+    // Read by the pool's observable-gauge callbacks.
+    pub(super) connection_state: Arc<AtomicConnectionState>,
 }
 
 impl ShutdownHandle<()> for ClientHandle {
@@ -531,7 +532,7 @@ impl ShutdownHandle<()> for ClientHandle {
 }
 
 impl ClientHandle {
-    pub fn subscribe(&self, metrics: Arc<ServerMetrics>) -> BmcConnectionSubscription {
+    pub(super) fn subscribe(&self, metrics: Arc<ServerMetrics>) -> BmcConnectionSubscription {
         tracing::debug!("new bmc subscription");
         metrics.total_clients.add(1, &[]);
         metrics.bmc_clients.add(
@@ -551,11 +552,11 @@ impl ClientHandle {
 
 /// An individual "subscription" to a BMC connection, expected to be used by a frontend. Metrics
 /// are affected when one is created or dropped.
-pub struct BmcConnectionSubscription {
-    pub machine_id: MachineId,
-    pub to_frontend_msg_weak_tx: broadcast::WeakSender<ToFrontendMessage>,
-    pub to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
-    pub kind: connection::Kind,
+pub(crate) struct BmcConnectionSubscription {
+    pub(crate) machine_id: MachineId,
+    pub(crate) to_frontend_msg_weak_tx: broadcast::WeakSender<ToFrontendMessage>,
+    pub(crate) to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
+    pub(crate) kind: connection::Kind,
     // Not pub, to make sure we go through ClientHandle::subscribe() to build, so we get the
     // right metrics
     metrics: Arc<ServerMetrics>,

--- a/crates/ssh-console/src/bmc/client_pool.rs
+++ b/crates/ssh-console/src/bmc/client_pool.rs
@@ -40,7 +40,11 @@ use crate::shutdown_handle::{ReadyHandle, ShutdownHandle};
 use crate::ssh_server::ServerMetrics;
 
 /// Spawn a background task that connects to all BMC's in the environment, reconnecting if they fail.
-pub fn spawn(config: Arc<Config>, forge_api_client: ForgeApiClient, meter: &Meter) -> Handle {
+pub(crate) fn spawn(
+    config: Arc<Config>,
+    forge_api_client: ForgeApiClient,
+    meter: &Meter,
+) -> Handle {
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let (ready_tx, ready_rx) = oneshot::channel();
     let members: Arc<RwLock<HashMap<MachineId, ClientHandle>>> = Default::default();
@@ -65,7 +69,7 @@ pub fn spawn(config: Arc<Config>, forge_api_client: ForgeApiClient, meter: &Mete
 
 /// A owned handle to the entire BMC client pool background task. The pool will shut down when this is
 /// dropped.
-pub struct Handle {
+pub(crate) struct Handle {
     connection_store: BmcConnectionStore,
     shutdown_tx: oneshot::Sender<()>,
     ready_rx: Option<oneshot::Receiver<()>>,
@@ -73,7 +77,7 @@ pub struct Handle {
 }
 
 impl Handle {
-    pub fn connection_store(&self) -> BmcConnectionStore {
+    pub(crate) fn connection_store(&self) -> BmcConnectionStore {
         self.connection_store.clone()
     }
 }
@@ -92,10 +96,10 @@ impl ReadyHandle for Handle {
 
 /// An Arc reference to the available BMC connections in this pool
 #[derive(Clone)]
-pub struct BmcConnectionStore(Arc<RwLock<HashMap<MachineId, ClientHandle>>>);
+pub(crate) struct BmcConnectionStore(Arc<RwLock<HashMap<MachineId, ClientHandle>>>);
 
 impl BmcConnectionStore {
-    pub async fn get_connection(
+    pub(crate) async fn get_connection(
         &self,
         machine_or_instance_id: &str,
         config: &Config,
@@ -167,7 +171,7 @@ impl BmcConnectionStore {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum GetConnectionError {
+pub(crate) enum GetConnectionError {
     #[error("{machine_or_instance_id} is not a valid machine_id or instance ID")]
     InvalidMachineId { machine_or_instance_id: String },
     #[error("error looking up instance ID {instance_id}: {tonic_status}")]
@@ -193,18 +197,18 @@ struct BmcPool {
     metrics: Arc<BmcPoolMetrics>,
 }
 
-pub struct BmcPoolMetrics {
+pub(super) struct BmcPoolMetrics {
     grpc_total_hosts: Gauge<u64>,
     total_machines: Gauge<u64>,
     _failed_machines: ObservableGauge<u64>,
     _healthy_machines: ObservableGauge<u64>,
     _bmc_status: ObservableGauge<u64>,
 
-    // per-BMC metrics (need to be pub, since code outside this module is setting them
-    pub bmc_bytes_received_total: Counter<u64>,
-    pub bmc_rx_errors_total: Counter<u64>,
-    pub bmc_tx_errors_total: Counter<u64>,
-    pub bmc_recovery_attempts: Gauge<u64>,
+    // Updated by the BMC client and connection workers.
+    pub(super) bmc_bytes_received_total: Counter<u64>,
+    pub(super) bmc_rx_errors_total: Counter<u64>,
+    pub(super) bmc_tx_errors_total: Counter<u64>,
+    pub(super) bmc_recovery_attempts: Gauge<u64>,
 }
 
 impl BmcPoolMetrics {
@@ -281,7 +285,7 @@ impl BmcPoolMetrics {
     }
 
     #[cfg(test)]
-    pub(crate) fn for_test() -> Self {
+    pub(super) fn for_test() -> Self {
         Self::new(
             &opentelemetry::global::meter("ssh-console-ipmi-test"),
             Arc::default(),

--- a/crates/ssh-console/src/bmc/connection.rs
+++ b/crates/ssh-console/src/bmc/connection.rs
@@ -36,7 +36,7 @@ use crate::bmc::vendor::{BmcVendor, BmcVendorDetectionError, SshBmcVendor};
 use crate::config::{Config, ConfigError};
 use crate::shutdown_handle::ShutdownHandle;
 
-pub async fn spawn(
+pub(super) async fn spawn(
     connection_details: ConnectionDetails,
     broadcast_to_frontend_tx: broadcast::Sender<ToFrontendMessage>,
     metrics: Arc<BmcPoolMetrics>,
@@ -62,7 +62,7 @@ pub async fn spawn(
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum SpawnError {
+pub(super) enum SpawnError {
     #[error(transparent)]
     Ssh(#[from] connection_impl::ssh::SpawnError),
     #[error(transparent)]
@@ -79,7 +79,7 @@ impl SpawnError {
 ///
 /// This information is normally gotten by calling GetBMCMetadData on carbide-api, but it can
 /// also obey overridden information from ssh-console's config.
-pub async fn lookup(
+pub(super) async fn lookup(
     machine_or_instance_id: &str,
     config: &Config,
     forge_api_client: &ForgeApiClient,
@@ -238,7 +238,7 @@ pub async fn lookup(
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum LookupError {
+pub(super) enum LookupError {
     #[error("configuration error: {0}")]
     Config(#[from] ConfigError),
     #[error("error looking up instance ID {instance_id}: {tonic_status}")]
@@ -267,10 +267,10 @@ pub enum LookupError {
 }
 
 /// A handle to a BMC connection, which will shut down when dropped.
-pub struct Handle {
-    pub to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
-    pub shutdown_tx: oneshot::Sender<()>,
-    pub join_handle: JoinHandle<Result<(), SpawnError>>,
+pub(super) struct Handle {
+    pub(super) to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
+    pub(super) shutdown_tx: oneshot::Sender<()>,
+    pub(super) join_handle: JoinHandle<Result<(), SpawnError>>,
 }
 
 impl From<ipmi::Handle> for Handle {
@@ -312,27 +312,27 @@ impl ShutdownHandle<Result<(), SpawnError>> for Handle {
 }
 
 #[derive(Debug, Clone)]
-pub enum ConnectionDetails {
+pub(super) enum ConnectionDetails {
     Ssh(Arc<ssh::ConnectionDetails>),
     Ipmi(Arc<ipmi::ConnectionDetails>),
 }
 
 impl ConnectionDetails {
-    pub fn addr(&self) -> SocketAddr {
+    pub(super) fn addr(&self) -> SocketAddr {
         match self {
             ConnectionDetails::Ssh(s) => s.addr,
             ConnectionDetails::Ipmi(i) => i.addr,
         }
     }
 
-    pub fn machine_id(&self) -> MachineId {
+    pub(super) fn machine_id(&self) -> MachineId {
         match self {
             ConnectionDetails::Ssh(s) => s.machine_id,
             ConnectionDetails::Ipmi(i) => i.machine_id,
         }
     }
 
-    pub fn kind(&self) -> Kind {
+    pub(super) fn kind(&self) -> Kind {
         match self {
             ConnectionDetails::Ssh(_) => Kind::Ssh,
             ConnectionDetails::Ipmi(_) => Kind::Ipmi,
@@ -341,7 +341,7 @@ impl ConnectionDetails {
 }
 
 #[derive(Copy, Clone)]
-pub enum Kind {
+pub(crate) enum Kind {
     Ssh,
     Ipmi,
 }
@@ -349,7 +349,7 @@ pub enum Kind {
 /// Represents the state of a connection to a BMC
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum State {
+pub(super) enum State {
     Disconnected = 0,
     Connecting = 1,
     Connected = 2,
@@ -379,21 +379,21 @@ impl TryFrom<u8> for State {
 /// Wrapper for an AtomicU8 representing a [`State`], so that the state can be shared
 /// between threads.
 #[derive(Debug)]
-pub struct AtomicConnectionState(AtomicU8);
+pub(super) struct AtomicConnectionState(AtomicU8);
 
 impl AtomicConnectionState {
     #[inline]
-    pub fn new(state: State) -> Self {
+    pub(super) fn new(state: State) -> Self {
         Self(AtomicU8::new(state.into()))
     }
 
     #[inline]
-    pub fn load(&self) -> State {
+    pub(super) fn load(&self) -> State {
         State::try_from(self.0.load(Ordering::SeqCst)).expect("BUG: connection state corrupted")
     }
 
     #[inline]
-    pub fn store(&self, state: State) {
+    pub(super) fn store(&self, state: State) {
         self.0.store(state.into(), Ordering::SeqCst);
     }
 }

--- a/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ipmi.rs
@@ -63,7 +63,7 @@ const SOL_DEACTIVATE_TIMEOUT: Duration = Duration::from_secs(10);
 /// `to_frontend_tx` is a [`russh::Channel`] to send data from ipmitool to the SSH frontend.
 ///
 /// Returns a [`mpsc::Sender<ChannelMsg>`] that the frontend can use to send data to ipmitool.
-pub async fn spawn(
+pub(in crate::bmc) async fn spawn(
     connection_details: Arc<ConnectionDetails>,
     to_frontend_tx: broadcast::Sender<ToFrontendMessage>,
     config: Arc<Config>,
@@ -199,14 +199,14 @@ pub async fn spawn(
 }
 
 /// A handle to a BMC connection, which will shut down when dropped.
-pub struct Handle {
-    pub to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
-    pub shutdown_tx: oneshot::Sender<()>,
-    pub join_handle: JoinHandle<Result<(), SpawnError>>,
+pub(in crate::bmc) struct Handle {
+    pub(in crate::bmc) to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
+    pub(in crate::bmc) shutdown_tx: oneshot::Sender<()>,
+    pub(in crate::bmc) join_handle: JoinHandle<Result<(), SpawnError>>,
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum SpawnError {
+pub(in crate::bmc) enum SpawnError {
     #[error("error spawning a PTY for ipmitool: {0}")]
     PtyAlloc(#[from] PtyAllocError),
     #[error("error setting up pty: {reason}: {error}")]
@@ -258,7 +258,7 @@ impl SpawnError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum SolDeactivateError {
+pub(in crate::bmc) enum SolDeactivateError {
     #[error("error spawning ipmitool for SOL deactivation: {error}")]
     Spawning { error: std::io::Error },
     #[error("error waiting for ipmitool SOL deactivation: {error}")]
@@ -367,7 +367,7 @@ async fn run_sol_deactivate_command(
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ProcessLoopError {
+pub(in crate::bmc) enum ProcessLoopError {
     #[error("error polling from pty master fd: {error}")]
     PollingFromPty { error: std::io::Error },
     #[error("error writing data from ipmitool to frontend channel: no active receivers")]
@@ -387,13 +387,13 @@ pub enum ProcessLoopError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum SendFrontendMessageToIpmiConsoleError {
+pub(in crate::bmc) enum SendFrontendMessageToIpmiConsoleError {
     #[error("error writing to ipmitool pty: {error}")]
     WritingToPty { error: std::io::Error },
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum PowerResetError {
+pub(in crate::bmc) enum PowerResetError {
     #[error("error spawning ipmitool for power reset: {error}")]
     Spawning { error: std::io::Error },
     #[error("ipmitool error running power reset: {error}")]
@@ -804,11 +804,11 @@ fn sol_activate_command(
 }
 
 #[derive(Clone)]
-pub struct ConnectionDetails {
-    pub machine_id: MachineId,
-    pub addr: SocketAddr,
-    pub user: String,
-    pub password: String,
+pub(in crate::bmc) struct ConnectionDetails {
+    pub(in crate::bmc) machine_id: MachineId,
+    pub(in crate::bmc) addr: SocketAddr,
+    pub(in crate::bmc) user: String,
+    pub(in crate::bmc) password: String,
 }
 
 impl Debug for ConnectionDetails {

--- a/crates/ssh-console/src/bmc/connection_impl/mod.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/mod.rs
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-pub mod ipmi;
-pub mod ssh;
+pub(super) mod ipmi;
+pub(super) mod ssh;
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use tokio::sync::oneshot;

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -47,7 +47,7 @@ static RUSSH_CLIENT_CONFIG: LazyLock<Arc<russh::client::Config>> =
     LazyLock::new(russh_client_config);
 
 /// Connect to a BMC one time, returning a [`Handle`]. Will not retry on connection errors.
-pub async fn spawn(
+pub(in crate::bmc) async fn spawn(
     connection_details: Arc<ConnectionDetails>,
     to_frontend_tx: broadcast::Sender<ToFrontendMessage>,
     metrics: Arc<BmcPoolMetrics>,
@@ -180,14 +180,14 @@ pub async fn spawn(
 }
 
 /// A handle to a BMC connection, which will shut down when dropped.
-pub struct Handle {
-    pub to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
-    pub shutdown_tx: oneshot::Sender<()>,
-    pub join_handle: JoinHandle<Result<(), SpawnError>>,
+pub(in crate::bmc) struct Handle {
+    pub(in crate::bmc) to_bmc_msg_tx: mpsc::Sender<ToBmcMessage>,
+    pub(in crate::bmc) shutdown_tx: oneshot::Sender<()>,
+    pub(in crate::bmc) join_handle: JoinHandle<Result<(), SpawnError>>,
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum SpawnError {
+pub(in crate::bmc) enum SpawnError {
     #[error("error sending message from BMC to frontend: no active receivers")]
     SendingMsgToFrontend,
     #[error("error connecting to SSH BMC: {0}")]
@@ -201,7 +201,7 @@ pub enum SpawnError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ClientCreationError {
+pub(in crate::bmc) enum ClientCreationError {
     #[error("error connecting to {addr}: {error}")]
     Connection {
         addr: SocketAddr,
@@ -233,7 +233,7 @@ pub enum ClientCreationError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum ConsoleActivateError {
+pub(in crate::bmc) enum ConsoleActivateError {
     #[error("error while {phase}: {error}")]
     Request {
         phase: &'static str,
@@ -700,13 +700,13 @@ fn test_ringbuf_contains() {
 }
 
 #[derive(Clone)]
-pub struct ConnectionDetails {
-    pub machine_id: MachineId,
-    pub addr: SocketAddr,
-    pub user: String,
-    pub password: String,
-    pub ssh_key_path: Option<PathBuf>,
-    pub bmc_vendor: SshBmcVendor,
+pub(in crate::bmc) struct ConnectionDetails {
+    pub(in crate::bmc) machine_id: MachineId,
+    pub(in crate::bmc) addr: SocketAddr,
+    pub(in crate::bmc) user: String,
+    pub(in crate::bmc) password: String,
+    pub(in crate::bmc) ssh_key_path: Option<PathBuf>,
+    pub(in crate::bmc) bmc_vendor: SshBmcVendor,
 }
 
 impl Debug for ConnectionDetails {

--- a/crates/ssh-console/src/bmc/message_proxy.rs
+++ b/crates/ssh-console/src/bmc/message_proxy.rs
@@ -28,7 +28,7 @@ use tokio::task::JoinHandle;
 use crate::shutdown_handle::ShutdownHandle;
 
 /// Proxy messages from the BMC to the user's connection.
-pub fn spawn(
+pub(crate) fn spawn(
     mut from_bmc_rx: broadcast::Receiver<ToFrontendMessage>,
     to_frontend_tx: russh::ChannelWriteHalf<Msg>,
     peer_addr: String,
@@ -74,7 +74,7 @@ pub fn spawn(
     }
 }
 
-pub struct Handle {
+pub(crate) struct Handle {
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
 }
@@ -87,7 +87,7 @@ impl ShutdownHandle<()> for Handle {
 
 /// Holds messages to be sent to a frontend: Data from the BMC channel, or connection status messages.
 #[derive(Clone)]
-pub enum ToFrontendMessage {
+pub(crate) enum ToFrontendMessage {
     /// Data coming from the BMC
     Channel(Arc<ChannelMsg>),
     /// An alert that the console was connected or disconnected
@@ -97,7 +97,7 @@ pub enum ToFrontendMessage {
 }
 
 #[derive(Clone)]
-pub enum ConnectionChangeMessage {
+pub(crate) enum ConnectionChangeMessage {
     Disconnected,
     Connected {
         last_disconnect: Option<DateTime<Utc>>,
@@ -153,7 +153,7 @@ impl From<ConnectionChangeMessage> for Arc<ChannelMsg> {
 /// This is the main proxy logic between the frontend SSH connection and the backend BMC connection.
 /// This whole thing would be unnecessary if [`russh::channels::ChanelWriteHalf::send_msg`] were
 /// public. :(
-pub(crate) async fn proxy_channel_message<S>(
+pub(super) async fn proxy_channel_message<S>(
     channel_msg: &russh::ChannelMsg,
     channel: &russh::ChannelWriteHalf<S>,
 ) -> Result<(), MessageProxyError>
@@ -259,7 +259,7 @@ where
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum MessageProxyError {
+pub(super) enum MessageProxyError {
     #[error("error sending {what}: {error}")]
     Sending {
         what: &'static str,
@@ -268,7 +268,7 @@ pub enum MessageProxyError {
 }
 
 #[derive(Debug)]
-pub enum ToBmcMessage {
+pub(crate) enum ToBmcMessage {
     /// Normal SSH message
     ChannelMsg(ChannelMsg),
     /// Exec request (e.g. power reset)
@@ -283,7 +283,7 @@ pub enum ToBmcMessage {
 }
 
 #[derive(Debug)]
-pub struct ExecReply {
-    pub output: Vec<u8>,
-    pub exit_status: u32,
+pub(crate) struct ExecReply {
+    pub(crate) output: Vec<u8>,
+    pub(crate) exit_status: u32,
 }

--- a/crates/ssh-console/src/bmc/mod.rs
+++ b/crates/ssh-console/src/bmc/mod.rs
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-pub mod client;
-pub mod client_pool;
-pub mod connection;
+pub(super) mod client;
+pub(super) mod client_pool;
+pub(super) mod connection;
 mod connection_impl;
-pub mod message_proxy;
+pub(super) mod message_proxy;
 mod pending_output_line;
-pub mod vendor;
+pub(super) mod vendor;

--- a/crates/ssh-console/src/bmc/pending_output_line.rs
+++ b/crates/ssh-console/src/bmc/pending_output_line.rs
@@ -17,14 +17,14 @@
 
 /// A pending output line is data we received from a BMC after the last newline character, and is
 /// useful to relay to the user after they've connected so they can see what the latest output was.
-pub struct PendingOutputLine(Vec<u8>);
+pub(super) struct PendingOutputLine(Vec<u8>);
 
 impl PendingOutputLine {
-    pub fn with_max_size(max_size: usize) -> Self {
+    pub(super) fn with_max_size(max_size: usize) -> Self {
         Self(Vec::with_capacity(max_size))
     }
 
-    pub fn extend(&mut self, data: &[u8]) {
+    pub(super) fn extend(&mut self, data: &[u8]) {
         // If there's a newline in the data, start from there
         let newline_index = if let Some(newline_index) = data.iter().position(|b| *b == b'\n') {
             self.0.clear();
@@ -48,7 +48,7 @@ impl PendingOutputLine {
         self.0.extend(slice);
     }
 
-    pub fn get(&self) -> &[u8] {
+    pub(super) fn get(&self) -> &[u8] {
         &self.0
     }
 }

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -67,7 +67,7 @@ pub enum SshBmcVendor {
 }
 
 impl BmcVendor {
-    pub fn detect_from_api_vendor(
+    pub(in crate::bmc) fn detect_from_api_vendor(
         vendor_string: &str,
         machine_id: &MachineId,
     ) -> Result<Self, BmcVendorDetectionError> {
@@ -121,7 +121,7 @@ impl BmcVendor {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum BmcVendorDetectionError {
+pub(in crate::bmc) enum BmcVendorDetectionError {
     #[error("unknown or unsupported sys_vendor string: {sys_vendor}")]
     UnknownSysVendor { sys_vendor: String },
 }
@@ -151,7 +151,7 @@ impl<'de> Deserialize<'de> for BmcVendor {
 }
 
 impl SshBmcVendor {
-    pub fn serial_activate_command(&self) -> Option<&'static [u8]> {
+    pub(in crate::bmc) fn serial_activate_command(&self) -> Option<&'static [u8]> {
         match self {
             SshBmcVendor::Dell => Some(b"connect com2"),
             SshBmcVendor::Lenovo => Some(b"console kill 1\nconsole 1"),
@@ -161,7 +161,7 @@ impl SshBmcVendor {
         }
     }
 
-    pub fn bmc_prompt(&self) -> Option<&'static [u8]> {
+    pub(in crate::bmc) fn bmc_prompt(&self) -> Option<&'static [u8]> {
         match self {
             SshBmcVendor::Dell => Some(b"\nracadm>>"),
             SshBmcVendor::Lenovo => Some(b"\nsystem>"),
@@ -171,7 +171,7 @@ impl SshBmcVendor {
         }
     }
 
-    pub fn fallback_serial_activate_commands_if_needed(
+    pub(in crate::bmc) fn fallback_serial_activate_commands_if_needed(
         &self,
         prompt_buf: &[u8],
         fallback_sent: bool,
@@ -190,7 +190,7 @@ impl SshBmcVendor {
         }
     }
 
-    pub fn should_accept_sol_activation_output(
+    pub(in crate::bmc) fn should_accept_sol_activation_output(
         &self,
         prompt_buf: &[u8],
         skip_data_read_len: usize,

--- a/crates/ssh-console/src/console_logger.rs
+++ b/crates/ssh-console/src/console_logger.rs
@@ -34,7 +34,7 @@ use crate::config::Config;
 use crate::shutdown_handle::ShutdownHandle;
 
 /// Spawn a background task which logs all output from a BMC
-pub fn spawn(
+pub(crate) fn spawn(
     machine_id: MachineId,
     addr: SocketAddr,
     message_rx: broadcast::Receiver<ToFrontendMessage>,
@@ -51,7 +51,7 @@ pub fn spawn(
     }
 }
 
-pub struct ConsoleLoggerHandle {
+pub(crate) struct ConsoleLoggerHandle {
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
 }

--- a/crates/ssh-console/src/frontend.rs
+++ b/crates/ssh-console/src/frontend.rs
@@ -79,7 +79,7 @@ lazy_static! {
         [opentelemetry::KeyValue::new("auth_type", "public_key",)];
 }
 
-pub struct Handler {
+pub(crate) struct Handler {
     config: Arc<Config>,
     forge_api_client: ForgeApiClient,
     bmc_connection_store: BmcConnectionStore,
@@ -99,7 +99,7 @@ struct PerClientState {
 }
 
 impl Handler {
-    pub fn new(
+    pub(crate) fn new(
         bmc_connection_store: BmcConnectionStore,
         config: Arc<Config>,
         forge_api_client: ForgeApiClient,
@@ -620,7 +620,7 @@ impl russh::server::Handler for Handler {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum HandlerError {
+pub(crate) enum HandlerError {
     #[error("BUG: {method} called but we don't have an authenticated user")]
     MissingAuthenticatedUser { method: &'static str },
     #[error("could not get BMC connection for {machine}: {error}")]
@@ -653,7 +653,7 @@ pub enum HandlerError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum PubkeyAuthError {
+pub(crate) enum PubkeyAuthError {
     #[error("error reading authorized_keys file at {path}: {error}")]
     ReadingAuthorizedKeys {
         path: String,

--- a/crates/ssh-console/src/io_util.rs
+++ b/crates/ssh-console/src/io_util.rs
@@ -26,7 +26,7 @@ use tokio::io::unix::AsyncFd;
 
 /// Allocate a pty with `nix::pty::openpty`, ensuring its file descriptors are set with O_NONBLOCK,
 /// and return it.
-pub fn alloc_pty(cols: u16, rows: u16) -> Result<OpenptyResult, PtyAllocError> {
+pub(crate) fn alloc_pty(cols: u16, rows: u16) -> Result<OpenptyResult, PtyAllocError> {
     // set up raw mode so the child sees a “dumb” terminal
     let libc_termios = libc::termios {
         c_iflag: 0,
@@ -67,7 +67,7 @@ pub fn alloc_pty(cols: u16, rows: u16) -> Result<OpenptyResult, PtyAllocError> {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum PtyAllocError {
+pub(crate) enum PtyAllocError {
     #[error("error {what}: {error}")]
     Io {
         error: std::io::Error,
@@ -76,7 +76,10 @@ pub enum PtyAllocError {
 }
 
 /// Make `pty_slave` the controlling terminal for the given command when it is executed.
-pub fn set_controlling_terminal_on_exec(command: &mut tokio::process::Command, pty_slave: RawFd) {
+pub(crate) fn set_controlling_terminal_on_exec(
+    command: &mut tokio::process::Command,
+    pty_slave: RawFd,
+) {
     // SAFETY: the pre_exec closure runs in the forked process before exec, where setsid() and
     // setting TIOCSCTTY are commonly allowed things.
     unsafe {
@@ -104,7 +107,10 @@ fn set_nonblocking<F: AsFd>(fd: &F) -> nix::Result<()> {
 
 /// Waits for the fd to be ready for writing, and writes the data to it, looping repeatedly until
 /// all data is written.
-pub async fn write_data_to_async_fd(data: &[u8], fd: &AsyncFd<OwnedFd>) -> std::io::Result<usize> {
+pub(crate) async fn write_data_to_async_fd(
+    data: &[u8],
+    fd: &AsyncFd<OwnedFd>,
+) -> std::io::Result<usize> {
     let mut written = 0;
     loop {
         let mut guard = fd.writable().await?;

--- a/crates/ssh-console/src/main.rs
+++ b/crates/ssh-console/src/main.rs
@@ -23,7 +23,7 @@ use ssh_console::shutdown_handle::ShutdownHandle;
 use tracing::metadata::LevelFilter;
 
 #[tokio::main(flavor = "multi_thread")]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     setup_logging(&cli);
 

--- a/crates/ssh-console/src/metrics.rs
+++ b/crates/ssh-console/src/metrics.rs
@@ -34,7 +34,7 @@ use crate::config::Config;
 use crate::shutdown_handle::ShutdownHandle;
 use crate::tcp_listener;
 
-pub async fn spawn(
+pub(crate) async fn spawn(
     config: Arc<Config>,
     metrics_state: Arc<MetricsState>,
 ) -> Result<MetricsHandle, SpawnError> {
@@ -93,6 +93,7 @@ pub async fn spawn(
 }
 
 #[derive(thiserror::Error, Debug)]
+// Kept public because `crate::SpawnError` exposes it as a payload.
 pub enum SpawnError {
     #[error("error listening on metrics address: {0}")]
     Listen(std::io::Error),
@@ -125,14 +126,14 @@ fn serve_metrics(
     Ok(response.expect("BUG: Response::builder error"))
 }
 
-pub struct MetricsHandle {
+pub(crate) struct MetricsHandle {
     metrics_address: std::net::SocketAddr,
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
 }
 
 impl MetricsHandle {
-    pub fn metrics_address(&self) -> std::net::SocketAddr {
+    pub(crate) fn metrics_address(&self) -> std::net::SocketAddr {
         self.metrics_address
     }
 }
@@ -143,9 +144,9 @@ impl ShutdownHandle<()> for MetricsHandle {
     }
 }
 
-pub struct MetricsState {
-    pub meter: Meter,
-    pub registry: prometheus::Registry,
+pub(crate) struct MetricsState {
+    pub(crate) meter: Meter,
+    pub(crate) registry: prometheus::Registry,
     _meter_provider: SdkMeterProvider,
 }
 
@@ -158,7 +159,7 @@ impl Default for MetricsState {
 impl MetricsState {
     /// `MetricsState::new` creates ssh-console's registry and installs the
     /// same provider globally for generated Forge-client RED metrics.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let registry = prometheus::Registry::new();
         let exporter = opentelemetry_prometheus::exporter()
             .with_registry(registry.clone())

--- a/crates/ssh-console/src/ssh_cert_parsing.rs
+++ b/crates/ssh-console/src/ssh_cert_parsing.rs
@@ -19,7 +19,7 @@ use russh::keys::Certificate;
 use crate::config::{CertAuthorization, CertAuthorizationStrategy, KeyIdFormat};
 
 /// Search for the given role in the Key ID field of a certificate, returning if it is declared.
-pub fn certificate_contains_role(
+pub(crate) fn certificate_contains_role(
     certificate: &Certificate,
     role: &str,
     cert_authorization: &CertAuthorization,
@@ -42,7 +42,7 @@ pub fn certificate_contains_role(
 }
 
 /// Try to get the username from the given certificate, or return None if we couldn't find one.
-pub fn get_user_from_certificate<'a>(
+pub(crate) fn get_user_from_certificate<'a>(
     certificate: &'a Certificate,
     cert_authorization: &CertAuthorization,
 ) -> Option<&'a str> {

--- a/crates/ssh-console/src/ssh_server.rs
+++ b/crates/ssh-console/src/ssh_server.rs
@@ -35,7 +35,7 @@ use crate::frontend::{Handler, HandlerError};
 use crate::shutdown_handle::ShutdownHandle;
 use crate::tcp_listener;
 
-pub async fn spawn(
+pub(crate) async fn spawn(
     config: Arc<Config>,
     forge_api_client: ForgeApiClient,
     bmc_connection_store: BmcConnectionStore,
@@ -90,6 +90,7 @@ pub async fn spawn(
 }
 
 #[derive(thiserror::Error, Debug)]
+// Kept public because `crate::SpawnError` exposes it as a payload.
 pub enum SpawnError {
     #[error("error reading host key file at {path}: {error}")]
     ReadingHostKeyFile {
@@ -103,14 +104,14 @@ pub enum SpawnError {
     },
 }
 
-pub struct Handle {
+pub(crate) struct Handle {
     listen_address: SocketAddr,
     shutdown_tx: oneshot::Sender<()>,
     join_handle: JoinHandle<()>,
 }
 
 impl Handle {
-    pub fn listen_address(&self) -> SocketAddr {
+    pub(crate) fn listen_address(&self) -> SocketAddr {
         self.listen_address
     }
 }
@@ -132,7 +133,7 @@ struct SshServer {
 impl SshServer {
     /// Run an instance of ssh-console on the given socket, looping forever until `shutdown` is
     /// received (or if the sending end of `shutdown` is dropped.)
-    pub async fn run(mut self, socket: TcpListener, mut shutdown: oneshot::Receiver<()>) {
+    async fn run(mut self, socket: TcpListener, mut shutdown: oneshot::Receiver<()>) {
         loop {
             tokio::select! {
                 accept_result = socket.accept() => {
@@ -203,14 +204,14 @@ impl SshServer {
     }
 }
 
-pub struct ServerMetrics {
-    pub total_clients: UpDownCounter<i64>,
-    pub client_auth_failures_total: Counter<u64>,
+pub(crate) struct ServerMetrics {
+    pub(crate) total_clients: UpDownCounter<i64>,
+    pub(crate) client_auth_failures_total: Counter<u64>,
     _auth_enforced: ObservableGauge<u64>,
     _include_dpus: ObservableGauge<u64>,
 
     // per-BMC stats
-    pub bmc_clients: UpDownCounter<i64>,
+    pub(crate) bmc_clients: UpDownCounter<i64>,
 }
 
 impl ServerMetrics {

--- a/crates/ssh-console/tests/util/ipmi_sim.rs
+++ b/crates/ssh-console/tests/util/ipmi_sim.rs
@@ -25,15 +25,15 @@ use nix::pty::openpty;
 use nix::unistd;
 use tokio::io::unix::AsyncFd;
 
-pub type IpmiSimHandle = bmc_mock::ipmi_sim::IpmiSimHandle;
+pub(super) type IpmiSimHandle = bmc_mock::ipmi_sim::IpmiSimHandle;
 
-pub struct ActiveSolSession {
+pub(crate) struct ActiveSolSession {
     _ipmitool: tokio::process::Child,
     _pty_master: AsyncFd<OwnedFd>,
 }
 
 impl ActiveSolSession {
-    pub async fn assert_console_works(&self, expected_prompt: &[u8]) -> eyre::Result<()> {
+    pub(crate) async fn assert_console_works(&self, expected_prompt: &[u8]) -> eyre::Result<()> {
         const PROBE: &[u8] = b"original-sol-owner-probe\r";
 
         tokio::time::timeout(Duration::from_secs(10), async {
@@ -83,7 +83,7 @@ impl ActiveSolSession {
     }
 }
 
-pub async fn activate_sol(port: u16) -> eyre::Result<ActiveSolSession> {
+pub(crate) async fn activate_sol(port: u16) -> eyre::Result<ActiveSolSession> {
     let pty = openpty(None, None).context("failed to allocate ipmitool pty")?;
     set_nonblocking(&pty.master).context("failed to make ipmitool pty nonblocking")?;
 
@@ -174,7 +174,7 @@ fn set_nonblocking(fd: &OwnedFd) -> nix::Result<()> {
 /// Run an instance of ipmi_sim and a corresponding instance of a mock serial console, for tests to
 /// use. Accepts a `prompt` parameter which will be echoed back when the clients send data (for
 /// tests to assert that it's the expected host.)
-pub async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
+pub(super) async fn run(prompt: String) -> eyre::Result<IpmiSimHandle> {
     let bmc = bmc_mock::test_support::generic_supermicro_bmc().await;
     bmc.state
         .account_service_state

--- a/crates/ssh-console/tests/util/metrics.rs
+++ b/crates/ssh-console/tests/util/metrics.rs
@@ -20,7 +20,10 @@ use eyre::Context;
 use prometheus_text_parser::ParsedPrometheusMetrics;
 use ssh_console_mock_api_server::MockHost;
 
-pub async fn assert_metrics(metrics_str: String, mock_hosts: &[MockHost]) -> eyre::Result<()> {
+pub(super) async fn assert_metrics(
+    metrics_str: String,
+    mock_hosts: &[MockHost],
+) -> eyre::Result<()> {
     let metrics: ParsedPrometheusMetrics = metrics_str.parse().context("error parsing metrics")?;
     let metrics = metrics.metrics;
 

--- a/crates/ssh-console/tests/util/mod.rs
+++ b/crates/ssh-console/tests/util/mod.rs
@@ -34,46 +34,46 @@ use crate::util::metrics::assert_metrics;
 use crate::util::ssh_client::ConnectionConfig;
 use crate::{ADMIN_SSH_KEY_PATH, TENANT_SSH_KEY_PATH, TENANT_SSH_PUBKEY};
 
-pub mod ipmi_sim;
+pub(super) mod ipmi_sim;
 mod metrics;
-pub mod ssh_client;
-pub mod ssh_console_test_helper;
+pub(super) mod ssh_client;
+pub(super) mod ssh_console_test_helper;
 
-pub mod fixtures {
+mod fixtures {
     use std::path::PathBuf;
 
     use api_test_helper::utils::REPO_ROOT;
 
     lazy_static::lazy_static! {
-        pub static ref BMC_MOCK_CERTS_DIR: PathBuf = REPO_ROOT
+        pub(super) static ref BMC_MOCK_CERTS_DIR: PathBuf = REPO_ROOT
             .join("crates/bmc-mock")
             .canonicalize()
             .unwrap();
-        pub static ref LOCALHOST_CERTS_DIR: PathBuf = REPO_ROOT
+        pub(super) static ref LOCALHOST_CERTS_DIR: PathBuf = REPO_ROOT
             .join("dev/certs/localhost")
             .canonicalize()
             .unwrap();
-        pub static ref SSH_HOST_PUBKEY: PathBuf = REPO_ROOT
+        pub(super) static ref SSH_HOST_PUBKEY: PathBuf = REPO_ROOT
             .join("crates/ssh-console/tests/fixtures/ssh_host_ed25519_key.pub")
             .canonicalize()
             .unwrap();
-        pub static ref AUTHORIZED_KEYS_PATH: PathBuf = REPO_ROOT
+        pub(super) static ref AUTHORIZED_KEYS_PATH: PathBuf = REPO_ROOT
             .join("crates/ssh-console/tests/fixtures/authorized_keys")
             .canonicalize()
             .unwrap();
-        pub static ref SSH_HOST_KEY: PathBuf = REPO_ROOT
+        pub(super) static ref SSH_HOST_KEY: PathBuf = REPO_ROOT
             .join("crates/ssh-console/tests/fixtures/ssh_host_ed25519_key")
             .canonicalize()
             .unwrap();
-        pub static ref API_CA_CERT: PathBuf = REPO_ROOT
+        pub(super) static ref API_CA_CERT: PathBuf = REPO_ROOT
             .join("dev/certs/localhost/ca.crt")
             .canonicalize()
             .unwrap();
-        pub static ref API_CLIENT_CERT: PathBuf = REPO_ROOT
+        pub(super) static ref API_CLIENT_CERT: PathBuf = REPO_ROOT
             .join("dev/certs/localhost/client.crt")
             .canonicalize()
             .unwrap();
-        pub static ref API_CLIENT_KEY: PathBuf = REPO_ROOT
+        pub(super) static ref API_CLIENT_KEY: PathBuf = REPO_ROOT
             .join("dev/certs/localhost/client.key")
             .canonicalize()
             .unwrap();
@@ -83,7 +83,7 @@ pub mod fixtures {
 /// Runs a baseline test environment for comparing results for leagacy ssh-console and (soon) new
 /// ssh-console. Adds to api_test_helper's IntegrationTestEnvironment by running an ipmi_sim and a
 /// machine-a-tron environment with 2 machines. Also creates tenants/orgs/instances.
-pub async fn run_baseline_test_environment(
+pub(crate) async fn run_baseline_test_environment(
     machines: Vec<MockBmcType>,
 ) -> eyre::Result<Option<BaselineTestEnvironment>> {
     let mock_bmc_handles: Vec<(MockBmcHandle, MachineId, MockBmcType)> =
@@ -189,14 +189,14 @@ pub async fn run_baseline_test_environment(
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum MockBmcType {
+pub(crate) enum MockBmcType {
     Ssh,
     LenovoSr650Ssh,
     DpuSsh,
     Ipmi,
 }
 
-pub enum MockBmcHandle {
+enum MockBmcHandle {
     Ssh(MockSshServerHandle),
     Ipmi(Box<IpmiSimHandle>),
 }
@@ -210,14 +210,14 @@ impl HostnameQuerying for KnownHostname {
     }
 }
 
-pub struct BaselineTestEnvironment {
-    pub mock_api_server: MockApiServerHandle,
-    pub mock_hosts: Arc<Vec<MockHost>>,
+pub(crate) struct BaselineTestEnvironment {
+    pub(crate) mock_api_server: MockApiServerHandle,
+    pub(crate) mock_hosts: Arc<Vec<MockHost>>,
     _mock_bmc_handles: Vec<MockBmcHandle>,
 }
 
 impl BaselineTestEnvironment {
-    pub async fn run_baseline_assertions<MetricsFn>(
+    pub(crate) async fn run_baseline_assertions<MetricsFn>(
         &self,
         addr: SocketAddr,
         connection_name: &str,
@@ -340,7 +340,7 @@ impl BaselineTestEnvironment {
 }
 
 #[allow(clippy::enum_variant_names)]
-pub enum BaselineTestAssertion {
+pub(crate) enum BaselineTestAssertion {
     ConnectAsMachineId,
     ConnectAsInstanceId,
     FillLogsAsMachineId(usize),

--- a/crates/ssh-console/tests/util/ssh_client.rs
+++ b/crates/ssh-console/tests/util/ssh_client.rs
@@ -36,15 +36,15 @@ static PROMPT_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 static BMC_BACKDOOR_SEQUENCE: &[u8] = b"backdoor_escape_console\n";
 
 #[derive(Copy, Clone)]
-pub struct ConnectionConfig<'a> {
-    pub connection_name: &'a str,
-    pub user: &'a str,
-    pub private_key_path: &'a Path,
-    pub addr: SocketAddr,
-    pub expected_prompt: &'a [u8],
+pub(crate) struct ConnectionConfig<'a> {
+    pub(crate) connection_name: &'a str,
+    pub(crate) user: &'a str,
+    pub(crate) private_key_path: &'a Path,
+    pub(crate) addr: SocketAddr,
+    pub(crate) expected_prompt: &'a [u8],
 }
 
-pub async fn assert_connection_works_with_retries_and_timeout(
+pub(crate) async fn assert_connection_works_with_retries_and_timeout(
     connection_config: &ConnectionConfig<'_>,
     retry_count: u8,
     per_try_timeout: Duration,
@@ -84,7 +84,7 @@ pub async fn assert_connection_works_with_retries_and_timeout(
     }
 }
 
-pub async fn assert_connection_works(
+pub(crate) async fn assert_connection_works(
     ConnectionConfig {
         connection_name,
         user,
@@ -242,7 +242,7 @@ pub async fn assert_connection_works(
     result
 }
 
-pub async fn fill_logs(
+pub(crate) async fn fill_logs(
     ConnectionConfig {
         connection_name: _,
         user,
@@ -332,7 +332,7 @@ pub async fn fill_logs(
     Ok(())
 }
 
-pub async fn assert_reboot_behavior(
+pub(crate) async fn assert_reboot_behavior(
     ConnectionConfig {
         connection_name: _,
         user,
@@ -437,7 +437,7 @@ enum ConnectionTestState {
     TryingBackdoorEscape,
 }
 
-pub struct PermissiveSshClient;
+pub(crate) struct PermissiveSshClient;
 
 impl russh::client::Handler for PermissiveSshClient {
     type Error = eyre::Error;

--- a/crates/ssh-console/tests/util/ssh_console_test_helper.rs
+++ b/crates/ssh-console/tests/util/ssh_console_test_helper.rs
@@ -31,14 +31,14 @@ use crate::util::fixtures::{
 };
 
 #[derive(Default)]
-pub struct ConfigOverrides {
-    pub reconnect_interval_base: Option<Duration>,
-    pub reconnect_interval_max: Option<Duration>,
-    pub successful_connection_minimum_duration: Option<Duration>,
-    pub force_deactivate_conflicting_ipmi_sol_sessions: Option<bool>,
+pub(crate) struct ConfigOverrides {
+    pub(crate) reconnect_interval_base: Option<Duration>,
+    pub(crate) reconnect_interval_max: Option<Duration>,
+    pub(crate) successful_connection_minimum_duration: Option<Duration>,
+    pub(crate) force_deactivate_conflicting_ipmi_sol_sessions: Option<bool>,
 }
 
-pub async fn spawn(
+pub(crate) async fn spawn(
     carbide_port: u16,
     config_overrides: Option<ConfigOverrides>,
 ) -> eyre::Result<NewSshConsoleHandle> {
@@ -115,14 +115,14 @@ pub async fn spawn(
     })
 }
 
-pub struct NewSshConsoleHandle {
-    pub addr: SocketAddr,
-    pub metrics_address: SocketAddr,
-    pub logs_dir: TempDir,
-    pub spawn_handle: ssh_console::SpawnHandle,
+pub(crate) struct NewSshConsoleHandle {
+    pub(crate) addr: SocketAddr,
+    pub(crate) metrics_address: SocketAddr,
+    pub(crate) logs_dir: TempDir,
+    pub(crate) spawn_handle: ssh_console::SpawnHandle,
 }
 
-pub async fn get_metrics(addr: SocketAddr) -> eyre::Result<String> {
+pub(crate) async fn get_metrics(addr: SocketAddr) -> eyre::Result<String> {
     use http_body_util::BodyExt;
     String::from_utf8_lossy(
         hyper_util::client::legacy::Builder::new(TokioExecutor::new())


### PR DESCRIPTION
This adopts the new style guide rules around module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout the BMC and console group.

Primary callouts are:
- Replace unrestricted `pub` across `ssh-console`, `bmc-explorer`, `bmc-proxy`, `ipmi`, `host-support`, `redfish`, and `nvue-client` with private, `pub(super)`, `pub(crate)`, or named-ancestor visibility based on actual callers.
- Keep the BMC explorer and Redfish test-support surfaces public where downstream crate and integration-test callers rely on them.
- Restrict ssh-console's BMC connection tree to its parent module while keeping frontend messages and vendor types available at the crate boundaries that use them.
- Make binary entrypoints, configuration internals, implementation types, helper methods, and test utilities visible only where their callers need them.
- Preserve public library APIs, error surfaces, serialized configuration, test fixtures, and runtime behavior.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4554.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

All 208 touched-crate unit and integration tests passed, including the `ssh-console` integration suite. I also ran:

```bash
cargo test --locked --all-features -p carbide-ssh-console -p bmc-explorer -p carbide-bmc-proxy -p carbide-ipmi -p carbide-host-support -p carbide-redfish -p nvue-client
cargo clippy --locked --all-targets --all-features -p carbide-ssh-console -p bmc-explorer -p carbide-bmc-proxy -p carbide-ipmi -p carbide-host-support -p carbide-redfish -p nvue-client --message-format short -- --force-warn unreachable-pub
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
git diff --check
```

## Additional Notes

The initial visibility lint identified 192 overbroad declarations across 40 files. Narrowing those parent items exposed 145 contained fields and helpers whose visibility could move with them; the final 43-file diff tightens 337 declarations. The unrestricted public surfaces left are backed by cross-crate callers, integration-test consumers, or intentional root re-exports.

Local CodeRabbit, read-only Claude, and self-reviews completed over the full diff. All applicable findings are incorporated.


Closes #4554
