### PR TITLE
refactor(generated): adopt style guide rules for pub/module visibility

### DIFF
--- a/crates/agent/src/dhcp_server_grpc_client.rs
+++ b/crates/agent/src/dhcp_server_grpc_client.rs
@@ -16,6 +16,11 @@
  */
 
 mod proto {
+    #![allow(
+        unreachable_pub,
+        reason = "tonic_prost_build emits public items for this crate-internal protocol module"
+    )]
+
     tonic::include_proto!("dhcp_server_control");
 }
 

--- a/crates/api-core/src/admission/engine.rs
+++ b/crates/api-core/src/admission/engine.rs
@@ -125,7 +125,7 @@ pub(super) enum ClientKeyRef<'a> {
 }
 
 impl ClientKeyRef<'_> {
-    pub fn to_client_key(self) -> ClientKey {
+    fn to_client_key(self) -> ClientKey {
         match self {
             ClientKeyRef::Default => ClientKey::Default,
             ClientKeyRef::ExternalUser(u) => ClientKey::ExternalUser(u.to_owned()),

--- a/crates/api-web/src/filters.rs
+++ b/crates/api-web/src/filters.rs
@@ -20,6 +20,11 @@
  * Askama makes all these functions accessible as template filters.
  */
 
+#![allow(
+    unreachable_pub,
+    reason = "askama::filter_fn emits public helper items inside this template-filter module"
+)]
+
 use std::collections::BTreeSet;
 use std::fmt::{Display, Write};
 use std::str::FromStr;

--- a/crates/api-web/src/ipxe_template.rs
+++ b/crates/api-web/src/ipxe_template.rs
@@ -35,6 +35,11 @@ fn ipxe_template_visibility_fmt(visibility: &i32) -> Cow<'static, str> {
 }
 
 mod filters {
+    #![allow(
+        unreachable_pub,
+        reason = "askama::filter_fn emits public helper items inside this template-filter module"
+    )]
+
     pub(super) use super::super::filters::option_fmt;
 
     #[askama::filter_fn]

--- a/crates/api-web/src/redfish_actions.rs
+++ b/crates/api-web/src/redfish_actions.rs
@@ -205,6 +205,11 @@ pub(super) async fn cancel(AxumState(state): AxumState<Arc<Api>>, request_id: St
 }
 
 mod filters {
+    #![allow(
+        unreachable_pub,
+        reason = "askama::filter_fn emits public helper items inside this template-filter module"
+    )]
+
     use std::fmt::Write;
 
     use askama_escape::Escaper;

--- a/crates/api-web/src/resource_pool.rs
+++ b/crates/api-web/src/resource_pool.rs
@@ -28,6 +28,11 @@ use rpc::forge::forge_server::Forge;
 use super::Base;
 
 mod filters {
+    #![allow(
+        unreachable_pub,
+        reason = "askama::filter_fn emits public helper items inside this template-filter module"
+    )]
+
     #[askama::filter_fn]
     pub(super) fn resource_pool_allocated_fmt(
         pool: &super::forgerpc::ResourcePool,

--- a/crates/dhcp-server/src/grpc_server.rs
+++ b/crates/dhcp-server/src/grpc_server.rs
@@ -28,6 +28,11 @@ use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
 mod proto {
+    #![allow(
+        unreachable_pub,
+        reason = "tonic_prost_build emits public items for this crate-internal protocol module"
+    )]
+
     tonic::include_proto!("dhcp_server_control");
 }
 

--- a/crates/dhcp/src/kea/mod.rs
+++ b/crates/dhcp/src/kea/mod.rs
@@ -15,4 +15,8 @@
  * limitations under the License.
  */
 /// cbindgen:ignore
+#[allow(
+    unreachable_pub,
+    reason = "Kea loads these public hook symbols from the dynamic library"
+)]
 mod ffi;

--- a/crates/dhcp/src/lib.rs
+++ b/crates/dhcp/src/lib.rs
@@ -35,12 +35,32 @@ use rpc::forge_tls_client::ForgeClientConfig;
 use tokio::runtime::{Builder, Runtime};
 
 mod cache;
+#[allow(
+    unreachable_pub,
+    reason = "cbindgen exposes this module's public items through the Kea C++ ABI"
+)]
 mod discovery;
+#[allow(
+    unreachable_pub,
+    reason = "cbindgen exposes this module's public items through the Kea C++ ABI"
+)]
 mod discovery_v6;
 mod kea;
 mod kea_logger;
+#[allow(
+    unreachable_pub,
+    reason = "cbindgen exposes this module's public items through the Kea C++ ABI"
+)]
 mod lease_expiration;
+#[allow(
+    unreachable_pub,
+    reason = "cbindgen exposes this module's public items through the Kea C++ ABI"
+)]
 mod machine;
+#[allow(
+    unreachable_pub,
+    reason = "cbindgen exposes this module's public items through the Kea C++ ABI"
+)]
 mod machine_v6;
 mod metrics;
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/dpf/src/crds/mod.rs
+++ b/crates/dpf/src/crds/mod.rs
@@ -15,4 +15,9 @@
  * limitations under the License.
  */
 
