### PR TITLE
feat(helm): add ipmi sim support config to machine-a-tron

### DIFF
--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -1417,6 +1417,7 @@ where
         mock_bmc_ssh_server: false,
         mock_bmc_ssh_port: None,
         enable_ipmi_simulation: false,
+        ipmi_reachable_port: None,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
     };

--- a/crates/api-integration-tests/tests/rack.rs
+++ b/crates/api-integration-tests/tests/rack.rs
@@ -178,6 +178,7 @@ async fn run_machine_a_tron_racks_test(
         mock_bmc_ssh_server: false,
         mock_bmc_ssh_port: None,
         enable_ipmi_simulation: false,
+        ipmi_reachable_port: None,
         hw_mac_address_ranges: None,
         mac_address_pool: None,
     };

--- a/crates/machine-a-tron/Dockerfile
+++ b/crates/machine-a-tron/Dockerfile
@@ -79,7 +79,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iputils-ping \
     libssl3 \
     libudev1 \
-    openipmi-utils \
+    openipmi \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/machine-a-tron/bin /tmp/machine-a-tron-data

--- a/crates/machine-a-tron/Dockerfile
+++ b/crates/machine-a-tron/Dockerfile
@@ -74,10 +74,12 @@ LABEL org.opencontainers.image.vendor="NVIDIA"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
+    ipmitool \
     iproute2 \
     iputils-ping \
     libssl3 \
     libudev1 \
+    openipmi-utils \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/machine-a-tron/bin /tmp/machine-a-tron-data

--- a/crates/machine-a-tron/Dockerfile
+++ b/crates/machine-a-tron/Dockerfile
@@ -1,21 +1,25 @@
 # syntax=docker/dockerfile:1.7
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
-# Cross-compilation: the BUILDER always runs NATIVE on the build host
-# ($BUILDPLATFORM) and cross-compiles to x86_64-unknown-linux-gnu. This is not
-# a Mac convenience: building the amd64 stage the naive way on an Apple
-# Silicon host runs rustc under QEMU emulation, and QEMU SEGFAULTs assembling
-# aws-lc-sys's hand-written x86-64 assembly (s2n-bignum) — even though the
-# resulting binary runs fine on real x86_64. On an x86_64 build host the
-# builder is simply native and the "cross" compile is a no-op.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build from the repo root:
 #
-#   docker buildx build \
-#     --platform linux/amd64 \
+#   docker buildx build --platform linux/amd64 \
 #     -f crates/machine-a-tron/Dockerfile \
-#     --build-arg VERSION=0.1.0 \
-#     -t machine-a-tron:latest \
-#     .
+#     --build-arg VERSION=0.1.0 -t machine-a-tron:latest .
 #
 ARG RUST_VERSION=1.96.0
 

--- a/crates/machine-a-tron/Dockerfile
+++ b/crates/machine-a-tron/Dockerfile
@@ -21,6 +21,12 @@
 #     -f crates/machine-a-tron/Dockerfile \
 #     --build-arg VERSION=0.1.0 -t machine-a-tron:latest .
 #
+# NOTE: Cross-compilation architecture
+# The BUILDER stage always runs NATIVE on the build host ($BUILDPLATFORM) and
+# cross-compiles to x86_64-unknown-linux-gnu. This avoids QEMU emulation when
+# building on Apple Silicon hosts, which would otherwise SEGFAULT while
+# assembling aws-lc-sys's hand-written x86-64 assembly code.
+#
 ARG RUST_VERSION=1.96.0
 
 FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-slim-bookworm AS builder

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -157,7 +157,7 @@ impl BmcMockWrapper {
         } else {
             None
         };
