### PR TITLE
fix(ci): verify pull request secret-scan ranges

### DIFF
--- a/.github/ci/resolve-pr-scan-range.sh
+++ b/.github/ci/resolve-pr-scan-range.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# The copy PR bot rewrites its synthetic branch after rebases and force-pushes,
+# so that branch's previous SHA is not a durable scan boundary. Resolve the
+# current PR base and emit nothing unless it and this workflow's commit form a
+# non-empty range in the checkout. Otherwise, fail before the scanner can
+# report a clean result.
+
+fail() {
+	printf '::error::Could not resolve PR secret-scan range: %s\n' "$1" >&2
+	exit 1
+}
+
+for variable_name in \
+	GH_TOKEN \
+	GITHUB_REF \
+	GITHUB_REPOSITORY \
+	GITHUB_SHA \
+	GITHUB_WORKSPACE; do
+	[[ -n "${!variable_name:-}" ]] || fail "\`${variable_name}\` is not set"
+done
+
+if [[ "$GITHUB_REF" =~ ^refs/heads/pull-request/([1-9][0-9]*)$ ]]; then
+	pull_request_number="${BASH_REMATCH[1]}"
+else
+	fail "\`GITHUB_REF\` is not a pull request ref: ${GITHUB_REF}"
+fi
+
+commit_pattern='^[0-9a-fA-F]{40}$'
+[[ "$GITHUB_SHA" =~ $commit_pattern ]] \
+	|| fail "\`GITHUB_SHA\` is not a full commit SHA"
+
+if ! pull_request_json=$(curl --disable --fail --silent --show-error \
+	--connect-timeout 10 \
+	--max-time 30 \
+	-H "Authorization: Bearer ${GH_TOKEN}" \
+	-H 'Accept: application/vnd.github+json' \
+	-H 'X-GitHub-Api-Version: 2022-11-28' \
+	"https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${pull_request_number}"); then
+	fail "could not load pull request #${pull_request_number} from GitHub"
+fi
+
+if ! base_sha=$(jq --exit-status --raw-output \
+	'.base.sha | select(type == "string")' \
+	<<< "$pull_request_json"); then
+	fail "GitHub returned incomplete data for pull request #${pull_request_number}"
+fi
+
+[[ "$base_sha" =~ $commit_pattern ]] \
+	|| fail "GitHub returned an invalid pull request base"
+
+if ! merge_base=$(git -C "$GITHUB_WORKSPACE" merge-base "$base_sha" "$GITHUB_SHA"); then
+	fail "could not compute a merge base for the pull request base and workflow commit"
+fi
+[[ "${merge_base,,}" != "${GITHUB_SHA,,}" ]] \
+	|| fail "the pull request scan range is empty"
+
+printf 'base=%s\nhead=%s\n' "${merge_base,,}" "${GITHUB_SHA,,}"

