### PR TITLE
fix(dpf): detect outdated DPUs by BlueFieldSoftware, not just flavor

### DIFF
--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -37,16 +37,18 @@ pub struct DpuMachineUpdate {
     pub dpf_managed: bool,
 }
 
-/// A DPU identified via DPF whose installed BFB no longer matches the
-/// expected one. Produced by the DPF query layer and joined to host snapshots
-/// by [`DpuMachineUpdate::find_outdated_dpus_dpf`].
+/// A DPU identified via DPF whose installed BFB or BlueFieldSoftware no longer
+/// matches the expected one. Produced by the DPF query layer and joined to host
+/// snapshots by [`DpuMachineUpdate::find_outdated_dpus_dpf`].
 #[derive(Debug, Clone)]
 pub struct OutdatedDpfDpu {
     pub dpu_machine_id: MachineId,
-    /// Expected BFB filename (e.g. `dpf-operator-system-bf-bundle-<hash>.bfb`).
-    /// Used as the `firmware_version` field for traceability when this DPU is
-    /// turned into a [`DpuMachineUpdate`].
-    pub target_bfb: String,
+    /// Expected provisioning source: a BFB filename (e.g.
+    /// `dpf-operator-system-bf-bundle-<hash>.bfb`) or a BlueFieldSoftware CR
+    /// name, depending on which one the owning DPUDeployment declares. Used as
+    /// the `firmware_version` field for traceability when this DPU is turned
+    /// into a [`DpuMachineUpdate`].
+    pub target_source: String,
 }
 
 impl DpuMachineUpdate {
@@ -190,7 +192,7 @@ impl DpuMachineUpdate {
             by_host.entry(host_id).or_default().push(DpuMachineUpdate {
                 host_machine_id: host_id,
                 dpu_machine_id: outdated.dpu_machine_id,
-                firmware_version: outdated.target_bfb.clone(),
+                firmware_version: outdated.target_source.clone(),
                 dpf_managed: true,
             });
         }

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1751,7 +1751,7 @@ fn dpu_mismatch(namespace: &str, dpu: &DPU, deployment: &DPUDeployment) -> Optio
     // instead: the DPUSet strategy is OnDelete, so an existing DPU keeps the
     // spec it was created with, and a spec mismatch means it predates the
     // current deployment.
-    let (source_matches, target_bfb) = match (
+    let (source_matches, target_source) = match (
         deployment.spec.dpus.bfb.as_deref(),
         deployment.spec.dpus.blue_field_software.as_deref(),
     ) {
@@ -1787,7 +1787,7 @@ fn dpu_mismatch(namespace: &str, dpu: &DPU, deployment: &DPUDeployment) -> Optio
     Some(DpuMismatch {
         dpu_cr_name: cr_name,
         dpu_labels: dpu.metadata.labels.clone().unwrap_or_default(),
-        target_bfb,
+        target_source,
     })
 }
 
@@ -4040,7 +4040,7 @@ mod tests {
         );
 
         let mismatch = dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).expect("outdated");
-        assert_eq!(mismatch.target_bfb, "test-namespace-bf-bundle-new.bfb");
+        assert_eq!(mismatch.target_source, "test-namespace-bf-bundle-new.bfb");
     }
 
     #[test]
@@ -4066,7 +4066,7 @@ mod tests {
         let dpu = dpu_with(None, Some("bf-software-old"), TEST_FLAVOR, None);
 
         let mismatch = dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).expect("outdated");
-        assert_eq!(mismatch.target_bfb, "bf-software-new");
+        assert_eq!(mismatch.target_source, "bf-software-new");
     }
 
     #[test]
@@ -4078,7 +4078,7 @@ mod tests {
         let dpu = dpu_with(None, Some("bf-software-abc"), TEST_FLAVOR, None);
 
         let mismatch = dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).expect("outdated");
-        assert_eq!(mismatch.target_bfb, "bf-software-abc");
+        assert_eq!(mismatch.target_source, "bf-software-abc");
     }
 
     /// The DPU CRD requires exactly one provisioning source. A deployment that

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -43,6 +43,7 @@ use crate::crds::dpudevices_generated::{DPUDevice, DpuDeviceSpec};
 use crate::crds::dpunodes_generated::{
     DPUNode, DpuNodeDpus, DpuNodeNodeRebootMethod, DpuNodeNodeRebootMethodExternal, DpuNodeSpec,
 };