+#![allow(
+    unreachable_pub,
+    reason = "kopium emits public re-exports inside private generated prelude modules"
+)]
+
 include!(concat!(env!("OUT_DIR"), "/crds/mod.rs"));

--- a/crates/health/src/collectors/nvue/gnmi/mod.rs
+++ b/crates/health/src/collectors/nvue/gnmi/mod.rs
@@ -20,12 +20,16 @@ mod on_change_processor;
 mod sample_processor;
 pub(in crate::collectors) mod subscriber;
 
-// prost generates ExtensionId::EidUnset / EidExperimental from gnmi_ext.proto,
-// where the proto convention prefixes every value with the enum abbreviation.
-// clippy flags the shared "Eid" prefix but we can't control generated code.
-#[allow(clippy::enum_variant_names)]
 mod proto {
-    #[allow(clippy::enum_variant_names)]
+    // prost generates ExtensionId::EidUnset / EidExperimental from gnmi_ext.proto,
+    // where the proto convention prefixes every value with the enum abbreviation.
+    // clippy flags the shared "Eid" prefix but we can't control generated code.
+    #![allow(clippy::enum_variant_names)]
+    #![allow(
+        unreachable_pub,
+        reason = "tonic_prost_build emits public items for this crate-internal protocol module"
+    )]
+
     mod gnmi_ext {
         tonic::include_proto!("gnmi_ext");
     }

--- a/crates/machine-controller/src/rpc.rs
+++ b/crates/machine-controller/src/rpc.rs
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-#[allow(dead_code)]
 pub(crate) mod scout_firmware_upgrade {
+    #![allow(dead_code)]
+    #![allow(
+        unreachable_pub,
+        reason = "tonic_prost_build emits public items for this crate-internal protocol module"
+    )]
+
     include!(concat!(env!("OUT_DIR"), "/scout_firmware_upgrade.rs"));
 }

--- a/crates/ssh-console-mock-api-server/src/generated/mod.rs
+++ b/crates/ssh-console-mock-api-server/src/generated/mod.rs
@@ -14,30 +14,66 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod common;
+pub(super) mod common;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod dns;
+mod dns;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod forge;
+pub(super) mod forge;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod health;
+mod health;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod machine_discovery;
+pub(super) mod machine_discovery;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod measured_boot;
+mod measured_boot;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod mlx_device;
+mod mlx_device;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod scout_firmware_upgrade;
+mod scout_firmware_upgrade;
+#[allow(
+    unreachable_pub,
+    reason = "tonic_prost_build emits public items in this generated module"
+)]
 #[allow(non_snake_case, unknown_lints, clippy::all)]
 #[rustfmt::skip]
-pub mod site_explorer;
+mod site_explorer;


### PR DESCRIPTION
This adopts the new style guide rules around `pub` and module visibility introduced in https://github.com/NVIDIA/infra-controller/pull/4522, defining the intentional generated and non-Rust boundaries that remain after the crate cleanup passes.

Primary callouts are:

- Keep generated tonic, prost, and Kopium output unchanged, with reasoned `unreachable_pub` allowances at the source-owned module or `include!` boundary that owns each output.
- Narrow the SSH mock's generated-module index to its actual callers before allowing each generator-owned child module.
- Keep Askama's 22 generated filter helpers inside the four modules where `#[askama::filter_fn]` expands them.
- Preserve 55 cbindgen and dynamically loaded Kea symbols at six module-scoped C/C++ ABI boundaries.
- Make the one API Core helper added after its crate cleanup private.
- Leave runtime behavior, wire contracts, templates, and generator-owned source unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4547.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The focused test runs covered 949 existing tests across the affected crates. The six packages touched by the final review adjustment were rerun afterward.

```bash
cargo test --locked -p carbide-agent -p carbide-dhcp-server -p carbide-dpf -p carbide-health -p carbide-ssh-console-mock-api-server -p carbide-api-web --all-features
cargo test --locked -p carbide-dhcp --lib --all-features
cargo test --locked -p carbide-api-core admission::engine::tests --lib
cargo test --locked -p carbide-machine-controller --lib --all-features
cargo clippy --locked --workspace --all-targets --all-features --message-format short -- --cap-lints warn -W unreachable-pub
cargo clippy --locked --workspace --all-targets --all-features --message-format short -- -D unreachable-pub
cargo make format-nightly
cargo make check-format-nightly
cargo make clippy
cargo make carbide-lints
git diff --check
```

## Additional Notes

The raw forced-lint inventory contains 1,729 intentional declarations: 1,400 in the SSH mock's generated children, 252 in `OUT_DIR` or Kopium output, 22 emitted by Askama, and 55 at the Kea ABI. The normal workspace lint and the strict `-D unreachable-pub` run both complete with no diagnostics outside the reviewed boundaries.

`make core/tests` could not start the 32 Machine Controller SQLx integration cases because the local Docker daemon is unavailable. The Machine Controller library tests and the full all-target/all-feature Clippy build passed locally; CI retains coverage of the Docker-backed path.

The tracked generated outputs and cbindgen header retained their pre-change hashes.

Closes #4547
