### PR TITLE
docs: pull our configuration guidance into STYLE_GUIDE.md

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -411,6 +411,26 @@ pub async fn create_resource(
 }
 ```
 
+## Configuration ownership and precedence
+
+Before adding a configuration option, ask whether the behavior can be safe and predictable without a knob. Keep true
+protocol invariants non-configurable and hard safety caps as named constants. When operators need to tune an operational
+limit, bound it with a non-configurable hard maximum and reject out-of-range values before activation. Do not bake
+values tied to one site or environment, such as cluster names, namespaces, and addresses, into behavior; expose them
+through configuration instead.
+
+When behavior must vary, give each setting one canonical owner and resolution path. Define what omission means: use a
+safe default when omission has a safe and predictable meaning; otherwise require the setting and fail validation.
+Validate values before they become active. State whether changes require a restart or take effect dynamically, and
+define precedence, fallback, and conflict behavior across every supported source.
+
+This does not require one storage location. Files, environment variables, command-line flags, Helm values, database
+values, and APIs can all be valid sources, but overlapping sources must resolve through one declared contract.
+
+Do not copy a configuration schema into another interface just to expose it. Reference the canonical contract or
+generate the interface from it when practical, and keep interface-specific adapters limited to translation and
+precedence.
+
 ## Crate Features
 
 Avoid using crate features unless there is a good reason. Our CI runners only build with the default features you get


### PR DESCRIPTION
_This continues the series from https://github.com/NVIDIA/infra-controller/pull/4641, https://github.com/NVIDIA/infra-controller/pull/4608,  https://github.com/NVIDIA/infra-controller/pull/4648, (and related to https://github.com/NVIDIA/infra-controller/pull/4522), with more to come._

This is an attempt to capture the general NICo maintainer design principles and guidance around configuration ownership for the codebase. This change is derived from the pre-OSS review corpus as a whole -- years of MRs and tens of thousands of comments and discussions. As such, it leans into the guiding design decisions and principles used to define and grow the project into the product we have today.

**The idea is to ensure we capture our core principles in `STYLE_GUIDE.md`**. If any of those principles have changed, we should capture that too, ensuring we don't lose sight of why decisions were made as the codebase evolves with new contributors, human and agentic alike.

**For this change specifically, I focused on where configuration belongs** (and how it resolves). The search through previous reviews surfaced discussions related to:
- Duplicate sources.
- Unsafe defaults
- Hard-coded site values.
- Reloading config/values.
- Unnecessary knobs.

This pulls out the recurring parts:

- First ask whether a configuration option is necessary.
- Give variable behavior one canonical owner and resolution path.
- Define omission and fallback behavior, validation, precedence and conflict handling.
- Restart and/or [dynamic] update behavior.
- Keep site-level and environment-specific values behind declared configuration instead of baking them in.
- Keep true protocol invariants non-configurable; tunable operational limits still have a hard, non-configurable maximum.

It also keeps the important exceptions that configuration does not have one universal storage location and that some settings must be required and fail closed because no safe default exists. Files, flags, environment variables, Helm, database values, and APIs can each be the right owner; the rule is to make ownership, omission behavior, and precedence explicit instead of creating accidental parallel sources.

Again, we can always adjust this now or later. The hope is that we don't lose the reasoning behind why we made certain decisions to get us where we are now, and can continue using that reasoning to help drive future decisions.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4626

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes


Closes #4626