+use crate::crds::dpus_generated::DPU;
 use crate::crds::dpuserviceconfigurations_generated::{
     DPUServiceConfiguration, DpuServiceConfigurationInterfaces,
     DpuServiceConfigurationServiceConfiguration,
@@ -1637,28 +1638,34 @@ impl<R: DpuRepository, L> DpfSdk<R, L> {
 }
 
 impl<R: DpuDeploymentRepository + DpuRepository, L> DpfSdk<R, L> {
-    /// Find DPUs whose installed BFB or `spec.dpuFlavor` no longer matches
-    /// the values declared on the DPUDeployment that owns them.
+    /// Find DPUs whose installed BFB, BlueFieldSoftware, or `spec.dpuFlavor` no
+    /// longer matches the values declared on the DPUDeployment that owns them.
     ///
     /// Each DPU is expected to carry the
     /// `svc.dpu.nvidia.com/owned-by-dpudeployment` label (set by the DPF
     /// operator) whose value is `<namespace>_<deployment_name>`. We use that
-    /// label to look up the owning DPUDeployment and read `spec.dpus.bfb`
-    /// (BFB CR name) and `spec.dpus.flavor` from it for the comparison.
+    /// label to look up the owning DPUDeployment and read `spec.dpus.flavor`
+    /// plus whichever provisioning source it declares — `spec.dpus.bfb` (BFB CR
+    /// name) or `spec.dpus.blueFieldSoftware` (BlueFieldSoftware CR name) — for
+    /// the comparison.
     ///
     /// Reading from the deployment — rather than from carbide config —
     /// keeps the comparison correct when multiple DPUDeployments coexist,
-    /// each pinning their DPUs to a different BFB or flavor.
+    /// each pinning their DPUs to a different image or flavor.
     ///
     /// The DPF operator stores the downloaded BFB on disk as
     /// `/bfb/<namespace>-<bfb_cr_name>.bfb` and reflects that path in
     /// `DPU.status.bfbFile`, so the expected filename is just
-    /// `<namespace>-<spec.dpus.bfb>.bfb`.
+    /// `<namespace>-<spec.dpus.bfb>.bfb`. BlueFieldSoftware has no equivalent
+    /// installed-version field in `DPU.status`, so it is compared against
+    /// `DPU.spec.blueFieldSoftware`.
     ///
     /// DPUs are skipped (not flagged) when:
-    /// - the owned-by label is missing or points to an unknown deployment, or
+    /// - the owned-by label is missing or points to an unknown deployment,
     /// - the owning DPUDeployment is not currently reconciled
-    ///   (`DPUSetsReconciled=True` with matching `observedGeneration`),
+    ///   (`DPUSetsReconciled=True` with matching `observedGeneration`), or
+    /// - the owning DPUDeployment declares neither or both provisioning
+    ///   sources, which the DPU CRD forbids,
     ///
     /// to avoid acting on a partially-reconciled or mislabeled cluster.
     ///
@@ -1714,48 +1721,74 @@ impl<R: DpuDeploymentRepository + DpuRepository, L> DpfSdk<R, L> {
                     return None;
                 };
 
-                let expected_flavor = deployment.spec.dpus.flavor.clone().unwrap_or_default();
-                let flavor_matches = dpu.spec.dpu_flavor == expected_flavor;
-
-                // BF4-class deployments provision from a BlueFieldSoftware CR
-                // (`spec.dpus.bfb` is unset) rather than a BFB. We have no
-                // BFB filename to compare against in that case, so only the
-                // flavor is checked to avoid falsely flagging every BF4 DPU as
-                // outdated.
-                // TODO: compare the installed BlueFieldSoftware version once the
-                // DPU status exposes it, so BF4 software changes trigger reprovisioning.
-                let Some(expected_bfb_cr_name) = deployment.spec.dpus.bfb.clone() else {
-                    if flavor_matches {
-                        return None;
-                    }
-                    return Some(DpuMismatch {
-                        dpu_cr_name: cr_name,
-                        dpu_labels: dpu.metadata.labels.clone().unwrap_or_default(),
-                        target_bfb: String::new(),
-                    });
-                };
-
-                let expected_filename = format!("{}-{}.bfb", self.namespace, expected_bfb_cr_name);
-
-                let current_basename = dpu
-                    .status
-                    .as_ref()
-                    .and_then(|s| s.bfb_file.as_deref())
-                    .map(bfb_file_basename);
-                let bfb_matches = current_basename == Some(expected_filename.as_str());
-                if bfb_matches && flavor_matches {
-                    return None;
-                }
-                Some(DpuMismatch {
-                    dpu_cr_name: cr_name,
-                    dpu_labels: dpu.metadata.labels.clone().unwrap_or_default(),
-                    target_bfb: expected_filename,
-                })
+                dpu_mismatch(&self.namespace, &dpu, deployment)
             })
             .collect();
 
         Ok(mismatches)
     }
