### PR TITLE
devspace: Don't disable RBAC

### DIFF
--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -14,7 +14,6 @@ nico-api:
   siteConfig:
     enabled: true
     nicoApiSiteConfig: |
-      bypass_rbac = true
       attestation_enabled = false
       dpu_ipmi_tool_impl = "test"
       initial_domain_name = "local.nico"


### PR DESCRIPTION
Running with RBAC disabled can make API's with incorrect RBAC settings seem like they work correctly when they don't... devspace's config overrides should be limited to areas where we can't easily simulate production (like disabling attestion and using a mock ipmitool.)

## Related issues
#4631
#4341 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Deployed via devspace and verified that I could reproduce the bug in #4341

## Additional Notes