--- a/.github/ci/test-resolve-pr-scan-range.sh
+++ b/.github/ci/test-resolve-pr-scan-range.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+resolver="${script_dir}/resolve-pr-scan-range.sh"
+fixture_dir=$(mktemp -d)
+trap 'rm -rf -- "$fixture_dir"' EXIT
+
+repository="${fixture_dir}/repository"
+mock_bin="${fixture_dir}/bin"
+mkdir -p "$repository" "$mock_bin"
+
+cat > "${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${MOCK_CURL_FAIL:-false}" != true ]] || exit 22
+[[ "$*" == *'/repos/NVIDIA/infra-controller/pulls/4786'* ]] || exit 64
+printf '%s' "$MOCK_PULL_REQUEST_JSON"
+EOF
+chmod +x "${mock_bin}/curl"
+
+git -C "$repository" init --quiet --initial-branch=main
+git -C "$repository" config user.email ci-test@nvidia.com
+git -C "$repository" config user.name 'CI Test'
+git -C "$repository" config commit.gpgsign false
+git -C "$repository" config core.hooksPath /dev/null
+
+printf 'shared\n' > "${repository}/shared.txt"
+git -C "$repository" add shared.txt
+git -C "$repository" commit --quiet -m 'shared base'
+merge_base=$(git -C "$repository" rev-parse HEAD)
+
+git -C "$repository" switch --quiet -c pull-request
+printf 'pull request\n' > "${repository}/pull-request.txt"
+git -C "$repository" add pull-request.txt
+git -C "$repository" commit --quiet -m 'pull request change'
+head_sha=$(git -C "$repository" rev-parse HEAD)
+
+git -C "$repository" switch --quiet main
+printf 'main\n' > "${repository}/main.txt"
+git -C "$repository" add main.txt
+git -C "$repository" commit --quiet -m 'main change'
+base_sha=$(git -C "$repository" rev-parse HEAD)
+git -C "$repository" switch --quiet pull-request
+
+missing_sha=ffffffffffffffffffffffffffffffffffffffff
+
+pull_request_json() {
+	local base=$1
+
+	jq --null-input --compact-output \
+		--arg base "$base" \
+		'{base: {sha: $base}}'
+}
+
+run_resolver() {
+	local payload=$1
+	local ref=$2
+	local event_head=$3
+	local curl_fail=${4:-false}
+
+	PATH="${mock_bin}:${PATH}" \
+	GH_TOKEN='not-a-real-token' \
+	GITHUB_REF="$ref" \
+	GITHUB_REPOSITORY='NVIDIA/infra-controller' \
+	GITHUB_SHA="$event_head" \
+	GITHUB_WORKSPACE="$repository" \
+	MOCK_PULL_REQUEST_JSON="$payload" \
+	MOCK_CURL_FAIL="$curl_fail" \
+		bash "$resolver"
+}
+
+expect_failure() {
+	local name=$1
+	local expected_error=$2
+	local payload=$3
+	local ref=$4
+	local event_head=$5
+	local curl_fail=${6:-false}
+	local output
+
+	if output=$(run_resolver "$payload" "$ref" "$event_head" "$curl_fail" \
+		2> "${fixture_dir}/error"); then
+		printf 'Expected failure for %s\n' "$name" >&2
+		exit 1
+	fi
+	[[ -z "$output" ]] || {
+		printf 'Failure %s wrote step outputs: %s\n' "$name" "$output" >&2
+		exit 1
+	}
+	if ! grep -Fq "::error::Could not resolve PR secret-scan range: ${expected_error}" \
+		"${fixture_dir}/error"; then
+		printf 'Failure %s did not report the expected error: %s\nActual error:\n' \
+			"$name" "$expected_error" >&2
+		cat "${fixture_dir}/error" >&2
+		exit 1
+	fi
+}
+
+valid_payload=$(pull_request_json "$base_sha")
+expected_output=$(printf 'base=%s\nhead=%s' "$merge_base" "$head_sha")
+actual_output=$(run_resolver \
+	"$valid_payload" \
+	refs/heads/pull-request/4786 \
+	"$head_sha")
+[[ "$actual_output" == "$expected_output" ]] || {
+	printf 'Expected:\n%s\nActual:\n%s\n' "$expected_output" "$actual_output" >&2
+	exit 1
+}
+
+expect_failure \
+	'malformed PR ref' \
+	'`GITHUB_REF` is not a pull request ref' \
+	"$valid_payload" \
+	refs/heads/main \
+	"$head_sha"
+expect_failure \
+	'invalid workflow commit' \
+	'`GITHUB_SHA` is not a full commit SHA' \
+	"$valid_payload" \
+	refs/heads/pull-request/4786 \
+	invalid
+expect_failure \
+	'missing base commit' \
+	'could not compute a merge base for the pull request base and workflow commit' \
+	"$(pull_request_json "$missing_sha")" \
+	refs/heads/pull-request/4786 \
+	"$head_sha"
+expect_failure \
+	'invalid API base' \
+	'GitHub returned an invalid pull request base' \
+	"$(pull_request_json invalid)" \
+	refs/heads/pull-request/4786 \
+	"$head_sha"
+expect_failure \
+	'empty scan range' \
+	'the pull request scan range is empty' \
+	"$(pull_request_json "$head_sha")" \
+	refs/heads/pull-request/4786 \
+	"$head_sha"
+expect_failure \
+	'incomplete API response' \
+	'GitHub returned incomplete data for pull request #4786' \
+	'{}' \
+	refs/heads/pull-request/4786 \
+	"$head_sha"
+expect_failure \
+	'API request failure' \
+	'could not load pull request #4786 from GitHub' \
+	"$valid_payload" \
+	refs/heads/pull-request/4786 \
+	"$head_sha" \
+	true
+
+printf 'Checked the PR secret-scan range resolver.\n'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: Test CI final-gate checker
         run: python3 -B .github/ci/test_check_ci_gate.py
 
+      - name: Test PR secret-scan range resolver
+        run: bash .github/ci/test-resolve-pr-scan-range.sh
+
       - name: Check Core CI final-gate inventory
         run: python3 -B .github/ci/check_ci_gate.py inventory --policy core .github/workflows/ci.yaml
 
@@ -1341,39 +1344,35 @@ jobs:
           persist-credentials: false
           fetch-depth: 0  # Full history for secret scanning
 
