### PR TITLE
feat(helm): template machine-a-tron rack configuration

### DIFF
--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -180,6 +180,16 @@ nico-machine-a-tron:
       - spiffe://nico.local/nico-system/sa/machine-a-tron
   pods:
     mat-0:
+      racks:
+        gb200:
+          type: wiwynn_gb200_nvl72
+          rack_profile_id: NVL72
+          ids:
+            - rack-001
+          dpu_reboot_delay: 20
+          host_reboot_delay: 10
+          oob_dhcp_relay_address: 192.168.192.1
+          admin_dhcp_relay_address: 192.168.176.1
       machines:
         rack-machines:
           hwType: wiwynn_gb200_nvl

--- a/helm/charts/nico-machine-a-tron/templates/_helpers.tpl
+++ b/helm/charts/nico-machine-a-tron/templates/_helpers.tpl
@@ -50,12 +50,12 @@ app.kubernetes.io/component: machine-a-tron
 {{- end }}
 
 {{/*
-Count pods with machines defined.
+Count configured pods.
 */}}
 {{- define "nico-machine-a-tron.activePods" -}}
 {{- $activePods := 0 -}}
 {{- range $podName, $podConfig := .Values.pods -}}
-{{- if and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0) -}}
+{{- if and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0)) -}}
 {{- $activePods = add $activePods 1 -}}
 {{- end -}}
 {{- end -}}

--- a/helm/charts/nico-machine-a-tron/templates/certificate.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/certificate.yaml
@@ -4,9 +4,9 @@
 
 {{- range $podName, $podConfig := .Values.pods }}
 {{/*
-Skip pods without machines
+Skip unconfigured pods
 */}}
-{{- if not (and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0)) }}
+{{- if not (and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0))) }}
 {{- continue }}
 {{- end }}
 

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -7,7 +7,7 @@ Build ordered list of pod names for consistent MAC address indexing
 */}}
 {{- $podList := list }}
 {{- range $podName, $podConfig := .Values.pods }}
-{{- if and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0) }}
+{{- if and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0)) }}
 {{- $podList = append $podList $podName }}
 {{- end }}
 {{- end }}
@@ -36,9 +36,9 @@ Build ordered list of pod names for consistent MAC address indexing
 
 {{- range $podName, $podConfig := .Values.pods }}
 {{/*
-Skip pods without machines
+Skip unconfigured pods
 */}}
-{{- if not (and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0)) }}
+{{- if not (and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0))) }}
 {{- continue }}
 {{- end }}
 
@@ -148,7 +148,22 @@ data:
     {{- end }}
     {{- end }}
 
-    {{- range $sectionName, $section := $podConfig.machines }}
+    {{- $racks := $podConfig.racks | default dict }}
+    {{- $machines := $podConfig.machines | default dict }}
+
+    {{- range $sectionName, $section := $racks }}
+
+    [racks.{{ $sectionName }}]
+    type = {{ $section.type | quote }}
+    rack_profile_id = {{ $section.rack_profile_id | quote }}
+    ids = {{ $section.ids | toJson }}
+    dpu_reboot_delay = {{ $section.dpu_reboot_delay | default $defaults.dpuRebootDelay | int }}
+    host_reboot_delay = {{ $section.host_reboot_delay | default $defaults.hostRebootDelay | int }}
+    oob_dhcp_relay_address = {{ $section.oob_dhcp_relay_address | quote }}
+    admin_dhcp_relay_address = {{ $section.admin_dhcp_relay_address | quote }}
+    {{- end }}
+
+    {{- range $sectionName, $section := $machines }}
     {{- if $section }}
 
     [machines.{{ $sectionName }}]
@@ -173,6 +188,10 @@ data:
     {{- end }}
     dpus_in_nic_mode = {{ $section.dpusInNicMode | default $defaults.dpusInNicMode | default false }}
     {{- end }}
+    {{- end }}
+
+    {{- if and (gt (len $racks) 0) (eq (len $machines) 0) }}
+    [machines]
     {{- end }}
     {{- end }}
 {{- end }}

--- a/helm/charts/nico-machine-a-tron/templates/deployment.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/deployment.yaml
@@ -9,9 +9,9 @@
 
 {{- range $podName, $podConfig := .Values.pods }}
 {{/*
-Skip pods without machines (or empty machines)
+Skip unconfigured pods
 */}}
