### PR TITLE
ci: Split aarch64 build chain, fix sccache hash poisoning

### DIFF
--- a/.github/ci/test_validate_boot_outputs.py
+++ b/.github/ci/test_validate_boot_outputs.py
@@ -46,6 +46,11 @@ EXPECTED_BUILD_IDENTITIES = {
         build_type="ephemeral",
         arch="aarch64",
     ),
+    ("package", "aarch64"): BuildIdentity(
+        cargo_make_task="package-scout-aarch64-ci",
+        build_type="package",
+        arch="aarch64",
+    ),
 }
 
 
@@ -176,7 +181,9 @@ class ValidateBootOutputsTests(unittest.TestCase):
 
     def test_ephemeral_contracts_keep_downloaded_boot_inputs(self) -> None:
         # Keep this inventory independent from the production constants. A
-        # boot-input change must update this reviewable handoff contract too.
+        # handoff change must update this reviewable contract too. The x86_64
+        # job downloads the full boot bundle and re-uploads it; the aarch64
+        # job downloads only the forge-scout deb from the package-scout job.
         expected_boot_inputs = {
             "x86_64": {
                 "pxe/static/blobs/internal/x86_64/ipxe.efi",
@@ -188,19 +195,6 @@ class ValidateBootOutputsTests(unittest.TestCase):
                 "target/debs/forge-scout_*_amd64.deb",
             },
             "aarch64": {
-                "pxe/static/blobs/internal/aarch64/secure-boot-pk.pem",
-                "pxe/static/blobs/internal/aarch64/ipxe.efi",
-                "pxe/static/blobs/internal/aarch64/carbide.efi",
-                "pxe/static/blobs/internal/aarch64/carbide.root",
-                "pxe/static/blobs/internal/aarch64/preingestion.bfb",
-                "pxe/static/blobs/internal/aarch64/forge.bfb",
-                "pxe/static/blobs/internal/apt/dists/focal/Release",
-                "pxe/static/blobs/internal/apt/dists/focal/main/binary-arm64/Packages",
-                "pxe/static/blobs/internal/apt/dists/focal/main/binary-arm64/Release",
-                "pxe/static/blobs/internal/apt/pool/base/f/forge-dpu/forge-dpu_*_arm64.deb",
-                "pxe/static/blobs/internal/apt/pool/base/f/forge-scout/forge-scout_*_arm64.deb",
-                "target/aarch64-unknown-linux-gnu/release/forge-scout",
-                "target/debs/forge-dpu_*_arm64.deb",
                 "target/debs/forge-scout_*_arm64.deb",
             },
         }
@@ -229,7 +223,7 @@ class ValidateBootOutputsTests(unittest.TestCase):
     def test_ephemeral_contracts_reject_missing_boot_inputs(self) -> None:
         boot_inputs = {
             "x86_64": "pxe/static/blobs/internal/x86_64/ipxe.efi",
-            "aarch64": "pxe/static/blobs/internal/aarch64/secure-boot-pk.pem",
+            "aarch64": "target/debs/forge-scout_*_arm64.deb",
         }
 
         for arch, boot_input in boot_inputs.items():

--- a/.github/ci/validate_boot_outputs.py
+++ b/.github/ci/validate_boot_outputs.py
@@ -105,9 +105,9 @@ EPHEMERAL_GENERATED_OUTPUTS: dict[str, tuple[str, ...]] = {
 }
 
 
-# These contracts describe the four tasks selected by Core CI:
+# These contracts describe the five tasks selected by Core CI:
 # `build-boot-artifacts-x86-host-ci`, `build-boot-artifacts-bfb-ci`,
-# `create-ephemeral-image-x86-host-ci`, and
+# `package-scout-aarch64-ci`, `create-ephemeral-image-x86-host-ci`, and
 # `create-ephemeral-image-arm-host-ci`. Each key also locks the task to its
 # expected build type and architecture. A new caller must use one complete
 # identity below or add a contract that describes its actual outputs.
@@ -147,11 +147,25 @@ CONTRACTS: dict[BuildIdentity, ArtifactContract] = {
         build_type="ephemeral",
         arch="aarch64",
     ): ArtifactContract(
+        # Unlike x86_64 above, this job does not carry the boot bundle: it
+        # downloads only the forge-scout deb from the package-scout job, and
+        # the release-artifacts carrier takes the boot blobs from the bfb
+        # job's own artifact.
         required=(
-            BOOT_REQUIRED_OUTPUTS["aarch64"]
+            ("target/debs/forge-scout_*_arm64.deb",)
             + EPHEMERAL_GENERATED_OUTPUTS["aarch64"]
         ),
         optional=("build.log",),
+        disabled=(UNBUILT_ADMIN_CLI,),
+    ),
+    BuildIdentity(
+        cargo_make_task="package-scout-aarch64-ci",
+        build_type="package",
+        arch="aarch64",
+    ): ArtifactContract(
+        # The deb is the whole deliverable; the symbolication copy of the
+        # unstripped binary ships in the bfb job's boot artifact.
+        required=("target/debs/forge-scout_*_arm64.deb",),
         disabled=(UNBUILT_ADMIN_CLI,),
     ),
 }

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -17,8 +17,13 @@ on:
         required: true
         type: string
       build_type:
