### PR TITLE
fix(health): preserve Redfish OEM extensions in log records

### DIFF
--- a/crates/health/src/collectors/logs/periodic.rs
+++ b/crates/health/src/collectors/logs/periodic.rs
@@ -418,12 +418,20 @@ impl<B: Bmc + 'static> LogsCollector<B> {
                     })
                     .flatten();
 
-                let mut attributes = Vec::with_capacity(3);
+                let mut attributes = Vec::with_capacity(4);
+
                 if let Some(machine_id) = &machine_id {
                     attributes.push((Cow::Borrowed("machine_id"), machine_id.clone()));
                 }
                 attributes.push((Cow::Borrowed("entry_id"), entry.base.id.clone()));
                 attributes.push((Cow::Borrowed("service_id"), service_id.clone()));
+
+                if let Some(oem) = &entry.base.base.oem {
+                    attributes.push((
+                        Cow::Borrowed("redfish.oem"),
+                        oem.additional_properties.to_string(),
+                    ));
+                }
 
                 let log_event = CollectorEvent::Log(
                     LogRecord {

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -204,6 +204,13 @@ fn event_to_logs<B: Bmc>(
                 attributes.push((Cow::Borrowed("resolution"), resolution.clone()));
             }
 
+            if let Some(oem) = &record.base.base.oem {
+                attributes.push((
+                    Cow::Borrowed("redfish.oem"),
+                    oem.additional_properties.to_string(),
+                ));
+            }
+
             let diagnostic_record = if include_diagnostics {
                 make_diagnostic_record(DiagnosticPayload {
                     diagnostic_data: nullable_str(&record.diagnostic_data),
@@ -234,6 +241,50 @@ fn event_to_logs<B: Bmc>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::endpoint::test_support::{mac, test_endpoint};
+
+    #[test]
+    fn sse_event_preserves_oem_extensions() -> Result<(), HealthError> {
+        let payload = serde_json::from_value(serde_json::json!({
+            "@odata.id": "/redfish/v1/EventService/SSE#/Event1",
+            "@odata.type": "#Event.v1_0_0.Event",
+            "Id": "1",
+            "Name": "Event Array",
+            "Events": [
+                {
+                    "@odata.id": "/redfish/v1/EventService/SSE#/Events/1",
+                    "MemberId": "1",
+                    "EventType": "Alert",
+                    "MessageId": "Example.1.0.Event",
+                    "Oem": {
+                        "Nvidia": {
+                            "ErrorId": "example-error-id"
+                        }
+                    }
+                }
+            ]
+        }))?;
+
+        let endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+
+        let events = map_payload(Ok(payload), endpoint.bmc().as_ref(), false);
+
+        let [Ok(CollectorEvent::Log(record))] = events.as_slice() else {
+            panic!("expected one SSE log record");
+        };
+
+        let oem = record
+            .attributes
+            .iter()
+            .find_map(|(key, value)| (key.as_ref() == "redfish.oem").then_some(value));
+
+        assert_eq!(
+            oem.map(String::as_str),
+            Some(r#"{"Nvidia":{"ErrorId":"example-error-id"}}"#)
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn health_to_severity_known_variants() {


### PR DESCRIPTION
Preserve OEM extensions when `health` converts Redfish events into log records. This helps downstream log consumers access vendor error identifiers or other OEM diagnostics.

## Related issues

Resolves #4748

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)