### PR TITLE
feat(admin-cli): manage tenant SitePrefixes

### DIFF
--- a/crates/admin-cli/cli_domains.yaml
+++ b/crates/admin-cli/cli_domains.yaml
@@ -47,6 +47,7 @@ network:
   - vpc
   - vpc-peering
   - vpc-prefix
+  - site-prefix
   - network-segment
   - network-device
   - network-security-group

--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -26,8 +26,8 @@ use crate::{
     machine_validation, managed_host, managed_switch, mlx, network_devices, network_security_group,
     network_segment, nvl_domain, nvl_logical_partition, nvl_partition, nvlink_nmxc_endpoints,
     operating_system, os_image, ping, power_shelf, rack, redfish, resource_pool, rms, route_server,
-    scout_stream, secrets, set, site_explorer, sku, spx_partition, ssh, switch, tenant,
-    tenant_keyset, tpm_ca, trim_table, version, vpc, vpc_peering, vpc_prefix,
+    scout_stream, secrets, set, site_explorer, site_prefix, sku, spx_partition, ssh, switch,
+    tenant, tenant_keyset, tpm_ca, trim_table, version, vpc, vpc_peering, vpc_prefix,
 };
 
 const MAX_INTERNAL_PAGE_SIZE: usize = 100;
@@ -361,6 +361,8 @@ pub(crate) enum CliCommand {
     Set(set::Cmd),
     #[clap(about = "Site explorer functions", subcommand)]
     SiteExplorer(site_explorer::Cmd),
+    #[clap(about = "SitePrefix management", subcommand)]
+    SitePrefix(site_prefix::Cmd),
     #[clap(about = "Manage machine SKUs", subcommand)]
     Sku(sku::Cmd),
     #[clap(

--- a/crates/admin-cli/src/errors.rs
+++ b/crates/admin-cli/src/errors.rs
@@ -18,6 +18,7 @@
 use carbide_uuid::dpu_remediations::RemediationId;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine::{MachineId, MachineIdParseError};
+use carbide_uuid::site_prefix::SitePrefixId;
 use carbide_uuid::switch::{SwitchId, SwitchIdParseError};
 use rpc::forge_tls_client::ForgeTlsClientError;
 
@@ -85,6 +86,9 @@ pub(crate) enum CarbideCliError {
 
     #[error("tenant with id {0} not found")]
     TenantNotFound(String),
+
+    #[error("no SitePrefix found with id {0}")]
+    SitePrefixNotFound(SitePrefixId),
 
     #[error("I/O error. does the file exist? {0}")]
     IOError(#[from] std::io::Error),

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -107,6 +107,7 @@ mod scout_stream;
 mod secrets;
 mod set;
 mod site_explorer;
+mod site_prefix;
 mod sku;
 mod spx_partition;
 mod ssh;
@@ -277,6 +278,7 @@ async fn main() -> color_eyre::Result<()> {
         CliCommand::Set(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Ssh(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::SiteExplorer(cmd) => cmd.dispatch(ctx).await?,
+        CliCommand::SitePrefix(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Sku(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Switch(cmd) => cmd.dispatch(ctx).await?,
         CliCommand::Tenant(cmd) => cmd.dispatch(ctx).await?,

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -41,6 +41,7 @@ use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::nvlink::{NvLinkLogicalPartitionId, NvLinkPartitionId};
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::rack::RackId;
+use carbide_uuid::site_prefix::SitePrefixId;
 use carbide_uuid::spx::SpxPartitionId;
 use carbide_uuid::switch::SwitchId;
 use carbide_uuid::vpc::{VpcId, VpcPrefixId};
@@ -202,7 +203,7 @@ impl ApiClient {
     /// with `InvalidArgument`). The cap is read from `RuntimeConfig`, the same
     /// source `version` already exposes. A zero/unset cap means the server
     /// enforces no limit, so we fall back to `page_size` -- `chunks(0)` panics.
-    async fn effective_chunk_size(&self, page_size: usize) -> CarbideCliResult<usize> {
+    pub(crate) async fn effective_chunk_size(&self, page_size: usize) -> CarbideCliResult<usize> {
         let cap = self
             .0
             .version(true)
@@ -672,6 +673,25 @@ impl ApiClient {
             .histories
             .remove(&vpc_prefix_id.to_string())
             .map(|h| h.records)
+            .unwrap_or_default())
+    }
+
+    /// Fetches controller state history for a single SitePrefix.
+    pub(crate) async fn get_site_prefix_state_history(
+        &self,
+        site_prefix_id: SitePrefixId,
+    ) -> CarbideCliResult<Vec<rpc::StateHistoryRecord>> {
+        let mut result = self
+            .0
+            .find_site_prefix_state_histories(rpc::SitePrefixStateHistoriesRequest {
+                site_prefix_ids: vec![site_prefix_id],
+            })
+            .await?;
+
+        Ok(result
+            .histories
+            .remove(&site_prefix_id.to_string())
+            .map(|history| history.records)
             .unwrap_or_default())
     }
 

--- a/crates/admin-cli/src/site_prefix/common.rs
+++ b/crates/admin-cli/src/site_prefix/common.rs
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::site_prefix::SitePrefixId;
+use rpc::forge::{SitePrefix, SitePrefixSearchFilter, SitePrefixesByIdsRequest};
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::rpc::ApiClient;
+
+pub(super) async fn find_ids(
+    api_client: &ApiClient,
+    filter: SitePrefixSearchFilter,
+) -> CarbideCliResult<Vec<SitePrefixId>> {
+    Ok(api_client
+        .0
+        .find_site_prefix_ids(filter)
+        .await?
+        .site_prefix_ids)
+}
+
+pub(super) async fn find_by_ids(
+    api_client: &ApiClient,
+    page_size: usize,
+    site_prefix_ids: &[SitePrefixId],
+) -> CarbideCliResult<Vec<SitePrefix>> {
+    let mut site_prefixes = Vec::with_capacity(site_prefix_ids.len());
+    if site_prefix_ids.is_empty() {
+        return Ok(site_prefixes);
+    }
+
+    let page_size = api_client.effective_chunk_size(page_size).await?;
+    for page in site_prefix_ids.chunks(page_size) {
+        let response = api_client
+            .0
+            .find_site_prefixes_by_ids(SitePrefixesByIdsRequest {
+                site_prefix_ids: page.to_vec(),
+            })
+            .await?;
+        site_prefixes.extend(response.site_prefixes);
+    }
+
+    Ok(site_prefixes)
+}
+
+pub(super) async fn find_one_by_id(
+    api_client: &ApiClient,
+    site_prefix_id: SitePrefixId,
+) -> CarbideCliResult<SitePrefix> {
+    let mut site_prefixes = find_by_ids(api_client, 1, &[site_prefix_id]).await?;
+    match site_prefixes.len() {
+        0 => Err(CarbideCliError::SitePrefixNotFound(site_prefix_id)),
+        1 => Ok(site_prefixes
+            .pop()
+            .expect("one SitePrefix was returned by the API")),
+        returned_count => Err(CarbideCliError::GenericError(format!(
+            "the API returned {returned_count} SitePrefixes for ID {site_prefix_id}"
+        ))),
+    }
+}

--- a/crates/admin-cli/src/site_prefix/create.rs
+++ b/crates/admin-cli/src/site_prefix/create.rs
@@ -1,0 +1,115 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::site_prefix::SitePrefixId;
+use clap::Parser;
+use ipnet::IpNet;
+use rpc::forge::{Metadata, SitePrefixCreationRequest};
+
+use super::output::SitePrefixOutput;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+use crate::metadata::parse_rpc_labels;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Create a tenant-managed SitePrefix:
+    $ nico-admin-cli site-prefix create --tenant-organization-id fds34511233a \
+    --prefix 10.0.0.0/16 --name tenant-private-space
+
+Create a SitePrefix with metadata:
+    $ nico-admin-cli site-prefix create --tenant-organization-id fds34511233a \
+    --prefix 192.168.0.0/20 --name lab-space --description \"Private lab address space\" \
+    --label environment:lab --label team:networking
+
+Supply a stable ID for an exact retry or reconciliation workflow:
+    $ nico-admin-cli site-prefix create --tenant-organization-id fds34511233a \
+    --site-prefix-id 12345678-1234-5678-90ab-cdef01234567 \
+    --prefix 172.16.0.0/16 --name tenant-private-space
+
+")]
+pub(crate) struct Args {
+    #[clap(
+        long,
+        visible_alias = "tenant-org-id",
+        value_name = "TENANT_ORGANIZATION_ID",
+        help = "Tenant organization that will own the SitePrefix"
+    )]
+    tenant_organization_id: String,
+
+    #[clap(
+        long,
+        value_name = "CIDR",
+        help = "Canonical RFC1918 IPv4 prefix with a length from /8 through /31"
+    )]
+    prefix: IpNet,
+
+    #[clap(long, value_name = "NAME", help = "SitePrefix name")]
+    name: String,
+
+    #[clap(long, value_name = "DESCRIPTION", help = "SitePrefix description")]
+    description: Option<String>,
+
+    #[clap(
+        long = "label",
+        value_name = "KEY[:VALUE]",
+        action = clap::ArgAction::Append,
+        help = "Metadata label; repeat this option to add more than one"
+    )]
+    labels: Vec<String>,
+
+    #[clap(
+        long,
+        value_name = "SITE_PREFIX_ID",
+        help = "Use this SitePrefix ID instead of generating one locally"
+    )]
+    site_prefix_id: Option<SitePrefixId>,
+}
+
+impl From<Args> for SitePrefixCreationRequest {
+    fn from(args: Args) -> Self {
+        let id = match args.site_prefix_id {
+            Some(id) => id,
+            None => SitePrefixId::new(),
+        };
+
+        Self {
+            id: Some(id),
+            tenant_organization_id: args.tenant_organization_id,
+            prefix: args.prefix.to_string(),
+            metadata: Some(Metadata {
+                name: args.name,
+                description: args.description.unwrap_or_default(),
+                labels: parse_rpc_labels(args.labels),
+            }),
+        }
+    }
+}
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        let request: SitePrefixCreationRequest = self.into();
+        let site_prefix = ctx.api_client.0.create_site_prefix(request).await?;
+
+        SitePrefixOutput::one(site_prefix)
+            .write(&ctx.config.format, &mut ctx.output_file)
+            .await
+    }
+}