-        description: 'Build type: boot or ephemeral'
+        description: 'Build type: boot, ephemeral, or package (compile-and-package only, uploads just target/debs)'
         required: true
+        type: string
+      prereq_artifact:
+        description: 'Artifact holding the prerequisite files for an ephemeral build. Defaults to the full boot-artifacts archive; point it at a package-artifacts archive to fetch only the forge-scout .deb the mkosi build actually consumes.'
+        required: false
+        default: ''
         type: string
       build_container:
         description: 'Build container image to use (for container mode only)'
@@ -51,7 +56,11 @@ on:
       extras_container:
         description: 'Location of additional artifacts to place into the built images'
         required: false
-        default: false
+        # An empty string, not boolean false: this is a string input, and the
+        # old boolean default reached callers as the literal text "false" --
+        # any job omitting the input would then try to docker-login to a
+        # registry named "false". Empty engages the nvcr.io fallback instead.
+        default: ''
         type: string
 
 jobs:
@@ -135,12 +144,12 @@ jobs:
           echo "✅ mkosi commit: $(cd pxe/mkosi && git rev-parse --short HEAD)"
           echo "✅ Submodules ready"
 
-      # For ephemeral builds, download boot artifacts first
+      # For ephemeral builds, download the prerequisite artifacts first
       - name: Download prerequisite boot artifacts
         if: inputs.build_type == 'ephemeral'
         uses: actions/download-artifact@v4
         with:
-          name: boot-artifacts-${{ inputs.arch }}-${{ github.run_id }}
+          name: ${{ inputs.prereq_artifact != '' && inputs.prereq_artifact || format('boot-artifacts-{0}-{1}', inputs.arch, github.run_id) }}
           path: .
         continue-on-error: false
 
@@ -513,9 +522,10 @@ jobs:
       # ephemeral failures also upload `build.log` through the separate
       # best-effort step below.
       #
-      # Upload the files used by later jobs. The package task writes
-      # forge-scout to `target/debs/`; the ephemeral job downloads that boot
-      # bundle, and `copy-forge-scout-*` in `pxe/Makefile.toml` copies the deb
+      # Upload the files used by later jobs. The package-scout task writes
+      # forge-scout to `target/debs/`; the ephemeral job downloads that deb
+      # (x86_64 still downloads the full boot bundle), and
+      # `copy-forge-scout-*` in `pxe/Makefile.toml` copies the deb
       # into mkosi staging. `Dockerfile.release-artifacts-*` consumes
       # `pxe/static/blobs/internal/`. Excluding the rest of the cargo target tree
       # and `mkosi.profiles` staging inputs removes ~14 GB of upload/download
@@ -526,7 +536,7 @@ jobs:
       # that are already compressed. `if-no-files-found` checks the path list as
       # a whole; the validator above is what requires each contract entry.
       - name: Upload artifacts
-        if: ${{ success() }}
+        if: ${{ success() && inputs.build_type != 'package' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.build_type }}-artifacts-${{ inputs.arch }}-${{ github.run_id }}
@@ -534,6 +544,32 @@ jobs:
             pxe/static/blobs/
             target/debs/
             target/aarch64-unknown-linux-gnu/release/forge-scout
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 1
+
+      # The package build's deliverable is the .deb set alone -- not the
+      # unstripped binary, whose copy for symbolication ships in the boot
+      # artifact. Staged under a directory that reproduces the repo-relative
+      # layout (same pattern as the bluefield binaries in ci.yaml) because
+      # upload-artifact roots the archive at the least common ancestor of what
+      # it matched: uploading target/debs/ directly would drop the target/
+      # prefix that the pxe copy-forge-scout tasks expect after download.
+      - name: Stage package artifacts for upload
+        if: ${{ success() && inputs.build_type == 'package' }}
+        run: |
+          mkdir -p package-artifacts-dir/target
+          cp -r target/debs package-artifacts-dir/target/debs
+
+      # .deb payloads are already compressed, hence compression-level 0. The
+      # name matches the release-artifacts download pattern (*-<arch>-<run_id>),
+      # which is harmless: the carrier images COPY only pxe/static/blobs/.
+      - name: Upload package artifacts
+        if: ${{ success() && inputs.build_type == 'package' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.build_type }}-artifacts-${{ inputs.arch }}-${{ github.run_id }}
+          path: package-artifacts-dir/
           if-no-files-found: error
           compression-level: 0
           retention-days: 1

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -56,10 +56,11 @@ on:
       extras_container:
         description: 'Location of additional artifacts to place into the built images'
         required: false
-        # An empty string, not boolean false: this is a string input, and the
-        # old boolean default reached callers as the literal text "false" --
-        # any job omitting the input would then try to docker-login to a
-        # registry named "false". Empty engages the nvcr.io fallback instead.
+        # An empty string, not boolean false: this is a string input, so a
+        # boolean default reaches callers as the literal text "false" and any
+        # job omitting the input then tries to docker login to a registry
+        # named "false". An empty value engages the `nvcr.io` fallback
+        # instead.
         default: ''
         type: string
 
@@ -548,22 +549,23 @@ jobs:
           compression-level: 0
           retention-days: 1
 
