### PR TITLE
chore: update nv-redfish to 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7819,9 +7819,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ebec199a41aa356229f9474566dd259b5342ee0ffa03693cb71e71b8efae15"
+checksum = "42762fc262b81359c6f05cb8b6bdd7d42d9fee3210a1680885b2376a9f9911ec"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -7836,9 +7836,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-bmc-http"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1312af6ba88347e7baf899dcbc4028a4fe90f1e0a0cbf9642437cc93e1f8e39e"
+checksum = "bed037619507a81fe1b241e04414f9562a8da41b6774c13df55a9330644117af"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7861,9 +7861,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8490d57e2e32eea59b06602a9f509b135bab373fd89f567079c3c42a353ecb3"
+checksum = "566a75a8c7d75b0d8e24289e2d8c9792ed102ede29ab7a4996510c90b21a3fce"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -7876,9 +7876,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-csdl-compiler"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4908c4aa3667e616b31a519d7bc4956c1347c506818e3e3659e87f4db841bc"
+checksum = "5838f179f001a8250aa08ae69abac660e8d29f2dd8041fa5806579b64b1b734c"
 dependencies = [
  "clap",
  "clap_derive",
@@ -7894,9 +7894,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-dispatcher"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc269d07729c6dcd15554acd0df6771b591916f8edd0e80df6838148b4fa12"
+checksum = "14522a81dc4de549fcc88b755ed5505d5f5e26ed65a04c7ebec684191ae609ae"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -7904,9 +7904,9 @@ dependencies = [
 
 [[package]]
 name = "nv-redfish-schema"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02475039687858405479c5a1773d58d54256bd59be139eec5350072c1f452733"
+checksum = "eccdaff625f93aa51bd52880bbabdfd43323f75224238a4a85f5f9eefdbf2b78"
 dependencies = [
  "glob",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ opentelemetry-semantic-conventions = "0.32.1"
 tracing-opentelemetry = "0.33.0"
 
 # NV-Redfish
-nv-redfish = { version = "0.14.1" }
-nv-redfish-dispatcher = { version = "0.14.1" }
+nv-redfish = { version = "0.14.2" }
+nv-redfish-dispatcher = { version = "0.14.2" }
 
 ########
 # MARK: - Pinned packages that we can't upgrade due to conflicts or just bugs


### PR DESCRIPTION
Updates nv-redfish to 0.14.2 https://github.com/NVIDIA/nv-redfish/releases/tag/v0.14.2

Introduces fixes for VR Hardware SSE connections missing fields

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