--- a/crates/admin-cli/src/site_prefix/delete.rs
+++ b/crates/admin-cli/src/site_prefix/delete.rs
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::site_prefix::SitePrefixId;
+use clap::Parser;
+use rpc::forge::SitePrefixDeletionRequest;
+
+use super::output::SitePrefixOutput;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::{CarbideCliError, CarbideCliResult};
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Record retirement intent for a tenant-managed SitePrefix:
+    $ nico-admin-cli site-prefix delete 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a
+
+Use the explicit retirement alias for the same operation:
+    $ nico-admin-cli site-prefix retire 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a
+
+")]
+pub(crate) struct Args {
+    #[clap(
+        value_name = "SITE_PREFIX_ID",
+        help = "SitePrefix to move into the Deleting state"
+    )]
+    site_prefix_id: SitePrefixId,
+
+    #[clap(
+        long,
+        visible_alias = "tenant-org-id",
+        value_name = "TENANT_ORGANIZATION_ID",
+        help = "Owning tenant organization; Core rejects a different tenant"
+    )]
+    tenant_organization_id: String,
+}
+
+impl From<Args> for SitePrefixDeletionRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            id: Some(args.site_prefix_id),
+            tenant_organization_id: args.tenant_organization_id,
+        }
+    }
+}
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        let request: SitePrefixDeletionRequest = self.into();
+        let response = ctx.api_client.0.delete_site_prefix(request).await?;
+        let site_prefix = response.site_prefix.ok_or_else(|| {
+            CarbideCliError::GenericError(
+                "the API did not return the retired SitePrefix".to_string(),
+            )
+        })?;
+
+        SitePrefixOutput::one(site_prefix)
+            .write(&ctx.config.format, &mut ctx.output_file)
+            .await
+    }
+}

--- a/crates/admin-cli/src/site_prefix/mod.rs
+++ b/crates/admin-cli/src/site_prefix/mod.rs
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+mod common;
+mod create;
+mod delete;
+mod output;
+mod show;
+mod state_history;
+mod update;
+
+#[cfg(test)]
+mod tests;
+
+use clap::Parser;
+
+use crate::cfg::dispatch::Dispatch;
+
+#[derive(Parser, Debug, Dispatch)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List SitePrefixes:
+    $ nico-admin-cli site-prefix show
+
+Show one SitePrefix by ID:
+    $ nico-admin-cli site-prefix show 12345678-1234-5678-90ab-cdef01234567
+
+Create a tenant-managed SitePrefix:
+    $ nico-admin-cli site-prefix create --tenant-organization-id fds34511233a \
+    --prefix 10.0.0.0/16 --name tenant-private-space
+
+Retire a tenant-managed SitePrefix:
+    $ nico-admin-cli site-prefix delete 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a
+
+")]
+#[clap(rename_all = "kebab_case")]
+pub(crate) enum Cmd {
+    /// List SitePrefixes or show one by ID
+    Show(show::Args),
+    /// Create a tenant-managed, datacenter-only SitePrefix in Provisioning
+    Create(create::Args),
+    /// Replace the complete metadata document on a tenant-managed SitePrefix
+    ///
+    /// Tenant ownership, CIDR, authority, and routing scope are immutable.
+    Update(update::Args),
+    /// Record retirement intent and return the retained Deleting SitePrefix
+    ///
+    /// This is not a force-delete path. The CIDR and quota slot remain in use
+    /// until child resources and the dataplane have drained.
+    #[clap(visible_alias = "retire")]
+    Delete(delete::Args),
+    /// Show all lifecycle state history for a SitePrefix, or an empty collection
+    StateHistory(state_history::Args),
+}

