### PR TITLE
patch(v2.1): allow site-agent to call REST-proxied admin operations

### DIFF
--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -300,7 +300,7 @@ impl InternalRBACRules {
         x.perm("AdminGrowResourcePool", vec![ForgeAdminCLI]);
         x.perm("SetMaintenance", vec![ForgeAdminCLI, SiteAgent, Flow]);
         x.perm("SetDynamicConfig", vec![ForgeAdminCLI, Machineatron]);
-        x.perm("TriggerDpuReprovisioning", vec![ForgeAdminCLI]);
+        x.perm("TriggerDpuReprovisioning", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("TriggerHostReprovisioning", vec![ForgeAdminCLI, Flow]);
         x.perm("ListDpuWaitingForReprovisioning", vec![ForgeAdminCLI]);
         x.perm("MarkManualFirmwareUpgradeComplete", vec![ForgeAdminCLI]);
@@ -516,7 +516,7 @@ impl InternalRBACRules {
         );
         x.perm("HeartbeatMachineValidationRun", vec![Scout, SiteAgent]);
         x.perm("AdminBmcReset", vec![ForgeAdminCLI]);
-        x.perm("AdminPowerControl", vec![ForgeAdminCLI, Flow]);
+        x.perm("AdminPowerControl", vec![ForgeAdminCLI, SiteAgent, Flow]);
         x.perm("DisableSecureBoot", vec![ForgeAdminCLI]);
         x.perm("MachineSetup", vec![ForgeAdminCLI]);
         x.perm("SetDpuFirstBootOrder", vec![ForgeAdminCLI]);
@@ -1134,6 +1134,27 @@ mod rbac_rule_tests {
                 "elektra-site-agent".to_string()
             )]
         ));
+
+        // REST admin operations proxy to Core as the site agent (issue #4597).
+        for method in ["AdminPowerControl", "TriggerDpuReprovisioning"] {
+            assert!(
+                InternalRBACRules::allowed_from_static(
+                    method,
+                    &[Principal::SpiffeServiceIdentifier(
+                        "elektra-site-agent".to_string()
+                    )]
+                ),
+                "{method} should allow the site agent"
+            );
+            assert!(
+                !InternalRBACRules::allowed_from_static(
+                    method,
+                    &[Principal::SpiffeServiceIdentifier("nico-dns".to_string())]
+                ),
+                "{method} should reject unrelated services"
+            );
+        }
+
         assert!(InternalRBACRules::allowed_from_static(
             "FindNetworkSegmentsByIds",
             &[


### PR DESCRIPTION
## Summary

Backport of #4639, which has already been reviewed and merged into `main`,
to `release/v2.1`.

The 2.1 release has the same REST-to-Core proxy paths and missing
SiteAgent RBAC permissions. This patch applies the same one-file change,
allowing SiteAgent to call `AdminPowerControl` and
`TriggerDpuReprovisioning` with the same regression coverage.

## Related issues

- Backport of merged PR #4639
- Related to #4597

## Type of Change

- [ ] Add - New feature or capability
- [ ] Change - Changes in existing functionality
- [x] Fix - Bug fixes
- [ ] Remove - Removed features or deprecated functionality
- [ ] Internal - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] This PR contains breaking changes

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Same regression coverage as #4639: assertions for both methods using the
literal `elektra-site-agent` SPIFFE service identifier, plus negative
assertions confirming an unrelated service (`nico-dns`) is still denied.

Verified against `release/v2.1` in a Linux container:

- `cargo test --locked -p carbide-api-core --lib auth::internal_rbac_rules`
  - 2 passed; 0 failed; 0 ignored; 0 measured; 1537 filtered out
- `cargo make clippy-flow`
- `cargo make carbide-lints`
- `cargo make lint-error-messages`
  - scanned 2875 files; all `C-GOOD-ERR`
- `cargo make check-format-nightly`
- `cargo make check-event-names`
  - checked 194 `event_name` declarations
- `cargo make check-workspace-deps`
- `cargo make check-metric-docs`
  - 123 counters/histograms documented
- `cargo make check-licenses`
  - licenses OK
- `cargo make check-bans`
  - bans OK; duplicate-crate warnings were non-fatal

The aggregate `cargo make pre-commit-verify-workspace` task was not run
because the available Docker image does not include Go or Buf, which are
required by `generate-rest-core-proto`. The change does not modify proto
sources or generated output. All nine remaining gate tasks listed above
were run individually and passed.

## Additional Notes

**Scope.** This is a targeted backport. It changes only the two RBAC
entries confirmed by #4597; no other permissions are modified. See #4639
for the full audit of REST-proxied methods.

**Known limitation.** This allows REST-proxied admin operations to reach
Core as the site agent. It does not make Core distinguish between “a
Provider admin requested this through REST” and “the site agent initiated
it directly”—the original Provider-admin identity is lost at the
`ExecuteCoreGRPC` proxy boundary. Propagating it would be a cross-cutting
change and is out of scope.
