### PR TITLE
feat(health): add endpoint TCP reachability telemetry

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -201,6 +201,16 @@ max_jitter = "40ms"
 refresh_interval = "60m"
 discovery_concurrency = 1
 
+# Optional direct TCP checks for ports used by eligible enabled collectors.
+# Every check emits a metric; "unreachable" logs failures and "all" logs every result.
+# Checks bypass BMC proxies and do not verify TLS, authentication, or protocol readiness.
+# Results never create health reports or alerts.
+[collectors.reachability]
+enabled = true
+interval = "30s"
+timeout = "3s"
+log_mode = "unreachable"
+
 [collectors.sensors]
 sensor_fetch_interval = "1m"
 sensor_fetch_concurrency = 10

--- a/crates/health/src/collectors/mod.rs
+++ b/crates/health/src/collectors/mod.rs
@@ -27,6 +27,7 @@ mod nmxt;
 mod nvue;
 #[cfg(test)]
 pub(in crate::collectors) mod projection_test_support;
+mod reachability;
 mod runtime;
 mod sensors;
 mod telemetry;
@@ -43,9 +44,14 @@ pub use logs::{
     SseLogCollector, SseLogCollectorConfig,
 };
 pub use nmxc::{NmxcCollector, NmxcCollectorConfig};
+pub(crate) use nmxt::NMXT_PORT;
 pub use nmxt::{NmxtCollector, NmxtCollectorConfig};
 pub(crate) use nvue::gnmi::subscriber::spawn_gnmi_collector;
 pub use nvue::rest::collector::{NvueRestCollector, NvueRestCollectorConfig};
