### PR TITLE
feat(health): Emit latency and health metrics for BMC interactions

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -440,5 +440,6 @@ enable_bmc_latency_metrics = false
 
 # Defaults to ["all"]. Set a subset to control emitted labels. Allowed values:
 # "all", "http_response_status_code", "http_request_method", "http_path",
-# "server_address", "url_scheme", "bmc_vendor", "bmc_model".
+# "server_address", "url_scheme", "bmc_vendor", "bmc_model", "entity_type",
+# "machine_id", "rack_id".
 bmc_latency_attributes = ["all"]

--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -433,3 +433,12 @@ leaking_tray_threshold = 2
 # Listener exposes /metrics (service), /telemetry (Prometheus sink hardware samples), /livez (health).
 endpoint = "0.0.0.0:9009"
 prefix = "carbide_hardware_health"
+
+# Disabled by default. When enabled, emits {prefix}_bmc_latency_ms for outbound
+# Redfish HTTP requests to BMCs.
+enable_bmc_latency_metrics = false
+
+# Defaults to ["all"]. Set a subset to control emitted labels. Allowed values:
+# "all", "http_response_status_code", "http_request_method", "http_path",
+# "server_address", "url_scheme", "bmc_vendor", "bmc_model".
+bmc_latency_attributes = ["all"]

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -37,7 +37,10 @@ use rpc::forge_tls_client::{ApiConfig, ForgeClientConfig};
 use url::Url;
 
 use crate::HealthError;
-use crate::bmc::{BmcClient, BoxFuture, CredentialProvider};
+use crate::bmc::{
+    BmcClient, BmcLatencyInstrumentation, BoxFuture, CredentialProvider,
+    bmc_latency_endpoint_labels,
+};
 use crate::endpoint::{
     BmcAddr, BmcCredentials, BmcEndpoint, EndpointMetadata, EndpointSource, MachineData,
     PowerShelfData, SharedSystemUuid, SwitchData, SwitchEndpointRole,
@@ -599,6 +602,12 @@ impl ApiEndpointSource {
         rack_id: Option<RackId>,
         credential_kind: ApiCredentialKind,
     ) -> Result<Arc<BmcEndpoint>, HealthError> {
+        let bmc_latency_instrumentation = self.bmc_latency_metrics.clone().map(|metrics| {
+            BmcLatencyInstrumentation::new(
+                metrics,
+                bmc_latency_endpoint_labels(metadata.as_ref(), rack_id.as_ref()),
+            )
+        });
         let cached = {
             let mut cache = self.bmc_client_cache.lock().expect("cache mutex poisoned");
             cache_or_create_bmc_client(&mut cache, addr.mac, credential_kind, |kind| {
@@ -612,7 +621,7 @@ impl ApiEndpointSource {
                     provider,
                     self.proxy_url.clone(),
                     self.cache_size,
-                    self.bmc_latency_metrics.clone(),
+                    bmc_latency_instrumentation,
                 )?))
             })?
         };

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -42,6 +42,7 @@ use crate::endpoint::{
     BmcAddr, BmcCredentials, BmcEndpoint, EndpointMetadata, EndpointSource, MachineData,
     PowerShelfData, SharedSystemUuid, SwitchData, SwitchEndpointRole,
 };
+use crate::metrics::BmcLatencyMetrics;
 
 /// [`ApiEndpointSource`].
 #[derive(Clone)]
@@ -291,6 +292,7 @@ pub struct ApiEndpointSource {
     reqwest: ReqwestClient,
     proxy_url: Option<Url>,
     cache_size: usize,
+    bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     bmc_client_cache: Mutex<HashMap<MacAddress, CachedBmcClient>>,
 }
 
@@ -307,12 +309,14 @@ impl ApiEndpointSource {
         reqwest: ReqwestClient,
         proxy_url: Option<Url>,
         cache_size: usize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Self {
         Self {
             api,
             reqwest,
             proxy_url,
             cache_size,
+            bmc_latency_metrics,
             bmc_client_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -608,6 +612,7 @@ impl ApiEndpointSource {
                     provider,
                     self.proxy_url.clone(),
                     self.cache_size,
+                    self.bmc_latency_metrics.clone(),
                 )?))
             })?
         };
@@ -798,6 +803,7 @@ mod tests {
             provider,
             None,
             10,
+            None,
         )?))
     }
 

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use std::any::Any;
+use std::error::Error as StdError;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
@@ -38,6 +40,7 @@ use url::Url;
 
 use crate::HealthError;
 use crate::endpoint::{BmcAddr, BmcCredentials};
