### PR TITLE
fix(api): change shutdown_handler start fn visibility

### DIFF
--- a/crates/api/src/shutdown_handler.rs
+++ b/crates/api/src/shutdown_handler.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 
 /// Start a task that will wait for SIGINT or SIGTERM, and will cancel the given CancellationToken
 /// when either of them occur.
-pub fn start(join_set: &mut JoinSet<()>, cancel_token: CancellationToken) {
+pub(crate) fn start(join_set: &mut JoinSet<()>, cancel_token: CancellationToken) {
     // Register the signals before returning
     let signal_future = shutdown_signal();
 


### PR DESCRIPTION
Restrict `shutdown_handler::start` to crate visibility. The function is only used within `carbide-api`, and public visibility triggers the `unreachable_pub` lint during container builds.

## Related issues

None, urgent build fix.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)