### PR TITLE
refactor(proto): deduplicate extern_paths for tonic wrapper & prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,9 +2753,11 @@ dependencies = [
  "prost-build",
  "prost-reflect",
  "prost-types",
+ "quote",
  "syn 2.0.117",
  "tempfile",
  "thiserror 2.0.18",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -11926,6 +11928,7 @@ name = "tonic-client-wrapper"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "carbide-proto-compiler",
  "heck",
  "lazy_static",
  "prettyplease",

--- a/crates/proto-compiler/Cargo.toml
+++ b/crates/proto-compiler/Cargo.toml
@@ -27,9 +27,11 @@ repository.workspace = true
 prost-build = { workspace = true }
 prost-reflect = { workspace = true }
 prost-types = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["full", "parsing"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
 prost = { workspace = true }

--- a/crates/proto-compiler/src/extern_paths.rs
+++ b/crates/proto-compiler/src/extern_paths.rs
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::collections::HashMap;
+
+pub struct ExternPaths(Vec<(String, syn::Type)>);
+
+pub type ExternPathSearchIndex<'a> = HashMap<&'a str, &'a syn::Type>;
+
+impl ExternPaths {
+    pub fn new<T: AsRef<str>>(input: impl Iterator<Item = (T, syn::Type)>) -> Self {
+        Self(input.map(|(k, v)| (k.as_ref().to_string(), v)).collect())
+    }
+
+    pub fn build_index(&self) -> ExternPathSearchIndex<'_> {
+        self.0.iter().map(|(k, v)| (k.as_str(), v)).collect()
+    }
+}
+
+pub trait TonicBuilderExternPaths {
+    fn extern_paths(self, paths: &ExternPaths) -> Self;
+}
+
+impl TonicBuilderExternPaths for tonic_prost_build::Builder {
+    fn extern_paths(self, paths: &ExternPaths) -> Self {
+        paths.0.iter().fold(self, |builder, (name, rust_type)| {
+            builder.extern_path(name, quote::quote! { #rust_type }.to_string())
+        })
+    }
+}

--- a/crates/proto-compiler/src/lib.rs
+++ b/crates/proto-compiler/src/lib.rs
@@ -52,8 +52,10 @@
 //! Cargo's `OUT_DIR`.
 
 mod compiler;
+mod extern_paths;
 mod schema;
 
 pub use compiler::{CompilerConfig, Error, compile};
+pub use extern_paths::{ExternPathSearchIndex, ExternPaths, TonicBuilderExternPaths};
 pub use schema::Schema;
 pub use syn;

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -17,7 +17,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use carbide_proto_compiler::{CompilerConfig, compile, syn};
+use carbide_proto_compiler::{CompilerConfig, ExternPaths, TonicBuilderExternPaths, compile, syn};
 use tonic_client_wrapper::codegen;
 
 const PROTO_FILES: &[&str] = &[
@@ -55,6 +55,152 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // annotation values. No sanitization or prost_types re-encoding occurs.
     fs::write(&reflection, &schema.raw_descriptor_set)?;
 
+    let extern_paths = ExternPaths::new(
+        [
+            (
+                ".common.MachineId",
+                syn::parse_quote!(::carbide_uuid::machine::MachineId),
+            ),
+            (
+                ".common.DomainId",
+                syn::parse_quote!(::carbide_uuid::domain::DomainId),
+            ),
+            (
+                ".common.RemediationId",
+                syn::parse_quote!(::carbide_uuid::dpu_remediations::RemediationId),
+            ),
+            (
+                ".common.MachineInterfaceId",
+                syn::parse_quote!(::carbide_uuid::machine::MachineInterfaceId),
+            ),
+            (
+                ".common.VpcId",
+                syn::parse_quote!(::carbide_uuid::vpc::VpcId),
+            ),
+            (
+                ".common.VpcPrefixId",
+                syn::parse_quote!(::carbide_uuid::vpc::VpcPrefixId),
+            ),
+            (
+                ".common.SitePrefixId",
+                syn::parse_quote!(::carbide_uuid::site_prefix::SitePrefixId),
+            ),
+            (
+                ".common.VpcPeeringId",
+                syn::parse_quote!(::carbide_uuid::vpc_peering::VpcPeeringId),
+            ),
+            (
+                ".common.IBPartitionId",
+                syn::parse_quote!(::carbide_uuid::infiniband::IBPartitionId),
+            ),
+            (
+                ".common.SpxPartitionId",
+                syn::parse_quote!(::carbide_uuid::spx::SpxPartitionId),
+            ),
+            (
+                ".common.InstanceId",
+                syn::parse_quote!(::carbide_uuid::instance::InstanceId),
+            ),
+            (
+                ".common.NetworkSegmentId",
+                syn::parse_quote!(::carbide_uuid::network::NetworkSegmentId),
+            ),
+            (
+                ".common.DpaInterfaceId",
+                syn::parse_quote!(::carbide_uuid::dpa_interface::DpaInterfaceId),
+            ),
+            (
+                ".common.NetworkPrefixId",
+                syn::parse_quote!(::carbide_uuid::network::NetworkPrefixId),
+            ),
+            (
+                ".common.SwitchId",
+                syn::parse_quote!(::carbide_uuid::switch::SwitchId),
+            ),
+            (
+                ".common.PowerShelfId",
+                syn::parse_quote!(::carbide_uuid::power_shelf::PowerShelfId),
+            ),
+            (
+                ".common.ComputeAllocationId",
+                syn::parse_quote!(::carbide_uuid::compute_allocation::ComputeAllocationId),
+            ),
+            (
+                ".common.OperatingSystemId",
+                syn::parse_quote!(::carbide_uuid::operating_system::OperatingSystemId),
+            ),
+            (
+                ".common.IpxeTemplateId",
+                syn::parse_quote!(::carbide_uuid::ipxe_template::IpxeTemplateId),
+            ),
+            (
+                ".common.MachineValidationId",
+                syn::parse_quote!(::carbide_uuid::machine_validation::MachineValidationId),
+            ),
+            (
+                ".common.RackId",
+                syn::parse_quote!(::carbide_uuid::rack::RackId),
+            ),
+            (
+                ".common.RackProfileId",
+                syn::parse_quote!(::carbide_uuid::rack::RackProfileId),
+            ),
+            (
+                ".common.NVLinkPartitionId",
+                syn::parse_quote!(::carbide_uuid::nvlink::NvLinkPartitionId),
+            ),
+            (
+                ".common.NVLinkLogicalPartitionId",
+                syn::parse_quote!(::carbide_uuid::nvlink::NvLinkLogicalPartitionId),
+            ),
+            (
+                ".common.NVLinkDomainId",
+                syn::parse_quote!(::carbide_uuid::nvlink::NvLinkDomainId),
+            ),
+            (
+                ".measured_boot.MeasurementSystemProfileId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementSystemProfileId),
+            ),
+            (
+                ".measured_boot.MeasurementSystemProfileAttrId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementSystemProfileAttrId),
+            ),
+            (
+                ".measured_boot.MeasurementBundleId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementBundleId),
+            ),
+            (
+                ".measured_boot.MeasurementBundleValueId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementBundleValueId),
+            ),
+            (
+                ".measured_boot.MeasurementReportId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementReportId),
+            ),
+            (
+                ".measured_boot.MeasurementReportValueId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementReportValueId),
+            ),
+            (
+                ".measured_boot.MeasurementJournalId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementJournalId),
+            ),
+            (
+                ".measured_boot.MeasurementApprovedMachineId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementApprovedMachineId),
+            ),
+            (
+                ".measured_boot.MeasurementApprovedProfileId",
+                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementApprovedProfileId),
+            ),
+            (
+                ".common.DeviceId",
+                syn::parse_quote!(::carbide_uuid::device::DeviceId),
+            ),
+        ]
+        .into_iter(),
+    );
+
     let derive_prost_builder =
         "#[cfg_attr(feature = \"test-support\", derive(carbide_prost_builder::Builder))]";
 
@@ -89,41 +235,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .extern_path(".google.protobuf.Duration", "crate::Duration")
         .extern_path(".google.protobuf.Timestamp", "crate::Timestamp")
-        .extern_path(".common.DomainId", "::carbide_uuid::domain::DomainId")
-        .extern_path(".common.DpaInterfaceId", "::carbide_uuid::dpa_interface::DpaInterfaceId")
-        .extern_path(".common.IBPartitionId", "::carbide_uuid::infiniband::IBPartitionId")
-        .extern_path(".common.SpxPartitionId", "::carbide_uuid::spx::SpxPartitionId")
-        .extern_path(".common.InstanceId", "::carbide_uuid::instance::InstanceId")
-        .extern_path(".common.MachineId", "::carbide_uuid::machine::MachineId")
-        .extern_path(".common.MachineInterfaceId", "::carbide_uuid::machine::MachineInterfaceId")
-        .extern_path(".common.NetworkPrefixId", "::carbide_uuid::network::NetworkPrefixId")
-        .extern_path(".common.NetworkSegmentId", "::carbide_uuid::network::NetworkSegmentId")
-        .extern_path(".common.PowerShelfId", "::carbide_uuid::power_shelf::PowerShelfId")
-        .extern_path(".common.RackId", "::carbide_uuid::rack::RackId")
-        .extern_path(".common.RackProfileId", "::carbide_uuid::rack::RackProfileId")
-        .extern_path(".common.NVLinkPartitionId", "::carbide_uuid::nvlink::NvLinkPartitionId")
-        .extern_path(".common.NVLinkLogicalPartitionId", "::carbide_uuid::nvlink::NvLinkLogicalPartitionId")
-        .extern_path(".common.NVLinkDomainId", "::carbide_uuid::nvlink::NvLinkDomainId")
-        .extern_path(".common.RemediationId", "carbide_uuid::dpu_remediations::RemediationId")
-        .extern_path(".common.SwitchId", "::carbide_uuid::switch::SwitchId")
-        .extern_path(".common.VpcId", "::carbide_uuid::vpc::VpcId")
-        .extern_path(".common.VpcPeeringId", "::carbide_uuid::vpc_peering::VpcPeeringId")
-        .extern_path(".common.VpcPrefixId", "::carbide_uuid::vpc::VpcPrefixId")
-        .extern_path(".common.SitePrefixId", "::carbide_uuid::site_prefix::SitePrefixId")
-        .extern_path(".common.ComputeAllocationId", "::carbide_uuid::compute_allocation::ComputeAllocationId")
-        .extern_path(".common.OperatingSystemId", "::carbide_uuid::operating_system::OperatingSystemId")
-        .extern_path(".common.IpxeTemplateId", "::carbide_uuid::ipxe_template::IpxeTemplateId")
-        .extern_path(".common.MachineValidationId", "::carbide_uuid::machine_validation::MachineValidationId")
-        .extern_path(".measured_boot.MeasurementSystemProfileId", "::carbide_uuid::measured_boot::MeasurementSystemProfileId")
-        .extern_path(".measured_boot.MeasurementSystemProfileAttrId", "::carbide_uuid::measured_boot::MeasurementSystemProfileAttrId")
-        .extern_path(".measured_boot.MeasurementBundleId", "::carbide_uuid::measured_boot::MeasurementBundleId")
-        .extern_path(".measured_boot.MeasurementBundleValueId", "::carbide_uuid::measured_boot::MeasurementBundleValueId")
-        .extern_path(".measured_boot.MeasurementReportId", "::carbide_uuid::measured_boot::MeasurementReportId")
-        .extern_path(".measured_boot.MeasurementReportValueId", "::carbide_uuid::measured_boot::MeasurementReportValueId")
-        .extern_path(".measured_boot.MeasurementJournalId", "::carbide_uuid::measured_boot::MeasurementJournalId")
-        .extern_path(".measured_boot.MeasurementApprovedMachineId", "::carbide_uuid::measured_boot::MeasurementApprovedMachineId")
-        .extern_path(".measured_boot.MeasurementApprovedProfileId", "::carbide_uuid::measured_boot::MeasurementApprovedProfileId")
-        .extern_path(".common.DeviceId", "::carbide_uuid::device::DeviceId")
+        .extern_paths(&extern_paths)
         .include_file("prost_common.rs")
         .type_attribute(".health", "#[derive(serde::Deserialize, serde::Serialize)]")
         .type_attribute(
@@ -1121,148 +1233,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         inner_rpc_client_type: "crate::forge_tls_client::ForgeClientT".to_string(),
         root_files: vec!["forge.proto".to_string()],
         generated_types_path_within_crate: "protos".to_string(),
-        extern_paths: vec![
-            (
-                ".common.MachineId",
-                syn::parse_quote!(::carbide_uuid::machine::MachineId),
-            ),
-            (
-                ".common.DomainId",
-                syn::parse_quote!(::carbide_uuid::domain::DomainId),
-            ),
-            (
-                ".common.RemediationId",
-                syn::parse_quote!(::carbide_uuid::dpu_remediations::RemediationId),
-            ),
-            (
-                ".common.MachineInterfaceId",
-                syn::parse_quote!(::carbide_uuid::machine::MachineInterfaceId),
-            ),
-            (
-                ".common.VpcId",
-                syn::parse_quote!(::carbide_uuid::vpc::VpcId),
-            ),
-            (
-                ".common.VpcPrefixId",
-                syn::parse_quote!(::carbide_uuid::vpc::VpcPrefixId),
-            ),
-            (
-                ".common.SitePrefixId",
-                syn::parse_quote!(::carbide_uuid::site_prefix::SitePrefixId),
-            ),
-            (
-                ".common.VpcPeeringId",
-                syn::parse_quote!(::carbide_uuid::vpc_peering::VpcPeeringId),
-            ),
-            (
-                ".common.IBPartitionId",
-                syn::parse_quote!(::carbide_uuid::infiniband::IBPartitionId),
-            ),
-            (
-                ".common.SpxPartitionId",
-                syn::parse_quote!(::carbide_uuid::spx::SpxPartitionId),
-            ),
-            (
-                ".common.InstanceId",
-                syn::parse_quote!(::carbide_uuid::instance::InstanceId),
-            ),
-            (
-                ".common.NetworkSegmentId",
-                syn::parse_quote!(::carbide_uuid::network::NetworkSegmentId),
-            ),
-            (
-                ".common.DpaInterfaceId",
-                syn::parse_quote!(::carbide_uuid::dpa_interface::DpaInterfaceId),
-            ),
-            (
-                ".common.NetworkPrefixId",
-                syn::parse_quote!(::carbide_uuid::network::NetworkPrefixId),
-            ),
-            (
-                ".common.SwitchId",
-                syn::parse_quote!(::carbide_uuid::switch::SwitchId),
-            ),
-            (
-                ".common.PowerShelfId",
-                syn::parse_quote!(::carbide_uuid::power_shelf::PowerShelfId),
-            ),
-            (
-                ".common.ComputeAllocationId",
-                syn::parse_quote!(::carbide_uuid::compute_allocation::ComputeAllocationId),
-            ),
-            (
-                ".common.OperatingSystemId",
-                syn::parse_quote!(::carbide_uuid::operating_system::OperatingSystemId),
-            ),
-            (
-                ".common.IpxeTemplateId",
-                syn::parse_quote!(::carbide_uuid::ipxe_template::IpxeTemplateId),
-            ),
-            (
-                ".common.MachineValidationId",
-                syn::parse_quote!(::carbide_uuid::machine_validation::MachineValidationId),
-            ),
-            (
-                ".common.RackId",
-                syn::parse_quote!(::carbide_uuid::rack::RackId),
-            ),
-            (
-                ".common.RackProfileId",
-                syn::parse_quote!(::carbide_uuid::rack::RackProfileId),
-            ),
-            (
-                ".common.NVLinkPartitionId",
-                syn::parse_quote!(::carbide_uuid::nvlink::NvLinkPartitionId),
-            ),
-            (
-                ".common.NVLinkLogicalPartitionId",
-                syn::parse_quote!(::carbide_uuid::nvlink::NvLinkLogicalPartitionId),
-            ),
-            (
-                ".common.NVLinkDomainId",
-                syn::parse_quote!(::carbide_uuid::nvlink::NvLinkDomainId),
-            ),
-            (
-                ".measured_boot.MeasurementSystemProfileId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementSystemProfileId),
-            ),
-            (
-                ".measured_boot.MeasurementSystemProfileAttrId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementSystemProfileAttrId),
-            ),
-            (
-                ".measured_boot.MeasurementBundleId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementBundleId),
-            ),
-            (
-                ".measured_boot.MeasurementBundleValueId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementBundleValueId),
-            ),
-            (
-                ".measured_boot.MeasurementReportId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementReportId),
-            ),
-            (
-                ".measured_boot.MeasurementReportValueId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementReportValueId),
-            ),
-            (
-                ".measured_boot.MeasurementJournalId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementJournalId),
-            ),
-            (
-                ".measured_boot.MeasurementApprovedMachineId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementApprovedMachineId),
-            ),
-            (
-                ".measured_boot.MeasurementApprovedProfileId",
-                syn::parse_quote!(::carbide_uuid::measured_boot::MeasurementApprovedProfileId),
-            ),
-            (
-                ".common.DeviceId",
-                syn::parse_quote!(::carbide_uuid::device::DeviceId),
-            ),
-        ],
+        extern_paths: extern_paths.build_index(),
     };
     let client_wrapper_generator =
         codegen::CodeGenerator::new(client_wrapper_config, &schema.file_descriptor_set)?;
@@ -1276,7 +1247,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         wrapper_name: "NmxCApiClient".to_string(),
         inner_rpc_client_type: "crate::forge_tls_client::NmxCClientT".to_string(),
         root_files: vec!["nmx_c.proto".to_string()],
-        extern_paths: vec![],
+        extern_paths: Default::default(),
         generated_types_path_within_crate: "protos".to_string(),
     };
     let nmx_c_client_wrapper =

--- a/crates/tonic-client-wrapper/Cargo.toml
+++ b/crates/tonic-client-wrapper/Cargo.toml
@@ -35,6 +35,8 @@ codegen = [
 ]
 
 [dependencies]
+carbide-proto-compiler = { path = "../proto-compiler" }
+
 thiserror = { workspace = true }
 tonic = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/tonic-client-wrapper/src/codegen.rs
+++ b/crates/tonic-client-wrapper/src/codegen.rs
@@ -29,6 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 
+use carbide_proto_compiler::ExternPathSearchIndex;
 use heck::{ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{LexError, TokenStream};
 use prost_types::field_descriptor_proto::Label;
@@ -61,7 +62,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Configures code generation of a tonic client wrapper.
-pub struct Config {
+pub struct Config<'a> {
     /// The name of the generated tonic client wrapper.
     pub wrapper_name: String,
     /// The fully qualified type of the tonic client this wrapper will call.
@@ -85,7 +86,7 @@ pub struct Config {
 
     /// List of protobuf types to override with specific Rust types. This should mirror any types
     /// customized through `tonic_prost_build::Builder::extern_path` so the generated code matches.
-    pub extern_paths: Vec<(ProtobufType, RustType)>,
+    pub extern_paths: ExternPathSearchIndex<'a>,
 }
 
 pub type ProtobufType = &'static str;
@@ -101,7 +102,7 @@ pub struct CodeGenerator<'a> {
     root_files: Vec<&'a FileDescriptorProto>,
     generated_types_path_within_crate: TokenStream,
     message_types: HashMap<String, MessageWithPackage<'a>>,
-    extern_paths: HashMap<ProtobufType, RustType>,
+    extern_paths: ExternPathSearchIndex<'a>,
 }
 
 impl<'a> CodeGenerator<'a> {
@@ -110,7 +111,7 @@ impl<'a> CodeGenerator<'a> {
     /// [`Config::root_files`] chooses service roots within `descriptor_set`;
     /// imported and otherwise unselected files remain available for resolving
     /// method types.
-    pub fn new(config: Config, descriptor_set: &'a FileDescriptorSet) -> Result<Self> {
+    pub fn new(config: Config<'a>, descriptor_set: &'a FileDescriptorSet) -> Result<Self> {
         let inner_rpc_client_type =
             config
                 .inner_rpc_client_type
@@ -174,15 +175,13 @@ impl<'a> CodeGenerator<'a> {
             })
             .collect();
 
-        let extern_paths = config.extern_paths.into_iter().collect();
-
         Ok(Self {
             inner_rpc_client_type,
             wrapper_name,
             root_files,
             generated_types_path_within_crate,
             message_types,
-            extern_paths,
+            extern_paths: config.extern_paths,
         })
     }
 
@@ -679,6 +678,8 @@ fn write_token_stream_if_not_up_to_date<T: AsRef<Path>>(
 
 #[cfg(test)]
 mod tests {
+    use carbide_proto_compiler::ExternPaths;
+
     use super::*;
 
     fn descriptor_set(proto_files: &[(&str, &str)]) -> FileDescriptorSet {
@@ -698,19 +699,29 @@ mod tests {
             .expect("Could not compile test descriptors")
     }
 
-    fn test_config(root_files: Vec<String>) -> Config {
+    fn extern_paths() -> ExternPaths {
+        ExternPaths::new([(".ExternType", syn::parse_quote!(crate::CustomExternType))].into_iter())
+    }
+
+    fn test_config<'a>(root_files: Vec<String>, extern_paths: &'a ExternPaths) -> Config<'a> {
         Config {
             wrapper_name: "TestWrapper".to_string(),
             inner_rpc_client_type: "TestInnerClient".to_string(),
             generated_types_path_within_crate: "test".to_string(),
             root_files,
-            extern_paths: vec![(".ExternType", syn::parse_quote!(crate::CustomExternType))],
+            extern_paths: extern_paths.build_index(),
         }
     }
 
-    fn test_generator(descriptor_set: &FileDescriptorSet) -> CodeGenerator<'_> {
-        CodeGenerator::new(test_config(vec!["test.proto".to_string()]), descriptor_set)
-            .expect("Could not build CodeGenerator")
+    fn test_generator<'a>(
+        descriptor_set: &'a FileDescriptorSet,
+        extern_paths: &'a ExternPaths,
+    ) -> CodeGenerator<'a> {
+        CodeGenerator::new(
+            test_config(vec!["test.proto".to_string()], extern_paths),
+            descriptor_set,
+        )
+        .expect("Could not build CodeGenerator")
     }
 
     #[test]
@@ -718,8 +729,9 @@ mod tests {
         let descriptor_set =
             descriptor_set(&[("test.proto", include_str!("test_fixtures/test.proto"))]);
 
+        let extern_paths = extern_paths();
         match CodeGenerator::new(
-            test_config(vec!["missing.proto".to_string()]),
+            test_config(vec!["missing.proto".to_string()], &extern_paths),
             &descriptor_set,
         ) {
             Err(Error::MissingRootFile(root_file)) => assert_eq!(root_file, "missing.proto"),
@@ -728,7 +740,10 @@ mod tests {
         }
 
         match CodeGenerator::new(
-            test_config(vec!["test.proto".to_string(), "test.proto".to_string()]),
+            test_config(
+                vec!["test.proto".to_string(), "test.proto".to_string()],
+                &extern_paths,
+            ),
             &descriptor_set,
         ) {
             Err(Error::DuplicateRootFile(root_file)) => assert_eq!(root_file, "test.proto"),
@@ -741,7 +756,7 @@ mod tests {
             .file
             .push(descriptor_set.file[0].clone());
         match CodeGenerator::new(
-            test_config(vec!["test.proto".to_string()]),
+            test_config(vec!["test.proto".to_string()], &extern_paths),
             &duplicate_descriptor_set,
         ) {
             Err(Error::DuplicateRootFile(root_file)) => assert_eq!(root_file, "test.proto"),
@@ -796,8 +811,9 @@ mod tests {
                 "#,
             ),
         ]);
+        let extern_paths = extern_paths();
         let generator = CodeGenerator::new(
-            test_config(vec!["selected.proto".to_string()]),
+            test_config(vec!["selected.proto".to_string()], &extern_paths),
             &descriptor_set,
         )
         .expect("Could not build CodeGenerator");
@@ -825,9 +841,10 @@ mod tests {
 
     #[test]
     fn generated_files_match_golden() {
+        let extern_paths = extern_paths();
         let descriptor_set =
             descriptor_set(&[("test.proto", include_str!("test_fixtures/golden.proto"))]);
-        let generator = test_generator(&descriptor_set);
+        let generator = test_generator(&descriptor_set, &extern_paths);
         let output_dir = temp_dir::TempDir::new().expect("Could not create temporary directory");
         let wrapper_path = output_dir.path().join("wrapper.rs");
         let converters_path = output_dir.path().join("converters.rs");
@@ -853,7 +870,8 @@ mod tests {
     fn test_rpc_wrapper_method() {
         let descriptor_set =
             descriptor_set(&[("test.proto", include_str!("test_fixtures/test.proto"))]);
-        let generator = test_generator(&descriptor_set);
+        let extern_paths = extern_paths();
+        let generator = test_generator(&descriptor_set, &extern_paths);
 
         let methods = generator
             .root_files
@@ -1012,7 +1030,8 @@ mod tests {
     fn test_convenience_wrapper_method() {
         let descriptor_set =
             descriptor_set(&[("test.proto", include_str!("test_fixtures/test.proto"))]);
-        let generator = test_generator(&descriptor_set);
+        let extern_paths = extern_paths();
+        let generator = test_generator(&descriptor_set, &extern_paths);
 
         {
             let message_with_package = generator.message_types.get(".VoidRequest").unwrap();


### PR DESCRIPTION
Extern paths are paths of mapping between protobuf types and generated types in code. Before this PR these paths were passed to tonic wrapper generator and tonic prost builder independently and efficiently it was duplicted.

This PR fixes duplication and use single source for mapping for both usages. 

## Related issues

This is preliminary work for #4594 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