+}
+
+/// Compare one DPU against the DPUDeployment that owns it.
+///
+/// Returns `None` when the DPU already matches the deployment (so a
+/// reprovision would be pointless) and `Some` describing the drift when it does
+/// not. Also returns `None` when the deployment is malformed, so a bad
+/// deployment never triggers a fleet-wide reprovision.
+///
+/// Split out of [`DpfSdk::find_outdated_dpus_dpf`] so the comparison can be
+/// exercised directly, without standing up repository mocks for a namespace
+/// scan.
+fn dpu_mismatch(namespace: &str, dpu: &DPU, deployment: &DPUDeployment) -> Option<DpuMismatch> {
+    let cr_name = dpu.metadata.name.clone()?;
+    let expected_flavor = deployment.spec.dpus.flavor.clone().unwrap_or_default();
+    let flavor_matches = dpu.spec.dpu_flavor == expected_flavor;
+
+    // A DPUDeployment provisions from either a BFB or a BlueFieldSoftware CR;
+    // the DPU CRD enforces that exactly one is set. BFB staleness is read from
+    // `status.bfbFile`, the image actually installed. BlueFieldSoftware has no
+    // installed-version field in status, so it is compared against `spec`
+    // instead: the DPUSet strategy is OnDelete, so an existing DPU keeps the
+    // spec it was created with, and a spec mismatch means it predates the
+    // current deployment.
+    let (source_matches, target_bfb) = match (
+        deployment.spec.dpus.bfb.as_deref(),
+        deployment.spec.dpus.blue_field_software.as_deref(),
+    ) {
+        (Some(expected_bfb_cr_name), None) => {
+            let expected_filename = format!("{namespace}-{expected_bfb_cr_name}.bfb");
+            let current_basename = dpu
+                .status
+                .as_ref()
+                .and_then(|s| s.bfb_file.as_deref())
+                .map(bfb_file_basename);
+            let matches = current_basename == Some(expected_filename.as_str());
+            (matches, expected_filename)
+        }
+        (None, Some(expected_software)) => {
+            let matches = dpu.spec.blue_field_software.as_deref() == Some(expected_software);
+            (matches, expected_software.to_string())
+        }
+        // Neither or both set violates the DPU CRD's
+        // `has(self.bfb) != has(self.blueFieldSoftware)` rule. Skip rather than
+        // reprovision every DPU off a malformed deployment.
+        _ => {
+            tracing::warn!(
+                dpu_name = %cr_name,
+                "Owning DPUDeployment sets neither or both of bfb and blueFieldSoftware; skipping"
+            );
+            return None;
+        }
+    };
+
+    if source_matches && flavor_matches {
+        return None;
+    }
+    Some(DpuMismatch {
+        dpu_cr_name: cr_name,
+        dpu_labels: dpu.metadata.labels.clone().unwrap_or_default(),
+        target_bfb,
+    })
 }
 
 /// Extract the trailing filename from a `DPU.status.bfbFile` path
@@ -3926,5 +3959,144 @@ mod tests {
             run,
         )
         .await;
