### PR TITLE
patch(v2.1): use lowercase phone_home post key

### DIFF
--- a/rest-api/api/pkg/api/model/util/testdata/cloud-init-phone-home.schema.json
+++ b/rest-api/api/pkg/api/model/util/testdata/cloud-init-phone-home.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The cc_phone_home schema from https://github.com/canonical/cloud-init/blob/26.1/cloudinit/config/schemas/schema-cloud-config-v1.json#L2351-L2398.",
+  "type": "object",
+  "required": [
+    "phone_home"
+  ],
+  "properties": {
+    "phone_home": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL to send the phone home data to."
+        },
+        "post": {
+          "description": "A list of keys to post or ``all``. Default: ``all``.",
+          "oneOf": [
+            {
+              "enum": [
+                "all"
+              ]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "pub_key_rsa",
+                  "pub_key_ecdsa",
+                  "pub_key_ed25519",
+                  "instance_id",
+                  "hostname",
+                  "fqdn"
+                ]
+              }
+            }
+          ]
+        },
+        "tries": {
+          "type": "integer",
+          "description": "The number of times to try sending the phone home data. Default: ``10``.",
+          "default": 10
+        }
+      }
+    }
+  }
+}

--- a/rest-api/api/pkg/api/model/util/util.go
+++ b/rest-api/api/pkg/api/model/util/util.go
@@ -16,7 +16,7 @@ import (
 const (
 	// configuration for phone home
 	SitePhoneHomeName    = "phone_home"
-	SitePhoneHomePost    = "POST"
+	SitePhoneHomePost    = "post"
 	SitePhoneHomePostAll = "all"
 	SitePhoneHomeUrl     = "url"
 	SiteCloudConfig      = "#cloud-config"

--- a/rest-api/api/pkg/api/model/util/util_test.go
+++ b/rest-api/api/pkg/api/model/util/util_test.go
@@ -6,10 +6,32 @@ package util
 import (
 	"testing"
 
+	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+func TestInsertedPhoneHomeMatchesCloudInitSchema(t *testing.T) {
+	documentRoot := unmarshalDocumentRoot(t, `autoinstall:
+  version: 1
+`)
+	require.NoError(t, InsertPhoneHomeIntoUserData(documentRoot, "http://169.254.169.254/phone_home"))
+
+	autoinstallNode := mappingNodeValue(documentRoot, "autoinstall")
+	require.NotNil(t, autoinstallNode)
+	targetUserDataNode := mappingNodeValue(autoinstallNode, "user-data")
+	require.NotNil(t, targetUserDataNode)
+
+	var targetUserData any
+	require.NoError(t, targetUserDataNode.Decode(&targetUserData))
+
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
+	schema, err := compiler.Compile("testdata/cloud-init-phone-home.schema.json")
+	require.NoError(t, err)
+	require.NoError(t, schema.Validate(targetUserData))
+}
 
 func TestInsertPhoneHomeIntoUserData(t *testing.T) {
 	const phoneHomeURL = "http://169.254.169.254/phone-home"

--- a/rest-api/go.mod
+++ b/rest-api/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.33.0
 	github.com/samber/lo v1.52.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
@@ -370,7 +371,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.29.0 // indirect
 	github.com/securego/gosec/v2 v2.26.1 // indirect


### PR DESCRIPTION
Backport of #4670 to `release/v2.1`.

## What changed

- Use the lowercase `post` property in the cloud-init `phone_home` configuration.
- Add schema-backed coverage for the generated nested `autoinstall.user-data` phone-home configuration.

## Why

Ubuntu validates nested cloud-config strictly and rejects the uppercase `POST` property, leaving affected installations stuck in `Provisioning`. Cloud-init mandates the lowercase `post` property.

## Validation

- `go test ./api/pkg/api/model/util`

Ref: 6569456