### PR TITLE
fix(health): keep gNMI STREAM request streams open

### DIFF
--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -17,6 +17,7 @@
 
 use std::time::Duration;
 
+use tokio_stream::StreamExt;
 use tonic::metadata::MetadataMap;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use tonic::{Extensions, Request};
@@ -242,7 +243,9 @@ impl GnmiClient {
         let subscribe_request = build_sample_subscribe_request(paths, sample_interval_nanos);
 
         let auth = build_auth_metadata(&self.username, &self.password)?;
-        let stream = tokio_stream::once(subscribe_request);
+
+        let stream = tokio_stream::once(subscribe_request).chain(tokio_stream::pending());
+
         let request = Request::from_parts(auth, Extensions::default(), stream);
 
         let response = client
@@ -270,7 +273,9 @@ impl GnmiClient {
         let subscribe_request = build_on_change_subscribe_request(prefix, paths);
 
         let auth = build_auth_metadata(&self.username, &self.password)?;
-        let stream = tokio_stream::once(subscribe_request);
+
+        let stream = tokio_stream::once(subscribe_request).chain(tokio_stream::pending());
+
         let request = Request::from_parts(auth, Extensions::default(), stream);
 
         let response = client


### PR DESCRIPTION
Keep the client stream open after sending the initial gNMI `SubscriptionList` for SAMPLE and ON_CHANGE STREAM subscriptions. This allows the gNMI target to return `sync_response` and subsequent telemetry without treating request-stream EOF as RPC termination.

The gNMI specification does not explicitly require the client stream to remain open. However, many gNMI target implementations interpret request-stream EOF as termination of the subscription. Keeping the client stream open is a safe compatibility fix.

## Related issues

Fixes #4754

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)