+    }
+
+    const TEST_FLAVOR: &str = "test-flavor";
+
+    fn deployment_with(source: DpuProvisioningSource, flavor: &str) -> DPUDeployment {
+        build_deployment(
+            &[],
+            "test-deployment",
+            &source,
+            flavor,
+            TEST_NAMESPACE,
+            &[],
+            BTreeMap::new(),
+            DpuDeploymentType::Bf3,
+        )
+    }
+
+    /// Build a DPU through serde so the literal only names the fields each test
+    /// cares about; every other CRD field defaults, and adding one upstream does
+    /// not churn these tests.
+    fn dpu_with(
+        bfb: Option<&str>,
+        blue_field_software: Option<&str>,
+        flavor: &str,
+        installed_bfb_file: Option<&str>,
+    ) -> DPU {
+        let spec = serde_json::json!({
+            "bfb": bfb,
+            "blueFieldSoftware": blue_field_software,
+            "dpuDeviceName": "device-001",
+            "dpuFlavor": flavor,
+            "dpuNodeName": "node-host-001",
+            "nodeEffect": {},
+            "serialNumber": "SN123",
+        });
+        let status = serde_json::json!({
+            "phase": "Ready",
+            "bfbFile": installed_bfb_file,
+        });
+
+        DPU {
+            metadata: kube::core::ObjectMeta {
+                name: Some("node-host-001-device-001".to_string()),
+                namespace: Some(TEST_NAMESPACE.to_string()),
+                ..Default::default()
+            },
+            spec: serde_json::from_value(spec).expect("valid DpuSpec"),
+            status: Some(serde_json::from_value(status).expect("valid DpuStatus")),
+        }
+    }
+
+    #[test]
+    fn bfb_dpu_matching_its_deployment_is_not_outdated() {
+        let deployment = deployment_with(
+            DpuProvisioningSource::Bfb("bf-bundle-abc".to_string()),
+            TEST_FLAVOR,
+        );
+        let dpu = dpu_with(
+            Some("bf-bundle-abc"),
+            None,
+            TEST_FLAVOR,
+            Some("/bfb/test-namespace-bf-bundle-abc.bfb"),
+        );
+
+        assert!(dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).is_none());
+    }
+
+    #[test]
+    fn bfb_dpu_running_an_older_image_is_outdated() {
+        let deployment = deployment_with(
+            DpuProvisioningSource::Bfb("bf-bundle-new".to_string()),
+            TEST_FLAVOR,
+        );
+        let dpu = dpu_with(
+            Some("bf-bundle-old"),
+            None,
+            TEST_FLAVOR,
+            Some("/bfb/test-namespace-bf-bundle-old.bfb"),
+        );
+
+        let mismatch = dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).expect("outdated");
+        assert_eq!(mismatch.target_bfb, "test-namespace-bf-bundle-new.bfb");
+    }
+
+    #[test]
+    fn blue_field_software_dpu_matching_its_deployment_is_not_outdated() {
+        let deployment = deployment_with(
+            DpuProvisioningSource::BlueFieldSoftware("bf-software-abc".to_string()),
+            TEST_FLAVOR,
+        );
+        let dpu = dpu_with(None, Some("bf-software-abc"), TEST_FLAVOR, None);
+
+        assert!(dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).is_none());
+    }
+
+    /// A BlueFieldSoftware change used to be invisible: with no BFB to compare,
+    /// only the flavor was checked, so a BF4 DPU pinned to superseded software
+    /// was reported as up to date and never reprovisioned.
+    #[test]
+    fn blue_field_software_change_marks_dpu_outdated() {
+        let deployment = deployment_with(
+            DpuProvisioningSource::BlueFieldSoftware("bf-software-new".to_string()),
+            TEST_FLAVOR,
+        );
+        let dpu = dpu_with(None, Some("bf-software-old"), TEST_FLAVOR, None);
+
+        let mismatch = dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).expect("outdated");
+        assert_eq!(mismatch.target_bfb, "bf-software-new");
+    }
+
+    #[test]
+    fn flavor_change_marks_blue_field_software_dpu_outdated() {
+        let deployment = deployment_with(
+            DpuProvisioningSource::BlueFieldSoftware("bf-software-abc".to_string()),
+            "new-flavor",
+        );
+        let dpu = dpu_with(None, Some("bf-software-abc"), TEST_FLAVOR, None);
+
+        let mismatch = dpu_mismatch(TEST_NAMESPACE, &dpu, &deployment).expect("outdated");
+        assert_eq!(mismatch.target_bfb, "bf-software-abc");
+    }
+
+    /// The DPU CRD requires exactly one provisioning source. A deployment that
+    /// satisfies neither side of that rule must not reprovision the fleet.
+    #[test]
+    fn deployment_with_both_or_neither_source_is_skipped() {
+        let dpu = dpu_with(Some("bf-bundle-abc"), None, TEST_FLAVOR, None);
+
+        let mut both = deployment_with(
+            DpuProvisioningSource::Bfb("bf-bundle-abc".to_string()),
+            TEST_FLAVOR,
+        );
+        both.spec.dpus.blue_field_software = Some("bf-software-abc".to_string());
+        assert!(dpu_mismatch(TEST_NAMESPACE, &dpu, &both).is_none());
+
+        let mut neither = both;
+        neither.spec.dpus.bfb = None;
+        neither.spec.dpus.blue_field_software = None;
+        assert!(dpu_mismatch(TEST_NAMESPACE, &dpu, &neither).is_none());
     }
 }

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -121,7 +121,7 @@ pub struct DpuMismatch {
     /// deployment this is the expected BFB filename (e.g.
     /// `<namespace>-bf-bundle-<sha256>.bfb`); for a BlueFieldSoftware-based one
     /// it is the expected BlueFieldSoftware CR name.
-    pub target_bfb: String,
+    pub target_source: String,
 }
 
 /// Service type for configPorts (DPUServiceConfiguration).

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -109,15 +109,18 @@ pub struct DpfProxyDetails {
     pub no_proxy: Vec<String>,
 }
 
