### PR TITLE
fix(api): make reverse DNS safe for duplicate addresses

### DIFF
--- a/crates/api-core/src/db_init.rs
+++ b/crates/api-core/src/db_init.rs
@@ -39,6 +39,9 @@ use sqlx::{Pool, Postgres};
 use crate::CarbideError;
 use crate::api::Api;
 
+const STATIC_ASSIGNMENTS_IPV4_PREFIX: &str = "169.254.254.254/32";
+const STATIC_ASSIGNMENTS_IPV6_PREFIX: &str = "100::/128";
+
 /// Create a Domain if we don't already have one.
 /// Returns true if we created an entry in the db (we had no domains yet), false otherwise.
 pub(crate) async fn create_initial_domain(
@@ -66,27 +69,26 @@ pub(crate) async fn create_initial_domain(
 }
 
 #[derive(Debug, PartialEq, Eq)]
-enum SeedNetworkDomainSelection {
+enum InitialNetworkDomainSelection {
     Selected(DomainId),
     NoForwardDomain,
     Ambiguous(Vec<String>),
 }
 
-/// Select the forward domain used to parent config-seeded network segments.
+/// Select the forward domain used by configured initial network segments.
 ///
 /// Reverse-DNS zones share the domains table and must not make a sole forward
 /// domain appear ambiguous.
-fn select_seed_network_domain(
+fn select_initial_network_domain(
     domains: &[Domain],
     configured_domain_name: Option<&str>,
-) -> SeedNetworkDomainSelection {
+) -> InitialNetworkDomainSelection {
     let forward_domains = domains
         .iter()
         .filter(|domain| {
             let name = domain.name.trim_end_matches('.');
             !matches!(name, "in-addr.arpa" | "ip6.arpa")
-                && !name.ends_with(".in-addr.arpa")
-                && !name.ends_with(".ip6.arpa")
+                && db::dns::normalize_reverse_zone_name(name).is_none()
         })
         .collect_vec();
 
@@ -96,14 +98,14 @@ fn select_seed_network_domain(
             .filter(|domain| domain.name == domain_name)
             .collect_vec();
         if let [domain] = configured_domains.as_slice() {
-            return SeedNetworkDomainSelection::Selected(domain.id);
+            return InitialNetworkDomainSelection::Selected(domain.id);
         }
     }
 
     match forward_domains.as_slice() {
-        [] => SeedNetworkDomainSelection::NoForwardDomain,
-        [domain] => SeedNetworkDomainSelection::Selected(domain.id),
-        domains => SeedNetworkDomainSelection::Ambiguous(
+        [] => InitialNetworkDomainSelection::NoForwardDomain,
+        [domain] => InitialNetworkDomainSelection::Selected(domain.id),
+        domains => InitialNetworkDomainSelection::Ambiguous(
             domains
                 .iter()
                 .map(|domain| domain.name.clone())
@@ -124,16 +126,16 @@ pub(crate) async fn create_initial_networks(
         ObjectColumnFilter::<db::dns::domain::IdColumn>::All,
     )
     .await?;
-    let domain_id = match select_seed_network_domain(
+    let domain_id = match select_initial_network_domain(
         &domains,
         api.runtime_config.initial_domain_name.as_deref(),
     ) {
-        SeedNetworkDomainSelection::Selected(domain_id) => domain_id,
-        SeedNetworkDomainSelection::NoForwardDomain => {
+        InitialNetworkDomainSelection::Selected(domain_id) => domain_id,
+        InitialNetworkDomainSelection::NoForwardDomain => {
             tracing::warn!("No forward domain configured, skipping initial network creation");
             return Ok(());
         }
-        SeedNetworkDomainSelection::Ambiguous(forward_domains) => {
+        InitialNetworkDomainSelection::Ambiguous(forward_domains) => {
             tracing::warn!(
                 ?forward_domains,
                 configured_domain_name = ?api.runtime_config.initial_domain_name,
@@ -170,8 +172,9 @@ pub(crate) async fn create_initial_networks(
             None
         };
 
-        // Capture before `save` moves `ns`. `insert_network_def` needs
-        // the id because `network_def.segment_id` is FK-bound to it.
+        // Capture before `save_without_reverse_zones` moves `ns`.
+        // `insert_network_def` needs the id because
+        // `network_def.segment_id` is FK-bound to it.
         let segment_id = ns.id;
         // update_network_segments_svi_ip will take care of allocating svi ip.
         tracing::info!(
@@ -179,7 +182,10 @@ pub(crate) async fn create_initial_networks(
             network_segment = ?ns,
             "Creating network segment from config",
         );
-        crate::handlers::network_segment::save(api, &mut txn, ns, true, false).await?;
+        crate::handlers::network_segment::save_without_reverse_zones(
+            api, &mut txn, ns, true, false,
+        )
+        .await?;
         // Snapshot the network definition in the same transaction as the network_segment row,
         // so the two stay consistent across restarts.
         db::network_segment::insert_network_def(&mut txn, name, segment_id, def).await?;
@@ -190,6 +196,22 @@ pub(crate) async fn create_initial_networks(
     }
 
     ensure_static_assignments_segment(api, &mut txn, Some(domain_id)).await?;
+    let network_definition_names = networks.keys().cloned().collect_vec();
+    let mut reverse_zone_prefixes = db::network_prefix::find_persisted_for_network_definitions(
+        &mut txn,
+        &network_definition_names,
+    )
+    .await?;
+    let static_assignments = db::network_segment::static_assignments(&mut txn).await?;
+    if !static_assignments.is_marked_as_deleted() {
+        reverse_zone_prefixes.extend(
+            static_assignments
+                .prefixes
+                .iter()
+                .map(|prefix| prefix.prefix),
+        );
+    }
+    db::dns::ensure_reverse_zones(&reverse_zone_prefixes, &mut txn).await?;
 
     txn.commit().await?;
     Ok(())
@@ -316,13 +338,13 @@ pub(crate) async fn ensure_static_assignments_segment(
         mtu: 1500,
         prefixes: vec![
             NewNetworkPrefix {
-                prefix: "169.254.254.254/32".parse().unwrap(),
+                prefix: STATIC_ASSIGNMENTS_IPV4_PREFIX.parse().unwrap(),
                 gateway: None,
                 dhcpv6_link_address: None,
                 num_reserved: 1,
             },
             NewNetworkPrefix {
-                prefix: "100::/128".parse().unwrap(),
+                prefix: STATIC_ASSIGNMENTS_IPV6_PREFIX.parse().unwrap(),
                 gateway: None,
                 dhcpv6_link_address: None,
                 num_reserved: 1,
@@ -334,7 +356,7 @@ pub(crate) async fn ensure_static_assignments_segment(
         can_stretch: Some(false),
         allocation_strategy: model::network_segment::AllocationStrategy::Reserved,
     };
-    crate::handlers::network_segment::save(api, txn, ns, true, false).await?;
+    crate::handlers::network_segment::save_without_reverse_zones(api, txn, ns, true, false).await?;
     tracing::info!(
         network_segment_name = segment_name,
         "Created internal segment for holding static assignments",
@@ -621,7 +643,9 @@ mod tests {
     }
 
     #[test]
-    fn seed_network_domain_selection_distinguishes_forward_and_reverse_domains() {
+    fn initial_network_domain_selection_distinguishes_forward_and_reverse_domains() {
+        // Reverse zones share the `domains` table, but only a forward domain
+        // may become the parent for configured initial network segments.
         check_values(
             [
                 Check {
@@ -630,19 +654,19 @@ mod tests {
                         domains: vec![],
                         configured_domain_name: None,
                     },
-                    expect: SeedNetworkDomainSelection::NoForwardDomain,
+                    expect: InitialNetworkDomainSelection::NoForwardDomain,
                 },
                 Check {
                     scenario: "the configured domain wins among multiple forward domains",
                     input: DomainSelectionCase {
                         domains: vec![
                             domain(1, "legacy.example"),
-                            domain(2, "0.20.172.in-addr.arpa"),
+                            domain(2, "0.20.172.IN-ADDR.ARPA."),
                             domain(3, "site.example"),
                         ],
                         configured_domain_name: Some("site.example"),
                     },
-                    expect: SeedNetworkDomainSelection::Selected(domain_id(3)),
+                    expect: InitialNetworkDomainSelection::Selected(domain_id(3)),
                 },
                 Check {
                     scenario: "a renamed configured domain falls back to the sole forward domain",
@@ -653,7 +677,7 @@ mod tests {
                         ],
                         configured_domain_name: Some("site.example"),
                     },
-                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                    expect: InitialNetworkDomainSelection::Selected(domain_id(1)),
                 },
                 Check {
                     scenario: "an API-created domain works without initial_domain_name",
@@ -665,7 +689,7 @@ mod tests {
                         ],
                         configured_domain_name: None,
                     },
-                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                    expect: InitialNetworkDomainSelection::Selected(domain_id(1)),
                 },
                 Check {
                     scenario: "reverse domains alone do not become the forward domain",
@@ -676,7 +700,7 @@ mod tests {
                         ],
                         configured_domain_name: None,
                     },
-                    expect: SeedNetworkDomainSelection::NoForwardDomain,
+                    expect: InitialNetworkDomainSelection::NoForwardDomain,
                 },
                 Check {
                     scenario: "a configured reverse domain does not override the forward domain",
@@ -687,7 +711,7 @@ mod tests {
                         ],
                         configured_domain_name: Some("0.20.172.in-addr.arpa"),
                     },
-                    expect: SeedNetworkDomainSelection::Selected(domain_id(1)),
+                    expect: InitialNetworkDomainSelection::Selected(domain_id(1)),
                 },
                 Check {
                     scenario: "multiple forward domains without a configured match are ambiguous",
@@ -699,7 +723,7 @@ mod tests {
                         ],
                         configured_domain_name: None,
                     },
-                    expect: SeedNetworkDomainSelection::Ambiguous(vec![
+                    expect: InitialNetworkDomainSelection::Ambiguous(vec![
                         "one.example".to_string(),
                         "two.example".to_string(),
                     ]),
@@ -710,7 +734,7 @@ mod tests {
                         domains: vec![domain(1, "site.example"), domain(2, "site.example")],
                         configured_domain_name: Some("site.example"),
                     },
-                    expect: SeedNetworkDomainSelection::Ambiguous(vec![
+                    expect: InitialNetworkDomainSelection::Ambiguous(vec![
                         "site.example".to_string(),
                         "site.example".to_string(),
                     ]),
@@ -719,7 +743,7 @@ mod tests {
             |DomainSelectionCase {
                  domains,
                  configured_domain_name,
-             }| { select_seed_network_domain(&domains, configured_domain_name) },
+             }| { select_initial_network_domain(&domains, configured_domain_name) },
         );
     }
 }

--- a/crates/api-core/src/handlers/dns.rs
+++ b/crates/api-core/src/handlers/dns.rs
@@ -170,14 +170,10 @@ pub(crate) async fn get_all_domain_metadata(
 
     let domain_name = db::dns::normalize_domain(&metadata_request.domain);
 
-    let domains = db::dns::domain::find_by(
-        &api.database_connection,
-        db::ObjectColumnFilter::<db::dns::domain::NameColumn>::One(
-            db::dns::domain::NameColumn,
-            &domain_name.as_str(),
-        ),
-    )
-    .await?;
+    // Reverse zones may be stored with or without the trailing root dot, so
+    // resolve their normalized identity. Forward domains retain the existing
+    // exact lookup after the request normalization above.
+    let domains = db::dns::domain::find_by_name(&api.database_connection, &domain_name).await?;
 
     let domain = domains.first().ok_or_else(|| CarbideError::NotFoundError {
         kind: "domain",

--- a/crates/api-core/src/handlers/domain.rs
+++ b/crates/api-core/src/handlers/domain.rs
@@ -18,6 +18,7 @@ use ::rpc::protos::dns::{
     CreateDomainRequest, Domain, DomainDeletionRequest, DomainDeletionResult, DomainList,
     DomainSearchQuery, UpdateDomainRequest,
 };
+use carbide_uuid::domain::DomainId;
 use db::dns::domain;
 use db::{self, ObjectColumnFilter};
 use model::dns::NewDomain;
@@ -25,6 +26,34 @@ use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
 use crate::api::Api;
+
+/// Locks every reverse-zone identity affected by a domain write, then rejects
+/// a proposed name already used by another live domain. Updates may retain
+/// their own normalized name, while creates have no domain to exclude.
+async fn lock_and_ensure_reverse_zone_name_available(
+    txn: &mut db::Transaction<'_>,
+    names_to_lock: &[String],
+    proposed_name: &str,
+    current_domain_id: Option<DomainId>,
+) -> Result<(), CarbideError> {
+    db::dns::lock_reverse_zone_names(txn, names_to_lock).await?;
+
+    let Some(reverse_zone_name) = db::dns::normalize_reverse_zone_name(proposed_name) else {
+        return Ok(());
+    };
+    let domains = domain::find_reverse_zone_by_normalized_name(txn, &reverse_zone_name).await?;
+    if domains
+        .iter()
+        .any(|existing| Some(existing.id) != current_domain_id)
+    {
+        return Err(CarbideError::AlreadyFoundError {
+            kind: "reverse DNS zone",
+            id: reverse_zone_name,
+        });
+    }
+
+    Ok(())
+}
 
 pub(crate) async fn create(
     api: &Api,
@@ -35,6 +64,13 @@ pub(crate) async fn create(
     let mut txn = api.txn_begin().await?;
 
     let req = request.into_inner();
+    lock_and_ensure_reverse_zone_name_available(
+        &mut txn,
+        std::slice::from_ref(&req.name),
+        &req.name,
+        None,
+    )
+    .await?;
     let new_domain = NewDomain::new(req.name);
 
     let domain = domain::persist(new_domain, &mut txn).await?;
@@ -69,11 +105,21 @@ pub(crate) async fn update(
                 id: uuid.to_string(),
             })?;
 
+    let previous_name = domain.name.clone();
     domain.name = domain_proto.name;
+
+    let reverse_zone_names = [previous_name, domain.name.clone()];
+    lock_and_ensure_reverse_zone_name_available(
+        &mut txn,
+        &reverse_zone_names,
+        &domain.name,
+        Some(domain.id),
+    )
+    .await?;
 
     domain.increment_serial();
 
-    let updated_domain = domain::update(&mut domain, &mut txn).await?;
+    let updated_domain = domain::update(&domain, &mut txn).await?;
 
     txn.commit().await?;
 
@@ -98,6 +144,8 @@ pub(crate) async fn delete(
                 kind: "domain",
                 id: uuid.to_string(),
             })?;
+
+    db::dns::lock_reverse_zone_names(&mut txn, std::slice::from_ref(&domain.name)).await?;
 
     // TODO: This needs to validate that nothing references the domain anymore
     // (like NetworkSegments)

--- a/crates/api-core/src/handlers/network_segment.rs
+++ b/crates/api-core/src/handlers/network_segment.rs
@@ -270,9 +270,12 @@ pub(crate) async fn delete(
     // A network's reverse-DNS zone exists only because the network does, so it
     // is dropped with the segment -- the inverse of the create-time hook in
     // `save`.
-    for network_prefix in &segment.prefixes {
-        db::dns::remove_reverse_zone(network_prefix.prefix, txn.as_mut()).await?;
-    }
+    let prefixes = segment
+        .prefixes
+        .iter()
+        .map(|network_prefix| network_prefix.prefix)
+        .collect::<Vec<_>>();
+    db::dns::remove_reverse_zones(&prefixes, segment.id, &mut txn).await?;
 
     txn.commit().await?;
 
@@ -337,11 +340,44 @@ pub(crate) async fn find_state_histories(
     Ok(tonic::Response::new(response))
 }
 
-// Called by db_init::create_initial_networks
+/// `save` is the single-segment persistence path used by the
+/// `CreateNetworkSegment` handler. It writes the segment, performs its resource
+/// allocations, and creates every reverse-DNS zone derived from the persisted
+/// prefixes before the caller commits. The segment and its zones therefore
+/// become visible together, and a zone failure rolls the segment back as well.
+///
+/// Startup uses [`save_without_reverse_zones`] instead. It persists every
+/// configured segment first, resolves config drift through the stored
+/// `network_def.segment_id` links, then acquires the complete sorted zone-lock
+/// set once before creating any missing zones.
 pub(crate) async fn save(
     api: &Api,
-    // Note: This is a PgTransaction, not a PgConnection, because we will be doing table locking,
-    // which must happen in a transaction.
+    txn: &mut PgTransaction<'_>,
+    ns: NewNetworkSegment,
+    set_to_ready: bool,
+    allocate_svi_ip: bool,
+) -> Result<NetworkSegment, CarbideError> {
+    let network_segment =
+        save_without_reverse_zones(api, txn, ns, set_to_ready, allocate_svi_ip).await?;
+    let prefixes = network_segment
+        .prefixes
+        .iter()
+        .map(|network_prefix| network_prefix.prefix)
+        .collect::<Vec<_>>();
+    db::dns::ensure_reverse_zones(&prefixes, txn).await?;
+    Ok(network_segment)
+}
+
+/// `save_without_reverse_zones` performs the segment write, resource-pool
+/// allocations, and optional SVI allocation without updating DNS.
+///
+/// [`save`] follows it immediately with one segment's DNS update.
+/// [`crate::db_init::create_initial_networks`] uses it for configured segments
+/// and the static-assignments anchor so startup can update all reverse zones
+/// once, in the same transaction and with a stable lock order. Any other caller
+/// must arrange the matching DNS update before committing.
+pub(crate) async fn save_without_reverse_zones(
+    api: &Api,
     txn: &mut PgTransaction<'_>,
     mut ns: NewNetworkSegment,
     set_to_ready: bool,
@@ -370,13 +406,6 @@ pub(crate) async fn save(
             return Err(err.into());
         }
     };
-
-    // A network's reverse-DNS zone is derived from its prefix and created with
-    // it, so PTR lookups for the network's addresses resolve without anyone
-    // hand-authoring the zone.
-    for network_prefix in &network_segment.prefixes {
-        db::dns::ensure_reverse_zone(network_prefix.prefix, txn.as_mut()).await?;
-    }
 
     if allocate_svi_ip {
         db::network_segment::allocate_svi_ip(&network_segment, txn).await?;

--- a/crates/api-core/src/test_support/network_segment.rs
+++ b/crates/api-core/src/test_support/network_segment.rs
@@ -106,10 +106,15 @@ pub async fn create_static_assignments_segment(
     crate::db_init::ensure_static_assignments_segment(api, &mut txn, subdomain_id)
         .await
         .unwrap();
-    txn.commit().await.unwrap();
-
-    let mut txn = api.database_connection.begin().await.unwrap();
     let seg = db::network_segment::static_assignments(&mut txn)
+        .await
+        .unwrap();
+    let prefixes = seg
+        .prefixes
+        .iter()
+        .map(|prefix| prefix.prefix)
+        .collect::<Vec<_>>();
+    db::dns::ensure_reverse_zones(&prefixes, &mut txn)
         .await
         .unwrap();
     txn.commit().await.unwrap();

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -623,7 +623,7 @@ pub(in crate::tests) async fn test_create_initial_networks(
     let initial_domain_id = admin
         .config
         .subdomain_id
-        .expect("config-seeded network should use the forward domain");
+        .expect("configured initial network should use the forward domain");
 
     let underlay = db::network_segment::find_by_name(&mut txn, "DEV1-C09-IPMI-01").await?;
     assert_eq!(underlay.config.mtu, 1500);
@@ -699,6 +699,142 @@ pub(in crate::tests) async fn test_create_initial_networks(
     assert_eq!(added.config.subdomain_id, Some(initial_domain_id));
     txn.commit().await?;
 
+    Ok(())
+}
+
+/// Builds the smallest configured underlay needed by startup reconciliation
+/// tests. Callers choose only the CIDR and gateway that distinguish each case.
+fn initial_underlay_definition(prefix: &str, gateway: &str) -> NetworkDefinition {
+    NetworkDefinition {
+        segment_type: NetworkDefinitionSegmentType::Underlay,
+        prefix: prefix.parse().unwrap(),
+        prefix_v6: None,
+        gateway: gateway.parse().unwrap(),
+        dhcpv6_link_address: None,
+        mtu: 1500,
+        reserve_first: 5,
+        allocation_strategy: Default::default(),
+        vpc_name: None,
+    }
+}
+
+/// Persists an initial segment and its durable `network_def` link without
+/// creating DNS. This leaves startup as the only path that can repair the
+/// missing reverse zone.
+async fn persist_initial_network_without_reverse_zone(
+    pool: &sqlx::PgPool,
+    name: &str,
+    definition: &NetworkDefinition,
+) -> Result<NetworkSegment, Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+    let domains = db::dns::domain::find_by_name(txn.as_mut(), "dwrt1.com").await?;
+    let [domain] = domains.as_slice() else {
+        panic!("test fixture should have exactly one forward domain");
+    };
+    let mut segment = NewNetworkSegment::build_from(name, domain.id, definition)?;
+    segment.can_stretch = Some(true);
+    let segment =
+        db::network_segment::persist(segment, txn.as_mut(), NetworkSegmentControllerState::Ready)
+            .await?;
+    db::network_segment::insert_network_def(txn.as_mut(), name, segment.id, definition).await?;
+    txn.commit().await?;
+    Ok(segment)
+}
+
+#[crate::sqlx_test]
+async fn test_initial_network_reverse_zones_follow_persisted_config_drift(
+    db_pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // The stored `network_def.segment_id` identifies the segment startup must
+    // repair. A changed config CIDR must not create a zone for data that was
+    // never persisted.
+    let env =
+        create_test_env_with_overrides(db_pool.clone(), TestEnvOverrides::no_network_segments())
+            .await;
+    let original = initial_underlay_definition("10.44.0.0/16", "10.44.0.1");
+    let drifted = initial_underlay_definition("10.55.0.0/16", "10.55.0.1");
+    let original_segment =
+        persist_initial_network_without_reverse_zone(&db_pool, "drifted-underlay", &original)
+            .await?;
+
+    crate::db_init::create_initial_networks(
+        &env.api,
+        &env.pool,
+        &HashMap::from([("drifted-underlay".to_string(), drifted.clone())]),
+    )
+    .await?;
+
+    let mut txn = db_pool.begin().await?;
+    let segment = db::network_segment::find_by_name(&mut txn, "drifted-underlay").await?;
+    assert_eq!(segment.id, original_segment.id);
+    assert_eq!(segment.prefixes.len(), 1);
+    assert_eq!(segment.prefixes[0].prefix, original.prefix);
+    assert_eq!(
+        db::network_segment::stored_def(txn.as_mut(), "drifted-underlay").await?,
+        Some(original.clone()),
+        "config drift must not replace the stored declaration",
+    );
+
+    let original_zone = db::dns::cidr_to_reverse_zone(original.prefix).unwrap();
+    let original_domains =
+        db::dns::domain::find_reverse_zone_by_normalized_name(txn.as_mut(), &original_zone).await?;
+    assert_eq!(
+        original_domains.len(),
+        1,
+        "startup should create the zone for the persisted prefix",
+    );
+
+    let drifted_zone = db::dns::cidr_to_reverse_zone(drifted.prefix).unwrap();
+    assert!(
+        db::dns::domain::find_reverse_zone_by_normalized_name(txn.as_mut(), &drifted_zone)
+            .await?
+            .is_empty(),
+        "startup must not create an orphan zone for an unapplied declaration",
+    );
+    txn.commit().await?;
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_initial_network_restart_does_not_restore_deleted_static_assignment_zones(
+    db_pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // The static-assignments row may remain during soft-delete drainage, but
+    // restart must not recreate the reverse zones removed with that segment.
+    let env =
+        create_test_env_with_overrides(db_pool.clone(), TestEnvOverrides::no_network_segments())
+            .await;
+    let networks = HashMap::new();
+    crate::db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
+
+    let mut txn = db_pool.begin().await?;
+    let static_assignments = db::network_segment::static_assignments(txn.as_mut()).await?;
+    let reverse_zones = static_assignments
+        .prefixes
+        .iter()
+        .map(|prefix| db::dns::cidr_to_reverse_zone(prefix.prefix).unwrap())
+        .collect::<Vec<_>>();
+    txn.commit().await?;
+
+    env.api
+        .delete_network_segment(Request::new(rpc::forge::NetworkSegmentDeletionRequest {
+            id: Some(static_assignments.id),
+        }))
+        .await?;
+    crate::db_init::create_initial_networks(&env.api, &env.pool, &networks).await?;
+
+    let mut txn = db_pool.begin().await?;
+    let static_assignments = db::network_segment::static_assignments(txn.as_mut()).await?;
+    assert!(static_assignments.is_marked_as_deleted());
+    for reverse_zone in reverse_zones {
+        assert!(
+            db::dns::domain::find_reverse_zone_by_normalized_name(txn.as_mut(), &reverse_zone,)
+                .await?
+                .is_empty(),
+            "startup must not restore reverse zones for a soft-deleted static-assignments segment",
+        );
+    }
+    txn.commit().await?;
     Ok(())
 }
 

--- a/crates/api-db/migrations/20260807232133_duplicate_address_reverse_dns.sql
+++ b/crates/api-db/migrations/20260807232133_duplicate_address_reverse_dns.sql
@@ -1,0 +1,16 @@
+-- Forward-domain duplicates remain supported. Normalized reverse-zone names
+-- identify the same DNS zone, so live dotted and non-dotted spellings must not
+-- coexist. Existing normalized duplicates make this migration fail without
+-- changing any rows so an operator can reconcile them deliberately.
+CREATE UNIQUE INDEX domains_live_reverse_zone_name_key
+    ON domains ((lower(rtrim(name, '.'))))
+    WHERE deleted IS NULL
+      AND (
+          lower(rtrim(name, '.')) LIKE '%.in-addr.arpa'
+          OR lower(rtrim(name, '.')) LIKE '%.ip6.arpa'
+      );
+
+-- PTR resolution probes overlay addresses directly when deciding whether an
+-- address has one owner or is ambiguous across VPCs.
+CREATE INDEX instance_addresses_address_idx
+    ON instance_addresses (address);

--- a/crates/api-db/src/dns/domain.rs
+++ b/crates/api-db/src/dns/domain.rs
@@ -176,11 +176,42 @@ pub async fn find_all_by<'a, C: ColumnInfo<'a, TableType = Domain>>(
         .map_err(|e| DatabaseError::query(query.sql(), e))
 }
 
+/// Finds live domains named `name`.
+///
+/// Reverse-zone names compare case-insensitively without a trailing dot
+/// because those spellings identify the same DNS zone. Forward-domain names
+/// retain their exact-match behavior.
 pub async fn find_by_name(
     txn: impl DbReader<'_>,
     name: &str,
 ) -> Result<Vec<Domain>, DatabaseError> {
-    find_by(txn, ObjectColumnFilter::One(NameColumn, &name)).await
+    if let Some(reverse_zone_name) = super::normalize_reverse_zone_name(name) {
+        find_reverse_zone_by_normalized_name(txn, &reverse_zone_name).await
+    } else {
+        find_by(txn, ObjectColumnFilter::One(NameColumn, &name)).await
+    }
+}
+
+/// Finds the live reverse-zone identity represented by `name`, treating a
+/// trailing dot as presentation rather than part of the identity.
+pub async fn find_reverse_zone_by_normalized_name(
+    txn: impl DbReader<'_>,
+    name: &str,
+) -> Result<Vec<Domain>, DatabaseError> {
+    let query = "SELECT * FROM domains
+                 WHERE lower(rtrim(name, '.')) = $1
+                   AND deleted IS NULL
+                   AND (
+                       lower(rtrim(name, '.')) LIKE '%.in-addr.arpa'
+                       OR lower(rtrim(name, '.')) LIKE '%.ip6.arpa'
+                   )";
+    let name = super::normalize_domain(name);
+    sqlx::query_as::<_, DbDomain>(query)
+        .bind(name)
+        .fetch_all(txn)
+        .await
+        .map(|domains| domains.into_iter().map(Domain::from).collect())
+        .map_err(|error| DatabaseError::query(query, error))
 }
 
 /// Find the domain with the given ID, even if it is deleted.
@@ -210,29 +241,64 @@ pub async fn find_by_uuids(
         .map(|domains| domains.into_iter().map(|d| (d.id, d)).collect())
 }
 
+/// Soft-deletes a domain while its update timestamp still matches the snapshot
+/// whose reverse-zone lock the caller acquired. A zero-row update means that
+/// snapshot is stale, including when another writer updated or deleted the
+/// domain or the row no longer exists.
 pub async fn delete(value: Domain, txn: &mut PgConnection) -> Result<Domain, DatabaseError> {
-    let query = "UPDATE domains SET updated=NOW(), deleted=NOW() WHERE id=$1 RETURNING *";
+    // PostgreSQL evaluates both assignments from the pre-update row. Reusing
+    // this expression gives `updated` and `deleted` the same monotonic value,
+    // so the returned row has one timestamp for the deletion version.
+    let query = "UPDATE domains
+                 SET updated = GREATEST(statement_timestamp(), updated + interval '1 microsecond'),
+                     deleted = GREATEST(statement_timestamp(), updated + interval '1 microsecond')
+                 WHERE id = $1
+                   AND updated = $2
+                 RETURNING *";
     sqlx::query_as::<_, DbDomain>(query)
         .bind(value.id)
+        .bind(value.updated)
         .fetch_one(txn)
         .await
         .map(Domain::from)
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|error| match error {
+            sqlx::Error::RowNotFound => {
+                DatabaseError::ConcurrentModificationError("domain", value.updated.to_rfc3339())
+            }
+            error => DatabaseError::query(query, error),
+        })
 }
 
-pub async fn update(value: &mut Domain, txn: &mut PgConnection) -> Result<Domain, DatabaseError> {
+/// Updates a domain while its update timestamp still matches the snapshot whose
+/// reverse-zone locks the caller acquired. A zero-row update also covers a row
+/// that no longer exists. The new timestamp always advances, including for
+/// multiple updates in one transaction, so a later writer cannot reuse the same
+/// snapshot.
+pub async fn update(value: &Domain, txn: &mut PgConnection) -> Result<Domain, DatabaseError> {
     validate_domain_name(&value.name)?;
 
-    let query = "UPDATE domains SET name=$1, updated=NOW(), soa=$2 WHERE id=$3 RETURNING *";
+    let query = "UPDATE domains
+                 SET name = $1,
+                     updated = GREATEST(statement_timestamp(), updated + interval '1 microsecond'),
+                     soa = $2
+                 WHERE id = $3
+                   AND updated = $4
+                 RETURNING *";
 
     sqlx::query_as::<_, DbDomain>(query)
         .bind(&value.name)
         .bind(sqlx::types::Json(&value.soa))
         .bind(value.id)
+        .bind(value.updated)
         .fetch_one(txn)
         .await
         .map(Domain::from)
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|error| match error {
+            sqlx::Error::RowNotFound => {
+                DatabaseError::ConcurrentModificationError("domain", value.updated.to_rfc3339())
+            }
+            error => DatabaseError::query(query, error),
+        })
 }
 
 #[cfg(test)]

--- a/crates/api-db/src/dns/domain/test_create_domain.rs
+++ b/crates/api-db/src/dns/domain/test_create_domain.rs
@@ -34,9 +34,10 @@ async fn create_delete_valid_domain(pool: sqlx::PgPool) {
 
     assert!(domain.is_ok());
 
-    let delete_result = db::dns::domain::delete(domain.unwrap(), &mut txn).await;
-
-    assert!(delete_result.is_ok());
+    let deleted = db::dns::domain::delete(domain.unwrap(), &mut txn)
+        .await
+        .unwrap();
+    assert_eq!(deleted.deleted, Some(deleted.updated));
 
     let domains = db::dns::domain::find_by(
         txn.as_mut(),
@@ -48,6 +49,69 @@ async fn create_delete_valid_domain(pool: sqlx::PgPool) {
     assert_eq!(domains.len(), 0);
 
     txn.commit().await.unwrap();
+}
+
+#[crate::sqlx_test]
+async fn normalized_reverse_zone_names_are_unique(pool: sqlx::PgPool) {
+    // Dotted and non-dotted names identify the same reverse zone, so the
+    // database must reject a second live spelling through the partial index.
+    let mut txn = pool.begin().await.unwrap();
+    db::dns::domain::persist(NewDomain::new("0.10.in-addr.arpa"), txn.as_mut())
+        .await
+        .unwrap();
+
+    let duplicate =
+        db::dns::domain::persist(NewDomain::new("0.10.in-addr.arpa."), txn.as_mut()).await;
+
+    assert!(matches!(
+        duplicate,
+        Err(DatabaseError::Sqlx(error))
+            if matches!(
+                &error.source,
+                sqlx::Error::Database(database_error)
+                    if database_error.is_unique_violation()
+                        && database_error.constraint()
+                            == Some("domains_live_reverse_zone_name_key")
+            )
+    ));
+}
+
+#[crate::sqlx_test]
+async fn reverse_zone_search_uses_normalized_identity(pool: sqlx::PgPool) {
+    // Reverse-zone lookup accepts case and root-dot spelling differences, but
+    // forward-domain lookup keeps its historical exact-name contract.
+    let mut txn = pool.begin().await.unwrap();
+    let reverse = db::dns::domain::persist(NewDomain::new("0.10.in-addr.arpa."), txn.as_mut())
+        .await
+        .unwrap();
+    let forward = db::dns::domain::persist(NewDomain::new("tenant.example.com"), txn.as_mut())
+        .await
+        .unwrap();
+
+    for name in [
+        "0.10.in-addr.arpa",
+        "0.10.in-addr.arpa.",
+        "0.10.IN-ADDR.ARPA.",
+    ] {
+        let matches = db::dns::domain::find_by_name(txn.as_mut(), name)
+            .await
+            .unwrap();
+        assert_eq!(matches.len(), 1, "reverse-zone spelling {name}");
+        assert_eq!(matches[0].id, reverse.id, "reverse-zone spelling {name}");
+    }
+
+    let exact_forward = db::dns::domain::find_by_name(txn.as_mut(), "tenant.example.com")
+        .await
+        .unwrap();
+    assert_eq!(exact_forward.len(), 1);
+    assert_eq!(exact_forward[0].id, forward.id);
+    assert!(
+        db::dns::domain::find_by_name(txn.as_mut(), "tenant.example.com.")
+            .await
+            .unwrap()
+            .is_empty(),
+        "forward-domain searches retain exact name semantics"
+    );
 }
 
 #[crate::sqlx_test]
@@ -138,9 +202,57 @@ async fn update_domain(pool: sqlx::PgPool) {
         .await
         .expect("Unable to create transaction on database pool");
 
-    let update_result = db::dns::domain::update(&mut updated_domain, &mut txn).await;
+    let update_result = db::dns::domain::update(&updated_domain, &mut txn).await;
 
     txn.commit().await.unwrap();
 
     assert!(update_result.is_ok());
+}
+
+#[crate::sqlx_test]
+async fn stale_domain_snapshot_cannot_overwrite_a_newer_update(pool: sqlx::PgPool) {
+    // Even inside one transaction, the first write advances the optimistic
+    // timestamp so a second write from the original snapshot is rejected.
+    let mut txn = pool.begin().await.unwrap();
+    let original_name = "0.10.in-addr.arpa";
+    let original = db::dns::domain::persist(NewDomain::new(original_name), txn.as_mut())
+        .await
+        .unwrap();
+    let mut first = original.clone();
+    let mut stale = original;
+
+    first.name = "1.10.in-addr.arpa".to_string();
+    db::dns::domain::update(&first, txn.as_mut()).await.unwrap();
+
+    // Both writes happen in one transaction, so this also proves the update
+    // token advances independently of PostgreSQL's transaction timestamp.
+    stale.name = "2.10.in-addr.arpa".to_string();
+    let result = db::dns::domain::update(&stale, txn.as_mut()).await;
+    assert!(matches!(
+        result,
+        Err(DatabaseError::ConcurrentModificationError("domain", _))
+    ));
+}
+
+#[crate::sqlx_test]
+async fn stale_domain_snapshot_cannot_delete_a_newer_row(pool: sqlx::PgPool) {
+    // Reverse-zone cleanup must not delete a row that changed after the caller
+    // selected the snapshot used to acquire its lock.
+    let mut txn = pool.begin().await.unwrap();
+    let original = db::dns::domain::persist(NewDomain::new("3.10.in-addr.arpa"), txn.as_mut())
+        .await
+        .unwrap();
+    let mut updated = original.clone();
+    let stale = original;
+
+    updated.name = "4.10.in-addr.arpa".to_string();
+    db::dns::domain::update(&updated, txn.as_mut())
+        .await
+        .unwrap();
+
+    let result = db::dns::domain::delete(stale, txn.as_mut()).await;
+    assert!(matches!(
+        result,
+        Err(DatabaseError::ConcurrentModificationError("domain", _))
+    ));
 }

--- a/crates/api-db/src/dns/mod.rs
+++ b/crates/api-db/src/dns/mod.rs
@@ -21,9 +21,10 @@ pub mod resource_record;
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use carbide_uuid::network::NetworkSegmentId;
 use ipnetwork::IpNetwork;
 use model::dns::NewDomain;
-use sqlx::PgConnection;
+use sqlx::PgTransaction;
 
 use crate::DatabaseResult;
 
@@ -31,6 +32,17 @@ pub fn normalize_domain(name: &str) -> String {
     let normalized_domain = name.trim_end_matches('.').to_ascii_lowercase();
     tracing::debug!(input = %name, normalized = %normalized_domain, "normalized domain name");
     normalized_domain
+}
+
+/// Returns the normalized identity for a reverse-DNS zone name. A trailing dot
+/// is presentation-only; forward domain names return `None`.
+pub fn normalize_reverse_zone_name(name: &str) -> Option<String> {
+    let name = normalize_domain(name);
+    if name.ends_with(".in-addr.arpa") || name.ends_with(".ip6.arpa") {
+        Some(name)
+    } else {
+        None
+    }
 }
 
 /// Parse a reverse-DNS (PTR) query name into the address it points at -- the
@@ -122,48 +134,233 @@ pub fn cidr_to_reverse_zone(prefix: IpNetwork) -> Option<String> {
 /// called wherever a network segment is created; non-aligned prefixes are skipped
 /// (see [`cidr_to_reverse_zone`]).
 ///
-/// The find-then-create avoids duplicating a zone an earlier same-prefix segment
-/// already created (domain names are not unique). It does not need to guard
-/// concurrent creation: network prefixes are globally non-overlapping
-/// (`network_prefixes_prefix_excl`), so two segments never map to the same zone,
-/// and a duplicate prefix fails in `network_segment::save` before this runs.
-pub async fn ensure_reverse_zone(prefix: IpNetwork, txn: &mut PgConnection) -> DatabaseResult<()> {
-    let Some(zone) = cidr_to_reverse_zone(prefix) else {
-        tracing::debug!(%prefix, "no reverse zone: prefix is not octet/nibble aligned");
-        return Ok(());
-    };
-    if domain::find_by_name(&mut *txn, &zone).await?.is_empty() {
-        tracing::info!(zone = %zone, %prefix, "creating reverse-DNS zone for network prefix");
-        domain::persist(NewDomain::new(zone), txn).await?;
+/// The transaction-scoped zone lock makes the find-then-create atomic. When
+/// VPC-scoped prefix reuse is enabled, equal prefixes will share one
+/// reverse-zone row until the DNS request path has a trusted VPC discriminator.
+pub async fn ensure_reverse_zones(
+    prefixes: &[IpNetwork],
+    txn: &mut PgTransaction<'_>,
+) -> DatabaseResult<()> {
+    let reverse_zones = reverse_zones_for_prefixes(prefixes);
+    let zone_names = reverse_zones
+        .iter()
+        .map(|(zone, _)| zone.clone())
+        .collect::<Vec<_>>();
+    lock_normalized_reverse_zone_names(txn, &zone_names).await?;
+
+    for (zone, prefix) in reverse_zones {
+        ensure_reverse_zone_locked(prefix, zone, txn).await?;
     }
     Ok(())
 }
 
 /// Remove the reverse-DNS zone derived from a network prefix -- the inverse of
-/// [`ensure_reverse_zone`]. A network's reverse zone exists only because the
+/// [`ensure_reverse_zones`]. A network's reverse zone exists only because the
 /// network does, so it is dropped wherever a network segment is deleted;
 /// non-aligned prefixes never had a zone and are skipped (see
 /// [`cidr_to_reverse_zone`]).
 ///
-/// The zone is soft-deleted, matching the segment's own deletion. No refcount is
-/// needed: network prefixes are globally non-overlapping
-/// (`network_prefixes_prefix_excl`), so the zone has no other owner.
-/// `find_by_name` returns only live domains, so deleting an already-deleted
-/// segment removes nothing a second time.
-pub async fn remove_reverse_zone(prefix: IpNetwork, txn: &mut PgConnection) -> DatabaseResult<()> {
-    let Some(zone) = cidr_to_reverse_zone(prefix) else {
-        tracing::debug!(%prefix, "no reverse zone: prefix is not octet/nibble aligned");
-        return Ok(());
-    };
-    for domain in domain::find_by_name(&mut *txn, &zone).await? {
-        tracing::info!(zone = %zone, %prefix, "removing reverse-DNS zone for deleted network prefix");
-        domain::delete(domain, &mut *txn).await?;
+/// The zone is soft-deleted, matching the segment's own deletion, only after no
+/// other live segment uses the same prefix. The zone lock serializes that check
+/// with both creates and other deletions.
+pub async fn remove_reverse_zones(
+    prefixes: &[IpNetwork],
+    removed_segment_id: NetworkSegmentId,
+    txn: &mut PgTransaction<'_>,
+) -> DatabaseResult<()> {
+    let reverse_zones = reverse_zones_for_prefixes(prefixes);
+    let zone_names = reverse_zones
+        .iter()
+        .map(|(zone, _)| zone.clone())
+        .collect::<Vec<_>>();
+    lock_normalized_reverse_zone_names(txn, &zone_names).await?;
+
+    for (zone, prefix) in reverse_zones {
+        remove_reverse_zone_locked(prefix, zone, removed_segment_id, txn).await?;
     }
     Ok(())
 }
 
+fn reverse_zones_for_prefixes(prefixes: &[IpNetwork]) -> Vec<(String, IpNetwork)> {
+    let mut reverse_zones = prefixes
+        .iter()
+        .filter_map(|prefix| match cidr_to_reverse_zone(*prefix) {
+            Some(zone) => Some((zone, *prefix)),
+            None => {
+                tracing::debug!(%prefix, "no reverse zone: prefix is not octet/nibble aligned");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    reverse_zones.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    reverse_zones.dedup_by(|left, right| left.0 == right.0);
+    reverse_zones
+}
+
+async fn ensure_reverse_zone_locked(
+    prefix: IpNetwork,
+    zone: String,
+    txn: &mut PgTransaction<'_>,
+) -> DatabaseResult<()> {
+    if !reverse_zone_has_live_prefix(txn, prefix).await? {
+        return Ok(());
+    }
+
+    let domains = domain::find_reverse_zone_by_normalized_name(txn.as_mut(), &zone).await?;
+    match domains.as_slice() {
+        [] => {
+            tracing::info!(zone = %zone, %prefix, "creating reverse-DNS zone for network prefix");
+            domain::persist(NewDomain::new(zone), txn.as_mut()).await?;
+        }
+        [_] => {}
+        _ => {
+            return Err(crate::DatabaseError::Internal {
+                message: format!("multiple live domains represent reverse zone {zone}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+async fn remove_reverse_zone_locked(
+    prefix: IpNetwork,
+    zone: String,
+    removed_segment_id: NetworkSegmentId,
+    txn: &mut PgTransaction<'_>,
+) -> DatabaseResult<()> {
+    if reverse_zone_has_other_live_prefix(txn, prefix, removed_segment_id).await? {
+        return Ok(());
+    }
+
+    let domains = domain::find_reverse_zone_by_normalized_name(txn.as_mut(), &zone).await?;
+    match domains.as_slice() {
+        [] => {}
+        [domain] => {
+            tracing::info!(zone = %zone, %prefix, "removing reverse-DNS zone for deleted network prefix");
+            domain::delete(domain.clone(), txn.as_mut()).await?;
+        }
+        _ => {
+            return Err(crate::DatabaseError::Internal {
+                message: format!("multiple live domains represent reverse zone {zone}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Serializes participating reverse-zone writes by normalized name. These are
+/// transaction-scoped PostgreSQL advisory locks, not row or table locks. The
+/// database's live reverse-name uniqueness constraint remains the backstop for
+/// writers outside these paths. Every lock is acquired in sorted name order
+/// so a transaction touching both address families cannot deadlock with the
+/// same names in another order.
+pub async fn lock_reverse_zone_names(
+    txn: &mut PgTransaction<'_>,
+    names: &[String],
+) -> DatabaseResult<()> {
+    let names = names
+        .iter()
+        .filter_map(|name| normalize_reverse_zone_name(name))
+        .collect::<Vec<_>>();
+    lock_normalized_reverse_zone_names(txn, &names).await
+}
+
+async fn lock_normalized_reverse_zone_names(
+    txn: &mut PgTransaction<'_>,
+    names: &[String],
+) -> DatabaseResult<()> {
+    let mut names = names.to_vec();
+    names.sort_unstable();
+    names.dedup();
+    let query = "SELECT pg_advisory_xact_lock(hashtextextended('dns:reverse-zone:' || $1, 0))";
+    for name in &names {
+        sqlx::query(query)
+            .bind(name)
+            .execute(txn.as_mut())
+            .await
+            .map_err(|error| crate::DatabaseError::query(query, error))?;
+    }
+    Ok(())
+}
+
+async fn reverse_zone_has_live_prefix(
+    txn: &mut PgTransaction<'_>,
+    prefix: IpNetwork,
+) -> DatabaseResult<bool> {
+    let query = r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM network_prefixes np
+            JOIN network_segments ns ON ns.id = np.segment_id
+            WHERE np.prefix = $1::cidr
+              AND ns.deleted IS NULL
+        )
+    "#;
+    sqlx::query_scalar(query)
+        .bind(prefix)
+        .fetch_one(txn.as_mut())
+        .await
+        .map_err(|error| crate::DatabaseError::query(query, error))
+}
+
+async fn reverse_zone_has_other_live_prefix(
+    txn: &mut PgTransaction<'_>,
+    prefix: IpNetwork,
+    removed_segment_id: NetworkSegmentId,
+) -> DatabaseResult<bool> {
+    let query = r#"
+        SELECT EXISTS (
+            SELECT 1
+            FROM network_prefixes np
+            JOIN network_segments ns ON ns.id = np.segment_id
+            WHERE np.prefix = $1::cidr
+              AND ns.id != $2
+              AND ns.deleted IS NULL
+        )
+    "#;
+    sqlx::query_scalar(query)
+        .bind(prefix)
+        .bind(removed_segment_id)
+        .fetch_one(txn.as_mut())
+        .await
+        .map_err(|e| crate::DatabaseError::query(query, e))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use carbide_uuid::network::NetworkSegmentId;
+    use tokio::sync::Barrier;
+
+    /// Inserts the minimum live segment and prefix rows without touching DNS.
+    /// The returned segment ID lets deletion tests retire the exact owner.
+    async fn insert_network_prefix(
+        txn: &mut sqlx::PgTransaction<'_>,
+        name: &str,
+        prefix: ipnetwork::IpNetwork,
+    ) -> NetworkSegmentId {
+        let segment_id = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ($1, 'test')
+             RETURNING id",
+        )
+        .bind(name)
+        .fetch_one(txn.as_mut())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO network_prefixes (segment_id, prefix, num_reserved)
+             VALUES ($1, $2::cidr, 0)",
+        )
+        .bind(segment_id)
+        .bind(prefix)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+        segment_id
+    }
 
     #[test]
     fn cidr_to_reverse_zone_derives_aligned_prefixes() {
@@ -189,16 +386,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn reverse_zone_batches_are_sorted_and_deduplicated() {
+        // Different callers may supply the same v4/v6 prefixes in any order.
+        // Every batch must converge on one stable advisory-lock sequence.
+        let ipv4 = "10.0.0.0/16".parse().unwrap();
+        let ipv6 = "fd00::/16".parse().unwrap();
+        let reverse_zones = super::reverse_zones_for_prefixes(&[ipv4, ipv6, ipv4]);
+
+        assert_eq!(reverse_zones.len(), 2);
+        assert!(
+            reverse_zones
+                .windows(2)
+                .all(|zones| zones[0].0 < zones[1].0),
+            "all callers acquire unique reverse-zone locks in sorted name order"
+        );
+    }
+
     #[crate::sqlx_test]
     async fn ensure_reverse_zone_creates_idempotently(pool: sqlx::PgPool) {
         let mut txn = pool.begin().await.unwrap();
         let prefix: ipnetwork::IpNetwork = "10.0.0.0/16".parse().unwrap();
+        insert_network_prefix(&mut txn, "idempotent", prefix).await;
 
         // First call creates the zone; the second is a no-op.
-        super::ensure_reverse_zone(prefix, txn.as_mut())
+        super::ensure_reverse_zones(&[prefix], &mut txn)
             .await
             .unwrap();
-        super::ensure_reverse_zone(prefix, txn.as_mut())
+        super::ensure_reverse_zones(&[prefix], &mut txn)
             .await
             .unwrap();
         let zones = super::domain::find_by_name(txn.as_mut(), "0.10.in-addr.arpa")
@@ -208,22 +423,58 @@ mod tests {
 
         // A non-aligned prefix derives no zone, so nothing is created.
         let unaligned: ipnetwork::IpNetwork = "10.1.0.0/25".parse().unwrap();
-        super::ensure_reverse_zone(unaligned, txn.as_mut())
+        super::ensure_reverse_zones(&[unaligned], &mut txn)
             .await
             .unwrap();
         assert!(super::cidr_to_reverse_zone(unaligned).is_none());
     }
 
     #[crate::sqlx_test]
+    async fn an_existing_reverse_zone_is_reused(pool: sqlx::PgPool) {
+        // A dotted domain created through the Domain API already represents
+        // this zone, so network creation must reuse it instead of inserting a
+        // second spelling.
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let mut txn = pool.begin().await.unwrap();
+        insert_network_prefix(&mut txn, "existing-zone", prefix).await;
+        let manual = super::domain::persist(
+            model::dns::NewDomain::new("0.10.in-addr.arpa."),
+            txn.as_mut(),
+        )
+        .await
+        .unwrap();
+
+        super::ensure_reverse_zones(&[prefix], &mut txn)
+            .await
+            .unwrap();
+
+        let domains =
+            super::domain::find_reverse_zone_by_normalized_name(txn.as_mut(), "0.10.in-addr.arpa")
+                .await
+                .unwrap();
+        let [domain] = domains.as_slice() else {
+            panic!("the existing reverse zone should be reused");
+        };
+        assert_eq!(domain.id, manual.id);
+        assert_eq!(domain.name, "0.10.in-addr.arpa.");
+    }
+
+    #[crate::sqlx_test]
     async fn remove_reverse_zone_deletes_the_zone(pool: sqlx::PgPool) {
         let mut txn = pool.begin().await.unwrap();
         let prefix: ipnetwork::IpNetwork = "10.0.0.0/16".parse().unwrap();
+        let removed_segment_id = insert_network_prefix(&mut txn, "removed-zone", prefix).await;
 
         // A network's zone is dropped when the network is deleted.
-        super::ensure_reverse_zone(prefix, txn.as_mut())
+        super::ensure_reverse_zones(&[prefix], &mut txn)
             .await
             .unwrap();
-        super::remove_reverse_zone(prefix, txn.as_mut())
+        sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+            .bind(removed_segment_id)
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        super::remove_reverse_zones(&[prefix], removed_segment_id, &mut txn)
             .await
             .unwrap();
         let zones = super::domain::find_by_name(txn.as_mut(), "0.10.in-addr.arpa")
@@ -232,7 +483,7 @@ mod tests {
         assert!(zones.is_empty(), "reverse zone removed with its network");
 
         // Removing again finds no live zone, so deleting a segment twice is a no-op.
-        super::remove_reverse_zone(prefix, txn.as_mut())
+        super::remove_reverse_zones(&[prefix], removed_segment_id, &mut txn)
             .await
             .unwrap();
         let after_second = super::domain::find_by_name(txn.as_mut(), "0.10.in-addr.arpa")
@@ -242,11 +493,12 @@ mod tests {
 
         // Removing a non-aligned prefix (which never had a zone) leaves other zones intact.
         let control: ipnetwork::IpNetwork = "10.2.0.0/16".parse().unwrap();
-        super::ensure_reverse_zone(control, txn.as_mut())
+        insert_network_prefix(&mut txn, "control-zone", control).await;
+        super::ensure_reverse_zones(&[control], &mut txn)
             .await
             .unwrap();
         let unaligned: ipnetwork::IpNetwork = "10.1.0.0/25".parse().unwrap();
-        super::remove_reverse_zone(unaligned, txn.as_mut())
+        super::remove_reverse_zones(&[unaligned], removed_segment_id, &mut txn)
             .await
             .unwrap();
         let control_zones = super::domain::find_by_name(txn.as_mut(), "2.10.in-addr.arpa")
@@ -259,6 +511,322 @@ mod tests {
         );
     }
 
+    #[crate::sqlx_test]
+    async fn a_stale_prefix_snapshot_does_not_recreate_a_removed_zone(pool: sqlx::PgPool) {
+        // Startup can collect prefixes before a concurrent segment deletion.
+        // The liveness check under the zone lock must catch that stale read.
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let mut setup = pool.begin().await.unwrap();
+        let removed_segment_id = insert_network_prefix(&mut setup, "stale-snapshot", prefix).await;
+        super::ensure_reverse_zones(&[prefix], &mut setup)
+            .await
+            .unwrap();
+        setup.commit().await.unwrap();
+
+        let mut delete = pool.begin().await.unwrap();
+        sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+            .bind(removed_segment_id)
+            .execute(delete.as_mut())
+            .await
+            .unwrap();
+        super::remove_reverse_zones(&[prefix], removed_segment_id, &mut delete)
+            .await
+            .unwrap();
+        delete.commit().await.unwrap();
+
+        // Startup may have read this prefix before the delete acquired its
+        // zone lock. Revalidation under the same lock must reject that stale
+        // snapshot after the delete commits.
+        let mut startup = pool.begin().await.unwrap();
+        super::ensure_reverse_zones(&[prefix], &mut startup)
+            .await
+            .unwrap();
+        startup.commit().await.unwrap();
+
+        let zones = super::domain::find_by_name(&pool, "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert!(zones.is_empty(), "a deleted prefix cannot regain its zone");
+    }
+
+    #[crate::sqlx_test]
+    async fn concurrent_opposite_order_reverse_zone_creates_do_not_deadlock(pool: sqlx::PgPool) {
+        // Two dual-stack creators begin together with opposite input order.
+        // Sorted lock acquisition must let both finish and leave one zone per
+        // address family.
+        // Each task waits at the same barrier before opening its transaction so
+        // the two lock batches compete rather than running sequentially.
+        async fn create_zones(
+            pool: sqlx::PgPool,
+            barrier: Arc<Barrier>,
+            prefixes: Vec<ipnetwork::IpNetwork>,
+        ) {
+            barrier.wait().await;
+            let mut txn = pool.begin().await.unwrap();
+            super::ensure_reverse_zones(&prefixes, &mut txn)
+                .await
+                .unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let ipv4 = "10.0.0.0/16".parse().unwrap();
+        let ipv6 = "fd00::/16".parse().unwrap();
+        let mut setup = pool.begin().await.unwrap();
+        insert_network_prefix(&mut setup, "ordered-ipv4", ipv4).await;
+        insert_network_prefix(&mut setup, "ordered-ipv6", ipv6).await;
+        setup.commit().await.unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                create_zones(pool.clone(), barrier.clone(), vec![ipv4, ipv6]),
+                create_zones(pool.clone(), barrier, vec![ipv6, ipv4])
+            )
+        })
+        .await
+        .expect("sorted reverse-zone lock ordering must not deadlock");
+
+        for zone in ["0.10.in-addr.arpa", "0.0.d.f.ip6.arpa"] {
+            let zones = super::domain::find_by_name(&pool, zone).await.unwrap();
+            assert_eq!(zones.len(), 1, "concurrent creates reuse {zone}");
+        }
+    }
+
+    #[crate::sqlx_test]
+    async fn concurrent_manual_and_network_writers_share_one_zone(pool: sqlx::PgPool) {
+        // A Domain API writer and network lifecycle writer use the same zone
+        // lock, so their find-then-create operations leave one live identity.
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let zone = "0.10.in-addr.arpa".to_string();
+        let mut setup = pool.begin().await.unwrap();
+        insert_network_prefix(&mut setup, "manual-race", prefix).await;
+        setup.commit().await.unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+
+        let manual_writer = async {
+            barrier.wait().await;
+            let mut txn = pool.begin().await.unwrap();
+            super::lock_reverse_zone_names(&mut txn, std::slice::from_ref(&zone))
+                .await
+                .unwrap();
+            if super::domain::find_reverse_zone_by_normalized_name(txn.as_mut(), &zone)
+                .await
+                .unwrap()
+                .is_empty()
+            {
+                super::domain::persist(model::dns::NewDomain::new(zone.clone()), txn.as_mut())
+                    .await
+                    .unwrap();
+            }
+            txn.commit().await.unwrap();
+        };
+        let network_writer = async {
+            barrier.wait().await;
+            let mut txn = pool.begin().await.unwrap();
+            super::ensure_reverse_zones(&[prefix], &mut txn)
+                .await
+                .unwrap();
+            txn.commit().await.unwrap();
+        };
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(manual_writer, network_writer)
+        })
+        .await
+        .expect("manual and network reverse-zone writers must finish");
+
+        let domains = super::domain::find_reverse_zone_by_normalized_name(&pool, &zone)
+            .await
+            .unwrap();
+        assert_eq!(domains.len(), 1);
+    }
+
+    #[crate::sqlx_test]
+    async fn shared_reverse_zone_is_removed_after_its_last_prefix(pool: sqlx::PgPool) {
+        // Equal prefixes share one zone: deleting the first retains it, while
+        // deleting the final live prefix removes it.
+        let mut txn = pool.begin().await.unwrap();
+        sqlx::query(
+            "ALTER TABLE network_prefixes DROP CONSTRAINT IF EXISTS network_prefixes_prefix_excl",
+        )
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let first_segment_id = insert_network_prefix(&mut txn, "first", prefix).await;
+        let second_segment_id = insert_network_prefix(&mut txn, "second", prefix).await;
+        super::ensure_reverse_zones(&[prefix], &mut txn)
+            .await
+            .unwrap();
+
+        sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+            .bind(first_segment_id)
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        super::remove_reverse_zones(&[prefix], first_segment_id, &mut txn)
+            .await
+            .unwrap();
+        let zones = super::domain::find_by_name(txn.as_mut(), "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert_eq!(zones.len(), 1, "the second prefix still needs the zone");
+
+        sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+            .bind(second_segment_id)
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+        super::remove_reverse_zones(&[prefix], second_segment_id, &mut txn)
+            .await
+            .unwrap();
+        let zones = super::domain::find_by_name(txn.as_mut(), "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert!(zones.is_empty(), "the last prefix removes the reverse zone");
+    }
+
+    #[crate::sqlx_test]
+    #[allow(txn_held_across_await)] // Intentionally hold mutations open to force the race.
+    async fn concurrent_create_and_delete_preserve_the_shared_zone(pool: sqlx::PgPool) {
+        // A replacement prefix created while the old segment drains still
+        // needs the shared zone after both transactions commit.
+        let mut setup = pool.begin().await.unwrap();
+        sqlx::query(
+            "ALTER TABLE network_prefixes DROP CONSTRAINT IF EXISTS network_prefixes_prefix_excl",
+        )
+        .execute(setup.as_mut())
+        .await
+        .unwrap();
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let removed_segment_id = insert_network_prefix(&mut setup, "removed", prefix).await;
+        super::ensure_reverse_zones(&[prefix], &mut setup)
+            .await
+            .unwrap();
+        setup.commit().await.unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let delete = async {
+            barrier.wait().await;
+            let mut txn = pool.begin().await.unwrap();
+            sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+                .bind(removed_segment_id)
+                .execute(txn.as_mut())
+                .await
+                .unwrap();
+            barrier.wait().await;
+            super::remove_reverse_zones(&[prefix], removed_segment_id, &mut txn)
+                .await
+                .unwrap();
+            txn.commit().await.unwrap();
+        };
+        let create = async {
+            barrier.wait().await;
+            let mut txn = pool.begin().await.unwrap();
+            insert_network_prefix(&mut txn, "replacement", prefix).await;
+            barrier.wait().await;
+            super::ensure_reverse_zones(&[prefix], &mut txn)
+                .await
+                .unwrap();
+            txn.commit().await.unwrap();
+        };
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(delete, create)
+        })
+        .await
+        .expect("concurrent create and delete must finish");
+
+        let zones = super::domain::find_by_name(&pool, "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert_eq!(zones.len(), 1, "the replacement prefix retains the zone");
+    }
+
+    #[crate::sqlx_test]
+    #[allow(txn_held_across_await)] // Intentionally hold both deletions open to force the race.
+    async fn concurrent_deletes_remove_the_last_shared_zone(pool: sqlx::PgPool) {
+        // Both owners become deleted before either lifecycle call can decide
+        // whether another live prefix remains. Serialization must still remove
+        // the final zone exactly once.
+        let mut setup = pool.begin().await.unwrap();
+        sqlx::query(
+            "ALTER TABLE network_prefixes DROP CONSTRAINT IF EXISTS network_prefixes_prefix_excl",
+        )
+        .execute(setup.as_mut())
+        .await
+        .unwrap();
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let first_segment_id = insert_network_prefix(&mut setup, "delete-first", prefix).await;
+        let second_segment_id = insert_network_prefix(&mut setup, "delete-second", prefix).await;
+        super::ensure_reverse_zones(&[prefix], &mut setup)
+            .await
+            .unwrap();
+        setup.commit().await.unwrap();
+
+        // Start both deletions together, then make their zone removals contend
+        // only after both segment rows are marked deleted.
+        async fn delete_prefix(
+            pool: sqlx::PgPool,
+            barrier: Arc<Barrier>,
+            prefix: ipnetwork::IpNetwork,
+            network_segment_id: NetworkSegmentId,
+        ) {
+            barrier.wait().await;
+            let mut txn = pool.begin().await.unwrap();
+            sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+                .bind(network_segment_id)
+                .execute(txn.as_mut())
+                .await
+                .unwrap();
+            barrier.wait().await;
+            super::remove_reverse_zones(&[prefix], network_segment_id, &mut txn)
+                .await
+                .unwrap();
+            txn.commit().await.unwrap();
+        }
+
+        let barrier = Arc::new(Barrier::new(2));
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                delete_prefix(pool.clone(), barrier.clone(), prefix, first_segment_id),
+                delete_prefix(pool.clone(), barrier, prefix, second_segment_id)
+            )
+        })
+        .await
+        .expect("concurrent deletes must finish");
+
+        let zones = super::domain::find_by_name(&pool, "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert!(zones.is_empty(), "the last shared prefix removes the zone");
+    }
+
+    #[crate::sqlx_test]
+    async fn rolled_back_reverse_zone_create_can_be_retried(pool: sqlx::PgPool) {
+        // PostgreSQL releases both the insert and transaction-scoped zone lock
+        // on rollback, so a later transaction can create the zone normally.
+        let prefix = "10.0.0.0/16".parse().unwrap();
+        let mut setup = pool.begin().await.unwrap();
+        insert_network_prefix(&mut setup, "rollback", prefix).await;
+        setup.commit().await.unwrap();
+
+        let mut rolled_back = pool.begin().await.unwrap();
+        super::ensure_reverse_zones(&[prefix], &mut rolled_back)
+            .await
+            .unwrap();
+        rolled_back.rollback().await.unwrap();
+
+        let mut committed = pool.begin().await.unwrap();
+        super::ensure_reverse_zones(&[prefix], &mut committed)
+            .await
+            .unwrap();
+        committed.commit().await.unwrap();
+
+        let zones = super::domain::find_by_name(&pool, "0.10.in-addr.arpa")
+            .await
+            .unwrap();
+        assert_eq!(zones.len(), 1, "the retry creates one live reverse zone");
+    }
+
     #[test]
     fn test_normalize_domain_name() {
         use carbide_test_support::value_scenarios;
@@ -269,6 +837,26 @@ mod tests {
                 "example.com." => "example.com".to_string(),
                 "EXAMPLE.COM." => "example.com".to_string(),
                 "Example.Com" => "example.com".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn normalizes_only_reverse_zone_names() {
+        // Only child zones below the ARPA roots use normalized identity.
+        // Forward names and the roots themselves keep their existing behavior.
+        use carbide_test_support::value_scenarios;
+
+        value_scenarios!(
+            run = |name: &str| super::normalize_reverse_zone_name(name);
+            "reverse zones" {
+                "0.10.IN-ADDR.ARPA." => Some("0.10.in-addr.arpa".to_string()),
+                "0.0.d.f.ip6.arpa" => Some("0.0.d.f.ip6.arpa".to_string()),
+            }
+            "forward and arpa-root names" {
+                "tenant.example.com" => None,
+                "in-addr.arpa" => None,
+                "ip6.arpa." => None,
             }
         );
     }

--- a/crates/api-db/src/dns/resource_record.rs
+++ b/crates/api-db/src/dns/resource_record.rs
@@ -79,13 +79,29 @@ pub async fn get_soa_record(
     txn: impl DbReader<'_>,
     query_name: &str,
 ) -> Result<Option<DbSoaRecord>, DatabaseError> {
-    let domain_name = crate::dns::normalize_domain(query_name);
-    const QUERY: &str = "SELECT soa from domains WHERE name=$1";
-    sqlx::query_as::<_, DbSoaRecord>(QUERY)
+    let (query, domain_name) =
+        if let Some(reverse_zone) = crate::dns::normalize_reverse_zone_name(query_name) {
+            (
+                "SELECT soa FROM domains
+             WHERE lower(rtrim(name, '.')) = $1
+               AND deleted IS NULL
+               AND (
+                   lower(rtrim(name, '.')) LIKE '%.in-addr.arpa'
+                   OR lower(rtrim(name, '.')) LIKE '%.ip6.arpa'
+               )",
+                reverse_zone,
+            )
+        } else {
+            (
+                "SELECT soa FROM domains WHERE name = $1 AND deleted IS NULL",
+                crate::dns::normalize_domain(query_name),
+            )
+        };
+    sqlx::query_as::<_, DbSoaRecord>(query)
         .bind(domain_name)
         .fetch_optional(txn)
         .await
-        .map_err(|e| DatabaseError::query(QUERY, e))
+        .map_err(|e| DatabaseError::query(query, e))
 }
 
 pub async fn find_record(
@@ -141,30 +157,65 @@ impl<'r> FromRow<'r, PgRow> for DbPtrRecord {
 ///   `host_inband` (the host's own address, answered by the machine source).
 ///
 /// Both look up by `address`, so the query rides the address indexes rather than
-/// scanning. The two arms are disjoint (an overlay address is never a machine
-/// interface address), so the `UNION` only ever merges an accidental exact match.
+/// scanning. Ownership is counted before checking whether an owner has enough DNS
+/// metadata to publish a name. More than one matching row means the address is
+/// ambiguous without a VPC-scoped DNS request, so the query returns no PTR answer
+/// instead of choosing the only owner that happens to have a publishable name.
+/// Any still-stored overlay address whose segment row remains present counts as
+/// an owner, including during soft-delete cleanup, so stale state can only
+/// suppress a PTR answer.
+/// Owner and candidate collection stop at two because the only states that matter
+/// are zero, one, and ambiguous.
 pub async fn find_ptr_record(
     txn: impl DbReader<'_>,
     address: IpAddr,
 ) -> Result<Vec<DbPtrRecord>, DatabaseError> {
     let query = r#"
-    SELECT
-        concat(mi.hostname, '.', d.name, '.') AS ptr_content,
-        COALESCE(meta.ttl, 300) AS ttl,
-        d.id AS domain_id
-    FROM machine_interface_addresses mia
-    JOIN machine_interfaces mi ON mi.id = mia.interface_id
-    JOIN domains d ON d.id = mi.domain_id
-    LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
-    WHERE mia.address = $1::inet
-      AND (mi.primary_interface = TRUE OR mi.interface_type = 'Bmc')
-    UNION
-    SELECT
-        q_name AS ptr_content,
-        COALESCE(ttl, 300) AS ttl,
-        domain_id
-    FROM dns_records_instance
-    WHERE resource_record = $1::inet"#;
+    WITH address_owners AS (
+        SELECT 1
+        FROM (
+            SELECT mia.id
+            FROM machine_interface_addresses mia
+            WHERE mia.address = $1::inet
+            UNION ALL
+            SELECT ia.id
+            FROM instance_addresses ia
+            JOIN network_segments ns ON ns.id = ia.segment_id
+            WHERE ia.address = $1::inet
+              AND ns.network_segment_type <> 'host_inband'
+        ) all_owners
+        LIMIT 2
+    ),
+    ptr_candidates AS (
+        SELECT ptr_content, ttl, domain_id
+        FROM (
+            SELECT
+                concat(mi.hostname, '.', d.name, '.') AS ptr_content,
+                COALESCE(meta.ttl, 300) AS ttl,
+                d.id AS domain_id
+            FROM machine_interface_addresses mia
+            JOIN machine_interfaces mi ON mi.id = mia.interface_id
+            JOIN domains d ON d.id = mi.domain_id
+            LEFT JOIN dns_record_metadata meta ON meta.id = mi.id
+            WHERE mia.address = $1::inet
+              AND (mi.primary_interface = TRUE OR mi.interface_type = 'Bmc')
+              AND d.deleted IS NULL
+            UNION ALL
+            SELECT
+                instance_records.q_name AS ptr_content,
+                COALESCE(instance_records.ttl, 300) AS ttl,
+                instance_records.domain_id
+            FROM dns_records_instance instance_records
+            JOIN domains d ON d.id = instance_records.domain_id
+            WHERE instance_records.resource_record = $1::inet
+              AND d.deleted IS NULL
+        ) all_candidates
+        LIMIT 2
+    )
+    SELECT ptr_content, ttl, domain_id
+    FROM ptr_candidates
+    WHERE (SELECT count(*) FROM address_owners) = 1
+      AND (SELECT count(*) FROM ptr_candidates) = 1"#;
 
     sqlx::query_as::<_, DbPtrRecord>(query)
         .bind(address.to_string())
@@ -223,11 +274,13 @@ mod tests {
     use super::find_record;
     use crate::dns::domain;
 
-    /// Seed a machine, an instance on it, a forward zone, and a network segment of
-    /// `segment_type` whose forward zone is that domain. Returns the instance and
-    /// segment so a caller can attach addresses and look them up.
+    /// Seeds a machine, its instance, a forward zone, and a network segment of
+    /// `segment_type`. `fixture_name` keeps their database-unique names separate
+    /// when one test creates multiple address owners. The returned IDs let the
+    /// caller attach addresses and look them up.
     async fn seed_instance_segment(
         conn: &mut sqlx::PgConnection,
+        fixture_name: &str,
         zone: &str,
         segment_type: &str,
     ) -> (InstanceId, NetworkSegmentId, VpcId) {
@@ -236,19 +289,19 @@ mod tests {
             .unwrap();
         let vpc_id: VpcId =
             sqlx::query_scalar("INSERT INTO vpcs (name, version) VALUES ($1, $2) RETURNING id")
-                .bind("vpc-2408")
+                .bind(format!("vpc-{fixture_name}"))
                 .bind("1")
                 .fetch_one(&mut *conn)
                 .await
                 .unwrap();
         sqlx::query("INSERT INTO machines (id, dpf) VALUES ($1, '{}'::jsonb)")
-            .bind("test-machine-2408")
+            .bind(format!("test-machine-{fixture_name}"))
             .execute(&mut *conn)
             .await
             .unwrap();
         let instance_id: InstanceId =
             sqlx::query_scalar("INSERT INTO instances (machine_id) VALUES ($1) RETURNING id")
-                .bind("test-machine-2408")
+                .bind(format!("test-machine-{fixture_name}"))
                 .fetch_one(&mut *conn)
                 .await
                 .unwrap();
@@ -256,7 +309,7 @@ mod tests {
             "INSERT INTO network_segments (name, version, network_segment_type, subdomain_id, vpc_id)
              VALUES ($1, $2, $3::network_segment_type_t, $4, $5) RETURNING id",
         )
-        .bind("seg-2408")
+        .bind(format!("seg-{fixture_name}"))
         .bind("1")
         .bind(segment_type)
         .bind(zone_domain.id)
@@ -322,7 +375,7 @@ mod tests {
 
         let mut txn = pool.begin().await.unwrap();
         let (instance_id, segment_id, vpc_id) =
-            seed_instance_segment(txn.as_mut(), "tenant.example.com", "tenant").await;
+            seed_instance_segment(txn.as_mut(), "forward", "tenant.example.com", "tenant").await;
         for case in &cases {
             add_address(
                 txn.as_mut(),
@@ -358,8 +411,13 @@ mod tests {
         // already published by the shortname view -- the instance arm must skip it
         // so it is not served twice.
         let mut txn = pool.begin().await.unwrap();
-        let (instance_id, segment_id, vpc_id) =
-            seed_instance_segment(txn.as_mut(), "host.example.com", "host_inband").await;
+        let (instance_id, segment_id, vpc_id) = seed_instance_segment(
+            txn.as_mut(),
+            "host-forward",
+            "host.example.com",
+            "host_inband",
+        )
+        .await;
         add_address(
             txn.as_mut(),
             instance_id,
@@ -403,7 +461,7 @@ mod tests {
 
         let mut txn = pool.begin().await.unwrap();
         let (instance_id, segment_id, vpc_id) =
-            seed_instance_segment(txn.as_mut(), "tenant.example.com", "tenant").await;
+            seed_instance_segment(txn.as_mut(), "reverse", "tenant.example.com", "tenant").await;
         for case in &cases {
             add_address(
                 txn.as_mut(),
@@ -430,13 +488,156 @@ mod tests {
     }
 
     #[crate::sqlx_test]
+    async fn duplicate_overlay_addresses_have_no_reverse_ptr(pool: sqlx::PgPool) {
+        // An address shared by two VPCs has two valid names. Until the request
+        // includes VPC identity, PTR lookup must return neither one.
+        let mut txn = pool.begin().await.unwrap();
+        for (fixture_name, zone) in [
+            ("duplicate-a", "tenant-a.example.com"),
+            ("duplicate-b", "tenant-b.example.com"),
+        ] {
+            let (instance_id, segment_id, vpc_id) =
+                seed_instance_segment(txn.as_mut(), fixture_name, zone, "tenant").await;
+            add_address(
+                txn.as_mut(),
+                instance_id,
+                segment_id,
+                vpc_id,
+                "10.1.2.3",
+                "10.1.2.0/24",
+            )
+            .await;
+        }
+
+        let ptrs = super::find_ptr_record(txn.as_mut(), "10.1.2.3".parse().unwrap())
+            .await
+            .unwrap();
+        assert!(
+            ptrs.is_empty(),
+            "an address shared by separate VPCs has no unscoped PTR answer"
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn a_stored_address_on_a_deleted_segment_still_suppresses_reverse_ptr(
+        pool: sqlx::PgPool,
+    ) {
+        // Cleanup may retain an address after its segment is soft-deleted. It
+        // still counts as an owner so stale state can only suppress another
+        // tenant's PTR, never expose it.
+        let mut txn = pool.begin().await.unwrap();
+        let (named_instance_id, named_segment_id, named_vpc_id) =
+            seed_instance_segment(txn.as_mut(), "named-owner", "named.example.com", "tenant").await;
+        add_address(
+            txn.as_mut(),
+            named_instance_id,
+            named_segment_id,
+            named_vpc_id,
+            "10.1.2.3",
+            "10.1.2.0/24",
+        )
+        .await;
+        sqlx::query("UPDATE network_segments SET deleted = NOW() WHERE id = $1")
+            .bind(named_segment_id)
+            .execute(txn.as_mut())
+            .await
+            .unwrap();
+
+        let (unnamed_instance_id, unnamed_segment_id, unnamed_vpc_id) = seed_instance_segment(
+            txn.as_mut(),
+            "unnamed-owner",
+            "unnamed.example.com",
+            "tenant",
+        )
+        .await;
+        sqlx::query(
+            "INSERT INTO instance_addresses (instance_id, address, segment_id, prefix, vpc_id)
+             VALUES ($1::uuid, $2::inet, $3::uuid, $4::cidr, $5::uuid)",
+        )
+        .bind(unnamed_instance_id)
+        .bind("10.1.2.3")
+        .bind(unnamed_segment_id)
+        .bind("10.1.2.0/24")
+        .bind(unnamed_vpc_id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+
+        let ptrs = super::find_ptr_record(txn.as_mut(), "10.1.2.3".parse().unwrap())
+            .await
+            .unwrap();
+        assert!(
+            ptrs.is_empty(),
+            "a retained address from a deleted segment remains fail-closed"
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn duplicate_non_publishing_machine_address_has_no_reverse_ptr(pool: sqlx::PgPool) {
+        // Ownership is counted before DNS eligibility. A Data interface that
+        // would not publish its own PTR still makes the overlay owner's answer
+        // ambiguous.
+        let mut txn = pool.begin().await.unwrap();
+        let (instance_id, segment_id, vpc_id) = seed_instance_segment(
+            txn.as_mut(),
+            "machine-duplicate",
+            "tenant.example.com",
+            "tenant",
+        )
+        .await;
+        add_address(
+            txn.as_mut(),
+            instance_id,
+            segment_id,
+            vpc_id,
+            "10.1.2.3",
+            "10.1.2.0/24",
+        )
+        .await;
+
+        let interface_id: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces (
+                 segment_id, mac_address, primary_interface, hostname, interface_type
+             )
+             VALUES ($1, '02:00:00:00:38:89', false, 'non-publishing', 'Data')
+             RETURNING id",
+        )
+        .bind(segment_id)
+        .fetch_one(txn.as_mut())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO machine_interface_addresses (interface_id, address)
+             VALUES ($1, $2::inet)",
+        )
+        .bind(interface_id)
+        .bind("10.1.2.3")
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+
+        let ptrs = super::find_ptr_record(txn.as_mut(), "10.1.2.3".parse().unwrap())
+            .await
+            .unwrap();
+        assert!(
+            ptrs.is_empty(),
+            "a non-publishing machine owner still makes an unscoped PTR answer ambiguous"
+        );
+    }
+
+    #[crate::sqlx_test]
     async fn host_inband_instance_addresses_have_no_instance_ptr(pool: sqlx::PgPool) {
         // A host_inband address is the host's own; its PTR comes from the machine
         // source, not the instance arm. With no machine interface here there is no
         // answer -- proving the instance arm excludes host_inband.
         let mut txn = pool.begin().await.unwrap();
-        let (instance_id, segment_id, vpc_id) =
-            seed_instance_segment(txn.as_mut(), "host.example.com", "host_inband").await;
+        let (instance_id, segment_id, vpc_id) = seed_instance_segment(
+            txn.as_mut(),
+            "host-reverse",
+            "host.example.com",
+            "host_inband",
+        )
+        .await;
         add_address(
             txn.as_mut(),
             instance_id,
@@ -457,5 +658,128 @@ mod tests {
             ptrs.is_empty(),
             "host_inband addresses are not answered by the instance arm"
         );
+    }
+
+    #[crate::sqlx_test]
+    async fn soa_lookup_uses_the_recreated_live_reverse_zone(pool: sqlx::PgPool) {
+        // A deleted reverse-zone spelling may be recreated as a new live row.
+        // SOA lookup must select that live replacement instead of the old row.
+        let mut txn = pool.begin().await.unwrap();
+        let mut old = NewDomain::new("0.10.in-addr.arpa");
+        old.soa.as_mut().unwrap().0.primary_ns = "old.example.com".to_string();
+        let old = domain::persist(old, txn.as_mut()).await.unwrap();
+        domain::delete(old, txn.as_mut()).await.unwrap();
+
+        let mut replacement = NewDomain::new("0.10.in-addr.arpa");
+        replacement.soa.as_mut().unwrap().0.primary_ns = "new.example.com".to_string();
+        domain::persist(replacement, txn.as_mut()).await.unwrap();
+
+        let soa = super::get_soa_record(txn.as_mut(), "0.10.in-addr.arpa.")
+            .await
+            .unwrap()
+            .expect("the live replacement has an SOA record");
+        assert_eq!(soa.0.primary_ns, "new.example.com");
+    }
+
+    #[crate::sqlx_test]
+    async fn a_deleted_forward_domain_has_no_soa_record(pool: sqlx::PgPool) {
+        // Soft deletion removes a forward zone from service even though its
+        // SOA data remains stored for lifecycle history.
+        let mut txn = pool.begin().await.unwrap();
+        let domain = domain::persist(NewDomain::new("deleted.example.com"), txn.as_mut())
+            .await
+            .unwrap();
+        domain::delete(domain, txn.as_mut()).await.unwrap();
+
+        let soa = super::get_soa_record(txn.as_mut(), "deleted.example.com")
+            .await
+            .unwrap();
+        assert!(soa.is_none(), "a deleted forward zone cannot serve SOA");
+    }
+
+    #[crate::sqlx_test]
+    async fn a_deleted_instance_domain_has_no_reverse_ptr(pool: sqlx::PgPool) {
+        // An overlay address remains stored while its domain is deleted, but
+        // DNS must not publish a PTR through that inactive zone.
+        let mut txn = pool.begin().await.unwrap();
+        let (instance_id, segment_id, vpc_id) = seed_instance_segment(
+            txn.as_mut(),
+            "deleted-instance-domain",
+            "deleted-instance.example.com",
+            "tenant",
+        )
+        .await;
+        add_address(
+            txn.as_mut(),
+            instance_id,
+            segment_id,
+            vpc_id,
+            "10.1.2.3",
+            "10.1.2.0/24",
+        )
+        .await;
+        let domains = domain::find_by_name(txn.as_mut(), "deleted-instance.example.com")
+            .await
+            .unwrap();
+        let [instance_domain] = domains.as_slice() else {
+            panic!("test fixture should have exactly one instance domain");
+        };
+        domain::delete(instance_domain.clone(), txn.as_mut())
+            .await
+            .unwrap();
+
+        let ptrs = super::find_ptr_record(txn.as_mut(), "10.1.2.3".parse().unwrap())
+            .await
+            .unwrap();
+        assert!(ptrs.is_empty(), "a deleted domain cannot publish PTR");
+    }
+
+    #[crate::sqlx_test]
+    async fn a_deleted_machine_domain_has_no_reverse_ptr(pool: sqlx::PgPool) {
+        // A machine interface keeps its address while its domain is deleted,
+        // but DNS must not publish a PTR through that inactive zone.
+        let mut txn = pool.begin().await.unwrap();
+        let (_, segment_id, _) = seed_instance_segment(
+            txn.as_mut(),
+            "deleted-machine-domain",
+            "deleted-machine.example.com",
+            "tenant",
+        )
+        .await;
+        let domains = domain::find_by_name(txn.as_mut(), "deleted-machine.example.com")
+            .await
+            .unwrap();
+        let [machine_domain] = domains.as_slice() else {
+            panic!("test fixture should have exactly one machine domain");
+        };
+        let machine_domain = machine_domain.clone();
+        let interface_id: uuid::Uuid = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces (
+                 segment_id, mac_address, primary_interface, hostname,
+                 interface_type, domain_id
+             )
+             VALUES ($1, '02:00:00:00:38:90', true, 'deleted-machine', 'Data', $2)
+             RETURNING id",
+        )
+        .bind(segment_id)
+        .bind(machine_domain.id)
+        .fetch_one(txn.as_mut())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO machine_interface_addresses (interface_id, address)
+             VALUES ($1, $2::inet)",
+        )
+        .bind(interface_id)
+        .bind("10.1.2.3")
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+        domain::delete(machine_domain, txn.as_mut()).await.unwrap();
+
+        let ptrs = super::find_ptr_record(txn.as_mut(), "10.1.2.3".parse().unwrap())
+            .await
+            .unwrap();
+        assert!(ptrs.is_empty(), "a deleted domain cannot publish PTR");
     }
 }

--- a/crates/api-db/src/network_prefix.rs
+++ b/crates/api-db/src/network_prefix.rs
@@ -173,6 +173,34 @@ pub async fn find_by<'a, C: super::ColumnInfo<'a, TableType = NetworkPrefix>>(
         .map_err(|e| DatabaseError::query(query.sql(), e))
 }
 
+/// Return the persisted prefixes for configured network definitions.
+///
+/// `network_def.segment_id` is the durable link between a config declaration
+/// and the segment it originally created or unambiguously backfilled. Looking
+/// up prefixes through that link preserves the existing config-drift contract:
+/// a changed declaration does not make startup act on a CIDR that was never
+/// persisted.
+pub async fn find_persisted_for_network_definitions(
+    txn: impl DbReader<'_>,
+    network_definition_names: &[String],
+) -> Result<Vec<IpNetwork>, DatabaseError> {
+    if network_definition_names.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let query = "SELECT np.prefix
+                 FROM network_prefixes np
+                 INNER JOIN network_def nd ON nd.segment_id = np.segment_id
+                 INNER JOIN network_segments ns ON ns.id = nd.segment_id
+                 WHERE nd.name = ANY($1)
+                   AND ns.deleted IS NULL";
+    sqlx::query_scalar(query)
+        .bind(network_definition_names)
+        .fetch_all(txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))
+}
+
 // Return a list of network segment prefixes that are associated with this
 // VPC but are _not_ associated with a VPC prefix.
 pub async fn find_by_vpc(


### PR DESCRIPTION
Global prefix uniqueness meant reverse DNS could assume one `NetworkPrefix` owned each reverse zone and one address owner could answer each PTR lookup. Tenant-managed SitePrefixes will eventually allow isolated VPCs to reuse address space, so those assumptions must be removed before overlap is enabled.

This change normalizes reverse-zone names and uses a transaction-scoped PostgreSQL advisory lock for each affected name. Equal prefixes reuse one live `Domain` row, removal keeps that row until the last live equal prefix is gone, and creation rechecks prefix liveness under the lock so a stale startup snapshot cannot recreate an orphan zone.

PTR lookup now counts the raw owners of an address before returning the existing forward name. If more than one owner exists, it returns no record and preserves the current NXDOMAIN behavior instead of selecting one tenant's name. Startup derives zones from persisted `NetworkPrefix` rows, so config drift cannot create a zone for a CIDR Core never applied.

The database migration is one 16-line file with two indexes: normalized uniqueness for live reverse-zone names and a non-unique overlay-address lookup index. It adds no ownership column and rewrites no DNS data. Existing normalized duplicate live reverse-zone names stop the migration for operator reconciliation.

This is safety plumbing only. It does not enable duplicate prefix allocation, add VPC-scoped DNS views, or change direct `Domain` CRUD authority.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/3889

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Tests cover unique and ambiguous PTRs, shared-zone create/delete races, lock ordering, startup config drift, stale snapshots, soft-deleted forward-domain SOA/PTR suppression, rollback, and unique-address compatibility.

## Additional Notes

These are per-name advisory locks, not row or table locks. The existing global prefix-overlap constraints remain in place until the separate overlap work lands.

Closes #3889