-      # On a PR's first push, github.event.before is all zeros because the branch
-      # is new. Without an explicit base, TruffleHog scans the entire repo history
-      # instead of just the commits on this PR. We look up the PR's actual target
-      # branch and compute the merge base so the scan is scoped to this PR only.
-      - name: Compute TruffleHog scan base
-        id: scan-base
+      # The copy PR bot can create or rewrite its synthetic branch, so
+      # `github.event.before` can be all zeroes or name a commit that no longer
+      # exists. Resolve both ends from the current PR for every synthetic push.
+      - name: Compute TruffleHog scan range
+        id: scan-range
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BEFORE="${{ github.event.before }}"
-          if [[ ("$BEFORE" == "0000000000000000000000000000000000000000" || -z "$BEFORE") && "$GITHUB_REF" == refs/heads/pull-request/* ]]; then
-            PR_NUM="${GITHUB_REF_NAME##pull-request/}"
-            BASE_BRANCH=$(curl -fsSL \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUM}" \
-              | jq -r '.base.ref')
-            BEFORE=$(git merge-base "origin/${BASE_BRANCH}" HEAD)
-          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            # Tag pushes also have an all-zeros before. Scope the scan to commits
-            # since the previous tag so we don't re-scan the entire history on
-            # every release.
-            PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${GITHUB_REF_NAME}$" | head -1)
-            if [[ -n "$PREV_TAG" ]]; then
-              BEFORE=$(git merge-base "refs/tags/${PREV_TAG}" HEAD)
+          if [[ "$GITHUB_REF" == refs/heads/pull-request/* ]]; then
+            bash .github/ci/resolve-pr-scan-range.sh >> "$GITHUB_OUTPUT"
+          else
+            BEFORE="${{ github.event.before }}"
+            if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+              # Tag pushes also have an all-zeros before. Scope the scan to commits
+              # since the previous tag so we don't re-scan the entire history on
+              # every release.
+              PREV_TAG=$(git tag --sort=-version:refname | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+              if [[ -n "$PREV_TAG" ]]; then
+                BEFORE=$(git merge-base "refs/tags/${PREV_TAG}" HEAD)
+              fi
             fi
+            echo "base=$BEFORE" >> "$GITHUB_OUTPUT"
           fi
-          echo "base=$BEFORE" >> "$GITHUB_OUTPUT"
 
       - name: Run TruffleHog Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@9a9ce3a7770a8b53d2726afa920be3276bc3ddd7
         with:
-          base: ${{ steps.scan-base.outputs.base }}
+          base: ${{ steps.scan-range.outputs.base }}
+          head: ${{ steps.scan-range.outputs.head }}
           extra-args: '--results=verified,unknown --only-verified'
           post-pr-comment: 'false'
           fail-on-findings: 'true'

--- a/.github/workflows/rest-ci.yml
+++ b/.github/workflows/rest-ci.yml
@@ -123,9 +123,17 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Compute TruffleHog scan range
+        id: scan-range
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/ci/resolve-pr-scan-range.sh >> "$GITHUB_OUTPUT"
       - name: Run TruffleHog Scan
         uses: NVIDIA/dsx-github-actions/.github/actions/trufflehog-scan@f435aa6bf125fe6f9e5ac438f8cef75f90e29a2b
         with:
+          base: ${{ steps.scan-range.outputs.base }}
+          head: ${{ steps.scan-range.outputs.head }}
           extra-args: '--results=verified,unknown --only-verified'
           post-pr-comment: 'true'
           fail-on-findings: 'true'


### PR DESCRIPTION
## TLDR

This fixes how Core and REST tell TruffleHog which commits to scan. On a PR's first CI run, GitHub has no previous commit, which caused REST to scan the entire repository history. After a force-push, the next run can have the opposite problem: `copy-pr-bot` replaces its internal PR branch, but GitHub still identifies that branch's now-missing old commit as the starting point. TruffleHog then scans zero bytes, and the surrounding action still reports success -- so yes, we failed open. Both workflows now ignore that unreliable previous commit for PR runs, look up the PR's current base, use the commit that started the workflow as the current head, and calculate the real range from the fetched Git history before starting TruffleHog. If that range cannot be calculated, the workflow fails before the scan; this keeps the first run from scanning the whole repository and prevents this missing-commit case from going green after scanning nothing.

## Expected green-run effect

No reliable steady-state speedup. The first synthetic REST scan on this PR processed 11,464 bytes instead of the roughly 446 MB full-history scan we observed on #4742 -- about 39,000x less scan input. This is still primarily a correctness fix; normal update scans should take about the same time.

## What it really buys us

One latest green Core or REST secret check now proves that the repository-side range was resolved from the current PR and passed to the scanner. Rebases and force-pushes can no longer make that run depend on a stale or missing synthetic-branch commit.

## Testing

- `bash -n .github/ci/resolve-pr-scan-range.sh .github/ci/test-resolve-pr-scan-range.sh`
- `bash .github/ci/test-resolve-pr-scan-range.sh`
- `python3 -B .github/ci/test_check_ci_gate.py`
- Core and REST final-gate inventory checks
- CI token-permission checker fixtures, plus the Core and stale-workflow permission checks
- Core and REST concurrency-policy checks
- `actionlint` for both edited workflows, ignoring only the repository's known custom-runner labels
- `cargo make check-format-nightly`
- `cargo make clippy`
- cached Carbide-lints workflow (`--all-targets --all-features`)
- `git diff --check`

Hosted acceptance exercised the initial synthetic push and two rewritten heads. On the initial head, Core and REST both resolved `00ece37...b8acd55`, scanned 6 chunks / 11,464 bytes, and reported no source errors. On the first rewrite, the push event contained stale `before=b8acd55`, but both workflows resolved `00ece37...eb5f72f` and scanned the same real range. After the final simplification and rebase, the event contained stale `before=eb5f72f`; both workflows instead resolved `7d9b87e...d79119f`, scanned 6 chunks / 9,129 bytes, and passed. Final-head Core CI completed 52 jobs with zero failures, and REST's final gate also passed.

This supports https://github.com/NVIDIA/infra-controller/issues/4786

Closes #4786
