### PR TITLE
ci: share final gate checks across Core and REST

### DIFF
--- a/.github/ci/check_ci_gate.py
+++ b/.github/ci/check_ci_gate.py
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Keep every Core CI job accounted for by the final required check.
+"""Keep every CI job accounted for by its final required check.
 
 GitHub Actions makes `needs` a static list: it waits for the jobs named there,
-but adding a new top-level job does not update `core-ci-pass` or warn us that
-the job was omitted. The `inventory` command reads the small part of the
-workflow used by the gate and requires every job to be gated or explicitly
-exempted. It also protects the gate's `if: always()` condition so a failed
-dependency cannot skip the required check.
+but adding a new top-level job does not update a final gate or warn us that the
+job was omitted. The `inventory` command reads the small part of the workflow
+used by the selected gate policy and requires every job to be gated or
+explicitly exempted. It also protects the gate's `if: always()` condition so a
+failed dependency cannot skip the required check.
 
 The `results` command evaluates `${{ toJson(needs) }}` from `NEEDS_JSON`.
 `success` and `skipped` pass because conditional jobs legitimately omit work.
@@ -26,27 +26,15 @@ import os
 import re
 import sys
 from collections import Counter
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 
-GATE_JOB = "core-ci-pass"
-EXEMPT_JOBS = {
-    "build-summary": (
-        "This reporting-only job writes the Actions summary and does not validate "
-        "build output."
-    ),
-    "notify-build-status": (
-        "This administrative job reports the completed build to Slack on protected refs."
-    ),
-    GATE_JOB: "A job cannot depend on itself.",
-}
-
-# We only need the root job IDs plus `core-ci-pass.if` and
-# `core-ci-pass.needs`. Keep this grammar deliberately narrow and reject
-# unfamiliar formatting: silently skipping a line could let a job escape the
-# required check.
+# We only need the root job IDs plus the selected gate's `if` and `needs`
+# fields. Keep this grammar deliberately narrow and reject unfamiliar
+# formatting: silently skipping a line could let a job escape the required
+# check.
 JOB_KEY = re.compile(r"^  (?P<job>[A-Za-z_][A-Za-z0-9_-]*):(?:\s*#.*)?$")
 NEEDS_ITEM = re.compile(r"^      - (?P<job>[A-Za-z_][A-Za-z0-9_-]*)(?:\s*#.*)?$")
 GATE_IF = re.compile(r"^    if:\s*(?P<condition>.*)$")
@@ -55,6 +43,48 @@ PASSING_RESULTS = frozenset({"success", "skipped"})
 
 class WorkflowFormatError(ValueError):
     """The workflow does not use the job layout this checker can verify."""
+
+
+@dataclass(frozen=True)
+class GatePolicy:
+    """Name one final gate and every job intentionally outside it.
+
+    `display_name` identifies the lane in human-readable output. `gate_job`
+    is the top-level job that branch protection requires. Each exemption maps
+    a job ID to the reviewed reason it cannot or should not gate that lane.
+    """
+
+    display_name: str
+    gate_job: str
+    exemptions: Mapping[str, str]
+
+
+CORE_POLICY = GatePolicy(
+    display_name="Core CI",
+    gate_job="core-ci-pass",
+    exemptions={
+        "build-summary": (
+            "This reporting-only job writes the Actions summary and does not "
+            "validate build output."
+        ),
+        "notify-build-status": (
+            "This administrative job reports the completed build to Slack on "
+            "protected refs."
+        ),
+        "core-ci-pass": "A job cannot depend on itself.",
+    },
+)
+
+REST_POLICY = GatePolicy(
+    display_name="REST CI",
+    gate_job="rest-ci-pass",
+    exemptions={"rest-ci-pass": "A job cannot depend on itself."},
+)
+
+POLICIES: Mapping[str, GatePolicy] = {
+    "core": CORE_POLICY,
+    "rest": REST_POLICY,
+}
 
 
 @dataclass(frozen=True)
@@ -118,15 +148,18 @@ def _find_jobs(lines: list[str]) -> tuple[list[str], dict[str, int]]:
 
 
 def _parse_gate(
-    lines: list[str], jobs: list[str], positions: Mapping[str, int]
+    lines: list[str],
+    jobs: list[str],
+    positions: Mapping[str, int],
+    gate_job: str,
 ) -> list[str]:
     """Protect the gate condition and read its complete block-style `needs` list."""
 
-    gate_start = positions.get(GATE_JOB)
+    gate_start = positions.get(gate_job)
     if gate_start is None:
-        raise WorkflowFormatError(f"the workflow does not define `{GATE_JOB}`")
+        raise WorkflowFormatError(f"the workflow does not define `{gate_job}`")
 
-    gate_index = jobs.index(GATE_JOB)
+    gate_index = jobs.index(gate_job)
     gate_end = (
         positions[jobs[gate_index + 1]] if gate_index + 1 < len(jobs) else len(lines)
     )
@@ -138,12 +171,12 @@ def _parse_gate(
     ]
     if len(gate_conditions) != 1:
         raise WorkflowFormatError(
-            f"expected one gate-level `if` on `{GATE_JOB}`, "
+            f"expected one gate-level `if` on `{gate_job}`, "
             f"found {len(gate_conditions)}"
         )
     if gate_conditions[0] != "always()":
         raise WorkflowFormatError(
-            f"`{GATE_JOB}.if` must be `always()`, found {gate_conditions[0]!r}"
+            f"`{gate_job}.if` must be `always()`, found {gate_conditions[0]!r}"
         )
 
     needs_lines = [
@@ -153,7 +186,8 @@ def _parse_gate(
     ]
     if len(needs_lines) != 1:
         raise WorkflowFormatError(
-            f"expected one block-style `needs` list on `{GATE_JOB}`, found {len(needs_lines)}"
+            f"expected one block-style `needs` list on `{gate_job}`, "
+            f"found {len(needs_lines)}"
         )
 
     needs: list[str] = []
@@ -164,7 +198,7 @@ def _parse_gate(
         indentation = _leading_spaces(line)
         if indentation == 4 and line.startswith("    - "):
             raise WorkflowFormatError(
-                f"line {index + 1} must indent `{GATE_JOB}.needs` items "
+                f"line {index + 1} must indent `{gate_job}.needs` items "
                 f"by six spaces: {line!r}"
             )
         if indentation <= 4:
@@ -173,22 +207,23 @@ def _parse_gate(
         match = NEEDS_ITEM.fullmatch(line)
         if match is None:
             raise WorkflowFormatError(
-                f"line {index + 1} is not a supported `{GATE_JOB}.needs` item: {line!r}"
+                f"line {index + 1} is not a supported `{gate_job}.needs` item: "
+                f"{line!r}"
             )
         needs.append(match.group("job"))
 
     if not needs:
-        raise WorkflowFormatError(f"`{GATE_JOB}.needs` contains no jobs")
+        raise WorkflowFormatError(f"`{gate_job}.needs` contains no jobs")
 
     return needs
 
 
-def parse_workflow(workflow_text: str) -> WorkflowInventory:
+def parse_workflow(workflow_text: str, gate_job: str) -> WorkflowInventory:
     """Parse the small part of a GitHub Actions workflow the gate relies on."""
 
     lines = workflow_text.splitlines()
     jobs, positions = _find_jobs(lines)
-    gate_needs = _parse_gate(lines, jobs, positions)
+    gate_needs = _parse_gate(lines, jobs, positions, gate_job)
     return WorkflowInventory(jobs=tuple(jobs), gate_needs=tuple(gate_needs))
 
 
@@ -240,17 +275,15 @@ def _inventory_errors(
     return errors
 
 
-def inventory_errors(
-    workflow_text: str, exemptions: Mapping[str, str] = EXEMPT_JOBS
-) -> list[str]:
+def inventory_errors(workflow_text: str, policy: GatePolicy) -> list[str]:
     """Parse the workflow and explain every invalid gate classification."""
 
     try:
-        inventory = parse_workflow(workflow_text)
+        inventory = parse_workflow(workflow_text, policy.gate_job)
     except WorkflowFormatError as error:
         return [str(error)]
 
-    return _inventory_errors(inventory, exemptions)
+    return _inventory_errors(inventory, policy.exemptions)
 
 
 def result_errors(needs_context: Mapping[str, object]) -> list[str]:
@@ -287,7 +320,7 @@ def _print_annotations(errors: list[str]) -> None:
         print(f"::error::{error}")
 
 
-def _check_inventory(workflow_path: Path) -> int:
+def _check_inventory(workflow_path: Path, policy: GatePolicy) -> int:
     """Check one workflow file and report inventory errors as annotations.
 
     Returns zero only when the file is readable, uses the supported layout,