-{{- if not (and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0)) }}
+{{- if not (and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0))) }}
 {{- continue }}
 {{- end }}
 

--- a/helm/charts/nico-machine-a-tron/templates/pvc.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/pvc.yaml
@@ -4,8 +4,8 @@
 {{- $baseName := include "nico-machine-a-tron.name" . }}
 
 {{- range $podName, $podConfig := .Values.pods }}
-{{/* Skip pods without machines */}}
-{{- if not (and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0)) }}
+{{/* Skip unconfigured pods */}}
+{{- if not (and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0))) }}
 {{- continue }}
 {{- end }}
 

--- a/helm/charts/nico-machine-a-tron/templates/service.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/service.yaml
@@ -4,9 +4,9 @@
 
 {{- range $podName, $podConfig := .Values.pods }}
 {{/*
-Skip pods without machines
+Skip unconfigured pods
 */}}
-{{- if not (and $podConfig $podConfig.machines (gt (len $podConfig.machines) 0)) }}
+{{- if not (and $podConfig (or (gt (len ($podConfig.machines | default dict)) 0) (gt (len ($podConfig.racks | default dict)) 0))) }}
 {{- continue }}
 {{- end }}
 

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -66,6 +66,58 @@ tests:
       - hasDocuments:
           count: 2
 
+  - it: should render an atomic rack
+    set:
+      pods:
+        mat-0:
+          machines:
+            rack-machines: null
+          racks:
+            gb200:
+              type: wiwynn_gb200_nvl72
+              rack_profile_id: NVL72
+              ids:
+                - rack-001
+              dpu_reboot_delay: 20
+              host_reboot_delay: 10
+              oob_dhcp_relay_address: 10.96.64.1
+              admin_dhcp_relay_address: 192.168.176.1
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: '\[racks\.gb200\]'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'rack_profile_id = "NVL72"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: '\[machines\]'
+      - notMatchRegex:
+          path: data["mat.toml"]
+          pattern: '\[machines\.rack-machines\]'
+
+  - it: should render racks and machines together
+    set:
+      pods:
+        mat-0:
+          racks:
+            gb200:
+              type: wiwynn_gb200_nvl72
+              rack_profile_id: NVL72
+              ids:
+                - rack-001
+              dpu_reboot_delay: 20
+              host_reboot_delay: 10
+              oob_dhcp_relay_address: 10.96.64.1
+              admin_dhcp_relay_address: 192.168.176.1
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: '\[racks\.gb200\]'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: '\[machines\.rack-machines\]'
+
   - it: should use machineDefaults for all machine groups
     set:
       machineDefaults:

--- a/helm/charts/nico-machine-a-tron/tests/deployment_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/deployment_test.yaml
@@ -127,3 +127,22 @@ tests:
           value: nico-machine-a-tron-mat-1-tls
         documentIndex: 1
         template: deployment.yaml
+
+  - it: should deploy a rack-only pod
+    set:
+      pods:
+        mat-0: null
+        rack-sim:
+          racks:
+            gb200:
+              type: wiwynn_gb200_nvl72
+              rack_profile_id: NVL72
+              ids:
+                - rack-001
+              oob_dhcp_relay_address: 10.96.64.1
+              admin_dhcp_relay_address: 192.168.176.1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: nico-machine-a-tron-rack-sim
+        template: deployment.yaml

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -242,6 +242,17 @@ pods:
   ## Names must be valid K8s label values (alphanumeric, -, _, ., max 63 chars)
   mat-0:
 
+    # racks:
+    #   gb200:
+    #     type: wiwynn_gb200_nvl72
+    #     rack_profile_id: NVL72
+    #     ids:
+    #       - rack-001
+    #     dpu_reboot_delay: 20
+    #     host_reboot_delay: 10
+    #     oob_dhcp_relay_address: "192.168.192.1"
+    #     admin_dhcp_relay_address: "192.168.176.1"
+
     ## Machine groups for this pod
     machines:
       rack-machines:


### PR DESCRIPTION
Adds Helm support for configuring Machine-A-Tron atomic racks through `pods.<pod>.racks`.

Racks and machines are rendered independently, allowing rack-only, machine-only, or combined simulations. Existing default machine behavior remains unchanged when no rack configuration is supplied. Tilt values now exercise the combined rack and machine configuration.

## Related issues

None.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Validated with Helm lint and rendered the default, rack-only, and combined rack-and-machine configurations. The generated `mat.toml` was also parsed to verify its structure.