### PR TITLE
fix(api): scope shutdown handler entry point to its caller

### DIFF
--- a/crates/api/src/shutdown_handler.rs
+++ b/crates/api/src/shutdown_handler.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 
 /// Start a task that will wait for SIGINT or SIGTERM, and will cancel the given CancellationToken
 /// when either of them occur.
-pub fn start(join_set: &mut JoinSet<()>, cancel_token: CancellationToken) {
+pub(super) fn start(join_set: &mut JoinSet<()>, cancel_token: CancellationToken) {
     // Register the signals before returning
     let signal_future = shutdown_signal();
 


### PR DESCRIPTION
When https://github.com/NVIDIA/infra-controller/pull/4504 added shutdown signal handling, `shutdown_handler::start` was made `pub` even though its only caller is the sibling `run` module. Now that https://github.com/NVIDIA/infra-controller/pull/4743 denies `unreachable-pub` workspace-wide, current `main` fails `lint-police` at that declaration.

So this scopes the function to `pub(super)`, matching its private module's parent boundary while keeping the sibling caller available. Shutdown behavior stays the same.

This supports the updated Rust visibility scoping guidelines in `STYLE_GUIDE.md`, established in https://github.com/NVIDIA/infra-controller/pull/4522.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4795.
Part of https://github.com/NVIDIA/infra-controller/issues/4558.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo check --locked -p carbide-api --all-targets --all-features`
- `cargo test --locked -p carbide-api --all-features`
- `cargo make format-nightly`
- `cargo make clippy`
- Cached Carbide-lints workflow from `refresh_carbide_lints.md`

## Additional Notes

This changes only Rust visibility. Shutdown behavior and externally reachable APIs remain unchanged.

Closes #4795
