### PR TITLE
fix(admin-cli,api-web): show all interface addresses in remaining views

### DIFF
--- a/crates/api-web/src/instance.rs
+++ b/crates/api-web/src/instance.rs
@@ -454,7 +454,7 @@ impl From<forgerpc::Instance> for InstanceDetail {
 }
 
 async fn get_network_segments_map_for_instance(
-    state: Arc<Api>,
+    state: &Api,
     if_configs: &[forgerpc::InstanceInterfaceConfig],
 ) -> Result<HashMap<NetworkSegmentId, NetworkSegment>, tonic::Status> {
     let network_segment_ids: Vec<NetworkSegmentId> = if_configs
@@ -483,14 +483,9 @@ async fn get_network_segments_map_for_instance(
 }
 
 async fn get_vpc_map_for_instance(
-    state: Arc<Api>,
-    network_segments_map: &HashMap<NetworkSegmentId, NetworkSegment>,
+    state: &Api,
+    vpc_ids: Vec<VpcId>,
 ) -> Result<HashMap<VpcId, forgerpc::Vpc>, tonic::Status> {
-    let vpc_ids: Vec<VpcId> = network_segments_map
-        .values()
-        .filter_map(|ns| ns.config.as_ref().and_then(|c| c.vpc_id))
-        .collect();
-
     let vpc_req = tonic::Request::new(forgerpc::VpcsByIdsRequest { vpc_ids });
 
     let vpcs = state.find_vpcs_by_ids(vpc_req).await?.into_inner().vpcs;
@@ -504,16 +499,17 @@ async fn get_vpc_map_for_instance(
 }
 
 async fn get_interfaces_for_instance_detail(
-    state: Arc<Api>,
+    state: &Api,
     instance: &forgerpc::Instance,
 ) -> Result<Vec<InstanceInterface>, tonic::Status> {
-    let mut interfaces = Vec::new();
-    let if_configs = instance
+    let network_config = instance
         .config
         .as_ref()
-        .and_then(|config| config.network.as_ref())
+        .and_then(|config| config.network.as_ref());
+    let if_configs = network_config
         .map(|config| config.interfaces.as_slice())
         .unwrap_or_default();
+    let is_auto_network = network_config.is_some_and(|config| config.auto_config.is_some());
     let if_status = instance
         .status
         .as_ref()
@@ -521,55 +517,90 @@ async fn get_interfaces_for_instance_detail(
         .map(|status| status.interfaces.as_slice())
         .unwrap_or_default();
 
-    if if_configs.len() != if_status.len() {
-        return Ok(interfaces);
+    if !is_auto_network && if_configs.len() != if_status.len() {
+        return Ok(Vec::new());
     }
 
-    let network_segments_map =
-        get_network_segments_map_for_instance(state.clone(), if_configs).await?;
+    let network_segments_map = if is_auto_network {
+        HashMap::new()
+    } else {
+        get_network_segments_map_for_instance(state, if_configs).await?
+    };
 
-    let vpc_map = get_vpc_map_for_instance(state, &network_segments_map).await?;
+    let vpc_ids = if is_auto_network {
+        if_status
+            .iter()
+            .filter_map(|status| status.vpc_id)
+            .collect()
+    } else {
+        network_segments_map
+            .values()
+            .filter_map(|segment| segment.config.as_ref().and_then(|config| config.vpc_id))
+            .collect()
+    };
 
-    for (i, interface) in if_configs.iter().enumerate() {
-        let mut vpc_id = "".to_string();
-        let mut vpc_name = "".to_string();
+    let vpc_map = get_vpc_map_for_instance(state, vpc_ids).await?;
 
-        if let Some(ns_id) = interface.network_segment_id
-            && let Some(ns) = network_segments_map.get(&ns_id)
-            && let Some(vpc_id_val) = ns.config.as_ref().and_then(|c| c.vpc_id)
-            && let Some(vpc) = vpc_map.get(&vpc_id_val)
-        {
-            vpc_id = vpc.id.map(|id| id.to_string()).unwrap_or_default();
-            vpc_name = vpc
-                .metadata
-                .as_ref()
-                .map(|x| x.name.as_str())
-                .unwrap_or("<no name>")
-                .to_string();
-        }
+    let interfaces = if_status
+        .iter()
+        .enumerate()
+        .map(|(index, status)| {
+            let interface = if_configs.get(index);
+            let function_type = match interface {
+                Some(interface) => {
+                    forgerpc::InterfaceFunctionType::try_from(interface.function_type)
+                        .ok()
+                        .map(|interface_type| format!("{interface_type:?}"))
+                        .unwrap_or_else(|| "INVALID".to_string())
+                }
+                None => match status.virtual_function_id {
+                    Some(_) => format!("{:?}", forgerpc::InterfaceFunctionType::Virtual),
+                    None => format!("{:?}", forgerpc::InterfaceFunctionType::Physical),
+                },
+            };
+            let vpc_id = if is_auto_network {
+                status.vpc_id
+            } else {
+                interface
+                    .and_then(|interface| interface.network_segment_id)
+                    .and_then(|network_segment_id| network_segments_map.get(&network_segment_id))
+                    .and_then(|segment| segment.config.as_ref())
+                    .and_then(|config| config.vpc_id)
+            };
+            let vpc = vpc_id.and_then(|vpc_id| vpc_map.get(&vpc_id));
+            let mac_address = status
+                .mac_address
+                .clone()
+                .unwrap_or("<unknown>".to_string());
+            InstanceInterface {
+                function_type,
+                vf_id: status
+                    .virtual_function_id
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
+                segment_id: interface
+                    .map(|interface| interface.network_segment_id.unwrap_or_default().to_string())
+                    .unwrap_or_default(),
+                mac_address,
+                addresses: status.addresses.join(", "),
+                gateways: status.gateways.join(", "),
+                vpc_id: vpc
+                    .and_then(|vpc| vpc.id)
+                    .map(|id| id.to_string())
+                    .unwrap_or_default(),
+                vpc_name: vpc
+                    .map(|vpc| {
+                        vpc.metadata
+                            .as_ref()
+                            .map(|metadata| metadata.name.as_str())
+                            .unwrap_or("<no name>")
+                    })
+                    .unwrap_or_default()
+                    .to_string(),
+            }
+        })
+        .collect();
 
-        let status = &if_status[i];
-        let mac_address = status
-            .mac_address
-            .clone()
-            .unwrap_or("<unknown>".to_string());
-        interfaces.push(InstanceInterface {
-            function_type: forgerpc::InterfaceFunctionType::try_from(interface.function_type)
-                .ok()
-                .map(|ty| format!("{ty:?}"))
-                .unwrap_or_else(|| "INVALID".to_string()),
-            vf_id: status
-                .virtual_function_id
-                .map(|id| id.to_string())
-                .unwrap_or_default(),
-            segment_id: interface.network_segment_id.unwrap_or_default().to_string(),
-            mac_address,
-            addresses: status.addresses.clone().join(", "),
-            gateways: status.gateways.clone().join(", "),
-            vpc_id,
-            vpc_name,
-        });
-    }
     Ok(interfaces)
 }
 
@@ -629,7 +660,7 @@ pub(super) async fn detail(
         return (StatusCode::OK, Json(instance)).into_response();
     }
 
-    let instance_detail_interfaces = get_interfaces_for_instance_detail(state.clone(), &instance)
+    let instance_detail_interfaces = get_interfaces_for_instance_detail(&state, &instance)
         .await
         .unwrap_or_else(|_| Vec::new());
     let mut instance_detail: InstanceDetail = instance.into();
@@ -639,3 +670,92 @@ pub(super) async fn detail(
 
 impl super::Base for InstanceShow {}
 impl super::Base for InstanceDetail {}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_harness::TestHarness;
+
+    use super::*;
+
+    #[crate::sqlx_test]
+    async fn auto_network_instance_detail_uses_status_interfaces(
+        pool: sqlx::PgPool,
+    ) -> eyre::Result<()> {
+        let test_harness = TestHarness::builder(pool).build().await;
+        let vpc_id = test_harness
+            .network_controller()
+            .create_vpc("auto network instance detail")
+            .await;
+        let instance = forgerpc::Instance {
+            config: Some(forgerpc::InstanceConfig {
+                network: Some(forgerpc::InstanceNetworkConfig {
+                    interfaces: Vec::new(),
+                    auto_config: Some(forgerpc::InstanceNetworkAutoConfig {
+                        vpc_id: Some(vpc_id),
+                    }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            status: Some(forgerpc::InstanceStatus {
+                network: Some(forgerpc::InstanceNetworkStatus {
+                    interfaces: vec![
+                        forgerpc::InstanceInterfaceStatus {
+                            mac_address: Some("02:00:00:00:00:01".to_string()),
+                            addresses: vec!["192.0.2.10".to_string(), "2001:db8::10".to_string()],
+                            gateways: vec![
+                                "192.0.2.1/24".to_string(),
+                                "2001:db8::1/64".to_string(),
+                            ],
+                            vpc_id: Some(vpc_id),
+                            ..Default::default()
+                        },
+                        forgerpc::InstanceInterfaceStatus {
+                            virtual_function_id: Some(7),
+                            mac_address: Some("02:00:00:00:00:02".to_string()),
+                            addresses: vec!["2001:db8::20".to_string()],
+                            gateways: vec!["2001:db8::1/64".to_string()],
+                            vpc_id: Some(vpc_id),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let interfaces = get_interfaces_for_instance_detail(test_harness.api(), &instance).await?;
+
+        assert_eq!(interfaces.len(), 2);
+        let physical_interface = &interfaces[0];
+        assert_eq!(physical_interface.function_type, "Physical");
+        assert!(physical_interface.segment_id.is_empty());
+        assert_eq!(physical_interface.mac_address, "02:00:00:00:00:01");
+        assert_eq!(physical_interface.addresses, "192.0.2.10, 2001:db8::10");
+        assert_eq!(physical_interface.gateways, "192.0.2.1/24, 2001:db8::1/64");
+        assert_eq!(physical_interface.vpc_id, vpc_id.to_string());
+        assert_eq!(physical_interface.vpc_name, "auto network instance detail");
+
+        let virtual_interface = &interfaces[1];
+        assert_eq!(virtual_interface.function_type, "Virtual");
+        assert_eq!(virtual_interface.vf_id, "7");
+        assert!(virtual_interface.segment_id.is_empty());
+        assert_eq!(virtual_interface.mac_address, "02:00:00:00:00:02");
+        assert_eq!(virtual_interface.addresses, "2001:db8::20");
+        assert_eq!(virtual_interface.gateways, "2001:db8::1/64");
+        assert_eq!(virtual_interface.vpc_id, vpc_id.to_string());
+        assert_eq!(virtual_interface.vpc_name, "auto network instance detail");
+
+        let mut detail: InstanceDetail = instance.into();
+        detail.interfaces = interfaces;
+        let html = detail.render()?;
+        assert!(html.contains("192.0.2.10, 2001:db8::10"));
+        assert!(html.contains("2001:db8::20"));
+        assert!(html.contains(&format!("/admin/vpc/{vpc_id}")));
+        assert!(!html.contains("href=\"/admin/network-segment/\""));
+
+        Ok(())
+    }
+}

--- a/crates/api-web/src/managed_host.rs
+++ b/crates/api-web/src/managed_host.rs
@@ -171,15 +171,7 @@ impl ManagedHostRowDisplay {
             .interfaces
             .into_iter()
             .find(|i| i.primary_interface)
-            .map(|i| {
-                (
-                    i.addresses
-                        .first()
-                        .map(|i| i.to_string())
-                        .unwrap_or_default(),
-                    i.mac_address.to_string(),
-                )
-            })
+            .map(|i| (i.addresses.iter().join(","), i.mac_address.to_string()))
             .unwrap_or_default();
 
         Self {
@@ -238,7 +230,7 @@ impl From<model::machine::Machine> for AttachedDpuRowDisplay {
             .unwrap_or_default();
         let primary_iface = item.status.interfaces.iter().find(|i| i.primary_interface);
         let oob_ip = primary_iface
-            .and_then(|t| t.addresses.first().map(|a| a.to_string()))
+            .map(|interface| interface.addresses.iter().join(","))
             .unwrap_or_default();
         let oob_mac = primary_iface
             .map(|t| t.mac_address.to_string())
@@ -870,6 +862,7 @@ impl super::Base for ManagedHostShow {}
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use model::machine::LoadSnapshotOptions;
 
     use super::ManagedHostRowDisplay;
@@ -905,8 +898,56 @@ mod tests {
             "Unexpected number of managed host snapshots"
         );
 
-        let snapshot = snapshots.into_iter().next().unwrap();
+        let mut snapshot = snapshots.into_iter().next().unwrap();
         assert_eq!(snapshot.host_snapshot.id, machine_id);
+
+        snapshot
+            .host_snapshot
+            .status
+            .interfaces
+            .iter_mut()
+            .find(|interface| interface.primary_interface)
+            .expect("host should have a primary interface")
+            .addresses
+            .push("2001:db8::10".parse().unwrap());
+        for (dpu, address) in snapshot
+            .dpu_snapshots
+            .iter_mut()
+            .zip(["2001:db8::20", "2001:db8::30"])
+        {
+            dpu.status
+                .interfaces
+                .iter_mut()
+                .find(|interface| interface.primary_interface)
+                .expect("DPU should have a primary interface")
+                .addresses
+                .push(address.parse().unwrap());
+        }
+
+        let host_admin_ips = snapshot
+            .host_snapshot
+            .status
+            .interfaces
+            .iter()
+            .find(|interface| interface.primary_interface)
+            .expect("host should have a primary interface")
+            .addresses
+            .iter()
+            .join(",");
+        let dpu_oob_ips: Vec<String> = snapshot
+            .dpu_snapshots
+            .iter()
+            .map(|dpu| {
+                dpu.status
+                    .interfaces
+                    .iter()
+                    .find(|interface| interface.primary_interface)
+                    .expect("DPU should have a primary interface")
+                    .addresses
+                    .iter()
+                    .join(",")
+            })
+            .collect();
 
         let sla_config = model::machine::slas::MachineSlaConfig::new(
             env.api()
@@ -935,7 +976,7 @@ mod tests {
         assert_eq!(row.machine_id, machine_id.to_string());
         assert!(!row.health_sources.is_empty());
         assert!(row.health_probe_alerts.is_empty());
-        assert!(!row.host_admin_ip.is_empty());
+        assert_eq!(row.host_admin_ip, host_admin_ips);
         assert_eq!(row.host_admin_mac, mh.host.primary_mac().to_string());
         assert!(row.state_reason.is_empty());
 
@@ -948,7 +989,7 @@ mod tests {
         assert_eq!(row.dpus[0].bmc_ip, build_data.dpu_bmc_ip(0).to_string());
         assert_eq!(row.dpus[0].bmc_mac, dpu_1.bmc_mac.to_string());
         assert_eq!(row.dpus[0].oob_mac, dpu_1.oob_mac().to_string());
-        assert!(!row.dpus[0].oob_ip.is_empty(), "dpu should show an oob ip");
+        assert_eq!(row.dpus[0].oob_ip, dpu_oob_ips[0]);
 
         assert_eq!(
             row.dpus[1].machine_id,
@@ -957,7 +998,7 @@ mod tests {
         assert_eq!(row.dpus[1].bmc_ip, build_data.dpu_bmc_ip(1).to_string());
         assert_eq!(row.dpus[1].bmc_mac, dpu_2.bmc_mac.to_string());
         assert_eq!(row.dpus[1].oob_mac, dpu_2.oob_mac().to_string());
-        assert!(!row.dpus[1].oob_ip.is_empty(), "dpu should show an oob ip");
+        assert_eq!(row.dpus[1].oob_ip, dpu_oob_ips[1]);
 
         Ok(())
     }

--- a/crates/api-web/templates/instance_detail.html
+++ b/crates/api-web/templates/instance_detail.html
@@ -49,7 +49,7 @@
 <table class="detailsview">
 	<tr><th>Function type</th><td>{{ interface.function_type }}</td></tr>
 	<tr><th>VF ID</th><td>{{ interface.vf_id }}</td></tr>
-	<tr><th>Segment ID</th><td><a href="/admin/network-segment/{{ interface.segment_id }}">{{ interface.segment_id }}</a></td></tr>
+	<tr><th>Segment ID</th><td>{% if !interface.segment_id.is_empty() %}<a href="/admin/network-segment/{{ interface.segment_id }}">{{ interface.segment_id }}</a>{% endif %}</td></tr>
 	<tr><th>MAC Address</th><td>{{ interface.mac_address }}</td></tr>
 	<tr><th>IP Addresses</th><td>{{ interface.addresses }}</td></tr>
 	<tr><th>Gateways</th><td>{{ interface.gateways }}</td></tr>

--- a/crates/rpc-utils/src/managed_host_display.rs
+++ b/crates/rpc-utils/src/managed_host_display.rs
@@ -160,7 +160,12 @@ impl From<Machine> for ManagedHostOutput {
     fn from(machine: Machine) -> ManagedHostOutput {
         let primary_interface = machine.interfaces.iter().find(|x| x.primary_interface);
         let (host_admin_ip, host_admin_mac) = primary_interface
-            .map(|x| (x.address.first().cloned(), Some(x.mac_address.clone())))
+            .map(|x| {
+                (
+                    x.address.join(",").none_if_empty(),
+                    Some(x.mac_address.clone()),
+                )
+            })
             .unwrap_or((None, None));
 
         let BmcInfoDisplay {
@@ -690,6 +695,27 @@ mod tests {
                 None => None,
                 Some(Timestamp::from(UNIX_EPOCH)) => Some("1970-01-01 00:00:00 UTC".to_string()),
                 Some(Timestamp::from(UNIX_EPOCH + Duration::from_secs(1_700_000_000))) => Some("2023-11-14 22:13:20 UTC".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn managed_host_output_preserves_all_primary_interface_addresses() {
+        value_scenarios!(
+            run = |addresses| ManagedHostOutput::from(Machine {
+                interfaces: vec![rpc::MachineInterface {
+                    primary_interface: true,
+                    address: addresses,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })
+            .host_admin_ip;
+            "primary interface address lists" {
+                Vec::<String>::new() => None,
+                vec!["192.0.2.10".to_string()] => Some("192.0.2.10".to_string()),
+                vec!["192.0.2.10".to_string(), "2001:db8::10".to_string()]
+                    => Some("192.0.2.10,2001:db8::10".to_string()),
             }
         );
     }


### PR DESCRIPTION
The machine and instance status APIs already keep every interface address, but a couple of operator views were still losing them. Managed-host output picked `.first()` from the primary interface, and the instance detail page expected config + status interfaces to have matching lengths -- which meant auto-networked instances displayed no interfaces at all.

So, managed-host rows now join every primary-interface address, and auto-network instance details build their rows from the resolved status interfaces. Explicitly configured instances keep their existing config/status pairing, and the existing scalar fields stay string-compatible with addresses joined in their original order.

And, I added IPv4 + IPv6 regression tests for both paths!

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/2407

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-rpc-utils --lib`
- `make core/tests TEST_ARGS="-p carbide-api-web auto_network_instance_detail_uses_status_interfaces --lib"`
- `make core/tests TEST_ARGS="-p carbide-api-web test_managed_host_row_display --lib"`
- `cargo make clippy`
- Cached Carbide-lints workflow with `--all-targets --all-features`

## Additional Notes

This keeps the existing managed-host output fields string-compatible and does not change scalar endpoint-selection behavior such as Ansible's `ansible_host`.

Closes #2407
