### PR TITLE
patch(v2.1): trufflehog scan base for PRs first commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1193,9 +1193,39 @@ jobs:
           persist-credentials: false
           fetch-depth: 0  # Full history for secret scanning
 
+      # On a PR's first push, github.event.before is all zeros because the branch
+      # is new. Without an explicit base, TruffleHog scans the entire repo history
+      # instead of just the commits on this PR. We look up the PR's actual target
+      # branch and compute the merge base so the scan is scoped to this PR only.
+      - name: Compute TruffleHog scan base
+        id: scan-base
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BEFORE="${{ github.event.before }}"
+          if [[ ("$BEFORE" == "0000000000000000000000000000000000000000" || -z "$BEFORE") && "$GITHUB_REF" == refs/heads/pull-request/* ]]; then
+            PR_NUM="${GITHUB_REF_NAME##pull-request/}"
+            BASE_BRANCH=$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}" \
+              | jq -r '.base.ref')
+            BEFORE=$(git merge-base "origin/${BASE_BRANCH}" HEAD)
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            # Tag pushes also have an all-zeros before. Scope the scan to commits
+            # since the previous tag so we don't re-scan the entire history on
+            # every release.
+            PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+            if [[ -n "$PREV_TAG" ]]; then
+              BEFORE=$(git merge-base "refs/tags/${PREV_TAG}" HEAD)
+            fi
+          fi
+          echo "base=$BEFORE" >> "$GITHUB_OUTPUT"
+
       - name: Run TruffleHog Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
+          base: ${{ steps.scan-base.outputs.base }}
           extra-args: '--results=verified,unknown --only-verified'
           post-pr-comment: 'false'
           fail-on-findings: 'true'


### PR DESCRIPTION
Backports #4715

This fixes the trufflehog scan job for PRs on their first CI push and for tag pushes.

On a PR's first push, GitHub sets github.event.before to the all-zeros SHA (`0000000000000000000000000000000000000000`) because the branch is new. The trufflehog action treats this as an absent base, causing TruffleHog to scan the entire repository history (~444 MB) instead of just the commits introduced by the PR. Scanning the full history triggers hundreds of false-positive "verified Lob" findings (TruffleHog #5184 (https://github.com/trufflesecurity/trufflehog/issues/5184)).

The fix detects the all-zeros case and looks up the PR's actual target branch via the GitHub API, then computes the real merge base:

```bash
# Before: base was empty, TruffleHog scanned all of history
base: ${{ github.event.before }}  # "0000000000000000000000000000000000000000"

# After: merge base is resolved explicitly
PR_NUM="${GITHUB_REF_NAME##pull-request/}"
BASE_BRANCH=$(curl ... /pulls/${PR_NUM} | jq -r '.base.ref')
BEFORE=$(git merge-base "origin/${BASE_BRANCH}" HEAD)

# After (tag): merge base resolved against previous tag
PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${GITHUB_REF_NAME}$" | head -1)
BEFORE=$(git merge-base "refs/tags/${PREV_TAG}" HEAD)
```

Tag pushes have the same all-zeros problem since the tag ref is also new, so the fix handles those too — finding the most recent previous tag and computing the merge base against it. On subsequent pushes to the same PR branch and on pushes to main, `github.event.before` is a real commit SHA so the logic is skipped and behavior is unchanged.

| Scenario | `github.event.before` | `GITHUB_REF` | Before fix | After fix |
|---|---|---|---|---|
| PR — first push | `000...000` | `refs/heads/pull-request/*` | TruffleHog scans full repo history, hundreds of false-positive Lob findings, exit 183 | Resolves merge base via API, scans only PR commits |
| PR — subsequent pushes | real SHA | `refs/heads/pull-request/*` | Scans commits since last push (correct) | Same — `if` block skipped, unchanged |
| Push to `main` | real SHA | `refs/heads/main` | Scans commits since last push (correct) | Same — `if` block skipped, unchanged | | Tag push | `000...000` | `refs/tags/*` | TruffleHog scans full repo history | scans commits since last tag |

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

