### PR TITLE
refactor(lifecycle): adopt style guide rules around pub/module visibility

### DIFF
--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -38,7 +38,7 @@ use crate::mock_ssh_server::{MockSshServerHandle, PromptBehavior};
 /// BmcMockWrapper launches a single instance of bmc-mock, configured to mock a single BMC for
 /// either a DPU or a Host. It will rewrite certain responses to customize them for the machines
 /// machine-a-tron is mocking.
-pub struct BmcMockWrapper {
+pub(super) struct BmcMockWrapper {
     ssh_prompt_behavior: PromptBehavior,
     app_context: Arc<MachineATronContext>,
     bmc_mock_router: Router,
@@ -49,7 +49,7 @@ pub struct BmcMockWrapper {
 }
 
 impl BmcMockWrapper {
-    pub fn new(
+    pub(super) fn new(
         machine_info: &MachineInfo,
         app_context: Arc<MachineATronContext>,
         callbacks: Arc<dyn Callbacks>,
@@ -81,7 +81,7 @@ impl BmcMockWrapper {
 
     /// Starts the per-machine Redfish server and any enabled SSH and IPMI simulators.
     /// When requested, the BMC address is first added as an alias on the configured interface.
-    pub async fn start(
+    pub(super) async fn start(
         &mut self,
         address: SocketAddr,
         add_ip_alias: bool,
@@ -183,7 +183,7 @@ impl BmcMockWrapper {
 
     /// Starts only the optional IPMI simulator when Redfish is served by a shared BMC mock.
     /// Returns `None` when IPMI simulation is disabled or the machine does not support IPMI SOL.
-    pub async fn start_ipmi_only(
+    pub(super) async fn start_ipmi_only(
         &self,
         bind_ip: std::net::IpAddr,
     ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
@@ -221,24 +221,24 @@ impl BmcMockWrapper {
         .map_err(MachineStateError::IpmiSim)
     }
 
-    pub fn router(&self) -> &Router {
+    pub(super) fn router(&self) -> &Router {
         &self.bmc_mock_router
     }
 
-    pub fn state(&self) -> &BmcState {
+    pub(super) fn state(&self) -> &BmcState {
         &self.bmc_mock_state
     }
 }
 
 #[derive(Debug)]
-pub struct BmcMockWrapperHandle {
-    pub _bmc_mock: Option<CombinedServer>,
-    pub ssh_handle: Option<MockSshServerHandle>,
+pub(super) struct BmcMockWrapperHandle {
+    _bmc_mock: Option<CombinedServer>,
+    pub(super) ssh_handle: Option<MockSshServerHandle>,
     _ipmi_sim_handle: Option<IpmiSimHandle>,
 }
 
 impl BmcMockWrapperHandle {
-    pub fn ipmi_endpoint(&self) -> Option<IpmiEndpoint> {
+    pub(super) fn ipmi_endpoint(&self) -> Option<IpmiEndpoint> {
         self._ipmi_sim_handle.as_ref().map(|handle| handle.endpoint)
     }
 }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -781,7 +781,7 @@ where
     }
 }
 
-pub fn deserialize_machine_config<'a, D>(
+fn deserialize_machine_config<'a, D>(
     deserializer: D,
 ) -> Result<BTreeMap<String, Arc<MachineConfig>>, D::Error>
 where

--- a/crates/machine-a-tron/src/dhcp_wrapper.rs
+++ b/crates/machine-a-tron/src/dhcp_wrapper.rs
@@ -30,13 +30,13 @@ use crate::config::{DhcpType, MachineATronConfig};
 use crate::dhcp_wrapper_udp::UdpDhcpClient;
 pub use crate::dhcp_wrapper_udp::UdpDhcpService;
 
-pub type DhcpRelayResult<T> = Result<T, DhcpRelayError>;
+pub(super) type DhcpRelayResult<T> = Result<T, DhcpRelayError>;
 
 #[derive(Debug)]
-pub struct DhcpRequestInfo {
-    pub mac_address: MacAddress,
-    pub relay_address: Ipv4Addr,
-    pub vendor_class: Option<&'static str>,
+pub(super) struct DhcpRequestInfo {
+    pub(super) mac_address: MacAddress,
+    pub(super) relay_address: Ipv4Addr,
+    pub(super) vendor_class: Option<&'static str>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -121,9 +121,9 @@ fn vendor_class_for(machine: DhcpMachine, requester: DhcpRequester) -> Option<&'
 }
 
 #[derive(Clone, Debug)]
-pub struct DhcpResponseInfo {
-    pub interface_id: Option<MachineInterfaceId>,
-    pub ip_address: Ipv4Addr,
+pub(super) struct DhcpResponseInfo {
+    pub(super) interface_id: Option<MachineInterfaceId>,
+    pub(super) ip_address: Ipv4Addr,
 }
 
 #[derive(Clone, Debug)]
@@ -151,7 +151,7 @@ impl DhcpClient {
         }
     }
 
-    pub async fn request_ip(
+    pub(super) async fn request_ip(
         &self,
         request_info: DhcpRequestInfo,
     ) -> DhcpRelayResult<DhcpResponseInfo> {
@@ -212,7 +212,7 @@ async fn request_ip_from_api(
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum DhcpRelayError {
+pub(super) enum DhcpRelayError {
     #[error("client API error: {0}")]
     ClientApiError(#[from] ClientApiError),
     #[error("invalid DHCP record: {0}")]
@@ -251,20 +251,20 @@ impl From<tonic::Status> for DhcpRelayError {
 /// a steady (booted) state (and have a ManagedHostNetworkConfig.)
 #[derive(Debug, Clone)]
 #[allow(clippy::enum_variant_names)] // Dumb lint. "End" is a semantically important suffix here.
-pub enum DpuDhcpRelay {
+pub(super) enum DpuDhcpRelay {
     HostEnd(mpsc::UnboundedSender<DhcpRelayReply>),
     DpuEnd(DpuDhcpRelayServer),
 }
 
-pub type DhcpRelayReply = oneshot::Sender<DhcpRelayResult<DhcpResponseInfo>>;
+pub(super) type DhcpRelayReply = oneshot::Sender<DhcpRelayResult<DhcpResponseInfo>>;
 
 #[derive(Debug, Clone)]
-pub struct DpuDhcpRelayServer {
+pub(super) struct DpuDhcpRelayServer {
     request_rx: Arc<RwLock<mpsc::UnboundedReceiver<DhcpRelayReply>>>,
 }
 
 impl DpuDhcpRelayServer {
-    pub fn new(reply_rx: mpsc::UnboundedReceiver<DhcpRelayReply>) -> Self {
+    pub(super) fn new(reply_rx: mpsc::UnboundedReceiver<DhcpRelayReply>) -> Self {
         Self {
             request_rx: Arc::new(RwLock::new(reply_rx)),
         }
@@ -279,7 +279,10 @@ impl DpuDhcpRelayServer {
     ///
     /// The caller, [`MachineStateMachine`], stores the stop handle in the MachineUp state, so it is
     /// implicitly dropped (and this task stopped) when the mock DPU is rebooted.
-    pub fn spawn(&self, network_config: ManagedHostNetworkConfigResponse) -> oneshot::Sender<()> {
+    pub(super) fn spawn(
+        &self,
+        network_config: ManagedHostNetworkConfigResponse,
+    ) -> oneshot::Sender<()> {
         let (stop_tx, mut stop_rx) = oneshot::channel::<()>();
         let request_rx = self.request_rx.clone();
         tokio::spawn(async move {

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -40,7 +40,7 @@ use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, End
 use crate::tui::HostDetails;
 use crate::{MachineConfig, saturating_add_duration_to_instant};
 
-pub struct DpuMachine {
+pub(super) struct DpuMachine {
     mat_id: Uuid,
     // The mat_id of the host that owns this DPU
     host_id: Uuid,
@@ -61,7 +61,7 @@ pub struct DpuMachine {
 }
 
 impl DpuMachine {
-    pub fn from_persisted(
+    pub(super) fn from_persisted(
         persisted_dpu_machine: PersistedDpuMachine,
         mat_host: Uuid,
         app_context: Arc<MachineATronContext>,
@@ -111,7 +111,7 @@ impl DpuMachine {
         }
     }
 
-    pub fn new(
+    pub(super) fn new(
         hw_type: HardwareType,
         mat_host: Uuid,
         dpu_index: u8,
@@ -172,7 +172,7 @@ impl DpuMachine {
     }
 
     #[instrument(skip_all, fields(mat_host_id = %self.host_id, dpu_index = self.dpu_index))]
-    pub fn start(mut self, paused: bool) -> DpuMachineHandle {
+    pub(super) fn start(mut self, paused: bool) -> DpuMachineHandle {
         self.paused = paused;
         let (message_tx, mut message_rx) = mpsc::unbounded_channel();
         let mat_id = self.mat_id;
@@ -316,7 +316,7 @@ impl DpuMachine {
         result
     }
 
-    pub fn dpu_info(&self) -> &DpuMachineInfo {
+    pub(super) fn dpu_info(&self) -> &DpuMachineInfo {
         &self.dpu_info
     }
 }

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -42,7 +42,7 @@ use crate::saturating_add_duration_to_instant;
 use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus};
 use crate::tui::{HostDetails, UiUpdate};
 
-pub struct HostMachine {
+pub(super) struct HostMachine {
     mat_id: Uuid,
     machine_config_section: String,
     host_info: HostMachineInfo,
@@ -63,7 +63,7 @@ pub struct HostMachine {
 }
 
 impl HostMachine {
-    pub fn from_persisted(
+    pub(super) fn from_persisted(
         persisted_device: PersistedDevice,
         machine_config_section: String,
         app_context: Arc<MachineATronContext>,
@@ -150,7 +150,7 @@ impl HostMachine {
         }
     }
 
-    pub fn new(
+    pub(super) fn new(
         app_context: Arc<MachineATronContext>,
         machine_config_section: String,
         config: Arc<MachineConfig>,
@@ -518,7 +518,7 @@ impl HostMachine {
 }
 
 // Shared with DpuMachine
-pub enum HandleMessageResult {
+pub(super) enum HandleMessageResult {
     ContinuePolling,
     ProcessStateNow,
 }
@@ -589,11 +589,11 @@ impl MachineHandle {
         }))
     }
 
-    pub fn mat_id(&self) -> Uuid {
+    pub(super) fn mat_id(&self) -> Uuid {
         self.0.mat_id
     }
 
-    pub fn observed_machine_id(&self) -> Option<MachineId> {
+    pub(super) fn observed_machine_id(&self) -> Option<MachineId> {
         self.0
             .live_state
             .read()
@@ -603,7 +603,7 @@ impl MachineHandle {
             .map(|m| m.to_owned())
     }
 
-    pub async fn api_state(&self) -> eyre::Result<String> {
+    pub(super) async fn api_state(&self) -> eyre::Result<String> {
         let (tx, rx) = oneshot::channel();
         self.0
             .message_tx
@@ -615,7 +615,7 @@ impl MachineHandle {
         self.0.bmc_injection.clone()
     }
 
-    pub async fn wait_until_machine_up_with_api_state(
+    pub(super) async fn wait_until_machine_up_with_api_state(
         &self,
         state: &str,
         timeout: Duration,
@@ -634,36 +634,39 @@ impl MachineHandle {
         Ok(())
     }
 
-    pub fn attach_to_tui(&self, tui_event_tx: Option<mpsc::Sender<UiUpdate>>) -> eyre::Result<()> {
+    pub(super) fn attach_to_tui(
+        &self,
+        tui_event_tx: Option<mpsc::Sender<UiUpdate>>,
+    ) -> eyre::Result<()> {
         Ok(self
             .0
             .message_tx
             .send(HostMachineMessage::AttachToUI(tui_event_tx))?)
     }
 
-    pub fn pause(&self) -> eyre::Result<()> {
+    pub(super) fn pause(&self) -> eyre::Result<()> {
         self.0
             .message_tx
             .send(HostMachineMessage::SetPaused(true))?;
         Ok(())
     }
 
-    pub fn resume(&self) -> eyre::Result<()> {
+    pub(super) fn resume(&self) -> eyre::Result<()> {
         self.0
             .message_tx
             .send(HostMachineMessage::SetPaused(false))?;
         Ok(())
     }
 
-    pub fn host_info(&self) -> &HostMachineInfo {
+    pub(super) fn host_info(&self) -> &HostMachineInfo {
         &self.0.host_info
     }
 
-    pub fn machine_config_section(&self) -> &str {
+    pub(super) fn machine_config_section(&self) -> &str {
         &self.0.machine_config_section
     }
 
-    pub fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
+    pub(super) fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
         let live_state = self.0.live_state.read().unwrap();
         DeviceStatus {
             mat_id: self.0.mat_id.to_string(),
@@ -692,7 +695,7 @@ impl MachineHandle {
         }
     }
 
-    pub fn persisted(&self) -> PersistedDevice {
+    pub(super) fn persisted(&self) -> PersistedDevice {
         let live_state = self.0.live_state.read().unwrap();
         PersistedDevice {
             hw_type: self.0.host_info.hw_type,
@@ -714,11 +717,11 @@ impl MachineHandle {
         }
     }
 
-    pub fn dpus(&self) -> &[DpuMachineHandle] {
+    pub(super) fn dpus(&self) -> &[DpuMachineHandle] {
         &self.0.dpus
     }
 
-    pub async fn delete_from_api(self, api_client: ApiClient) -> eyre::Result<()> {
+    pub(super) async fn delete_from_api(self, api_client: ApiClient) -> eyre::Result<()> {
         let delete_by = match self
             .0
             .live_state
@@ -758,7 +761,7 @@ impl MachineHandle {
         Ok(())
     }
 
-    pub fn abort(&self) {
+    pub(super) fn abort(&self) {
         for dpu in &self.0.dpus {
             dpu.abort();
         }
@@ -767,7 +770,7 @@ impl MachineHandle {
         }
     }
 
-    pub async fn abort_and_wait(&self) -> eyre::Result<()> {
+    pub(super) async fn abort_and_wait(&self) -> eyre::Result<()> {
         let mut join_handles = self
             .0
             .dpus
@@ -789,11 +792,11 @@ impl MachineHandle {
         Ok(())
     }
 
-    pub fn bmc_ssh_host_pubkey(&self) -> Option<String> {
+    pub(super) fn bmc_ssh_host_pubkey(&self) -> Option<String> {
         self.0.live_state.read().unwrap().ssh_host_key.clone()
     }
 
-    pub fn bmc_ip(&self) -> Option<Ipv4Addr> {
+    pub(super) fn bmc_ip(&self) -> Option<Ipv4Addr> {
         self.0.live_state.read().unwrap().bmc_ip
     }
 }

--- a/crates/machine-a-tron/src/machine_fsm.rs
+++ b/crates/machine-a-tron/src/machine_fsm.rs
@@ -19,10 +19,10 @@ use bmc_mock::{BmcEvent, MockPowerState};
 
 use crate::machine_state_machine::OsImage;
 
-pub type FsmReturn<Fsm> = (Fsm, Vec<Action>);
+type FsmReturn<Fsm> = (Fsm, Vec<Action>);
 
 #[derive(Clone, Copy, Debug)]
-pub enum MachineFsm {
+pub(super) enum MachineFsm {
     BmcInit { power_on: bool, bmc_only: bool },
     Init,
     MachineDown,
@@ -33,14 +33,14 @@ pub enum MachineFsm {
 }
 
 impl MachineFsm {
-    pub fn init(power_on: bool, bmc_only: bool) -> FsmReturn<Self> {
+    pub(super) fn init(power_on: bool, bmc_only: bool) -> FsmReturn<Self> {
         (
             Self::BmcInit { power_on, bmc_only },
             vec![Action::Dhcp(DhcpType::Bmc)],
         )
     }
 
-    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+    pub(super) fn event(self, event: Event) -> (Self, Vec<Action>) {
         // A managed DPU that applied a staged NIC-mode flip is now a plain NIC,
         // not a DPU: converge it to the dormant BMC-only track from any active
         // state. Producing this transition here (rather than assigning the state
@@ -65,11 +65,11 @@ impl MachineFsm {
         }
     }
 
-    pub fn is_up(&self) -> bool {
+    pub(super) fn is_up(&self) -> bool {
         matches!(self, Self::MachineUp { .. } | Self::BmcOnlyMachineUp)
     }
 
-    pub fn power_state(&self) -> MockPowerState {
+    pub(super) fn power_state(&self) -> MockPowerState {
         match self {
             Self::BmcInit { power_on: true, .. } => MockPowerState::On,
             Self::BmcInit {
@@ -84,7 +84,7 @@ impl MachineFsm {
         }
     }
 
-    pub fn state_string(&self) -> &'static str {
+    pub(super) fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
             Self::Init => "Init",
@@ -96,7 +96,7 @@ impl MachineFsm {
         }
     }
 
-    pub fn booted_os(&self) -> Option<OsImage> {
+    pub(super) fn booted_os(&self) -> Option<OsImage> {
         match self {
             Self::MachineUp {
                 os_fsm: OsFsm::Scout { .. },
@@ -273,7 +273,7 @@ impl MachineFsm {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum Event {
+pub(super) enum Event {
     DhcpComplete(DhcpType),
     PowerOn,
     PowerOff,
@@ -288,7 +288,7 @@ pub enum Event {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum Action {
+pub(super) enum Action {
     SetupBmc,
     SetTimer(Timer),
     Dhcp(DhcpType),
@@ -301,7 +301,7 @@ pub enum Action {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum Timer {
+pub(super) enum Timer {
     PowerCycle,
     MachineOn,
     ScoutAgentControlPoll,
@@ -309,20 +309,20 @@ pub enum Timer {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum DhcpType {
+pub(super) enum DhcpType {
     Bmc,
     Machine,
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum OsFsm {
+pub(super) enum OsFsm {
     None,
     Scout(ScoutFsm),
     DpuAgent(DpuAgentFsm),
 }
 
 impl OsFsm {
-    pub fn init_actions(&self) -> Vec<Action> {
+    fn init_actions(&self) -> Vec<Action> {
         match self {
             Self::None => vec![],
             Self::Scout(_) => vec![Action::InitialDiscoveryRequest(OsImage::Scout)],
@@ -330,7 +330,7 @@ impl OsFsm {
         }
     }
 
-    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+    fn event(self, event: Event) -> (Self, Vec<Action>) {
         match self {
             Self::None => (self, vec![]),
             Self::Scout(scout_fsm) => {
@@ -347,7 +347,7 @@ impl OsFsm {
     /// A failed OS parked waiting to be rebooted -- e.g. its machine was
     /// force-deleted and its agent hit `MachineNotFound`. The host must reboot
     /// on the next power-on to re-PXE and re-ingest.
-    pub fn is_awaiting_reboot(&self) -> bool {
+    fn is_awaiting_reboot(&self) -> bool {
         matches!(
             self,
             Self::Scout(ScoutFsm::FailedAndWaitForReboot)
@@ -357,14 +357,14 @@ impl OsFsm {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum ScoutFsm {
+pub(super) enum ScoutFsm {
     Discovery,
     PollingLoop,
     FailedAndWaitForReboot,
 }
 
 impl ScoutFsm {
-    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+    fn event(self, event: Event) -> (Self, Vec<Action>) {
         match self {
             Self::Discovery => self.fsm_discovery(event),
             Self::PollingLoop => self.fsm_polling_loop(event),
@@ -372,7 +372,7 @@ impl ScoutFsm {
         }
     }
 
-    pub fn fsm_discovery(self, event: Event) -> (Self, Vec<Action>) {
+    fn fsm_discovery(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::InitialDiscoveryCompleted => (
                 Self::PollingLoop,
@@ -383,7 +383,7 @@ impl ScoutFsm {
         }
     }
 
-    pub fn fsm_polling_loop(self, event: Event) -> (Self, Vec<Action>) {
+    fn fsm_polling_loop(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::AgentControlCompleted => {
                 (self, vec![Action::SetTimer(Timer::ScoutAgentControlPoll)])
@@ -398,7 +398,7 @@ impl ScoutFsm {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub enum DpuAgentFsm {
+pub(super) enum DpuAgentFsm {
     Discovery,
     AgentControl,
     NetworkObservation,
@@ -406,7 +406,7 @@ pub enum DpuAgentFsm {
 }
 
 impl DpuAgentFsm {
-    pub fn event(self, event: Event) -> (Self, Vec<Action>) {
+    fn event(self, event: Event) -> (Self, Vec<Action>) {
         match self {
             Self::Discovery => self.fsm_discovery(event),
             Self::AgentControl => self.fsm_agent_control(event),
@@ -415,7 +415,7 @@ impl DpuAgentFsm {
         }
     }
 
-    pub fn fsm_discovery(self, event: Event) -> (Self, Vec<Action>) {
+    fn fsm_discovery(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::InitialDiscoveryCompleted => (
                 Self::AgentControl,
@@ -426,7 +426,7 @@ impl DpuAgentFsm {
         }
     }
 
-    pub fn fsm_agent_control(self, event: Event) -> (Self, Vec<Action>) {
+    fn fsm_agent_control(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::TimerAlert(Timer::DpuAgentControlPoll) => {
                 (self, vec![Action::AgentControlRequest(OsImage::DpuAgent)])
@@ -440,7 +440,7 @@ impl DpuAgentFsm {
         }
     }
 
-    pub fn fsm_network_observation(self, event: Event) -> (Self, Vec<Action>) {
+    fn fsm_network_observation(self, event: Event) -> (Self, Vec<Action>) {
         match event {
             Event::NetworkObservationCompleted => (
                 Self::AgentControl,

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -52,7 +52,7 @@ use crate::machine_utils::{
 };
 use crate::{PersistedDevice, PersistedDpuMachine};
 
-pub type DpuDhcpRelayHandle = oneshot::Sender<()>;
+type DpuDhcpRelayHandle = oneshot::Sender<()>;
 
 // RFC 2131 section 4.1's Ethernet example starts at four seconds, doubles to a
 // 64-second base, and adds uniform jitter from -1 through +1 second.
@@ -153,10 +153,10 @@ fn direct_dhcp_relay_address(
 ///
 /// This code is in common between DPUs and Hosts.(ie. anything that has a BMC, boots via DHCP, can
 /// receive PXE instructions, etc.)
-pub struct MachineStateMachine {
-    pub live_state: Arc<RwLock<LiveState>>,
-    pub mat_host_id: Uuid,
-    pub installed_os: OsImage,
+pub(super) struct MachineStateMachine {
+    pub(super) live_state: Arc<RwLock<LiveState>>,
+    pub(super) mat_host_id: Uuid,
+    pub(super) installed_os: OsImage,
 
     fsm: MachineFsm,
     bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
@@ -180,13 +180,13 @@ pub struct MachineStateMachine {
 }
 
 #[derive(Debug, Clone)]
-pub struct LiveStateCallbacks {
+struct LiveStateCallbacks {
     state: Arc<RwLock<LiveState>>,
     command_channel: mpsc::UnboundedSender<BmcCommand>,
 }
 
 impl LiveStateCallbacks {
-    pub fn new(
+    fn new(
         state: Arc<RwLock<LiveState>>,
         command_channel: mpsc::UnboundedSender<BmcCommand>,
     ) -> Self {
@@ -222,7 +222,7 @@ impl Callbacks for LiveStateCallbacks {
 }
 
 #[derive(Debug, Clone)]
-pub struct LiveStateHostnameQuery(pub Arc<RwLock<LiveState>>);
+struct LiveStateHostnameQuery(Arc<RwLock<LiveState>>);
 
 impl HostnameQuerying for LiveStateHostnameQuery {
     fn get_hostname(&'_ self) -> Cow<'_, str> {
@@ -239,24 +239,24 @@ impl HostnameQuerying for LiveStateHostnameQuery {
 /// Represents state which changes over time with this machine. This is kept in an `Arc<RwLock>` so
 /// that callers can query it at any time. It is updated after every state transition.
 #[derive(Debug)]
-pub struct LiveState {
-    pub is_up: bool,
-    pub power_state: MockPowerState, // reflects the "desired" power state of the machine. Affects whether next_state will boot the machine or not.
-    pub observed_machine_id: Option<MachineId>,
-    pub machine_ip: Option<Ipv4Addr>,
-    pub bmc_ip: Option<Ipv4Addr>,
-    pub ipmi_endpoint: Option<IpmiEndpoint>,
-    pub booted_os: MaybeOsImage,
-    pub next_boot_kind: Option<BootOptionKind>,
-    pub installed_os: OsImage,
-    pub state_string: Option<&'static str>,
-    pub api_state: String,
-    pub tpm_ek_certificate: Option<Vec<u8>>,
-    pub ssh_host_key: Option<String>,
+pub(super) struct LiveState {
+    pub(super) is_up: bool,
+    pub(super) power_state: MockPowerState, // reflects the "desired" power state of the machine. Affects whether next_state will boot the machine or not.
+    pub(super) observed_machine_id: Option<MachineId>,
+    pub(super) machine_ip: Option<Ipv4Addr>,
+    pub(super) bmc_ip: Option<Ipv4Addr>,
+    pub(super) ipmi_endpoint: Option<IpmiEndpoint>,
+    pub(super) booted_os: MaybeOsImage,
+    pub(super) next_boot_kind: Option<BootOptionKind>,
+    pub(super) installed_os: OsImage,
+    pub(super) state_string: Option<&'static str>,
+    pub(super) api_state: String,
+    pub(super) tpm_ek_certificate: Option<Vec<u8>>,
+    pub(super) ssh_host_key: Option<String>,
     /// For a DPU machine, whether its BlueField has flipped to NIC mode. Lets the
     /// owning host observe the flip through the DPU handle and converge (detach
     /// its DPU DHCP relay). Always false for a host machine.
-    pub dpu_flipped_to_nic_mode: bool,
+    pub(super) dpu_flipped_to_nic_mode: bool,
 }
 
 impl Default for LiveState {
@@ -282,7 +282,7 @@ impl Default for LiveState {
 }
 
 impl LiveState {
-    pub fn ui_next_boot_kind(&self) -> &'static str {
+    pub(super) fn ui_next_boot_kind(&self) -> &'static str {
         match self.next_boot_kind {
             Some(BootOptionKind::Disk) => "Disk",
             Some(BootOptionKind::Network) => "Network",
@@ -308,13 +308,13 @@ pub enum BmcRegistrationMode {
     None(u16),
 }
 
-pub enum PersistedMachine {
+pub(super) enum PersistedMachine {
     Host(PersistedDevice),
     Dpu(PersistedDpuMachine),
 }
 
 impl MachineStateMachine {
-    pub fn from_persisted(
+    pub(super) fn from_persisted(
         persisted_machine: PersistedMachine,
         machine_info: MachineInfo,
         config: Arc<MachineConfig>,
@@ -357,7 +357,7 @@ impl MachineStateMachine {
         }
     }
 
-    pub fn new(
+    pub(super) fn new(
         machine_info: MachineInfo,
         config: Arc<MachineConfig>,
         app_context: Arc<MachineATronContext>,
@@ -396,7 +396,7 @@ impl MachineStateMachine {
         }
     }
 
-    pub async fn advance(&mut self) -> Duration {
+    pub(super) async fn advance(&mut self) -> Duration {
         if let Some(duration) = self.process_actions().await {
             duration
         } else {
@@ -437,7 +437,7 @@ impl MachineStateMachine {
         }
     }
 
-    pub async fn process_actions(&mut self) -> Option<Duration> {
+    async fn process_actions(&mut self) -> Option<Duration> {
         while let Some(action) = self.actions.front() {
             self.update_live_state();
             if matches!(action, FsmAction::Dhcp(_))
@@ -916,7 +916,7 @@ impl MachineStateMachine {
         }
         Ok(())
     }
-    pub async fn dpu_agent_network_observation(
+    async fn dpu_agent_network_observation(
         &self,
     ) -> Result<Option<DpuDhcpRelayHandle>, MachineStateError> {
         let machine_id = self
@@ -958,7 +958,7 @@ impl MachineStateMachine {
         }
     }
 
-    pub fn update_live_state(&self) {
+    pub(super) fn update_live_state(&self) {
         let mut live_state = self.live_state.write().unwrap();
         live_state.is_up = self.fsm.is_up();
         live_state.machine_ip = self.machine_ip();
@@ -991,7 +991,7 @@ impl MachineStateMachine {
     /// Whether this machine still relays its data-plane DHCP through a managed
     /// DPU. False once the relay is detached (see `detach_dpu_dhcp_relay`) or for
     /// a host that never had a managed DPU.
-    pub fn has_dpu_dhcp_relay(&self) -> bool {
+    pub(super) fn has_dpu_dhcp_relay(&self) -> bool {
         self.dpu_dhcp_relay.is_some()
     }
 
@@ -999,7 +999,7 @@ impl MachineStateMachine {
     /// mode it is a plain NIC, so the host DHCPs directly on its own (former-DPU
     /// host) MAC -- the same MAC, so a retained boot interface still matches on
     /// re-ingestion. Idempotent.
-    pub fn detach_dpu_dhcp_relay(&mut self) {
+    pub(super) fn detach_dpu_dhcp_relay(&mut self) {
         self.dpu_dhcp_relay = None;
         self.dpu_dhcp_relay_handle = None;
     }
@@ -1011,7 +1011,7 @@ impl MachineStateMachine {
     /// host-facing MAC becomes the host's own plain-NIC MAC, so the host keeps
     /// DHCPing on the same MAC and a retained boot interface still matches.
     /// No-op for a non-host machine or a host that already has no DPUs.
-    pub fn drop_managed_dpus(&mut self) {
+    pub(super) fn drop_managed_dpus(&mut self) {
         if let MachineInfo::Host(host) = &mut self.machine_info {
             if host.dpus.is_empty() {
                 return;
@@ -1147,7 +1147,7 @@ impl MachineStateMachine {
         Ok(())
     }
 
-    pub fn set_system_power(&mut self, request: SystemPowerControl) -> SetSystemPowerResult {
+    pub(super) fn set_system_power(&mut self, request: SystemPowerControl) -> SetSystemPowerResult {
         use SystemPowerControl::*;
         match request {
             On | ForceOn => self.fsm_event(Event::PowerOn),
@@ -1163,17 +1163,17 @@ impl MachineStateMachine {
         Ok(())
     }
 
-    pub fn machine_id(&self) -> Option<MachineId> {
+    fn machine_id(&self) -> Option<MachineId> {
         self.machine_discovery_result
             .as_ref()
             .and_then(|result| result.machine_id)
     }
 
-    pub fn machine_ip(&self) -> Option<Ipv4Addr> {
+    fn machine_ip(&self) -> Option<Ipv4Addr> {
         self.machine_dhcp_info.as_ref().map(|v| v.ip_address)
     }
 
-    pub fn bmc_ip(&self) -> Option<Ipv4Addr> {
+    fn bmc_ip(&self) -> Option<Ipv4Addr> {
         self.bmc_dhcp_info.as_ref().map(|v| v.ip_address)
     }
 
@@ -1181,7 +1181,7 @@ impl MachineStateMachine {
         self.bmc_injection.clone()
     }
 
-    pub fn booted_os(&self) -> MaybeOsImage {
+    pub(super) fn booted_os(&self) -> MaybeOsImage {
         MaybeOsImage(self.fsm.booted_os())
     }
 
@@ -1289,7 +1289,7 @@ impl Display for OsImage {
 }
 
 #[derive(Debug, Default)]
-pub struct MaybeOsImage(pub Option<OsImage>);
+pub(super) struct MaybeOsImage(pub(super) Option<OsImage>);
 
 impl Display for MaybeOsImage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -1301,7 +1301,7 @@ impl Display for MaybeOsImage {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum MachineStateError {
+pub(super) enum MachineStateError {
     #[error(
         "invalid machine state: missing interface_id for this machine in machine discovery results"
     )]
@@ -1345,7 +1345,7 @@ impl From<tonic::Status> for MachineStateError {
     }
 }
 #[derive(thiserror::Error, Debug)]
-pub enum AddressConfigError {
+pub(super) enum AddressConfigError {
     #[error("error running ip command: {0}")]
     Io(#[from] std::io::Error),
     #[error("error running ip command: {0:?}, output: {1:?}")]

--- a/crates/machine-a-tron/src/machine_utils.rs
+++ b/crates/machine-a-tron/src/machine_utils.rs
@@ -37,14 +37,14 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone)]
-pub enum PxeResponse {
+pub(super) enum PxeResponse {
     Exit,
     Scout,    // PXE script is booting scout.efi
     DpuAgent, // PXE script is booting carbide.efi
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum PxeError {
+pub(super) enum PxeError {
     #[error("API client error running PXE request: {0}")]
     ClientApi(#[from] ClientApiError),
     #[error("PXE request failed with status: {0}")]
@@ -53,7 +53,7 @@ pub enum PxeError {
     Reqwest(#[from] reqwest::Error),
 }
 
-pub async fn forge_agent_control(
+pub(super) async fn forge_agent_control(
     app_context: &MachineATronContext,
     machine_id: MachineId,
 ) -> Option<ForgeAgentControlResponse> {
@@ -76,7 +76,9 @@ pub async fn forge_agent_control(
     }
 }
 
-pub fn get_validation_id(response: &ForgeAgentControlResponse) -> Option<MachineValidationId> {
+pub(super) fn get_validation_id(
+    response: &ForgeAgentControlResponse,
+) -> Option<MachineValidationId> {
     if let Some(rpc::forge::forge_agent_control_response::Action::MachineValidation(
         machine_validation,
     )) = &response.action
@@ -87,7 +89,7 @@ pub fn get_validation_id(response: &ForgeAgentControlResponse) -> Option<Machine
     }
 }
 
-pub async fn send_pxe_boot_request(
+pub(super) async fn send_pxe_boot_request(
     app_context: &MachineATronContext,
     arch: MachineArchitecture,
     client_ip: std::net::IpAddr,
@@ -135,7 +137,7 @@ pub async fn send_pxe_boot_request(
     Ok(response)
 }
 
-pub async fn get_next_free_machine(
+pub(super) async fn get_next_free_machine(
     provisionable_handles: &Vec<DeviceHandle>,
     assigned_mat_ids: &HashSet<Uuid>,
 ) -> Option<DeviceHandle> {
@@ -151,7 +153,7 @@ pub async fn get_next_free_machine(
     None
 }
 
-pub async fn add_address_to_interface(
+pub(super) async fn add_address_to_interface(
     address: &str,
     interface: &str,
 ) -> Result<(), AddressConfigError> {

--- a/crates/machine-a-tron/src/power_shelf_fsm.rs
+++ b/crates/machine-a-tron/src/power_shelf_fsm.rs
@@ -16,10 +16,10 @@
  */
 use bmc_mock::MockPowerState;
 
-pub type FsmReturn = (PowerShelfFsm, Vec<Action>);
+type FsmReturn = (PowerShelfFsm, Vec<Action>);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PowerShelfFsm {
+pub(super) enum PowerShelfFsm {
     BmcInit {
         power_on: bool,
         power_cycle_pending: bool,
@@ -35,7 +35,7 @@ pub enum PowerShelfFsm {
 }
 
 impl PowerShelfFsm {
-    pub fn init(power_on: bool) -> FsmReturn {
+    pub(super) fn init(power_on: bool) -> FsmReturn {
         (
             Self::BmcInit {
                 power_on,
@@ -46,7 +46,7 @@ impl PowerShelfFsm {
         )
     }
 
-    pub fn event(self, event: Event) -> FsmReturn {
+    pub(super) fn event(self, event: Event) -> FsmReturn {
         match event {
             Event::Pause => return (self.with_paused(true), vec![]),
             Event::Resume => return (self.with_paused(false), vec![]),
@@ -67,7 +67,7 @@ impl PowerShelfFsm {
         }
     }
 
-    pub fn is_paused(&self) -> bool {
+    pub(super) fn is_paused(&self) -> bool {
         match self {
             Self::BmcInit { paused, .. }
             | Self::DeviceUp { paused }
@@ -75,7 +75,7 @@ impl PowerShelfFsm {
         }
     }
 
-    pub fn power_state(&self) -> MockPowerState {
+    pub(super) fn power_state(&self) -> MockPowerState {
         match self {
             Self::BmcInit { power_on: true, .. } | Self::DeviceUp { .. } => MockPowerState::On,
             Self::BmcInit {
@@ -85,7 +85,7 @@ impl PowerShelfFsm {
         }
     }
 
-    pub fn state_string(&self) -> &'static str {
+    pub(super) fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
             Self::DeviceUp { .. } => "BmcOnly/DeviceUp",
@@ -229,7 +229,7 @@ fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Event {
+pub(super) enum Event {
     DhcpComplete,
     PowerOn,
     PowerOff,
@@ -240,7 +240,7 @@ pub enum Event {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Action {
+pub(super) enum Action {
     Dhcp,
     SetupBmc,
     SetTimer(Timer),
@@ -248,7 +248,7 @@ pub enum Action {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Timer {
+pub(super) enum Timer {
     PowerCycle,
 }
 

--- a/crates/machine-a-tron/src/switch_fsm.rs
+++ b/crates/machine-a-tron/src/switch_fsm.rs
@@ -16,10 +16,10 @@
  */
 use bmc_mock::MockPowerState;
 
-pub type FsmReturn = (SwitchFsm, Vec<Action>);
+type FsmReturn = (SwitchFsm, Vec<Action>);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SwitchFsm {
+pub(super) enum SwitchFsm {
     BmcInit {
         power_on: bool,
         power_cycle_pending: bool,
@@ -38,7 +38,7 @@ pub enum SwitchFsm {
 }
 
 impl SwitchFsm {
-    pub fn init(power_on: bool) -> FsmReturn {
+    pub(super) fn init(power_on: bool) -> FsmReturn {
         (
             Self::BmcInit {
                 power_on,
@@ -49,7 +49,7 @@ impl SwitchFsm {
         )
     }
 
-    pub fn event(self, event: Event) -> FsmReturn {
+    pub(super) fn event(self, event: Event) -> FsmReturn {
         match event {
             Event::Pause => return (self.with_paused(true), vec![]),
             Event::Resume => return (self.with_paused(false), vec![]),
@@ -71,7 +71,7 @@ impl SwitchFsm {
         }
     }
 
-    pub fn is_paused(&self) -> bool {
+    pub(super) fn is_paused(&self) -> bool {
         match self {
             Self::BmcInit { paused, .. }
             | Self::NvosInit { paused }
@@ -80,7 +80,7 @@ impl SwitchFsm {
         }
     }
 
-    pub fn power_state(&self) -> MockPowerState {
+    pub(super) fn power_state(&self) -> MockPowerState {
         match self {
             Self::BmcInit { power_on: true, .. }
             | Self::NvosInit { .. }
@@ -92,7 +92,7 @@ impl SwitchFsm {
         }
     }
 
-    pub fn state_string(&self) -> &'static str {
+    pub(super) fn state_string(&self) -> &'static str {
         match self {
             Self::BmcInit { .. } => "BmcInit",
             Self::NvosInit { .. } => "NvosInit",
@@ -268,7 +268,7 @@ fn cancel_timer_action(power_cycle_pending: bool) -> Vec<Action> {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Event {
+pub(super) enum Event {
     DhcpComplete(DhcpEndpoint),
     PowerOn,
     PowerOff,
@@ -279,7 +279,7 @@ pub enum Event {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Action {
+pub(super) enum Action {
     Dhcp(DhcpEndpoint),
     SetupBmc,
     StopNvos,
@@ -288,12 +288,12 @@ pub enum Action {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Timer {
+pub(super) enum Timer {
     PowerCycle,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DhcpEndpoint {
+pub(super) enum DhcpEndpoint {
     Bmc,
     Nvos,
 }

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -587,7 +587,7 @@ async fn handle_dpf_reprovisioning(
 /// together. All other states (Reprovisioning, WaitingForReady, DeviceReady)
 /// advance the given `dpu_snapshot` independently. DeviceReady acts as a sync
 /// barrier that waits for all DPUs before proceeding.
-pub async fn handle_dpf_state(
+pub(super) async fn handle_dpf_state(
     state: &ManagedHostStateSnapshot,
     dpu_snapshot: &Machine,
     dpf_state: &DpfState,

--- a/crates/machine-controller/src/handler/helpers.rs
+++ b/crates/machine-controller/src/handler/helpers.rs
@@ -26,7 +26,7 @@ use model::machine::{
 };
 use state_controller::state_handler::StateHandlerError;
 
-pub trait NextState {
+pub(super) trait NextState {
     fn next_bfb_install_state(
         &self,
         current_state: &ManagedHostState,
@@ -166,7 +166,7 @@ pub trait NextState {
     }
 }
 
-pub trait DpuDiscoveringStateHelper {
+pub(super) trait DpuDiscoveringStateHelper {
     fn next_state(
         self,
         current_state: &ManagedHostState,
@@ -197,7 +197,7 @@ impl DpuDiscoveringStateHelper for DpuDiscoveringState {
     }
 }
 
-pub trait DpuInitStateHelper {
+pub(super) trait DpuInitStateHelper {
     fn next_state(
         self,
         current_state: &ManagedHostState,
@@ -487,7 +487,7 @@ impl NextState for DpuInitNextStateResolver {
     }
 }
 
-pub(crate) trait ReprovisionStateHelper {
+pub(super) trait ReprovisionStateHelper {
     fn next_state_with_all_dpus_updated(
         self,
         current_state: &ManagedHostState,
@@ -580,7 +580,7 @@ impl ReprovisionStateHelper for ReprovisionState {
     }
 }
 
-pub trait ManagedHostStateHelper {
+pub(super) trait ManagedHostStateHelper {
     fn all_dpu_states_in_sync(&self) -> Result<bool, StateHandlerError>;
 }
 
@@ -622,7 +622,7 @@ fn reprovision_dpf_states_in_sync(
     ))
 }
 
-pub fn all_equal<A>(states: &[A]) -> Result<bool, StateHandlerError>
+pub(super) fn all_equal<A>(states: &[A]) -> Result<bool, StateHandlerError>
 where
     A: PartialEq,
 {

--- a/crates/machine-controller/src/handler/maintenance.rs
+++ b/crates/machine-controller/src/handler/maintenance.rs
@@ -38,7 +38,7 @@ use crate::context::MachineStateHandlerContextObjects;
 
 /// Handles the Maintenance state for a host, dispatching on the requested
 /// operation (`PowerOn` / `PowerOff` / `Reset`).
-pub async fn handle_maintenance(
+pub(super) async fn handle_maintenance(
     host_machine_id: &MachineId,
     mh_snapshot: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
@@ -279,7 +279,7 @@ async fn finish_maintenance_with_error(
 
 /// If a maintenance request has been posted via `machine_maintenance_requested`,
 /// transitions to [`ManagedHostState::Maintenance`] with the requested operation.
-pub fn maintenance_transition_if_requested(
+pub(super) fn maintenance_transition_if_requested(
     mh_snapshot: &ManagedHostStateSnapshot,
 ) -> Option<StateHandlerOutcome<ManagedHostState>> {
     let req = mh_snapshot

--- a/crates/machine-controller/src/handler/power.rs
+++ b/crates/machine-controller/src/handler/power.rs
@@ -30,13 +30,13 @@ use crate::handler::{PowerOptionConfig, handler_host_power_control, host_power_s
 
 // If power state is Paused and Reset, state machine can't take any decision on it.
 // Ignore power manager with a log and moved to state machine.
-pub enum UsablePowerState {
+enum UsablePowerState {
     Usable(PowerState),
     NotUsable(libredfish::PowerState),
 }
 
 // Handle power related stuff and return updated power options.
-pub async fn handle_power(
+pub(super) async fn handle_power(
     mh_snapshot: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     power_options_config: &PowerOptionConfig,
@@ -69,7 +69,7 @@ pub async fn handle_power(
     }
 }
 
-pub async fn handle_power_desired_on(
+pub(super) async fn handle_power_desired_on(
     current_power_options: &PowerOptions,
     mh_snapshot: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
@@ -159,7 +159,7 @@ pub async fn handle_power_desired_on(
     Ok(PowerHandlingOutcome::new(new_power_options, true, None))
 }
 
-pub async fn get_updated_power_options_desired_off(
+pub(super) async fn get_updated_power_options_desired_off(
     current_power_options: &PowerOptions,
     mh_snapshot: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,

--- a/crates/machine-controller/tests/integration/env.rs
+++ b/crates/machine-controller/tests/integration/env.rs
@@ -33,14 +33,14 @@ use model::machine::slas::MachineSlaConfig;
 use state_controller::controller::StateController;
 use tokio_util::sync::CancellationToken;
 
-pub struct Env {
-    pub test_harness: TestHarness,
-    pub redfish_sim: Arc<RedfishSim>,
+pub(super) struct Env {
+    pub(super) test_harness: TestHarness,
+    pub(super) redfish_sim: Arc<RedfishSim>,
     machine_controller: StateController<MachineStateControllerIO>,
     _cancel_token: CancellationToken,
 }
 
-pub struct EnvBuilder {
+pub(super) struct EnvBuilder {
     pool: PgPool,
     runtime_config: CarbideConfig,
     component_manager: Option<Arc<ComponentManager>>,
@@ -48,7 +48,7 @@ pub struct EnvBuilder {
 }
 
 impl Env {
-    pub fn builder(pool: PgPool) -> EnvBuilder {
+    pub(super) fn builder(pool: PgPool) -> EnvBuilder {
         let mut runtime_config = test_support::default_config::get();
         runtime_config.machine_state_controller.dpu_wait_time = chrono::Duration::zero();
         runtime_config.machine_state_controller.power_down_wait = chrono::Duration::zero();
@@ -63,23 +63,26 @@ impl Env {
         }
     }
 
-    pub async fn run_single_iteration(&mut self) {
+    pub(super) async fn run_single_iteration(&mut self) {
         self.machine_controller.run_single_iteration().boxed().await;
     }
 }
 
 impl EnvBuilder {
-    pub fn configure_runtime(mut self, configure: impl FnOnce(&mut CarbideConfig)) -> Self {
+    pub(super) fn configure_runtime(mut self, configure: impl FnOnce(&mut CarbideConfig)) -> Self {
         configure(&mut self.runtime_config);
         self
     }
 
-    pub fn with_component_manager(mut self, component_manager: Arc<ComponentManager>) -> Self {
+    pub(super) fn with_component_manager(
+        mut self,
+        component_manager: Arc<ComponentManager>,
+    ) -> Self {
         self.component_manager = Some(component_manager);
         self
     }
 
-    pub fn with_credential_manager(
+    pub(super) fn with_credential_manager(
         mut self,
         credential_manager: Arc<dyn CredentialManager>,
     ) -> Self {
@@ -87,7 +90,7 @@ impl EnvBuilder {
         self
     }
 
-    pub async fn build(self) -> Env {
+    pub(super) async fn build(self) -> Env {
         let Self {
             pool,
             runtime_config,

--- a/crates/machine-validation/src/machine_validation.rs
+++ b/crates/machine-validation/src/machine_validation.rs
@@ -37,8 +37,8 @@ use crate::{
     MachineValidation, MachineValidationError, MachineValidationFilter, MachineValidationManager,
     SCHME,
 };
-pub const MAX_STRING_STD_SIZE: usize = 1024 * 1024; // 1MB in bytes;
-pub const DEFAULT_TIMEOUT: u64 = 3600;
+const MAX_STRING_STD_SIZE: usize = 1024 * 1024; // 1MB in bytes;
+const DEFAULT_TIMEOUT: u64 = 3600;
 
 // The API manager clamps heartbeat-based stale reconciliation to at least three missed beats, so
 // low stale_run_timeout config values cannot fail healthy runs between these heartbeat updates.

--- a/crates/preingestion-manager/src/errors.rs
+++ b/crates/preingestion-manager/src/errors.rs
@@ -36,4 +36,4 @@ impl PreingestionManagerError {
     }
 }
 
-pub type PreingestionManagerResult<T> = Result<T, PreingestionManagerError>;
+pub(super) type PreingestionManagerResult<T> = Result<T, PreingestionManagerError>;

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -30,14 +30,14 @@ use opentelemetry::StringValue;
 use opentelemetry::metrics::Meter;
 
 #[derive(Clone, Debug)]
-pub struct PreingestionMetrics {
-    pub machines_in_preingestion: usize,
-    pub waiting_for_installation: usize,
-    pub delayed_uploading: u64,
+pub(super) struct PreingestionMetrics {
+    pub(super) machines_in_preingestion: usize,
+    pub(super) waiting_for_installation: usize,
+    pub(super) delayed_uploading: u64,
 }
 
 impl PreingestionMetrics {
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             machines_in_preingestion: 0,
             waiting_for_installation: 0,
@@ -91,12 +91,12 @@ fn hydrate_meter(meter: Meter, shared_metrics: SharedMetricsHolder<PreingestionM
     }
 }
 
-pub struct MetricHolder {
+pub(super) struct MetricHolder {
     last_iteration_metrics: SharedMetricsHolder<PreingestionMetrics>,
 }
 
 impl MetricHolder {
-    pub fn new(meter: Meter, hold_period: std::time::Duration) -> Self {
+    pub(super) fn new(meter: Meter, hold_period: std::time::Duration) -> Self {
         let last_iteration_metrics = SharedMetricsHolder::with_hold_period(hold_period);
         hydrate_meter(meter, last_iteration_metrics.clone());
         Self {
@@ -105,7 +105,7 @@ impl MetricHolder {
     }
 
     /// Updates the most recent metrics
-    pub fn update_metrics(&self, metrics: PreingestionMetrics) {
+    pub(super) fn update_metrics(&self, metrics: PreingestionMetrics) {
         self.last_iteration_metrics.update(metrics);
     }
 }
@@ -261,10 +261,10 @@ pub(crate) enum FirmwareUploadFinished {
 pub(crate) struct MultipartFirmwareUploadUnsupported {
     /// The BMC whose multipart route rejected the upload.
     #[context]
-    pub bmc_ip_address: IpAddr,
+    pub(crate) bmc_ip_address: IpAddr,
     /// The Redfish unsupported-route error that triggered fallback.
     #[context]
-    pub error: String,
+    pub(crate) error: String,
 }
 
 /// `FirmwareComponentType` as a bounded metric label. The manual impl is the
@@ -273,7 +273,7 @@ pub(crate) struct MultipartFirmwareUploadUnsupported {
 /// derive out of reach from here. The rendering mirrors what
 /// `#[derive(LabelValue)]` would produce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct FirmwareComponentLabel(pub FirmwareComponentType);
+pub(crate) struct FirmwareComponentLabel(pub(crate) FirmwareComponentType);
 
 impl LabelValue for FirmwareComponentLabel {
     fn label_value(&self) -> StringValue {
@@ -496,16 +496,16 @@ pub(crate) struct PreingestionPowerControl {
 )]
 pub(crate) struct PowerControlFinished {
     #[label]
-    pub operation: PowerOperation,
+    pub(crate) operation: PowerOperation,
     #[label]
-    pub outcome: Outcome,
+    pub(crate) outcome: Outcome,
     #[context]
-    pub bmc_ip_address: IpAddr,
+    pub(crate) bmc_ip_address: IpAddr,
     #[context]
-    pub power_step: PowerControlStep,
+    pub(crate) power_step: PowerControlStep,
     /// The Redfish failure; empty when the operation returned `Ok`.
     #[context]
-    pub error: String,
+    pub(crate) error: String,
 }
 
 impl DynamicLog for PowerControlFinished {

--- a/crates/preingestion-manager/tests/integration/common.rs
+++ b/crates/preingestion-manager/tests/integration/common.rs
@@ -26,7 +26,7 @@ use model::site_explorer::{
 };
 use sqlx::PgConnection;
 
-pub async fn insert_endpoint_version(
+pub(super) async fn insert_endpoint_version(
     txn: &mut PgConnection,
     addr: &str,
     bmc_version: &str,

--- a/crates/site-explorer/src/boot_order_tracker.rs
+++ b/crates/site-explorer/src/boot_order_tracker.rs
@@ -25,7 +25,7 @@ use model::site_explorer::{
     BootOrder, ComputerSystem, EndpointExplorationReport, ExploredManagedHost,
 };
 
-pub trait BootOrderReporter: Send + Sync {
+pub(super) trait BootOrderReporter: Send + Sync {
     fn report(
         &self,
         reason: BootOrderReportReason,
@@ -51,7 +51,7 @@ const BOOT_ORDER_MAX_LOGGED_HOST_PER_ITERATION: u32 = 10;
 /// reconciliates boot order expected by managed host state machine
 /// and H/W.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BootOrderReportReason {
+pub(super) enum BootOrderReportReason {
     ChangeDetected,
     PeriodicUpdate,
     NewHost,
@@ -69,7 +69,7 @@ impl fmt::Display for BootOrderReportReason {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-pub struct TracingBootOrderReporter;
+pub(super) struct TracingBootOrderReporter;
 
 impl BootOrderReporter for TracingBootOrderReporter {
     fn report(
@@ -92,7 +92,7 @@ impl BootOrderReporter for TracingBootOrderReporter {
     }
 }
 
-pub struct BootOrderTracker<R = TracingBootOrderReporter> {
+pub(super) struct BootOrderTracker<R = TracingBootOrderReporter> {
     cached_boot_order: HashMap<IpAddr, BootOrderStatus>,
     reporter: R,
 }
@@ -108,7 +108,7 @@ impl<R: Default> Default for BootOrderTracker<R> {
 
 #[cfg(test)]
 impl<R> BootOrderTracker<R> {
-    pub fn new(reporter: R) -> Self {
+    fn new(reporter: R) -> Self {
         Self {
             cached_boot_order: HashMap::new(),
             reporter,
@@ -117,7 +117,7 @@ impl<R> BootOrderTracker<R> {
 }
 
 impl<R: BootOrderReporter> BootOrderTracker<R> {
-    pub fn track_hosts(
+    pub(super) fn track_hosts(
         &mut self,
         now: Instant,
         reports: &[(ExploredManagedHost, EndpointExplorationReport)],
@@ -196,14 +196,14 @@ struct BootOrderStatus {
 }
 
 impl BootOrderStatus {
-    pub fn new(report_time: std::time::Instant, systems: &[ComputerSystem]) -> Self {
+    fn new(report_time: std::time::Instant, systems: &[ComputerSystem]) -> Self {
         BootOrderStatus {
             report_time,
             boot_order: Self::collect_boot_order(systems),
         }
     }
 
-    pub fn boot_order_updated(&mut self, systems: &[ComputerSystem]) -> bool {
+    fn boot_order_updated(&mut self, systems: &[ComputerSystem]) -> bool {
         if systems.len() != self.boot_order.len() {
             self.boot_order = Self::collect_boot_order(systems);
             return true;

--- a/crates/site-explorer/src/credentials.rs
+++ b/crates/site-explorer/src/credentials.rs
@@ -26,17 +26,17 @@ use model::site_explorer::EndpointExplorationError;
 
 use super::metrics::SiteExplorationMetrics;
 
-pub fn get_bmc_root_credential_key(bmc_mac_address: MacAddress) -> CredentialKey {
+pub(super) fn get_bmc_root_credential_key(bmc_mac_address: MacAddress) -> CredentialKey {
     CredentialKey::BmcCredentials {
         credential_type: BmcCredentialType::BmcRoot { bmc_mac_address },
     }
 }
 
-pub fn get_bmc_nvos_admin_credential_key(bmc_mac_address: MacAddress) -> CredentialKey {
+fn get_bmc_nvos_admin_credential_key(bmc_mac_address: MacAddress) -> CredentialKey {
     CredentialKey::SwitchNvosAdmin { bmc_mac_address }
 }
 
-pub struct CredentialClient {
+pub(super) struct CredentialClient {
     credential_manager: Arc<dyn CredentialManager>,
 }
 
@@ -105,11 +105,11 @@ impl CredentialClient {
         }
     }
 
-    pub fn new(credential_manager: Arc<dyn CredentialManager>) -> Self {
+    pub(super) fn new(credential_manager: Arc<dyn CredentialManager>) -> Self {
         Self { credential_manager }
     }
 
-    pub async fn check_preconditions(
+    pub(super) async fn check_preconditions(
         &self,
         _metrics: &mut SiteExplorationMetrics,
     ) -> Result<(), EndpointExplorationError> {
@@ -134,7 +134,7 @@ impl CredentialClient {
     /// the legacy unversioned path. There is no unversioned "current" alias --
     /// the rotation table is the single source of truth for which version is
     /// live.
-    pub async fn get_sitewide_bmc_root_credentials(
+    pub(super) async fn get_sitewide_bmc_root_credentials(
         &self,
         version: u32,
     ) -> Result<Credentials, EndpointExplorationError> {
@@ -144,7 +144,7 @@ impl CredentialClient {
         self.get_credentials(&key).await
     }
 
-    pub async fn get_sitewide_dpu_bmc_service_password(
+    pub(super) async fn get_sitewide_dpu_bmc_service_password(
         &self,
         create_if_missing: bool,
     ) -> Result<String, EndpointExplorationError> {
@@ -179,7 +179,7 @@ impl CredentialClient {
     /// 3. Model's publicly-documented factory default (`DpuModel::default_factory_credentials`)
     ///
     /// Never fails: vault misses are silently swallowed and the hardcoded fallback is returned.
-    pub async fn get_dpu_factory_default_credentials(
+    pub(super) async fn get_dpu_factory_default_credentials(
         &self,
         model: bmc_vendor::DpuModel,
     ) -> Credentials {
@@ -208,7 +208,7 @@ impl CredentialClient {
         }
     }
 
-    pub async fn get_bmc_root_credentials(
+    pub(super) async fn get_bmc_root_credentials(
         &self,
         bmc_mac_address: MacAddress,
     ) -> Result<Credentials, EndpointExplorationError> {
@@ -216,7 +216,7 @@ impl CredentialClient {
         self.get_credentials(&bmc_root_credential_key).await
     }
 
-    pub async fn get_switch_nvos_admin_credentials(
+    pub(super) async fn get_switch_nvos_admin_credentials(
         &self,
         bmc_mac_address: MacAddress,
     ) -> Result<Credentials, EndpointExplorationError> {
@@ -225,7 +225,7 @@ impl CredentialClient {
             .await
     }
 
-    pub async fn set_bmc_root_credentials(
+    pub(super) async fn set_bmc_root_credentials(
         &self,
         bmc_mac_address: MacAddress,
         credentials: &Credentials,
@@ -235,7 +235,7 @@ impl CredentialClient {
             .await
     }
 
-    pub async fn set_bmc_nvos_admin_credentials(
+    pub(super) async fn set_bmc_nvos_admin_credentials(
         &self,
         bmc_mac_address: MacAddress,
         credentials: &Credentials,

--- a/crates/site-explorer/src/endpoint_lock.rs
+++ b/crates/site-explorer/src/endpoint_lock.rs
@@ -28,13 +28,13 @@ use std::sync::{Arc, Mutex};
 /// duplicate probe is harmless and writes are still guarded by optimistic concurrency. If `nico-api`
 /// is ever scaled to multiple active replicas, this would no longer dedupe across them.
 #[derive(Clone, Default)]
-pub struct EndpointExplorationLocks {
+pub(super) struct EndpointExplorationLocks {
     in_flight: Arc<Mutex<HashSet<IpAddr>>>,
 }
 
 /// A claim on exploring a single endpoint. The endpoint is released when this is dropped, including
 /// on panic or task cancellation.
-pub struct EndpointExplorationGuard {
+pub(super) struct EndpointExplorationGuard {
     in_flight: Arc<Mutex<HashSet<IpAddr>>>,
     bmc_ip: IpAddr,
 }
@@ -51,7 +51,7 @@ impl Drop for EndpointExplorationGuard {
 impl EndpointExplorationLocks {
     /// Try to claim exclusive exploration of `bmc_ip` within this process. Returns `None` if another
     /// task is already exploring it.
-    pub fn try_claim(&self, bmc_ip: IpAddr) -> Option<EndpointExplorationGuard> {
+    pub(super) fn try_claim(&self, bmc_ip: IpAddr) -> Option<EndpointExplorationGuard> {
         let claimed = self
             .in_flight
             .lock()

--- a/crates/site-explorer/src/managed_host.rs
+++ b/crates/site-explorer/src/managed_host.rs
@@ -29,16 +29,16 @@ use model::site_explorer::ExploredManagedHost;
 /// It sets the machine_id when attaching the first DPU to a given host.
 /// It will use the machine_id from this structure when attaching all other DPUs to a host.
 #[derive(Debug, Clone)]
-pub struct ManagedHost<'a> {
+pub(super) struct ManagedHost<'a> {
     /// Retrieved from the explored_managed_host table
-    pub explored_host: &'a ExploredManagedHost,
+    pub(super) explored_host: &'a ExploredManagedHost,
     /// The site explorer uses the machine_id as the host's machine ID when attaching a DPU to a host.
     /// The site explorer sets this field as part of attaching the first DPU to a host in the create_managed_host function.
-    pub machine_id: Option<MachineId>,
+    pub(super) machine_id: Option<MachineId>,
 }
 
 impl<'a> ManagedHost<'a> {
-    pub fn init(explored_host: &'a ExploredManagedHost) -> Self {
+    pub(super) fn init(explored_host: &'a ExploredManagedHost) -> Self {
         Self {
             explored_host,
             machine_id: None,

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -594,25 +594,25 @@ pub(crate) enum BmcResetFinished {
 )]
 pub(crate) struct BmcResetTimestampPersistenceFailed {
     #[label]
-    pub method: BmcResetMethod,
+    pub(crate) method: BmcResetMethod,
     #[context]
-    pub bmc_ip_address: IpAddr,
+    pub(crate) bmc_ip_address: IpAddr,
     #[context]
-    pub error: String,
+    pub(crate) error: String,
 }
 
 /// Instruments that are used by the Site Explorer
-pub struct SiteExplorerInstruments {
-    pub endpoint_exploration_duration: Histogram<f64>,
-    pub endpoint_exploration_step_latency: Histogram<f64>,
-    pub site_explorer_phase_latency: Histogram<f64>,
-    pub site_explorer_create_machines_latency: Histogram<f64>,
-    pub site_explorer_create_power_shelves_latency: Histogram<f64>,
-    pub site_explorer_create_switches_latency: Histogram<f64>,
+struct SiteExplorerInstruments {
+    endpoint_exploration_duration: Histogram<f64>,
+    endpoint_exploration_step_latency: Histogram<f64>,
+    site_explorer_phase_latency: Histogram<f64>,
+    site_explorer_create_machines_latency: Histogram<f64>,
+    site_explorer_create_power_shelves_latency: Histogram<f64>,
+    site_explorer_create_switches_latency: Histogram<f64>,
 }
 
 impl SiteExplorerInstruments {
-    pub fn new(
+    fn new(
         meter: Meter,
         shared_metrics: SharedMetricsHolder<SiteExplorationMetrics>,
         config: &SiteExplorerConfig,
@@ -1100,7 +1100,7 @@ impl SiteExplorerInstruments {
     /// Emits the latency metrics that are captured during a single site explorer
     /// iteration. Those are emitted immediately as histograms, whereas the
     /// amount of objects in states is emitted as gauges.
-    pub fn emit_latency_metrics(&self, metrics: &SiteExplorationMetrics) {
+    fn emit_latency_metrics(&self, metrics: &SiteExplorationMetrics) {
         if let Some(latency) = metrics.create_machines_latency {
             self.site_explorer_create_machines_latency
                 .record(1000.0 * latency.as_secs_f64(), &[]);
@@ -1141,7 +1141,7 @@ impl SiteExplorerInstruments {
 ///
 /// Since we want to keep the amount of dimensions in metrics down, only the top
 /// level error information is copied and details are omitted.
-pub fn exploration_error_to_metric_label(error: &EndpointExplorationError) -> String {
+pub(super) fn exploration_error_to_metric_label(error: &EndpointExplorationError) -> String {
     match error {
         EndpointExplorationError::ConnectionRefused { .. } => "connection_refused",
         EndpointExplorationError::ConnectionTimeout { .. } => "connection_timeout",
@@ -1172,13 +1172,13 @@ pub fn exploration_error_to_metric_label(error: &EndpointExplorationError) -> St
 }
 
 /// Stores Metric data shared between SiteExplorer and the OpenTelemetry background task
-pub struct MetricHolder {
+pub(super) struct MetricHolder {
     instruments: SiteExplorerInstruments,
     last_iteration_metrics: SharedMetricsHolder<SiteExplorationMetrics>,
 }
 
 impl MetricHolder {
-    pub fn new(
+    pub(super) fn new(
         meter: Meter,
         hold_period: std::time::Duration,
         config: &SiteExplorerConfig,
@@ -1193,7 +1193,7 @@ impl MetricHolder {
     }
 
     /// Updates the most recent metrics
-    pub fn update_metrics(&self, mut metrics: SiteExplorationMetrics) {
+    pub(super) fn update_metrics(&self, mut metrics: SiteExplorationMetrics) {
         // Emit the last recent latency metrics
         self.instruments.emit_latency_metrics(&metrics);
         // We don't need to store the latency metrics anymore

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -49,13 +49,13 @@ const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
 // RedfishClient is a wrapper around a redfish client pool and implements redfish utility functions that the site explorer utilizes.
 // TODO: In the future, we should refactor a lot of this client's work to api/src/redfish.rs because other components in carbide can utilize this functionality.
 // Eventually, this file should only have code related to generating the site exploration report.
-pub struct RedfishClient {
+pub(super) struct RedfishClient {
     redfish_client_pool: Arc<dyn RedfishClientPool>,
     nv_redfish_client_pool: Arc<NvRedfishClientPool>,
 }
 
 impl RedfishClient {
-    pub fn new(
+    pub(super) fn new(
         redfish_client_pool: Arc<dyn RedfishClientPool>,
         nv_redfish_client_pool: Arc<NvRedfishClientPool>,
     ) -> Self {
@@ -98,7 +98,7 @@ impl RedfishClient {
         .await
     }
 
-    pub async fn create_direct_redfish_client(
+    async fn create_direct_redfish_client(
         &self,
         bmc_ip_address: SocketAddr,
         Credentials::UsernamePassword { username, password }: Credentials,
@@ -121,7 +121,7 @@ impl RedfishClient {
             .await
     }
 
-    pub async fn get_redfish_product(
+    pub(super) async fn get_redfish_product(
         &self,
         bmc_ip_address: SocketAddr,
     ) -> Result<Option<String>, EndpointExplorationError> {
@@ -135,7 +135,7 @@ impl RedfishClient {
         Ok(service_root.product)
     }
 
-    pub async fn get_redfish_vendor(
+    pub(super) async fn get_redfish_vendor(
         &self,
         bmc_ip_address: SocketAddr,
     ) -> Result<RedfishVendor, EndpointExplorationError> {
@@ -177,7 +177,10 @@ impl RedfishClient {
     /// (e.g. `"BlueField-3 DPU"`). This makes a single anonymous `/redfish/v1` call and
     /// parses that field. Returns `DpuModel::Unknown` on any error or unrecognized string
     /// so callers can fall back to the catch-all factory credential.
-    pub async fn get_dpu_model_hint(&self, bmc_ip_address: SocketAddr) -> ::bmc_vendor::DpuModel {
+    pub(super) async fn get_dpu_model_hint(
+        &self,
+        bmc_ip_address: SocketAddr,
+    ) -> ::bmc_vendor::DpuModel {
         let client = match self.create_anon_redfish_client(bmc_ip_address).await {
             Ok(c) => c,
             Err(_) => return ::bmc_vendor::DpuModel::Unknown,
@@ -193,7 +196,7 @@ impl RedfishClient {
             .unwrap_or_default()
     }
 
-    pub async fn validate_bmc_credentials(
+    pub(super) async fn validate_bmc_credentials(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -212,7 +215,7 @@ impl RedfishClient {
     /// credentials, delegating to the shared `RedfishClientPool` probe (an
     /// anonymous service-root read with a credentialed chassis-manufacturer
     /// fallback for BMCs that don't populate the service-root vendor).
-    pub async fn probe_bmc_vendor(
+    pub(super) async fn probe_bmc_vendor(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -227,7 +230,7 @@ impl RedfishClient {
             .map_err(map_redfish_client_creation_error)
     }
 
-    pub async fn set_bmc_root_password(
+    pub(super) async fn set_bmc_root_password(
         &self,
         bmc_ip_address: SocketAddr,
         vendor: RedfishVendor,
@@ -252,7 +255,7 @@ impl RedfishClient {
             .map_err(map_redfish_client_creation_error)
     }
 
-    pub async fn set_bf4_dpu_service_password(
+    pub(super) async fn set_bf4_dpu_service_password(
         &self,
         bmc_ip_address: SocketAddr,
         root_credentials: Credentials,
@@ -269,7 +272,7 @@ impl RedfishClient {
             .map_err(map_redfish_client_creation_error)
     }
 
-    pub async fn generate_exploration_report(
+    pub(super) async fn generate_exploration_report(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -395,7 +398,7 @@ impl RedfishClient {
         })
     }
 
-    pub async fn nv_generate_exploration_report(
+    pub(super) async fn nv_generate_exploration_report(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -432,7 +435,7 @@ impl RedfishClient {
         Ok(report)
     }
 
-    pub async fn reset_bmc(
+    pub(super) async fn reset_bmc(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -447,7 +450,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn get_power_state(
+    pub(super) async fn get_power_state(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -460,7 +463,7 @@ impl RedfishClient {
         client.get_power_state().await.map_err(map_redfish_error)
     }
 
-    pub async fn power(
+    pub(super) async fn power(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -475,7 +478,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn disable_secure_boot(
+    pub(super) async fn disable_secure_boot(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -493,7 +496,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn lockdown(
+    pub(super) async fn lockdown(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -509,7 +512,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn lockdown_status(
+    pub(super) async fn lockdown_status(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -526,7 +529,7 @@ impl RedfishClient {
         Ok(response)
     }
 
-    pub async fn enable_infinite_boot(
+    pub(super) async fn enable_infinite_boot(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -544,7 +547,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn is_infinite_boot_enabled(
+    pub(super) async fn is_infinite_boot_enabled(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -560,7 +563,7 @@ impl RedfishClient {
             .map_err(map_redfish_error)
     }
 
-    pub async fn machine_setup(
+    pub(super) async fn machine_setup(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -603,7 +606,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn set_boot_order_dpu_first(
+    pub(super) async fn set_boot_order_dpu_first(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -622,7 +625,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn set_nic_mode(
+    pub(super) async fn set_nic_mode(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -638,7 +641,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn is_viking(
+    pub(super) async fn is_viking(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -658,7 +661,7 @@ impl RedfishClient {
         )
     }
 
-    pub async fn clear_nvram(
+    pub(super) async fn clear_nvram(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -672,7 +675,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn create_bmc_user(
+    pub(super) async fn create_bmc_user(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -692,7 +695,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn delete_bmc_user(
+    pub(super) async fn delete_bmc_user(
         &self,
         bmc_ip_address: SocketAddr,
         credentials: Credentials,
@@ -710,7 +713,7 @@ impl RedfishClient {
         Ok(())
     }
 
-    pub async fn probe_vendor_name_from_chassis(
+    pub(super) async fn probe_vendor_name_from_chassis(
         &self,
         bmc_ip_address: SocketAddr,
         username: String,

--- a/crates/site-explorer/tests/integration/env.rs
+++ b/crates/site-explorer/tests/integration/env.rs
@@ -26,14 +26,14 @@ use carbide_test_harness::prelude::*;
 /// Keep this shared env to the setup common to most site-explorer tests.
 /// Tests that need extra domains, segments, or other one-off objects should
 /// create those objects locally instead of adding fields here.
-pub struct Env {
-    pub pool: PgPool,
-    pub underlay_segment: TestNetworkSegment,
-    pub test_harness: TestHarness,
+pub(super) struct Env {
+    pub(super) pool: PgPool,
+    pub(super) underlay_segment: TestNetworkSegment,
+    pub(super) test_harness: TestHarness,
 }
 
 impl Env {
-    pub async fn new(pool: PgPool) -> Self {
+    pub(super) async fn new(pool: PgPool) -> Self {
         let test_harness = TestHarness::builder(pool.clone()).build().await;
         let domain = test_harness.test_domain().await;
         let nc = test_harness.network_controller();
@@ -45,16 +45,19 @@ impl Env {
         }
     }
 
-    pub fn api(&self) -> &Api {
+    pub(super) fn api(&self) -> &Api {
         self.test_harness.api()
     }
 
-    pub fn test_site_explorer(&self, explorer_config: SiteExplorerConfig) -> TestSiteExplorer {
+    pub(super) fn test_site_explorer(
+        &self,
+        explorer_config: SiteExplorerConfig,
+    ) -> TestSiteExplorer {
         test_site_explorer(&self.test_harness, explorer_config)
     }
 }
 
-pub fn test_site_explorer(
+pub(super) fn test_site_explorer(
     test_harness: &TestHarness,
     explorer_config: SiteExplorerConfig,
 ) -> TestSiteExplorer {

--- a/crates/state-controller/src/controller/processor.rs
+++ b/crates/state-controller/src/controller/processor.rs
@@ -146,7 +146,7 @@ impl<IO: StateControllerIO> StateProcessor<IO> {
     /// amount of time between runs.
     ///
     /// The controller task will continue to run until `stop_receiver` was signaled
-    pub async fn run(mut self) {
+    pub(super) async fn run(mut self) {
         let dispatch_interval = self.iteration_config.processor_dispatch_interval;
         let max_jitter = (dispatch_interval.as_millis() / 3) as u64;
 

--- a/crates/state-controller/src/tests.rs
+++ b/crates/state-controller/src/tests.rs
@@ -395,27 +395,21 @@ async fn test_queue_objects(pool: sqlx::PgPool) -> sqlx::Result<()> {
 struct TestStateControllerIO {}
 
 #[derive(Debug, Clone)]
-pub struct TestObject {
-    pub id: String,
-    pub controller_state: Versioned<TestObjectControllerState>,
-    #[allow(dead_code)]
-    pub controller_state_outcome: Option<PersistentStateHandlerOutcome>,
+struct TestObject {
+    id: String,
+    controller_state: Versioned<TestObjectControllerState>,
 }
 
 impl<'r> FromRow<'r, PgRow> for TestObject {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         let controller_state: sqlx::types::Json<TestObjectControllerState> =
             row.try_get("controller_state")?;
-        let state_outcome: Option<sqlx::types::Json<PersistentStateHandlerOutcome>> =
-            row.try_get("controller_state_outcome")?;
-
         Ok(TestObject {
             id: row.try_get("id")?,
             controller_state: Versioned::new(
                 controller_state.0,
                 row.try_get("controller_state_version")?,
             ),
-            controller_state_outcome: state_outcome.map(|x| x.0),
         })
     }
 }
@@ -423,13 +417,13 @@ impl<'r> FromRow<'r, PgRow> for TestObject {
 /// State of a IB subnet as tracked by the controller
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "state", rename_all = "lowercase")]
-pub enum TestObjectControllerState {
+enum TestObjectControllerState {
     A,
     B,
     C,
 }
 
-pub struct TestStateControllerContextObjects {}
+struct TestStateControllerContextObjects {}
 
 impl StateHandlerContextObjects for TestStateControllerContextObjects {
     type Services = ();
@@ -743,11 +737,11 @@ async fn test_state_controller_handle_set_wait_all_propagates_panic(
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct TestConcurrencyStateHandler {
+struct TestConcurrencyStateHandler {
     /// The total count for the handler
-    pub count: Arc<AtomicUsize>,
+    count: Arc<AtomicUsize>,
     /// We count for every object ID how often the handler was called
-    pub counts_per_id: Arc<Mutex<HashMap<String, usize>>>,
+    counts_per_id: Arc<Mutex<HashMap<String, usize>>>,
 }
 
 #[async_trait::async_trait]
@@ -849,7 +843,7 @@ async fn test_multiple_state_controllers_schedule_object_only_once(
 
 /// A state handler that transitions from A -> B -> C
 #[derive(Debug, Default, Clone)]
-pub struct TestTransitionStateHandler;
+struct TestTransitionStateHandler;
 
 #[async_trait::async_trait]
 impl StateHandler for TestTransitionStateHandler {
@@ -879,7 +873,7 @@ impl StateHandler for TestTransitionStateHandler {
 
 /// A state handler that transitions from A -> B -> A
 #[derive(Debug, Default, Clone)]
-pub struct CyclicTransitionStateHandler;
+struct CyclicTransitionStateHandler;
 
 #[async_trait::async_trait]
 impl StateHandler for CyclicTransitionStateHandler {
@@ -979,7 +973,7 @@ struct CapturedStateChange {
 }
 
 /// A hook that sends events through a channel for deterministic test verification
-pub struct ChannelHook {
+struct ChannelHook {
     sender: tokio::sync::mpsc::UnboundedSender<CapturedStateChange>,
 }
 
@@ -1134,8 +1128,8 @@ async fn test_state_controller_manual_enqueuing(pool: sqlx::PgPool) -> eyre::Res
 /// A state handler that fails with `ManualInterventionRequired` on its first
 /// invocation, a transient error on its second, and succeeds afterwards.
 #[derive(Debug, Default, Clone)]
-pub struct TestManualInterventionStateHandler {
-    pub calls: Arc<AtomicUsize>,
+struct TestManualInterventionStateHandler {
+    calls: Arc<AtomicUsize>,
 }
 
 #[async_trait::async_trait]
@@ -1509,8 +1503,8 @@ async fn test_per_object_state_metrics_sla_and_state_based_intervention(
 /// A state handler that reports the object as deleted on its second
 /// invocation.
 #[derive(Debug, Default, Clone)]
-pub struct TestDeletionStateHandler {
-    pub calls: Arc<AtomicUsize>,
+struct TestDeletionStateHandler {
+    calls: Arc<AtomicUsize>,
 }
 
 #[async_trait::async_trait]
@@ -1572,9 +1566,9 @@ async fn test_per_object_state_metrics_cleared_on_deletion(pool: sqlx::PgPool) -
 /// object's controller-state version out from under the processor and then
 /// returns a transition, which must lose the optimistic version check.
 #[derive(Debug, Clone)]
-pub struct TestLockLossStateHandler {
-    pub pool: sqlx::PgPool,
-    pub calls: Arc<AtomicUsize>,
+struct TestLockLossStateHandler {
+    pool: sqlx::PgPool,
+    calls: Arc<AtomicUsize>,
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
This adopts the new style guide rules around module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout the lifecycle-controller crates.

Primary callouts are:
- Replace 224 overbroad declarations across Machine-a-tron, Site Explorer, Machine Controller, State Controller, Preingestion Manager, and Machine Validation with private, `pub(super)`, or `pub(crate)` visibility based on actual callers.
- Keep cross-crate controller contracts and explicit integration-test support public where their callers still need them.
- Scope internal state processors, handlers, metrics, simulator helpers, and test fixtures to their actual modules.
- Remove an unused State Controller test field exposed during dead-code cleanup.
- Leave the generated Machine Controller declarations owned by VSC-01 unchanged and preserve runtime behavior.

Tests updated!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4553.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The targeted unit, integration, and doc-test suites for all six crates passed. I also ran:

```bash
make core/tests TEST_ARGS="-p carbide-machine-a-tron -p carbide-site-explorer -p carbide-machine-controller -p state-controller -p carbide-preingestion-manager -p carbide-machine-validation"
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
cargo clippy --locked --all-targets --all-features -p carbide-machine-a-tron -p carbide-site-explorer -p carbide-machine-controller -p state-controller -p carbide-preingestion-manager -p carbide-machine-validation -- --force-warn unreachable-pub
git diff --check
```

## Additional Notes

The initial compiler-backed visibility inventory identified 224 overbroad declarations across these six crates. The final 28-file diff resolves every tracked-source finding. The only remaining warnings are two generated Machine Controller declarations that are owned by VSC-01 and excluded from this issue.

Local CodeRabbit and read-only Claude reviews completed over the full diff. All applicable findings are incorporated.


Closes #4553