-        let ipmi_sim_handle = self.start_ipmi_sim(address.ip(), None).await?;
+        let ipmi_sim_handle = self.start_ipmi_sim(address.ip()).await?;
 
         tracing::info!(
             listen_address = ?address,
@@ -188,7 +188,7 @@ impl BmcMockWrapper {
         bind_ip: std::net::IpAddr,
     ) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
         Ok(self
-            .start_ipmi_sim(bind_ip, Some(DEFAULT_IPMI_PORT))
+            .start_ipmi_sim(bind_ip)
             .await?
             .map(|ipmi_sim_handle| BmcMockWrapperHandle {
                 _bmc_mock: None,
@@ -200,11 +200,20 @@ impl BmcMockWrapper {
     async fn start_ipmi_sim(
         &self,
         bind_ip: std::net::IpAddr,
-        reachable_port: Option<u16>,
     ) -> Result<Option<IpmiSimHandle>, MachineStateError> {
         if !self.app_context.app_config.enable_ipmi_simulation || !self.supports_ipmi_console {
             return Ok(None);
         }
+
+        // Determine the reachable port advertised through Redfish:
+        // - None (unset): Use default port
+        // - Some(0): Use dynamic port (same as listen port)
+        // - Some(n): Use the specified port
+        let reachable_port = match self.app_context.app_config.ipmi_reachable_port {
+            None => Some(DEFAULT_IPMI_PORT),
+            Some(0) => None,
+            Some(port) => Some(port),
+        };
 
         let console_prompt = format!("root@{} # ", self.hostname.get_hostname());
         bmc_mock::ipmi_sim::start(

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -415,6 +415,13 @@ pub struct MachineATronConfig {
     #[serde(default = "default_false")]
     pub enable_ipmi_simulation: bool,
 
+    /// IPMI port advertised through Redfish for client connections.
+    /// - Unset/None: Use default port
+    /// - 0: Use dynamic port (same as listen port)
+    /// - 1-65535: Use this specific port
+    #[serde(default)]
+    pub ipmi_reachable_port: Option<u16>,
+
     /// Set this to configure the port to use when mocking a BMC SSH server. If unset and
     /// use_single_bmc_mock is true, it will pick a random port. If unset and use_single_bmc_mock
     /// is false, it will use port 2222 for each IP alias. (Port 22 is problematic because it
@@ -1194,6 +1201,11 @@ scout_run_interval = "5s"
     #[test]
     fn ipmi_simulation_is_disabled_by_default() {
         assert!(!rack_config().enable_ipmi_simulation);
+    }
+
+    #[test]
+    fn ipmi_reachable_port_is_unset_by_default() {
+        assert!(rack_config().ipmi_reachable_port.is_none());
     }
 
     #[test]

--- a/dev/deployment/devspace/Dockerfile.machine-a-tron
+++ b/dev/deployment/devspace/Dockerfile.machine-a-tron
@@ -35,10 +35,12 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
+  ipmitool \
   iproute2 \
   iputils-ping \
   libssl3 \
   libudev1 \
+  openipmi \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/machine-a-tron/bin /tmp/machine-a-tron-data

--- a/dev/k8s/machine-a-tron-controller/README.md
+++ b/dev/k8s/machine-a-tron-controller/README.md
@@ -8,7 +8,8 @@ Services for mock BMC endpoints.
 - Auto-discovers machine-a-tron pods via `nvidia-infra-controller/mat-service=true`
   label
 - Creates ClusterIP Services with BMC IP for each mock BMC
-- Supports Redfish (TCP 443) ports
+- Supports Redfish (TCP 443) and IPMI (UDP 623) ports
+- IPMI ports are dynamically added when machine-a-tron reports `bmc.ipmi` in status
 - Multi-pod deployments with pod-specific routing
 - Automatic cleanup of stale Services
 
@@ -81,6 +82,13 @@ Created Services have:
 - `nvidia-infra-controller/mat-api-state`
 - `nvidia-infra-controller/mat-power-state`
 - `nvidia-infra-controller/mat-hardware-type`
+- `nvidia-infra-controller/mat-ipmi-listen-port` (when IPMI enabled)
+
+**Ports:**
+
+- `redfish` (TCP) - Always present for Redfish API access
+- `ipmi` (UDP) - Present only when machine-a-tron reports `bmc.ipmi` in status
+  (requires `enableIpmiSimulation: true` in Helm values)
 
 ## Development
 

--- a/dev/k8s/machine-a-tron-controller/README.md
+++ b/dev/k8s/machine-a-tron-controller/README.md
@@ -82,13 +82,12 @@ Created Services have:
 - `nvidia-infra-controller/mat-api-state`
 - `nvidia-infra-controller/mat-power-state`
 - `nvidia-infra-controller/mat-hardware-type`
-- `nvidia-infra-controller/mat-ipmi-listen-port` (when IPMI enabled)
+- `nvidia-infra-controller/mat-ipmi-listen-port` (when `bmc.ipmi` reported in status)
 
 **Ports:**
 
 - `redfish` (TCP) - Always present for Redfish API access
 - `ipmi` (UDP) - Present only when machine-a-tron reports `bmc.ipmi` in status
-  (requires `enableIpmiSimulation: true` in Helm values)
 
 ## Development
 

--- a/dev/k8s/machine-a-tron-controller/pkg/matclient/client.go
+++ b/dev/k8s/machine-a-tron-controller/pkg/matclient/client.go
@@ -150,7 +150,7 @@ func (c *Client) GetMachinesStatus(ctx context.Context) (*MachinesStatusResponse
 	if err != nil {
 		return nil, fmt.Errorf("executing request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodySize))

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -253,6 +253,17 @@ machineATron:
 | `0` | Use dynamic port (required for K8s controller mode) |
 | `1-65535` | Use specified port |
 
+**Deployment Mode Considerations:**
+
+| Mode | IPMI Accessible? | Notes |
+|------|------------------|-------|
+| Controller mode (`useSingleBmcMock: true` + `mat-k8s-controller`) |Yes | Use `ipmiReachablePort: 0`. Controller creates per-BMC Services with dynamic IPMI ports. |
+| Shared-proxy mode (`useSingleBmcMock: true` without controller) |No | No per-BMC Services to route dynamic IPMI ports. IPMI simulators run but are not externally reachable. |
+| Override mode (`useSingleBmcMock: false`) |Yes | Each BMC gets its own IP address. Use `ipmiReachablePort: 623` (default) or a fixed port. |
+
+> **Note:** IPMI ports are only added to Services for host machines with
+> IPMI-capable hardware types (eg, NVIDIA GB300, Supermicro GB300)
+
 When using K8s controller mode (`machineATron.useSingleBmcMock: true`), set
 `ipmiReachablePort: 0` so each IPMI simulator gets a unique dynamic port that
 the `mat-k8s-controller` can map to individual Services.
@@ -264,7 +275,7 @@ When enabled:
 2. The `/machines/status` API reports `bmc.ipmi` with `reachable_port` and
    `listen_port` for each BMC with IPMI enabled
 3. The `mat-k8s-controller` creates UDP Service ports for IPMI access alongside
-   the existing TCP Redfish port
+   the existing TCP Redfish port (controller mode only)
 
 **Requirements:**
 

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -253,7 +253,7 @@ machineATron:
 | `0` | Use dynamic port (required for K8s controller mode) |
 | `1-65535` | Use specified port |
 
-When using K8s controller mode (`use_single_bmc_mock: true`), set
+When using K8s controller mode (`machineATron.useSingleBmcMock: true`), set
 `ipmiReachablePort: 0` so each IPMI simulator gets a unique dynamic port that
 the `mat-k8s-controller` can map to individual Services.
 

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -241,7 +241,21 @@ hardware types have IPMI support).
 ```yaml
 machineATron:
   enableIpmiSimulation: true
+  # For K8s controller mode, use dynamic ports so each BMC gets a unique port
+  ipmiReachablePort: 0
 ```
+
+**Port Configuration:**
+
+| `ipmiReachablePort` | Behavior |
+|---------------------|----------|
+| Unset (default) | Advertise port 623 in Redfish |
+| `0` | Use dynamic port (required for K8s controller mode) |
+| `1-65535` | Use specified port |
+
+When using K8s controller mode (`use_single_bmc_mock: true`), set
+`ipmiReachablePort: 0` so each IPMI simulator gets a unique dynamic port that
+the `mat-k8s-controller` can map to individual Services.
 
 When enabled:
 
@@ -254,7 +268,7 @@ When enabled:
 
 **Requirements:**
 
-- The machine-a-tron container image must include `ipmi_sim` (from `openipmi-utils`)
+- The machine-a-tron container image must include `ipmi_sim` (from `openipmi`)
   and `ipmitool` - these are included in the standard image
 - Only IPMI-capable hardware types will expose IPMI endpoints
 

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -160,13 +160,19 @@ spec:
     port: 443
     targetPort: 1266  # Redfish listen port from machine-a-tron (default: service.bmcMock.port)
     protocol: TCP
+  - name: ipmi        # Only present when IPMI simulation is enabled and BMC reports bmc.ipmi
+    port: 623
+    targetPort: 16023  # IPMI listen port from machine-a-tron
+    protocol: UDP
   selector:
     app.kubernetes.io/name: nico-machine-a-tron
     nvidia-infra-controller/pod-name: mat-0
 ```
 
 The `targetPort` is the Redfish listen port reported by machine-a-tron, which
-defaults to the configured `service.bmcMock.port` (1266).
+defaults to the configured `service.bmcMock.port` (1266). When IPMI simulation
+is enabled and the BMC reports `bmc.ipmi` in its status, the controller also
+adds a dynamic target UDP port for IPMI access.
 
 ### Requirements
 
@@ -225,6 +231,32 @@ pods:
         oobDhcpRelayAddress: "10.96.64.1"
         adminDhcpRelayAddress: "192.168.176.1"
 ```
+
+### IPMI/SOL Simulation
+
+Enable IPMI/SOL simulation to expose per-BMC IPMI endpoints for IPMI-capable
+mocked BMCs. This is optional and only affects BMCs that support IPMI (not all
+hardware types have IPMI support).
+
+```yaml
+machineATron:
+  enableIpmiSimulation: true
+```
+
+When enabled:
+
+1. Machine-a-tron starts an independent IPMI simulator (`ipmi_sim`) for each
+   IPMI-capable host BMC
+2. The `/machines/status` API reports `bmc.ipmi` with `reachable_port` and
+   `listen_port` for each BMC with IPMI enabled
+3. The `mat-k8s-controller` creates UDP Service ports for IPMI access alongside
+   the existing TCP Redfish port
+
+**Requirements:**
+
+- The machine-a-tron container image must include `ipmi_sim` (from `openipmi-utils`)
+  and `ipmitool` - these are included in the standard image
+- Only IPMI-capable hardware types will expose IPMI endpoints
 
 ### MAC Address Pool Configuration
 

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -95,6 +95,9 @@ data:
     {{- if $root.Values.machineATron.enableIpmiSimulation }}
     enable_ipmi_simulation = true
     {{- end }}
+    {{- if (hasKey $root.Values.machineATron "ipmiReachablePort") }}
+    ipmi_reachable_port = {{ $root.Values.machineATron.ipmiReachablePort }}
+    {{- end }}
     {{- if $root.Values.machineATron.hostBmcPassword }}
     host_bmc_password = {{ $root.Values.machineATron.hostBmcPassword | quote }}
     {{- end }}

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -92,6 +92,9 @@ data:
     {{- end }}
     cleanup_on_quit = {{ $root.Values.machineATron.cleanupOnQuit }}
     register_expected_machines = {{ $root.Values.machineATron.registerExpectedMachines }}
+    {{- if $root.Values.machineATron.enableIpmiSimulation }}
+    enable_ipmi_simulation = true
+    {{- end }}
     {{- if $root.Values.machineATron.hostBmcPassword }}
     host_bmc_password = {{ $root.Values.machineATron.hostBmcPassword | quote }}
     {{- end }}

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -84,3 +84,18 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: 'scout_run_interval = "120s"'
+
+  - it: should not include enable_ipmi_simulation by default
+    asserts:
+      - notMatchRegex:
+          path: data["mat.toml"]
+          pattern: "enable_ipmi_simulation"
+
+  - it: should include enable_ipmi_simulation when enabled
+    set:
+      machineATron:
+        enableIpmiSimulation: true
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "enable_ipmi_simulation = true"

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -99,3 +99,29 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: "enable_ipmi_simulation = true"
+
+  - it: should not include ipmi_reachable_port by default
+    asserts:
+      - notMatchRegex:
+          path: data["mat.toml"]
+          pattern: "ipmi_reachable_port"
+
+  - it: should include ipmi_reachable_port when set to 0 for dynamic
+    set:
+      machineATron:
+        enableIpmiSimulation: true
+        ipmiReachablePort: 0
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "ipmi_reachable_port = 0"
+
+  - it: should include ipmi_reachable_port when set to custom value
+    set:
+      machineATron:
+        enableIpmiSimulation: true
+        ipmiReachablePort: 12345
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: "ipmi_reachable_port = 12345"

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -137,6 +137,9 @@ machineATron:
   persistDir: "/tmp/machine-a-tron-data"
   cleanupOnQuit: false
   enableIpmiSimulation: false
+  # IPMI port advertised through Redfish. Unset uses default 623
+  # Set to 0 for dynamic port (required for mat-k8s-controller)
+  # ipmiReachablePort: 0
   registerExpectedMachines: true
   hostBmcPassword: ""
   dpuBmcPassword: ""

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -136,6 +136,7 @@ machineATron:
   configureBmcProxyHost: ""
   persistDir: "/tmp/machine-a-tron-data"
   cleanupOnQuit: false
+  enableIpmiSimulation: false
   registerExpectedMachines: true
   hostBmcPassword: ""
   dpuBmcPassword: ""


### PR DESCRIPTION
This PR completes the IPMI sim support for machine-a-tron (MAT) k8s controller mode

**Background:** Previous PRs (#3542, #3687) added IPMI sim support to MAT and the controller already has the logic to create udp service ports

When enabled, each IPMI BMC gets an independent IPMI sim and the controller automatically creates udp service ports for IPMI access alongside the existing TCP Redfish ports.

## Related issues
Closes #4413

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

**Tests results:**
- `helm unittest helm/charts/nico-machine-a-tron` - All 23 tests pass (including 4 new IPMI config tests)
- `go test ./...` in `dev/k8s/machine-a-tron-controller` - All tests pass