### PR TITLE
fix(api): retry force-delete cleanup on deadlock or serialization fai…

### DIFF
--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -393,6 +393,18 @@ impl CarbideError {
     pub fn internal(message: String) -> Self {
         CarbideError::Internal { message }
     }
+
+    /// Returns true if this error is a Postgres deadlock (`40P01`) or
+    /// serialization failure (`40001`), both of which are safe to retry.
+    pub(crate) fn is_retryable_transaction_error(&self) -> bool {
+        matches!(
+            self,
+            CarbideError::DBError(db::AnnotatedSqlxError {
+                source: sqlx::Error::Database(db_err),
+                ..
+            }) if matches!(db_err.code().as_deref(), Some("40P01") | Some("40001"))
+        )
+    }
 }
 
 impl OperatorError for CarbideError {

--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -394,6 +394,19 @@ impl CarbideError {
         CarbideError::Internal { message }
     }
 
+    /// Returns the Postgres SQLSTATE code if this is a database error, or `None` otherwise.
+    pub(crate) fn pg_sqlstate(&self) -> Option<String> {
+        if let CarbideError::DBError(db::AnnotatedSqlxError {
+            source: sqlx::Error::Database(db_err),
+            ..
+        }) = self
+        {
+            db_err.code().map(|c| c.into_owned())
+        } else {
+            None
+        }
+    }
+
     /// Returns true if this error is a Postgres deadlock (`40P01`) or
     /// serialization failure (`40001`), both of which are safe to retry.
     pub(crate) fn is_retryable_transaction_error(&self) -> bool {

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::forge as rpc;
@@ -329,6 +330,190 @@ pub(crate) async fn update_machine_metadata(
     Ok(tonic::Response::new(()))
 }
 
+/// Runs the DB cleanup transaction for a force-delete.
+///
+/// All operations follow the lock-ordering established for the rest of the
+/// system so this transaction cannot deadlock with the site-explorer or
+/// allocator under normal conditions. When it does lose a deadlock race, the
+/// caller retries: every operation here is idempotent because a deadlock
+/// causes Postgres to roll back this transaction, leaving the DB unchanged.
+///
+/// BMC credential clearing is intentionally excluded: that is an out-of-band
+/// operation the caller performs after the transaction commits.
+async fn force_delete_cleanup_txn(
+    api: &Api,
+    host_machine: Option<&Machine>,
+    dpu_machines: &[Machine],
+    request: &rpc::AdminForceDeleteMachineRequest,
+    response: &mut rpc::AdminForceDeleteMachineResponse,
+) -> Result<(), CarbideError> {
+    // Admission permit BEFORE the transaction: waiters on the admin-segment
+    // advisory lock must queue in memory, not on open pool connections.
+    let _admin_admission = db::machine_interface::admin_lock_admission().await;
+    let mut txn = api.txn_begin().await?;
+
+    // Advisory-lock the admin segments before any row locks so the deletion
+    // follows the allocator lock order -- segment advisory lock first, then
+    // machine interface/address rows (the convention
+    // `reconcile_admin_addresses_for_host` documents). This serializes the
+    // deletion against the allocator, reconcile, and discovery transactions
+    // that hold those locks while they touch interface rows, so the two
+    // sides can't hold segment locks and interface rows in opposite orders.
+    // All admin segments, rather than a set computed from this machine's
+    // interfaces: the snapshots predate the BMC work above, and they omit
+    // BMC-typed interfaces that `force_cleanup` still row-locks.
+    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
+
+    // Clean up the explored tables next, in site-explorer's write order
+    // (`explored_managed_hosts`, then each machine topology and its
+    // `explored_endpoints` row, then interface rows), so this delete and a
+    // concurrent exploration pass can't hold the same tables in opposite
+    // orders.
+    if let Some(machine) = host_machine
+        && let Some(addr) = machine.status.bmc_info.ip
+    {
+        // If this delete waited out a concurrent exploration rewrite, its
+        // statement snapshot can miss the row that rewrite re-inserted; the
+        // leftover clears on the next exploration pass, which rebuilds the
+        // table from the (now deleted) explored endpoints.
+        db::explored_managed_host::delete_by_host_bmc_addr(&mut txn, addr).await?;
+    }
+
+    let mut machines_by_bmc_ip = host_machine
+        .iter()
+        .copied()
+        .chain(dpu_machines.iter())
+        .filter_map(|machine| machine.status.bmc_info.ip.map(|address| (address, machine)))
+        .collect::<Vec<_>>();
+    // Any transaction touching multiple explored_endpoints needs to sort them the same way to avoid
+    // deadlocks: sort by IP.
+    machines_by_bmc_ip.sort_by_key(|(address, _)| *address);
+
+    for (addr, machine) in machines_by_bmc_ip {
+        tracing::info!(
+            bmc_ip_address = %addr,
+            machine_id = %machine.id,
+            "Cleaning up explored endpoint",
+        );
+
+        // Site Explorer refreshes firmware in machine_topologies before it
+        // updates this endpoint. Lock in the same order; force_cleanup later
+        // deletes the already-locked topology row.
+        db::machine_topology::lock_by_machine_id(&mut txn, &machine.id).await?;
+        db::explored_endpoints::delete(&mut txn, addr).await?;
+    }
+
+    if let Some(machine) = host_machine {
+        if request.delete_bmc_interfaces
+            && let Some(bmc_ip) = machine.status.bmc_info.ip
+        {
+            response.host_bmc_interface_associated = true;
+            if db::machine_interface::delete_by_ip(&mut txn, bmc_ip)
+                .await?
+                .is_some()
+            {
+                response.host_bmc_interface_deleted = true;
+            }
+        }
+        db::machine::force_cleanup(&mut txn, &machine.id).await?;
+
+        if request.delete_interfaces {
+            for interface in &machine.status.interfaces {
+                // The delete retains each row's boot interface pair in
+                // `retained_boot_interfaces`, so a re-ingested machine
+                // recovers its boot target before its first DHCP.
+                db::machine_interface::delete(&interface.id, &mut txn).await?;
+            }
+            response.host_interfaces_deleted = true;
+        }
+
+        if let Err(e) =
+            db::attestation::ek_cert_verification_status::delete_ca_verification_status_by_machine_id(
+                &mut txn,
+                &machine.id,
+            )
+            .await
+        {
+            // just log the error and carry on
+            tracing::error!(
+                machine_id = %machine.id,
+                error = %e,
+                "Could not remove EK certificate status",
+            );
+        }
+    }
+
+    for dpu_machine in dpu_machines {
+        // Free up all loopback IPs allocated for this DPU.
+        db::vpc_dpu_loopback::delete_and_deallocate(
+            &api.common_pools,
+            &dpu_machine.id,
+            &mut txn,
+            true,
+        )
+        .await?;
+
+        if let Some(loopback_ip) = dpu_machine.network_config.loopback_ip {
+            db::resource_pool::release(
+                &api.common_pools.ethernet.pool_loopback_ip,
+                &mut txn,
+                loopback_ip,
+            )
+            .await?
+        }
+
+        // The machine snapshot predates `ForceDeletion`, so a concurrent
+        // backfill can make its IPv6 field stale. The pool owner remains the
+        // authoritative reservation source during deletion.
+        if let Some(loopback_ip_v6) = db::resource_pool::find_owned_allocation(
+            &api.common_pools.ethernet.pool_loopback_ip_v6,
+            &mut txn,
+            model::resource_pool::OwnerType::Machine,
+            &dpu_machine.id.to_string(),
+        )
+        .await
+        .map_err(CarbideError::from)?
+        {
+            db::resource_pool::release(
+                &api.common_pools.ethernet.pool_loopback_ip_v6,
+                &mut txn,
+                loopback_ip_v6,
+            )
+            .await?
+        }
+
+        db::network_devices::dpu_to_network_device_map::delete(&mut txn, &dpu_machine.id).await?;
+
+        if request.delete_bmc_interfaces
+            && let Some(bmc_ip) = dpu_machine.status.bmc_info.ip
+        {
+            response.dpu_bmc_interface_associated = true;
+            if db::machine_interface::delete_by_ip(&mut txn, bmc_ip)
+                .await?
+                .is_some()
+            {
+                response.dpu_bmc_interface_deleted = true;
+            }
+        }
+        if let Some(asn) = dpu_machine.asn {
+            db::resource_pool::release(&api.common_pools.ethernet.pool_fnn_asn, &mut txn, asn)
+                .await?;
+        }
+        db::machine::force_cleanup(&mut txn, &dpu_machine.id).await?;
+
+        if request.delete_interfaces {
+            for interface in &dpu_machine.status.interfaces {
+                db::machine_interface::delete(&interface.id, &mut txn).await?;
+            }
+            response.dpu_interfaces_deleted = true;
+        }
+    }
+
+    txn.commit().await?;
+
+    Ok(())
+}
+
 pub(crate) async fn admin_force_delete_machine(
     api: &Api,
     request: Request<rpc::AdminForceDeleteMachineRequest>,
@@ -336,7 +521,7 @@ pub(crate) async fn admin_force_delete_machine(
     log_request_data(&request);
 
     let (_metadata, extensions, request) = request.into_parts();
-    let query = request.host_query;
+    let query = &request.host_query;
 
     let mut response = rpc::AdminForceDeleteMachineResponse {
         all_done: true,
@@ -350,7 +535,7 @@ pub(crate) async fn admin_force_delete_machine(
 
     let mut txn = api.txn_begin().await?;
 
-    let machine = match db::machine::find_by_query(&mut txn, &query).await? {
+    let machine = match db::machine::find_by_query(&mut txn, query).await? {
         Some(machine) => machine,
         None => {
             // If the machine was already deleted, then there is nothing to do
@@ -638,181 +823,47 @@ pub(crate) async fn admin_force_delete_machine(
         }
     }
 
-    // Admission permit BEFORE the transaction: waiters on the admin-segment
-    // advisory lock must queue in memory, not on open pool connections.
-    let _admin_admission = db::machine_interface::admin_lock_admission().await;
-    let mut txn = api.txn_begin().await?;
-    let mut machines_to_clear_credentials = Vec::new();
-
-    // Advisory-lock the admin segments before any row locks so the deletion
-    // follows the allocator lock order -- segment advisory lock first, then
-    // machine interface/address rows (the convention
-    // `reconcile_admin_addresses_for_host` documents). This serializes the
-    // deletion against the allocator, reconcile, and discovery transactions
-    // that hold those locks while they touch interface rows, so the two
-    // sides can't hold segment locks and interface rows in opposite orders.
-    // All admin segments, rather than a set computed from this machine's
-    // interfaces: the snapshots predate the BMC work above, and they omit
-    // BMC-typed interfaces that `force_cleanup` still row-locks.
-    db::machine_interface::lock_all_admin_segments(&mut txn).await?;
-
-    // Clean up the explored tables next, in site-explorer's write order
-    // (`explored_managed_hosts`, then each machine topology and its
-    // `explored_endpoints` row, then interface rows), so this delete and a
-    // concurrent exploration pass can't hold the same tables in opposite
-    // orders.
-    if let Some(machine) = &host_machine
-        && let Some(addr) = machine.status.bmc_info.ip
-    {
-        // If this delete waited out a concurrent exploration rewrite, its
-        // statement snapshot can miss the row that rewrite re-inserted; the
-        // leftover clears on the next exploration pass, which rebuilds the
-        // table from the (now deleted) explored endpoints.
-        db::explored_managed_host::delete_by_host_bmc_addr(&mut txn, addr).await?;
-    }
-
-    let mut machines_by_bmc_ip = host_machine
-        .iter()
-        .chain(dpu_machines.iter())
-        .filter_map(|machine| machine.status.bmc_info.ip.map(|address| (address, machine)))
-        .collect::<Vec<_>>();
-    // Any transaction touching multiple explored_endpoints needs to sort them the same way to avoid
-    // deadlocks: sort by IP.
-    machines_by_bmc_ip.sort_by_key(|(address, _)| *address);
-
-    for (addr, machine) in machines_by_bmc_ip {
-        tracing::info!(
-            bmc_ip_address = %addr,
-            machine_id = %machine.id,
-            "Cleaning up explored endpoint",
-        );
-
-        // Site Explorer refreshes firmware in machine_topologies before it
-        // updates this endpoint. Lock in the same order; force_cleanup later
-        // deletes the already-locked topology row.
-        db::machine_topology::lock_by_machine_id(&mut txn, &machine.id).await?;
-        db::explored_endpoints::delete(&mut txn, addr).await?;
-    }
-
-    if let Some(machine) = &host_machine {
-        if request.delete_bmc_interfaces
-            && let Some(bmc_ip) = machine.status.bmc_info.ip
-        {
-            response.host_bmc_interface_associated = true;
-            if db::machine_interface::delete_by_ip(&mut txn, bmc_ip)
-                .await?
-                .is_some()
-            {
-                response.host_bmc_interface_deleted = true;
-            }
-        }
-        db::machine::force_cleanup(&mut txn, &machine.id).await?;
-
-        if request.delete_interfaces {
-            for interface in &machine.status.interfaces {
-                // The delete retains each row's boot interface pair in
-                // `retained_boot_interfaces`, so a re-ingested machine
-                // recovers its boot target before its first DHCP.
-                db::machine_interface::delete(&interface.id, &mut txn).await?;
-            }
-            response.host_interfaces_deleted = true;
-        }
-
-        if request.delete_bmc_credentials {
-            machines_to_clear_credentials.push(machine);
-        }
-
-        if let Err(e) =
-            db::attestation::ek_cert_verification_status::delete_ca_verification_status_by_machine_id(
-                &mut txn,
-                &machine.id,
-            )
-            .await
-        {
-            // just log the error and carry on
-            tracing::error!(
-                machine_id = %machine.id,
-                error = %e,
-                "Could not remove EK certificate status",
-            );
-        }
-    }
-
-    for dpu_machine in dpu_machines.iter() {
-        // Free up all loopback IPs allocated for this DPU.
-        db::vpc_dpu_loopback::delete_and_deallocate(
-            &api.common_pools,
-            &dpu_machine.id,
-            &mut txn,
-            true,
-        )
-        .await?;
-
-        if let Some(loopback_ip) = dpu_machine.network_config.loopback_ip {
-            db::resource_pool::release(
-                &api.common_pools.ethernet.pool_loopback_ip,
-                &mut txn,
-                loopback_ip,
-            )
-            .await?
-        }
-
-        // The machine snapshot predates `ForceDeletion`, so a concurrent
-        // backfill can make its IPv6 field stale. The pool owner remains the
-        // authoritative reservation source during deletion.
-        if let Some(loopback_ip_v6) = db::resource_pool::find_owned_allocation(
-            &api.common_pools.ethernet.pool_loopback_ip_v6,
-            &mut txn,
-            model::resource_pool::OwnerType::Machine,
-            &dpu_machine.id.to_string(),
+    // Retry the cleanup transaction on deadlock or serialization failure.
+    // Both are transient: Postgres aborted our transaction, the conflicting
+    // transaction has already committed, and a fresh attempt will succeed
+    // once its locks are released. The backoff starts at 50 ms and doubles
+    // each attempt (50, 100, 200, 400 ms) for up to five total attempts.
+    const MAX_CLEANUP_ATTEMPTS: u32 = 5;
+    for attempt in 0..MAX_CLEANUP_ATTEMPTS {
+        match force_delete_cleanup_txn(
+            api,
+            host_machine.as_ref(),
+            &dpu_machines,
+            &request,
+            &mut response,
         )
         .await
-        .map_err(CarbideError::from)?
         {
-            db::resource_pool::release(
-                &api.common_pools.ethernet.pool_loopback_ip_v6,
-                &mut txn,
-                loopback_ip_v6,
-            )
-            .await?
-        }
-
-        db::network_devices::dpu_to_network_device_map::delete(&mut txn, &dpu_machine.id).await?;
-
-        if request.delete_bmc_interfaces
-            && let Some(bmc_ip) = dpu_machine.status.bmc_info.ip
-        {
-            response.dpu_bmc_interface_associated = true;
-            if db::machine_interface::delete_by_ip(&mut txn, bmc_ip)
-                .await?
-                .is_some()
+            Ok(()) => break,
+            Err(error)
+                if error.is_retryable_transaction_error() && attempt + 1 < MAX_CLEANUP_ATTEMPTS =>
             {
-                response.dpu_bmc_interface_deleted = true;
+                let delay = Duration::from_millis(50u64 << attempt);
+                tracing::warn!(
+                    attempt_number = attempt + 1,
+                    retry_delay_milliseconds = delay.as_millis(),
+                    error = %error,
+                    "force-delete cleanup transaction deadlocked; retrying",
+                );
+                tokio::time::sleep(delay).await;
             }
-        }
-        if let Some(asn) = dpu_machine.asn {
-            db::resource_pool::release(&api.common_pools.ethernet.pool_fnn_asn, &mut txn, asn)
-                .await?;
-        }
-        db::machine::force_cleanup(&mut txn, &dpu_machine.id).await?;
-
-        if request.delete_interfaces {
-            for interface in &dpu_machine.status.interfaces {
-                db::machine_interface::delete(&interface.id, &mut txn).await?;
-            }
-            response.dpu_interfaces_deleted = true;
-        }
-
-        if request.delete_bmc_credentials {
-            machines_to_clear_credentials.push(dpu_machine);
+            Err(error) => return Err(error.into()),
         }
     }
 
-    txn.commit().await?;
-
     // Do BMC operations outside a transaction to avoid long-running transactions
-    for machine in machines_to_clear_credentials {
-        clear_bmc_credentials(api, machine).await?;
+    if request.delete_bmc_credentials {
+        if let Some(machine) = &host_machine {
+            clear_bmc_credentials(api, machine).await?;
+        }
+        for dpu_machine in &dpu_machines {
+            clear_bmc_credentials(api, dpu_machine).await?;
+        }
     }
 
     Ok(Response::new(response))

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -432,20 +432,18 @@ async fn force_delete_cleanup_txn(
             response.host_interfaces_deleted = true;
         }
 
-        if let Err(e) =
-            db::attestation::ek_cert_verification_status::delete_ca_verification_status_by_machine_id(
-                &mut txn,
-                &machine.id,
-            )
-            .await
-        {
-            // just log the error and carry on
+        db::attestation::ek_cert_verification_status::delete_ca_verification_status_by_machine_id(
+            &mut txn,
+            &machine.id,
+        )
+        .await
+        .inspect_err(|e| {
             tracing::error!(
                 machine_id = %machine.id,
                 error = %e,
                 "Could not remove EK certificate status",
             );
-        }
+        })?;
     }
 
     for dpu_machine in dpu_machines {
@@ -852,8 +850,9 @@ pub(crate) async fn admin_force_delete_machine(
                 tracing::warn!(
                     attempt_number = attempt + 1,
                     retry_delay_milliseconds = delay.as_millis(),
+                    pg_sqlstate = error.pg_sqlstate().as_deref().unwrap_or("unknown"),
                     error = %error,
-                    "force-delete cleanup transaction deadlocked; retrying",
+                    "force-delete cleanup transaction conflict; retrying",
                 );
                 tokio::time::sleep(delay).await;
             }

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -338,6 +338,11 @@ pub(crate) async fn update_machine_metadata(
 /// caller retries: every operation here is idempotent because a deadlock
 /// causes Postgres to roll back this transaction, leaving the DB unchanged.
 ///
+/// Response flags are accumulated into a local value and returned only after
+/// commit. A Postgres rollback does not restore in-memory state, so keeping
+/// the response local ensures the caller only ever sees flags that correspond
+/// to the committed transaction.
+///
 /// BMC credential clearing is intentionally excluded: that is an out-of-band
 /// operation the caller performs after the transaction commits.
 async fn force_delete_cleanup_txn(
@@ -345,8 +350,8 @@ async fn force_delete_cleanup_txn(
     host_machine: Option<&Machine>,
     dpu_machines: &[Machine],
     request: &rpc::AdminForceDeleteMachineRequest,
-    response: &mut rpc::AdminForceDeleteMachineResponse,
-) -> Result<(), CarbideError> {
+) -> Result<rpc::AdminForceDeleteMachineResponse, CarbideError> {
+    let mut response = rpc::AdminForceDeleteMachineResponse::default();
     // Admission permit BEFORE the transaction: waiters on the admin-segment
     // advisory lock must queue in memory, not on open pool connections.
     let _admin_admission = db::machine_interface::admin_lock_admission().await;
@@ -511,7 +516,7 @@ async fn force_delete_cleanup_txn(
 
     txn.commit().await?;
 
-    Ok(())
+    Ok(response)
 }
 
 pub(crate) async fn admin_force_delete_machine(
@@ -830,16 +835,16 @@ pub(crate) async fn admin_force_delete_machine(
     // each attempt (50, 100, 200, 400 ms) for up to five total attempts.
     const MAX_CLEANUP_ATTEMPTS: u32 = 5;
     for attempt in 0..MAX_CLEANUP_ATTEMPTS {
-        match force_delete_cleanup_txn(
-            api,
-            host_machine.as_ref(),
-            &dpu_machines,
-            &request,
-            &mut response,
-        )
-        .await
-        {
-            Ok(()) => break,
+        match force_delete_cleanup_txn(api, host_machine.as_ref(), &dpu_machines, &request).await {
+            Ok(cleanup) => {
+                response.host_bmc_interface_associated = cleanup.host_bmc_interface_associated;
+                response.host_bmc_interface_deleted = cleanup.host_bmc_interface_deleted;
+                response.host_interfaces_deleted = cleanup.host_interfaces_deleted;
+                response.dpu_bmc_interface_associated = cleanup.dpu_bmc_interface_associated;
+                response.dpu_bmc_interface_deleted = cleanup.dpu_bmc_interface_deleted;
+                response.dpu_interfaces_deleted = cleanup.dpu_interfaces_deleted;
+                break;
+            }
             Err(error)
                 if error.is_retryable_transaction_error() && attempt + 1 < MAX_CLEANUP_ATTEMPTS =>
             {

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -437,7 +437,6 @@ impl DatabaseError {
             _ => false,
         }
     }
-
 }
 
 pub type DatabaseResult<T> = Result<T, DatabaseError>;

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -437,6 +437,7 @@ impl DatabaseError {
             _ => false,
         }
     }
+
 }
 
 pub type DatabaseResult<T> = Result<T, DatabaseError>;


### PR DESCRIPTION
…lure

`admin_force_delete_machine` splits work across two transactions: the first commits the `ForceDeletion` state, and the second runs the actual DB cleanup. The machine-controller explicitly no-ops on `ForceDeletion` ("delete is done directly in api.rs"), so if the cleanup transaction is aborted by Postgres. The machine is permanently wedged until an operator manually re-invokes machine force-delete`.

This fixes the error case by extracting the cleanup transaction into `force_delete_cleanup_txn` and retrying up to five times on SQLSTATE `40P01` (deadlock) or `40001` (serialization failure), with exponential backoff starting at 50 ms. Postgres aborts the losing transaction on deadlock, leaving the DB unchanged, so the retry is safe.

Fixes #6447095

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)


