### PR TITLE
fix(nv-redfish): pin to 0.12.0 to restore SSE compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7814,9 +7814,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2592edb56672a2c7edf127a376cc1ee487ba0e3c6f1de089e0a8074e731fae2c"
+checksum = "a479451ed177b194f1516905192cca7afcb19df746929a696cde25bb59505d22"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ opentelemetry-semantic-conventions = "0.32.1"
 tracing-opentelemetry = "0.33.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.12.1" }
+nv-redfish = { version = "=0.12.0" }
 nv-redfish-dispatcher = { version = "0.13.0" }
 
 ########


### PR DESCRIPTION
## Summary

- Pin `nv-redfish` to `=0.12.0` in the workspace `Cargo.toml`
- Downgrade `Cargo.lock` accordingly

## Problem

`nv-redfish 0.12.1` made `EventType` a required field in the Redfish `EventRecord` struct. Newer BMC firmware omits `EventType` (deprecated in Redfish schema 1.2+), causing nico-health (`forge-hw-health`) to crash and reconnect on every SSE event received:

```
level=ERROR msg="streaming collector stream error, reconnecting"
  error="BmcError(JSON error: missing field `EventType`)"
```

This renders real-time SSE event collection non-functional against production BMC firmware.

## Fix

Pin to `0.12.0` which treats `EventType` as optional, restoring compatibility. The proper long-term fix is for nv-redfish to make the field `Option<EventType>` — this pin is a stopgap until that lands.

Signed-off-by: Dasa Chandramouli <dchandramoul@nvidia.com>