### PR TITLE
refactor(shared): adopt style guide rules around pub/module visibility

### DIFF
--- a/crates/api-db/src/explored_endpoints.rs
+++ b/crates/api-db/src/explored_endpoints.rs
@@ -127,7 +127,7 @@ pub async fn find_ips(
     _filter: model::site_explorer::ExploredEndpointSearchFilter,
 ) -> Result<Vec<IpAddr>, DatabaseError> {
     #[derive(Debug, Clone, Copy, FromRow)]
-    pub struct ExploredEndpointIp(IpAddr);
+    struct ExploredEndpointIp(IpAddr);
     // grab list of IPs
     let mut builder = sqlx::QueryBuilder::new("SELECT address FROM explored_endpoints");
     let query = builder.build_query_as();

--- a/crates/api-db/src/explored_managed_host.rs
+++ b/crates/api-db/src/explored_managed_host.rs
@@ -57,7 +57,7 @@ pub async fn find_ips(
     _filter: model::site_explorer::ExploredManagedHostSearchFilter,
 ) -> Result<Vec<IpAddr>, DatabaseError> {
     #[derive(Debug, Clone, Copy, FromRow)]
-    pub struct ExploredManagedHostIp(IpAddr);
+    struct ExploredManagedHostIp(IpAddr);
     // grab list of IPs
     let mut builder = sqlx::QueryBuilder::new("SELECT host_bmc_ip FROM explored_managed_hosts");
     let query = builder.build_query_as();

--- a/crates/api-db/src/ib_partition.rs
+++ b/crates/api-db/src/ib_partition.rs
@@ -172,7 +172,7 @@ pub async fn find_pkey_by_partition_id(
     id: IBPartitionId,
 ) -> Result<Option<u16>, DatabaseError> {
     #[derive(Debug, Clone, FromRow)]
-    pub struct Pkey(String);
+    struct Pkey(String);
 
     let mut query = FilterableQueryBuilder::new("SELECT status->>'pkey' FROM ib_partitions")
         .filter(&ObjectColumnFilter::One(IdColumn, &id));

--- a/crates/api-db/src/measured_boot/report.rs
+++ b/crates/api-db/src/measured_boot/report.rs
@@ -291,7 +291,7 @@ struct JournalData {
 }
 
 impl JournalData {
-    pub async fn new_from_values(
+    async fn new_from_values(
         txn: &mut PgTransaction<'_>,
         machine_id: MachineId,
         values: &[PcrRegisterValue],

--- a/crates/api-model/src/dpa_interface/slas.rs
+++ b/crates/api-model/src/dpa_interface/slas.rs
@@ -21,12 +21,12 @@ use std::time::Duration;
 
 // TODO(chet): Revisit these SLAs -- they seem a little high. Operations
 // like lock/unlock are pretty instantaneous, and profile is ~seconds.
-pub const LOCKING: Duration = Duration::from_secs(15 * 60);
+pub(super) const LOCKING: Duration = Duration::from_secs(15 * 60);
 // ...BUT applying firmware actually can take a while. SuperNIC flashing
 // seems to be roughly 7 minutes to flash then 1 minute to reset, but
 // that's resetting the device, not the entire host. As of now it seems
 // like resetting the device is enough, but we may end up needing to
 // do a full power cycle of the host, which would definitely take a bit.
-pub const APPLY_FIRMWARE: Duration = Duration::from_secs(30 * 60);
-pub const APPLY_PROFILE: Duration = Duration::from_secs(15 * 60);
-pub const UNLOCKING: Duration = Duration::from_secs(15 * 60);
+pub(super) const APPLY_FIRMWARE: Duration = Duration::from_secs(30 * 60);
+pub(super) const APPLY_PROFILE: Duration = Duration::from_secs(15 * 60);
+pub(super) const UNLOCKING: Duration = Duration::from_secs(15 * 60);

--- a/crates/api-model/src/ib_partition/slas.rs
+++ b/crates/api-model/src/ib_partition/slas.rs
@@ -19,5 +19,5 @@
 
 use std::time::Duration;
 
-pub const PROVISIONING: Duration = Duration::from_secs(15 * 60);
-pub const DELETING: Duration = Duration::from_secs(15 * 60);
+pub(super) const PROVISIONING: Duration = Duration::from_secs(15 * 60);
+pub(super) const DELETING: Duration = Duration::from_secs(15 * 60);

--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -314,7 +314,7 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn serialize_mac_address() {
+    fn serialize_mac_address() {
         let mac = MacAddress::new([1, 2, 3, 4, 5, 6]);
         let serialized = serde_json::to_string(&SerializableMacAddress::from(mac)).unwrap();
         assert_eq!(serialized, "\"01:02:03:04:05:06\"");

--- a/crates/api-model/src/network_segment/slas.rs
+++ b/crates/api-model/src/network_segment/slas.rs
@@ -19,5 +19,5 @@
 
 use std::time::Duration;
 
-pub const PROVISIONING: Duration = Duration::from_secs(15 * 60);
-pub const DELETING_DBDELETE: Duration = Duration::from_secs(15 * 60);
+pub(super) const PROVISIONING: Duration = Duration::from_secs(15 * 60);
+pub(super) const DELETING_DBDELETE: Duration = Duration::from_secs(15 * 60);

--- a/crates/api-model/src/power_shelf/mod.rs
+++ b/crates/api-model/src/power_shelf/mod.rs
@@ -33,7 +33,7 @@ use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
 
 pub mod power_shelf_id;
-pub mod slas;
+mod slas;
 
 #[derive(Debug, Clone)]
 pub struct NewPowerShelf {

--- a/crates/api-model/src/power_shelf/slas.rs
+++ b/crates/api-model/src/power_shelf/slas.rs
@@ -16,13 +16,13 @@
  */
 
 /// SLA for PowerShelf initialization in seconds
-pub const INITIALIZING: u64 = 300; // 5 minutes
+pub(super) const INITIALIZING: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf fetching data in seconds
-pub const FETCHING_DATA: u64 = 300; // 5 minutes
+pub(super) const FETCHING_DATA: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf configuring in seconds
-pub const CONFIGURING: u64 = 300; // 5 minutes
+pub(super) const CONFIGURING: u64 = 300; // 5 minutes
 
 // /// SLA for PowerShelf ready in seconds
 // pub const READY: u64 = 0; // 0 minutes
@@ -31,15 +31,15 @@ pub const CONFIGURING: u64 = 300; // 5 minutes
 // pub const ERROR: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf deleting in seconds
-pub const DELETING: u64 = 300; // 5 minutes
+pub(super) const DELETING: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf maintenance (PowerOn / PowerOff) in seconds
-pub const MAINTENANCE: u64 = 300; // 5 minutes
+pub(super) const MAINTENANCE: u64 = 300; // 5 minutes
 
 /// SLA for PowerShelf BMC (PMC) credential rotation in seconds. Generous enough
 /// to absorb a slow BMC plus the rotation engine's short per-device backoff
 /// without tripping the SLA on the first retry.
-pub const ROTATING_BMC: u64 = 15 * 60; // 15 minutes
+pub(super) const ROTATING_BMC: u64 = 15 * 60; // 15 minutes
 
 /// SLA for PowerShelf rack-level reprovisioning (firmware wait) in seconds
-pub const REPROVISIONING: u64 = 3600; // 1 hour
+pub(super) const REPROVISIONING: u64 = 3600; // 1 hour

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -734,7 +734,7 @@ mod serialize_option_display {
 
     use serde::{Deserialize, Deserializer, Serializer, de};
 
-    pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    pub(super) fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where
         T: Display,
         S: Serializer,
@@ -745,7 +745,7 @@ mod serialize_option_display {
         }
     }
 
-    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    pub(super) fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
     where
         T: FromStr,
         T::Err: Display,

--- a/crates/api-model/src/switch/mod.rs
+++ b/crates/api-model/src/switch/mod.rs
@@ -33,7 +33,7 @@ use crate::controller_outcome::PersistentStateHandlerOutcome;
 use crate::health::HealthReportSources;
 use crate::metadata::Metadata;
 
-pub mod slas;
+mod slas;
 pub mod switch_id;
 
 #[derive(Debug, Clone)]

--- a/crates/api-model/src/switch/slas.rs
+++ b/crates/api-model/src/switch/slas.rs
@@ -16,16 +16,16 @@
  */
 
 /// SLA for Switch initialization in seconds
-pub const INITIALIZING: u64 = 300; // 5 minutes
+pub(super) const INITIALIZING: u64 = 300; // 5 minutes
 
 /// SLA for Switch configuring in seconds
-pub const CONFIGURING: u64 = 300; // 5 minutes
+pub(super) const CONFIGURING: u64 = 300; // 5 minutes
 
 /// SLA for Switch fetch-info in seconds
-pub const FETCH_INFO: u64 = 300; // 5 minutes
+pub(super) const FETCH_INFO: u64 = 300; // 5 minutes
 
 /// SLA for Switch validating in seconds
-pub const VALIDATING: u64 = 300; // 5 minutes
+pub(super) const VALIDATING: u64 = 300; // 5 minutes
 
 // /// SLA for Switch ready in seconds
 // pub const READY: u64 = 0; // 0 minutes
@@ -34,12 +34,12 @@ pub const VALIDATING: u64 = 300; // 5 minutes
 // pub const ERROR: u64 = 300; // 5 minutes
 
 /// SLA for Switch deleting in seconds
-pub const DELETING: u64 = 300; // 5 minutes
+pub(super) const DELETING: u64 = 300; // 5 minutes
 
 /// SLA for Switch maintenance (PowerOn / PowerOff / Reset) in seconds
-pub const MAINTENANCE: u64 = 300; // 5 minutes
+pub(super) const MAINTENANCE: u64 = 300; // 5 minutes
 
 /// SLA for Switch BMC credential rotation in seconds. Generous enough to absorb
 /// a slow BMC plus the rotation engine's short per-device backoff without
 /// tripping the SLA on the first retry.
-pub const ROTATING_BMC: u64 = 15 * 60; // 15 minutes
+pub(super) const ROTATING_BMC: u64 = 15 * 60; // 15 minutes

--- a/crates/api/src/logging.rs
+++ b/crates/api/src/logging.rs
@@ -49,7 +49,7 @@ fn admin_ui_log_stream_layer(
     enable_admin_ui.then(|| LogStreamLayer::new(log_stream.clone()))
 }
 
-pub fn setup_logging(
+pub(super) fn setup_logging(
     debug: u8,
     extra_logfmt_event_fields: Vec<String>,
     override_logging_subscriber: Option<impl SubscriberInitExt>,

--- a/crates/libmlx/tests/runner/common/mod.rs
+++ b/crates/libmlx/tests/runner/common/mod.rs
@@ -25,7 +25,7 @@ use libmlx::variables::variable::MlxConfigVariable;
 use serde_json::json;
 
 /// Creates a test registry with common variable types for testing
-pub fn create_test_registry() -> MlxVariableRegistry {
+pub(super) fn create_test_registry() -> MlxVariableRegistry {
     let variables = vec![
         // Boolean variable
         MlxConfigVariable::builder()
@@ -130,7 +130,7 @@ pub fn create_test_registry() -> MlxVariableRegistry {
 }
 
 /// Creates a simple registry with minimal variables for focused testing
-pub fn create_minimal_test_registry() -> MlxVariableRegistry {
+pub(super) fn create_minimal_test_registry() -> MlxVariableRegistry {
     let variables = vec![
         MlxConfigVariable::builder()
             .name("TEST_BOOL")
@@ -150,7 +150,7 @@ pub fn create_minimal_test_registry() -> MlxVariableRegistry {
 }
 
 /// Creates sample mlxconfig JSON response for testing
-pub fn create_sample_json_response(device: &str) -> serde_json::Value {
+pub(super) fn create_sample_json_response(device: &str) -> serde_json::Value {
     json!({
         "Device #1": {
             "description": "Test BlueField-3 Device",
@@ -199,7 +199,7 @@ pub fn create_sample_json_response(device: &str) -> serde_json::Value {
 }
 
 /// Creates test device info
-pub fn create_test_device_info() -> QueriedDeviceInfo {
+pub(super) fn create_test_device_info() -> QueriedDeviceInfo {
     QueriedDeviceInfo::new()
         .with_device_id("01:00.0")
         .with_device_type("BlueField3")

--- a/crates/libnmxc/src/nmxc_api.rs
+++ b/crates/libnmxc/src/nmxc_api.rs
@@ -35,12 +35,12 @@ fn default_context() -> nmxc_model::Context {
     }
 }
 
-pub struct NmxcApi {
+pub(super) struct NmxcApi {
     client: NmxControllerClient<TraceInjectService<Channel>>,
 }
 
 impl NmxcApi {
-    pub fn new(client: NmxControllerClient<TraceInjectService<Channel>>) -> Self {
+    pub(super) fn new(client: NmxControllerClient<TraceInjectService<Channel>>) -> Self {
         Self { client }
     }
 }

--- a/crates/libnmxm/src/nmxm_api.rs
+++ b/crates/libnmxm/src/nmxm_api.rs
@@ -66,11 +66,11 @@ macro_rules! async_operation {
 }
 
 #[derive(Clone)]
-pub struct NmxmApi {
-    pub client: NmxmApiClient,
+pub(super) struct NmxmApi {
+    client: NmxmApiClient,
 }
 impl NmxmApi {
-    pub fn new(client: &NmxmApiClient) -> Self {
+    pub(super) fn new(client: &NmxmApiClient) -> Self {
         Self {
             client: client.clone(),
         }

--- a/crates/mqttea/tests/client.rs
+++ b/crates/mqttea/tests/client.rs
@@ -29,21 +29,21 @@ use rumqttc::AsyncClient;
 use tokio::sync::Mutex;
 
 #[derive(Clone, PartialEq, prost::Message, serde::Serialize, serde::Deserialize)]
-pub struct HelloWorld {
+struct HelloWorld {
     #[prost(string, tag = "1")]
-    pub message: String,
+    message: String,
     #[prost(int64, tag = "2")]
-    pub timestamp: i64,
+    timestamp: i64,
     #[prost(string, tag = "3")]
-    pub device_id: String,
+    device_id: String,
 }
 
 // Test message type for registration testing
 #[derive(Clone, Debug, PartialEq)]
 struct DogMessage {
-    pub breed: String,
-    pub age: u32,
-    pub payload: Vec<u8>,
+    breed: String,
+    age: u32,
+    payload: Vec<u8>,
 }
 
 impl RawMessageType for DogMessage {

--- a/crates/mqttea/tests/registry.rs
+++ b/crates/mqttea/tests/registry.rs
@@ -27,13 +27,13 @@ use mqttea::traits::RawMessageType;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, prost::Message)]
-pub struct HelloWorld {
+struct HelloWorld {
     #[prost(string, tag = "1")]
-    pub message: String,
+    message: String,
     #[prost(int64, tag = "2")]
-    pub timestamp: i64,
+    timestamp: i64,
     #[prost(string, tag = "3")]
-    pub device_id: String,
+    device_id: String,
 }
 
 // Test message types for various serialization formats

--- a/crates/uuid/src/device/mod.rs
+++ b/crates/uuid/src/device/mod.rs
@@ -96,14 +96,14 @@ mod proto {
     /// This lets RPC code use [`super::DeviceId`] directly while retaining the
     /// nested-message wire representation required by the oneof.
     #[derive(Clone, prost::Message)]
-    pub struct DeviceId {
+    pub(super) struct DeviceId {
         #[prost(oneof = "device_id::Value", tags = "1, 2, 3")]
-        pub value: Option<device_id::Value>,
+        value: Option<device_id::Value>,
     }
 
-    pub mod device_id {
+    mod device_id {
         #[derive(Clone, prost::Oneof)]
-        pub enum Value {
+        pub(super) enum Value {
             #[prost(message, tag = "1")]
             Machine(crate::machine::MachineId),
             #[prost(message, tag = "2")]
@@ -363,7 +363,7 @@ mod tests {
 
     mod reference_device_id {
         #[derive(Clone, PartialEq, prost::Oneof)]
-        pub enum Value {
+        pub(super) enum Value {
             #[prost(message, tag = "1")]
             Machine(crate::machine::MachineId),
             #[prost(message, tag = "2")]

--- a/crates/uuid/src/machine/mod.rs
+++ b/crates/uuid/src/machine/mod.rs
@@ -150,9 +150,9 @@ mod legacy_rpc {
     /// manually every time, while still interacting with peers that expect a `.common.MachineId`
     /// to be serialized.
     #[derive(prost::Message)]
-    pub struct MachineId {
+    pub(super) struct MachineId {
         #[prost(string, tag = "1")]
-        pub id: String,
+        pub(super) id: String,
     }
 
     impl From<super::MachineId> for MachineId {

--- a/crates/uuid/src/power_shelf/mod.rs
+++ b/crates/uuid/src/power_shelf/mod.rs
@@ -469,9 +469,9 @@ mod legacy_rpc {
     /// manually every time, while still interacting with peers that expect a `.common.PowerShelfId`
     /// to be serialized.
     #[derive(prost::Message)]
-    pub struct PowerShelfId {
+    pub(super) struct PowerShelfId {
         #[prost(string, tag = "1")]
-        pub id: String,
+        pub(super) id: String,
     }
 
     impl From<super::PowerShelfId> for PowerShelfId {

--- a/crates/uuid/src/rack/mod.rs
+++ b/crates/uuid/src/rack/mod.rs
@@ -157,9 +157,9 @@ mod legacy_rpc {
     /// }
     /// ```
     #[derive(prost::Message)]
-    pub struct RackId {
+    pub(super) struct RackId {
         #[prost(string, tag = "1")]
-        pub id: String,
+        pub(super) id: String,
     }
 
     impl From<super::RackId> for RackId {
@@ -267,9 +267,9 @@ impl prost::Message for RackProfileId {
 
 mod rack_profile_id_rpc {
     #[derive(prost::Message)]
-    pub struct RackProfileId {
+    pub(super) struct RackProfileId {
         #[prost(string, tag = "1")]
-        pub id: String,
+        pub(super) id: String,
     }
 
     impl From<super::RackProfileId> for RackProfileId {

--- a/crates/uuid/src/switch/mod.rs
+++ b/crates/uuid/src/switch/mod.rs
@@ -451,9 +451,9 @@ mod legacy_rpc {
     /// manually every time, while still interacting with peers that expect a `.common.SwitchId`
     /// to be serialized.
     #[derive(prost::Message)]
-    pub struct SwitchId {
+    pub(super) struct SwitchId {
         #[prost(string, tag = "1")]
-        pub id: String,
+        pub(super) id: String,
     }
 
     impl From<super::SwitchId> for SwitchId {

--- a/crates/uuid/src/typed_uuids.rs
+++ b/crates/uuid/src/typed_uuids.rs
@@ -434,8 +434,8 @@ macro_rules! typed_uuid_tests {
 mod tests {
     use super::*;
 
-    pub type ThingyId = TypedUuid<ThingyFlavor>;
-    pub struct ThingyFlavor {}
+    type ThingyId = TypedUuid<ThingyFlavor>;
+    struct ThingyFlavor {}
     impl UuidSubtype for ThingyFlavor {
         const TYPE_NAME: &'static str = "ThingyId";
     }
@@ -443,9 +443,9 @@ mod tests {
     typed_uuid_tests!(ThingyId, "ThingyId", "id");
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-    pub struct ThingyWithId {
-        pub id: ThingyId,
-        pub name: String,
+    struct ThingyWithId {
+        id: ThingyId,
+        name: String,
     }
 
     #[test]

--- a/crates/xtask/src/error_message_case.rs
+++ b/crates/xtask/src/error_message_case.rs
@@ -78,7 +78,7 @@ const FORMAT_MACROS: &[&str] = &["format", "format_args"];
 // keeps as an opaque token stream). Those are left as-is; widening the checker
 // further, and re-sweeping what it then catches, is a follow-up.
 
-pub fn check(fix: bool) -> eyre::Result<CheckOutcome> {
+pub(super) fn check(fix: bool) -> eyre::Result<CheckOutcome> {
     let repo_root = PathBuf::from(REPO_ROOT).canonicalize()?;
     let mut violations = Vec::new();
     let mut fixed_files = Vec::new();
@@ -203,7 +203,7 @@ fn push_violations(violations: &mut Vec<Violation>, rel: &Path, f: &Finding) {
     }
 }
 
-pub struct CheckOutcome {
+pub(super) struct CheckOutcome {
     violations: Vec<Violation>,
     fixed_files: Vec<(PathBuf, usize)>,
     fixing: bool,
@@ -213,7 +213,7 @@ pub struct CheckOutcome {
 }
 
 impl CheckOutcome {
-    pub fn report_and_exit(self) -> ! {
+    pub(super) fn report_and_exit(self) -> ! {
         if self.fixing {
             let sites: usize = self.fixed_files.iter().map(|(_, n)| n).sum();
             for (path, n) in &self.fixed_files {

--- a/crates/xtask/src/event_names.rs
+++ b/crates/xtask/src/event_names.rs
@@ -45,7 +45,7 @@ const GENERATED_SOURCE_DIRECTORIES: &[&str] = &["crates/ssh-console-mock-api-ser
 /// are rejected because they would bypass the identity checks. An unresolved
 /// ordinary `mod` is an error. Outlined children of the known generated-source
 /// directories are always skipped, whether their files are present or absent.
-pub fn check() -> eyre::Result<()> {
+pub(super) fn check() -> eyre::Result<()> {
     let metadata = MetadataCommand::new()
         .no_deps()
         .exec()

--- a/crates/xtask/src/isolated_package_builds.rs
+++ b/crates/xtask/src/isolated_package_builds.rs
@@ -20,7 +20,7 @@ use cargo_metadata::MetadataCommand;
 use eyre::{Context, ContextCompat, bail};
 
 /// Checks that every workspace package builds independently with default features.
-pub fn check() -> eyre::Result<()> {
+pub(super) fn check() -> eyre::Result<()> {
     let packages = workspace_packages()?;
     let mut failures = Vec::new();
 

--- a/crates/xtask/src/metric_docs.rs
+++ b/crates/xtask/src/metric_docs.rs
@@ -62,7 +62,7 @@ struct DeclaredMetric {
     source: PathBuf,
 }
 
-pub fn check(fix: bool) -> eyre::Result<()> {
+pub(super) fn check(fix: bool) -> eyre::Result<()> {
     let repo_root = PathBuf::from(REPO_ROOT).canonicalize()?;
     let catalogue_path = repo_root.join(CATALOGUE);
     let catalogue =

--- a/crates/xtask/src/squash_migrations.rs
+++ b/crates/xtask/src/squash_migrations.rs
@@ -32,7 +32,7 @@ use sqlx::postgres::PgConnectOptions;
 /// directory is created containing only the snapshot.
 #[derive(Parser)]
 #[command(name = "squash-migrations")]
-pub struct Args {
+pub(super) struct Args {
     /// Postgres user.
     /// Defaults to TESTDB_USER, assuming you're running
     /// this from the repo with a loaded up .envrc.
@@ -57,7 +57,7 @@ pub struct Args {
     migrations_dir: Option<PathBuf>,
 }
 
-pub async fn run(args: Args) -> Result<()> {
+pub(super) async fn run(args: Args) -> Result<()> {
     let migrations_dir = args
         .migrations_dir
         .as_ref()

--- a/crates/xtask/src/workspace_deps.rs
+++ b/crates/xtask/src/workspace_deps.rs
@@ -26,7 +26,7 @@ use walkdir::WalkDir;
 
 static REPO_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../.."); // crates/xtask/../..
 
-pub fn check(fix: bool) -> eyre::Result<CheckOutcome> {
+pub(super) fn check(fix: bool) -> eyre::Result<CheckOutcome> {
     let repo_root = PathBuf::from(REPO_ROOT).canonicalize()?;
     let mut workspace = Workspace::load(repo_root).context("error reading cargo.toml files")?;
 
@@ -42,13 +42,13 @@ pub fn check(fix: bool) -> eyre::Result<CheckOutcome> {
     }
 }
 
-pub enum CheckOutcome {
+pub(super) enum CheckOutcome {
     Success { fixed: Vec<(PathBuf, String)> },
     Failure { diffs: Vec<(PathBuf, String)> },
 }
 
 impl CheckOutcome {
-    pub fn report_and_exit(self) -> ! {
+    pub(super) fn report_and_exit(self) -> ! {
         match self {
             CheckOutcome::Success { fixed } if fixed.is_empty() => {
                 // All good, no fixes needed


### PR DESCRIPTION
This adopts the new style guide rules around module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, applying the correct visibility throughout the remaining shared model and tooling crates.

Primary callouts are:
- Resolve all 47 compiler-proven findings across `xtask`, `api-model`, `uuid`, `api-db`, `libmlx`, `mqttea`, `libnmxm`, `libnmxc`, and `api` with private or `pub(super)` visibility based on actual callers.
- Keep API/model DTO fields, intentional re-exports, UUID macros, and test-support surfaces public where downstream crates still use them.
- Scope SQL row helpers, SLA constants, UUID wire adapters, xtask command internals, library implementation types, and test fixtures to the modules that use them.
- Make the Switch and PowerShelf SLA modules private after direct caller review, along with the remaining private fields in the MQTT test messages.
- Leave generated source, serialized data, wire contracts, and runtime behavior unchanged.

Tests pass!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4557.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The targeted unit, integration, and doc-test suites for all nine crates passed, including a post-review rerun for `api-model` and `mqttea`. I also ran:

```bash
make core/tests TEST_ARGS="-p xtask -p carbide-api-model -p carbide-uuid -p carbide-api-db -p carbide-libmlx -p mqttea -p libnmxm -p libnmxc -p carbide-api --all-features"
cargo test --locked -p carbide-api-model -p mqttea --all-features
cargo make format-nightly
cargo make clippy
cargo make carbide-lints
cargo clippy --locked -p xtask -p carbide-api-model -p carbide-uuid -p carbide-api-db -p carbide-libmlx -p mqttea -p libnmxm -p libnmxc -p carbide-api --all-targets --all-features --message-format short -- --force-warn unreachable-pub
git diff --check
```

## Additional Notes

The current `main` baseline identified 47 overbroad declarations across these nine crates. The final 31-file diff also narrows adjacent fields and module boundaries with direct caller evidence. No `unreachable_pub` warning remains in the owned source trees.

Public API/model DTO fields, intentional re-exports, UUID/version macros, generated source, and test support with downstream consumers remain unchanged. This does not change serialized data, wire contracts, or runtime behavior.

Local CodeRabbit returned zero findings. The independent read-only Claude review found two applicable follow-through items around private MQTT test fields and the Switch/PowerShelf SLA module boundaries; both are incorporated.

The review also proposed spelling the crate-root `logging` child boundary as `pub(crate)` instead of `pub(super)`. That stays `pub(super)` because the `STYLE_GUIDE.md` caller table maps parent-module callers and descendants to `pub(super)`; although both spellings reach the same callers for a crate-root child, `pub(super)` records the actual relationship.


Closes #4557