+use crate::metrics::{BmcLatencyMetrics, BmcLatencyObservation};
 
 pub(crate) const CREDENTIAL_REFRESH_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -141,6 +144,12 @@ impl CredentialProvider for FixedCredentialProvider {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+struct BmcIdentity {
+    vendor: Option<String>,
+    model: Option<String>,
+}
+
 pub struct BmcClient {
     inner: HttpBmc<ReqwestClient>,
     addr: BmcAddr,
@@ -162,6 +171,10 @@ pub struct BmcClient {
     /// [`KnownBadCredentials`]. Only touched on the auth-failure path, so the
     /// healthy request path never takes this lock.
     known_bad_credentials: StdMutex<Option<KnownBadCredentials>>,
+    bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+    server_address: String,
+    url_scheme: String,
+    bmc_identity: StdMutex<BmcIdentity>,
 }
 
 impl BmcClient {
@@ -171,12 +184,15 @@ impl BmcClient {
         provider: Arc<dyn CredentialProvider>,
         proxy_url: Option<Url>,
         cache_size: usize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Result<Self, HealthError> {
+        let server_address = bmc_server_address(&addr);
+        let url_scheme = bmc_url_scheme(&addr).to_string();
         let bmc_url = bmc_url(&addr, proxy_url.as_ref())?;
         let headers = bmc_headers(&addr, proxy_url.as_ref())?;
 
-        // Currently nv-redfish BMC, requires credentials, so this placeholder is sued
-        // they will be replaced as soon as we call ensure_credentials
+        // Currently nv-redfish BMC requires credentials, so this placeholder is used;
+        // they will be replaced as soon as we call ensure_credentials.
         let placeholder =
             nv_redfish::bmc_http::BmcCredentials::username_password(String::new(), None::<String>);
         let inner = HttpBmc::with_custom_headers(
@@ -196,7 +212,63 @@ impl BmcClient {
             circuit: StdMutex::new(CircuitState::Closed),
             circuit_tripped: AtomicBool::new(false),
             known_bad_credentials: StdMutex::new(None),
+            bmc_latency_metrics,
+            server_address,
+            url_scheme,
+            bmc_identity: StdMutex::new(BmcIdentity::default()),
         })
+    }
+
+    fn record_bmc_latency(&self, method: &str, path: &str, status_code: &str, duration: Duration) {
+        let Some(metrics) = &self.bmc_latency_metrics else {
+            return;
+        };
+
+        let identity = self
+            .bmc_identity
+            .lock()
+            .expect("BMC identity mutex poisoned")
+            .clone();
+        metrics.observe(BmcLatencyObservation {
+            status_code,
+            method,
+            path,
+            server_address: &self.server_address,
+            url_scheme: &self.url_scheme,
+            bmc_vendor: identity.vendor.as_deref(),
+            bmc_model: identity.model.as_deref(),
+            duration,
+        });
+    }
+
+    fn note_bmc_identity_from<T: 'static>(&self, value: &T) {
+        if let Some(root) =
+            (value as &dyn Any).downcast_ref::<nv_redfish::schema::service_root::ServiceRoot>()
+        {
+            self.note_bmc_identity(
+                root.vendor.as_ref().and_then(Option::as_deref),
+                root.product.as_ref().and_then(Option::as_deref),
+            );
+        }
+    }
+
+    fn note_bmc_identity(&self, vendor: Option<&str>, model: Option<&str>) {
+        let vendor = vendor.and_then(normalize_identity_value);
+        let model = model.and_then(normalize_identity_value);
+        if vendor.is_none() && model.is_none() {
+            return;
+        }
+
+        let mut identity = self
+            .bmc_identity
+            .lock()
+            .expect("BMC identity mutex poisoned");
+        if let Some(vendor) = vendor {
+            identity.vendor = Some(vendor);
+        }
+        if let Some(model) = model {
+            identity.model = Some(model);
+        }
     }
 
     pub async fn ensure_credentials(&self) -> Result<(), HealthError> {
@@ -608,6 +680,18 @@ impl BmcClient {
     }
 }
 
+fn bmc_server_address(addr: &BmcAddr) -> String {
+    addr.ip.to_string()
+}
+
+fn bmc_url_scheme(addr: &BmcAddr) -> &'static str {
+    if addr.port.is_some_and(|port| port == 80) {
+        "http"
+    } else {
+        "https"
+    }
+}
+
 fn bmc_url(addr: &BmcAddr, proxy_url: Option<&Url>) -> Result<Url, HealthError> {
     match proxy_url {
         Some(url) => Ok(url.clone()),
@@ -630,6 +714,93 @@ fn bmc_headers(addr: &BmcAddr, proxy_url: Option<&Url>) -> Result<HeaderMap, Hea
     Ok(headers)
 }
 
+const UNKNOWN_HTTP_STATUS_CODE: &str = "unknown";
+
+fn normalize_identity_value(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn request_path(id: &ODataId) -> String {
+    id.to_string()
+}
+
+fn uri_reference_path(uri: &str) -> String {
+    if let Ok(url) = Url::parse(uri) {
+        return url.path().to_string();
+    }
+
+    let path = uri.split_once('?').map_or(uri, |(path, _query)| path);
+    if path.is_empty() {
+        uri.to_string()
+    } else {
+        path.to_string()
+    }
+}
+
+// The nv-redfish Bmc surface exposes exact HTTP status codes for error
+// responses, but decodes successful responses before health can inspect the raw
+// response. Successful observations therefore use the Redfish status expected
+// for the operation.
+fn result_status_code<T>(result: &Result<T, HealthError>, success_status_code: &str) -> String {
+    match result {
+        Ok(_) => success_status_code.to_string(),
+        Err(error) => {
+            error_status_code(error).unwrap_or_else(|| UNKNOWN_HTTP_STATUS_CODE.to_string())
+        }
+    }
+}
+
+fn modification_result_status_code<T>(
+    result: &Result<ModificationResponse<T>, HealthError>,
+    entity_status_code: &str,
+) -> String {
+    match result {
+        Ok(ModificationResponse::Entity(_)) => entity_status_code.to_string(),
+        Ok(ModificationResponse::Task(_)) => http::StatusCode::ACCEPTED.as_u16().to_string(),
+        Ok(ModificationResponse::Empty) => http::StatusCode::NO_CONTENT.as_u16().to_string(),
+        Err(error) => {
+            error_status_code(error).unwrap_or_else(|| UNKNOWN_HTTP_STATUS_CODE.to_string())
+        }
+    }
+}
+
+fn error_status_code(error: &HealthError) -> Option<String> {
+    match error {
+        HealthError::BmcError(inner) => bmc_source_status_code(inner.as_ref()),
+        HealthError::HttpError(message) => http_error_status_code(message),
+        _ => None,
+    }
+}
+
+fn bmc_source_status_code(error: &(dyn StdError + 'static)) -> Option<String> {
+    if let Some(BmcError::InvalidResponse { status, .. }) = error.downcast_ref::<BmcError>() {
+        return Some(status.as_u16().to_string());
+    }
+
+    error
+        .downcast_ref::<HealthError>()
+        .and_then(error_status_code)
+}
+
+fn http_error_status_code(message: &str) -> Option<String> {
+    message
+        .split(|character: char| !character.is_ascii_digit())
+        .find_map(|token| {
+            if token.len() != 3 {
+                return None;
+            }
+            let code = token.parse::<u16>().ok()?;
+            http::StatusCode::from_u16(code)
+                .ok()
+                .map(|status| status.as_u16().to_string())
+        })
+}
+
 impl Bmc for BmcClient {
     type Error = HealthError;
 
@@ -638,11 +809,21 @@ impl Bmc for BmcClient {
         id: &ODataId,
         query: ExpandQuery,
     ) -> Result<Arc<T>, Self::Error> {
-        self.read_with_auth_retry(|| async {
-            self.inner
-                .expand(id, query.clone())
-                .await
-                .map_err(HealthError::from)
+        let path = request_path(id);
+        self.read_with_auth_retry(|| {
+            let path = path.clone();
+            let query = query.clone();
+            async move {
+                let started = Instant::now();
+                let result = self
+                    .inner
+                    .expand::<T>(id, query)
+                    .await
+                    .map_err(HealthError::from);
+                let status_code = result_status_code(&result, "200");
+                self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
+                result
+            }
         })
         .await
     }
@@ -651,8 +832,21 @@ impl Bmc for BmcClient {
         &self,
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
-        self.read_with_auth_retry(|| async { self.inner.get(id).await.map_err(HealthError::from) })
-            .await
+        let path = request_path(id);
+        self.read_with_auth_retry(|| {
+            let path = path.clone();
+            async move {
+                let started = Instant::now();
+                let result = self.inner.get::<T>(id).await.map_err(HealthError::from);
+                if let Ok(value) = &result {
+                    self.note_bmc_identity_from(value.as_ref());
+                }
+                let status_code = result_status_code(&result, "200");
+                self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
+                result
+            }
+        })
+        .await
     }
 
     async fn filter<T: EntityTypeRef + for<'de> Deserialize<'de> + 'static>(
@@ -660,11 +854,21 @@ impl Bmc for BmcClient {
         id: &ODataId,
         query: FilterQuery,
     ) -> Result<Arc<T>, Self::Error> {
-        self.read_with_auth_retry(|| async {
-            self.inner
-                .filter(id, query.clone())
-                .await
-                .map_err(HealthError::from)
+        let path = request_path(id);
+        self.read_with_auth_retry(|| {
+            let path = path.clone();
+            let query = query.clone();
+            async move {
+                let started = Instant::now();
+                let result = self
+                    .inner
+                    .filter::<T>(id, query)
+                    .await
+                    .map_err(HealthError::from);
+                let status_code = result_status_code(&result, "200");
+                self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
+                result
+            }
         })
         .await
     }
@@ -675,11 +879,17 @@ impl Bmc for BmcClient {
         query: &V,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
+        let path = request_path(id);
         self.guarded(async {
-            self.inner
-                .create(id, query)
+            let started = Instant::now();
+            let result = self
+                .inner
+                .create::<V, R>(id, query)
                 .await
-                .map_err(HealthError::from)
+                .map_err(HealthError::from);
+            let status_code = modification_result_status_code(&result, "201");
+            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
+            result
         })
         .await
     }
@@ -694,11 +904,17 @@ impl Bmc for BmcClient {
         update: &V,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
+        let path = request_path(id);
         self.guarded(async {
-            self.inner
-                .update(id, etag, update)
+            let started = Instant::now();
+            let result = self
+                .inner
+                .update::<V, R>(id, etag, update)
                 .await
-                .map_err(HealthError::from)
+                .map_err(HealthError::from);
+            let status_code = modification_result_status_code(&result, "200");
+            self.record_bmc_latency("PATCH", &path, &status_code, started.elapsed());
+            result
         })
         .await
     }
@@ -714,11 +930,17 @@ impl Bmc for BmcClient {
         V: Send + Sync + Serialize,
     {
         self.ensure_credentials().await?;
+        let path = uri_reference_path(uri);
         self.guarded(async {
-            self.inner
-                .multipart_update(uri, request)
+            let started = Instant::now();
+            let result = self
+                .inner
+                .multipart_update::<U, V, R>(uri, request)
                 .await
-                .map_err(HealthError::from)
+                .map_err(HealthError::from);
+            let status_code = modification_result_status_code(&result, "200");
+            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
+            result
         })
         .await
     }
@@ -728,8 +950,15 @@ impl Bmc for BmcClient {
         id: &ODataId,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
-        self.guarded(async { self.inner.delete(id).await.map_err(HealthError::from) })
-            .await
+        let path = request_path(id);
+        self.guarded(async {
+            let started = Instant::now();
+            let result = self.inner.delete::<R>(id).await.map_err(HealthError::from);
+            let status_code = modification_result_status_code(&result, "200");
+            self.record_bmc_latency("DELETE", &path, &status_code, started.elapsed());
+            result
+        })
+        .await
     }
 
     async fn action<
@@ -741,11 +970,17 @@ impl Bmc for BmcClient {
         params: &T,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
+        let path = uri_reference_path(action.target.as_str());
         self.guarded(async {
-            self.inner
-                .action(action, params)
+            let started = Instant::now();
+            let result = self
+                .inner
+                .action::<T, R>(action, params)
                 .await
-                .map_err(HealthError::from)
+                .map_err(HealthError::from);
+            let status_code = modification_result_status_code(&result, "200");
+            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
+            result
         })
         .await
     }
@@ -762,9 +997,17 @@ impl Bmc for BmcClient {
         // flood — many short requests against a dead endpoint — not a single
         // long-lived connection. Routing item errors here would also couple
         // log-stream health to sensor/discovery collection.
+        let path = uri_reference_path(uri);
         let stream = self
-            .read_with_auth_retry(|| async {
-                self.inner.stream(uri).await.map_err(HealthError::from)
+            .read_with_auth_retry(|| {
+                let path = path.clone();
+                async move {
+                    let started = Instant::now();
+                    let result = self.inner.stream::<T>(uri).await.map_err(HealthError::from);
+                    let status_code = result_status_code(&result, "200");
+                    self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
+                    result
+                }
             })
             .await?;
         Ok(Box::pin(stream.map_err(HealthError::from)))
@@ -779,11 +1022,17 @@ impl Bmc for BmcClient {
         query: &V,
     ) -> Result<SessionCreateResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
+        let path = request_path(id);
         self.guarded(async {
-            self.inner
-                .create_session(id, query)
+            let started = Instant::now();
+            let result = self
+                .inner
+                .create_session::<V, R>(id, query)
                 .await
-                .map_err(HealthError::from)
+                .map_err(HealthError::from);
+            let status_code = result_status_code(&result, "201");
+            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
+            result
         })
         .await
     }
@@ -878,9 +1127,11 @@ mod tests {
     use carbide_test_support::value_scenarios;
     use mac_address::MacAddress;
     use nv_redfish::bmc_http::reqwest::ClientParams as ReqwestClientParams;
+    use prometheus::{Encoder, Registry, TextEncoder};
 
     use super::*;
     use crate::endpoint::BmcAddr;
+    use crate::metrics::BmcLatencyAttribute;
 
     struct CountingProvider {
         calls: Arc<AtomicUsize>,
@@ -973,7 +1224,7 @@ mod tests {
             },
             None,
         );
-        BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("constructor ok")
+        BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("constructor ok")
     }
 
     fn dummy_error() -> HealthError {
@@ -1020,8 +1271,9 @@ mod tests {
             port: Some(port),
             mac: MacAddress::from_str("00:11:22:33:44:55").expect("mac"),
         };
-        let client =
-            Arc::new(BmcClient::new(reqwest(), addr, provider, None, 10).expect("constructor ok"));
+        let client = Arc::new(
+            BmcClient::new(reqwest(), addr, provider, None, 10, None).expect("constructor ok"),
+        );
 
         assert_eq!(
             client.collector_sweep(),
@@ -1234,7 +1486,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10)
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None)
             .expect("constructor succeeds");
 
         assert_eq!(
@@ -1258,7 +1510,7 @@ mod tests {
             Some(Duration::from_millis(50)),
         );
         let client =
-            Arc::new(BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok"));
+            Arc::new(BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok"));
 
         let mut handles = Vec::new();
         for _ in 0..16 {
@@ -1302,7 +1554,7 @@ mod tests {
         let provider = Arc::new(FlakyProvider {
             attempts: AtomicUsize::new(0),
         });
-        let client = BmcClient::new(reqwest(), test_addr(), provider.clone(), None, 10)
+        let client = BmcClient::new(reqwest(), test_addr(), provider.clone(), None, 10, None)
             .expect("constructor succeeds");
 
         assert!(client.ensure_credentials().await.is_err());
@@ -1321,7 +1573,7 @@ mod tests {
             Some(Duration::from_millis(50)),
         );
         let client =
-            Arc::new(BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok"));
+            Arc::new(BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok"));
         client.ensure_credentials().await.expect("init ok");
         assert_eq!(calls.load(AtomicOrdering::SeqCst), 1);
 
@@ -1382,7 +1634,7 @@ mod tests {
             handed_out: StdMutex::new(Vec::new()),
             calls: calls.clone(),
         });
-        let client = BmcClient::new(reqwest(), test_addr(), provider.clone(), None, 10)
+        let client = BmcClient::new(reqwest(), test_addr(), provider.clone(), None, 10, None)
             .expect("constructor ok");
 
         client.ensure_credentials().await.expect("init ok");
@@ -1416,8 +1668,15 @@ mod tests {
         }
 
         let client = Arc::new(
-            BmcClient::new(reqwest(), test_addr(), Arc::new(HangingProvider), None, 10)
-                .expect("constructor ok"),
+            BmcClient::new(
+                reqwest(),
+                test_addr(),
+                Arc::new(HangingProvider),
+                None,
+                10,
+                None,
+            )
+            .expect("constructor ok"),
         );
         let refresh_client = client.clone();
         let refresh = tokio::spawn(async move {
@@ -1447,8 +1706,15 @@ mod tests {
         }
 
         let client = Arc::new(
-            BmcClient::new(reqwest(), test_addr(), Arc::new(HangingProvider), None, 10)
-                .expect("constructor ok"),
+            BmcClient::new(
+                reqwest(),
+                test_addr(),
+                Arc::new(HangingProvider),
+                None,
+                10,
+                None,
+            )
+            .expect("constructor ok"),
         );
         let ensure_client = client.clone();
         let ensure = tokio::spawn(async move { ensure_client.ensure_credentials().await });
@@ -1472,7 +1738,7 @@ mod tests {
             },
             None,
         );
-        let recovered = BmcClient::new(reqwest(), test_addr(), recovery_provider, None, 10)
+        let recovered = BmcClient::new(reqwest(), test_addr(), recovery_provider, None, 10, None)
             .expect("constructor ok");
         recovered.ensure_credentials().await.expect("recovery ok");
         assert_eq!(recovery_calls.load(AtomicOrdering::SeqCst), 1);
@@ -1520,7 +1786,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(auth_error()), Ok("body")]);
 
         let value = client
@@ -1546,7 +1812,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(HealthError::HttpError(
             "request failed with HTTP 404".to_string(),
         ))]);
@@ -1574,7 +1840,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(auth_error()), Err(auth_error())]);
 
         client
@@ -1617,7 +1883,7 @@ mod tests {
         let provider = Arc::new(InitOnceThenFailingProvider {
             calls: AtomicUsize::new(0),
         });
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(auth_error())]);
 
         let error = client
@@ -1647,7 +1913,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let attempts = Arc::new(AtomicUsize::new(0));
@@ -1692,7 +1958,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
 
         let (first, first_attempts) = scripted_op(vec![Err(auth_error()), Err(auth_error())]);
         client
@@ -1736,7 +2002,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let generation = client.credential_generation.load(Ordering::Acquire);
@@ -1770,7 +2036,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let stale_generation = client.credential_generation.load(Ordering::Acquire) - 1;
@@ -1801,7 +2067,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let observed = client.credential_generation.load(Ordering::Acquire);
@@ -1841,7 +2107,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         client.ensure_credentials().await.expect("init ok");
 
         let attempts = Arc::new(AtomicUsize::new(0));
@@ -1883,7 +2149,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, _) = scripted_op(vec![
             Err(auth_error()),
             Err(HealthError::HttpError("HTTP 500".to_string())),
@@ -1914,7 +2180,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, attempts) = scripted_op(vec![Err(forbidden_error()), Err(forbidden_error())]);
 
         client
@@ -1944,7 +2210,7 @@ mod tests {
             },
             None,
         );
-        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10).expect("ok");
+        let client = BmcClient::new(reqwest(), test_addr(), provider, None, 10, None).expect("ok");
         let (op, _) = scripted_op(vec![Err(auth_error()), Err(auth_error())]);
 
         client
@@ -2027,11 +2293,21 @@ mod tests {
     }
 
     const ENTITY_BODY: &str = r#"{"@odata.id":"/redfish/v1"}"#;
+    const SERVICE_ROOT_BODY: &str = r##"{
+        "@odata.id": "/redfish/v1",
+        "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
+        "Id": "RootService",
+        "Name": "Root Service",
+        "Links": {},
+        "Product": "GB200 BMC",
+        "RedfishVersion": "1.15.0",
+        "Vendor": "NVIDIA"
+    }"##;
 
     /// Minimal Redfish entity, so the wire-level tests below can drive the real
     /// `get`/`delete` implementations without depending on the shape of any
     /// particular generated schema type.
-    #[derive(Deserialize)]
+    #[derive(Debug, Deserialize)]
     struct TestEntity {
         #[serde(rename = "@odata.id")]
         odata_id: ODataId,
@@ -2080,6 +2356,7 @@ mod tests {
                 let reason = match status {
                     200 => "OK",
                     401 => "Unauthorized",
+                    503 => "Service Unavailable",
                     _ => panic!("unsupported test response status {status}"),
                 };
                 let response = format!(
@@ -2094,6 +2371,13 @@ mod tests {
     }
 
     fn client_against(base_url: Url) -> (BmcClient, Arc<AtomicUsize>) {
+        client_against_with_metrics(base_url, None)
+    }
+
+    fn client_against_with_metrics(
+        base_url: Url,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+    ) -> (BmcClient, Arc<AtomicUsize>) {
         let (provider, provider_calls) = CountingProvider::new(
             BmcCredentials::SessionToken {
                 token: "t".to_string(),
@@ -2102,9 +2386,147 @@ mod tests {
         );
         // `bmc_url` returns a proxy URL verbatim, so this points the client at
         // the local server over plain HTTP without needing TLS.
-        let client = BmcClient::new(reqwest(), test_addr(), provider, Some(base_url), 10)
-            .expect("constructor ok");
+        let client = BmcClient::new(
+            reqwest(),
+            test_addr(),
+            provider,
+            Some(base_url),
+            10,
+            bmc_latency_metrics,
+        )
+        .expect("constructor ok");
         (client, provider_calls)
+    }
+
+    fn bmc_latency_metrics(prefix: &str) -> (Registry, Arc<BmcLatencyMetrics>) {
+        bmc_latency_metrics_with_attributes(prefix, &BmcLatencyAttribute::ATTRIBUTES)
+    }
+
+    fn bmc_latency_metrics_with_attributes(
+        prefix: &str,
+        attributes: &[BmcLatencyAttribute],
+    ) -> (Registry, Arc<BmcLatencyMetrics>) {
+        let registry = Registry::new();
+        let metrics = Arc::new(
+            BmcLatencyMetrics::new_with_attributes(&registry, prefix, attributes)
+                .expect("BMC latency metrics register"),
+        );
+        (registry, metrics)
+    }
+
+    fn render_metrics(registry: &Registry) -> String {
+        let encoder = TextEncoder::new();
+        let mut buffer = Vec::new();
+        encoder
+            .encode(&registry.gather(), &mut buffer)
+            .expect("metrics encode");
+        String::from_utf8(buffer).expect("prometheus text is UTF-8")
+    }
+
+    fn assert_bmc_latency_series(metrics: &str, labels: &[&str]) {
+        assert!(
+            metrics.lines().any(|line| {
+                line.starts_with("test_health_bmc_latency_ms_bucket")
+                    && labels.iter().all(|label| line.contains(label))
+            }),
+            "missing BMC latency series with labels {labels:?}; metrics:
+{metrics}",
+        );
+    }
+
+    #[tokio::test]
+    async fn bmc_latency_metric_records_status_method_path_and_identity() {
+        let (registry, metrics) = bmc_latency_metrics("test_health");
+        let (base_url, _requests, server) =
+            spawn_scripted_http_server(vec![(200, SERVICE_ROOT_BODY)]);
+        let (client, _provider_calls) = client_against_with_metrics(base_url, Some(metrics));
+
+        let root = client
+            .get::<nv_redfish::schema::service_root::ServiceRoot>(&ODataId::service_root())
+            .await
+            .expect("service root response decodes");
+        assert_eq!(
+            root.vendor.as_ref().and_then(Option::as_deref),
+            Some("NVIDIA")
+        );
+
+        let metrics = render_metrics(&registry);
+        assert!(metrics.contains("# HELP test_health_bmc_latency_ms"));
+        assert_bmc_latency_series(
+            &metrics,
+            &[
+                "http_response_status_code=\"200\"",
+                "http_request_method=\"GET\"",
+                "http_path=\"/redfish/v1\"",
+                "server_address=\"10.0.0.1\"",
+                "url_scheme=\"https\"",
+                "bmc_vendor=\"NVIDIA\"",
+                "bmc_model=\"GB200 BMC\"",
+            ],
+        );
+        server.join().expect("test server thread");
+    }
+
+    #[tokio::test]
+    async fn bmc_latency_metric_records_http_error_status() {
+        let (registry, metrics) = bmc_latency_metrics("test_health");
+        let (base_url, _requests, server) = spawn_scripted_http_server(vec![(503, "{}")]);
+        let (client, _provider_calls) = client_against_with_metrics(base_url, Some(metrics));
+
+        client
+            .get::<TestEntity>(&ODataId::service_root())
+            .await
+            .expect_err("503 must surface to the caller");
+
+        let metrics = render_metrics(&registry);
+        assert_bmc_latency_series(
+            &metrics,
+            &[
+                "http_response_status_code=\"503\"",
+                "http_request_method=\"GET\"",
+                "http_path=\"/redfish/v1\"",
+                "server_address=\"10.0.0.1\"",
+                "url_scheme=\"https\"",
+                "bmc_vendor=\"unknown\"",
+                "bmc_model=\"unknown\"",
+            ],
+        );
+        server.join().expect("test server thread");
+    }
+
+    #[tokio::test]
+    async fn bmc_latency_metric_uses_configured_attributes_only() {
+        let (registry, metrics) = bmc_latency_metrics_with_attributes(
+            "test_health",
+            &[
+                BmcLatencyAttribute::HttpResponseStatusCode,
+                BmcLatencyAttribute::ServerAddress,
+                BmcLatencyAttribute::UrlScheme,
+            ],
+        );
+        let (base_url, _requests, server) =
+            spawn_scripted_http_server(vec![(200, SERVICE_ROOT_BODY)]);
+        let (client, _provider_calls) = client_against_with_metrics(base_url, Some(metrics));
+
+        client
+            .get::<nv_redfish::schema::service_root::ServiceRoot>(&ODataId::service_root())
+            .await
+            .expect("service root response decodes");
+
+        let metrics = render_metrics(&registry);
+        assert_bmc_latency_series(
+            &metrics,
+            &[
+                "http_response_status_code=\"200\"",
+                "server_address=\"10.0.0.1\"",
+                "url_scheme=\"https\"",
+            ],
+        );
+        assert!(!metrics.contains("http_request_method="));
+        assert!(!metrics.contains("http_path="));
+        assert!(!metrics.contains("bmc_vendor="));
+        assert!(!metrics.contains("bmc_model="));
+        server.join().expect("test server thread");
     }
 
     #[tokio::test]

--- a/crates/health/src/bmc.rs
+++ b/crates/health/src/bmc.rs
@@ -15,31 +15,32 @@
  * limitations under the License.
  */
 
-use std::any::Any;
-use std::error::Error as StdError;
+use std::any::{Any, type_name};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
 use carbide_utils::redfish::format_forwarded_host_parameter;
+use carbide_uuid::rack::RackId;
 use futures::TryStreamExt;
 use http::HeaderMap;
 use http::header::{self, InvalidHeaderValue};
 use nv_redfish::bmc_http::reqwest::{BmcError, Client as ReqwestClient};
-use nv_redfish::bmc_http::{CacheSettings, HttpBmc};
+use nv_redfish::bmc_http::{CacheSettings, HttpBmc, HttpClient};
 use nv_redfish::core::query::{ExpandQuery, FilterQuery};
 use nv_redfish::core::upload::{MultipartUpdateRequest, UploadReader};
 use nv_redfish::core::{
     Action, Bmc, BoxTryStream, EntityTypeRef, Expandable, ModificationResponse, ODataETag, ODataId,
     SessionCreateResponse,
 };
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, OnceCell};
 use url::Url;
 
 use crate::HealthError;
-use crate::endpoint::{BmcAddr, BmcCredentials};
+use crate::endpoint::{BmcAddr, BmcCredentials, EndpointMetadata};
 use crate::metrics::{BmcLatencyMetrics, BmcLatencyObservation};
 
 pub(crate) const CREDENTIAL_REFRESH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -150,8 +151,52 @@ struct BmcIdentity {
     model: Option<String>,
 }
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BmcLatencyEndpointLabels {
+    pub(crate) machine_id: Option<String>,
+    pub(crate) rack_id: Option<String>,
+}
+
+impl BmcLatencyEndpointLabels {
+    pub(crate) fn new(machine_id: Option<String>, rack_id: Option<String>) -> Self {
+        Self {
+            machine_id,
+            rack_id,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct BmcLatencyInstrumentation {
+    metrics: Arc<BmcLatencyMetrics>,
+    endpoint_labels: BmcLatencyEndpointLabels,
+}
+
+impl BmcLatencyInstrumentation {
+    pub(crate) fn new(
+        metrics: Arc<BmcLatencyMetrics>,
+        endpoint_labels: BmcLatencyEndpointLabels,
+    ) -> Self {
+        Self {
+            metrics,
+            endpoint_labels,
+        }
+    }
+}
+
+pub(crate) fn bmc_latency_endpoint_labels(
+    metadata: Option<&EndpointMetadata>,
+    rack_id: Option<&RackId>,
+) -> BmcLatencyEndpointLabels {
+    let machine_id = match metadata {
+        Some(EndpointMetadata::Machine(machine)) => machine.machine_id.map(|id| id.to_string()),
+        _ => None,
+    };
+    BmcLatencyEndpointLabels::new(machine_id, rack_id.map(ToString::to_string))
+}
+
 pub struct BmcClient {
-    inner: HttpBmc<ReqwestClient>,
+    inner: HttpBmc<InstrumentedHttpClient>,
     addr: BmcAddr,
     provider: Arc<dyn CredentialProvider>,
     credential_generation: AtomicU64,
@@ -171,32 +216,37 @@ pub struct BmcClient {
     /// [`KnownBadCredentials`]. Only touched on the auth-failure path, so the
     /// healthy request path never takes this lock.
     known_bad_credentials: StdMutex<Option<KnownBadCredentials>>,
-    bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
-    server_address: String,
-    url_scheme: String,
-    bmc_identity: StdMutex<BmcIdentity>,
+    bmc_identity: Arc<StdMutex<BmcIdentity>>,
 }
 
 impl BmcClient {
-    pub fn new(
+    pub(crate) fn new(
         reqwest: ReqwestClient,
         addr: BmcAddr,
         provider: Arc<dyn CredentialProvider>,
         proxy_url: Option<Url>,
         cache_size: usize,
-        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+        bmc_latency_instrumentation: Option<BmcLatencyInstrumentation>,
     ) -> Result<Self, HealthError> {
         let server_address = bmc_server_address(&addr);
         let url_scheme = bmc_url_scheme(&addr).to_string();
         let bmc_url = bmc_url(&addr, proxy_url.as_ref())?;
         let headers = bmc_headers(&addr, proxy_url.as_ref())?;
+        let bmc_identity = Arc::new(StdMutex::new(BmcIdentity::default()));
+        let http_client = InstrumentedHttpClient::new(
+            reqwest,
+            bmc_latency_instrumentation,
+            server_address,
+            url_scheme,
+            Arc::clone(&bmc_identity),
+        );
 
         // Currently nv-redfish BMC requires credentials, so this placeholder is used;
         // they will be replaced as soon as we call ensure_credentials.
         let placeholder =
             nv_redfish::bmc_http::BmcCredentials::username_password(String::new(), None::<String>);
         let inner = HttpBmc::with_custom_headers(
-            reqwest,
+            http_client,
             bmc_url,
             placeholder,
             CacheSettings::with_capacity(cache_size),
@@ -212,33 +262,8 @@ impl BmcClient {
             circuit: StdMutex::new(CircuitState::Closed),
             circuit_tripped: AtomicBool::new(false),
             known_bad_credentials: StdMutex::new(None),
-            bmc_latency_metrics,
-            server_address,
-            url_scheme,
-            bmc_identity: StdMutex::new(BmcIdentity::default()),
+            bmc_identity,
         })
-    }
-
-    fn record_bmc_latency(&self, method: &str, path: &str, status_code: &str, duration: Duration) {
-        let Some(metrics) = &self.bmc_latency_metrics else {
-            return;
-        };
-
-        let identity = self
-            .bmc_identity
-            .lock()
-            .expect("BMC identity mutex poisoned")
-            .clone();
-        metrics.observe(BmcLatencyObservation {
-            status_code,
-            method,
-            path,
-            server_address: &self.server_address,
-            url_scheme: &self.url_scheme,
-            bmc_vendor: identity.vendor.as_deref(),
-            bmc_model: identity.model.as_deref(),
-            duration,
-        });
     }
 
     fn note_bmc_identity_from<T: 'static>(&self, value: &T) {
@@ -680,6 +705,238 @@ impl BmcClient {
     }
 }
 
+#[derive(Clone)]
+struct InstrumentedHttpClient {
+    inner: ReqwestClient,
+    bmc_latency_instrumentation: Option<BmcLatencyInstrumentation>,
+    server_address: String,
+    url_scheme: String,
+    bmc_identity: Arc<StdMutex<BmcIdentity>>,
+}
+
+impl InstrumentedHttpClient {
+    fn new(
+        inner: ReqwestClient,
+        bmc_latency_instrumentation: Option<BmcLatencyInstrumentation>,
+        server_address: String,
+        url_scheme: String,
+        bmc_identity: Arc<StdMutex<BmcIdentity>>,
+    ) -> Self {
+        Self {
+            inner,
+            bmc_latency_instrumentation,
+            server_address,
+            url_scheme,
+            bmc_identity,
+        }
+    }
+
+    fn observe(
+        &self,
+        method: &str,
+        url: &Url,
+        status_code: &str,
+        entity_type: &str,
+        duration: Duration,
+    ) {
+        let Some(instrumentation) = &self.bmc_latency_instrumentation else {
+            return;
+        };
+
+        let identity = self
+            .bmc_identity
+            .lock()
+            .expect("BMC identity mutex poisoned")
+            .clone();
+        let endpoint_labels = &instrumentation.endpoint_labels;
+        instrumentation.metrics.observe(BmcLatencyObservation {
+            status_code,
+            method,
+            path: url.path(),
+            server_address: &self.server_address,
+            url_scheme: &self.url_scheme,
+            bmc_vendor: identity.vendor.as_deref(),
+            bmc_model: identity.model.as_deref(),
+            entity_type,
+            machine_id: endpoint_labels.machine_id.as_deref(),
+            rack_id: endpoint_labels.rack_id.as_deref(),
+            duration,
+        });
+    }
+
+    fn observe_result<T>(
+        &self,
+        method: &str,
+        url: &Url,
+        result: &Result<T, BmcError>,
+        success_status_code: &str,
+        duration: Duration,
+    ) {
+        let status_code = result_status_code(result, success_status_code);
+        self.observe(method, url, &status_code, entity_type_name::<T>(), duration);
+    }
+
+    fn observe_modification_result<T>(
+        &self,
+        method: &str,
+        url: &Url,
+        result: &Result<ModificationResponse<T>, BmcError>,
+        entity_status_code: &str,
+        duration: Duration,
+    ) {
+        let status_code = modification_result_status_code(result, entity_status_code);
+        self.observe(method, url, &status_code, entity_type_name::<T>(), duration);
+    }
+}
+
+impl HttpClient for InstrumentedHttpClient {
+    type Error = BmcError;
+
+    async fn get<T>(
+        &self,
+        url: Url,
+        credentials: &nv_redfish::bmc_http::BmcCredentials,
+        etag: Option<ODataETag>,
+        custom_headers: &HeaderMap,
+    ) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let result = self
+            .inner
+            .get::<T>(url, credentials, etag, custom_headers)
+            .await;
+        self.observe_result("GET", &request_url, &result, "200", started.elapsed());
+        result
+    }
+
+    async fn post<B, T>(
+        &self,
+        url: Url,
+        body: &B,
+        credentials: &nv_redfish::bmc_http::BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let entity_status_code = post_entity_status_code(&request_url);
+        let result = self
+            .inner
+            .post::<B, T>(url, body, credentials, custom_headers)
+            .await;
+        self.observe_modification_result(
+            "POST",
+            &request_url,
+            &result,
+            entity_status_code,
+            started.elapsed(),
+        );
+        result
+    }
+
+    async fn post_session<B, T>(
+        &self,
+        url: Url,
+        body: &B,
+        custom_headers: &HeaderMap,
+    ) -> Result<SessionCreateResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let result = self
+            .inner
+            .post_session::<B, T>(url, body, custom_headers)
+            .await;
+        self.observe_result("POST", &request_url, &result, "201", started.elapsed());
+        result
+    }
+
+    async fn post_multipart_update<U, V, T>(
+        &self,
+        url: Url,
+        request: MultipartUpdateRequest<'_, U, V>,
+        credentials: &nv_redfish::bmc_http::BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync,
+        V: Serialize + Send + Sync,
+    {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let result = self
+            .inner
+            .post_multipart_update::<U, V, T>(url, request, credentials, custom_headers)
+            .await;
+        self.observe_modification_result("POST", &request_url, &result, "200", started.elapsed());
+        result
+    }
+
+    async fn patch<B, T>(
+        &self,
+        url: Url,
+        etag: ODataETag,
+        body: &B,
+        credentials: &nv_redfish::bmc_http::BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let result = self
+            .inner
+            .patch::<B, T>(url, etag, body, credentials, custom_headers)
+            .await;
+        self.observe_modification_result("PATCH", &request_url, &result, "200", started.elapsed());
+        result
+    }
+
+    async fn delete<T>(
+        &self,
+        url: Url,
+        credentials: &nv_redfish::bmc_http::BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let result = self
+            .inner
+            .delete::<T>(url, credentials, custom_headers)
+            .await;
+        self.observe_modification_result("DELETE", &request_url, &result, "200", started.elapsed());
+        result
+    }
+
+    async fn sse<T: Sized + for<'de> Deserialize<'de> + Send>(
+        &self,
+        url: Url,
+        credentials: &nv_redfish::bmc_http::BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<BoxTryStream<T, Self::Error>, Self::Error> {
+        let started = Instant::now();
+        let request_url = url.clone();
+        let result = self.inner.sse::<T>(url, credentials, custom_headers).await;
+        self.observe_result("GET", &request_url, &result, "200", started.elapsed());
+        result
+    }
+}
+
 fn bmc_server_address(addr: &BmcAddr) -> String {
     addr.ip.to_string()
 }
@@ -725,38 +982,17 @@ fn normalize_identity_value(value: &str) -> Option<String> {
     }
 }
 
-fn request_path(id: &ODataId) -> String {
-    id.to_string()
-}
-
-fn uri_reference_path(uri: &str) -> String {
-    if let Ok(url) = Url::parse(uri) {
-        return url.path().to_string();
-    }
-
-    let path = uri.split_once('?').map_or(uri, |(path, _query)| path);
-    if path.is_empty() {
-        uri.to_string()
-    } else {
-        path.to_string()
-    }
-}
-
-// The nv-redfish Bmc surface exposes exact HTTP status codes for error
-// responses, but decodes successful responses before health can inspect the raw
-// response. Successful observations therefore use the Redfish status expected
-// for the operation.
-fn result_status_code<T>(result: &Result<T, HealthError>, success_status_code: &str) -> String {
+fn result_status_code<T>(result: &Result<T, BmcError>, success_status_code: &str) -> String {
     match result {
         Ok(_) => success_status_code.to_string(),
         Err(error) => {
-            error_status_code(error).unwrap_or_else(|| UNKNOWN_HTTP_STATUS_CODE.to_string())
+            bmc_error_status_code(error).unwrap_or_else(|| UNKNOWN_HTTP_STATUS_CODE.to_string())
         }
     }
 }
 
 fn modification_result_status_code<T>(
-    result: &Result<ModificationResponse<T>, HealthError>,
+    result: &Result<ModificationResponse<T>, BmcError>,
     entity_status_code: &str,
 ) -> String {
     match result {
@@ -764,41 +1000,34 @@ fn modification_result_status_code<T>(
         Ok(ModificationResponse::Task(_)) => http::StatusCode::ACCEPTED.as_u16().to_string(),
         Ok(ModificationResponse::Empty) => http::StatusCode::NO_CONTENT.as_u16().to_string(),
         Err(error) => {
-            error_status_code(error).unwrap_or_else(|| UNKNOWN_HTTP_STATUS_CODE.to_string())
+            bmc_error_status_code(error).unwrap_or_else(|| UNKNOWN_HTTP_STATUS_CODE.to_string())
         }
     }
 }
 
-fn error_status_code(error: &HealthError) -> Option<String> {
-    match error {
-        HealthError::BmcError(inner) => bmc_source_status_code(inner.as_ref()),
-        HealthError::HttpError(message) => http_error_status_code(message),
-        _ => None,
-    }
-}
-
-fn bmc_source_status_code(error: &(dyn StdError + 'static)) -> Option<String> {
-    if let Some(BmcError::InvalidResponse { status, .. }) = error.downcast_ref::<BmcError>() {
+fn bmc_error_status_code(error: &BmcError) -> Option<String> {
+    if let BmcError::InvalidResponse { status, .. } = error {
         return Some(status.as_u16().to_string());
     }
 
-    error
-        .downcast_ref::<HealthError>()
-        .and_then(error_status_code)
+    None
 }
 
-fn http_error_status_code(message: &str) -> Option<String> {
-    message
-        .split(|character: char| !character.is_ascii_digit())
-        .find_map(|token| {
-            if token.len() != 3 {
-                return None;
-            }
-            let code = token.parse::<u16>().ok()?;
-            http::StatusCode::from_u16(code)
-                .ok()
-                .map(|status| status.as_u16().to_string())
-        })
+fn post_entity_status_code(url: &Url) -> &'static str {
+    if url.path().contains("/Actions/") {
+        "200"
+    } else {
+        "201"
+    }
+}
+
+fn entity_type_name<T>() -> &'static str {
+    let type_name = type_name::<T>();
+    let without_generics = type_name.split('<').next().unwrap_or(type_name);
+    without_generics
+        .rsplit("::")
+        .next()
+        .unwrap_or(without_generics)
 }
 
 impl Bmc for BmcClient {
@@ -809,21 +1038,11 @@ impl Bmc for BmcClient {
         id: &ODataId,
         query: ExpandQuery,
     ) -> Result<Arc<T>, Self::Error> {
-        let path = request_path(id);
-        self.read_with_auth_retry(|| {
-            let path = path.clone();
-            let query = query.clone();
-            async move {
-                let started = Instant::now();
-                let result = self
-                    .inner
-                    .expand::<T>(id, query)
-                    .await
-                    .map_err(HealthError::from);
-                let status_code = result_status_code(&result, "200");
-                self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
-                result
-            }
+        self.read_with_auth_retry(|| async {
+            self.inner
+                .expand(id, query.clone())
+                .await
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -832,19 +1051,12 @@ impl Bmc for BmcClient {
         &self,
         id: &ODataId,
     ) -> Result<Arc<T>, Self::Error> {
-        let path = request_path(id);
-        self.read_with_auth_retry(|| {
-            let path = path.clone();
-            async move {
-                let started = Instant::now();
-                let result = self.inner.get::<T>(id).await.map_err(HealthError::from);
-                if let Ok(value) = &result {
-                    self.note_bmc_identity_from(value.as_ref());
-                }
-                let status_code = result_status_code(&result, "200");
-                self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
-                result
+        self.read_with_auth_retry(|| async move {
+            let result = self.inner.get::<T>(id).await.map_err(HealthError::from);
+            if let Ok(value) = &result {
+                self.note_bmc_identity_from(value.as_ref());
             }
+            result
         })
         .await
     }
@@ -854,21 +1066,11 @@ impl Bmc for BmcClient {
         id: &ODataId,
         query: FilterQuery,
     ) -> Result<Arc<T>, Self::Error> {
-        let path = request_path(id);
-        self.read_with_auth_retry(|| {
-            let path = path.clone();
-            let query = query.clone();
-            async move {
-                let started = Instant::now();
-                let result = self
-                    .inner
-                    .filter::<T>(id, query)
-                    .await
-                    .map_err(HealthError::from);
-                let status_code = result_status_code(&result, "200");
-                self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
-                result
-            }
+        self.read_with_auth_retry(|| async {
+            self.inner
+                .filter(id, query.clone())
+                .await
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -879,17 +1081,11 @@ impl Bmc for BmcClient {
         query: &V,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
-        let path = request_path(id);
         self.guarded(async {
-            let started = Instant::now();
-            let result = self
-                .inner
-                .create::<V, R>(id, query)
+            self.inner
+                .create(id, query)
                 .await
-                .map_err(HealthError::from);
-            let status_code = modification_result_status_code(&result, "201");
-            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
-            result
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -904,17 +1100,11 @@ impl Bmc for BmcClient {
         update: &V,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
-        let path = request_path(id);
         self.guarded(async {
-            let started = Instant::now();
-            let result = self
-                .inner
-                .update::<V, R>(id, etag, update)
+            self.inner
+                .update(id, etag, update)
                 .await
-                .map_err(HealthError::from);
-            let status_code = modification_result_status_code(&result, "200");
-            self.record_bmc_latency("PATCH", &path, &status_code, started.elapsed());
-            result
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -930,17 +1120,11 @@ impl Bmc for BmcClient {
         V: Send + Sync + Serialize,
     {
         self.ensure_credentials().await?;
-        let path = uri_reference_path(uri);
         self.guarded(async {
-            let started = Instant::now();
-            let result = self
-                .inner
-                .multipart_update::<U, V, R>(uri, request)
+            self.inner
+                .multipart_update(uri, request)
                 .await
-                .map_err(HealthError::from);
-            let status_code = modification_result_status_code(&result, "200");
-            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
-            result
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -950,15 +1134,8 @@ impl Bmc for BmcClient {
         id: &ODataId,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
-        let path = request_path(id);
-        self.guarded(async {
-            let started = Instant::now();
-            let result = self.inner.delete::<R>(id).await.map_err(HealthError::from);
-            let status_code = modification_result_status_code(&result, "200");
-            self.record_bmc_latency("DELETE", &path, &status_code, started.elapsed());
-            result
-        })
-        .await
+        self.guarded(async { self.inner.delete(id).await.map_err(HealthError::from) })
+            .await
     }
 
     async fn action<
@@ -970,17 +1147,11 @@ impl Bmc for BmcClient {
         params: &T,
     ) -> Result<ModificationResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
-        let path = uri_reference_path(action.target.as_str());
         self.guarded(async {
-            let started = Instant::now();
-            let result = self
-                .inner
-                .action::<T, R>(action, params)
+            self.inner
+                .action(action, params)
                 .await
-                .map_err(HealthError::from);
-            let status_code = modification_result_status_code(&result, "200");
-            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
-            result
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -997,17 +1168,9 @@ impl Bmc for BmcClient {
         // flood — many short requests against a dead endpoint — not a single
         // long-lived connection. Routing item errors here would also couple
         // log-stream health to sensor/discovery collection.
-        let path = uri_reference_path(uri);
         let stream = self
-            .read_with_auth_retry(|| {
-                let path = path.clone();
-                async move {
-                    let started = Instant::now();
-                    let result = self.inner.stream::<T>(uri).await.map_err(HealthError::from);
-                    let status_code = result_status_code(&result, "200");
-                    self.record_bmc_latency("GET", &path, &status_code, started.elapsed());
-                    result
-                }
+            .read_with_auth_retry(|| async {
+                self.inner.stream(uri).await.map_err(HealthError::from)
             })
             .await?;
         Ok(Box::pin(stream.map_err(HealthError::from)))
@@ -1022,17 +1185,11 @@ impl Bmc for BmcClient {
         query: &V,
     ) -> Result<SessionCreateResponse<R>, Self::Error> {
         self.ensure_credentials().await?;
-        let path = request_path(id);
         self.guarded(async {
-            let started = Instant::now();
-            let result = self
-                .inner
-                .create_session::<V, R>(id, query)
+            self.inner
+                .create_session(id, query)
                 .await
-                .map_err(HealthError::from);
-            let status_code = result_status_code(&result, "201");
-            self.record_bmc_latency("POST", &path, &status_code, started.elapsed());
-            result
+                .map_err(HealthError::from)
         })
         .await
     }
@@ -2298,7 +2455,11 @@ mod tests {
         "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
         "Id": "RootService",
         "Name": "Root Service",
-        "Links": {},
+        "Links": {
+            "Sessions": {
+                "@odata.id": "/redfish/v1/SessionService/Sessions"
+            }
+        },
         "Product": "GB200 BMC",
         "RedfishVersion": "1.15.0",
         "Vendor": "NVIDIA"
@@ -2386,13 +2547,22 @@ mod tests {
         );
         // `bmc_url` returns a proxy URL verbatim, so this points the client at
         // the local server over plain HTTP without needing TLS.
+        let bmc_latency_instrumentation = bmc_latency_metrics.map(|metrics| {
+            BmcLatencyInstrumentation::new(
+                metrics,
+                BmcLatencyEndpointLabels::new(
+                    Some("fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg".to_string()),
+                    Some("rack-1".to_string()),
+                ),
+            )
+        });
         let client = BmcClient::new(
             reqwest(),
             test_addr(),
             provider,
             Some(base_url),
             10,
-            bmc_latency_metrics,
+            bmc_latency_instrumentation,
         )
         .expect("constructor ok");
         (client, provider_calls)
@@ -2437,8 +2607,8 @@ mod tests {
     #[tokio::test]
     async fn bmc_latency_metric_records_status_method_path_and_identity() {
         let (registry, metrics) = bmc_latency_metrics("test_health");
-        let (base_url, _requests, server) =
-            spawn_scripted_http_server(vec![(200, SERVICE_ROOT_BODY)]);
+        let (base_url, requests, server) =
+            spawn_scripted_http_server(vec![(200, SERVICE_ROOT_BODY), (200, SERVICE_ROOT_BODY)]);
         let (client, _provider_calls) = client_against_with_metrics(base_url, Some(metrics));
 
         let root = client
@@ -2449,6 +2619,15 @@ mod tests {
             root.vendor.as_ref().and_then(Option::as_deref),
             Some("NVIDIA")
         );
+
+        // The HTTP wrapper observes before the BmcClient sees the decoded
+        // ServiceRoot, so the first ServiceRoot request seeds identity and the
+        // next upstream request carries it as metric labels.
+        client
+            .get::<nv_redfish::schema::service_root::ServiceRoot>(&ODataId::service_root())
+            .await
+            .expect("second service root response decodes");
+        assert_eq!(requests.load(AtomicOrdering::SeqCst), 2);
 
         let metrics = render_metrics(&registry);
         assert!(metrics.contains("# HELP test_health_bmc_latency_ms"));
@@ -2462,6 +2641,9 @@ mod tests {
                 "url_scheme=\"https\"",
                 "bmc_vendor=\"NVIDIA\"",
                 "bmc_model=\"GB200 BMC\"",
+                "entity_type=\"ServiceRoot\"",
+                "machine_id=\"fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg\"",
+                "rack_id=\"rack-1\"",
             ],
         );
         server.join().expect("test server thread");
@@ -2489,6 +2671,9 @@ mod tests {
                 "url_scheme=\"https\"",
                 "bmc_vendor=\"unknown\"",
                 "bmc_model=\"unknown\"",
+                "entity_type=\"TestEntity\"",
+                "machine_id=\"fm100ht038bg3qsho433vkg684heguv282qaggmrsh2ugn1qk096n2c6hcg\"",
+                "rack_id=\"rack-1\"",
             ],
         );
         server.join().expect("test server thread");
@@ -2526,6 +2711,9 @@ mod tests {
         assert!(!metrics.contains("http_path="));
         assert!(!metrics.contains("bmc_vendor="));
         assert!(!metrics.contains("bmc_model="));
+        assert!(!metrics.contains("entity_type="));
+        assert!(!metrics.contains("machine_id="));
+        assert!(!metrics.contains("rack_id="));
         server.join().expect("test server thread");
     }
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1745,6 +1745,10 @@ pub struct MetricsConfig {
     /// Emit per-request BMC latency histograms.
     pub enable_bmc_latency_metrics: bool,
     /// Label attributes emitted on the BMC latency histogram.
+    #[serde(
+        default = "default_bmc_latency_attributes",
+        deserialize_with = "deserialize_bmc_latency_attributes"
+    )]
     pub bmc_latency_attributes: Vec<BmcLatencyAttribute>,
 }
 
@@ -1764,20 +1768,65 @@ impl Default for MetricsConfig {
             endpoint: "0.0.0.0:9009".to_string(),
             prefix: "carbide_hardware_health".to_string(),
             enable_bmc_latency_metrics: false,
-            bmc_latency_attributes: vec![BmcLatencyAttribute::All],
+            bmc_latency_attributes: default_bmc_latency_attributes(),
         }
     }
 }
 
+fn default_bmc_latency_attributes() -> Vec<BmcLatencyAttribute> {
+    BmcLatencyAttribute::ATTRIBUTES.to_vec()
+}
+
+fn deserialize_bmc_latency_attributes<'de, D>(
+    deserializer: D,
+) -> Result<Vec<BmcLatencyAttribute>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let labels = Vec::<String>::deserialize(deserializer)?;
+    let mut has_all = false;
+    let mut unknown = Vec::new();
+
+    for label in &labels {
+        if label == "all" {
+            has_all = true;
+        } else if BmcLatencyAttribute::from_label_name(label).is_none() {
+            unknown.push(label.as_str());
+        }
+    }
+
+    if !unknown.is_empty() {
+        return Err(serde::de::Error::custom(format!(
+            "unknown BMC latency attribute(s): {}; allowed values are: {}",
+            unknown.join(", "),
+            bmc_latency_attribute_allowed_values().join(", ")
+        )));
+    }
+
+    if has_all {
+        return Ok(default_bmc_latency_attributes());
+    }
+
+    let requested = labels.iter().map(String::as_str).collect::<HashSet<_>>();
+    Ok(BmcLatencyAttribute::ATTRIBUTES
+        .iter()
+        .copied()
+        .filter(|attribute| requested.contains(attribute.label_name()))
+        .collect())
+}
+
+fn bmc_latency_attribute_allowed_values() -> Vec<&'static str> {
+    let mut values = vec!["all"];
+    values.extend(
+        BmcLatencyAttribute::ATTRIBUTES
+            .iter()
+            .map(|attribute| attribute.label_name()),
+    );
+    values
+}
+
 impl MetricsConfig {
     pub fn bmc_latency_attributes(&self) -> Vec<BmcLatencyAttribute> {
-        if self
-            .bmc_latency_attributes
-            .contains(&BmcLatencyAttribute::All)
-        {
-            return BmcLatencyAttribute::ATTRIBUTES.to_vec();
-        }
-
         BmcLatencyAttribute::ATTRIBUTES
             .iter()
             .copied()
@@ -3220,7 +3269,7 @@ reload_interval = "30s"
         assert!(!config.metrics.enable_bmc_latency_metrics);
         assert_eq!(
             config.metrics.bmc_latency_attributes,
-            vec![BmcLatencyAttribute::All]
+            BmcLatencyAttribute::ATTRIBUTES.to_vec()
         );
         assert_eq!(
             config.metrics.bmc_latency_attributes(),
@@ -3243,7 +3292,7 @@ reload_interval = "30s"
         let toml_content = r#"
 [metrics]
 enable_bmc_latency_metrics = true
-bmc_latency_attributes = ["http_response_status_code", "server_address", "url_scheme"]
+bmc_latency_attributes = ["http_response_status_code", "server_address", "url_scheme", "entity_type", "machine_id", "rack_id"]
 "#;
 
         let config: Config = Figment::new()
@@ -3259,6 +3308,9 @@ bmc_latency_attributes = ["http_response_status_code", "server_address", "url_sc
                 BmcLatencyAttribute::HttpResponseStatusCode,
                 BmcLatencyAttribute::ServerAddress,
                 BmcLatencyAttribute::UrlScheme,
+                BmcLatencyAttribute::EntityType,
+                BmcLatencyAttribute::MachineId,
+                BmcLatencyAttribute::RackId,
             ]
         );
 
@@ -3273,6 +3325,10 @@ bmc_latency_attributes = ["http_path", "all"]
             .extract()
             .expect("could not parse config toml file");
 
+        assert_eq!(
+            config.metrics.bmc_latency_attributes,
+            BmcLatencyAttribute::ATTRIBUTES.to_vec()
+        );
         assert_eq!(
             config.metrics.bmc_latency_attributes(),
             BmcLatencyAttribute::ATTRIBUTES.to_vec()

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -27,6 +27,8 @@ use rustls_pki_types::DnsName;
 use serde::{Deserialize, Deserializer, Serialize};
 use url::Url;
 
+use crate::metrics::BmcLatencyAttribute;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -1740,6 +1742,10 @@ pub struct MetricsConfig {
     pub endpoint: String,
     /// Prefix for all metrics, defaults to carbide_hardware_health
     pub prefix: String,
+    /// Emit per-request BMC latency histograms.
+    pub enable_bmc_latency_metrics: bool,
+    /// Label attributes emitted on the BMC latency histogram.
+    pub bmc_latency_attributes: Vec<BmcLatencyAttribute>,
 }
 
 impl Default for RateLimitConfig {
@@ -1757,7 +1763,37 @@ impl Default for MetricsConfig {
         Self {
             endpoint: "0.0.0.0:9009".to_string(),
             prefix: "carbide_hardware_health".to_string(),
+            enable_bmc_latency_metrics: false,
+            bmc_latency_attributes: vec![BmcLatencyAttribute::All],
         }
+    }
+}
+
+impl MetricsConfig {
+    pub fn bmc_latency_attributes(&self) -> Vec<BmcLatencyAttribute> {
+        if self
+            .bmc_latency_attributes
+            .contains(&BmcLatencyAttribute::All)
+        {
+            return BmcLatencyAttribute::ATTRIBUTES.to_vec();
+        }
+
+        BmcLatencyAttribute::ATTRIBUTES
+            .iter()
+            .copied()
+            .filter(|attribute| self.bmc_latency_attributes.contains(attribute))
+            .collect()
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.enable_bmc_latency_metrics && self.bmc_latency_attributes().is_empty() {
+            return Err(
+                "metrics.bmc_latency_attributes must not be empty when metrics.enable_bmc_latency_metrics is true"
+                    .to_string(),
+            );
+        }
+
+        Ok(())
     }
 }
 
@@ -1800,6 +1836,8 @@ impl Config {
         if self.endpoint_discovery_interval.is_zero() {
             return Err("endpoint_discovery_interval must be greater than 0".to_string());
         }
+
+        self.metrics.validate()?;
 
         if let Configurable::Enabled(rate_limit) = &self.rate_limit
             && rate_limit.bucket_replenish.is_zero()
@@ -2503,6 +2541,15 @@ username = "root"
                         targets: vec![otlp_target("http://localhost:4317")],
                     });
                 }) => Yields(()),
+
+                config_with(|config| {
+                    config.metrics.enable_bmc_latency_metrics = true;
+                    config.metrics.bmc_latency_attributes = vec![
+                        BmcLatencyAttribute::HttpResponseStatusCode,
+                        BmcLatencyAttribute::ServerAddress,
+                        BmcLatencyAttribute::UrlScheme,
+                    ];
+                }) => Yields(()),
             }
 
             "top-level settings" {
@@ -2515,6 +2562,13 @@ username = "root"
                     config.endpoint_discovery_interval = Duration::ZERO;
                 }) => FailsWith(
                     "endpoint_discovery_interval must be greater than 0".to_string()
+                ),
+
+                config_with(|config| {
+                    config.metrics.enable_bmc_latency_metrics = true;
+                    config.metrics.bmc_latency_attributes = vec![];
+                }) => FailsWith(
+                    "metrics.bmc_latency_attributes must not be empty when metrics.enable_bmc_latency_metrics is true".to_string()
                 ),
 
                 config_with(|config| {
@@ -3163,6 +3217,15 @@ reload_interval = "30s"
         assert_eq!(config.shards_count, 1);
         assert_eq!(config.cache_size, 100);
         assert_eq!(config.metrics.endpoint, "0.0.0.0:9009");
+        assert!(!config.metrics.enable_bmc_latency_metrics);
+        assert_eq!(
+            config.metrics.bmc_latency_attributes,
+            vec![BmcLatencyAttribute::All]
+        );
+        assert_eq!(
+            config.metrics.bmc_latency_attributes(),
+            BmcLatencyAttribute::ATTRIBUTES.to_vec()
+        );
         assert!(config.rate_limit.is_enabled());
         assert!(config.processors.leak_detection.is_enabled());
         assert!(config.collectors.leak_detector.is_enabled());
@@ -3173,6 +3236,47 @@ reload_interval = "30s"
         } else {
             panic!("health report sink should be enabled by default");
         }
+    }
+
+    #[test]
+    fn bmc_latency_metrics_config_parsing() {
+        let toml_content = r#"
+[metrics]
+enable_bmc_latency_metrics = true
+bmc_latency_attributes = ["http_response_status_code", "server_address", "url_scheme"]
+"#;
+
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(toml_content))
+            .extract()
+            .expect("could not parse config toml file");
+
+        assert!(config.metrics.enable_bmc_latency_metrics);
+        assert_eq!(
+            config.metrics.bmc_latency_attributes(),
+            vec![
+                BmcLatencyAttribute::HttpResponseStatusCode,
+                BmcLatencyAttribute::ServerAddress,
+                BmcLatencyAttribute::UrlScheme,
+            ]
+        );
+
+        let toml_content = r#"
+[metrics]
+bmc_latency_attributes = ["http_path", "all"]
+"#;
+
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(toml_content))
+            .extract()
+            .expect("could not parse config toml file");
+
+        assert_eq!(
+            config.metrics.bmc_latency_attributes(),
+            BmcLatencyAttribute::ATTRIBUTES.to_vec()
+        );
     }
 
     #[test]

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -1341,8 +1341,15 @@ mod tests {
             mac: MacAddress::from_str("99:88:77:66:55:44").expect("valid mac"),
         };
         let bmc = Arc::new(
-            BmcClient::new(reqwest(), addr.clone(), Arc::new(FailingProvider), None, 10)
-                .expect("constructor succeeds"),
+            BmcClient::new(
+                reqwest(),
+                addr.clone(),
+                Arc::new(FailingProvider),
+                None,
+                10,
+                None,
+            )
+            .expect("constructor succeeds"),
         );
         let endpoint = Arc::new(BmcEndpoint {
             addr,

--- a/crates/health/src/endpoint/cluster.rs
+++ b/crates/health/src/endpoint/cluster.rs
@@ -30,6 +30,7 @@ use crate::HealthError;
 use crate::bmc::{BmcClient, FixedCredentialProvider};
 use crate::config::ClusterEndpointSourceConfig;
 use crate::endpoint::{BmcAddr, BmcCredentials, BmcEndpoint, BoxFuture, EndpointSource};
+use crate::metrics::BmcLatencyMetrics;
 
 // ── Inventory file shape ──────────────────────────────────────────────────────
 
@@ -292,6 +293,7 @@ pub struct ClusterEndpointSource {
     reqwest: ReqwestClient,
     proxy_url: Option<Url>,
     cache_size: usize,
+    bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
 }
 
 impl ClusterEndpointSource {
@@ -300,12 +302,14 @@ impl ClusterEndpointSource {
         reqwest: &ReqwestClient,
         proxy_url: Option<&Url>,
         cache_size: usize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Self {
         Self {
             cfg,
             reqwest: reqwest.clone(),
             proxy_url: proxy_url.cloned(),
             cache_size,
+            bmc_latency_metrics,
         }
     }
 
@@ -321,6 +325,7 @@ impl ClusterEndpointSource {
             &self.reqwest,
             self.proxy_url.as_ref(),
             self.cache_size,
+            self.bmc_latency_metrics.clone(),
         );
         tracing::info!(endpoint_count = endpoints.len(), "Loaded cluster endpoints");
         Ok(endpoints)
@@ -394,6 +399,7 @@ fn build_endpoints(
     reqwest: &ReqwestClient,
     proxy_url: Option<&Url>,
     cache_size: usize,
+    bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
 ) -> Vec<Arc<BmcEndpoint>> {
     let mut endpoints = Vec::with_capacity(nodes.len());
     for node in nodes {
@@ -427,6 +433,7 @@ fn build_endpoints(
             provider,
             proxy_url.cloned(),
             cache_size,
+            bmc_latency_metrics.clone(),
         ) {
             Ok(c) => Arc::new(c),
             Err(e) => {

--- a/crates/health/src/endpoint/cluster.rs
+++ b/crates/health/src/endpoint/cluster.rs
@@ -27,7 +27,9 @@ use serde_json::json;
 use url::Url;
 
 use crate::HealthError;
-use crate::bmc::{BmcClient, FixedCredentialProvider};
+use crate::bmc::{
+    BmcClient, BmcLatencyInstrumentation, FixedCredentialProvider, bmc_latency_endpoint_labels,
+};
 use crate::config::ClusterEndpointSourceConfig;
 use crate::endpoint::{BmcAddr, BmcCredentials, BmcEndpoint, BoxFuture, EndpointSource};
 use crate::metrics::BmcLatencyMetrics;
@@ -422,6 +424,13 @@ fn build_endpoints(
             port,
             mac,
         };
+        let rack_id = node.rack.as_deref().map(RackId::new);
+        let bmc_latency_instrumentation = bmc_latency_metrics.clone().map(|metrics| {
+            BmcLatencyInstrumentation::new(
+                metrics,
+                bmc_latency_endpoint_labels(None, rack_id.as_ref()),
+            )
+        });
         let credentials = BmcCredentials::UsernamePassword {
             username: node.username,
             password: node.password,
@@ -433,7 +442,7 @@ fn build_endpoints(
             provider,
             proxy_url.cloned(),
             cache_size,
-            bmc_latency_metrics.clone(),
+            bmc_latency_instrumentation,
         ) {
             Ok(c) => Arc::new(c),
             Err(e) => {
@@ -448,7 +457,7 @@ fn build_endpoints(
         endpoints.push(Arc::new(BmcEndpoint {
             addr,
             metadata: None,
-            rack_id: node.rack.as_deref().map(RackId::new),
+            rack_id,
             labels: Default::default(),
             bmc,
         }));

--- a/crates/health/src/endpoint/mod.rs
+++ b/crates/health/src/endpoint/mod.rs
@@ -54,7 +54,7 @@ pub(crate) mod test_support {
     ) -> BmcEndpoint {
         let provider = Arc::new(FixedCredentialProvider::new(creds));
         let bmc = Arc::new(
-            BmcClient::new(reqwest(), addr.clone(), provider, None, 10)
+            BmcClient::new(reqwest(), addr.clone(), provider, None, 10, None)
                 .expect("fixed-credential BmcClient construction is infallible"),
         );
         BmcEndpoint {

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -26,7 +26,9 @@ use nv_redfish::bmc_http::reqwest::Client as ReqwestClient;
 use url::Url;
 
 use crate::HealthError;
-use crate::bmc::{BmcClient, FixedCredentialProvider};
+use crate::bmc::{
+    BmcClient, BmcLatencyInstrumentation, FixedCredentialProvider, bmc_latency_endpoint_labels,
+};
 use crate::config::{StaticBmcEndpoint, StaticSwitchEndpointRole};
 use crate::endpoint::{
     BmcAddr, BmcCredentials, BmcEndpoint, BoxFuture, EndpointMetadata, EndpointSource, MachineData,
@@ -189,13 +191,20 @@ impl StaticEndpointSource {
                 password: cfg.password.clone(),
             };
             let provider = Arc::new(FixedCredentialProvider::new(credentials));
+            let rack_id = cfg.rack_id.as_ref().map(|id| RackId::new(id.as_str()));
+            let bmc_latency_instrumentation = bmc_latency_metrics.clone().map(|metrics| {
+                BmcLatencyInstrumentation::new(
+                    metrics,
+                    bmc_latency_endpoint_labels(metadata.as_ref(), rack_id.as_ref()),
+                )
+            });
             let bmc = match BmcClient::new(
                 reqwest.clone(),
                 addr.clone(),
                 provider,
                 proxy_url.cloned(),
                 cache_size,
-                bmc_latency_metrics.clone(),
+                bmc_latency_instrumentation,
             ) {
                 Ok(client) => Arc::new(client),
                 Err(error) => {
@@ -210,7 +219,7 @@ impl StaticEndpointSource {
             let endpoint = BmcEndpoint {
                 addr,
                 metadata,
-                rack_id: cfg.rack_id.as_ref().map(|id| RackId::new(id.as_str())),
+                rack_id,
                 labels: cfg.labels.clone(),
                 bmc,
             };

--- a/crates/health/src/endpoint/sources.rs
+++ b/crates/health/src/endpoint/sources.rs
@@ -32,6 +32,7 @@ use crate::endpoint::{
     BmcAddr, BmcCredentials, BmcEndpoint, BoxFuture, EndpointMetadata, EndpointSource, MachineData,
     PowerShelfData, SharedSystemUuid, SwitchData, SwitchEndpointRole,
 };
+use crate::metrics::BmcLatencyMetrics;
 
 fn parse_static_nvlink_domain_uuid(
     value: Option<&str>,
@@ -67,6 +68,7 @@ impl StaticEndpointSource {
         reqwest: &ReqwestClient,
         proxy_url: Option<&Url>,
         cache_size: usize,
+        bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
     ) -> Self {
         let mut endpoints = Vec::with_capacity(configs.len());
 
@@ -193,6 +195,7 @@ impl StaticEndpointSource {
                 provider,
                 proxy_url.cloned(),
                 cache_size,
+                bmc_latency_metrics.clone(),
             ) {
                 Ok(client) => Arc::new(client),
                 Err(error) => {
@@ -321,7 +324,7 @@ mod tests {
             },
         ];
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.expect("fetch should work");
 
         assert_eq!(endpoints.len(), 1);
@@ -359,7 +362,7 @@ mod tests {
             labels: Default::default(),
         }];
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.unwrap();
 
         assert_eq!(endpoints.len(), 1);
@@ -415,7 +418,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.unwrap();
 
         assert_eq!(endpoints.len(), cases.len());
@@ -446,7 +449,7 @@ mod tests {
             labels: Default::default(),
         }];
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.unwrap();
 
         assert_eq!(endpoints.len(), 1);
@@ -487,7 +490,7 @@ mod tests {
             labels: std::collections::BTreeMap::from([("site".to_string(), "dev".to_string())]),
         }];
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.unwrap();
 
         assert_eq!(endpoints.len(), 1);
@@ -537,7 +540,7 @@ mod tests {
             labels: Default::default(),
         }];
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.unwrap();
 
         assert_eq!(endpoints.len(), 1);
@@ -564,7 +567,7 @@ mod tests {
             labels: Default::default(),
         }];
 
-        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10);
+        let source = StaticEndpointSource::from_config(&configs, &reqwest(), None, 10, None);
         let endpoints = source.fetch_bmc_hosts().await.unwrap();
 
         assert_eq!(endpoints.len(), 1);

--- a/crates/health/src/lib.rs
+++ b/crates/health/src/lib.rs
@@ -48,7 +48,7 @@ use crate::endpoint::{
     ClusterEndpointSource, CompositeEndpointSource, EndpointSource, StaticEndpointSource,
 };
 use crate::limiter::{BucketLimiter, NoopLimiter, RateLimiter};
-use crate::metrics::{MetricsManager, run_metrics_server};
+use crate::metrics::{BmcLatencyMetrics, MetricsManager, run_metrics_server};
 use crate::processor::{
     BmcIntrusionEventProcessor, EventProcessingPipeline, EventProcessor, HealthReportProcessor,
     LeakEventProcessor, RackLeakProcessor,
@@ -135,7 +135,10 @@ struct EndpointWiring {
     source: Arc<dyn EndpointSource>,
 }
 
-fn build_endpoint_wiring(config: &Config) -> Result<EndpointWiring, HealthError> {
+fn build_endpoint_wiring(
+    config: &Config,
+    bmc_latency_metrics: Option<Arc<BmcLatencyMetrics>>,
+) -> Result<EndpointWiring, HealthError> {
     let reqwest = ReqwestClient::with_params(ReqwestClientParams::new().accept_invalid_certs(true))
         .map_err(BmcError::ReqwestError)?;
     let mut sources: Vec<Arc<dyn EndpointSource>> = Vec::new();
@@ -146,6 +149,7 @@ fn build_endpoint_wiring(config: &Config) -> Result<EndpointWiring, HealthError>
             &reqwest,
             config.bmc_proxy_url.as_ref(),
             config.cache_size,
+            bmc_latency_metrics.clone(),
         );
         sources.push(Arc::new(static_source));
     }
@@ -162,6 +166,7 @@ fn build_endpoint_wiring(config: &Config) -> Result<EndpointWiring, HealthError>
             reqwest.clone(),
             config.bmc_proxy_url.clone(),
             config.cache_size,
+            bmc_latency_metrics.clone(),
         ));
         sources.push(endpoint_source as Arc<dyn EndpointSource>);
     }
@@ -172,6 +177,7 @@ fn build_endpoint_wiring(config: &Config) -> Result<EndpointWiring, HealthError>
             &reqwest,
             config.bmc_proxy_url.as_ref(),
             config.cache_size,
+            bmc_latency_metrics,
         );
         sources.push(Arc::new(cluster_source));
     }
@@ -350,6 +356,16 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
 
     let metrics_endpoint = config.metrics_addr()?;
     let metrics_manager = Arc::new(MetricsManager::new(&config.metrics.prefix)?);
+    let bmc_latency_metrics = if config.metrics.enable_bmc_latency_metrics {
+        let attributes = config.metrics.bmc_latency_attributes();
+        Some(Arc::new(BmcLatencyMetrics::new_with_attributes(
+            metrics_manager.global_registry(),
+            &config.metrics.prefix,
+            &attributes,
+        )?))
+    } else {
+        None
+    };
 
     // Back the global OpenTelemetry meter with a prometheus registry and
     // merge that registry into this binary's /metrics exposition, so events
@@ -393,7 +409,7 @@ pub async fn run_service(config: Config) -> Result<(), HealthError> {
 
     let EndpointWiring {
         source: endpoint_source,
-    } = build_endpoint_wiring(&config)?;
+    } = build_endpoint_wiring(&config, bmc_latency_metrics)?;
 
     let data_sink = build_data_sink(&config, metrics_manager.clone())?;
 

--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -34,6 +34,7 @@ use prometheus::proto::LabelPair;
 use prometheus::{
     Encoder, HistogramOpts, HistogramVec, IntCounterVec, Registry, TextEncoder, proto,
 };
+use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 
 use crate::HealthError;
@@ -45,6 +46,119 @@ pub fn operation_duration_buckets_seconds() -> Vec<f64> {
     vec![
         1.0, 2.0, 5.0, 10.0, 15.0, 20.0, 30.0, 45.0, 60.0, 90.0, 120.0, 180.0, 240.0, 300.0,
     ]
+}
+
+pub fn bmc_latency_buckets_ms() -> Vec<f64> {
+    vec![
+        5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1_000.0, 2_500.0, 5_000.0, 10_000.0, 30_000.0,
+        60_000.0,
+    ]
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BmcLatencyAttribute {
+    All,
+    HttpResponseStatusCode,
+    HttpRequestMethod,
+    HttpPath,
+    ServerAddress,
+    UrlScheme,
+    BmcVendor,
+    BmcModel,
+}
+
+impl BmcLatencyAttribute {
+    pub const ATTRIBUTES: [Self; 7] = [
+        Self::HttpResponseStatusCode,
+        Self::HttpRequestMethod,
+        Self::HttpPath,
+        Self::ServerAddress,
+        Self::UrlScheme,
+        Self::BmcVendor,
+        Self::BmcModel,
+    ];
+
+    pub fn label_name(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::HttpResponseStatusCode => "http_response_status_code",
+            Self::HttpRequestMethod => "http_request_method",
+            Self::HttpPath => "http_path",
+            Self::ServerAddress => "server_address",
+            Self::UrlScheme => "url_scheme",
+            Self::BmcVendor => "bmc_vendor",
+            Self::BmcModel => "bmc_model",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BmcLatencyMetrics {
+    latency_ms: HistogramVec,
+    attributes: Vec<BmcLatencyAttribute>,
+}
+
+pub struct BmcLatencyObservation<'a> {
+    pub status_code: &'a str,
+    pub method: &'a str,
+    pub path: &'a str,
+    pub server_address: &'a str,
+    pub url_scheme: &'a str,
+    pub bmc_vendor: Option<&'a str>,
+    pub bmc_model: Option<&'a str>,
+    pub duration: std::time::Duration,
+}
+
+impl BmcLatencyMetrics {
+    pub fn new(registry: &Registry, prefix: &str) -> Result<Self, prometheus::Error> {
+        Self::new_with_attributes(registry, prefix, &BmcLatencyAttribute::ATTRIBUTES)
+    }
+
+    pub fn new_with_attributes(
+        registry: &Registry,
+        prefix: &str,
+        attributes: &[BmcLatencyAttribute],
+    ) -> Result<Self, prometheus::Error> {
+        let label_names = attributes
+            .iter()
+            .map(|attribute| attribute.label_name())
+            .collect::<Vec<_>>();
+        let latency_ms = HistogramVec::new(
+            HistogramOpts::new(
+                format!("{prefix}_bmc_latency_ms"),
+                "Duration of outbound Redfish HTTP requests to BMCs, in milliseconds",
+            )
+            .buckets(bmc_latency_buckets_ms()),
+            &label_names,
+        )?;
+        registry.register(Box::new(latency_ms.clone()))?;
+
+        Ok(Self {
+            latency_ms,
+            attributes: attributes.to_vec(),
+        })
+    }
+
+    pub fn observe(&self, observation: BmcLatencyObservation<'_>) {
+        let labels = self
+            .attributes
+            .iter()
+            .map(|attribute| match attribute {
+                BmcLatencyAttribute::All => unreachable!("all is not a concrete metric label"),
+                BmcLatencyAttribute::HttpResponseStatusCode => observation.status_code,
+                BmcLatencyAttribute::HttpRequestMethod => observation.method,
+                BmcLatencyAttribute::HttpPath => observation.path,
+                BmcLatencyAttribute::ServerAddress => observation.server_address,
+                BmcLatencyAttribute::UrlScheme => observation.url_scheme,
+                BmcLatencyAttribute::BmcVendor => observation.bmc_vendor.unwrap_or("unknown"),
+                BmcLatencyAttribute::BmcModel => observation.bmc_model.unwrap_or("unknown"),
+            })
+            .collect::<Vec<_>>();
+        self.latency_ms
+            .with_label_values(&labels)
+            .observe(observation.duration.as_secs_f64() * 1_000.0);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -58,7 +58,6 @@ pub fn bmc_latency_buckets_ms() -> Vec<f64> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BmcLatencyAttribute {
-    All,
     HttpResponseStatusCode,
     HttpRequestMethod,
     HttpPath,
@@ -66,10 +65,13 @@ pub enum BmcLatencyAttribute {
     UrlScheme,
     BmcVendor,
     BmcModel,
+    EntityType,
+    MachineId,
+    RackId,
 }
 
 impl BmcLatencyAttribute {
-    pub const ATTRIBUTES: [Self; 7] = [
+    pub const ATTRIBUTES: [Self; 10] = [
         Self::HttpResponseStatusCode,
         Self::HttpRequestMethod,
         Self::HttpPath,
@@ -77,11 +79,13 @@ impl BmcLatencyAttribute {
         Self::UrlScheme,
         Self::BmcVendor,
         Self::BmcModel,
+        Self::EntityType,
+        Self::MachineId,
+        Self::RackId,
     ];
 
     pub fn label_name(self) -> &'static str {
         match self {
-            Self::All => "all",
             Self::HttpResponseStatusCode => "http_response_status_code",
             Self::HttpRequestMethod => "http_request_method",
             Self::HttpPath => "http_path",
@@ -89,7 +93,17 @@ impl BmcLatencyAttribute {
             Self::UrlScheme => "url_scheme",
             Self::BmcVendor => "bmc_vendor",
             Self::BmcModel => "bmc_model",
+            Self::EntityType => "entity_type",
+            Self::MachineId => "machine_id",
+            Self::RackId => "rack_id",
         }
+    }
+
+    pub fn from_label_name(label_name: &str) -> Option<Self> {
+        Self::ATTRIBUTES
+            .iter()
+            .copied()
+            .find(|attribute| attribute.label_name() == label_name)
     }
 }
 
@@ -107,6 +121,9 @@ pub struct BmcLatencyObservation<'a> {
     pub url_scheme: &'a str,
     pub bmc_vendor: Option<&'a str>,
     pub bmc_model: Option<&'a str>,
+    pub entity_type: &'a str,
+    pub machine_id: Option<&'a str>,
+    pub rack_id: Option<&'a str>,
     pub duration: std::time::Duration,
 }
 
@@ -145,7 +162,6 @@ impl BmcLatencyMetrics {
             .attributes
             .iter()
             .map(|attribute| match attribute {
-                BmcLatencyAttribute::All => unreachable!("all is not a concrete metric label"),
                 BmcLatencyAttribute::HttpResponseStatusCode => observation.status_code,
                 BmcLatencyAttribute::HttpRequestMethod => observation.method,
                 BmcLatencyAttribute::HttpPath => observation.path,
@@ -153,6 +169,9 @@ impl BmcLatencyMetrics {
                 BmcLatencyAttribute::UrlScheme => observation.url_scheme,
                 BmcLatencyAttribute::BmcVendor => observation.bmc_vendor.unwrap_or("unknown"),
                 BmcLatencyAttribute::BmcModel => observation.bmc_model.unwrap_or("unknown"),
+                BmcLatencyAttribute::EntityType => observation.entity_type,
+                BmcLatencyAttribute::MachineId => observation.machine_id.unwrap_or("unknown"),
+                BmcLatencyAttribute::RackId => observation.rack_id.unwrap_or("unknown"),
             })
             .collect::<Vec<_>>();
         self.latency_ms


### PR DESCRIPTION
Adds new config file flags to hw-health which make it emit a histogram metric for requests to BMCs. The metric with all properties attached will look like:
```
carbide_hardware_health_bmc_latency_ms_bucket{http_response_status_code="200",http_request_method="GET",http_path="/redfish/
  v1",server_address="1.3.5.12",url_scheme="https",bmc_vendor="NVIDIA",bmc_model="GB200 BMC",le="100"} 1
```

The metric can be explicitly enabled via setting
```toml
[metrics]
enable_bmc_latency_metrics = true
```

By default it will contain all available fields. If only a subset of fields should be emitted to reduce the amount of time series, the setting `metrics.bmc_latency_attributes` can be used to explicitly specify the attributes that should be included. Adding `all` to the list leads to emitting all attributes (default) again.

```toml
[metrics]
bmc_latency_attributes = ["http_response_status_code", "server_address", "url_scheme"]
```

Limitation:

The status code for success responses are estimated since nv-redfish does not expose it. It is always set to 200 for GET requests and 201 for creation requests. Status codes for error responses are accurate.

## Related issues

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