-/// A DPU CR whose installed BFB or `spec.dpuFlavor` does not match the
-/// expected one. Returned by [`crate::DpfSdk::find_outdated_dpus_dpf`]; the
-/// labels map is the DPU CR's `metadata.labels` so callers can map back to
-/// their own identifiers.
+/// A DPU CR whose installed BFB, BlueFieldSoftware, or `spec.dpuFlavor` does
+/// not match the expected one. Returned by
+/// [`crate::DpfSdk::find_outdated_dpus_dpf`]; the labels map is the DPU CR's
+/// `metadata.labels` so callers can map back to their own identifiers.
 #[derive(Debug, Clone)]
 pub struct DpuMismatch {
     pub dpu_cr_name: String,
     pub dpu_labels: std::collections::BTreeMap<String, String>,
-    /// Expected BFB filename (e.g. `<namespace>-bf-bundle-<sha256>.bfb`).
+    /// Expected provisioning source, for traceability only. For a BFB-based
+    /// deployment this is the expected BFB filename (e.g.
+    /// `<namespace>-bf-bundle-<sha256>.bfb`); for a BlueFieldSoftware-based one
+    /// it is the expected BlueFieldSoftware CR name.
     pub target_bfb: String,
 }
 

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -635,7 +635,7 @@ impl DpfOperations for DpfSdkOps {
             };
             out.push(OutdatedDpfDpu {
                 dpu_machine_id,
-                target_bfb: m.target_bfb,
+                target_source: m.target_source,
             });
         }
         Ok(out)


### PR DESCRIPTION
Carbide decides whether a DPU needs reprovisioning by comparing what it is running against what its owning DPUDeployment declares. A deployment provisions its DPUs from one of two sources: a BFB, or a BlueFieldSoftware CR for BF4-class hardware. The DPU CRD requires exactly one of the two to be set.

Only the BFB case was ever compared. When a deployment provisioned from BlueFieldSoftware there was no BFB to compare against, so the staleness check fell back to the DPU flavor alone. A BlueFieldSoftware change therefore never registered as drift: the DPU was reported up to date, was never queued for reprovisioning, and kept running superseded software indefinitely. Only a flavor change could dislodge it.

This compares whichever provisioning source the owning deployment actually declares, so a BlueFieldSoftware change now marks its DPUs outdated exactly as a BFB change already did.

A deployment that declares neither source, or both, violates the CRD's own constraint. Those are skipped and logged rather than read as drift, so a malformed deployment cannot queue every DPU beneath it for reprovisioning.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Covers each provisioning source both matching and drifting, a flavor change on a BlueFieldSoftware-provisioned DPU, and the malformed-deployment guard.

## Additional Notes

One asymmetry is worth knowing when reasoning about the behaviour. BFB staleness is judged against the image the DPU actually installed, whereas BlueFieldSoftware is judged against the software the DPU was created from, because DPU status exposes no installed BlueFieldSoftware version. This holds because DPUs are replaced rather than mutated when their deployment changes, so a DPU that predates the current software is still detected. It does mean the BlueFieldSoftware check answers "was this DPU created from the current software?" rather than "did it finish installing it?". If DPF later surfaces an installed version in DPU status, the check can be tightened to match the BFB path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
