### PR TITLE
fix(nvue-client): Add polling in NvueClient::apply_config_revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7916,6 +7916,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/nvue-client/Cargo.toml
+++ b/crates/nvue-client/Cargo.toml
@@ -35,6 +35,7 @@ serde = { features = ["derive"], workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 glob = { workspace = true }

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -17,6 +17,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use carbide_instrument::red;
 use reqwest::header::{ACCEPT, HeaderMap, HeaderValue};
@@ -24,7 +25,7 @@ use reqwest::{Client, ClientBuilder, Method, Response, Url};
 pub use serde_json::Value as JsonValue;
 
 use crate::config::{NvueConfig, NvueConfigWithHeader, NvueRevision};
-use crate::types::revision::RevisionData;
+use crate::types::revision::{RevisionApplyStatus, RevisionData, RevisionIssueSummary};
 
 #[derive(Debug)]
 pub struct NvueClient {
@@ -33,6 +34,13 @@ pub struct NvueClient {
 }
 
 impl NvueClient {
+    // In the past, we've seen calls to `nv config apply` take a long time, to
+    // the point where the timeout for that code path (outside this crate) was
+    // raised to 45s. We don't know for sure that we need the same budget here,
+    // but let's assume we do. -drew
+    const APPLY_CONFIG_REVISION_TIMEOUT: Duration = Duration::from_secs(45);
+    const APPLY_CONFIG_REVISION_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
     pub fn new(server_address: NvueServerAddress) -> Result<Self, NvueClientError> {
         build_client(&server_address).map(|client| Self {
             server_address,
@@ -178,9 +186,42 @@ impl NvueClient {
         let request = builder.build()?;
         let _response = self.execute("apply_config_revision", request).await?;
 
-        // FIXME: we should poll on the revision path until it reaches an
-        // "applied" state
-        Ok(())
+        let started = tokio::time::Instant::now();
+        let deadline = started + Self::APPLY_CONFIG_REVISION_TIMEOUT;
+
+        loop {
+            let revision = self.get_revision(revision_id).await?;
+
+            let now = tokio::time::Instant::now();
+            let remaining = deadline.checked_duration_since(now);
+
+            match (revision.apply_status(), remaining) {
+                (RevisionApplyStatus::Applied, _) => break Ok(()),
+                (RevisionApplyStatus::Failed(error_issues), _) => {
+                    break Err(NvueClientError::RevisionApplyFailed {
+                        revision_id: revision_id.to_owned(),
+                        reason: RevisionApplyFailureReason::Error,
+                        last_state: revision.state.clone(),
+                        progress: revision.transition_progress().map(String::from),
+                        error_issues,
+                    });
+                }
+                (RevisionApplyStatus::Pending, Some(remaining)) => {
+                    tokio::time::sleep(remaining.min(Self::APPLY_CONFIG_REVISION_POLL_INTERVAL))
+                        .await;
+                }
+                (RevisionApplyStatus::Pending, None) => {
+                    let elapsed = now - started;
+                    break Err(NvueClientError::RevisionApplyFailed {
+                        revision_id: revision_id.to_owned(),
+                        reason: RevisionApplyFailureReason::Timeout { waited: elapsed },
+                        last_state: revision.state.clone(),
+                        progress: revision.transition_progress().map(String::from),
+                        error_issues: Vec::new(),
+                    });
+                }
+            }
+        }
     }
 
     /// Create a new configuration using the values from `config`, then  apply
@@ -356,6 +397,32 @@ pub enum NvueClientError {
 
     #[error("schema mismatch between NVUE client and server: {0}")]
     SchemaMismatch(&'static str),
+
+    #[error(
+        "NVUE revision apply failed: revision_id={revision_id}, reason={reason}, last_state={last_state:?}, progress={progress:?}, error_issues={error_issues:?}"
+    )]
+    RevisionApplyFailed {
+        revision_id: String,
+        reason: RevisionApplyFailureReason,
+        last_state: Option<String>,
+        progress: Option<String>,
+        error_issues: Vec<RevisionIssueSummary>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevisionApplyFailureReason {
+    Error,
+    Timeout { waited: Duration },
+}
+
+impl std::fmt::Display for RevisionApplyFailureReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Error => f.write_str("error"),
+            Self::Timeout { waited } => write!(f, "timeout after {waited:?}"),
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -24,6 +24,7 @@ use reqwest::{Client, ClientBuilder, Method, Response, Url};
 pub use serde_json::Value as JsonValue;
 
 use crate::config::{NvueConfig, NvueConfigWithHeader, NvueRevision};
+use crate::types::revision::RevisionData;
 
 #[derive(Debug)]
 pub struct NvueClient {
@@ -130,6 +131,20 @@ impl NvueClient {
             .get_revision_id()
             .ok_or(NvueClientError::SchemaMismatch("Missing revision id"))?;
         Ok(revision_id)
+    }
+
+    /// Return data about the specified revision.
+    pub async fn get_revision(&self, revision_id: &str) -> Result<RevisionData, NvueClientError> {
+        let revision_path = format!("/nvue_v1/revision/{revision_id}");
+        let request = self.request(Method::GET, &revision_path)?.build()?;
+        let response = self.execute("get_revision", request).await?;
+
+        // For some reason, the NVUE schema allows the response to be nulled,
+        // but as far as we're concerned that's an error.
+        let revision_data: Option<_> = response.json().await?;
+        revision_data.ok_or(NvueClientError::SchemaMismatch(
+            "Revision response was null",
+        ))
     }
 
     /// Replace the specified config revision. Under the hood, this is a

--- a/crates/nvue-client/src/client.rs
+++ b/crates/nvue-client/src/client.rs
@@ -151,7 +151,7 @@ impl NvueClient {
         // but as far as we're concerned that's an error.
         let revision_data: Option<_> = response.json().await?;
         revision_data.ok_or(NvueClientError::SchemaMismatch(
-            "Revision response was null",
+            "revision response was null",
         ))
     }
 

--- a/crates/nvue-client/src/lib.rs
+++ b/crates/nvue-client/src/lib.rs
@@ -17,17 +17,7 @@
 
 pub mod client;
 pub mod config;
+pub mod types;
 
 pub use client::NvueClient;
 pub use config::NvueConfig;
-
-pub mod types {
-    #[derive(Debug, serde::Deserialize)]
-    #[serde(rename_all = "kebab-case")]
-    pub struct MacTableEntry {
-        pub mac: String,
-        pub interface: String,
-        pub entry_type: String,
-        pub vlan: Option<u16>,
-    }
-}

--- a/crates/nvue-client/src/types/mod.rs
+++ b/crates/nvue-client/src/types/mod.rs
@@ -1,0 +1,8 @@
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MacTableEntry {
+    pub mac: String,
+    pub interface: String,
+    pub entry_type: String,
+    pub vlan: Option<u16>,
+}

--- a/crates/nvue-client/src/types/mod.rs
+++ b/crates/nvue-client/src/types/mod.rs
@@ -1,3 +1,5 @@
+pub mod revision;
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct MacTableEntry {

--- a/crates/nvue-client/src/types/revision.rs
+++ b/crates/nvue-client/src/types/revision.rs
@@ -14,6 +14,62 @@ pub struct RevisionData {
     pub state_controls: Option<JsonValue>,
 }
 
+impl RevisionData {
+    pub(crate) fn apply_status(&self) -> RevisionApplyStatus {
+        let error_issues = self.error_issue_summaries();
+        if !error_issues.is_empty() {
+            return RevisionApplyStatus::Failed(error_issues);
+        }
+
+        if self.state.as_deref() == Some("applied") {
+            return RevisionApplyStatus::Applied;
+        }
+
+        RevisionApplyStatus::Pending
+    }
+
+    pub(crate) fn transition_progress(&self) -> Option<&str> {
+        self.transition
+            .as_ref()
+            .and_then(|transition| transition.progress.as_deref())
+    }
+
+    pub(crate) fn error_issue_summaries(&self) -> Vec<RevisionIssueSummary> {
+        self.transition
+            .as_ref()
+            .and_then(|transition| transition.issue.as_ref())
+            .into_iter()
+            .flat_map(|issues| issues.iter())
+            .filter(|(_, issue)| issue.severity == Some(RevisionIssueSeverity::Error))
+            .map(|(issue_id, issue)| RevisionIssueSummary {
+                issue_id: issue_id.clone(),
+                severity: RevisionIssueSeverity::Error,
+                code: issue.code.clone(),
+                message: issue.message.clone(),
+                data: issue.data.clone(),
+            })
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+// Note that this doesn't exactly model the `status` field of an NVUE revision,
+// despite some resemblance in the variant names.
+pub(crate) enum RevisionApplyStatus {
+    Applied,
+    Pending,
+    Failed(Vec<RevisionIssueSummary>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RevisionIssueSummary {
+    pub issue_id: String,
+    pub severity: RevisionIssueSeverity,
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub data: Option<BTreeMap<String, String>>,
+}
+
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RevisionTransition {
@@ -40,6 +96,144 @@ pub enum RevisionIssueSeverity {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classifies_revision_apply_status() {
+        struct Case {
+            name: &'static str,
+            revision: RevisionData,
+            expected_status: RevisionApplyStatus,
+            expected_progress: Option<&'static str>,
+        }
+
+        let cases = [
+            Case {
+                name: "applied revision without issues succeeds",
+                revision: revision(Some("applied"), None, vec![]),
+                expected_status: RevisionApplyStatus::Applied,
+                expected_progress: None,
+            },
+            Case {
+                name: "applying revision without issues remains pending",
+                revision: revision(Some("apply"), Some("checking"), vec![]),
+                expected_status: RevisionApplyStatus::Pending,
+                expected_progress: Some("checking"),
+            },
+            Case {
+                name: "unknown state without issues remains pending",
+                revision: revision(Some("unknown"), None, vec![]),
+                expected_status: RevisionApplyStatus::Pending,
+                expected_progress: None,
+            },
+            Case {
+                name: "missing state without issues remains pending",
+                revision: revision(None, None, vec![]),
+                expected_status: RevisionApplyStatus::Pending,
+                expected_progress: None,
+            },
+            Case {
+                name: "warning-only issues remain pending",
+                revision: revision(
+                    Some("apply"),
+                    Some("validating"),
+                    vec![(
+                        "1",
+                        issue(
+                            RevisionIssueSeverity::Warning,
+                            Some("sample-warning"),
+                            Some("sample warning"),
+                            None,
+                        ),
+                    )],
+                ),
+                expected_status: RevisionApplyStatus::Pending,
+                expected_progress: Some("validating"),
+            },
+            Case {
+                name: "error issue fails with issue summary",
+                revision: revision(
+                    Some("apply"),
+                    Some("failed"),
+                    vec![(
+                        "2",
+                        issue(
+                            RevisionIssueSeverity::Error,
+                            Some("sample-error"),
+                            Some("sample error"),
+                            Some(BTreeMap::from([(
+                                "path".to_string(),
+                                "/system".to_string(),
+                            )])),
+                        ),
+                    )],
+                ),
+                expected_status: RevisionApplyStatus::Failed(vec![RevisionIssueSummary {
+                    issue_id: "2".to_string(),
+                    severity: RevisionIssueSeverity::Error,
+                    code: Some("sample-error".to_string()),
+                    message: Some("sample error".to_string()),
+                    data: Some(BTreeMap::from([(
+                        "path".to_string(),
+                        "/system".to_string(),
+                    )])),
+                }]),
+                expected_progress: Some("failed"),
+            },
+        ];
+
+        for case in cases {
+            assert_eq!(
+                case.revision.apply_status(),
+                case.expected_status,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                case.revision.transition_progress(),
+                case.expected_progress,
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    fn revision(
+        state: Option<&str>,
+        progress: Option<&str>,
+        issues: Vec<(&str, RevisionIssue)>,
+    ) -> RevisionData {
+        RevisionData {
+            message: None,
+            state: state.map(str::to_owned),
+            transition: Some(RevisionTransition {
+                progress: progress.map(str::to_owned),
+                issue: (!issues.is_empty()).then(|| {
+                    issues
+                        .into_iter()
+                        .map(|(issue_id, issue)| (issue_id.to_string(), issue))
+                        .collect()
+                }),
+            }),
+            last_apply: None,
+            additional_data: None,
+            auto_prompt: None,
+            state_controls: None,
+        }
+    }
+
+    fn issue(
+        severity: RevisionIssueSeverity,
+        code: Option<&str>,
+        message: Option<&str>,
+        data: Option<BTreeMap<String, String>>,
+    ) -> RevisionIssue {
+        RevisionIssue {
+            severity: Some(severity),
+            code: code.map(str::to_owned),
+            message: message.map(str::to_owned),
+            data,
+        }
+    }
 
     #[test]
     fn parses_revision_data_with_transition_issue() {

--- a/crates/nvue-client/src/types/revision.rs
+++ b/crates/nvue-client/src/types/revision.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value as JsonValue;
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RevisionData {
+    pub message: Option<String>,
+    pub state: Option<String>,
+    pub transition: Option<RevisionTransition>,
+    pub last_apply: Option<JsonValue>,
+    pub additional_data: Option<JsonValue>,
+    pub auto_prompt: Option<JsonValue>,
+    pub state_controls: Option<JsonValue>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RevisionTransition {
+    pub progress: Option<String>,
+    pub issue: Option<BTreeMap<String, RevisionIssue>>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RevisionIssue {
+    pub severity: Option<RevisionIssueSeverity>,
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub data: Option<BTreeMap<String, String>>,
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RevisionIssueSeverity {
+    Error,
+    Warning,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_revision_data_with_transition_issue() {
+        let json = r#"
+        {
+            "additional-data": {
+                "parent-revision-id": "applied"
+            },
+            "auto-prompt": {
+                "ays": "ays_yes"
+            },
+            "last-apply": {
+                "apply-id": "rev_1_apply_1"
+            },
+            "message": "apply config",
+            "state": "apply",
+            "state-controls": {
+                "apply-type": "API"
+            },
+            "transition": {
+                "progress": "checking",
+                "issue": {
+                    "1": {
+                        "severity": "warning",
+                        "code": "sample-warning",
+                        "message": "sample warning",
+                        "data": {
+                            "path": "/system"
+                        }
+                    }
+                }
+            }
+        }
+        "#;
+
+        let revision: RevisionData = serde_json::from_str(json).expect("revision should parse");
+
+        assert_eq!(revision.message.as_deref(), Some("apply config"));
+        assert_eq!(revision.state.as_deref(), Some("apply"));
+        assert!(revision.additional_data.is_some());
+        assert!(revision.auto_prompt.is_some());
+        assert!(revision.last_apply.is_some());
+        assert!(revision.state_controls.is_some());
+
+        let transition = revision.transition.expect("transition should parse");
+        assert_eq!(transition.progress.as_deref(), Some("checking"));
+
+        let issues = transition.issue.expect("issues should parse");
+        let issue = issues.get("1").expect("issue should parse");
+        assert_eq!(issue.severity, Some(RevisionIssueSeverity::Warning));
+        assert_eq!(issue.code.as_deref(), Some("sample-warning"));
+        assert_eq!(issue.message.as_deref(), Some("sample warning"));
+        assert_eq!(
+            issue
+                .data
+                .as_ref()
+                .and_then(|data| data.get("path"))
+                .map(String::as_str),
+            Some("/system")
+        );
+    }
+}


### PR DESCRIPTION
I've been overly optimistic in `NvueClient::apply_config_revision()`, assuming that we don't need to care about checking the state of the revision we just applied. QA found a bug (tracked internally as NVbugs 6563638) that suggests this was a mistake. This branch adds polling logic in `apply_config_revision()`, with parsing of the revision data derived from the OpenAPI spec from NVUE in Cumulus Linux 5.16.0 (the most recent version I had handy).

## Related issues
- NVbugs 6563638

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


