### PR TITLE
feat(agent,fmds): expose dual-stack public IP metadata

### DIFF
--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -140,7 +140,8 @@ impl FmdsGrpcClient {
             .unwrap_or_default();
 
         let update = FmdsConfigUpdate {
-            address: metadata.address.clone(),
+            address: metadata.public_addresses.ipv4_string(),
+            address_ipv6: metadata.public_addresses.ipv6_string(),
             hostname: metadata.hostname.clone(),
             instance_name: metadata.instance_name.clone(),
             sitename: metadata.sitename.clone(),

--- a/crates/agent/src/instance_metadata_endpoint.rs
+++ b/crates/agent/src/instance_metadata_endpoint.rs
@@ -44,6 +44,7 @@ use crate::periodic_config_fetcher::InstanceMetadata;
 use crate::util::phone_home;
 
 const PUBLIC_IPV4_CATEGORY: &str = "public-ipv4";
+const PUBLIC_IPV6_CATEGORY: &str = "public-ipv6";
 const HOSTNAME_CATEGORY: &str = "hostname";
 const INSTANCE_NAME_CATEGORY: &str = "instance-name";
 const SITENAME_CATEGORY: &str = "sitename";
@@ -316,7 +317,8 @@ fn extract_metadata(
         (instance_meta.as_ref(), network_config.as_ref())
     {
         match category.as_str() {
-            PUBLIC_IPV4_CATEGORY => (StatusCode::OK, metadata.address.clone()),
+            PUBLIC_IPV4_CATEGORY => (StatusCode::OK, metadata.public_addresses.ipv4_string()),
+            PUBLIC_IPV6_CATEGORY => (StatusCode::OK, metadata.public_addresses.ipv6_string()),
             HOSTNAME_CATEGORY => (StatusCode::OK, metadata.hostname.clone()),
             INSTANCE_NAME_CATEGORY => match &metadata.instance_name {
                 Some(instance_name) if !instance_name.is_empty() => {
@@ -404,6 +406,8 @@ async fn get_metadata_params(
             MACHINE_ID_CATEGORY,
             INSTANCE_ID_CATEGORY,
             ASN_CATEGORY,
+            PUBLIC_IPV4_CATEGORY,
+            PUBLIC_IPV6_CATEGORY,
         ]
         .join("\n"),
     )
@@ -586,6 +590,8 @@ async fn post_phone_home(
 
 #[cfg(test)]
 mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
     use axum::http;
     use http_body_util::{BodyExt, Full};
     use hyper::body::Bytes;
@@ -593,7 +599,9 @@ mod tests {
     use uuid::uuid;
 
     use super::*;
-    use crate::periodic_config_fetcher::{IBDeviceConfig, IBInstanceConfig, InstanceMetadata};
+    use crate::periodic_config_fetcher::{
+        IBDeviceConfig, IBInstanceConfig, InstanceMetadata, PublicAddresses,
+    };
 
     async fn setup_server(
         metadata: Option<InstanceMetadata>,
@@ -604,7 +612,6 @@ mod tests {
         let mut mock_router_state = MockInstanceMetadataRouterState::new();
         mock_router_state
             .expect_read()
-            .times(2)
             .return_const((metadata.clone(), network_config.clone()));
 
         let arc_mock_router_state = Arc::new(mock_router_state);
@@ -655,7 +662,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_metadata_parameter_public_ipv4_category() {
+    async fn test_get_metadata_parameter_public_ip_categories() {
         let metadata = InstanceMetadata {
             instance_id: Some(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8").into()),
             machine_id: Some(
@@ -663,7 +670,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: Some(Ipv6Addr::LOCALHOST),
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -682,10 +692,32 @@ mod tests {
         send_request_and_check_response(
             server_port,
             "meta-data/public-ipv4",
-            &metadata.address,
+            "127.0.0.1",
             StatusCode::OK,
         )
         .await;
+        send_request_and_check_response(
+            server_port,
+            "meta-data/public-ipv6",
+            "::1",
+            StatusCode::OK,
+        )
+        .await;
+        server.abort();
+
+        let metadata = InstanceMetadata {
+            public_addresses: PublicAddresses::default(),
+            ..metadata
+        };
+        let (server, server_port) = setup_server(
+            Some(metadata),
+            Some(ManagedHostNetworkConfigResponse::default()),
+        )
+        .await;
+        send_request_and_check_response(server_port, "meta-data/public-ipv4", "", StatusCode::OK)
+            .await;
+        send_request_and_check_response(server_port, "meta-data/public-ipv6", "", StatusCode::OK)
+            .await;
         server.abort();
     }
 
@@ -698,7 +730,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -758,7 +793,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -776,6 +814,8 @@ mod tests {
             MACHINE_ID_CATEGORY,
             INSTANCE_ID_CATEGORY,
             ASN_CATEGORY,
+            PUBLIC_IPV4_CATEGORY,
+            PUBLIC_IPV6_CATEGORY,
         ]
         .join("\n");
 
@@ -806,7 +846,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -854,7 +897,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -906,7 +952,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -948,7 +997,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -997,7 +1049,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1039,7 +1094,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1081,7 +1139,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1123,7 +1184,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1165,7 +1229,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1207,7 +1274,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1242,7 +1312,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1277,7 +1350,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),
@@ -1308,7 +1384,10 @@ mod tests {
                     .parse()
                     .unwrap(),
             ),
-            address: "127.0.0.1".to_string(),
+            public_addresses: PublicAddresses {
+                ipv4: Some(Ipv4Addr::LOCALHOST),
+                ipv6: None,
+            },
             hostname: "localhost".to_string(),
             instance_name: Some("test-instance".to_string()),
             user_data: "\"userData\": {\"data\": 0}".to_string(),

--- a/crates/agent/src/periodic_config_fetcher.rs
+++ b/crates/agent/src/periodic_config_fetcher.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
@@ -50,11 +51,34 @@ pub(super) struct PeriodicConfigFetcher {
 pub(super) struct PeriodicConfigFetcherReader {
     state: Arc<PeriodicFetcherState>,
 }
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct PublicAddresses {
+    pub(super) ipv4: Option<Ipv4Addr>,
+    pub(super) ipv6: Option<Ipv6Addr>,
+}
+
+impl PublicAddresses {
+    /// Preserves FMDS's empty-string contract when no IPv4 address is assigned.
+    pub(super) fn ipv4_string(self) -> String {
+        self.ipv4
+            .map(|address| address.to_string())
+            .unwrap_or_default()
+    }
+
+    /// Preserves FMDS's empty-string contract when no IPv6 address is assigned.
+    pub(super) fn ipv6_string(self) -> String {
+        self.ipv6
+            .map(|address| address.to_string())
+            .unwrap_or_default()
+    }
+}
+
 /// The instance metadata - as fetched from the
 /// Forge Site Controller
 #[derive(Clone, Debug)]
 pub(super) struct InstanceMetadata {
-    pub(super) address: String,
+    pub(super) public_addresses: PublicAddresses,
     pub(super) hostname: String,
     pub(super) instance_name: Option<String>,
     pub(super) sitename: Option<String>,
@@ -255,6 +279,44 @@ async fn fetch(
     get_periodic_dpu_config(&mut client, dpu_machine_id).await
 }
 
+/// Picks the lowest address in each family across physical interfaces because HostInband status
+/// is built from maps and does not have a stable interface or address order.
+fn select_public_addresses(
+    interfaces: &[rpc::InstanceInterfaceStatus],
+) -> Result<PublicAddresses, eyre::Error> {
+    let mut public_addresses = PublicAddresses::default();
+
+    let addresses = interfaces
+        .iter()
+        .filter(|interface| interface.virtual_function_id.is_none())
+        .flat_map(|interface| &interface.addresses);
+
+    for value in addresses {
+        let address = value
+            .parse::<IpAddr>()
+            .wrap_err_with(|| format!("invalid physical interface address `{value}`"))?;
+
+        match address {
+            IpAddr::V4(address) => {
+                public_addresses.ipv4 = Some(
+                    public_addresses
+                        .ipv4
+                        .map_or(address, |current| current.min(address)),
+                );
+            }
+            IpAddr::V6(address) => {
+                public_addresses.ipv6 = Some(
+                    public_addresses
+                        .ipv6
+                        .map_or(address, |current| current.min(address)),
+                );
+            }
+        }
+    }
+
+    Ok(public_addresses)
+}
+
 fn instance_metadata_from_instance(
     instance: Option<Instance>,
     sitename: Option<String>,
@@ -279,17 +341,12 @@ fn instance_metadata_from_instance(
         .map(|metadata| metadata.name.clone())
         .filter(|name| !name.is_empty());
 
-    let pf_address = instance
+    let public_addresses = instance
         .status
         .as_ref()
         .and_then(|status| status.network.as_ref())
-        .and_then(|network| {
-            network
-                .interfaces
-                .iter()
-                .find(|interface| interface.virtual_function_id.is_none()) // We only want an IP address of a physical function
-                .and_then(|interface| interface.addresses.first().cloned())
-        })
+        .map(|network| select_public_addresses(&network.interfaces))
+        .transpose()?
         .unwrap_or_default();
 
     let user_data = instance
@@ -308,7 +365,7 @@ fn instance_metadata_from_instance(
     };
 
     Ok(Some(InstanceMetadata {
-        address: pf_address,
+        public_addresses,
         hostname,
         instance_name,
         sitename,
@@ -377,4 +434,79 @@ fn extract_instance_ib_config(instance: &Instance) -> Result<Vec<IBDeviceConfig>
     }
 
     Ok(devices)
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    #[test]
+    fn public_address_selection_is_family_specific_and_stable() {
+        let ipv4_low: Ipv4Addr = "192.0.2.10".parse().unwrap();
+        let ipv6_low: Ipv6Addr = "2001:db8::10".parse().unwrap();
+
+        scenarios!(
+            run = |interfaces: Vec<(Option<u32>, Vec<&str>)>| {
+                let interfaces = interfaces
+                    .into_iter()
+                    .map(|(virtual_function_id, addresses)| rpc::InstanceInterfaceStatus {
+                        virtual_function_id,
+                        addresses: addresses.into_iter().map(str::to_owned).collect(),
+                        ..Default::default()
+                    })
+                    .collect::<Vec<_>>();
+                select_public_addresses(&interfaces).map_err(drop)
+            };
+            "no addresses" {
+                vec![] => Yields(PublicAddresses::default()),
+            }
+
+            "one address family" {
+                vec![(None, vec!["192.0.2.20", "192.0.2.10"])] => Yields(PublicAddresses {
+                    ipv4: Some(ipv4_low),
+                    ipv6: None,
+                }),
+                vec![(None, vec!["2001:db8::20", "2001:db8::10"])] => Yields(PublicAddresses {
+                    ipv4: None,
+                    ipv6: Some(ipv6_low),
+                }),
+            }
+
+            "dual-stack address order" {
+                vec![(None, vec!["2001:db8::10", "192.0.2.20", "2001:db8::20", "192.0.2.10"])] => Yields(PublicAddresses {
+                    ipv4: Some(ipv4_low),
+                    ipv6: Some(ipv6_low),
+                }),
+                vec![(None, vec!["192.0.2.10", "2001:db8::20", "192.0.2.20", "2001:db8::10"])] => Yields(PublicAddresses {
+                    ipv4: Some(ipv4_low),
+                    ipv6: Some(ipv6_low),
+                }),
+            }
+
+            "dual-stack physical interface order" {
+                vec![
+                    (None, vec!["192.0.2.20", "192.0.2.10"]),
+                    (None, vec!["2001:db8::20", "2001:db8::10"]),
+                ] => Yields(PublicAddresses {
+                    ipv4: Some(ipv4_low),
+                    ipv6: Some(ipv6_low),
+                }),
+                vec![
+                    (None, vec!["2001:db8::10"]),
+                    (Some(0), vec!["192.0.2.1"]),
+                    (None, vec!["192.0.2.10"]),
+                ] => Yields(PublicAddresses {
+                    ipv4: Some(ipv4_low),
+                    ipv6: Some(ipv6_low),
+                }),
+            }
+
+            "invalid address" {
+                vec![(None, vec!["not-an-address"])] => Fails,
+            }
+        );
+    }
 }

--- a/crates/agent/src/tests/full.rs
+++ b/crates/agent/src/tests/full.rs
@@ -180,6 +180,39 @@ async fn test_fmds_get_data() -> eyre::Result<()> {
 
     assert_eq!(body_str, "test-instance");
 
+    // Core reports IPv6 first here, but FMDS still exposes each family through its own category.
+    let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
+    let request: hyper::Request<Full<Bytes>> = hyper::Request::builder()
+        .method(hyper::Method::GET)
+        .uri("http://0.0.0.0:7777/latest/meta-data/public-ipv4".to_string())
+        .body("".into())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = std::str::from_utf8(&body).unwrap();
+
+    assert_eq!(body_str, "10.217.104.146");
+
+    let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
+    let request: hyper::Request<Full<Bytes>> = hyper::Request::builder()
+        .method(hyper::Method::GET)
+        .uri("http://0.0.0.0:7777/latest/meta-data/public-ipv6".to_string())
+        .body("".into())
+        .unwrap();
+
+    let response = client.request(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let body_str = std::str::from_utf8(&body).unwrap();
+
+    assert_eq!(body_str, "2001:db8::146");
+
     // Test get machine_id
     let client = hyper_util::client::legacy::Client::builder(TokioExecutor::new()).build_http();
     let request: hyper::Request<Full<Bytes>> = hyper::Request::builder()
@@ -804,9 +837,18 @@ async fn handle_netconf(AxumState(state): AxumState<Arc<Mutex<State>>>) -> impl 
                 interfaces: vec![rpc::InstanceInterfaceStatus {
                     virtual_function_id: None,
                     mac_address: Some("5C:25:73:9E:92:F2".to_string()),
-                    addresses: vec!["10.217.104.146".to_string()],
-                    gateways: vec!["10.217.104.145/30".to_string()],
-                    prefixes: vec!["10.217.104.146/32".to_string()],
+                    addresses: vec![
+                        "2001:db8::146".to_string(),
+                        "10.217.104.146".to_string(),
+                    ],
+                    gateways: vec![
+                        "2001:db8::145/64".to_string(),
+                        "10.217.104.145/30".to_string(),
+                    ],
+                    prefixes: vec![
+                        "2001:db8::146/128".to_string(),
+                        "10.217.104.146/32".to_string(),
+                    ],
                     device: None,
                     device_instance: 0u32,
                     vpc_id: None,

--- a/crates/fmds/src/grpc_server.rs
+++ b/crates/fmds/src/grpc_server.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::net::{IpAddr, Ipv6Addr};
 use std::sync::Arc;
 
 use carbide_instrument::{Event, Outcome, emit};
@@ -106,6 +107,29 @@ impl FmdsGrpcServer {
             .config_update
             .ok_or_else(|| Status::invalid_argument("missing config_update"))?;
 
+        let legacy_address = match update.address.as_str() {
+            "" => None,
+            address => Some(address.parse::<IpAddr>().map_err(|error| {
+                Status::invalid_argument(format!("invalid `address` field `{address}`: {error}"))
+            })?),
+        };
+        let configured_ipv6 = match update.address_ipv6.as_str() {
+            "" => None,
+            address => Some(address.parse::<Ipv6Addr>().map_err(|error| {
+                Status::invalid_argument(format!(
+                    "invalid `address_ipv6` field `{address}`: {error}"
+                ))
+            })?),
+        };
+
+        // Older agents selected the first physical address for `address`, so it can contain IPv6.
+        // Treat that value as IPv6 during a rolling upgrade instead of serving it as `public-ipv4`.
+        let (public_ipv4, legacy_ipv6) = match legacy_address {
+            Some(IpAddr::V4(address)) => (Some(address), None),
+            Some(IpAddr::V6(address)) => (None, Some(address)),
+            None => (None, None),
+        };
+
         let ib_devices = if update.ib_devices.is_empty() {
             None
         } else {
@@ -132,7 +156,8 @@ impl FmdsGrpcServer {
         };
 
         let config = FmdsConfig {
-            address: update.address,
+            public_ipv4,
+            public_ipv6: configured_ipv6.or(legacy_ipv6),
             hostname: update.hostname,
             instance_name: update.instance_name.filter(|name| !name.is_empty()),
             sitename: update.sitename,
@@ -161,7 +186,8 @@ impl FmdsGrpcServer {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
-    use carbide_test_support::{Check, check_values};
+    use carbide_test_support::Outcome::{Fails, Yields};
+    use carbide_test_support::{Check, check_values, scenarios};
     use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
     use rpc::fmds::{FmdsConfigUpdate, FmdsMachineIdentityConfig, IbDevice, IbInstance};
 
@@ -174,6 +200,7 @@ mod tests {
     fn make_test_update() -> FmdsConfigUpdate {
         FmdsConfigUpdate {
             address: "10.0.0.1".to_string(),
+            address_ipv6: "2001:db8::1".to_string(),
             hostname: "test-host".to_string(),
             instance_name: Some("test-instance".to_string()),
             sitename: Some("test-site".to_string()),
@@ -229,7 +256,7 @@ mod tests {
         );
 
         let config = state.config.load_full().unwrap();
-        assert_eq!(config.address, "10.0.0.2");
+        assert_eq!(config.public_ipv4, Some("10.0.0.2".parse().unwrap()));
     }
 
     #[test]
@@ -245,7 +272,8 @@ mod tests {
         assert!(response.is_ok());
 
         let config = state.config.load_full().unwrap();
-        assert_eq!(config.address, "10.0.0.1");
+        assert_eq!(config.public_ipv4, Some("10.0.0.1".parse().unwrap()));
+        assert_eq!(config.public_ipv6, Some("2001:db8::1".parse().unwrap()));
         assert_eq!(config.hostname, "test-host");
         assert_eq!(config.instance_name.as_deref(), Some("test-instance"));
         assert_eq!(config.sitename.as_deref(), Some("test-site"));
@@ -261,6 +289,62 @@ mod tests {
 
         let config = state.config.load_full().unwrap();
         assert!(config.instance_name.is_none());
+    }
+
+    #[test]
+    fn test_update_config_classifies_legacy_and_dual_stack_addresses() {
+        struct AddressFields {
+            address: &'static str,
+            address_ipv6: &'static str,
+        }
+
+        scenarios!(
+            run = |fields: AddressFields| {
+                let state = make_test_state();
+                let server = FmdsGrpcServer::new(state.clone());
+                let mut update = make_test_update();
+                update.address = fields.address.to_string();
+                update.address_ipv6 = fields.address_ipv6.to_string();
+                server
+                    .apply_config_update(Request::new(UpdateConfigRequest {
+                        config_update: Some(update),
+                    }))
+                    .map_err(drop)?;
+                let config = state.config.load_full().unwrap();
+                Ok::<_, ()>((config.public_ipv4, config.public_ipv6))
+            };
+            "current dual-stack agent" {
+                AddressFields {
+                    address: "192.0.2.10",
+                    address_ipv6: "2001:db8::10",
+                } => Yields((
+                    Some("192.0.2.10".parse().unwrap()),
+                    Some("2001:db8::10".parse().unwrap()),
+                )),
+            }
+
+            "legacy agent" {
+                AddressFields {
+                    address: "192.0.2.10",
+                    address_ipv6: "",
+                } => Yields((Some("192.0.2.10".parse().unwrap()), None)),
+                AddressFields {
+                    address: "2001:db8::10",
+                    address_ipv6: "",
+                } => Yields((None, Some("2001:db8::10".parse().unwrap()))),
+            }
+
+            "invalid address" {
+                AddressFields {
+                    address: "not-an-address",
+                    address_ipv6: "",
+                } => Fails,
+                AddressFields {
+                    address: "192.0.2.10",
+                    address_ipv6: "not-an-address",
+                } => Fails,
+            }
+        );
     }
 
     #[test]

--- a/crates/fmds/src/rest_server.rs
+++ b/crates/fmds/src/rest_server.rs
@@ -28,6 +28,7 @@ use forge_dpu_fmds_shared::machine_identity;
 use crate::state::FmdsState;
 
 const PUBLIC_IPV4_CATEGORY: &str = "public-ipv4";
+const PUBLIC_IPV6_CATEGORY: &str = "public-ipv6";
 const HOSTNAME_CATEGORY: &str = "hostname";
 const INSTANCE_NAME_CATEGORY: &str = "instance-name";
 const SITENAME_CATEGORY: &str = "sitename";
@@ -112,7 +113,20 @@ fn extract_metadata(category: String, state: &FmdsState) -> (StatusCode, String)
     };
 
     match category.as_str() {
-        PUBLIC_IPV4_CATEGORY => (StatusCode::OK, config.address.clone()),
+        PUBLIC_IPV4_CATEGORY => (
+            StatusCode::OK,
+            config
+                .public_ipv4
+                .map(|address| address.to_string())
+                .unwrap_or_default(),
+        ),
+        PUBLIC_IPV6_CATEGORY => (
+            StatusCode::OK,
+            config
+                .public_ipv6
+                .map(|address| address.to_string())
+                .unwrap_or_default(),
+        ),
         HOSTNAME_CATEGORY => (StatusCode::OK, config.hostname.clone()),
         INSTANCE_NAME_CATEGORY => match &config.instance_name {
             Some(instance_name) if !instance_name.is_empty() => {
@@ -196,6 +210,8 @@ async fn get_metadata_params(State(_state): State<Arc<FmdsState>>) -> (StatusCod
             MACHINE_ID_CATEGORY,
             INSTANCE_ID_CATEGORY,
             ASN_CATEGORY,
+            PUBLIC_IPV4_CATEGORY,
+            PUBLIC_IPV6_CATEGORY,
         ]
         .join("\n"),
     )
@@ -367,7 +383,7 @@ async fn post_phone_home(State(state): State<Arc<FmdsState>>) -> (StatusCode, St
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use axum::http;
     use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
@@ -384,7 +400,8 @@ mod tests {
 
     fn make_test_config() -> FmdsConfig {
         FmdsConfig {
-            address: "10.0.0.1".to_string(),
+            public_ipv4: Some("10.0.0.1".parse().unwrap()),
+            public_ipv6: Some("2001:db8::1".parse().unwrap()),
             hostname: "test-host".to_string(),
             instance_name: Some("test-instance".to_string()),
             sitename: Some("test-site".to_string()),
@@ -481,14 +498,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_public_ipv4() {
+    async fn test_get_public_ip_addresses() {
+        struct PublicAddressCase {
+            public_ipv4: Option<Ipv4Addr>,
+            public_ipv6: Option<Ipv6Addr>,
+            expected_ipv4: &'static str,
+            expected_ipv6: &'static str,
+        }
+
         let state = make_test_state();
         state.update_config(make_test_config());
-        let (server, port) = setup_server(state).await;
+        let (server, port) = setup_server(state.clone()).await;
 
         let (status, body) = get_request(port, "meta-data/public-ipv4").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, "10.0.0.1");
+
+        let (status, body) = get_request(port, "meta-data/public-ipv6").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "2001:db8::1");
+
+        for case in [
+            PublicAddressCase {
+                public_ipv4: None,
+                public_ipv6: Some("2001:db8::1".parse().unwrap()),
+                expected_ipv4: "",
+                expected_ipv6: "2001:db8::1",
+            },
+            PublicAddressCase {
+                public_ipv4: Some("10.0.0.1".parse().unwrap()),
+                public_ipv6: None,
+                expected_ipv4: "10.0.0.1",
+                expected_ipv6: "",
+            },
+            PublicAddressCase {
+                public_ipv4: None,
+                public_ipv6: None,
+                expected_ipv4: "",
+                expected_ipv6: "",
+            },
+        ] {
+            state.update_config(FmdsConfig {
+                public_ipv4: case.public_ipv4,
+                public_ipv6: case.public_ipv6,
+                ..make_test_config()
+            });
+
+            let (status, body) = get_request(port, "meta-data/public-ipv4").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, case.expected_ipv4);
+
+            let (status, body) = get_request(port, "meta-data/public-ipv6").await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(body, case.expected_ipv6);
+        }
 
         server.abort();
     }
@@ -580,6 +643,8 @@ mod tests {
             "machine-id",
             "instance-id",
             "asn",
+            "public-ipv4",
+            "public-ipv6",
         ]
         .join("\n");
 
@@ -755,6 +820,7 @@ mod tests {
         let grpc_server = FmdsGrpcServer::new(state.clone());
         let update = FmdsConfigUpdate {
             address: "192.168.1.1".to_string(),
+            address_ipv6: "2001:db8::1".to_string(),
             hostname: "grpc-pushed-host".to_string(),
             instance_name: Some("grpc-pushed-instance".to_string()),
             sitename: Some("grpc-site".to_string()),
@@ -786,6 +852,10 @@ mod tests {
         let (status, body) = get_request(port, "meta-data/public-ipv4").await;
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, "192.168.1.1");
+
+        let (status, body) = get_request(port, "meta-data/public-ipv6").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, "2001:db8::1");
 
         let (status, body) = get_request(port, "meta-data/asn").await;
         assert_eq!(status, StatusCode::OK);

--- a/crates/fmds/src/state.rs
+++ b/crates/fmds/src/state.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;
 
 use arc_swap::{ArcSwap, ArcSwapOption};
@@ -88,7 +89,8 @@ impl FmdsState {
 /// Populated from FmdsConfigUpdate proto.
 #[derive(Clone, Debug)]
 pub struct FmdsConfig {
-    pub address: String,
+    pub public_ipv4: Option<Ipv4Addr>,
+    pub public_ipv6: Option<Ipv6Addr>,
     pub hostname: String,
     pub instance_name: Option<String>,
     pub sitename: Option<String>,
@@ -120,7 +122,8 @@ mod tests {
 
     fn make_test_config() -> FmdsConfig {
         FmdsConfig {
-            address: "10.0.0.1".to_string(),
+            public_ipv4: Some("10.0.0.1".parse().unwrap()),
+            public_ipv6: Some("2001:db8::1".parse().unwrap()),
             hostname: "test-host".to_string(),
             instance_name: Some("test-instance".to_string()),
             sitename: Some("test-site".to_string()),
@@ -195,7 +198,8 @@ mod tests {
         state.update_config(config);
 
         let loaded = state.config.load_full().unwrap();
-        assert_eq!(loaded.address, "10.0.0.1");
+        assert_eq!(loaded.public_ipv4, Some("10.0.0.1".parse().unwrap()));
+        assert_eq!(loaded.public_ipv6, Some("2001:db8::1".parse().unwrap()));
         assert_eq!(loaded.hostname, "test-host");
         assert_eq!(loaded.instance_name.as_deref(), Some("test-instance"));
         assert_eq!(loaded.sitename.as_deref(), Some("test-site"));

--- a/crates/rpc/proto/fmds.proto
+++ b/crates/rpc/proto/fmds.proto
@@ -40,6 +40,8 @@ message UpdateConfigResponse {
 // tenants via its REST API, ensuring the data stored
 // within FMDS is targeted specifically for FMDS use.
 message FmdsConfigUpdate {
+  // Current agents send the IPv4 value served by `GET …/meta-data/public-ipv4`.
+  // Older agents may send either address family here, so the field name stays `address` for wire compatibility.
   string address = 1;
   string hostname = 2;
   optional string sitename = 3;
@@ -56,6 +58,11 @@ message FmdsConfigUpdate {
 
   // Human-readable instance name from forge.Instance.metadata.name.
   optional string instance_name = 10;
+
+  // IPv6 value served by `GET …/meta-data/public-ipv6`.
+  // On each config update, an empty or omitted value falls back to an IPv6 value in the legacy
+  // `address` field; a non-empty value takes precedence.
+  string address_ipv6 = 11;
 }
 
 // Mirrors carbide-dpu-agent `[machine-identity]` for standalone FMDS.

--- a/rest-api/proto/core/gen/v1/fmds_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/fmds_nico.pb.go
@@ -110,21 +110,27 @@ func (*UpdateConfigResponse) Descriptor() ([]byte, []int) {
 // tenants via its REST API, ensuring the data stored
 // within FMDS is targeted specifically for FMDS use.
 type FmdsConfigUpdate struct {
-	state      protoimpl.MessageState `protogen:"open.v1"`
-	Address    string                 `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
-	Hostname   string                 `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Sitename   *string                `protobuf:"bytes,3,opt,name=sitename,proto3,oneof" json:"sitename,omitempty"`
-	InstanceId *InstanceId            `protobuf:"bytes,4,opt,name=instance_id,json=instanceId,proto3,oneof" json:"instance_id,omitempty"`
-	MachineId  *MachineId             `protobuf:"bytes,5,opt,name=machine_id,json=machineId,proto3,oneof" json:"machine_id,omitempty"`
-	UserData   string                 `protobuf:"bytes,6,opt,name=user_data,json=userData,proto3" json:"user_data,omitempty"`
-	IbDevices  []*IBDevice            `protobuf:"bytes,7,rep,name=ib_devices,json=ibDevices,proto3" json:"ib_devices,omitempty"`
-	Asn        uint32                 `protobuf:"varint,8,opt,name=asn,proto3" json:"asn,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Current agents send the IPv4 value served by `GET …/meta-data/public-ipv4`.
+	// Older agents may send either address family here, so the field name stays `address` for wire compatibility.
+	Address    string      `protobuf:"bytes,1,opt,name=address,proto3" json:"address,omitempty"`
+	Hostname   string      `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`
+	Sitename   *string     `protobuf:"bytes,3,opt,name=sitename,proto3,oneof" json:"sitename,omitempty"`
+	InstanceId *InstanceId `protobuf:"bytes,4,opt,name=instance_id,json=instanceId,proto3,oneof" json:"instance_id,omitempty"`
+	MachineId  *MachineId  `protobuf:"bytes,5,opt,name=machine_id,json=machineId,proto3,oneof" json:"machine_id,omitempty"`
+	UserData   string      `protobuf:"bytes,6,opt,name=user_data,json=userData,proto3" json:"user_data,omitempty"`
+	IbDevices  []*IBDevice `protobuf:"bytes,7,rep,name=ib_devices,json=ibDevices,proto3" json:"ib_devices,omitempty"`
+	Asn        uint32      `protobuf:"varint,8,opt,name=asn,proto3" json:"asn,omitempty"`
 	// Machine-identity (`GET …/meta-data/identity`) rate limits, timeouts, and optional HTTP sign proxy.
 	// When omitted, FMDS leaves machine-identity serving unchanged (startup defaults from `FmdsState::try_new`
 	// until the first update that includes this field).
 	MachineIdentity *FmdsMachineIdentityConfig `protobuf:"bytes,9,opt,name=machine_identity,json=machineIdentity,proto3,oneof" json:"machine_identity,omitempty"`
 	// Human-readable instance name from nico.Instance.metadata.name.
-	InstanceName  *string `protobuf:"bytes,10,opt,name=instance_name,json=instanceName,proto3,oneof" json:"instance_name,omitempty"`
+	InstanceName *string `protobuf:"bytes,10,opt,name=instance_name,json=instanceName,proto3,oneof" json:"instance_name,omitempty"`
+	// IPv6 value served by `GET …/meta-data/public-ipv6`.
+	// On each config update, an empty or omitted value falls back to an IPv6 value in the legacy
+	// `address` field; a non-empty value takes precedence.
+	AddressIpv6   string `protobuf:"bytes,11,opt,name=address_ipv6,json=addressIpv6,proto3" json:"address_ipv6,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -225,6 +231,13 @@ func (x *FmdsConfigUpdate) GetMachineIdentity() *FmdsMachineIdentityConfig {
 func (x *FmdsConfigUpdate) GetInstanceName() string {
 	if x != nil && x.InstanceName != nil {
 		return *x.InstanceName
+	}
+	return ""
+}
+
+func (x *FmdsConfigUpdate) GetAddressIpv6() string {
+	if x != nil {
+		return x.AddressIpv6
 	}
 	return ""
 }
@@ -433,7 +446,7 @@ const file_fmds_nico_proto_rawDesc = "" +
 	"\x0ffmds_nico.proto\x12\x04fmds\x1a\x11common_nico.proto\"R\n" +
 	"\x13UpdateConfigRequest\x12;\n" +
 	"\rconfig_update\x18\x01 \x01(\v2\x16.fmds.FmdsConfigUpdateR\fconfigUpdate\"\x16\n" +
-	"\x14UpdateConfigResponse\"\x86\x04\n" +
+	"\x14UpdateConfigResponse\"\xa9\x04\n" +
 	"\x10FmdsConfigUpdate\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12\x1f\n" +
@@ -448,7 +461,8 @@ const file_fmds_nico_proto_rawDesc = "" +
 	"\x03asn\x18\b \x01(\rR\x03asn\x12O\n" +
 	"\x10machine_identity\x18\t \x01(\v2\x1f.fmds.FmdsMachineIdentityConfigH\x03R\x0fmachineIdentity\x88\x01\x01\x12(\n" +
 	"\rinstance_name\x18\n" +
-	" \x01(\tH\x04R\finstanceName\x88\x01\x01B\v\n" +
+	" \x01(\tH\x04R\finstanceName\x88\x01\x01\x12!\n" +
+	"\faddress_ipv6\x18\v \x01(\tR\vaddressIpv6B\v\n" +
 	"\t_sitenameB\x0e\n" +
 	"\f_instance_idB\r\n" +
 	"\v_machine_idB\x13\n" +

--- a/rest-api/proto/core/src/v1/fmds_nico.proto
+++ b/rest-api/proto/core/src/v1/fmds_nico.proto
@@ -28,6 +28,8 @@ message UpdateConfigResponse {
 // tenants via its REST API, ensuring the data stored
 // within FMDS is targeted specifically for FMDS use.
 message FmdsConfigUpdate {
+  // Current agents send the IPv4 value served by `GET …/meta-data/public-ipv4`.
+  // Older agents may send either address family here, so the field name stays `address` for wire compatibility.
   string address = 1;
   string hostname = 2;
   optional string sitename = 3;
@@ -44,6 +46,11 @@ message FmdsConfigUpdate {
 
   // Human-readable instance name from nico.Instance.metadata.name.
   optional string instance_name = 10;
+
+  // IPv6 value served by `GET …/meta-data/public-ipv6`.
+  // On each config update, an empty or omitted value falls back to an IPv6 value in the legacy
+  // `address` field; a non-empty value takes precedence.
+  string address_ipv6 = 11;
 }
 
 // Mirrors nico-dpu-agent `[machine-identity]` for standalone FMDS.


### PR DESCRIPTION
FMDS was taking the first address from a physical interface and serving it as `public-ipv4`. Once an interface had both families, address order decided what tenants saw -- including the possibility of an IPv6 address showing up under the IPv4 name.

This keeps the lowest address from each family across every physical interface in `InstanceMetadata`, plumbs both through `FmdsConfigUpdate`, and serves `public-ipv4` + `public-ipv6` from typed values in both embedded and standalone FMDS. The old `address` field stays on the wire for IPv4 compatibility, and new FMDS still recognizes the IPv6 value an older agent may have put there.

Both fields are now listed under `/meta-data/`, while an unassigned family keeps the existing `200` + empty-body behavior. An older FMDS ignores `address_ipv6` until it is upgraded; for an IPv6-only instance, that replaces the old wrong-family value with an empty `public-ipv4` response.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2401.

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Closes #2401
