### PR TITLE
fix(bmc-explorer): tolerate invalid BlueField system interface MACs

### DIFF
--- a/crates/bmc-explorer/src/computer_system.rs
+++ b/crates/bmc-explorer/src/computer_system.rs
@@ -378,6 +378,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
         &self,
         hw_type: Option<hw::HwType>,
     ) -> Result<Vec<ModelEthernetInterface>, Error<B>> {
+        let is_bluefield = hw_type == Some(hw::HwType::Bluefield);
         let mut result = self
             .ethernet_interfaces
             .iter()
@@ -391,18 +392,18 @@ impl<B: Bmc> ExploredComputerSystem<B> {
                     })
                     .transpose()
                     .or_else(|err| {
-                        if iface
-                            .interface_enabled()
-                            .is_some_and(|is_enabled| !is_enabled)
+                        if is_bluefield
+                            || iface
+                                .interface_enabled()
+                                .is_some_and(|is_enabled| !is_enabled)
                         {
-                            // disabled interfaces sometimes populate the MAC address with junk,
-                            // ignore this error and create the interface with an empty mac address
-                            // in the exploration report
+                            // Some BlueField firmware and disabled interfaces can populate
+                            // MACAddress with junk. Keep the interface but omit its invalid MAC.
                             tracing::debug!(
                                 interface_id = %iface.id(),
                                 link_status = ?iface.link_status(),
                                 error = %err,
-                                "could not parse MAC address for a disabled interface"
+                                "ignoring invalid system interface MAC address"
                             );
                             Ok(None)
                         } else {
@@ -428,7 +429,7 @@ impl<B: Bmc> ExploredComputerSystem<B> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        if hw_type.is_some_and(|v| v == hw::HwType::Bluefield)
+        if is_bluefield
             && !result.iter().any(|iface| {
                 iface
                     .id

--- a/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
+++ b/crates/bmc-explorer/tests/integration/bluefield3_explore.rs
@@ -49,6 +49,48 @@ async fn explore_bluefield3_baseline() {
 }
 
 #[test]
+async fn explore_bluefield3_ignores_invalid_system_interface_mac() {
+    let h = test_support::dell_poweredge_r750_bluefield3_bmc(DpuSettings::default()).await;
+    h.state.injection.put(vec![bmc_mock::injection::Rule {
+        id: "invalid_system_interface_mac".into(),
+        selector: bmc_mock::injection::Selector::Path {
+            method: Some("GET".into()),
+            glob: "/redfish/v1/Systems/Bluefield/EthernetInterfaces/oob_net0".into(),
+        },
+        action: bmc_mock::injection::Action::JsonMerge(serde_json::json!({
+            "Id": "eth0",
+            "InterfaceEnabled": true,
+            "LinkStatus": "LinkDown",
+            "MACAddress": "00:00:11:e7:fe:80:00:00:00:00:00:00:02:00:00:03:00:18:00:01",
+        })),
+        remaining: None,
+    }]);
+
+    let report = nv_generate_exploration_report(h.service_root, &common::explorer_config())
+        .await
+        .unwrap();
+    let system = report.systems.first().expect("systems must be present");
+    let eth0 = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("eth0"))
+        .expect("invalid interface must be preserved");
+    let oob = system
+        .ethernet_interfaces
+        .iter()
+        .find(|interface| interface.id.as_deref() == Some("oob_net0"))
+        .expect("OOB interface must be preserved");
+
+    assert_eq!(eth0.mac_address, None);
+    assert!(oob.mac_address.is_some(), "valid OOB MAC must be preserved");
+    assert!(system.base_mac.is_some(), "DPU base MAC must be preserved");
+    assert!(
+        report.dpu_pairing_serial_number().is_some(),
+        "DPU pairing serial number must be preserved"
+    );
+}
+
+#[test]
 async fn explore_bluefield3_without_system_eth_interfaces() {
     let settings = DpuSettings {
         exposes_oob_eth: false,


### PR DESCRIPTION
Some pre-ingestion BlueField-3 BMC firmware reports non-48-bit values in the
`MACAddress` field of enabled ComputerSystem `eth0` and `eth1` interfaces.

The `nv-redfish` explorer currently fails the entire endpoint exploration when
it encounters one of these values. This prevents host/DPU pairing and blocks
ingestion before the normal DPU BMC and NIC firmware update can run.

This change treats an invalid MAC as absent only for BlueField ComputerSystem
interfaces. It preserves the interface and continues processing valid OOB
interfaces, the OEM BaseMAC, pairing serial number, DPU mode, and firmware
inventory.

Manager interfaces and non-BlueField ComputerSystem interfaces remain strict.

A regression test reproduces the failure using an enabled, link-down BF3
`eth0` with a sanitized 20-octet MAC value. It verifies that:

- Exploration succeeds.
- The invalid `eth0` is retained without a MAC.
- The valid OOB MAC is retained.
- The OEM BaseMAC and DPU pairing serial remain available.

## Related issues

Fixes #4756

Related historical changes:

- #465
- #516

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Passed locally:

```bash
cargo fmt --all -- --check
cargo test -p bmc-explorer
cargo clippy -p bmc-explorer --all-targets -- -D warnings
git diff --check
```

Results:

- 7 unit tests passed.
- 26 integration tests passed.
- Crate-level Clippy passed with warnings denied.
- Formatting and diff checks passed.

The repository-wide check was attempted with:

```bash
cargo make --no-workspace clippy-flow
```

It cannot complete on the current macOS host because `libudev-sys` requires
`pkg-config` and the Linux `libudev` development package. This PR remains a
draft until the same command passes on Linux.

## Additional Notes

The change is intentionally limited to MAC conversion for BlueField
ComputerSystem interfaces. It does not change manager-interface handling,
non-BlueField behavior, Site Explorer configuration, or firmware policy.