@@ -301,19 +334,20 @@ def _check_inventory(workflow_path: Path) -> int:
         return 1
 
     try:
-        inventory = parse_workflow(workflow_text)
+        inventory = parse_workflow(workflow_text, policy.gate_job)
     except WorkflowFormatError as error:
         _print_annotations([str(error)])
         return 1
 
-    errors = _inventory_errors(inventory, EXEMPT_JOBS)
+    errors = _inventory_errors(inventory, policy.exemptions)
     if errors:
         _print_annotations(errors)
         return 1
 
     print(
-        f"Core CI gate accounts for {len(inventory.jobs)} top-level jobs "
-        f"({len(inventory.gate_needs)} gated, {len(EXEMPT_JOBS)} exempt)."
+        f"{policy.display_name} gate accounts for {len(inventory.jobs)} "
+        f"top-level jobs ({len(inventory.gate_needs)} gated, "
+        f"{len(policy.exemptions)} exempt)."
     )
     return 0
 
@@ -352,28 +386,34 @@ def _check_results() -> int:
     return 0
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     """Parse the selected check and its command-specific arguments."""
 
     parser = argparse.ArgumentParser(
-        description="Check the Core CI final gate inventory and job results."
+        description="Check a CI final gate's job inventory and results."
     )
     commands = parser.add_subparsers(dest="command", required=True)
 
     inventory = commands.add_parser(
         "inventory", help="verify that every top-level job is gated or exempt"
     )