--- a/crates/admin-cli/src/site_prefix/output.rs
+++ b/crates/admin-cli/src/site_prefix/output.rs
@@ -1,0 +1,349 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use prettytable::{Cell, Row, Table};
+use rpc::admin_cli::OutputFormat;
+use rpc::forge::{
+    Metadata, SitePrefix, SitePrefixAuthority, SitePrefixLifecycleState, SitePrefixRoutingScope,
+};
+use serde::Serialize;
+
+use crate::errors::CarbideCliResult;
+use crate::{async_write, async_write_table_as_csv, async_writeln};
+
+#[derive(Debug, Serialize)]
+pub(super) struct SitePrefixView {
+    id: Option<String>,
+    prefix: Option<String>,
+    tenant_organization_id: Option<String>,
+    authority: Option<String>,
+    routing_scope: Option<String>,
+    lifecycle_state: Option<String>,
+    version: String,
+    quota: Option<QuotaView>,
+    metadata: Option<Metadata>,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct QuotaView {
+    used: u32,
+    limit: u32,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(super) enum SitePrefixOutput {
+    One(SitePrefixView),
+    Many(Vec<SitePrefixView>),
+}
+
+impl SitePrefixOutput {
+    pub(super) fn one(site_prefix: SitePrefix) -> Self {
+        Self::One(site_prefix.into())
+    }
+
+    pub(super) fn many(site_prefixes: Vec<SitePrefix>) -> Self {
+        Self::Many(site_prefixes.into_iter().map(Into::into).collect())
+    }
+
+    fn as_slice(&self) -> &[SitePrefixView] {
+        match self {
+            Self::One(site_prefix) => std::slice::from_ref(site_prefix),
+            Self::Many(site_prefixes) => site_prefixes.as_slice(),
+        }
+    }
+
+    fn table(&self) -> Table {
+        let mut table = Table::new();
+        table.set_titles(Row::new(
+            [
+                "SitePrefixId",
+                "Tenant Organization ID",
+                "Authority",
+                "Prefix",
+                "Routing Scope",
+                "Lifecycle State",
+                "Version",
+                "Quota",
+                "Name",
+            ]
+            .into_iter()
+            .map(Cell::new)
+            .collect(),
+        ));
+
+        for site_prefix in self.as_slice() {
+            table.add_row(Row::new(
+                site_prefix
+                    .row_values()
+                    .iter()
+                    .map(|value| Cell::new(value))
+                    .collect(),
+            ));
+        }
+
+        table
+    }
+
+    pub(super) async fn write(
+        &self,
+        format: &OutputFormat,
+        output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    ) -> CarbideCliResult<()> {
+        match format {
+            OutputFormat::Json => {
+                async_writeln!(output_file, "{}", serde_json::to_string_pretty(self)?)?
+            }
+            OutputFormat::Yaml => async_write!(output_file, "{}", serde_yaml::to_string(self)?)?,
+            OutputFormat::AsciiTable => async_write!(output_file, "{}", self.table())?,
+            OutputFormat::Csv => async_write_table_as_csv!(output_file, self.table())?,
+        }
+
+        Ok(())
+    }
+}
+
+impl SitePrefixView {
+    fn quota_display(&self) -> String {
+        self.quota
+            .as_ref()
+            .map(|quota| format!("{}/{}", quota.used, quota.limit))
+            .unwrap_or_else(|| "NA".to_string())
+    }
+
+    fn row_values(&self) -> Vec<String> {
+        let name = self
+            .metadata
+            .as_ref()
+            .map(|metadata| metadata.name.clone())
+            .unwrap_or_default();
+
+        vec![
+            self.id.clone().unwrap_or_default(),
+            self.tenant_organization_id.clone().unwrap_or_default(),
+            self.authority.clone().unwrap_or_else(|| "NA".to_string()),
+            self.prefix.clone().unwrap_or_default(),
+            self.routing_scope
+                .clone()
+                .unwrap_or_else(|| "NA".to_string()),
+            self.lifecycle_state
+                .clone()
+                .unwrap_or_else(|| "NA".to_string()),
+            self.version.clone(),
+            self.quota_display(),
+            name,
+        ]
+    }
+}
+
+impl From<SitePrefix> for SitePrefixView {
+    fn from(site_prefix: SitePrefix) -> Self {
+        let (prefix, tenant_organization_id, routing_scope) = match site_prefix.config {
+            Some(config) => (
+                Some(config.prefix),
+                config.tenant_organization_id,
+                Some(routing_scope_name(config.routing_scope)),
+            ),
+            None => (None, None, None),
+        };
+        let (authority, lifecycle_state, quota) = match site_prefix.status {
+            Some(status) => (
+                Some(authority_name(status.authority)),
+                Some(lifecycle_state_name(status.lifecycle_state)),
+                status.quota.map(|quota| QuotaView {
+                    used: quota.used,
+                    limit: quota.limit,
+                }),
+            ),
+            None => (None, None, None),
+        };
+
+        Self {
+            id: site_prefix.id.map(|id| id.to_string()),
+            prefix,
+            tenant_organization_id,
+            authority,
+            routing_scope,
+            lifecycle_state,
+            version: site_prefix.version,
+            quota,
+            metadata: site_prefix.metadata,
+            created_at: site_prefix.created_at.map(|time| time.to_string()),
+            updated_at: site_prefix.updated_at.map(|time| time.to_string()),
+        }
+    }
+}
+
+fn authority_name(value: i32) -> String {
+    match SitePrefixAuthority::try_from(value) {
+        Ok(SitePrefixAuthority::OperatorManaged) => "operator-managed".to_string(),
+        Ok(SitePrefixAuthority::TenantManaged) => "tenant-managed".to_string(),
+        Ok(SitePrefixAuthority::Unspecified) => "unspecified".to_string(),
+        Err(_) => format!("unknown ({value})"),
+    }
+}
+
+fn routing_scope_name(value: i32) -> String {
+    match SitePrefixRoutingScope::try_from(value) {
+        Ok(SitePrefixRoutingScope::DatacenterOnly) => "datacenter-only".to_string(),
+        Ok(SitePrefixRoutingScope::Unspecified) => "unspecified".to_string(),
+        Err(_) => format!("unknown ({value})"),
+    }
+}
+
+fn lifecycle_state_name(value: i32) -> String {
+    match SitePrefixLifecycleState::try_from(value) {
+        Ok(SitePrefixLifecycleState::Provisioning) => "provisioning".to_string(),
+        Ok(SitePrefixLifecycleState::Ready) => "ready".to_string(),
+        Ok(SitePrefixLifecycleState::Deleting) => "deleting".to_string(),
+        Ok(SitePrefixLifecycleState::Error) => "error".to_string(),
+        Ok(SitePrefixLifecycleState::Unspecified) => "unspecified".to_string(),
+        Err(_) => format!("unknown ({value})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+    use carbide_uuid::site_prefix::SitePrefixId;
+    use rpc::forge::{SitePrefixConfig, SitePrefixQuotaUsage, SitePrefixStatus};
+
+    use super::*;
+
+    #[test]
+    fn authority_names_are_operator_facing() {
+        value_scenarios!(authority_name:
+            "known authorities" {
+                SitePrefixAuthority::OperatorManaged as i32 => "operator-managed".to_string(),
+                SitePrefixAuthority::TenantManaged as i32 => "tenant-managed".to_string(),
+                SitePrefixAuthority::Unspecified as i32 => "unspecified".to_string(),
+            }
+
+            "unknown authority" {
+                99 => "unknown (99)".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn routing_scope_names_are_operator_facing() {
+        value_scenarios!(routing_scope_name:
+            "known routing scopes" {
+                SitePrefixRoutingScope::DatacenterOnly as i32 => "datacenter-only".to_string(),
+                SitePrefixRoutingScope::Unspecified as i32 => "unspecified".to_string(),
+            }
+
+            "unknown routing scope" {
+                99 => "unknown (99)".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn lifecycle_state_names_are_operator_facing() {
+        value_scenarios!(lifecycle_state_name:
+            "known lifecycle states" {
+                SitePrefixLifecycleState::Provisioning as i32 => "provisioning".to_string(),
+                SitePrefixLifecycleState::Ready as i32 => "ready".to_string(),
+                SitePrefixLifecycleState::Deleting as i32 => "deleting".to_string(),
+                SitePrefixLifecycleState::Error as i32 => "error".to_string(),
+                SitePrefixLifecycleState::Unspecified as i32 => "unspecified".to_string(),
+            }
+
+            "unknown lifecycle state" {
+                99 => "unknown (99)".to_string(),
+            }
+        );
+    }
+
+    struct OutputCase {
+        authority: SitePrefixAuthority,
+        tenant_organization_id: Option<&'static str>,
+        quota: Option<(u32, u32)>,
+    }
+
+    type OutputSummary = (Option<String>, Option<String>, Option<(u32, u32)>, String);
+
+    fn output_summary(
+        OutputCase {
+            authority,
+            tenant_organization_id,
+            quota,
+        }: OutputCase,
+    ) -> OutputSummary {
+        let site_prefix = SitePrefix {
+            id: Some(SitePrefixId::new()),
+            config: Some(SitePrefixConfig {
+                prefix: "10.0.0.0/16".to_string(),
+                tenant_organization_id: tenant_organization_id.map(str::to_string),
+                routing_scope: SitePrefixRoutingScope::DatacenterOnly as i32,
+            }),
+            status: Some(SitePrefixStatus {
+                authority: authority as i32,
+                lifecycle_state: SitePrefixLifecycleState::Ready as i32,
+                quota: quota.map(|(used, limit)| SitePrefixQuotaUsage { used, limit }),
+            }),
+            metadata: Some(Metadata::default()),
+            version: "V1-T0".to_string(),
+            created_at: None,
+            updated_at: None,
+        };
+        let view = SitePrefixView::from(site_prefix);
+        let table_quota = view.quota_display();
+        let quota = view.quota.as_ref().map(|quota| (quota.used, quota.limit));
+
+        (
+            view.authority,
+            view.tenant_organization_id,
+            quota,
+            table_quota,
+        )
+    }
+
+    #[test]
+    fn structured_and_table_output_distinguish_authority_and_quota() {
+        value_scenarios!(output_summary:
+            "operator-managed resource" {
+                OutputCase {
+                    authority: SitePrefixAuthority::OperatorManaged,
+                    tenant_organization_id: None,
+                    quota: None,
+                } => (
+                    Some("operator-managed".to_string()),
+                    None,
+                    None,
+                    "NA".to_string(),
+                ),
+            }
+
+            "tenant-managed resource" {
+                OutputCase {
+                    authority: SitePrefixAuthority::TenantManaged,
+                    tenant_organization_id: Some("fds34511233a"),
+                    quota: Some((3, 8)),
+                } => (
+                    Some("tenant-managed".to_string()),
+                    Some("fds34511233a".to_string()),
+                    Some((3, 8)),
+                    "3/8".to_string(),
+                ),
+            }
+        );
+    }
+}

--- a/crates/admin-cli/src/site_prefix/show.rs
+++ b/crates/admin-cli/src/site_prefix/show.rs
@@ -1,0 +1,232 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::site_prefix::SitePrefixId;
+use clap::{Parser, ValueEnum};
+use ipnet::IpNet;
+use rpc::forge::{
+    PrefixMatchType, SitePrefixAuthority, SitePrefixLifecycleState, SitePrefixRoutingScope,
+    SitePrefixSearchFilter,
+};
+
+use super::common::{find_by_ids, find_ids, find_one_by_id};
+use super::output::SitePrefixOutput;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+List all SitePrefixes:
+    $ nico-admin-cli site-prefix show
+
+Show one SitePrefix by ID:
+    $ nico-admin-cli site-prefix show 12345678-1234-5678-90ab-cdef01234567
+
+List tenant-managed SitePrefixes for one tenant:
+    $ nico-admin-cli site-prefix show --tenant-organization-id fds34511233a \
+    --authority tenant-managed
+
+List every SitePrefix with the same exact CIDR:
+    $ nico-admin-cli site-prefix show --prefix 10.0.0.0/16
+
+Limit an exact CIDR lookup to one tenant:
+    $ nico-admin-cli site-prefix show --prefix 10.0.0.0/16 \
+    --tenant-organization-id fds34511233a
+
+Find ready SitePrefixes that contain a smaller prefix:
+    $ nico-admin-cli site-prefix show --contains 10.0.8.0/24 --lifecycle-state ready
+
+")]
+pub(crate) struct Args {
+    #[clap(
+        value_name = "SITE_PREFIX_ID",
+        help = "SitePrefix ID to show; omit to search inventory",
+        conflicts_with_all = [
+            "tenant_organization_id",
+            "authority",
+            "routing_scope",
+            "lifecycle_state",
+            "prefix",
+            "contains",
+            "contained_by"
+        ]
+    )]
+    site_prefix_id: Option<SitePrefixId>,
+
+    #[clap(
+        long,
+        visible_alias = "tenant-org-id",
+        value_name = "TENANT_ORGANIZATION_ID",
+        help = "Return tenant-managed SitePrefixes owned by this tenant"
+    )]
+    tenant_organization_id: Option<String>,
+
+    #[clap(long, value_enum, help = "Filter by management authority")]
+    authority: Option<AuthorityArg>,
+
+    #[clap(long, value_enum, help = "Filter by routing scope")]
+    routing_scope: Option<RoutingScopeArg>,
+
+    #[clap(long, value_enum, help = "Filter by lifecycle state")]
+    lifecycle_state: Option<LifecycleStateArg>,
+
+    #[clap(
+        long,
+        value_name = "CIDR",
+        help = "Return every SitePrefix with this exact CIDR",
+        conflicts_with_all = ["contains", "contained_by"]
+    )]
+    prefix: Option<IpNet>,
+
+    #[clap(
+        long,
+        value_name = "CIDR",
+        help = "Return SitePrefixes that contain this prefix",
+        conflicts_with = "contained_by"
+    )]
+    contains: Option<IpNet>,
+
+    #[clap(
+        long,
+        value_name = "CIDR",
+        help = "Return SitePrefixes contained by this prefix"
+    )]
+    contained_by: Option<IpNet>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum AuthorityArg {
+    #[value(name = "operator-managed")]
+    Operator,
+    #[value(name = "tenant-managed")]
+    Tenant,
+}
+
+impl From<AuthorityArg> for SitePrefixAuthority {
+    fn from(value: AuthorityArg) -> Self {
+        match value {
+            AuthorityArg::Operator => Self::OperatorManaged,
+            AuthorityArg::Tenant => Self::TenantManaged,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "kebab_case")]
+enum RoutingScopeArg {
+    DatacenterOnly,
+}
+
+impl From<RoutingScopeArg> for SitePrefixRoutingScope {
+    fn from(value: RoutingScopeArg) -> Self {
+        match value {
+            RoutingScopeArg::DatacenterOnly => Self::DatacenterOnly,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[clap(rename_all = "kebab_case")]
+enum LifecycleStateArg {
+    Provisioning,
+    Ready,
+    Deleting,
+    Error,
+}
+
+impl From<LifecycleStateArg> for SitePrefixLifecycleState {
+    fn from(value: LifecycleStateArg) -> Self {
+        match value {
+            LifecycleStateArg::Provisioning => Self::Provisioning,
+            LifecycleStateArg::Ready => Self::Ready,
+            LifecycleStateArg::Deleting => Self::Deleting,
+            LifecycleStateArg::Error => Self::Error,
+        }
+    }
+}
+
+pub(super) enum ShowMethod {
+    Get(SitePrefixId),
+    Search(SitePrefixSearchFilter),
+}
+
+impl From<Args> for ShowMethod {
+    fn from(args: Args) -> Self {
+        if let Some(site_prefix_id) = args.site_prefix_id {
+            return Self::Get(site_prefix_id);
+        }
+
+        let (prefix_match, prefix_match_type) = if let Some(prefix) = args.prefix {
+            (
+                Some(prefix.to_string()),
+                Some(PrefixMatchType::PrefixExact as i32),
+            )
+        } else if let Some(prefix) = args.contains {
+            (
+                Some(prefix.to_string()),
+                Some(PrefixMatchType::PrefixContains as i32),
+            )
+        } else if let Some(prefix) = args.contained_by {
+            (
+                Some(prefix.to_string()),
+                Some(PrefixMatchType::PrefixContainedBy as i32),
+            )
+        } else {
+            (None, None)
+        };
+
+        Self::Search(SitePrefixSearchFilter {
+            tenant_organization_id: args.tenant_organization_id,
+            authority: args
+                .authority
+                .map(|authority| SitePrefixAuthority::from(authority) as i32),
+            routing_scope: args
+                .routing_scope
+                .map(|routing_scope| SitePrefixRoutingScope::from(routing_scope) as i32),
+            lifecycle_state: args
+                .lifecycle_state
+                .map(|lifecycle_state| SitePrefixLifecycleState::from(lifecycle_state) as i32),
+            prefix_match,
+            prefix_match_type,
+        })
+    }
+}
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        let output = match ShowMethod::from(self) {
+            ShowMethod::Get(site_prefix_id) => {
+                SitePrefixOutput::one(find_one_by_id(&ctx.api_client, site_prefix_id).await?)
+            }
+            ShowMethod::Search(filter) => {
+                let site_prefix_ids = find_ids(&ctx.api_client, filter).await?;
+                let site_prefixes = find_by_ids(
+                    &ctx.api_client,
+                    ctx.config.page_size,
+                    site_prefix_ids.as_slice(),
+                )
+                .await?;
+                SitePrefixOutput::many(site_prefixes)
+            }
+        };
+
+        output.write(&ctx.config.format, &mut ctx.output_file).await
+    }
+}

--- a/crates/admin-cli/src/site_prefix/state_history.rs
+++ b/crates/admin-cli/src/site_prefix/state_history.rs
@@ -1,0 +1,148 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::site_prefix::SitePrefixId;
+use clap::Parser;
+use prettytable::{Cell, Row, Table};
+use rpc::admin_cli::OutputFormat;
+use rpc::forge::StateHistoryRecord;
+use serde::{Deserialize, Serialize};
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+use crate::{async_write, async_write_table_as_csv, async_writeln};
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Show every lifecycle transition recorded for a SitePrefix:
+    $ nico-admin-cli site-prefix state-history 12345678-1234-5678-90ab-cdef01234567
+
+")]
+pub(crate) struct Args {
+    #[clap(value_name = "SITE_PREFIX_ID", help = "SitePrefix history to show")]
+    site_prefix_id: SitePrefixId,
+}
+
+#[derive(Debug, Serialize)]
+struct HistoryRecordView {
+    state: String,
+    version: String,
+    time: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LifecycleStateDocument {
+    state: String,
+}
+
+impl From<StateHistoryRecord> for HistoryRecordView {
+    fn from(record: StateHistoryRecord) -> Self {
+        Self {
+            state: display_state(&record.state),
+            version: record.version,
+            time: record.time.map(|time| time.to_string()),
+        }
+    }
+}
+
+impl HistoryRecordView {
+    fn table(records: &[Self]) -> Table {
+        let mut table = Table::new();
+        table.set_titles(Row::new(
+            ["State", "Version", "Time"]
+                .into_iter()
+                .map(Cell::new)
+                .collect(),
+        ));
+        for record in records {
+            table.add_row(Row::new(vec![
+                Cell::new(&record.state),
+                Cell::new(&record.version),
+                Cell::new(record.time.as_deref().unwrap_or_default()),
+            ]));
+        }
+        table
+    }
+}
+
+fn display_state(state: &str) -> String {
+    serde_json::from_str::<LifecycleStateDocument>(state)
+        .map(|document| document.state)
+        .unwrap_or_else(|_| state.to_string())
+}
+
+async fn write_history(
+    records: &[HistoryRecordView],
+    format: &OutputFormat,
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+) -> CarbideCliResult<()> {
+    match format {
+        OutputFormat::Json => {
+            async_writeln!(output_file, "{}", serde_json::to_string_pretty(records)?)?
+        }
+        OutputFormat::Yaml => async_write!(output_file, "{}", serde_yaml::to_string(records)?)?,
+        OutputFormat::AsciiTable => {
+            async_write!(output_file, "{}", HistoryRecordView::table(records))?
+        }
+        OutputFormat::Csv => {
+            async_write_table_as_csv!(output_file, HistoryRecordView::table(records))?
+        }
+    }
+
+    Ok(())
+}
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        let history = ctx
+            .api_client
+            .get_site_prefix_state_history(self.site_prefix_id)
+            .await?
+            .into_iter()
+            .map(HistoryRecordView::from)
+            .collect::<Vec<_>>();
+
+        write_history(&history, &ctx.config.format, &mut ctx.output_file).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::display_state;
+
+    #[test]
+    fn lifecycle_state_json_is_readable() {
+        value_scenarios!(display_state:
+            "state documents" {
+                r#"{"state":"provisioning"}"# => "provisioning".to_string(),
+                r#"{"state":"ready"}"# => "ready".to_string(),
+                r#"{"state":"deleting"}"# => "deleting".to_string(),
+                r#"{"state":"error"}"# => "error".to_string(),
+            }
+
+            "legacy or malformed values" {
+                "Ready" => "Ready".to_string(),
+                "not-json" => "not-json".to_string(),
+            }
+        );
+    }
+}

--- a/crates/admin-cli/src/site_prefix/tests.rs
+++ b/crates/admin-cli/src/site_prefix/tests.rs
@@ -1,0 +1,513 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_test_support::Outcome::*;
+use carbide_test_support::scenarios;
+use carbide_uuid::site_prefix::SitePrefixId;
+use clap::{CommandFactory, Parser};
+use rpc::forge::{
+    PrefixMatchType, SitePrefixCreationRequest, SitePrefixDeletionRequest, SitePrefixUpdateRequest,
+};
+
+use super::show::ShowMethod;
+use super::*;
+use crate::test_support::parse_leaf;
+
+const SITE_PREFIX_ID: &str = "12345678-1234-5678-90ab-cdef01234567";
+const TENANT_ORGANIZATION_ID: &str = "fds34511233a";
+
+#[test]
+fn command_tree_is_valid() {
+    Cmd::command().debug_assert();
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ShowRequestView {
+    site_prefix_id: Option<String>,
+    tenant_organization_id: Option<String>,
+    authority: Option<i32>,
+    routing_scope: Option<i32>,
+    lifecycle_state: Option<i32>,
+    prefix_match: Option<String>,
+    prefix_match_type: Option<i32>,
+}
+
+fn show_request(argv: &[&str]) -> Result<ShowRequestView, ()> {
+    let Cmd::Show(args) = Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? else {
+        return Err(());
+    };
+
+    Ok(match ShowMethod::from(args) {
+        ShowMethod::Get(site_prefix_id) => ShowRequestView {
+            site_prefix_id: Some(site_prefix_id.to_string()),
+            tenant_organization_id: None,
+            authority: None,
+            routing_scope: None,
+            lifecycle_state: None,
+            prefix_match: None,
+            prefix_match_type: None,
+        },
+        ShowMethod::Search(filter) => ShowRequestView {
+            site_prefix_id: None,
+            tenant_organization_id: filter.tenant_organization_id,
+            authority: filter.authority,
+            routing_scope: filter.routing_scope,
+            lifecycle_state: filter.lifecycle_state,
+            prefix_match: filter.prefix_match,
+            prefix_match_type: filter.prefix_match_type,
+        },
+    })
+}
+
+#[test]
+fn show_builds_duplicate_safe_requests() {
+    scenarios!(
+        run = show_request;
+        "inventory" {
+            &["site-prefix", "show"][..] => Yields(ShowRequestView {
+                site_prefix_id: None,
+                tenant_organization_id: None,
+                authority: None,
+                routing_scope: None,
+                lifecycle_state: None,
+                prefix_match: None,
+                prefix_match_type: None,
+            }),
+        }
+
+        "one resource by globally unique ID" {
+            &["site-prefix", "show", SITE_PREFIX_ID][..] => Yields(ShowRequestView {
+                site_prefix_id: Some(SITE_PREFIX_ID.to_string()),
+                tenant_organization_id: None,
+                authority: None,
+                routing_scope: None,
+                lifecycle_state: None,
+                prefix_match: None,
+                prefix_match_type: None,
+            }),
+        }
+
+        "an exact CIDR without a tenant remains a multi-match search" {
+            &["site-prefix", "show", "--prefix", "10.0.0.0/16"][..] => Yields(ShowRequestView {
+                site_prefix_id: None,
+                tenant_organization_id: None,
+                authority: None,
+                routing_scope: None,
+                lifecycle_state: None,
+                prefix_match: Some("10.0.0.0/16".to_string()),
+                prefix_match_type: Some(PrefixMatchType::PrefixExact as i32),
+            }),
+        }
+
+        "an exact CIDR can be scoped to its owning tenant" {
+            &[
+                "site-prefix",
+                "show",
+                "--prefix",
+                "10.0.0.0/16",
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+            ][..] => Yields(ShowRequestView {
+                site_prefix_id: None,
+                tenant_organization_id: Some(TENANT_ORGANIZATION_ID.to_string()),
+                authority: None,
+                routing_scope: None,
+                lifecycle_state: None,
+                prefix_match: Some("10.0.0.0/16".to_string()),
+                prefix_match_type: Some(PrefixMatchType::PrefixExact as i32),
+            }),
+        }
+
+        "inventory filters combine" {
+            &[
+                "site-prefix",
+                "show",
+                "--tenant-org-id",
+                TENANT_ORGANIZATION_ID,
+                "--authority",
+                "tenant-managed",
+                "--routing-scope",
+                "datacenter-only",
+                "--lifecycle-state",
+                "ready",
+                "--contained-by",
+                "10.0.0.0/8",
+            ][..] => Yields(ShowRequestView {
+                site_prefix_id: None,
+                tenant_organization_id: Some(TENANT_ORGANIZATION_ID.to_string()),
+                authority: Some(rpc::forge::SitePrefixAuthority::TenantManaged as i32),
+                routing_scope: Some(rpc::forge::SitePrefixRoutingScope::DatacenterOnly as i32),
+                lifecycle_state: Some(rpc::forge::SitePrefixLifecycleState::Ready as i32),
+                prefix_match: Some("10.0.0.0/8".to_string()),
+                prefix_match_type: Some(PrefixMatchType::PrefixContainedBy as i32),
+            }),
+        }
+
+        "contains uses the API's containing-prefix relationship" {
+            &["site-prefix", "show", "--contains", "10.0.8.0/24"][..] => Yields(ShowRequestView {
+                site_prefix_id: None,
+                tenant_organization_id: None,
+                authority: None,
+                routing_scope: None,
+                lifecycle_state: None,
+                prefix_match: Some("10.0.8.0/24".to_string()),
+                prefix_match_type: Some(PrefixMatchType::PrefixContains as i32),
+            }),
+        }
+    );
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct CreateRequestView {
+    has_id: bool,
+    tenant_organization_id: String,
+    prefix: String,
+    name: String,
+    description: String,
+    labels: Vec<(String, Option<String>)>,
+}
+
+fn create_request(argv: &[&str]) -> Result<(SitePrefixCreationRequest, CreateRequestView), ()> {
+    let Cmd::Create(args) = Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? else {
+        return Err(());
+    };
+    let request = SitePrefixCreationRequest::from(args);
+    let metadata = request.metadata.as_ref().ok_or(())?;
+    let view = CreateRequestView {
+        has_id: request.id.is_some(),
+        tenant_organization_id: request.tenant_organization_id.clone(),
+        prefix: request.prefix.clone(),
+        name: metadata.name.clone(),
+        description: metadata.description.clone(),
+        labels: metadata
+            .labels
+            .iter()
+            .map(|label| (label.key.clone(), label.value.clone()))
+            .collect(),
+    };
+    Ok((request, view))
+}
+
+#[test]
+fn create_builds_complete_tenant_requests() {
+    scenarios!(
+        run = |argv| create_request(argv).map(|(_, view)| view);
+        "required fields generate an ID and empty optional metadata" {
+            &[
+                "site-prefix",
+                "create",
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+                "--prefix",
+                "10.0.0.0/16",
+                "--name",
+                "private-space",
+            ][..] => Yields(CreateRequestView {
+                has_id: true,
+                tenant_organization_id: TENANT_ORGANIZATION_ID.to_string(),
+                prefix: "10.0.0.0/16".to_string(),
+                name: "private-space".to_string(),
+                description: String::new(),
+                labels: Vec::new(),
+            }),
+        }
+
+        "description and repeated labels are preserved" {
+            &[
+                "site-prefix",
+                "create",
+                "--tenant-org-id",
+                TENANT_ORGANIZATION_ID,
+                "--prefix",
+                "192.168.0.0/20",
+                "--name",
+                "lab-space",
+                "--description",
+                "Lab address space",
+                "--label",
+                "environment:lab",
+                "--label",
+                "owner",
+            ][..] => Yields(CreateRequestView {
+                has_id: true,
+                tenant_organization_id: TENANT_ORGANIZATION_ID.to_string(),
+                prefix: "192.168.0.0/20".to_string(),
+                name: "lab-space".to_string(),
+                description: "Lab address space".to_string(),
+                labels: vec![
+                    ("environment".to_string(), Some("lab".to_string())),
+                    ("owner".to_string(), None),
+                ],
+            }),
+        }
+    );
+}
+
+#[test]
+fn create_generates_distinct_non_nil_ids() {
+    let argv = [
+        "site-prefix",
+        "create",
+        "--tenant-organization-id",
+        TENANT_ORGANIZATION_ID,
+        "--prefix",
+        "10.0.0.0/16",
+        "--name",
+        "private-space",
+    ];
+    let first = create_request(&argv)
+        .expect("the first create arguments are valid")
+        .0
+        .id
+        .expect("create generates an ID");
+    let second = create_request(&argv)
+        .expect("the second create arguments are valid")
+        .0
+        .id
+        .expect("create generates an ID");
+
+    assert_ne!(first, SitePrefixId::nil());
+    assert_ne!(first, second);
+}
+
+#[test]
+fn create_preserves_a_caller_supplied_id() {
+    let (request, _) = create_request(&[
+        "site-prefix",
+        "create",
+        "--tenant-organization-id",
+        TENANT_ORGANIZATION_ID,
+        "--site-prefix-id",
+        SITE_PREFIX_ID,
+        "--prefix",
+        "172.16.0.0/16",
+        "--name",
+        "private-space",
+    ])
+    .expect("create arguments should produce a request");
+
+    assert_eq!(request.id, Some(SITE_PREFIX_ID.parse().unwrap()));
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct UpdateRequestView {
+    site_prefix_id: String,
+    tenant_organization_id: String,
+    name: String,
+    description: String,
+    labels: Vec<(String, Option<String>)>,
+    if_version_match: Option<String>,
+}
+
+fn update_request(argv: &[&str]) -> Result<UpdateRequestView, ()> {
+    let Cmd::Update(args) = Cmd::try_parse_from(argv.iter().copied()).map_err(drop)? else {
+        return Err(());
+    };
+    let request = SitePrefixUpdateRequest::from(args);
+    let metadata = request.metadata.ok_or(())?;
+
+    Ok(UpdateRequestView {
+        site_prefix_id: request.id.ok_or(())?.to_string(),
+        tenant_organization_id: request.tenant_organization_id,
+        name: metadata.name,
+        description: metadata.description,
+        labels: metadata
+            .labels
+            .into_iter()
+            .map(|label| (label.key, label.value))
+            .collect(),
+        if_version_match: request.if_version_match,
+    })
+}
+
+#[test]
+fn update_builds_complete_metadata_replacements() {
+    scenarios!(
+        run = update_request;
+        "omitted optional metadata clears the old values" {
+            &[
+                "site-prefix",
+                "update",
+                SITE_PREFIX_ID,
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+                "--name",
+                "new-name",
+            ][..] => Yields(UpdateRequestView {
+                site_prefix_id: SITE_PREFIX_ID.to_string(),
+                tenant_organization_id: TENANT_ORGANIZATION_ID.to_string(),
+                name: "new-name".to_string(),
+                description: String::new(),
+                labels: Vec::new(),
+                if_version_match: None,
+            }),
+        }
+
+        "description, labels, and expected version are preserved" {
+            &[
+                "site-prefix",
+                "update",
+                SITE_PREFIX_ID,
+                "--tenant-org-id",
+                TENANT_ORGANIZATION_ID,
+                "--name",
+                "new-name",
+                "--description",
+                "new description",
+                "--label",
+                "environment:production",
+                "--label",
+                "owner",
+                "--if-version-match",
+                "V4-T1750000000000000",
+            ][..] => Yields(UpdateRequestView {
+                site_prefix_id: SITE_PREFIX_ID.to_string(),
+                tenant_organization_id: TENANT_ORGANIZATION_ID.to_string(),
+                name: "new-name".to_string(),
+                description: "new description".to_string(),
+                labels: vec![
+                    ("environment".to_string(), Some("production".to_string())),
+                    ("owner".to_string(), None),
+                ],
+                if_version_match: Some("V4-T1750000000000000".to_string()),
+            }),
+        }
+    );
+}
+
+#[test]
+fn delete_and_retire_build_the_same_retirement_request() {
+    scenarios!(
+        run = |command| {
+            let argv = [
+                "site-prefix",
+                command,
+                SITE_PREFIX_ID,
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+            ];
+            let Cmd::Delete(args) = Cmd::try_parse_from(argv).map_err(drop)? else {
+                return Err(());
+            };
+            let request = SitePrefixDeletionRequest::from(args);
+            Ok((
+                request.id.map(|id| id.to_string()),
+                request.tenant_organization_id,
+            ))
+        };
+        "canonical delete command" {
+            "delete" => Yields((
+                Some(SITE_PREFIX_ID.to_string()),
+                TENANT_ORGANIZATION_ID.to_string(),
+            )),
+        }
+
+        "explicit retirement alias" {
+            "retire" => Yields((
+                Some(SITE_PREFIX_ID.to_string()),
+                TENANT_ORGANIZATION_ID.to_string(),
+            )),
+        }
+    );
+}
+
+#[test]
+fn state_history_requires_an_id() {
+    let matches = parse_leaf::<Cmd>(
+        &["site-prefix", "state-history", SITE_PREFIX_ID],
+        &["state-history"],
+    )
+    .expect("state-history arguments should parse");
+
+    assert_eq!(
+        matches
+            .get_one::<SitePrefixId>("site_prefix_id")
+            .map(ToString::to_string),
+        Some(SITE_PREFIX_ID.to_string())
+    );
+}
+
+#[test]
+fn invalid_invocations_fail_during_parsing() {
+    scenarios!(
+        run = |argv| Cmd::try_parse_from(argv.iter().copied()).map(drop).map_err(drop);
+        "show cannot combine an ID with inventory filters" {
+            &[
+                "site-prefix",
+                "show",
+                SITE_PREFIX_ID,
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+            ][..] => Fails,
+        }
+
+        "show cannot combine exact and contains relationships" {
+            &[
+                "site-prefix",
+                "show",
+                "--prefix",
+                "10.0.0.0/16",
+                "--contains",
+                "10.0.1.0/24",
+            ][..] => Fails,
+        }
+
+        "show cannot combine contains and contained-by relationships" {
+            &[
+                "site-prefix",
+                "show",
+                "--contains",
+                "10.0.1.0/24",
+                "--contained-by",
+                "10.0.0.0/8",
+            ][..] => Fails,
+        }
+
+        "create requires a tenant" {
+            &["site-prefix", "create", "--prefix", "10.0.0.0/16", "--name", "private-space"][..] => Fails,
+        }
+
+        "create requires a prefix" {
+            &[
+                "site-prefix",
+                "create",
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+                "--name",
+                "private-space",
+            ][..] => Fails,
+        }
+
+        "update requires replacement metadata name" {
+            &[
+                "site-prefix",
+                "update",
+                SITE_PREFIX_ID,
+                "--tenant-organization-id",
+                TENANT_ORGANIZATION_ID,
+            ][..] => Fails,
+        }
+
+        "delete requires the owning tenant" {
+            &["site-prefix", "delete", SITE_PREFIX_ID][..] => Fails,
+        }
+
+        "state-history requires an ID" {
+            &["site-prefix", "state-history"][..] => Fails,
+        }
+    );
+}

--- a/crates/admin-cli/src/site_prefix/update.rs
+++ b/crates/admin-cli/src/site_prefix/update.rs
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_uuid::site_prefix::SitePrefixId;
+use clap::Parser;
+use rpc::forge::{Metadata, SitePrefixUpdateRequest};
+
+use super::output::SitePrefixOutput;
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+use crate::metadata::parse_rpc_labels;
+
+#[derive(Parser, Debug)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Replace the metadata on a tenant-managed SitePrefix:
+    $ nico-admin-cli site-prefix update 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --name production-space \
+    --description \"Production private address space\" --label environment:production
+
+Reject the update if the SitePrefix changed since it was read:
+    $ nico-admin-cli site-prefix update 12345678-1234-5678-90ab-cdef01234567 \
+    --tenant-organization-id fds34511233a --name production-space \
+    --if-version-match V4-T1750000000000000
+
+")]
+pub(crate) struct Args {
+    #[clap(value_name = "SITE_PREFIX_ID", help = "SitePrefix to update")]
+    site_prefix_id: SitePrefixId,
+
+    #[clap(
+        long,
+        visible_alias = "tenant-org-id",
+        value_name = "TENANT_ORGANIZATION_ID",
+        help = "Owning tenant organization; Core rejects a different tenant"
+    )]
+    tenant_organization_id: String,
+
+    #[clap(long, value_name = "NAME", help = "Replacement SitePrefix name")]
+    name: String,
+
+    #[clap(
+        long,
+        value_name = "DESCRIPTION",
+        help = "Replacement description; omit this option to clear the description"
+    )]
+    description: Option<String>,
+
+    #[clap(
+        long = "label",
+        value_name = "KEY[:VALUE]",
+        action = clap::ArgAction::Append,
+        help = "Replacement metadata label; repeat for more than one and omit all labels to clear them"
+    )]
+    labels: Vec<String>,
+
+    #[clap(
+        long,
+        value_name = "VERSION",
+        help = "Update only when the stored SitePrefix has this V<number>-T<Unix-epoch-microseconds> version"
+    )]
+    if_version_match: Option<String>,
+}
+
+impl From<Args> for SitePrefixUpdateRequest {
+    fn from(args: Args) -> Self {
+        Self {
+            id: Some(args.site_prefix_id),
+            tenant_organization_id: args.tenant_organization_id,
+            metadata: Some(Metadata {
+                name: args.name,
+                description: args.description.unwrap_or_default(),
+                labels: parse_rpc_labels(args.labels),
+            }),
+            if_version_match: args.if_version_match,
+        }
+    }
+}
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        let request: SitePrefixUpdateRequest = self.into();
+        let site_prefix = ctx.api_client.0.update_site_prefix(request).await?;
+
+        SitePrefixOutput::one(site_prefix)
+            .write(&ctx.config.format, &mut ctx.output_file)
+            .await
+    }
+}


### PR DESCRIPTION
This adds `nico-admin-cli site-prefix` commands to list or show SitePrefixes, create tenant-managed prefixes, replace their metadata, retire them, and inspect lifecycle history.

SitePrefix IDs remain the identity because multiple tenants can own the same CIDR. Exact-CIDR searches therefore return collections, with optional tenant scoping. `delete` records retirement intent and returns the retained `Deleting` resource; it does not force-delete address space that may still have child resources or dataplane state.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4226

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Verified the top-level command and the `show`, `create`, `update`, `delete`, and `state-history` help output directly. The generated CLI reference belongs in the repository workflow's companion documentation Task and PR.

Closes #4226