-      # The package build's deliverable is the .deb set alone -- not the
-      # unstripped binary, whose copy for symbolication ships in the boot
-      # artifact. Staged under a directory that reproduces the repo-relative
-      # layout (same pattern as the bluefield binaries in ci.yaml) because
-      # upload-artifact roots the archive at the least common ancestor of what
-      # it matched: uploading target/debs/ directly would drop the target/
-      # prefix that the pxe copy-forge-scout tasks expect after download.
+      # The package build's deliverable is the `.deb` set alone, not the
+      # unstripped binary (its symbolication copy ships in the boot artifact).
+      # Staged under a directory that reproduces the repo-relative layout,
+      # same pattern as the bluefield binaries in ci.yaml: upload-artifact
+      # roots the archive at the least common ancestor of what it matched, so
+      # uploading `target/debs/` directly would drop the `target/` prefix the
+      # pxe copy-forge-scout tasks expect after download.
       - name: Stage package artifacts for upload
         if: ${{ success() && inputs.build_type == 'package' }}
         run: |
           mkdir -p package-artifacts-dir/target
           cp -r target/debs package-artifacts-dir/target/debs
 
-      # .deb payloads are already compressed, hence compression-level 0. The
-      # name matches the release-artifacts download pattern (*-<arch>-<run_id>),
-      # which is harmless: the carrier images COPY only pxe/static/blobs/.
+      # `.deb` payloads are already compressed, so `compression-level: 0`.
+      # The name matches the release-artifacts download pattern
+      # (`*-<arch>-<run_id>`), which is harmless: the carrier images COPY only
+      # `pxe/static/blobs/`.
       - name: Upload package artifacts
         if: ${{ success() && inputs.build_type == 'package' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -705,12 +705,13 @@ jobs:
   # ============================================================================
   # BUILD STAGE - Release Container
   # ============================================================================
-  # Deliberately does NOT depend on lint-police or check-rest-core-proto-sync.
-  # The container build consumes nothing either job produces, and gating on
-  # them serialized ~11m of linting (and, on proto-touching changes, ~5m of
-  # proto-sync checking plus queueing) in front of a ~29m build. Their failures
-  # still block the merge independently via core-ci-pass, so the gates are
-  # preserved while the jobs now run in parallel.
+  # Deliberately does NOT depend on `lint-police` or
+  # `check-rest-core-proto-sync`. The container build does not consume
+  # anything either job produces, and gating on them serialized `~11m` of
+  # linting (on proto-touching changes, `~5m` of proto-sync checking plus
+  # queueing) in front of a `~29m` build. Their failures still block the
+  # merge independently via `core-ci-pass`, so the gate is preserved while
+  # the jobs run in parallel.
   build-release-container-x86_64:
     if: >-
       ${{
@@ -846,9 +847,9 @@ jobs:
       # No layer cache, same reasoning as the release containers above: the
       # Dockerfile does `COPY . .` before the cargo build, so any new commit
       # invalidates the builder layer and nothing expensive can ever be
-      # restored. mode=max still exported the whole builder stage on main --
-      # multi-hundred-MB blobs per commit into the 50 GB Actions cache pool
-      # that sccache depends on.
+      # restored. `mode=max` still exported the whole builder stage on every
+      # main commit, pushing `388 MB` blobs into the `50 GB` Actions cache
+      # pool that sccache depends on.
       cache: false
       build_args: >-
         ${{ format('{{"VERSION":"{0}","CI_COMMIT_SHORT_SHA":"{1}"}}',
@@ -893,8 +894,8 @@ jobs:
     secrets: inherit
 
   # Like the release-container builds above, deliberately not gated on
-  # check-rest-core-proto-sync: the tests read nothing it produces, and
-  # core-ci-pass still fails the merge when the protos are out of sync.
+  # `check-rest-core-proto-sync`: the tests do not read anything it produces,
+  # and `core-ci-pass` still fails the merge when the protos are out of sync.
   test-release-container-services:
     if: >-
       ${{
@@ -1139,13 +1140,14 @@ jobs:
     secrets: inherit
 
   # The aarch64 ephemeral (mkosi) build consumes exactly one file from the
-  # boot stage: the packaged forge-scout .deb (pxe copy-forge-scout-aarch64).
-  # Waiting on the full bfb job serialized ~18 min of BFB assembly in front of
-  # a ~14 min mkosi build for that one file -- the longest chain in the run.
-  # This job packages the deb on its own so the mkosi build starts as soon as
-  # it exists, while bfb keeps feeding the release-artifacts carrier in
-  # parallel. bfb still compiles scout itself: its apt repo ships the deb
-  # inside the boot image.
+  # boot stage: the packaged forge-scout `.deb` (pxe `copy-forge-scout-aarch64`).
+  # Waiting on the full bfb job serialized `~18m` of BFB assembly in front of
+  # a `~14m` mkosi build for that one file, which was the longest chain in
+  # the run. This job packages the deb on its own so the mkosi build starts
+  # as soon as it exists, while bfb keeps feeding the release-artifacts
+  # carrier in parallel.
+  # bfb still compiles scout itself: its apt repo ships the deb inside the
+  # boot image.
   build-package-scout-aarch64:
     needs:
       - prepare
@@ -1161,6 +1163,14 @@ jobs:
       runner: linux-arm64-cpu16
       version: ${{ needs.prepare.outputs.version }}
       use_container: true
+      # Not for injection (`inject_extras` stays false, so the extras are
+      # never pulled or extracted). The extras host is what the workflow logs
+      # into for read-only pulls, and prepare pins this ref to the source
+      # registry. On mirrors with a non-NVCR source registry, omitting it
+      # logs into the `nvcr.io` fallback while the build container lives on
+      # the source host, and non-publishing runs never do the target login
+      # that could paper over that.
+      extras_container: ${{ needs.prepare.outputs.extras_container_ref }}
     secrets: inherit
 
   # ============================================================================
@@ -1193,7 +1203,7 @@ jobs:
       - prepare
       - build-package-scout-aarch64
     # Depends on the scout package, not the full bfb build: the forge-scout
-    # .deb is the only boot-stage input the mkosi build reads. The
+    # `.deb` is the only boot-stage input the mkosi build reads. The
     # release-artifacts carrier downstream still requires bfb to have
     # succeeded, so a bfb failure fails the run exactly as before.
     if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-package-scout-aarch64.result == 'success' }}
@@ -1209,9 +1219,9 @@ jobs:
       sa_enablement: true
       inject_extras: true
       extras_container: ${{ needs.prepare.outputs.extras_container_ref }}
-      # Fetch just the ~tens-of-MB deb archive instead of the multi-GB boot
-      # artifact -- a measured 2m06s-2m36s download for one consumed file. The
-      # boot blobs the carrier image needs still travel in bfb's own artifact.
+      # Fetch just the deb archive instead of the `5.4 GB` boot artifact, a
+      # measured `2m06s`-`2m36s` download for one consumed file. The boot
+      # blobs the carrier image needs still travel in bfb's own artifact.
       prereq_artifact: package-artifacts-aarch64-${{ github.run_id }}
     secrets: inherit
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -705,10 +705,12 @@ jobs:
   # ============================================================================
   # BUILD STAGE - Release Container
   # ============================================================================
-  # Deliberately does NOT depend on lint-police. The container build consumes
-  # nothing lint-police produces, and gating on it serialized ~11m of linting in
-  # front of a ~29m build. Lint failures still block the merge independently via
-  # core-ci-pass, so the gate is preserved while the two now run in parallel.
+  # Deliberately does NOT depend on lint-police or check-rest-core-proto-sync.
+  # The container build consumes nothing either job produces, and gating on
+  # them serialized ~11m of linting (and, on proto-touching changes, ~5m of
+  # proto-sync checking plus queueing) in front of a ~29m build. Their failures
+  # still block the merge independently via core-ci-pass, so the gates are
+  # preserved while the jobs now run in parallel.
   build-release-container-x86_64:
     if: >-
       ${{
@@ -717,13 +719,11 @@ jobs:
         && needs.prepare.result == 'success'
         && contains('success,skipped', needs.build-container-x86_64.result)
         && contains('success,skipped', needs.build-runtime-container-x86_64.result)
-        && contains('success,skipped', needs.check-rest-core-proto-sync.result)
       }}
     needs:
       - prepare
       - build-container-x86_64
       - build-runtime-container-x86_64
-      - check-rest-core-proto-sync
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
@@ -758,13 +758,11 @@ jobs:
         && needs.prepare.result == 'success'
         && contains('success,skipped', needs.build-container-aarch64.result)
         && contains('success,skipped', needs.build-runtime-container-aarch64.result)
-        && contains('success,skipped', needs.check-rest-core-proto-sync.result)
       }}
     needs:
       - prepare
       - build-container-aarch64
       - build-runtime-container-aarch64
-      - check-rest-core-proto-sync
     uses: ./.github/workflows/docker-build.yml
     with:
       source_registry_host: ${{ needs.prepare.outputs.source_registry_host }}
@@ -845,6 +843,13 @@ jobs:
     with:
       dockerfile_path: crates/machine-a-tron/Dockerfile
       context_path: .
+      # No layer cache, same reasoning as the release containers above: the
+      # Dockerfile does `COPY . .` before the cargo build, so any new commit
+      # invalidates the builder layer and nothing expensive can ever be
+      # restored. mode=max still exported the whole builder stage on main --
+      # multi-hundred-MB blobs per commit into the 50 GB Actions cache pool
+      # that sccache depends on.
+      cache: false
       build_args: >-
         ${{ format('{{"VERSION":"{0}","CI_COMMIT_SHORT_SHA":"{1}"}}',
           needs.prepare.outputs.version,
@@ -887,6 +892,9 @@ jobs:
       timeout_minutes: 30
     secrets: inherit
 
+  # Like the release-container builds above, deliberately not gated on
+  # check-rest-core-proto-sync: the tests read nothing it produces, and
+  # core-ci-pass still fails the merge when the protos are out of sync.
   test-release-container-services:
     if: >-
       ${{
@@ -895,13 +903,11 @@ jobs:
         && needs.prepare.result == 'success'
         && contains('success,skipped', needs.build-container-x86_64.result)
         && contains('success,skipped', needs.build-runtime-container-x86_64.result)
-        && contains('success,skipped', needs.check-rest-core-proto-sync.result)
       }}
     needs:
       - prepare
       - build-container-x86_64
       - build-runtime-container-x86_64
-      - check-rest-core-proto-sync
     runs-on: linux-amd64-cpu16
     steps:
       - name: Checkout code
@@ -1132,6 +1138,31 @@ jobs:
       extras_container: ${{ needs.prepare.outputs.extras_container_ref }}
     secrets: inherit
 
+  # The aarch64 ephemeral (mkosi) build consumes exactly one file from the
+  # boot stage: the packaged forge-scout .deb (pxe copy-forge-scout-aarch64).
+  # Waiting on the full bfb job serialized ~18 min of BFB assembly in front of
+  # a ~14 min mkosi build for that one file -- the longest chain in the run.
+  # This job packages the deb on its own so the mkosi build starts as soon as
+  # it exists, while bfb keeps feeding the release-artifacts carrier in
+  # parallel. bfb still compiles scout itself: its apt repo ships the deb
+  # inside the boot image.
+  build-package-scout-aarch64:
+    needs:
+      - prepare
+      - build-artifacts-container-aarch64
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && contains('success,skipped', needs.build-artifacts-container-aarch64.result) }}
+    uses: ./.github/workflows/build-boot-artifacts.yml
+    with:
+      target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
+      arch: aarch64
+      build_type: package
+      cargo_make_task: package-scout-aarch64-ci
+      build_container: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_ref }}
+      runner: linux-arm64-cpu16
+      version: ${{ needs.prepare.outputs.version }}
+      use_container: true
+    secrets: inherit
+
   # ============================================================================
   # BUILD STAGE - Ephemeral Images
   # ============================================================================
@@ -1160,9 +1191,12 @@ jobs:
   build-boot-artifacts-ephemeral-image-arm-host:
     needs:
       - prepare
-      - build-boot-artifacts-bfb
-    # Run only if boot artifacts succeeded (we need those artifacts); skip if cancelled
-    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-boot-artifacts-bfb.result == 'success' }}
+      - build-package-scout-aarch64
+    # Depends on the scout package, not the full bfb build: the forge-scout
+    # .deb is the only boot-stage input the mkosi build reads. The
+    # release-artifacts carrier downstream still requires bfb to have
+    # succeeded, so a bfb failure fails the run exactly as before.
+    if: ${{ !cancelled() && github.event_name != 'schedule' && needs.prepare.result == 'success' && needs.build-package-scout-aarch64.result == 'success' }}
     uses: ./.github/workflows/build-boot-artifacts.yml
     with:
       target_login: ${{ needs.prepare.outputs.publish_images == 'true' }}
@@ -1175,6 +1209,10 @@ jobs:
       sa_enablement: true
       inject_extras: true
       extras_container: ${{ needs.prepare.outputs.extras_container_ref }}
+      # Fetch just the ~tens-of-MB deb archive instead of the multi-GB boot
+      # artifact -- a measured 2m06s-2m36s download for one consumed file. The
+      # boot blobs the carrier image needs still travel in bfb's own artifact.
+      prereq_artifact: package-artifacts-aarch64-${{ github.run_id }}
     secrets: inherit
 
   # ============================================================================
@@ -2048,6 +2086,7 @@ jobs:
       - test-release-container-services
       - build-boot-artifacts-x86
       - build-boot-artifacts-bfb
+      - build-package-scout-aarch64
       - build-boot-artifacts-ephemeral-image-x86-host
       - build-boot-artifacts-ephemeral-image-arm-host
       - build-forge-cli-x86_64
@@ -2154,6 +2193,7 @@ jobs:
       - test-release-container-services
       - build-boot-artifacts-x86
       - build-boot-artifacts-bfb
+      - build-package-scout-aarch64
       - build-boot-artifacts-ephemeral-image-x86-host
       - build-boot-artifacts-ephemeral-image-arm-host
       - build-forge-cli-x86_64
@@ -2237,6 +2277,7 @@ jobs:
       # Boot and release artifacts
       - build-boot-artifacts-x86
       - build-boot-artifacts-bfb
+      - build-package-scout-aarch64
       - build-boot-artifacts-ephemeral-image-x86-host
       - build-boot-artifacts-ephemeral-image-arm-host
       - build-release-artifacts-x86-host

--- a/crates/version/src/lib.rs
+++ b/crates/version/src/lib.rs
@@ -21,14 +21,14 @@ use std::process::Command;
 /// Set build script environment variables. Call this from a build script.
 ///
 /// Everything here reads the environment with `std::env::var` at build-script
-/// *runtime*, never with `option_env!`. `option_env!` bakes the value into
-/// this crate's own compiled rlib, making machine- and commit-specific strings
-/// (USER, HOSTNAME, VERSION, CI_COMMIT_SHORT_SHA) part of carbide-version's
-/// compilation fingerprint: every build script that links this crate then
-/// recompiled whenever any of them differed -- in CI that is every runner and
-/// every commit -- and sccache could never reuse any of it. The same
+/// runtime, never with `option_env!`. `option_env!` bakes the value into this
+/// crate's own compiled rlib, so machine- and commit-specific strings
+/// (`USER`, `HOSTNAME`, `VERSION`, `CI_COMMIT_SHORT_SHA`) become part of
+/// carbide-version's compilation fingerprint: every build script that links
+/// this crate recompiles whenever one of them changes (in CI that is every
+/// runner and every commit), and sccache cannot reuse any of it. The same
 /// environment is present when the build script runs, so the values are
-/// identical; only the moment they are read changes.
+/// identical; the only difference is when they are read.
 pub fn build() {
     // In a git worktree in a container (local dev) none of the git commands will work because
     // the real git directory isn't mounted.
@@ -51,14 +51,14 @@ pub fn build() {
     println!("cargo:rustc-env=FORGE_BUILD_HOSTNAME={hostname}");
     println!("cargo:rustc-env=CARBIDE_BUILD_HOSTNAME={hostname}");
 
-    // The committer date of HEAD, not wall-clock `date`: a wall-clock stamp
-    // changes on every invocation, lands in the env-dep list of every crate
-    // that embeds v!(build_date), and guaranteed an sccache miss for those
-    // crates and all their dependents -- even for two jobs compiling the same
-    // commit in the same CI run. The committer date only moves when the commit
-    // does, which is the granularity of everything else stamped here. Without
-    // git (local containers) fall back to wall clock, where caching is not at
-    // stake.
+    // The committer date of HEAD, not wall-clock `date`. A wall-clock stamp
+    // changes on every invocation and lands in the env-dep list of every
+    // crate that embeds `v!(build_date)`, guaranteeing an sccache miss for
+    // those crates and all their dependents, even for two jobs compiling the
+    // same commit in the same CI run. The committer date only moves when the
+    // commit does, which is the granularity of everything else stamped here.
+    // Without git (local containers) fall back to wall clock, where caching
+    // is not at stake.
     let build_date = if can_git {
         run("git", &["log", "-1", "--format=%cI"])
     } else {
@@ -75,11 +75,24 @@ pub fn build() {
     println!("cargo:rustc-env=CARBIDE_BUILD_RUSTC_VERSION={rustc_version}");
 
     println!("cargo:rerun-if-env-changed=CARBIDE_BUILD_HELM_VERSION");
-    // Emitting any rerun-if directive replaces cargo's default rules, and the
-    // values below are now read at script runtime, so their env vars must be
-    // declared for a changed VERSION on an unchanged commit to still re-stamp.
-    println!("cargo:rerun-if-env-changed=VERSION");
-    println!("cargo:rerun-if-env-changed=CI_COMMIT_SHORT_SHA");
+    // Emitting any rerun-if directive replaces cargo's default rules, and
+    // every value stamped here is read at script runtime, so each env var
+    // must be declared here or a change on an unchanged commit does not
+    // re-stamp.
+    // `RUSTC` is deliberately absent: cargo sets it for build scripts itself,
+    // and `rerun-if-env-changed` cannot track cargo-provided variables.
+    for var in [
+        "VERSION",
+        "CI_COMMIT_SHORT_SHA",
+        "USER",
+        "HOSTNAME",
+        "REPO_ROOT",
+        "CONTAINER_REPO_ROOT",
+        "FORGE_VERSION_AVOID_REBUILD",
+        "CARBIDE_VERSION_AVOID_REBUILD",
+    ] {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
 
     if !can_git {
         println!("cargo:warning=No git, version will be blank");
@@ -198,9 +211,26 @@ fn git_allow() {
 }
 
 fn git_mark_safe_directory() {
+    // Only ever trust one concrete repository root. A wildcard
+    // (`safe.directory=*`) disables git's ownership check for every
+    // repository of this user, and outside CI that lands in a developer's
+    // real global config. With no root configured, leave git alone: the
+    // repo-dependent git calls fail softly through `run()`, and the affected
+    // version fields come out blank, the same as having no git at all.
     let repo_root = std::env::var("REPO_ROOT")
-        .or_else(|_| std::env::var("CONTAINER_REPO_ROOT"))
-        .unwrap_or_else(|_| "*".to_string());
+        .ok()
+        .filter(|v| !v.is_empty())
+        .or_else(|| {
+            std::env::var("CONTAINER_REPO_ROOT")
+                .ok()
+                .filter(|v| !v.is_empty())
+        });
+    let Some(repo_root) = repo_root else {
+        println!(
+            "cargo:warning=git reports dubious ownership and neither REPO_ROOT nor CONTAINER_REPO_ROOT is set; leaving safe.directory alone, version info may be blank"
+        );
+        return;
+    };
     run(
         "git",
         &["config", "--global", "--add", "safe.directory", &repo_root],

--- a/crates/version/src/lib.rs
+++ b/crates/version/src/lib.rs
@@ -19,46 +19,17 @@ use std::path::Path;
 use std::process::Command;
 
 /// Set build script environment variables. Call this from a build script.
+///
+/// Everything here reads the environment with `std::env::var` at build-script
+/// *runtime*, never with `option_env!`. `option_env!` bakes the value into
+/// this crate's own compiled rlib, making machine- and commit-specific strings
+/// (USER, HOSTNAME, VERSION, CI_COMMIT_SHORT_SHA) part of carbide-version's
+/// compilation fingerprint: every build script that links this crate then
+/// recompiled whenever any of them differed -- in CI that is every runner and
+/// every commit -- and sccache could never reuse any of it. The same
+/// environment is present when the build script runs, so the values are
+/// identical; only the moment they are read changes.
 pub fn build() {
-    // TODO: Remove after migration to new CARBIDE_ naming
-    println!(
-        "cargo:rustc-env=FORGE_BUILD_USER={}",
-        option_env!("USER").unwrap_or_default()
-    );
-    println!(
-        "cargo:rustc-env=CARBIDE_BUILD_USER={}",
-        option_env!("USER").unwrap_or_default()
-    );
-    // TODO: Remove after migration to new CARBIDE_ naming
-    println!(
-        "cargo:rustc-env=FORGE_BUILD_HOSTNAME={}",
-        option_env!("HOSTNAME").unwrap_or_default()
-    );
-    println!(
-        "cargo:rustc-env=CARBIDE_BUILD_HOSTNAME={}",
-        option_env!("HOSTNAME").unwrap_or_default()
-    );
-    // TODO: Remove after migration to new CARBIDE_ naming
-    println!(
-        "cargo:rustc-env=FORGE_BUILD_DATE={}",
-        run("date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"]) // like 'date --iso-8601=seconds --utc' but portable across GNU/BSD
-    );
-    println!(
-        "cargo:rustc-env=CARBIDE_BUILD_DATE={}",
-        run("date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"]) // like 'date --iso-8601=seconds --utc' but portable across GNU/BSD
-    );
-    // TODO: Remove after migration to new CARBIDE_ naming
-    println!(
-        "cargo:rustc-env=FORGE_BUILD_RUSTC_VERSION={}",
-        run(option_env!("RUSTC").unwrap_or("rustc"), &["--version"])
-    );
-    println!(
-        "cargo:rustc-env=CARBIDE_BUILD_RUSTC_VERSION={}",
-        run(option_env!("RUSTC").unwrap_or("rustc"), &["--version"])
-    );
-
-    println!("cargo:rerun-if-env-changed=CARBIDE_BUILD_HELM_VERSION");
-
     // In a git worktree in a container (local dev) none of the git commands will work because
     // the real git directory isn't mounted.
     let can_git = Command::new("git")
@@ -66,6 +37,50 @@ pub fn build() {
         .status()
         .map(|s| s.success())
         .unwrap_or(false);
+    if can_git {
+        git_allow();
+    }
+
+    let user = std::env::var("USER").unwrap_or_default();
+    // TODO: Remove after migration to new CARBIDE_ naming
+    println!("cargo:rustc-env=FORGE_BUILD_USER={user}");
+    println!("cargo:rustc-env=CARBIDE_BUILD_USER={user}");
+
+    let hostname = std::env::var("HOSTNAME").unwrap_or_default();
+    // TODO: Remove after migration to new CARBIDE_ naming
+    println!("cargo:rustc-env=FORGE_BUILD_HOSTNAME={hostname}");
+    println!("cargo:rustc-env=CARBIDE_BUILD_HOSTNAME={hostname}");
+
+    // The committer date of HEAD, not wall-clock `date`: a wall-clock stamp
+    // changes on every invocation, lands in the env-dep list of every crate
+    // that embeds v!(build_date), and guaranteed an sccache miss for those
+    // crates and all their dependents -- even for two jobs compiling the same
+    // commit in the same CI run. The committer date only moves when the commit
+    // does, which is the granularity of everything else stamped here. Without
+    // git (local containers) fall back to wall clock, where caching is not at
+    // stake.
+    let build_date = if can_git {
+        run("git", &["log", "-1", "--format=%cI"])
+    } else {
+        run("date", &["-u", "+%Y-%m-%dT%H:%M:%SZ"]) // like 'date --iso-8601=seconds --utc' but portable across GNU/BSD
+    };
+    // TODO: Remove after migration to new CARBIDE_ naming
+    println!("cargo:rustc-env=FORGE_BUILD_DATE={build_date}");
+    println!("cargo:rustc-env=CARBIDE_BUILD_DATE={build_date}");
+
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let rustc_version = run(&rustc, &["--version"]);
+    // TODO: Remove after migration to new CARBIDE_ naming
+    println!("cargo:rustc-env=FORGE_BUILD_RUSTC_VERSION={rustc_version}");
+    println!("cargo:rustc-env=CARBIDE_BUILD_RUSTC_VERSION={rustc_version}");
+
+    println!("cargo:rerun-if-env-changed=CARBIDE_BUILD_HELM_VERSION");
+    // Emitting any rerun-if directive replaces cargo's default rules, and the
+    // values below are now read at script runtime, so their env vars must be
+    // declared for a changed VERSION on an unchanged commit to still re-stamp.
+    println!("cargo:rerun-if-env-changed=VERSION");
+    println!("cargo:rerun-if-env-changed=CI_COMMIT_SHORT_SHA");
+
     if !can_git {
         println!("cargo:warning=No git, version will be blank");
         // still define it so that we can read it in a build time macro
@@ -80,18 +95,16 @@ pub fn build() {
         return;
     }
 
-    git_allow();
-
     // For these two in CI we use the env var, locally we query git
 
-    let sha = option_env!("CI_COMMIT_SHORT_SHA")
-        .map(String::from)
+    let sha = std::env::var("CI_COMMIT_SHORT_SHA")
+        .ok()
         .unwrap_or_else(|| run("git", &["rev-parse", "--short=8", "HEAD"]));
     // TODO: Remove after migration to new CARBIDE_ naming
     println!("cargo:rustc-env=FORGE_BUILD_GIT_HASH={sha}");
     println!("cargo:rustc-env=CARBIDE_BUILD_GIT_HASH={sha}");
 
-    let build_version = option_env!("VERSION").map(String::from).unwrap_or_else(|| {
+    let build_version = std::env::var("VERSION").ok().unwrap_or_else(|| {
         run(
             "git",
             &["describe", "--tags", "--first-parent", "--always", "--long"],
@@ -185,12 +198,12 @@ fn git_allow() {
 }
 
 fn git_mark_safe_directory() {
-    let repo_root = option_env!("REPO_ROOT")
-        .or(option_env!("CONTAINER_REPO_ROOT"))
-        .unwrap_or(r#"*"#);
+    let repo_root = std::env::var("REPO_ROOT")
+        .or_else(|_| std::env::var("CONTAINER_REPO_ROOT"))
+        .unwrap_or_else(|_| "*".to_string());
     run(
         "git",
-        &["config", "--global", "--add", "safe.directory", repo_root],
+        &["config", "--global", "--add", "safe.directory", &repo_root],
     );
 }
 

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -252,9 +252,9 @@ dependencies = [
   "add-secure-boot-pk-pem",
 ]
 
-# CI wrapper: build and package only the aarch64 forge-scout .deb. The
+# CI wrapper: build and package only the aarch64 forge-scout `.deb`. The
 # ephemeral-image build consumes exactly this one file from the boot stage
-# (see copy-forge-scout-aarch64), so CI runs this on its own to unblock the
+# (see `copy-forge-scout-aarch64`), so CI runs this on its own to unblock the
 # mkosi build instead of serializing it behind the full bfb assembly above.
 # The bfb task keeps its own package-scout dependency: its apt repo ships the
 # deb inside the boot image.

--- a/pxe/Makefile.toml
+++ b/pxe/Makefile.toml
@@ -252,6 +252,17 @@ dependencies = [
   "add-secure-boot-pk-pem",
 ]
 
+# CI wrapper: build and package only the aarch64 forge-scout .deb. The
+# ephemeral-image build consumes exactly this one file from the boot stage
+# (see copy-forge-scout-aarch64), so CI runs this on its own to unblock the
+# mkosi build instead of serializing it behind the full bfb assembly above.
+# The bfb task keeps its own package-scout dependency: its apt repo ships the
+# deb inside the boot image.
+[tasks.package-scout-aarch64-ci]
+dependencies = [
+  { name = "package-scout-aarch64-release-local", path = "${REPO_ROOT}" },
+]
+
 [tasks.create-ephemeral-image-x86-host-ci]
 category = "Ephemeral Image"
 dependencies = [


### PR DESCRIPTION
1. Proto-sync gate removed from the heavy jobs (`ci.yaml`): `build-release-container-x86_64`, `build-release-container-aarch64` & `test-release-container-services` no longer wait on `check-rest-core-proto-sync` (already required via core-ci-pass)
2. `cache: false` for machine-a-tron (`ci.yaml`) — `COPY . .` before compile always invalidates cache, so cache is disabled to reduce churn
3. aarch64 build chain is now split:
 - New `build-package-scout-aarch64` job compiles and packages just the forge-scout .deb (new wrapper task `package-scout-aarch64-ci`, new `build_type: package` in `build-boot-artifacts.yml` that uploads only target/debs/, staged so the repo-relative layout survives the artifact round-trip).
 - `ephemeral-image-arm-host` now depends on that job instead of the 18.5-min bfb job, and downloads the ~50 MB deb artifact instead of the 5.4 GB boot archive (was 2m+ of download for one file).
 - bfb runs in parallel and still feeds the carrier; the carrier's gate still requires bfb success, so failure semantics are unchanged. `core-ci-pass`, `build-summary`, and `notify-build-status` all track the new job. Side benefit: the ephemeral job's own artifact stops re-uploading the boot blobs it used to download, shrinking it ~8 GB → ~2.7 GB.
4. sccache hash poisoning fixed at the source (`crates/version/src/lib.rs`):
  - All option_env! reads became runtime std::env::var reads (identical values, but no longer baked into carbide-version's own rlib, so the lib and the ~600 build scripts linking it stop recompiling on every commit and every runner)
  - `BUILD_DATE` is now the commit's committer date instead of wall-clock (previously it changed every invocation, guaranteeing misses for the ~30 macro-using crates and their dependents even across jobs building the same commit). Added `rerun-if-env-changed` for VERSION/SHA to preserve re-stamp behavior in incremental builds. **"build date" now means commit date**, which is a reproducibility trade.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4574

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

This supports https://github.com/NVIDIA/infra-controller/issues/4781

Closes #4781