+pub(crate) use reachability::{
+    COLLECTOR_TYPE as REACHABILITY_COLLECTOR_TYPE, ReachabilityCollector,
+    ReachabilityCollectorStartConfig, ReachabilityService, ReachabilityTarget,
+};
 pub use runtime::{
     BackoffConfig, Collector, CollectorStartContext, EventStream, ExponentialBackoff,
     IterationResult, PeriodicCollector, StreamMetrics, StreamingCollector,

--- a/crates/health/src/collectors/nmxt.rs
+++ b/crates/health/src/collectors/nmxt.rs
@@ -42,7 +42,7 @@ use crate::sink::{CollectorEvent, DataSink, EventContext, MetricSample};
 use crate::tls::MtlsHttpClientProvider;
 
 /// default NMX-T port
-const NMXT_PORT: u16 = 9352;
+pub(crate) const NMXT_PORT: u16 = 9352;
 
 /// NMX-T endpoint
 const NMXT_ENDPOINT: &str = "/xcset/nvlink_domain_telemetry";

--- a/crates/health/src/collectors/reachability.rs
+++ b/crates/health/src/collectors/reachability.rs
@@ -1,0 +1,525 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use nv_redfish::core::Bmc;
+use tokio::net::TcpStream;
+
+use super::{IterationResult, PeriodicCollector};
+use crate::HealthError;
+use crate::config::ReachabilityLogMode;
+use crate::endpoint::BmcEndpoint;
+use crate::sink::{CollectorEvent, DataSink, EventContext, LogRecord, MetricSample};
+
+pub(crate) const COLLECTOR_TYPE: &str = "reachability";
+const METRIC_NAME: &str = "tcp_port";
+
+/// Collector service represented by a bounded reachability telemetry label.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReachabilityService {
+    Redfish,
+    NvueRest,
+    Gnmi,
+    Nmxt,
+    Nmxc,
+}
+
+impl ReachabilityService {
+    /// Returns the stable telemetry label value.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Redfish => "redfish",
+            Self::NvueRest => "nvue_rest",
+            Self::Gnmi => "gnmi",
+            Self::Nmxt => "nmxt",
+            Self::Nmxc => "nmxc",
+        }
+    }
+}
+
+/// TCP target and effective collector port selected by discovery.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ReachabilityTarget {
+    /// Collector service whose port is probed.
+    pub(crate) service: ReachabilityService,
+
+    /// Socket address selected from collector configuration.
+    pub(crate) address: SocketAddr,
+}
+
+impl ReachabilityTarget {
+    fn identity(&self) -> String {
+        format!("{}@{}", self.service.as_str(), self.address)
+    }
+}
+
+/// Result of one transport-level connection attempt.
+struct ProbeOutcome {
+    reachable: bool,
+    duration: Duration,
+    error: Option<String>,
+}
+
+/// Attempts a bounded TCP handshake without DNS or protocol exchange.
+async fn probe(address: SocketAddr, timeout: Duration) -> ProbeOutcome {
+    let started = Instant::now();
+    let result = tokio::time::timeout(timeout, TcpStream::connect(address)).await;
+    let duration = started.elapsed();
+
+    match result {
+        Ok(Ok(_stream)) => ProbeOutcome {
+            reachable: true,
+            duration,
+            error: None,
+        },
+        Ok(Err(error)) => ProbeOutcome {
+            reachable: false,
+            duration,
+            error: Some(error.to_string()),
+        },
+        Err(error) => ProbeOutcome {
+            reachable: false,
+            duration,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+/// Discovery-selected inputs for one reachability collector.
+pub(crate) struct ReachabilityCollectorStartConfig {
+    /// Effective collector ports to probe each cycle.
+    pub(crate) targets: Vec<ReachabilityTarget>,
+
+    /// Maximum duration for one connection attempt.
+    pub(crate) timeout: Duration,
+
+    /// Log policy, or `None` when no configured sink consumes log events.
+    pub(crate) log_mode: Option<ReachabilityLogMode>,
+
+    /// Sink route for metric and structured log observations.
+    pub(crate) sink: Arc<dyn DataSink>,
+}
+
+/// Periodic TCP probe collector that emits telemetry but no health reports.
+pub(crate) struct ReachabilityCollector {
+    targets: Vec<ReachabilityTarget>,
+    timeout: Duration,
+    log_mode: Option<ReachabilityLogMode>,
+    sink: Arc<dyn DataSink>,
+    event_context: EventContext,
+}
+
+impl<B: Bmc + 'static> PeriodicCollector<B> for ReachabilityCollector {
+    type Config = ReachabilityCollectorStartConfig;
+
+    fn new_runner(
+        _bmc: Arc<B>,
+        endpoint: Arc<BmcEndpoint>,
+        start_config: Self::Config,
+    ) -> Result<Self, HealthError> {
+        Ok(Self {
+            targets: start_config.targets,
+            timeout: start_config.timeout,
+            log_mode: start_config.log_mode,
+            sink: start_config.sink,
+            event_context: EventContext::from_endpoint(&endpoint, COLLECTOR_TYPE),
+        })
+    }
+
+    async fn run_iteration(&mut self) -> Result<IterationResult, HealthError> {
+        let mut fetch_failures = 0;
+
+        // Probe a target at a time so one endpoint cannot multiply connection fan-out.
+        for target in &self.targets {
+            let outcome = probe(target.address, self.timeout).await;
+
+            // Failed probes count as runtime fetch failures, but still emit observations.
+            fetch_failures += usize::from(!outcome.reachable);
+            self.emit_result(target, &outcome);
+        }
+
+        Ok(IterationResult {
+            refresh_triggered: true,
+            entity_count: Some(self.targets.len()),
+            fetch_failures,
+        })
+    }
+
+    fn collector_type(&self) -> &'static str {
+        COLLECTOR_TYPE
+    }
+
+    async fn stop(&mut self) {
+        // Prometheus uses this event to remove this collector's endpoint series.
+        self.sink
+            .handle_event(&self.event_context, &CollectorEvent::CollectorRemoved);
+    }
+}
+
+impl ReachabilityCollector {
+    /// Emits a metric and any log selected by the stateless policy.
+    fn emit_result(&self, target: &ReachabilityTarget, outcome: &ProbeOutcome) {
+        self.sink.handle_event(
+            &self.event_context,
+            &CollectorEvent::Metric(Box::new(MetricSample {
+                key: target.identity(),
+                name: METRIC_NAME.to_string(),
+                metric_type: "reachable".to_string(),
+                unit: "state".to_string(),
+                value: f64::from(outcome.reachable),
+                labels: vec![
+                    (
+                        Cow::Borrowed("service"),
+                        target.service.as_str().to_string(),
+                    ),
+                    (Cow::Borrowed("target_ip"), target.address.ip().to_string()),
+                    (Cow::Borrowed("port"), target.address.port().to_string()),
+                ],
+                // This is a transport observation, not a health threshold.
+                context: None,
+            })),
+        );
+
+        let emit_log = match self.log_mode {
+            Some(ReachabilityLogMode::All) => true,
+            Some(ReachabilityLogMode::Unreachable) => !outcome.reachable,
+            None => false,
+        };
+
+        if !emit_log {
+            return;
+        }
+
+        let (body, severity, message_id, state) = if outcome.reachable {
+            (
+                "TCP port is reachable",
+                "INFO",
+                "CarbideHealth.1.0.TcpPortReachable",
+                "reachable",
+            )
+        } else {
+            (
+                "TCP port is unreachable",
+                "WARN",
+                "CarbideHealth.1.0.TcpPortUnreachable",
+                "unreachable",
+            )
+        };
+
+        let mut attributes = vec![
+            (Cow::Borrowed("message_id"), message_id.to_string()),
+            (
+                Cow::Borrowed("message_args"),
+                format!("[\"{}\"]", target.identity()),
+            ),
+            (
+                Cow::Borrowed("reachability.service"),
+                target.service.as_str().to_string(),
+            ),
+            (
+                Cow::Borrowed("reachability.address"),
+                target.address.ip().to_string(),
+            ),
+            (
+                Cow::Borrowed("reachability.port"),
+                target.address.port().to_string(),
+            ),
+            (Cow::Borrowed("reachability.state"), state.to_string()),
+            (
+                Cow::Borrowed("reachability.probe_duration_seconds"),
+                outcome.duration.as_secs_f64().to_string(),
+            ),
+        ];
+
+        if let Some(error) = &outcome.error {
+            attributes.push((Cow::Borrowed("reachability.error"), error.clone()));
+        }
+
+        self.sink.handle_event(
+            &self.event_context,
+            &CollectorEvent::Log(Box::new(LogRecord {
+                body: body.to_string(),
+                severity: severity.to_string(),
+                attributes,
+                diagnostic_record: None,
+            })),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::endpoint::test_support::{mac, test_endpoint};
+    use crate::metrics::MetricsManager;
+    use crate::processor::{EventProcessingPipeline, HealthReportProcessor};
+    use crate::sink::PrometheusSink;
+
+    #[derive(Default)]
+    struct CapturingSink(Mutex<Vec<CollectorEvent>>);
+
+    impl DataSink for CapturingSink {
+        fn sink_type(&self) -> &'static str {
+            "capturing"
+        }
+
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), HealthError> {
+            self.0
+                .lock()
+                .expect("capturing sink mutex")
+                .push(event.clone());
+
+            Ok(())
+        }
+    }
+
+    fn target() -> ReachabilityTarget {
+        ReachabilityTarget {
+            service: ReachabilityService::Redfish,
+            address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 443),
+        }
+    }
+
+    fn collector(
+        sink: Arc<dyn DataSink>,
+        log_mode: Option<ReachabilityLogMode>,
+    ) -> ReachabilityCollector {
+        let mut endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+        endpoint
+            .labels
+            .insert("location".to_string(), "rack-a".to_string());
+
+        ReachabilityCollector {
+            targets: Vec::new(),
+            timeout: Duration::from_secs(1),
+            log_mode,
+            sink,
+            event_context: EventContext::from_endpoint(&endpoint, COLLECTOR_TYPE),
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_probe_reports_an_accepting_port_as_reachable() {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("test listener should bind");
+
+        let address = listener
+            .local_addr()
+            .expect("test listener should have an address");
+
+        let outcome = probe(address, Duration::from_secs(1)).await;
+
+        assert!(outcome.reachable);
+        assert_eq!(outcome.error, None);
+
+        drop(listener);
+        let outcome = probe(address, Duration::from_secs(1)).await;
+
+        assert!(!outcome.reachable);
+        assert!(outcome.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn iteration_emits_one_metric_for_each_target() {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("test listener should bind");
+
+        let address = listener
+            .local_addr()
+            .expect("test listener should have an address");
+
+        let sink = Arc::new(CapturingSink::default());
+        let mut collector = collector(sink.clone(), Some(ReachabilityLogMode::Unreachable));
+
+        collector.targets.push(ReachabilityTarget {
+            service: ReachabilityService::Redfish,
+            address,
+        });
+
+        <ReachabilityCollector as PeriodicCollector<crate::bmc::BmcClient>>::run_iteration(
+            &mut collector,
+        )
+        .await
+        .expect("probe cycle should complete");
+
+        let events = sink.0.lock().expect("sink mutex");
+
+        assert!(matches!(events.as_slice(), [CollectorEvent::Metric(_)]));
+    }
+
+    #[test]
+    fn log_modes_control_logs_without_suppressing_metrics() {
+        let cases = [
+            ("all success", Some(ReachabilityLogMode::All), true, 1),
+            ("all failure", Some(ReachabilityLogMode::All), false, 1),
+            (
+                "unreachable success",
+                Some(ReachabilityLogMode::Unreachable),
+                true,
+                0,
+            ),
+            (
+                "unreachable failure",
+                Some(ReachabilityLogMode::Unreachable),
+                false,
+                1,
+            ),
+            ("no log sink", None, false, 0),
+        ];
+
+        for (name, log_mode, reachable, expected_logs) in cases {
+            let sink = Arc::new(CapturingSink::default());
+            let collector = collector(sink.clone(), log_mode);
+
+            collector.emit_result(
+                &target(),
+                &ProbeOutcome {
+                    reachable,
+                    duration: Duration::from_millis(2),
+                    error: (!reachable).then(|| "probe failed".to_string()),
+                },
+            );
+
+            let events = sink.0.lock().expect("sink mutex");
+
+            let logs = events
+                .iter()
+                .filter_map(|event| match event {
+                    CollectorEvent::Log(log) => Some(log),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                events
+                    .iter()
+                    .filter(|event| matches!(event, CollectorEvent::Metric(metric) if metric.context.is_none()))
+                    .count(),
+                1,
+                "{name}",
+            );
+
+            assert_eq!(logs.len(), expected_logs, "{name}");
+
+            if log_mode == Some(ReachabilityLogMode::Unreachable) && !reachable {
+                let log = logs.first().expect("failed probe should emit a log record");
+
+                for (key, value) in [
+                    ("message_id", "CarbideHealth.1.0.TcpPortUnreachable"),
+                    ("reachability.service", "redfish"),
+                    ("reachability.address", "127.0.0.1"),
+                    ("reachability.port", "443"),
+                    ("reachability.state", "unreachable"),
+                    ("reachability.probe_duration_seconds", "0.002"),
+                    ("reachability.error", "probe failed"),
+                ] {
+                    assert!(
+                        log.attributes.iter().any(|(actual_key, actual_value)| {
+                            actual_key == key && actual_value == value
+                        }),
+                        "{name} should include {key}={value}",
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn metrics_are_created_on_observation_and_removed_when_collector_stops() {
+        let manager = Arc::new(MetricsManager::new("reachability_test").expect("metrics manager"));
+
+        let sink = Arc::new(
+            PrometheusSink::new(manager.clone(), "test").expect("prometheus sink should start"),
+        );
+
+        let collector = collector(sink.clone(), Some(ReachabilityLogMode::Unreachable));
+
+        collector.emit_result(
+            &target(),
+            &ProbeOutcome {
+                reachable: true,
+                duration: Duration::from_millis(2),
+                error: None,
+            },
+        );
+
+        let exposition = manager.export_telemetry().expect("telemetry exposition");
+        for expected in [
+            "test_tcp_port_reachable_state".to_string(),
+            "collector_type=\"reachability\"".to_string(),
+            "endpoint_key=\"00:11:22:33:44:55\"".to_string(),
+            "endpoint_ip=\"10.0.0.1\"".to_string(),
+            "location=\"rack-a\"".to_string(),
+            "service=\"redfish\"".to_string(),
+            "target_ip=\"127.0.0.1\"".to_string(),
+            "port=\"443\"".to_string(),
+        ] {
+            assert!(exposition.contains(&expected), "missing {expected}");
+        }
+
+        sink.handle_event(&collector.event_context, &CollectorEvent::CollectorRemoved);
+
+        assert!(
+            !manager
+                .export_telemetry()
+                .expect("telemetry exposition after collector removal")
+                .contains("test_tcp_port_reachable_state")
+        );
+    }
+
+    #[test]
+    fn normal_processor_pipeline_does_not_create_reachability_health_reports() {
+        let manager =
+            Arc::new(MetricsManager::new("reachability_pipeline").expect("metrics manager"));
+
+        let captured = Arc::new(CapturingSink::default());
+
+        let sink = Arc::new(EventProcessingPipeline::new(
+            vec![Arc::new(HealthReportProcessor::new())],
+            captured.clone(),
+            manager,
+        ));
+
+        let collector = collector(sink, Some(ReachabilityLogMode::Unreachable));
+
+        collector.emit_result(
+            &target(),
+            &ProbeOutcome {
+                reachable: true,
+                duration: Duration::from_millis(2),
+                error: None,
+            },
+        );
+
+        let events = captured.0.lock().expect("sink mutex");
+
+        assert!(matches!(events.as_slice(), [CollectorEvent::Metric(_)]));
+    }
+}

--- a/crates/health/src/collectors/reachability.rs
+++ b/crates/health/src/collectors/reachability.rs
@@ -33,7 +33,7 @@ pub(crate) const COLLECTOR_TYPE: &str = "reachability";
 const METRIC_NAME: &str = "tcp_port";
 
 /// Collector service represented by a bounded reachability telemetry label.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) enum ReachabilityService {
     Redfish,
     NvueRest,

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -371,7 +371,10 @@ impl StaticBmcEndpoint {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SinksConfig {
-    /// Tracing sink: logs all collector events through `tracing`.
+    /// Tracing sink: logs collector events through `tracing`.
+    ///
+    /// Reachability metrics are excluded because the collector emits explicit
+    /// structured records according to its `log_mode`.
     pub tracing: Configurable<TracingSinkConfig>,
 
     /// Prometheus sink: stores metric events in Prometheus exporter format.
@@ -859,6 +862,12 @@ pub struct CollectorsConfig {
 
     /// GPU inventory collector: compares OOB GPU count vs the assigned SKU.
     pub gpu_inventory: Configurable<GpuInventoryConfig>,
+
+    /// Direct TCP probes for ports used by enabled collectors.
+    ///
+    /// The probes report transport reachability only. They do not check TLS,
+    /// authentication, or collector protocol readiness.
+    pub reachability: Configurable<ReachabilityCollectorConfig>,
 }
 
 impl Default for CollectorsConfig {
@@ -875,7 +884,79 @@ impl Default for CollectorsConfig {
             nmxc: Configurable::Disabled,
             nvue: Configurable::Disabled,
             gpu_inventory: Configurable::Disabled,
+            reachability: Configurable::Disabled,
         }
+    }
+}
+
+/// Controls structured log emission for TCP reachability probes.
+///
+/// Metrics are emitted for every completed probe regardless of this setting.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReachabilityLogMode {
+    /// Emit a structured log for every successful and failed probe.
+    All,
+
+    /// Emit a structured log for every failed probe and suppress successful probes.
+    #[default]
+    Unreachable,
+}
+
+/// Global configuration for periodic TCP reachability probes.
+///
+/// The collector probes the BMC Redfish port when an enabled collector is
+/// eligible to use it, plus ports used by enabled eligible switch collectors.
+/// One global cadence applies to all targets; each collector's own configuration
+/// remains the source of truth for whether its target and port exist. Each
+/// completed probe is sent to configured metric sinks; configured log sinks
+/// receive policy-selected records.
+/// Results never create health reports. It is disabled by default.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ReachabilityCollectorConfig {
+    /// Interval between probe cycles for each endpoint.
+    ///
+    /// Every selected target is probed once per cycle and emits a state metric.
+    #[serde(with = "humantime_serde")]
+    pub interval: Duration,
+
+    /// Timeout for one TCP connection attempt.
+    ///
+    /// This bounds the TCP handshake only; it does not cover TLS or any
+    /// collector-specific protocol exchange.
+    #[serde(with = "humantime_serde")]
+    pub timeout: Duration,
+
+    /// Selects which completed probes emit structured log records.
+    ///
+    /// This policy is stateless: `unreachable` emits every failed probe, including
+    /// repeated failures after service restart. Metrics remain continuous in all modes.
+    pub log_mode: ReachabilityLogMode,
+}
+
+impl Default for ReachabilityCollectorConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(30),
+            timeout: Duration::from_secs(3),
+            log_mode: ReachabilityLogMode::Unreachable,
+        }
+    }
+}
+
+impl ReachabilityCollectorConfig {
+    /// Validates the probe cadence and timeout.
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        if self.interval.is_zero() {
+            return Err("[collectors.reachability].interval must be greater than 0".to_string());
+        }
+
+        if self.timeout.is_zero() {
+            return Err("[collectors.reachability].timeout must be greater than 0".to_string());
+        }
+
+        Ok(())
     }
 }
 
@@ -1808,6 +1889,10 @@ impl Config {
             nmxc.validate()?;
         }
 
+        if let Configurable::Enabled(reachability) = &self.collectors.reachability {
+            reachability.validate()?;
+        }
+
         if let Configurable::Enabled(gpu_inventory) = &self.collectors.gpu_inventory {
             if !self.endpoint_sources.carbide_api.is_enabled() {
                 return Err(
@@ -2102,8 +2187,19 @@ mod tests {
         assert!(config.collectors.logs.is_enabled());
         assert!(config.collectors.nvue.is_enabled());
         assert!(!config.collectors.nmxc.is_enabled());
+        assert!(config.collectors.reachability.is_enabled());
         assert!(!config.sinks.tracing.is_enabled());
         assert!(config.sinks.prometheus.is_enabled());
+
+        let reachability = config
+            .collectors
+            .reachability
+            .as_option()
+            .expect("example config enables reachability");
+
+        assert_eq!(reachability.interval, Duration::from_secs(30));
+        assert_eq!(reachability.timeout, Duration::from_secs(3));
+        assert_eq!(reachability.log_mode, ReachabilityLogMode::Unreachable);
 
         if let Configurable::Enabled(ref sensors) = config.collectors.sensors {
             assert_eq!(sensors.sensor_fetch_concurrency, 10);
@@ -4482,5 +4578,26 @@ max_backoff = "45s"
         let defaults = SseLogConfig::default();
         assert_eq!(defaults.initial_backoff, Duration::from_secs(1));
         assert_eq!(defaults.max_backoff, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn reachability_validation_rejects_non_positive_runtime_values() {
+        let mut config = ReachabilityCollectorConfig {
+            interval: Duration::ZERO,
+            ..ReachabilityCollectorConfig::default()
+        };
+
+        assert_eq!(
+            config.validate().expect_err("zero interval must fail"),
+            "[collectors.reachability].interval must be greater than 0"
+        );
+
+        config.interval = Duration::from_secs(1);
+        config.timeout = Duration::ZERO;
+
+        assert_eq!(
+            config.validate().expect_err("zero timeout must fail"),
+            "[collectors.reachability].timeout must be greater than 0"
+        );
     }
 }

--- a/crates/health/src/discovery/cleanup.rs
+++ b/crates/health/src/discovery/cleanup.rs
@@ -141,24 +141,33 @@ fn stop_collectors_for_keys(
     }
 }
 
-pub(super) fn stop_removed_bmc_collectors(
+/// Removes collectors for absent endpoints and waits for their shutdown hooks.
+///
+/// Completing shutdown before the iteration returns prevents a later discovery
+/// pass from starting replacements before old `CollectorRemoved` events arrive.
+pub(super) async fn stop_removed_bmc_collectors(
     ctx: &mut DiscoveryLoopContext,
     active_endpoints: &HashSet<Cow<'static, str>>,
 ) {
     let removed_keys = ctx.collectors.removed_keys(active_endpoints);
 
-    for kind in CollectorKind::ALL {
-        stop_collectors_for_keys(
-            ctx,
-            kind,
-            &removed_keys,
-            CollectorStopReason::EndpointRemoved,
-        );
-    }
+    let removed_collectors = CollectorKind::ALL
+        .into_iter()
+        .flat_map(|kind| {
+            take_collectors_for_keys(
+                ctx,
+                kind,
+                &removed_keys,
+                CollectorStopReason::EndpointRemoved,
+            )
+        })
+        .collect::<Vec<_>>();
 
     for key in &removed_keys {
         ctx.collectors.remove_inventory(key);
     }
+
+    join_all(removed_collectors.into_iter().map(Collector::stop)).await;
 
     if !removed_keys.is_empty() {
         tracing::info!(

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -24,6 +24,7 @@ use arc_swap::ArcSwapOption;
 use carbide_uuid::nvlink::NvLinkDomainId;
 use prometheus::{Histogram, HistogramOpts};
 
+use super::reachability::ReachabilitySpec;
 use crate::HealthError;
 use crate::api_client::ApiClientWrapper;
 use crate::bmc::BmcClient;
@@ -34,7 +35,7 @@ use crate::config::{
     LogsCollectorConfig as LogsCollectorOptions, MetricsCollectorConfig as MetricsCollectorOptions,
     MtlsProfileConfig, NmxcCollectorConfig as NmxcCollectorOptions,
     NmxtCollectorConfig as NmxtCollectorOptions, NvueCollectorConfig as NvueCollectorOptions,
-    SensorCollectorConfig as SensorCollectorOptions,
+    ReachabilityCollectorConfig, SensorCollectorConfig as SensorCollectorOptions,
     TelemetryCollectorConfig as TelemetryCollectorOptions,
 };
 use crate::limiter::RateLimiter;
@@ -55,6 +56,7 @@ pub(super) enum CollectorKind {
     NvueRest,
     NvueGnmi,
     GpuInventory,
+    Reachability,
 }
 
 impl CollectorKind {
@@ -87,8 +89,10 @@ pub(super) struct CollectorState {
     nvue_rest: HashMap<Cow<'static, str>, Collector>,
     nvue_gnmi: HashMap<Cow<'static, str>, Collector>,
     gpu_inventory: HashMap<Cow<'static, str>, Collector>,
+    reachability: HashMap<Cow<'static, str>, Collector>,
     inventories: HashMap<Cow<'static, str>, SharedInventory<BmcClient>>,
     switch_domain_uuids: HashMap<Cow<'static, str>, Option<NvLinkDomainId>>,
+    pub(super) reachability_specs: HashMap<Cow<'static, str>, ReachabilitySpec>,
 }
 
 impl CollectorState {
@@ -106,8 +110,10 @@ impl CollectorState {
             nvue_rest: HashMap::new(),
             nvue_gnmi: HashMap::new(),
             gpu_inventory: HashMap::new(),
+            reachability: HashMap::new(),
             inventories: HashMap::new(),
             switch_domain_uuids: HashMap::new(),
+            reachability_specs: HashMap::new(),
         }
     }
 
@@ -125,6 +131,7 @@ impl CollectorState {
             CollectorKind::NvueRest => &self.nvue_rest,
             CollectorKind::NvueGnmi => &self.nvue_gnmi,
             CollectorKind::GpuInventory => &self.gpu_inventory,
+            CollectorKind::Reachability => &self.reachability,
         }
     }
 
@@ -145,6 +152,7 @@ impl CollectorState {
             CollectorKind::NvueRest => &mut self.nvue_rest,
             CollectorKind::NvueGnmi => &mut self.nvue_gnmi,
             CollectorKind::GpuInventory => &mut self.gpu_inventory,
+            CollectorKind::Reachability => &mut self.reachability,
         }
     }
 
@@ -270,6 +278,12 @@ pub struct DiscoveryLoopContext {
 
     /// Whether any enabled sink consumes `CollectorEvent::Log` payloads.
     pub(crate) log_event_sink_enabled: bool,
+
+    /// Active reachability configuration.
+    ///
+    /// This is absent when the collector is disabled or no metric or log sink
+    /// can consume its observations.
+    pub(super) reachability_config: Option<ReachabilityCollectorConfig>,
     pub(crate) gpu_inventory_config: Configurable<GpuInventoryConfig>,
     pub(crate) api_client: Option<Arc<ApiClientWrapper>>,
     pub(crate) log_downgrade_registry: Arc<LogDowngradeRegistry>,
@@ -326,6 +340,13 @@ impl DiscoveryLoopContext {
                 .map(|reload_interval| MtlsHttpClientProvider::new(tls_config, reload_interval))
         });
 
+        let reachability_config =
+            if config.sinks.prometheus.is_enabled() || config.sinks.includes_log_events() {
+                config.collectors.reachability.as_option().cloned()
+            } else {
+                None
+            };
+
         Ok(Self {
             collectors: CollectorState::new(),
             discovery_iteration_histogram,
@@ -345,6 +366,7 @@ impl DiscoveryLoopContext {
             tls_config,
             tls_http_client_provider,
             log_event_sink_enabled: config.sinks.includes_log_events(),
+            reachability_config,
             gpu_inventory_config: config.collectors.gpu_inventory.clone(),
             api_client: match &config.endpoint_sources.carbide_api {
                 Configurable::Enabled(source_cfg) => Some(Arc::new(ApiClientWrapper::new(

--- a/crates/health/src/discovery/iteration.rs
+++ b/crates/health/src/discovery/iteration.rs
@@ -115,6 +115,9 @@ pub async fn run_discovery_iteration(
     // unregister the replacement's metrics.
     stop_stale_switch_collectors(ctx, &sharded_endpoints).await;
 
+    let active_endpoints = active_keys(&sharded_endpoints);
+    stop_removed_bmc_collectors(ctx, &active_endpoints).await;
+
     for endpoint in &sharded_endpoints {
         spawn_collectors_for_endpoint(ctx, endpoint, data_sink.clone(), metrics_prefix)?;
     }
@@ -125,8 +128,7 @@ pub async fn run_discovery_iteration(
     if matches!(&ctx.nmxc_config, Configurable::Enabled(_)) {
         // Endpoints can remain active while Carbide API changes primary or
         // NMX-C desired-state flags. Reconcile existing streams against the
-        // same target policy used for spawn before generic removed-endpoint
-        // cleanup runs.
+        // same target policy used for spawn.
         let nmxc_eligible_endpoints = nmxc_subscription_keys(&sharded_endpoints);
         stop_ineligible_nmxc_collectors(ctx, &nmxc_eligible_endpoints);
     } else {
@@ -134,9 +136,6 @@ pub async fn run_discovery_iteration(
         // remains eligible even though the endpoint keys may still be active.
         stop_ineligible_nmxc_collectors(ctx, &HashSet::new());
     }
-
-    let active_endpoints = active_keys(&sharded_endpoints);
-    stop_removed_bmc_collectors(ctx, &active_endpoints);
 
     let iteration_duration = iteration_start.elapsed();
     ctx.discovery_iteration_histogram
@@ -361,5 +360,84 @@ mod tests {
             .expect("NMX-T collector should have started");
 
         collector.stop().await;
+    }
+
+    #[tokio::test]
+    async fn discovery_iteration_waits_for_removed_nmxc_shutdown_before_spawn_error() {
+        let active_endpoint = endpoint(
+            MacAddress::from_str("00:00:00:00:00:31").unwrap(),
+            false,
+            None,
+        );
+
+        let source: Arc<dyn EndpointSource> = Arc::new(StaticEndpointSource::new(vec![
+            active_endpoint.as_ref().clone(),
+        ]));
+
+        let metrics_manager = Arc::new(
+            MetricsManager::new("removed_nmxc_shutdown").expect("metrics manager should start"),
+        );
+
+        let _conflicting_registry = metrics_manager
+            .create_collector_registry(
+                format!("entity_discovery_collector_{}", active_endpoint.key()),
+                "test",
+            )
+            .expect("conflicting registry should start");
+
+        let mut ctx = DiscoveryLoopContext::new(
+            Arc::new(NoopLimiter),
+            metrics_manager,
+            Arc::new(Config::default()),
+        )
+        .expect("discovery context should start");
+
+        let cancelled = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let collector_cancelled = Arc::clone(&cancelled);
+        let collector_release = Arc::clone(&release);
+
+        ctx.collectors.insert(
+            CollectorKind::Nmxc,
+            Cow::Borrowed("removed-switch"),
+            crate::collectors::Collector::spawn_task(move |cancel| async move {
+                cancel.cancelled().await;
+                collector_cancelled.notify_one();
+                collector_release.notified().await;
+            }),
+        );
+
+        let iteration = tokio::spawn(async move {
+            run_discovery_iteration(
+                source,
+                &ShardManager {
+                    shard: 0,
+                    shards_count: 1,
+                },
+                &mut ctx,
+                None,
+                "test",
+            )
+            .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), cancelled.notified())
+            .await
+            .expect("removed collector should be cancelled");
+
+        assert!(!iteration.is_finished());
+
+        release.notify_one();
+
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), iteration)
+            .await
+            .expect("discovery iteration should finish after collector shutdown")
+            .expect("discovery task should not panic")
+            .expect_err("collector registry conflict should fail spawning");
+
+        assert!(matches!(
+            error,
+            HealthError::PrometheusError(prometheus::Error::AlreadyReg)
+        ));
     }
 }

--- a/crates/health/src/discovery/iteration.rs
+++ b/crates/health/src/discovery/iteration.rs
@@ -28,6 +28,7 @@ use super::cleanup::{
 };
 use super::context::{CollectorKind, DiscoveryLoopContext};
 use super::identity::ensure_primary_system_uuid;
+use super::reachability::reconcile_reachability_collectors;
 use super::spawn::{spawn_collectors_for_endpoint, switch_supports_nmxc_subscription};
 use crate::HealthError;
 use crate::config::Configurable;
@@ -118,6 +119,9 @@ pub async fn run_discovery_iteration(
         spawn_collectors_for_endpoint(ctx, endpoint, data_sink.clone(), metrics_prefix)?;
     }
 
+    reconcile_reachability_collectors(ctx, &sharded_endpoints, data_sink.clone(), metrics_prefix)
+        .await?;
+
     if matches!(&ctx.nmxc_config, Configurable::Enabled(_)) {
         // Endpoints can remain active while Carbide API changes primary or
         // NMX-C desired-state flags. Reconcile existing streams against the
@@ -154,10 +158,14 @@ mod tests {
     use mac_address::MacAddress;
 
     use super::*;
+    use crate::config::{Config, Configurable, NmxtCollectorConfig, ReachabilityCollectorConfig};
     use crate::endpoint::test_support::endpoint_with_creds;
     use crate::endpoint::{
-        BmcAddr, BmcCredentials, EndpointMetadata, SwitchData, SwitchEndpointRole,
+        BmcAddr, BmcCredentials, EndpointMetadata, StaticEndpointSource, SwitchData,
+        SwitchEndpointRole,
     };
+    use crate::limiter::NoopLimiter;
+    use crate::metrics::MetricsManager;
 
     /// Builds a generic endpoint fixture for discovery iteration tests.
     fn endpoint(mac: MacAddress, switch: bool, rack_id: Option<RackId>) -> Arc<BmcEndpoint> {
@@ -293,5 +301,65 @@ mod tests {
         ]);
 
         assert_eq!(keys, HashSet::from([expected_key]));
+    }
+
+    #[tokio::test]
+    async fn reachability_does_not_change_duplicate_endpoint_spawning() {
+        let mac = MacAddress::from_str("00:00:00:00:00:21").unwrap();
+        let first = switch_endpoint(mac, false, false);
+        let mut duplicate = first.as_ref().clone();
+
+        let Some(EndpointMetadata::Switch(switch)) = duplicate.metadata.as_mut() else {
+            panic!("test endpoint should contain switch metadata");
+        };
+
+        switch.nmxt_enabled = true;
+
+        let source: Arc<dyn EndpointSource> = Arc::new(StaticEndpointSource::new(vec![
+            first.as_ref().clone(),
+            duplicate,
+        ]));
+
+        let mut config = Config::default();
+        config.endpoint_sources.carbide_api = Configurable::Disabled;
+        config.collectors.sensors = Configurable::Disabled;
+        config.collectors.leak_detector = Configurable::Disabled;
+        config.collectors.nmxt = Configurable::Enabled(NmxtCollectorConfig::default());
+        config.collectors.reachability =
+            Configurable::Enabled(ReachabilityCollectorConfig::default());
+
+        let metrics_manager = Arc::new(
+            MetricsManager::new("duplicate_keys_with_reachability")
+                .expect("metrics manager should start"),
+        );
+
+        let mut ctx =
+            DiscoveryLoopContext::new(Arc::new(NoopLimiter), metrics_manager, Arc::new(config))
+                .expect("discovery context should start");
+
+        let stats = run_discovery_iteration(
+            source,
+            &ShardManager {
+                shard: 0,
+                shards_count: 1,
+            },
+            &mut ctx,
+            None,
+            "test",
+        )
+        .await
+        .expect("discovery iteration should succeed");
+
+        assert_eq!(stats.discovered_endpoints, 2);
+        assert_eq!(stats.sharded_endpoints, 2);
+        assert!(ctx.collectors.contains(CollectorKind::Nmxt, &first.key()));
+
+        let collector = ctx
+            .collectors
+            .map_mut(CollectorKind::Nmxt)
+            .remove(first.key().as_str())
+            .expect("NMX-T collector should have started");
+
+        collector.stop().await;
     }
 }

--- a/crates/health/src/discovery/mod.rs
+++ b/crates/health/src/discovery/mod.rs
@@ -19,6 +19,7 @@ mod cleanup;
 mod context;
 mod identity;
 mod iteration;
+mod reachability;
 mod spawn;
 
 use std::time::Duration;

--- a/crates/health/src/discovery/reachability.rs
+++ b/crates/health/src/discovery/reachability.rs
@@ -295,6 +295,7 @@ mod tests {
         let mut config = Config::default();
         config.collectors.sensors = Configurable::Disabled;
         config.collectors.metrics = Configurable::Disabled;
+        config.collectors.telemetry = Configurable::Disabled;
         config.collectors.logs = Configurable::Disabled;
         config.collectors.firmware = Configurable::Disabled;
         config.collectors.leak_detector = Configurable::Disabled;
@@ -339,6 +340,11 @@ mod tests {
         sensor_config.collectors.sensors = Configurable::Enabled(Default::default());
 
         assert_eq!(targets_for_config(&bmc, &sensor_config, true), expected);
+
+        let mut telemetry_config = config_without_target_collectors();
+        telemetry_config.collectors.telemetry = Configurable::Enabled(Default::default());
+
+        assert_eq!(targets_for_config(&bmc, &telemetry_config, true), expected);
 
         let mut log_config = config_without_target_collectors();
         log_config.collectors.logs = Configurable::Enabled(Default::default());

--- a/crates/health/src/discovery/reachability.rs
+++ b/crates/health/src/discovery/reachability.rs
@@ -1,0 +1,588 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::future::join_all;
+
+use super::context::{CollectorKind, DiscoveryLoopContext};
+use super::spawn::collector_eligibility;
+use crate::HealthError;
+use crate::collectors::{
+    Collector, CollectorStartContext, NMXT_PORT, REACHABILITY_COLLECTOR_TYPE,
+    ReachabilityCollector, ReachabilityCollectorStartConfig, ReachabilityService,
+    ReachabilityTarget,
+};
+use crate::endpoint::BmcEndpoint;
+use crate::limiter::NoopLimiter;
+use crate::sink::{DataSink, EventContext};
+
+const DEFAULT_HTTPS_PORT: u16 = 443;
+
+/// Desired targets and sink-visible metadata for one endpoint.
+#[derive(Clone)]
+pub(super) struct ReachabilitySpec {
+    targets: Vec<ReachabilityTarget>,
+    event_context: EventContext,
+}
+
+impl PartialEq for ReachabilitySpec {
+    fn eq(&self, other: &Self) -> bool {
+        self.targets == other.targets
+            && sink_contexts_match(&self.event_context, &other.event_context)
+    }
+}
+
+impl Eq for ReachabilitySpec {}
+
+/// Compares only endpoint data exposed by metric and log sinks.
+fn sink_contexts_match(left: &EventContext, right: &EventContext) -> bool {
+    left.endpoint_key == right.endpoint_key
+        && left.addr.ip == right.addr.ip
+        && left.addr.port == right.addr.port
+        && left.addr.mac == right.addr.mac
+        && left.collector_type == right.collector_type
+        && left.machine_id() == right.machine_id()
+        && left.system_uuid() == right.system_uuid()
+        && left.driver_version() == right.driver_version()
+        && left.component_type() == right.component_type()
+        && left.switch_id() == right.switch_id()
+        && left.switch_endpoint_role() == right.switch_endpoint_role()
+        && left.switch_is_primary() == right.switch_is_primary()
+        && left.slot_number() == right.slot_number()
+        && left.tray_index() == right.tray_index()
+        && left.nvlink_domain_uuid() == right.nvlink_domain_uuid()
+        && left.switch_slot_number() == right.switch_slot_number()
+        && left.switch_tray_index() == right.switch_tray_index()
+        && left.power_shelf_id() == right.power_shelf_id()
+        && left.serial_number() == right.serial_number()
+        && left.rack_id() == right.rack_id()
+        && left.labels() == right.labels()
+}
+
+/// Reconciles reachability collectors against the latest discovered endpoints.
+///
+/// Duplicate source records may contribute different eligible services for the
+/// same key. Replacements await shutdown before starting so stale metric
+/// cleanup cannot remove new series.
+pub(super) async fn reconcile_reachability_collectors(
+    ctx: &mut DiscoveryLoopContext,
+    endpoints: &[Arc<BmcEndpoint>],
+    sink: Option<Arc<dyn DataSink>>,
+    metrics_prefix: &str,
+) -> Result<(), HealthError> {
+    let config = ctx.reachability_config.clone();
+
+    let mut desired: HashMap<Cow<'static, str>, (Arc<BmcEndpoint>, ReachabilitySpec)> =
+        HashMap::new();
+
+    if config.is_some() && sink.is_some() {
+        for endpoint in endpoints {
+            let key: Cow<'static, str> = Cow::Owned(endpoint.key());
+            let targets = resolve_targets(endpoint, ctx, true);
+
+            if targets.is_empty() {
+                continue;
+            }
+
+            if let Some((_, current)) = desired.get_mut(&key) {
+                // Match per-kind collector maps: the first eligible target wins
+                // for each service.
+                for target in targets {
+                    if current
+                        .targets
+                        .iter()
+                        .any(|existing| existing.service == target.service)
+                    {
+                        continue;
+                    }
+
+                    current.targets.push(target);
+                }
+
+                continue;
+            }
+
+            desired.insert(
+                key,
+                (
+                    endpoint.clone(),
+                    ReachabilitySpec {
+                        targets,
+                        event_context: EventContext::from_endpoint(
+                            endpoint,
+                            REACHABILITY_COLLECTOR_TYPE,
+                        ),
+                    },
+                ),
+            );
+        }
+    }
+
+    let stale_keys = ctx
+        .collectors
+        .reachability_specs
+        .iter()
+        .filter_map(|(key, current)| match desired.get(key) {
+            Some((_, next)) if next == current => None,
+            _ => Some(key.clone()),
+        })
+        .collect::<Vec<_>>();
+
+    let stale_collectors = {
+        let collectors = ctx.collectors.map_mut(CollectorKind::Reachability);
+
+        stale_keys
+            .iter()
+            .filter_map(|key| collectors.remove(key))
+            .collect::<Vec<_>>()
+    };
+
+    for key in &stale_keys {
+        ctx.collectors.reachability_specs.remove(key);
+    }
+
+    join_all(stale_collectors.into_iter().map(Collector::stop)).await;
+
+    let (Some(config), Some(sink)) = (config, sink) else {
+        return Ok(());
+    };
+
+    for (key, (endpoint, spec)) in desired {
+        if ctx.collectors.contains(CollectorKind::Reachability, &key) {
+            continue;
+        }
+
+        let collector_registry =
+            Arc::new(ctx.metrics_manager.create_collector_registry(
+                format!("reachability_collector_{key}"),
+                metrics_prefix,
+            )?);
+
+        match Collector::start::<ReachabilityCollector>(
+            endpoint.clone(),
+            endpoint.bmc().clone(),
+            ReachabilityCollectorStartConfig {
+                targets: spec.targets.clone(),
+                timeout: config.timeout,
+                log_mode: ctx.log_event_sink_enabled.then_some(config.log_mode),
+                sink: sink.clone(),
+            },
+            CollectorStartContext {
+                // TCP probes use their configured cadence independently of
+                // protocol collector rate limits.
+                limiter: Arc::new(NoopLimiter),
+                iteration_interval: config.interval,
+                collector_registry,
+                metrics_manager: ctx.metrics_manager.clone(),
+            },
+        ) {
+            Ok(collector) => {
+                ctx.collectors.reachability_specs.insert(key.clone(), spec);
+                ctx.collectors
+                    .insert(CollectorKind::Reachability, key.clone(), collector);
+
+                tracing::info!(endpoint_key = %key, "Started TCP reachability collection");
+            }
+
+            Err(error) => {
+                // An absent entry is retried on the next discovery pass.
+                tracing::error!(?error, endpoint_key = %key, "Could not start TCP reachability collection");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Maps shared collector eligibility and effective ports to TCP targets.
+fn resolve_targets(
+    endpoint: &BmcEndpoint,
+    ctx: &DiscoveryLoopContext,
+    data_sink_present: bool,
+) -> Vec<ReachabilityTarget> {
+    let eligibility = collector_eligibility(ctx, endpoint, data_sink_present);
+
+    if eligibility.redfish {
+        // Probe the discovered BMC directly, not its configured proxy.
+        return vec![ReachabilityTarget {
+            service: ReachabilityService::Redfish,
+            address: (
+                endpoint.addr.ip,
+                endpoint.addr.port.unwrap_or(DEFAULT_HTTPS_PORT),
+            )
+                .into(),
+        }];
+    }
+
+    let mut targets = Vec::new();
+
+    if eligibility.nvue_rest {
+        targets.push(ReachabilityTarget {
+            service: ReachabilityService::NvueRest,
+            address: (
+                endpoint.addr.ip,
+                endpoint.addr.port.unwrap_or(DEFAULT_HTTPS_PORT),
+            )
+                .into(),
+        });
+    }
+
+    if eligibility.nvue_gnmi
+        && let Some(gnmi) = ctx
+            .nvue_config
+            .as_option()
+            .and_then(|config| config.gnmi.as_option())
+    {
+        targets.push(ReachabilityTarget {
+            service: ReachabilityService::Gnmi,
+            address: (endpoint.addr.ip, gnmi.gnmi_port).into(),
+        });
+    }
+
+    if eligibility.nmxt {
+        targets.push(ReachabilityTarget {
+            service: ReachabilityService::Nmxt,
+            address: (endpoint.addr.ip, NMXT_PORT).into(),
+        });
+    }
+
+    if eligibility.nmxc
+        && let Some(nmxc) = ctx.nmxc_config.as_option()
+    {
+        targets.push(ReachabilityTarget {
+            service: ReachabilityService::Nmxc,
+            address: (endpoint.addr.ip, nmxc.grpc_port).into(),
+        });
+    }
+
+    targets
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+    use crate::config::{
+        Config, Configurable, NmxcCollectorConfig, NvueCollectorConfig, ReachabilityCollectorConfig,
+    };
+    use crate::endpoint::test_support::{mac, test_endpoint};
+    use crate::endpoint::{EndpointMetadata, SwitchData, SwitchEndpointRole};
+    use crate::metrics::MetricsManager;
+    use crate::sink::{CollectorEvent, EventContext};
+
+    #[derive(Default)]
+    struct NotifyingSink(tokio::sync::Notify);
+
+    impl DataSink for NotifyingSink {
+        fn sink_type(&self) -> &'static str {
+            "notifying"
+        }
+
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            _event: &CollectorEvent,
+        ) -> Result<(), HealthError> {
+            self.0.notify_one();
+            Ok(())
+        }
+    }
+
+    fn switch_endpoint(role: SwitchEndpointRole) -> BmcEndpoint {
+        let mut endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+        endpoint.addr.ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        endpoint.addr.port = Some(9443);
+
+        endpoint.metadata = Some(EndpointMetadata::Switch(SwitchData {
+            id: None,
+            serial: "switch-1".to_string(),
+            slot_number: None,
+            tray_index: None,
+            nvlink_domain_uuid: None,
+            endpoint_role: role,
+            is_primary: true,
+            nmxc_enabled: true,
+            nmxt_enabled: true,
+        }));
+
+        endpoint
+    }
+
+    fn config_without_target_collectors() -> Config {
+        let mut config = Config::default();
+        config.collectors.sensors = Configurable::Disabled;
+        config.collectors.metrics = Configurable::Disabled;
+        config.collectors.logs = Configurable::Disabled;
+        config.collectors.firmware = Configurable::Disabled;
+        config.collectors.leak_detector = Configurable::Disabled;
+        config.collectors.gpu_inventory = Configurable::Disabled;
+        config.collectors.nvue = Configurable::Disabled;
+        config.collectors.nmxt = Configurable::Disabled;
+        config.collectors.nmxc = Configurable::Disabled;
+        config.endpoint_sources.carbide_api = Configurable::Disabled;
+        config
+    }
+
+    fn targets_for_config(
+        endpoint: &BmcEndpoint,
+        config: &Config,
+        data_sink_present: bool,
+    ) -> Vec<ReachabilityTarget> {
+        let ctx = DiscoveryLoopContext::new(
+            Arc::new(NoopLimiter),
+            Arc::new(MetricsManager::new("reachability_targets").expect("metrics manager")),
+            Arc::new(config.clone()),
+        )
+        .expect("discovery context");
+
+        resolve_targets(endpoint, &ctx, data_sink_present)
+    }
+
+    #[test]
+    fn redfish_targets_follow_collector_spawn_gates() {
+        let mut bmc = test_endpoint(mac("00:11:22:33:44:54"));
+        bmc.addr.port = Some(8443);
+
+        let base = config_without_target_collectors();
+
+        let expected = vec![ReachabilityTarget {
+            service: ReachabilityService::Redfish,
+            address: (bmc.addr.ip, 8443).into(),
+        }];
+
+        assert!(targets_for_config(&bmc, &base, true).is_empty());
+
+        let mut sensor_config = base;
+        sensor_config.collectors.sensors = Configurable::Enabled(Default::default());
+
+        assert_eq!(targets_for_config(&bmc, &sensor_config, true), expected);
+
+        let mut log_config = config_without_target_collectors();
+        log_config.collectors.logs = Configurable::Enabled(Default::default());
+
+        assert!(
+            targets_for_config(&bmc, &log_config, false).is_empty(),
+            "auto log collection cannot start without a data sink",
+        );
+
+        let Configurable::Enabled(logs) = &mut log_config.collectors.logs else {
+            panic!("logs should be enabled");
+        };
+
+        logs.mode = crate::config::LogCollectionMode::Periodic;
+
+        assert_eq!(
+            targets_for_config(&bmc, &log_config, false),
+            expected,
+            "periodic log collection starts without a data sink",
+        );
+    }
+
+    #[test]
+    fn switch_targets_follow_spawn_gates_and_effective_ports() {
+        let mut config = config_without_target_collectors();
+        config.collectors.sensors = Configurable::Enabled(Default::default());
+
+        config.collectors.nvue = Configurable::Enabled(NvueCollectorConfig {
+            rest: Configurable::Enabled(Default::default()),
+            gnmi: Configurable::Enabled(crate::config::NvueGnmiConfig {
+                gnmi_port: 19_339,
+                ..Default::default()
+            }),
+        });
+
+        config.collectors.nmxt = Configurable::Enabled(Default::default());
+
+        config.collectors.nmxc = Configurable::Enabled(NmxcCollectorConfig {
+            grpc_port: 19_370,
+            ..Default::default()
+        });
+
+        config.sinks.tracing = Configurable::Enabled(Default::default());
+
+        let host = switch_endpoint(SwitchEndpointRole::Host);
+
+        assert_eq!(
+            targets_for_config(&host, &config, true),
+            vec![
+                ReachabilityTarget {
+                    service: ReachabilityService::NvueRest,
+                    address: (host.addr.ip, 9443).into(),
+                },
+                ReachabilityTarget {
+                    service: ReachabilityService::Gnmi,
+                    address: (host.addr.ip, 19_339).into(),
+                },
+                ReachabilityTarget {
+                    service: ReachabilityService::Nmxt,
+                    address: (host.addr.ip, NMXT_PORT).into(),
+                },
+                ReachabilityTarget {
+                    service: ReachabilityService::Nmxc,
+                    address: (host.addr.ip, 19_370).into(),
+                },
+            ]
+        );
+
+        let switch_bmc = switch_endpoint(SwitchEndpointRole::Bmc);
+
+        assert_eq!(
+            targets_for_config(&switch_bmc, &config, true),
+            vec![ReachabilityTarget {
+                service: ReachabilityService::Redfish,
+                address: (switch_bmc.addr.ip, 9443).into(),
+            }],
+        );
+    }
+
+    #[tokio::test]
+    async fn reconciliation_bypasses_shared_limiter_and_updates_only_reachability() {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("test listener should bind");
+
+        let listener_address = listener
+            .local_addr()
+            .expect("test listener should have an address");
+
+        let mut config = Config::default();
+
+        config.collectors.reachability = Configurable::Enabled(ReachabilityCollectorConfig {
+            interval: std::time::Duration::from_secs(300),
+            ..Default::default()
+        });
+
+        config.collectors.nmxt = Configurable::Enabled(Default::default());
+
+        let mut ctx = DiscoveryLoopContext::new_with_tls_config(
+            Arc::new(crate::limiter::BucketLimiter::new(
+                0,
+                std::time::Duration::from_secs(1),
+                std::time::Duration::ZERO,
+            )),
+            Arc::new(
+                MetricsManager::new("reachability_collector_state")
+                    .expect("metrics manager should start"),
+            ),
+            Arc::new(config),
+            None,
+        )
+        .expect("discovery context should start");
+
+        let mut endpoint = test_endpoint(mac("00:11:22:33:44:53"));
+        endpoint.addr.ip = listener_address.ip();
+        endpoint.addr.port = Some(listener_address.port());
+        let endpoint = Arc::new(endpoint);
+        let key = endpoint.key();
+        let mut duplicate = switch_endpoint(SwitchEndpointRole::Host);
+        duplicate.addr.mac = endpoint.addr.mac;
+        duplicate.addr.ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
+        let duplicate_ip = duplicate.addr.ip;
+
+        let sink = Arc::new(NotifyingSink::default());
+
+        reconcile_reachability_collectors(
+            &mut ctx,
+            &[endpoint.clone(), Arc::new(duplicate)],
+            Some(sink.clone()),
+            "test",
+        )
+        .await
+        .expect("collector should start");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), sink.0.notified())
+            .await
+            .expect("reachability should not wait for the shared collector limiter");
+
+        ctx.collectors.insert(
+            CollectorKind::Sensor,
+            Cow::Owned(key.clone()),
+            Collector::spawn_task(|_| async {}),
+        );
+
+        assert_eq!(ctx.collectors.len(CollectorKind::Reachability), 1);
+
+        let initial = ctx
+            .collectors
+            .reachability_specs
+            .get(key.as_str())
+            .expect("initial reachability spec");
+
+        assert_eq!(
+            initial.targets,
+            vec![
+                ReachabilityTarget {
+                    service: ReachabilityService::Redfish,
+                    address: listener_address,
+                },
+                ReachabilityTarget {
+                    service: ReachabilityService::Nmxt,
+                    address: (duplicate_ip, NMXT_PORT).into(),
+                },
+            ],
+            "later duplicates contribute services at their effective collector addresses",
+        );
+
+        let mut changed = endpoint.as_ref().clone();
+        changed.addr.ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8));
+        changed
+            .labels
+            .insert("location".to_string(), "rack-b".to_string());
+
+        let changed = Arc::new(changed);
+
+        reconcile_reachability_collectors(
+            &mut ctx,
+            std::slice::from_ref(&changed),
+            Some(sink.clone()),
+            "test",
+        )
+        .await
+        .expect("changed endpoint should replace reachability");
+
+        let updated = ctx
+            .collectors
+            .reachability_specs
+            .get(key.as_str())
+            .expect("updated reachability spec");
+
+        assert_eq!(updated.event_context.addr.ip, changed.addr.ip);
+
+        assert_eq!(
+            updated
+                .event_context
+                .labels
+                .get("location")
+                .map(String::as_str),
+            Some("rack-b")
+        );
+
+        assert!(ctx.collectors.contains(CollectorKind::Sensor, &key));
+
+        reconcile_reachability_collectors(&mut ctx, &[], Some(sink), "test")
+            .await
+            .expect("removed endpoint should stop reachability");
+
+        assert_eq!(ctx.collectors.len(CollectorKind::Reachability), 0);
+        assert!(ctx.collectors.reachability_specs.is_empty());
+        assert!(ctx.collectors.contains(CollectorKind::Sensor, &key));
+    }
+}

--- a/crates/health/src/discovery/reachability.rs
+++ b/crates/health/src/discovery/reachability.rs
@@ -35,45 +35,11 @@ use crate::sink::{DataSink, EventContext};
 
 const DEFAULT_HTTPS_PORT: u16 = 443;
 
-/// Desired targets and sink-visible metadata for one endpoint.
-#[derive(Clone)]
+/// Desired targets and event context for one endpoint.
+#[derive(Clone, PartialEq)]
 pub(super) struct ReachabilitySpec {
     targets: Vec<ReachabilityTarget>,
     event_context: EventContext,
-}
-
-impl PartialEq for ReachabilitySpec {
-    fn eq(&self, other: &Self) -> bool {
-        self.targets == other.targets
-            && sink_contexts_match(&self.event_context, &other.event_context)
-    }
-}
-
-impl Eq for ReachabilitySpec {}
-
-/// Compares only endpoint data exposed by metric and log sinks.
-fn sink_contexts_match(left: &EventContext, right: &EventContext) -> bool {
-    left.endpoint_key == right.endpoint_key
-        && left.addr.ip == right.addr.ip
-        && left.addr.port == right.addr.port
-        && left.addr.mac == right.addr.mac
-        && left.collector_type == right.collector_type
-        && left.machine_id() == right.machine_id()
-        && left.system_uuid() == right.system_uuid()
-        && left.driver_version() == right.driver_version()
-        && left.component_type() == right.component_type()
-        && left.switch_id() == right.switch_id()
-        && left.switch_endpoint_role() == right.switch_endpoint_role()
-        && left.switch_is_primary() == right.switch_is_primary()
-        && left.slot_number() == right.slot_number()
-        && left.tray_index() == right.tray_index()
-        && left.nvlink_domain_uuid() == right.nvlink_domain_uuid()
-        && left.switch_slot_number() == right.switch_slot_number()
-        && left.switch_tray_index() == right.switch_tray_index()
-        && left.power_shelf_id() == right.power_shelf_id()
-        && left.serial_number() == right.serial_number()
-        && left.rack_id() == right.rack_id()
-        && left.labels() == right.labels()
 }
 
 /// Reconciles reachability collectors against the latest discovered endpoints.
@@ -133,6 +99,11 @@ pub(super) async fn reconcile_reachability_collectors(
                 ),
             );
         }
+    }
+
+    // Normalize discovery order while retaining the existing service sequence.
+    for (_, spec) in desired.values_mut() {
+        spec.targets.sort_unstable_by_key(|target| target.service);
     }
 
     let stale_keys = ctx
@@ -501,7 +472,7 @@ mod tests {
 
         reconcile_reachability_collectors(
             &mut ctx,
-            &[endpoint.clone(), Arc::new(duplicate)],
+            &[Arc::new(duplicate), endpoint.clone()],
             Some(sink.clone()),
             "test",
         )
@@ -538,7 +509,7 @@ mod tests {
                     address: (duplicate_ip, NMXT_PORT).into(),
                 },
             ],
-            "later duplicates contribute services at their effective collector addresses",
+            "merged targets use stable service order and effective collector addresses",
         );
 
         let mut changed = endpoint.as_ref().clone();

--- a/crates/health/src/discovery/reachability.rs
+++ b/crates/health/src/discovery/reachability.rs
@@ -16,7 +16,7 @@
  */
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use futures::future::join_all;
@@ -38,8 +38,47 @@ const DEFAULT_HTTPS_PORT: u16 = 443;
 /// Desired targets and event context for one endpoint.
 #[derive(Clone, PartialEq)]
 pub(super) struct ReachabilitySpec {
-    targets: Vec<ReachabilityTarget>,
+    targets: BTreeMap<ReachabilityService, ReachabilityTarget>,
     event_context: EventContext,
+}
+
+/// Builds one order-independent reachability specification per endpoint key.
+///
+/// When sources repeat a key, the first eligible target for each service wins.
+fn desired_reachability_specs(
+    ctx: &DiscoveryLoopContext,
+    endpoints: &[Arc<BmcEndpoint>],
+) -> HashMap<Cow<'static, str>, (Arc<BmcEndpoint>, ReachabilitySpec)> {
+    let mut desired = HashMap::new();
+
+    for endpoint in endpoints {
+        let targets = resolve_targets(endpoint, ctx, true);
+
+        if targets.is_empty() {
+            continue;
+        }
+
+        let key: Cow<'static, str> = Cow::Owned(endpoint.key());
+
+        let (_, spec) = desired.entry(key).or_insert_with(|| {
+            (
+                endpoint.clone(),
+                ReachabilitySpec {
+                    targets: BTreeMap::new(),
+                    event_context: EventContext::from_endpoint(
+                        endpoint,
+                        REACHABILITY_COLLECTOR_TYPE,
+                    ),
+                },
+            )
+        });
+
+        for target in targets {
+            spec.targets.entry(target.service).or_insert(target);
+        }
+    }
+
+    desired
 }
 
 /// Reconciles reachability collectors against the latest discovered endpoints.
@@ -55,56 +94,11 @@ pub(super) async fn reconcile_reachability_collectors(
 ) -> Result<(), HealthError> {
     let config = ctx.reachability_config.clone();
 
-    let mut desired: HashMap<Cow<'static, str>, (Arc<BmcEndpoint>, ReachabilitySpec)> =
-        HashMap::new();
-
-    if config.is_some() && sink.is_some() {
-        for endpoint in endpoints {
-            let key: Cow<'static, str> = Cow::Owned(endpoint.key());
-            let targets = resolve_targets(endpoint, ctx, true);
-
-            if targets.is_empty() {
-                continue;
-            }
-
-            if let Some((_, current)) = desired.get_mut(&key) {
-                // Match per-kind collector maps: the first eligible target wins
-                // for each service.
-                for target in targets {
-                    if current
-                        .targets
-                        .iter()
-                        .any(|existing| existing.service == target.service)
-                    {
-                        continue;
-                    }
-
-                    current.targets.push(target);
-                }
-
-                continue;
-            }
-
-            desired.insert(
-                key,
-                (
-                    endpoint.clone(),
-                    ReachabilitySpec {
-                        targets,
-                        event_context: EventContext::from_endpoint(
-                            endpoint,
-                            REACHABILITY_COLLECTOR_TYPE,
-                        ),
-                    },
-                ),
-            );
-        }
-    }
-
-    // Normalize discovery order while retaining the existing service sequence.
-    for (_, spec) in desired.values_mut() {
-        spec.targets.sort_unstable_by_key(|target| target.service);
-    }
+    let desired = if config.is_some() && sink.is_some() {
+        desired_reachability_specs(ctx, endpoints)
+    } else {
+        HashMap::new()
+    };
 
     let stale_keys = ctx
         .collectors
@@ -150,7 +144,7 @@ pub(super) async fn reconcile_reachability_collectors(
             endpoint.clone(),
             endpoint.bmc().clone(),
             ReachabilityCollectorStartConfig {
-                targets: spec.targets.clone(),
+                targets: spec.targets.values().cloned().collect(),
                 timeout: config.timeout,
                 log_mode: ctx.log_event_sink_enabled.then_some(config.log_mode),
                 sink: sink.clone(),
@@ -498,7 +492,7 @@ mod tests {
             .expect("initial reachability spec");
 
         assert_eq!(
-            initial.targets,
+            initial.targets.values().cloned().collect::<Vec<_>>(),
             vec![
                 ReachabilityTarget {
                     service: ReachabilityService::Redfish,

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -117,6 +117,7 @@ pub(super) fn collector_eligibility(
         return CollectorEligibility {
             redfish: ctx.sensors_config.is_enabled()
                 || ctx.metrics_config.is_enabled()
+                || ctx.telemetry_config.is_enabled()
                 || logs
                 || ctx.firmware_config.is_enabled()
                 || ctx.leak_detector_config.is_enabled()

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -54,6 +54,98 @@ pub(super) fn switch_supports_nmxc_subscription(endpoint: &BmcEndpoint) -> bool 
     })
 }
 
+/// Transport services eligible to start for one endpoint.
+///
+/// Reachability uses this plan so it probes only services selected by the
+/// same collector configuration, endpoint-role, capability, and sink gates.
+/// A `true` field permits a collector start attempt; it does not mean that the
+/// collector started successfully or completed a protocol exchange.
+#[derive(Clone, Copy, Default)]
+pub(super) struct CollectorEligibility {
+    /// At least one eligible collector uses the discovered BMC Redfish socket.
+    pub(super) redfish: bool,
+
+    /// The endpoint is eligible for direct NMX-T collection.
+    pub(super) nmxt: bool,
+
+    /// The endpoint is eligible for direct NMX-C Subscribe collection.
+    pub(super) nmxc: bool,
+
+    /// The endpoint is eligible for direct NVUE REST collection.
+    pub(super) nvue_rest: bool,
+
+    /// The endpoint is eligible for direct NVUE gNMI collection.
+    pub(super) nvue_gnmi: bool,
+}
+
+/// Computes transport eligibility using collector spawn gates.
+///
+/// `data_sink_present` must describe the same optional sink passed to the spawn
+/// path. SSE and NMX-C collectors require that sink, while periodic Redfish
+/// collectors may still run without one. Non-host endpoints collapse all
+/// Redfish-backed collectors into one BMC transport; switch-host endpoints use
+/// only their direct NVUE, gNMI, NMX-T, and NMX-C transports.
+pub(super) fn collector_eligibility(
+    ctx: &DiscoveryLoopContext,
+    endpoint: &BmcEndpoint,
+    data_sink_present: bool,
+) -> CollectorEligibility {
+    let switch_host = endpoint
+        .switch_data()
+        .is_some_and(|switch| matches!(switch.endpoint_role, SwitchEndpointRole::Host));
+
+    if !switch_host {
+        // Periodic logs perform Redfish requests without a sink. SSE requires
+        // a sink, while Auto remains periodic-eligible after a downgrade.
+        let logs = ctx
+            .logs_config
+            .as_option()
+            .is_some_and(|config| match config.mode {
+                LogCollectionMode::Periodic => true,
+                LogCollectionMode::Sse => data_sink_present,
+                LogCollectionMode::Auto => {
+                    data_sink_present || ctx.log_downgrade_registry.is_downgraded(&endpoint.key())
+                }
+            });
+
+        let gpu_inventory = ctx.gpu_inventory_config.is_enabled()
+            && ctx.api_client.is_some()
+            && matches!(endpoint.metadata, Some(EndpointMetadata::Machine(_)));
+
+        // Generic collectors share the discovered BMC socket, so one target
+        // represents every enabled Redfish-backed collector on this endpoint.
+        return CollectorEligibility {
+            redfish: ctx.sensors_config.is_enabled()
+                || ctx.metrics_config.is_enabled()
+                || logs
+                || ctx.firmware_config.is_enabled()
+                || ctx.leak_detector_config.is_enabled()
+                || gpu_inventory,
+            ..Default::default()
+        };
+    }
+
+    let nvue = ctx.nvue_config.as_option();
+
+    // NMX-C emits log events, so spawning requires both a
+    // log-capable configured sink and the constructed sink pipeline.
+    let nmxc = ctx.nmxc_config.is_enabled()
+        && switch_supports_nmxc_subscription(endpoint)
+        && ctx.log_event_sink_enabled
+        && data_sink_present;
+
+    CollectorEligibility {
+        redfish: false,
+        nmxt: ctx.nmxt_config.is_enabled()
+            && endpoint
+                .switch_data()
+                .is_some_and(|switch| switch.nmxt_enabled),
+        nmxc,
+        nvue_rest: nvue.is_some_and(|config| config.rest.is_enabled()),
+        nvue_gnmi: nvue.is_some_and(|config| config.gnmi.is_enabled()),
+    }
+}
+
 pub(super) fn spawn_collectors_for_endpoint(
     ctx: &mut DiscoveryLoopContext,
     endpoint: &Arc<BmcEndpoint>,
@@ -531,10 +623,9 @@ fn spawn_switch_host_collectors(
     let key = endpoint.key();
     let endpoint_arc = endpoint.clone();
     let bmc = endpoint.bmc().clone();
+    let eligibility = collector_eligibility(ctx, endpoint, data_sink.is_some());
 
-    if endpoint
-        .switch_data()
-        .is_some_and(|switch| switch.nmxt_enabled)
+    if eligibility.nmxt
         && let Configurable::Enabled(nmxt_cfg) = &ctx.nmxt_config
         && !ctx.collectors.contains(CollectorKind::Nmxt, &key)
     {
@@ -635,7 +726,8 @@ fn spawn_switch_host_collectors(
         }
     }
 
-    if let Configurable::Enabled(nvue_cfg) = &ctx.nvue_config
+    if eligibility.nvue_rest
+        && let Configurable::Enabled(nvue_cfg) = &ctx.nvue_config
         && let Configurable::Enabled(rest_cfg) = &nvue_cfg.rest
         && !ctx.collectors.contains(CollectorKind::NvueRest, &key)
     {
@@ -680,10 +772,10 @@ fn spawn_switch_host_collectors(
         }
     }
 
-    if let Configurable::Enabled(nvue_cfg) = &ctx.nvue_config
+    if eligibility.nvue_gnmi
+        && let Configurable::Enabled(nvue_cfg) = &ctx.nvue_config
         && let Configurable::Enabled(gnmi_cfg) = &nvue_cfg.gnmi
         && !ctx.collectors.contains(CollectorKind::NvueGnmi, &key)
-        && matches!(endpoint.metadata, Some(EndpointMetadata::Switch(_)))
     {
         let collector_registry = Arc::new(
             ctx.metrics_manager

--- a/crates/health/src/endpoint/model.rs
+++ b/crates/health/src/endpoint/model.rs
@@ -37,8 +37,17 @@ use crate::bmc::{BmcClient, BoxFuture};
 ///
 /// Collectors clone endpoint metadata when they start, so this state must remain
 /// shared for a UUID resolved after collector startup to reach emitted events.
+/// Clones of the same state compare equal. Distinct states compare equal only
+/// after both cells are initialized with the same optional UUID.
 #[derive(Clone, Debug, Default)]
 pub struct SharedSystemUuid(Arc<OnceCell<Option<uuid::Uuid>>>);
+
+impl PartialEq for SharedSystemUuid {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+            || matches!((self.0.get(), other.0.get()), (Some(left), Some(right)) if left == right)
+    }
+}
 
 impl SharedSystemUuid {
     pub fn get(&self) -> Option<uuid::Uuid> {
@@ -135,7 +144,7 @@ impl BmcEndpoint {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum EndpointMetadata {
     Machine(MachineData),
     PowerShelf(PowerShelfData),
@@ -169,7 +178,7 @@ impl EndpointMetadata {
 }
 
 /// Metadata that describes a machine endpoint for health telemetry.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MachineData {
     /// Stable NICo machine identifier. None when running without NICo.
     pub machine_id: Option<MachineId>,
@@ -202,7 +211,7 @@ pub struct MachineData {
     pub driver_version: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PowerShelfData {
     pub id: Option<PowerShelfId>,
     pub serial: String,
@@ -214,7 +223,7 @@ pub enum SwitchEndpointRole {
     Host,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SwitchData {
     pub id: Option<SwitchId>,
     pub serial: String,
@@ -244,7 +253,7 @@ pub enum BmcCredentials {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BmcAddr {
     pub ip: IpAddr,
     pub port: Option<u16>,
@@ -438,5 +447,22 @@ mod tests {
         assert_eq!(query_count.load(Ordering::SeqCst), 1);
         assert_eq!(state.get(), None);
         assert_eq!(clone.get(), None);
+    }
+
+    #[tokio::test]
+    async fn shared_system_uuid_equality_distinguishes_unresolved_from_absent() {
+        let unresolved = SharedSystemUuid::default();
+        let other_unresolved = SharedSystemUuid::default();
+
+        assert_eq!(unresolved, unresolved.clone());
+        assert_ne!(unresolved, other_unresolved);
+
+        let initialized_absent = SharedSystemUuid::default();
+        initialized_absent
+            .get_or_try_init(|| async { Ok::<_, Infallible>(None) })
+            .await
+            .expect("infallible UUID initialization");
+
+        assert_ne!(initialized_absent, unresolved);
     }
 }

--- a/crates/health/src/processor/rack_leak.rs
+++ b/crates/health/src/processor/rack_leak.rs
@@ -34,7 +34,7 @@ struct RackLeakState {
 }
 
 impl RackLeakState {
-    fn remove_reporter(&mut self, endpoint_key: &str, collector_type: &'static str) {
+    fn remove_reporter(&mut self, endpoint_key: &str, collector_type: &'static str) -> bool {
         let last_reporter_removed =
             self.leaking_trays
                 .get_mut(endpoint_key)
@@ -46,6 +46,8 @@ impl RackLeakState {
         if last_reporter_removed {
             self.leaking_trays.remove(endpoint_key);
         }
+
+        last_reporter_removed
     }
 }
 
@@ -105,10 +107,17 @@ impl EventProcessor for RackLeakProcessor {
         };
 
         if matches!(event, CollectorEvent::CollectorRemoved) {
-            if let Some(mut entry) = self.racks.get_mut(rack_id) {
-                entry.remove_reporter(context.endpoint_key(), context.collector_type);
+            let Some(mut entry) = self.racks.get_mut(rack_id) else {
+                return Vec::new();
+            };
+
+            if !entry.remove_reporter(context.endpoint_key(), context.collector_type) {
+                return Vec::new();
             }
-            return Vec::new();
+
+            let report = self.build_report(entry.leaking_trays.len());
+
+            return vec![CollectorEvent::HealthReport(Arc::new(report))];
         }
 
         let CollectorEvent::HealthReport(report) = event else {
@@ -363,7 +372,13 @@ mod tests {
 
         let emitted = processor.process_event(&ctx_a, &CollectorEvent::CollectorRemoved);
 
-        assert!(emitted.is_empty());
+        let Some(CollectorEvent::HealthReport(report)) = emitted.first() else {
+            panic!("expected updated rack health report");
+        };
+
+        assert!(report.alerts.is_empty());
+        assert_eq!(report.successes.len(), 1);
+
         let Some(rack) = processor.racks.get(ctx_a.rack_id().expect("rack id")) else {
             panic!("expected rack state");
         };
@@ -430,7 +445,10 @@ mod tests {
         }
 
         processor.process_event(&second_context, &tray_leak_report(true));
-        processor.process_event(&first_context, &CollectorEvent::CollectorRemoved);
+
+        let emitted = processor.process_event(&first_context, &CollectorEvent::CollectorRemoved);
+
+        assert!(emitted.is_empty());
 
         {
             let rack = processor

--- a/crates/health/src/processor/rack_leak.rs
+++ b/crates/health/src/processor/rack_leak.rs
@@ -22,6 +22,7 @@ use carbide_uuid::rack::RackId;
 use dashmap::DashMap;
 
 use super::{EventContext, EventProcessor};
+use crate::collectors::REACHABILITY_COLLECTOR_TYPE;
 use crate::sink::{
     Classification, CollectorEvent, HealthReport, HealthReportAlert, HealthReportSuccess,
     HealthReportTarget, Probe, ReportSource,
@@ -87,6 +88,11 @@ impl EventProcessor for RackLeakProcessor {
         };
 
         if matches!(event, CollectorEvent::CollectorRemoved) {
+            // Reachability removal does not indicate that leak collection stopped.
+            if context.collector_type == REACHABILITY_COLLECTOR_TYPE {
+                return Vec::new();
+            }
+
             if let Some(mut entry) = self.racks.get_mut(rack_id) {
                 entry.leaking_trays.remove(context.endpoint_key());
             }
@@ -347,6 +353,30 @@ mod tests {
         };
         assert_eq!(rack.leaking_trays.len(), 1);
         assert!(rack.leaking_trays.contains(ctx_b.endpoint_key()));
+    }
+
+    #[test]
+    fn reachability_collector_removal_keeps_tray_state() {
+        let processor = RackLeakProcessor::new(1);
+        let leak_context = context_with_rack("42:9e:b1:bd:9d:dd", "rack-1");
+        let mut reachability_context = leak_context.clone();
+        reachability_context.collector_type = "reachability";
+
+        processor.process_event(&leak_context, &tray_leak_report(true));
+
+        let emitted =
+            processor.process_event(&reachability_context, &CollectorEvent::CollectorRemoved);
+
+        assert!(emitted.is_empty());
+
+        let Some(rack) = processor
+            .racks
+            .get(leak_context.rack_id().expect("rack id"))
+        else {
+            panic!("expected rack state");
+        };
+
+        assert!(rack.leaking_trays.contains(leak_context.endpoint_key()));
     }
 
     #[test]

--- a/crates/health/src/processor/rack_leak.rs
+++ b/crates/health/src/processor/rack_leak.rs
@@ -15,21 +15,38 @@
  * limitations under the License.
  */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use carbide_uuid::rack::RackId;
 use dashmap::DashMap;
 
 use super::{EventContext, EventProcessor};
-use crate::collectors::REACHABILITY_COLLECTOR_TYPE;
 use crate::sink::{
     Classification, CollectorEvent, HealthReport, HealthReportAlert, HealthReportSuccess,
     HealthReportTarget, Probe, ReportSource,
 };
 
 struct RackLeakState {
-    leaking_trays: HashSet<String>,
+    /// Maps each leaking tray's endpoint key to the collector types reporting it.
+    /// The tray remains active until every reporting collector retracts its state.
+    leaking_trays: HashMap<String, HashSet<&'static str>>,
+}
+
+impl RackLeakState {
+    fn remove_reporter(&mut self, endpoint_key: &str, collector_type: &'static str) {
+        let last_reporter_removed =
+            self.leaking_trays
+                .get_mut(endpoint_key)
+                .is_some_and(|reporters| {
+                    reporters.remove(collector_type);
+                    reporters.is_empty()
+                });
+
+        if last_reporter_removed {
+            self.leaking_trays.remove(endpoint_key);
+        }
+    }
 }
 
 pub struct RackLeakProcessor {
@@ -88,13 +105,8 @@ impl EventProcessor for RackLeakProcessor {
         };
 
         if matches!(event, CollectorEvent::CollectorRemoved) {
-            // Reachability removal does not indicate that leak collection stopped.
-            if context.collector_type == REACHABILITY_COLLECTOR_TYPE {
-                return Vec::new();
-            }
-
             if let Some(mut entry) = self.racks.get_mut(rack_id) {
-                entry.leaking_trays.remove(context.endpoint_key());
+                entry.remove_reporter(context.endpoint_key(), context.collector_type);
             }
             return Vec::new();
         }
@@ -121,13 +133,17 @@ impl EventProcessor for RackLeakProcessor {
             .racks
             .entry(rack_id.clone())
             .or_insert_with(|| RackLeakState {
-                leaking_trays: HashSet::new(),
+                leaking_trays: HashMap::new(),
             });
 
         if is_leaking {
-            entry.leaking_trays.insert(tray_key);
+            entry
+                .leaking_trays
+                .entry(tray_key)
+                .or_default()
+                .insert(context.collector_type);
         } else {
-            entry.leaking_trays.remove(&tray_key);
+            entry.remove_reporter(&tray_key, context.collector_type);
         }
 
         let leaking_count = entry.leaking_trays.len();
@@ -351,21 +367,22 @@ mod tests {
         let Some(rack) = processor.racks.get(ctx_a.rack_id().expect("rack id")) else {
             panic!("expected rack state");
         };
+
         assert_eq!(rack.leaking_trays.len(), 1);
-        assert!(rack.leaking_trays.contains(ctx_b.endpoint_key()));
+        assert!(rack.leaking_trays.contains_key(ctx_b.endpoint_key()));
     }
 
     #[test]
-    fn reachability_collector_removal_keeps_tray_state() {
+    fn unrelated_collector_removal_keeps_tray_state() {
         let processor = RackLeakProcessor::new(1);
         let leak_context = context_with_rack("42:9e:b1:bd:9d:dd", "rack-1");
-        let mut reachability_context = leak_context.clone();
-        reachability_context.collector_type = "reachability";
+        let mut unrelated_context = leak_context.clone();
+        unrelated_context.collector_type = "unrelated_collector";
 
         processor.process_event(&leak_context, &tray_leak_report(true));
 
         let emitted =
-            processor.process_event(&reachability_context, &CollectorEvent::CollectorRemoved);
+            processor.process_event(&unrelated_context, &CollectorEvent::CollectorRemoved);
 
         assert!(emitted.is_empty());
 
@@ -376,7 +393,72 @@ mod tests {
             panic!("expected rack state");
         };
 
-        assert!(rack.leaking_trays.contains(leak_context.endpoint_key()));
+        assert!(rack.leaking_trays.contains_key(leak_context.endpoint_key()));
+    }
+
+    #[test]
+    fn tray_state_remains_until_every_reporting_collector_retracts() {
+        let processor = RackLeakProcessor::new(1);
+        let first_context = context_with_rack("42:9e:b1:bd:9d:dd", "rack-1");
+        let mut second_context = first_context.clone();
+        second_context.collector_type = "second_leak_collector";
+
+        processor.process_event(&first_context, &tray_leak_report(true));
+        processor.process_event(&second_context, &tray_leak_report(true));
+
+        let emitted = processor.process_event(&second_context, &tray_leak_report(false));
+
+        let CollectorEvent::HealthReport(report) = &emitted[0] else {
+            panic!("expected health report");
+        };
+
+        assert_eq!(report.alerts.len(), 1);
+
+        {
+            let rack = processor
+                .racks
+                .get(first_context.rack_id().expect("rack id"))
+                .expect("expected rack state");
+
+            let reporters = rack
+                .leaking_trays
+                .get(first_context.endpoint_key())
+                .expect("expected leaking tray state");
+
+            assert_eq!(reporters.len(), 1);
+            assert!(reporters.contains(first_context.collector_type));
+        }
+
+        processor.process_event(&second_context, &tray_leak_report(true));
+        processor.process_event(&first_context, &CollectorEvent::CollectorRemoved);
+
+        {
+            let rack = processor
+                .racks
+                .get(first_context.rack_id().expect("rack id"))
+                .expect("expected rack state");
+
+            let reporters = rack
+                .leaking_trays
+                .get(first_context.endpoint_key())
+                .expect("expected leaking tray state");
+
+            assert_eq!(reporters.len(), 1);
+            assert!(reporters.contains(second_context.collector_type));
+        }
+
+        processor.process_event(&second_context, &CollectorEvent::CollectorRemoved);
+
+        let rack = processor
+            .racks
+            .get(first_context.rack_id().expect("rack id"))
+            .expect("expected rack state");
+
+        assert!(
+            !rack
+                .leaking_trays
+                .contains_key(first_context.endpoint_key())
+        );
     }
 
     #[test]

--- a/crates/health/src/sink/events.rs
+++ b/crates/health/src/sink/events.rs
@@ -42,7 +42,7 @@ pub enum HealthReportTarget {
     Switch,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct EventContext {
     pub endpoint_key: String,
     pub addr: BmcAddr,

--- a/crates/health/src/sink/tracing.rs
+++ b/crates/health/src/sink/tracing.rs
@@ -17,6 +17,7 @@
 
 use super::{CollectorEvent, DataSink, EventContext};
 use crate::HealthError;
+use crate::collectors::REACHABILITY_COLLECTOR_TYPE;
 use crate::config::TracingSinkConfig;
 
 /// Sink that writes health events through the process tracing subscriber.
@@ -43,6 +44,13 @@ impl DataSink for TracingSink {
         context: &EventContext,
         event: &CollectorEvent,
     ) -> Result<(), HealthError> {
+        if context.collector_type == REACHABILITY_COLLECTOR_TYPE
+            && matches!(event, CollectorEvent::Metric(_))
+        {
+            // Metric samples are not rendered as logs; log_mode controls probe logs.
+            return Ok(());
+        }
+
         match event {
             CollectorEvent::MetricCollectionStart => {
                 tracing::info!(
@@ -176,5 +184,39 @@ mod tests {
             log.field("attributes"),
             Some(r#"[("gentime", "2026-07-05 12:34:56"), ("user", "admin")]"#)
         );
+    }
+
+    #[test]
+    fn reachability_metrics_do_not_bypass_structured_log_policy() {
+        let sink = TracingSink::new(&TracingSinkConfig {
+            include_diagnostics: false,
+        });
+
+        let endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+        let context = EventContext::from_endpoint(&endpoint, REACHABILITY_COLLECTOR_TYPE);
+
+        let metric = CollectorEvent::Metric(
+            crate::sink::MetricSample {
+                key: "redfish@127.0.0.1:443".to_string(),
+                name: "tcp_port".to_string(),
+                metric_type: "reachable".to_string(),
+                unit: "state".to_string(),
+                value: 1.0,
+                labels: vec![],
+                context: None,
+            }
+            .into(),
+        );
+
+        assert!(capture_logs(|| sink.handle_event(&context, &metric)).is_empty());
+
+        let log = CollectorEvent::Log(Box::new(LogRecord {
+            body: "TCP port is reachable".to_string(),
+            severity: "INFO".to_string(),
+            attributes: vec![],
+            diagnostic_record: None,
+        }));
+
+        assert_eq!(capture_logs(|| sink.handle_event(&context, &log)).len(), 1);
     }
 }


### PR DESCRIPTION
Add opt-in TCP reachability observations to `carbide-health`. This allows metrics and logs consumers to distinguish transport failures from TLS, authentication, and protocol failures.

The collector derives targets and ports from the existing eligibility rules and configuration for Redfish, NVUE REST, gNMI, NMX-T, and NMX-C. BMC probes connect directly to the discovered endpoint, even when a BMC proxy is configured.

Each completed probe emits an endpoint-correlated `tcp_port_reachable_state` gauge. Structured logging is stateless: `unreachable` logs every failed probe, while `all` logs every completed probe. Reachability observations bypass health processors and do not create health reports or persisted alerts.

This feature is disabled by default. To enable, here's an example configuration:

```toml
[collectors.reachability]
enabled = true
interval = "30s"
timeout = "3s"
log_mode = "unreachable"
```

## Related issues

Resolves #4658

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Manual Testing

Method:

- Established an independent TCP baseline with socket connection attempts.
- Ran `health` collection against real NVOS switch host endpoints.
- Inspected Prometheus telemetry, structured JSONL logs, and discovery logs.

Coverage:

- Seven switch host endpoints.
- Reachable NVUE REST port 443.
- Unreachable NMX-T port 9352 and NMX-C port 9370.
- `all` and `unreachable` log modes.

Steps:

1. Probed each service port independently.

   Observed results:

   ```text
   nvue_rest_reachable=7
   nmxt_unreachable=7
   nmxc_unreachable=7
   ```

2. Enabled `log_mode = "all"` and inspected `/telemetry` and JSONL output.

   Selected redacted metric:

   ```text
   carbide_hardware_health_tcp_port_reachable_state{endpoint_key="<endpoint-key>",endpoint_mac="<endpoint-mac>",endpoint_ip="<endpoint-ip>",collector_type="reachability",serial_number="<switch-serial>",rack_id="<rack-id>",service="nmxt",port="9352",environment="lab",inventory="<inventory>"} 0
   ```

   Selected redacted log:

   ```json
   {"endpoint":"<endpoint-key>","collector":"reachability","component_type":"nvlink_switch","severity":"WARN","body":"TCP port is unreachable","attributes":[["message_id","CarbideHealth.1.0.TcpPortUnreachable"],["message_args","[\"nmxt@<endpoint-ip>:9352\"]"],["reachability.service","nmxt"],["reachability.address","<endpoint-ip>"],["reachability.port","9352"],["reachability.state","unreachable"],["reachability.error","Connection refused (os error 61)"]]}
   ```

3. Repeated the fleet run with `log_mode = "unreachable"`.

   Observed results:

   ```text
   metric_series=21
   reachable_logs=0
   unreachable_logs=84
   ```

   All 21 metric series remained available. The 84 records represent 14 failed targets across six cycles.

4. Configured two discovered endpoints with the same test key. The first enabled NVUE REST, while the later duplicate also enabled NMX-T.

   Observed results:

   ```text
   duplicate_warnings=1
   discovered_endpoint_count_one=1
   first_source_series=1
   later_source_or_nmxt_series=0
   nmxt_collector_started=0
   ```

Results:

- Emitted gauges matched the independent TCP baseline.
- All 21 series included endpoint identity and configured correlation metadata.
- The isolated JSONL run contained only reachability records and no health or alert records.
- Duplicate endpoint selection remained consistent between ordinary and reachability collectors.

## Additional Notes

A successful probe means only that the TCP handshake completed. It does not validate TLS, authentication, HTTP, gRPC, gNMI, NMX-C subscription, or collector readiness.