+    inventory.add_argument(
+        "--policy",
+        choices=tuple(POLICIES),
+        required=True,
+        help="select the workflow's reviewed gate policy",
+    )
     inventory.add_argument("workflow", type=Path)
     commands.add_parser("results", help="evaluate the job results in `NEEDS_JSON`")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Run the requested gate check."""
 
-    args = _parse_args()
+    args = _parse_args(argv)
     if args.command == "inventory":
-        return _check_inventory(args.workflow)
+        return _check_inventory(args.workflow, POLICIES[args.policy])
     return _check_results()
 
 

--- a/.github/ci/test_check_ci_gate.py
+++ b/.github/ci/test_check_ci_gate.py
@@ -2,18 +2,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Core CI final-gate inventory and result checks."""
+"""Tests for the shared CI final-gate inventory and result checks."""
 
 from __future__ import annotations
 
 import contextlib
 import io
 import os
+import tempfile
 import textwrap
 import unittest
+from dataclasses import replace
+from pathlib import Path
 from unittest import mock
 
-from check_core_ci_gate import _check_results, inventory_errors, result_errors
+from check_ci_gate import (
+    CORE_POLICY,
+    REST_POLICY,
+    inventory_errors,
+    main,
+    result_errors,
+)
 
 
 COMPLETE_WORKFLOW = textwrap.dedent(
@@ -40,11 +49,43 @@ COMPLETE_WORKFLOW = textwrap.dedent(
     """
 )
 
-EXEMPTIONS = {
-    "build-summary": "Reports the completed build.",
-    "notify-build-status": "Sends the administrative notification.",
-    "core-ci-pass": "A job cannot depend on itself.",
-}
+REST_WORKFLOW = textwrap.dedent(
+    """\
+    name: REST fixture
+
+    jobs:
+      changes:
+        runs-on: ubuntu-latest
+      prepare:
+        runs-on: ubuntu-latest
+      lint-and-test:
+        runs-on: ubuntu-latest
+      build-binaries:
+        runs-on: ubuntu-latest
+      security-secret-scan:
+        runs-on: ubuntu-latest
+      build-and-push:
+        runs-on: ubuntu-latest
+      build-and-push-pr:
+        runs-on: ubuntu-latest
+      helm:
+        runs-on: ubuntu-latest
+      rest-ci-pass:
+        runs-on: ubuntu-latest
+        if: always()
+        needs:
+          - changes
+          - prepare
+          - lint-and-test
+          - build-binaries
+          - security-secret-scan
+          - build-and-push
+          - build-and-push-pr
+          - helm
+        steps:
+          - run: true
+    """
+)
 
 
 class InventoryTests(unittest.TestCase):
@@ -55,19 +96,25 @@ class InventoryTests(unittest.TestCase):
             {
                 "name": "complete inventory",
                 "workflow": COMPLETE_WORKFLOW,
-                "exemptions": EXEMPTIONS,
+                "policy": CORE_POLICY,
                 "expected": [],
             },
             {
                 "name": "missing gate dependency",
                 "workflow": COMPLETE_WORKFLOW.replace("      - build\n", ""),
-                "exemptions": EXEMPTIONS,
+                "policy": CORE_POLICY,
                 "expected": ["top-level jobs are not gated or exempt: build"],
             },
             {
                 "name": "unknown exemption",
                 "workflow": COMPLETE_WORKFLOW,
-                "exemptions": {**EXEMPTIONS, "retired-job": "No longer used."},
+                "policy": replace(
+                    CORE_POLICY,
+                    exemptions={
+                        **CORE_POLICY.exemptions,
+                        "retired-job": "No longer used.",
+                    },
+                ),
                 "expected": ["exemptions are not top-level jobs: retired-job"],
             },
             {
@@ -75,7 +122,7 @@ class InventoryTests(unittest.TestCase):
                 "workflow": COMPLETE_WORKFLOW.replace(
                     "      - build\n", "      - build\n      - retired-job\n"
                 ),
-                "exemptions": EXEMPTIONS,
+                "policy": CORE_POLICY,
                 "expected": [
                     "gate dependencies are not top-level jobs: retired-job"
                 ],
@@ -83,7 +130,13 @@ class InventoryTests(unittest.TestCase):
             {
                 "name": "duplicate classification",
                 "workflow": COMPLETE_WORKFLOW,
-                "exemptions": {**EXEMPTIONS, "build": "Fixture duplicate."},
+                "policy": replace(
+                    CORE_POLICY,
+                    exemptions={
+                        **CORE_POLICY.exemptions,
+                        "build": "Fixture duplicate.",
+                    },
+                ),
                 "expected": ["jobs cannot be both gated and exempt: build"],
             },
             {
@@ -91,13 +144,16 @@ class InventoryTests(unittest.TestCase):
                 "workflow": COMPLETE_WORKFLOW.replace(
                     "      - build\n", "      - build\n      - build\n"
                 ),
-                "exemptions": EXEMPTIONS,
+                "policy": CORE_POLICY,
                 "expected": ["gate dependencies are listed more than once: build"],
             },
             {
                 "name": "empty exemption reason",
                 "workflow": COMPLETE_WORKFLOW,
-                "exemptions": {**EXEMPTIONS, "build-summary": ""},
+                "policy": replace(
+                    CORE_POLICY,
+                    exemptions={**CORE_POLICY.exemptions, "build-summary": ""},
+                ),
                 "expected": ["exemptions need a reason: build-summary"],
             },
         )
@@ -105,7 +161,36 @@ class InventoryTests(unittest.TestCase):
         for case in cases:
             with self.subTest(case["name"]):
                 self.assertEqual(
-                    inventory_errors(case["workflow"], case["exemptions"]),
+                    inventory_errors(case["workflow"], case["policy"]),
+                    case["expected"],
+                )
+
+    def test_lane_policies(self) -> None:
+        cases = (
+            {
+                "name": "REST policy",
+                "workflow": REST_WORKFLOW,
+                "policy": REST_POLICY,
+                "expected": [],
+            },
+            {
+                "name": "missing REST dependency",
+                "workflow": REST_WORKFLOW.replace("      - helm\n", ""),
+                "policy": REST_POLICY,
+                "expected": ["top-level jobs are not gated or exempt: helm"],
+            },
+            {
+                "name": "wrong policy",
+                "workflow": REST_WORKFLOW,
+                "policy": CORE_POLICY,
+                "expected": ["the workflow does not define `core-ci-pass`"],
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                self.assertEqual(
+                    inventory_errors(case["workflow"], case["policy"]),
                     case["expected"],
                 )
 
@@ -199,7 +284,64 @@ class InventoryTests(unittest.TestCase):
 
         for case in cases:
             with self.subTest(case["name"]):
-                self.assertEqual(inventory_errors(case["workflow"]), [case["expected"]])
+                self.assertEqual(
+                    inventory_errors(case["workflow"], CORE_POLICY),
+                    [case["expected"]],
+                )
+
+
+class CommandTests(unittest.TestCase):
+    """Verify policy selection and workflow-file handling at the CLI boundary."""
+
+    def test_inventory_command_accepts_each_policy(self) -> None:
+        cases = (
+            {
+                "name": "Core policy",
+                "policy": "core",
+                "workflow": COMPLETE_WORKFLOW,
+                "expected": "Core CI gate accounts for 5",
+            },
+            {
+                "name": "REST policy",
+                "policy": "rest",
+                "workflow": REST_WORKFLOW,
+                "expected": "REST CI gate accounts for 9",
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case["name"]):
+                with tempfile.TemporaryDirectory() as directory:
+                    workflow_path = Path(directory) / "workflow.yml"
+                    workflow_path.write_text(case["workflow"], encoding="utf-8")
+                    output = io.StringIO()
+                    with contextlib.redirect_stdout(output):
+                        return_code = main(
+                            [
+                                "inventory",
+                                "--policy",
+                                case["policy"],
+                                str(workflow_path),
+                            ]
+                        )
+
+                self.assertEqual(return_code, 0)
+                self.assertIn(case["expected"], output.getvalue())
+
+    def test_inventory_command_rejects_unknown_policy(self) -> None:
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaisesRegex(SystemExit, "2"):
+                main(["inventory", "--policy", "unknown", "workflow.yml"])
+
+    def test_inventory_command_rejects_unreadable_workflow(self) -> None:
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            return_code = main(
+                ["inventory", "--policy", "core", "/missing/workflow.yml"]
+            )
+
+        self.assertEqual(return_code, 1)
+        self.assertIn("::error::could not read", output.getvalue())
 
 
 class ResultTests(unittest.TestCase):
@@ -248,7 +390,7 @@ class ResultTests(unittest.TestCase):
         output = io.StringIO()
         with mock.patch.dict(os.environ, {"NEEDS_JSON": needs_json}):
             with contextlib.redirect_stdout(output):
-                return_code = _check_results()
+                return_code = main(["results"])
 
         self.assertEqual(return_code, 0)
         self.assertNotIn("::error::", output.getvalue())
@@ -302,7 +444,7 @@ class ResultTests(unittest.TestCase):
                 output = io.StringIO()
                 with mock.patch.dict(os.environ, {"NEEDS_JSON": case["needs_json"]}):
                     with contextlib.redirect_stdout(output):
-                        return_code = _check_results()
+                        return_code = main(["results"])
 
                 self.assertEqual(return_code, 1)
                 self.assertIn(case["expected"], output.getvalue())
@@ -311,7 +453,7 @@ class ResultTests(unittest.TestCase):
         output = io.StringIO()
         with mock.patch.dict(os.environ, {}, clear=True):
             with contextlib.redirect_stdout(output):
-                return_code = _check_results()
+                return_code = main(["results"])
 
         self.assertEqual(return_code, 1)
         self.assertIn("::error::`NEEDS_JSON` is not set", output.getvalue())

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,11 +61,11 @@ jobs:
       - name: Check Core CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh core
 
-      - name: Test Core CI final-gate checker
-        run: python3 -B .github/ci/test_check_core_ci_gate.py
+      - name: Test CI final-gate checker
+        run: python3 -B .github/ci/test_check_ci_gate.py
 
       - name: Check Core CI final-gate inventory
-        run: python3 -B .github/ci/check_core_ci_gate.py inventory .github/workflows/ci.yaml
+        run: python3 -B .github/ci/check_ci_gate.py inventory --policy core .github/workflows/ci.yaml
 
       - name: Detect non-rest changes
         id: non-rest-changes
@@ -2346,4 +2346,4 @@ jobs:
       - name: Decide pass/fail
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
-        run: python3 -B .github/ci/check_core_ci_gate.py results
+        run: python3 -B .github/ci/check_ci_gate.py results

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -33,6 +33,9 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Check REST CI final-gate inventory
+        run: python3 -B .github/ci/check_ci_gate.py inventory --policy rest .github/workflows/rest-ci.yml
+
       - name: Check REST CI concurrency policy
         run: bash scripts/check-ci-concurrency.sh rest
 
@@ -220,13 +223,17 @@ jobs:
   # ============================================================================
   # AGGREGATOR — single required check for branch protection
   # ============================================================================
-  # Fails iff any leaf job's result is `failure` or `cancelled`.
+  # Passes only when every required job reports `success` or `skipped`.
   # `skipped` counts as pass — that's how core-only PRs unblock when the
   # `changes` gate intentionally skips the REST pipeline, and it is also what
   # lets `build-and-push` and `build-and-push-pr` both sit in needs when
   # exactly one of the two ever runs.
-  # `changes` + `prepare` are in needs so a gate or prepare failure doesn't
-  # silently pass (downstream leaves become SKIPPED in those cases).
+  # Any other result, plus missing or malformed data, fails closed.
+  # Every job that can determine REST CI health is listed so an upstream
+  # failure cannot be hidden when its downstream jobs become `skipped`.
+  # The checker in `changes` rejects every job that is neither gated nor
+  # exempted and protects `if: always()` so a failed dependency cannot skip
+  # this required check.
   rest-ci-pass:
     name: rest-ci-pass
     runs-on: ubuntu-latest
@@ -240,19 +247,15 @@ jobs:
       - build-and-push
       - build-and-push-pr
       - helm
+    permissions:
+      contents: read
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Decide pass/fail
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
-        run: |
-          set -euo pipefail
-          echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
-          if echo "$NEEDS_JSON" | jq -e '
-            to_entries
-            | map(select(.value.result == "failure" or .value.result == "cancelled"))
-            | length > 0
-          ' >/dev/null; then
-            echo "::error::One or more required jobs failed or were cancelled"
-            exit 1
-          fi
-          echo "All required jobs OK (success or skipped)"
+        run: python3 -B .github/ci/check_ci_gate.py results


### PR DESCRIPTION
This is a follow-up to [#4655](https://github.com/NVIDIA/infra-controller/pull/4655), where we made Core verify that every top-level CI job is covered by `core-ci-pass`, but left REST on its own `jq` result check. Nothing catches a new REST job added without also updating `rest-ci-pass`, so the two required checks can drift even though they enforce the same rule.

So, this turns `check_core_ci_gate.py` into `check_ci_gate.py`, keeps the lane-specific gate names and exemptions in explicit policies, and runs the same inventory and result checks for both workflows.

- **Expected green-run effect:** No speedup is expected; `rest-ci-pass` adds one small hosted checkout before it evaluates the job results.
- **What it really buys us:** New REST jobs cannot quietly sit outside `rest-ci-pass`, and malformed result data now fails closed instead of passing through REST's separate `jq` check.

Core keeps its existing 52-job contract, while REST starts with all nine top-level jobs accounted for. `success` and `skipped` remain the only passing results; #4586 still owns deciding whether an individual skip was actually valid.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4741

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated both live workflow inventories, Actionlint, `cargo make format-nightly`, `cargo make clippy`, and the cached full Carbide-lints gate.

## Additional Notes

This deliberately preserves the current blanket acceptance of `skipped`. #4586 still owns classifier-aware skip validation, Actions API pagination, job-name mapping, cross-workflow correlation, and timing reports.

Closes #4741
