### PR TITLE
fix(health): collect periodic Redfish logs from switch BMCs

### DIFF
--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -31,7 +31,7 @@ use super::diagnostic::{
 };
 use crate::HealthError;
 use crate::collectors::{IterationResult, PeriodicCollector};
-use crate::endpoint::{BmcEndpoint, EndpointMetadata};
+use crate::endpoint::BmcEndpoint;
 use crate::sink::{CollectorEvent, DataSink, EventContext, LogRecord};
 
 /// Configuration for logs collector
@@ -266,10 +266,11 @@ impl<B: Bmc + 'static> LogsCollector<B> {
     }
 
     async fn collect_logs_from_services(&mut self) -> Result<(usize, usize), HealthError> {
-        let Some(EndpointMetadata::Machine(machine)) = &self.endpoint.metadata else {
+        if !self.endpoint.supports_periodic_logs() {
             return Ok((0, 0));
-        };
-        let machine_id = machine.machine_id.map(|id| id.to_string());
+        }
+
+        let machine_id = self.event_context.machine_id().map(|id| id.to_string());
 
         let Some(state) = self.state.as_mut() else {
             return Ok((0, 0));

--- a/crates/health/src/endpoint/model.rs
+++ b/crates/health/src/endpoint/model.rs
@@ -98,6 +98,23 @@ impl BmcEndpoint {
         }
     }
 
+    /// Returns whether this endpoint supports periodic Redfish log collection.
+    pub(crate) fn supports_periodic_logs(&self) -> bool {
+        match self.metadata.as_ref() {
+            Some(EndpointMetadata::Machine(_)) => true,
+            Some(EndpointMetadata::Switch(switch)) => {
+                switch.endpoint_role == SwitchEndpointRole::Bmc
+            }
+            Some(EndpointMetadata::PowerShelf(_)) => {
+                // Power shelves may expose compatible LogServices, but behavior depends on
+                // hardware and firmware. Keep collection disabled until future implementation
+                // and validation establish support.
+                false
+            }
+            None => false,
+        }
+    }
+
     pub fn bmc(&self) -> &Arc<BmcClient> {
         &self.bmc
     }
@@ -279,10 +296,14 @@ mod tests {
     use std::str::FromStr;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use carbide_test_support::{Check, check_values};
     use mac_address::MacAddress;
 
-    use super::{BmcAddr, BmcCredentials, SharedSystemUuid};
-    use crate::endpoint::test_support::endpoint_with_creds;
+    use super::{
+        BmcAddr, BmcCredentials, EndpointMetadata, MachineData, PowerShelfData, SharedSystemUuid,
+        SwitchData, SwitchEndpointRole,
+    };
+    use crate::endpoint::test_support::{endpoint_with_creds, mac, test_endpoint};
 
     fn addr(ip: &str, port: Option<u16>) -> BmcAddr {
         BmcAddr {
@@ -329,6 +350,73 @@ mod tests {
         );
 
         assert_eq!(endpoint.switch_connect_host_for_uri(), "[2001:db8::1]");
+    }
+
+    #[test]
+    fn periodic_log_collection_endpoint_eligibility() {
+        let switch_bmc = SwitchData {
+            id: None,
+            serial: "switch".to_string(),
+            slot_number: Some(1),
+            tray_index: Some(2),
+            nvlink_domain_uuid: None,
+            endpoint_role: SwitchEndpointRole::Bmc,
+            is_primary: true,
+            nmxc_enabled: false,
+            nmxt_enabled: false,
+        };
+
+        let switch_host = SwitchData {
+            endpoint_role: SwitchEndpointRole::Host,
+            ..switch_bmc.clone()
+        };
+
+        check_values(
+            [
+                Check {
+                    scenario: "machine BMC is eligible",
+                    input: Some(EndpointMetadata::Machine(MachineData {
+                        machine_id: None,
+                        machine_serial: None,
+                        system_uuid: SharedSystemUuid::default(),
+                        slot_number: None,
+                        tray_index: None,
+                        nvlink_domain_uuid: None,
+                        driver_version: None,
+                    })),
+                    expect: true,
+                },
+                Check {
+                    scenario: "switch BMC is eligible",
+                    input: Some(EndpointMetadata::Switch(switch_bmc)),
+                    expect: true,
+                },
+                Check {
+                    scenario: "switch host is not eligible",
+                    input: Some(EndpointMetadata::Switch(switch_host)),
+                    expect: false,
+                },
+                Check {
+                    scenario: "power shelf is not eligible",
+                    input: Some(EndpointMetadata::PowerShelf(PowerShelfData {
+                        id: None,
+                        serial: "power-shelf".to_string(),
+                    })),
+                    expect: false,
+                },
+                Check {
+                    scenario: "endpoint without metadata is not eligible",
+                    input: None,
+                    expect: false,
+                },
+            ],
+            |metadata| {
+                let mut endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+                endpoint.metadata = metadata;
+
+                endpoint.supports_periodic_logs()
+            },
+        );
     }
 
     #[tokio::test]

--- a/crates/health/src/otlp/convert.rs
+++ b/crates/health/src/otlp/convert.rs
@@ -673,9 +673,11 @@ mod tests {
     }
 
     #[test]
-    fn switch_bmc_resource_keeps_bmc_endpoint_identity_and_switch_metadata() {
+    fn switch_bmc_log_resource_keeps_endpoint_identity_and_switch_metadata() {
         let switch_id = test_switch_id("switch-bmc");
         let switch_id_attr = switch_id.to_string();
+        let nvlink_domain_uuid = NvLinkDomainId::new();
+        let nvlink_domain_uuid_attr = nvlink_domain_uuid.to_string();
         let context = EventContext {
             endpoint_key: "22:33:44:55:66:77".to_string(),
             addr: BmcAddr {
@@ -683,14 +685,14 @@ mod tests {
                 port: Some(443),
                 mac: MacAddress::from_str("22:33:44:55:66:77").expect("valid mac"),
             },
-            collector_type: "sensor_collector",
+            collector_type: "logs_collector",
             labels: Default::default(),
             metadata: Some(EndpointMetadata::Switch(SwitchData {
                 id: Some(switch_id),
                 serial: "SN-SWITCH-BMC-001".to_string(),
                 slot_number: Some(8),
                 tray_index: Some(4),
-                nvlink_domain_uuid: None,
+                nvlink_domain_uuid: Some(nvlink_domain_uuid),
                 endpoint_role: SwitchEndpointRole::Bmc,
                 is_primary: false,
                 nmxc_enabled: false,
@@ -698,28 +700,97 @@ mod tests {
             })),
             rack_id: Some(RackId::new("RACK_3")),
         };
+        let event = CollectorEvent::Log(Box::new(LogRecord {
+            body: "switch BMC event".to_string(),
+            severity: "INFO".to_string(),
+            attributes: Vec::new(),
+            diagnostic_record: None,
+        }));
 
-        let attrs = resource_attributes(&context);
+        let request = build_export_request(&[(context, event)], false);
+        let attrs = &request.resource_logs[0]
+            .resource
+            .as_ref()
+            .expect("log resource metadata")
+            .attributes;
 
+        assert_eq!(attr_value(attrs, "bmc.endpoint"), Some("22:33:44:55:66:77"));
+        assert_eq!(attr_value(attrs, "bmc.ip"), Some("10.0.2.1"));
+        assert_eq!(attr_value(attrs, "switch.endpoint"), None);
+        assert_eq!(attr_value(attrs, "switch.ip"), None);
         assert_eq!(
-            attr_value(&attrs, "bmc.endpoint"),
-            Some("22:33:44:55:66:77")
-        );
-        assert_eq!(attr_value(&attrs, "bmc.ip"), Some("10.0.2.1"));
-        assert_eq!(attr_value(&attrs, "switch.endpoint"), None);
-        assert_eq!(attr_value(&attrs, "switch.ip"), None);
-        assert_eq!(
-            attr_value(&attrs, "switch.id"),
+            attr_value(attrs, "switch.id"),
             Some(switch_id_attr.as_str())
         );
         assert_eq!(
-            attr_value(&attrs, "switch.serial_number"),
+            attr_value(attrs, "switch.serial_number"),
             Some("SN-SWITCH-BMC-001")
         );
-        assert_eq!(attr_value(&attrs, "switch.endpoint_role"), Some("bmc"));
-        assert_eq!(attr_bool_value(&attrs, "switch.is_primary"), Some(false));
-        assert_eq!(attr_value(&attrs, "nvlink.domain.uuid"), None);
-        assert_eq!(attr_value(&attrs, "component.type"), Some("nvlink_switch"));
+        assert_eq!(attr_value(attrs, "switch.endpoint_role"), Some("bmc"));
+        assert_eq!(attr_bool_value(attrs, "switch.is_primary"), Some(false));
+        assert_eq!(attr_int_value(attrs, "switch.slot_number"), Some(8));
+        assert_eq!(attr_int_value(attrs, "switch.tray_index"), Some(4));
+        assert_eq!(attr_value(attrs, "rack.id"), Some("RACK_3"));
+        assert_eq!(attr_value(attrs, "collector.type"), Some("logs_collector"));
+        assert_eq!(
+            attr_value(attrs, "nvlink.domain.uuid"),
+            Some(nvlink_domain_uuid_attr.as_str())
+        );
+        assert_eq!(attr_value(attrs, "component.type"), Some("nvlink_switch"));
+    }
+
+    #[test]
+    fn switch_bmc_log_resource_omits_unavailable_optional_metadata() {
+        let context = EventContext {
+            endpoint_key: "33:44:55:66:77:88".to_string(),
+            addr: BmcAddr {
+                ip: IpAddr::V4(Ipv4Addr::new(10, 0, 2, 2)),
+                port: Some(443),
+                mac: MacAddress::from_str("33:44:55:66:77:88").expect("valid mac"),
+            },
+            collector_type: "logs_collector",
+            labels: Default::default(),
+            metadata: Some(EndpointMetadata::Switch(SwitchData {
+                id: None,
+                serial: "SN-SWITCH-BMC-002".to_string(),
+                slot_number: None,
+                tray_index: None,
+                nvlink_domain_uuid: None,
+                endpoint_role: SwitchEndpointRole::Bmc,
+                is_primary: true,
+                nmxc_enabled: false,
+                nmxt_enabled: false,
+            })),
+            rack_id: None,
+        };
+        let event = CollectorEvent::Log(Box::new(LogRecord {
+            body: "switch BMC event".to_string(),
+            severity: "INFO".to_string(),
+            attributes: Vec::new(),
+            diagnostic_record: None,
+        }));
+
+        let request = build_export_request(&[(context, event)], false);
+        let attrs = &request.resource_logs[0]
+            .resource
+            .as_ref()
+            .expect("log resource metadata")
+            .attributes;
+
+        assert_eq!(attr_value(attrs, "bmc.endpoint"), Some("33:44:55:66:77:88"));
+        assert_eq!(attr_value(attrs, "bmc.ip"), Some("10.0.2.2"));
+        assert_eq!(
+            attr_value(attrs, "switch.serial_number"),
+            Some("SN-SWITCH-BMC-002")
+        );
+        assert_eq!(attr_value(attrs, "switch.endpoint_role"), Some("bmc"));
+        assert_eq!(attr_bool_value(attrs, "switch.is_primary"), Some(true));
+        assert_eq!(attr_value(attrs, "component.type"), Some("nvlink_switch"));
+        assert_eq!(attr_value(attrs, "switch.id"), None);
+        assert_eq!(attr_int_value(attrs, "switch.slot_number"), None);
+        assert_eq!(attr_int_value(attrs, "switch.tray_index"), None);
+        assert_eq!(attr_value(attrs, "nvlink.domain.uuid"), None);
+        assert_eq!(attr_value(attrs, "rack.id"), None);
     }
 
     #[test]


### PR DESCRIPTION
Enable periodic Redfish log collection for switch BMC endpoints. Switch BMCs enter the generic Redfish collector path, but periodic entry collection accepted only machine endpoint metadata.

## Related issues

Resolves #4727

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

No configuration, API, or persisted-state migration is required.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)