### PR TITLE
fix: discovery cleanup bug + dell machine_setup_status fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.3#b199e7bebeb8238fe1440f110d06affba5b6b799"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.4#7772f48f934805c66dab7f1a68c5fbaf6f781295"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.3" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.4" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -58,12 +58,12 @@ use model::machine::health_override::HARDWARE_HEALTH_OVERRIDE_PREFIX;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     BiosConfigInfo, BiosConfigState, BomValidating, BomValidatingContext, CleanupContext,
-    CleanupState, DpuDiscoveringState, DpuInitState, DpuReprovisionStates, FailureCause,
-    FailureDetails, FailureSource, HostPlatformConfigurationState, InstallDpuOsState,
-    InstanceState, LockdownMode, MachineState, MachineValidatingState, MachineValidationContext,
-    ManagedHostState, MeasuringState, PowerState, ReadyBootConfigState,
-    ReadyBootConfigTerminalFailure, SetBootOrderInfo, SetBootOrderState, SetSecureBootState,
-    SpdmMeasuringState, StateMachineArea, ValidationState,
+    CleanupState, CreateBossVolumeContext, CreateBossVolumeState, DpuDiscoveringState,
+    DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
+    HostPlatformConfigurationState, InstallDpuOsState, InstanceState, LockdownMode, MachineState,
+    MachineValidatingState, MachineValidationContext, ManagedHostState, MeasuringState, PowerState,
+    ReadyBootConfigState, ReadyBootConfigTerminalFailure, SecureEraseBossState, SetBootOrderInfo,
+    SetBootOrderState, SetSecureBootState, SpdmMeasuringState, StateMachineArea, ValidationState,
 };
 use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::machine_validation::MachineValidationState;
@@ -1044,6 +1044,80 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     assert!(matches!(
         host.current_state(),
         ManagedHostState::WaitingForCleanup { .. }
+    ));
+}
+
+#[crate::sqlx_test]
+async fn test_dell_boss_initial_discovery_skips_lockdown_states(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let mh = create_managed_host(&env).await;
+    env.redfish_sim
+        .set_boss_controller_id(Some("RAID.Slot.1".to_string()));
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::Init,
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::SecureEraseBoss {
+                secure_erase_boss_context,
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        } if secure_erase_boss_context.boss_controller_id == "RAID.Slot.1"
+            && secure_erase_boss_context.secure_erase_jid.is_none()
+            && secure_erase_boss_context.secure_erase_boss_state
+                == SecureEraseBossState::SecureEraseBoss
+            && secure_erase_boss_context.iteration == Some(0)
+    ));
+
+    db::machine::advance(
+        &host,
+        &mut txn,
+        &ManagedHostState::WaitingForCleanup {
+            cleanup_state: CleanupState::CreateBossVolume {
+                create_boss_volume_context: CreateBossVolumeContext {
+                    boss_controller_id: "RAID.Slot.1".to_string(),
+                    create_boss_volume_jid: Some("boss-job-1".to_string()),
+                    create_boss_volume_state: CreateBossVolumeState::WaitForJobCompletion,
+                    iteration: Some(0),
+                },
+            },
+            cleanup_context: CleanupContext::InitialDiscovery,
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    env.redfish_sim
+        .set_job_state_sequence(vec![libredfish::JobState::Completed]);
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    let host = mh.host().db_machine(&mut txn).await;
+    assert!(matches!(
+        host.current_state(),
+        ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        }
     ));
 }
 

--- a/crates/bmc-explorer/src/hw/dell.rs
+++ b/crates/bmc-explorer/src/hw/dell.rs
@@ -17,7 +17,7 @@
 
 use crate::hw::BiosAttr;
 
-pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 13] = [
+pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 14] = [
     BiosAttr::new_str("InBandManageabilityInterface", "Disabled"),
     BiosAttr::new_str("UefiVariableAccess", "Standard"),
     BiosAttr::new_any_str("SerialComm", &["OnConRedirAuto", "OnConRedir"]), // Second is legacy
@@ -30,5 +30,6 @@ pub const EXPECTED_BIOS_ATTRS: [BiosAttr; 13] = [
     BiosAttr::new_str("Tpm2Hierarchy", "Enabled"), // Setup puts "Clear" here.
     BiosAttr::new_str("Tpm2Algorithm", "SHA256"),
     BiosAttr::new_str("HttpDev1EnDis", "Enabled"),
+    BiosAttr::new_str("HttpDev1TlsMode", "None"),
     BiosAttr::new_str("PxeDev1EnDis", "Disabled"),
 ];

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1208,12 +1208,18 @@ impl MachineStateHandler {
                                 .await
                                 .map_err(|e| redfish_error("get_boss_controller", e))?
                         {
+                            let secure_erase_boss_state = match cleanup_context {
+                                CleanupContext::Deprovision => SecureEraseBossState::UnlockHost,
+                                CleanupContext::InitialDiscovery => {
+                                    SecureEraseBossState::SecureEraseBoss
+                                }
+                            };
                             let next_state = waiting_for_cleanup_state(
                                 CleanupState::SecureEraseBoss {
                                     secure_erase_boss_context: SecureEraseBossContext {
                                         boss_controller_id,
                                         secure_erase_jid: None,
-                                        secure_erase_boss_state: SecureEraseBossState::UnlockHost,
+                                        secure_erase_boss_state,
                                         iteration: Some(0),
                                     },
                                 },
@@ -1240,10 +1246,12 @@ impl MachineStateHandler {
 
                         match secure_erase_boss_context.secure_erase_boss_state {
                             SecureEraseBossState::UnlockHost => {
-                                redfish_client
-                                    .set_idrac_lockdown(EnabledDisabled::Disabled)
-                                    .await
-                                    .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                if matches!(cleanup_context, CleanupContext::Deprovision) {
+                                    redfish_client
+                                        .set_idrac_lockdown(EnabledDisabled::Disabled)
+                                        .await
+                                        .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                }
 
                                 let next_state = waiting_for_cleanup_state(
                                     CleanupState::SecureEraseBoss {
@@ -1423,10 +1431,12 @@ impl MachineStateHandler {
                                 .await
                             }
                             CreateBossVolumeState::LockHost => {
-                                redfish_client
-                                    .set_idrac_lockdown(EnabledDisabled::Enabled)
-                                    .await
-                                    .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                if matches!(cleanup_context, CleanupContext::Deprovision) {
+                                    redfish_client
+                                        .set_idrac_lockdown(EnabledDisabled::Enabled)
+                                        .await
+                                        .map_err(|e| redfish_error("set_idrac_lockdown", e))?;
+                                }
 
                                 let next_state = post_cleanup_state(*cleanup_context);
 
@@ -11698,24 +11708,30 @@ async fn wait_for_boss_controller_job_to_complete(
         // The job has completed; transition to next step in host cleanup
         libredfish::JobState::Completed => {
             // healthy path
-            let cleanup_state = match secure_erase_boss_controller {
+            let next_state = match (secure_erase_boss_controller, cleanup_context) {
                 // now that we have finished doing a secure erase of the BOSS controller
                 // we can do a standard secure erase of the remaining drives through the /usr/sbin/nvme tool
-                true => CleanupState::HostCleanup {
-                    boss_controller_id: Some(boss_controller_id),
-                },
-                // now that we have recreated the R1 volume on top of the BOSS controller, we can lock the host back down again.
-                false => CleanupState::CreateBossVolume {
-                    create_boss_volume_context: CreateBossVolumeContext {
-                        boss_controller_id,
-                        create_boss_volume_jid: None,
-                        create_boss_volume_state: CreateBossVolumeState::LockHost,
-                        iteration: Some(iterations),
+                (true, _) => waiting_for_cleanup_state(
+                    CleanupState::HostCleanup {
+                        boss_controller_id: Some(boss_controller_id),
                     },
-                },
+                    cleanup_context,
+                ),
+                // now that we have recreated the R1 volume on top of the BOSS controller, we can lock the host back down again.
+                (false, CleanupContext::Deprovision) => waiting_for_cleanup_state(
+                    CleanupState::CreateBossVolume {
+                        create_boss_volume_context: CreateBossVolumeContext {
+                            boss_controller_id,
+                            create_boss_volume_jid: None,
+                            create_boss_volume_state: CreateBossVolumeState::LockHost,
+                            iteration: Some(iterations),
+                        },
+                    },
+                    cleanup_context,
+                ),
+                (false, CleanupContext::InitialDiscovery) => post_cleanup_state(cleanup_context),
             };
 
-            let next_state = waiting_for_cleanup_state(cleanup_state, cleanup_context);
             Ok(StateHandlerOutcome::transition(next_state))
         }
         // The job has failed; handle error

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -58,6 +58,7 @@ struct RedfishSimState {
     machine_setup_bios_job_id: Option<String>,
     is_bios_setup: Option<bool>,
     default_lockdown: Option<EnabledDisabled>,
+    boss_controller_id: Option<String>,
     /// Override whether `lockdown_bmc` changes the observed state. `None`
     /// preserves the normal successful behavior; `Some(false)` models a BMC
     /// accepting the write without applying the requested policy.
@@ -295,6 +296,10 @@ impl RedfishSim {
 
     pub fn set_job_state_sequence(&self, states: Vec<JobState>) {
         self.state.lock().unwrap().job_state_sequence = VecDeque::from(states);
+    }
+
+    pub fn set_boss_controller_id(&self, boss_controller_id: Option<String>) {
+        self.state.lock().unwrap().boss_controller_id = boss_controller_id;
     }
 
     pub fn set_is_bios_setup(&self, ready: bool) {
@@ -1916,7 +1921,7 @@ impl Redfish for RedfishSimClient {
     fn get_boss_controller<'a>(
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { Ok(None) })
+        Box::pin(async move { Ok(self.state.lock().unwrap().boss_controller_id.clone()) })
     }
 
     fn decommission_storage_controller<'a>(


### PR DESCRIPTION
This PR:

- Skips Dell iDRAC unlock and relock states during initial-discovery cleanup, preventing lockdown before UEFI password setup.
- Preserves existing lockdown behavior for deprovision cleanup.
- Bumps libredfish to `v0.46.4` to verify Dell `HttpDev1TlsMode` during machine setup, preventing hosts from getting stuck in `WaitingForDiscovery` when TLS remains enabled.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4704
https://github.com/NVIDIA/infra-controller/issues/4710

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
