### PR TITLE
refactor(proto-compiler): support derive annotations in proto files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,6 +2465,7 @@ dependencies = [
  "carbide-instrument",
  "carbide-ipmi",
  "carbide-measured-boot",
+ "carbide-proto-compiler",
  "carbide-redfish",
  "carbide-secrets",
  "carbide-state-controller-common",

--- a/crates/machine-controller/Cargo.toml
+++ b/crates/machine-controller/Cargo.toml
@@ -93,6 +93,7 @@ tokio-util = { workspace = true }
 tonic = { workspace = true }
 
 [build-dependencies]
+carbide-proto-compiler = { path = "../proto-compiler" }
 tonic-prost-build = "0.14"
 
 [lints]

--- a/crates/proto-compiler/src/codegen.rs
+++ b/crates/proto-compiler/src/codegen.rs
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::{Error, Schema};
+
+pub(crate) struct Derive {
+    // Fully qualified Prost matcher. Message matchers intentionally apply to
+    // the message and all declarations nested within it.
+    protobuf_type: String,
+    derives: Vec<syn::Path>,
+}
+
+pub struct Codegen {
+    type_derives: Vec<Derive>,
+}
+
+impl Schema {
+    pub fn collect_codegen(&self) -> Result<Codegen, Error> {
+        let message_ext = self
+            .descriptor_pool
+            .codegen_ext("carbide.codegen.v1.message_derive")?;
+        let enum_ext = self
+            .descriptor_pool
+            .codegen_ext("carbide.codegen.v1.enum_derive")?;
+
+        let message_derives = self
+            .descriptor_pool
+            .all_messages()
+            .map(|descriptor| descriptor.collect_derives(&message_ext));
+        let enum_derives = self
+            .descriptor_pool
+            .all_enums()
+            .map(|descriptor| descriptor.collect_derives(&enum_ext));
+
+        let type_derives = message_derives
+            .chain(enum_derives)
+            .filter_map(|result| result.transpose())
+            .collect::<Result<_, _>>()?;
+
+        Ok(Codegen { type_derives })
+    }
+}
+
+pub trait TonicBuilderCodegenExt {
+    fn apply_codegen(self, codegen: &Codegen) -> Self;
+}
+
+impl TonicBuilderCodegenExt for tonic_prost_build::Builder {
+    fn apply_codegen(self, codegen: &Codegen) -> Self {
+        codegen.type_derives.iter().fold(self, |builder, target| {
+            target.derives.iter().fold(builder, |builder, attr| {
+                let attribute = quote::quote! {#[derive(#attr)]}.to_string();
+                builder.type_attribute(&target.protobuf_type, attribute)
+            })
+        })
+    }
+}
+
+trait DescriptorPoolExt {
+    fn codegen_ext(&self, name: &'static str) -> Result<prost_reflect::ExtensionDescriptor, Error>;
+}
+
+impl DescriptorPoolExt for prost_reflect::DescriptorPool {
+    fn codegen_ext(&self, name: &'static str) -> Result<prost_reflect::ExtensionDescriptor, Error> {
+        fn validate_derive(
+            d: prost_reflect::ExtensionDescriptor,
+        ) -> Result<prost_reflect::ExtensionDescriptor, Error> {
+            if !d.is_list() || d.kind() != prost_reflect::Kind::String {
+                Err(Error::InvalidCodegenExtension(d.full_name().to_owned()))
+            } else {
+                Ok(d)
+            }
+        }
+        self.get_extension_by_name(name)
+            .ok_or(Error::MissingCodegenExtension(name))
+            .and_then(validate_derive)
+    }
+}
+
+trait CollectDerives {
+    fn options(&self) -> prost_reflect::DynamicMessage;
+    fn full_name(&self) -> &str;
+    fn collect_derives(
+        &self,
+        ext: &prost_reflect::ExtensionDescriptor,
+    ) -> Result<Option<Derive>, Error> {
+        let derives = self
+            .options()
+            .get_extension(ext)
+            .as_list()
+            .into_iter()
+            .flatten()
+            .flat_map(|value| {
+                value.as_str().map(|str_value| {
+                    syn::parse_str::<syn::Path>(str_value).map_err(|source| {
+                        Error::InvalidRustDerive {
+                            protobuf_type: self.full_name().to_owned(),
+                            derive: str_value.to_owned(),
+                            source,
+                        }
+                    })
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(if derives.is_empty() {
+            None
+        } else {
+            Some(Derive {
+                protobuf_type: format!(".{}", self.full_name()),
+                derives,
+            })
+        })
+    }
+}
+
+impl CollectDerives for prost_reflect::MessageDescriptor {
+    fn full_name(&self) -> &str {
+        prost_reflect::MessageDescriptor::full_name(self)
+    }
+    fn options(&self) -> prost_reflect::DynamicMessage {
+        prost_reflect::MessageDescriptor::options(self)
+    }
+}
+
+impl CollectDerives for prost_reflect::EnumDescriptor {
+    fn full_name(&self) -> &str {
+        prost_reflect::EnumDescriptor::full_name(self)
+    }
+    fn options(&self) -> prost_reflect::DynamicMessage {
+        prost_reflect::EnumDescriptor::options(self)
+    }
+}

--- a/crates/proto-compiler/src/compiler.rs
+++ b/crates/proto-compiler/src/compiler.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 
 use prost_reflect::DescriptorPool;
 
-use crate::schema::Schema;
+use crate::{Error, Schema};
 
 /// Inputs to one protobuf frontend invocation.
 #[derive(Clone, Debug, Default)]
@@ -90,42 +90,4 @@ pub fn compile(config: &CompilerConfig) -> Result<Schema, Error> {
         file_descriptor_set,
         descriptor_pool,
     })
-}
-
-/// Failure while compiling or loading protobuf descriptors.
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    /// Temporary storage for the descriptor output could not be created.
-    #[error("failed to create temporary protobuf descriptor storage")]
-    CreateTemporaryDescriptor {
-        /// Underlying filesystem error.
-        #[source]
-        source: std::io::Error,
-    },
-
-    /// The protobuf frontend failed.
-    #[error("failed to compile protobuf descriptors")]
-    CompileProtobuf {
-        /// Error reported by prost-build or `protoc`.
-        #[source]
-        source: std::io::Error,
-    },
-
-    /// The raw descriptor set emitted by `protoc` could not be read.
-    #[error("failed to read protobuf descriptor set from `{path}`")]
-    ReadDescriptorSet {
-        /// Descriptor output path.
-        path: PathBuf,
-        /// Underlying filesystem error.
-        #[source]
-        source: std::io::Error,
-    },
-
-    /// The raw descriptor bytes could not be decoded into a descriptor pool.
-    #[error("failed to decode protobuf descriptor pool")]
-    DecodeDescriptorPool {
-        /// Descriptor decoding error.
-        #[source]
-        source: prost_reflect::DescriptorError,
-    },
 }

--- a/crates/proto-compiler/src/error.rs
+++ b/crates/proto-compiler/src/error.rs
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::PathBuf;
+
+/// Failure while compiling or loading protobuf descriptors.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Temporary storage for the descriptor output could not be created.
+    #[error("failed to create temporary protobuf descriptor storage")]
+    CreateTemporaryDescriptor {
+        /// Underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The protobuf frontend failed.
+    #[error("failed to compile protobuf descriptors")]
+    CompileProtobuf {
+        /// Error reported by prost-build or `protoc`.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The raw descriptor set emitted by `protoc` could not be read.
+    #[error("failed to read protobuf descriptor set from `{path}`")]
+    ReadDescriptorSet {
+        /// Descriptor output path.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The raw descriptor bytes could not be decoded into a descriptor pool.
+    #[error("failed to decode protobuf descriptor pool")]
+    DecodeDescriptorPool {
+        /// Descriptor decoding error.
+        #[source]
+        source: prost_reflect::DescriptorError,
+    },
+
+    /// A required code-generation extension was not present in the schema.
+    #[error("protobuf code-generation extension `{0}` is missing")]
+    MissingCodegenExtension(&'static str),
+
+    /// A code-generation extension has an unexpected protobuf type.
+    #[error("protobuf code-generation extension `{0}` has an invalid shape")]
+    InvalidCodegenExtension(String),
+
+    /// A derive annotation is not a valid Rust path.
+    #[error("invalid rust derive `{derive}` on protobuf type `{protobuf_type}`")]
+    InvalidRustDerive {
+        /// Fully qualified protobuf type name.
+        protobuf_type: String,
+        /// Invalid derive annotation.
+        derive: String,
+        /// Rust parser error.
+        #[source]
+        source: syn::Error,
+    },
+}

--- a/crates/proto-compiler/src/extern_paths.rs
+++ b/crates/proto-compiler/src/extern_paths.rs
@@ -31,11 +31,11 @@ impl ExternPaths {
     }
 }
 
-pub trait TonicBuilderExternPaths {
+pub trait TonicBuilderExternPathsExt {
     fn extern_paths(self, paths: &ExternPaths) -> Self;
 }
 
-impl TonicBuilderExternPaths for tonic_prost_build::Builder {
+impl TonicBuilderExternPathsExt for tonic_prost_build::Builder {
     fn extern_paths(self, paths: &ExternPaths) -> Self {
         paths.0.iter().fold(self, |builder, (name, rust_type)| {
             builder.extern_path(name, quote::quote! { #rust_type }.to_string())

--- a/crates/proto-compiler/src/lib.rs
+++ b/crates/proto-compiler/src/lib.rs
@@ -51,11 +51,15 @@
 //! exits; generated Rust and the `forge.bin` reflection descriptor remain in
 //! Cargo's `OUT_DIR`.
 
+mod codegen;
 mod compiler;
+mod error;
 mod extern_paths;
 mod schema;
 
-pub use compiler::{CompilerConfig, Error, compile};
-pub use extern_paths::{ExternPathSearchIndex, ExternPaths, TonicBuilderExternPaths};
+pub use codegen::{Codegen, TonicBuilderCodegenExt};
+pub use compiler::{CompilerConfig, compile};
+pub use error::Error;
+pub use extern_paths::{ExternPathSearchIndex, ExternPaths, TonicBuilderExternPathsExt};
 pub use schema::Schema;
 pub use syn;

--- a/crates/proto-compiler/tests/compiler.rs
+++ b/crates/proto-compiler/tests/compiler.rs
@@ -17,9 +17,10 @@
 
 use std::path::Path;
 
-use carbide_proto_compiler::{CompilerConfig, Error, Schema, compile};
+use carbide_proto_compiler::{CompilerConfig, Error, Schema, TonicBuilderCodegenExt, compile, syn};
 use prost::Message as _;
 use prost_reflect::{DescriptorPool, DynamicMessage, Kind};
+use syn::{Attribute, Item};
 
 const FIXTURE_PACKAGE: &str = "carbide.proto.compiler.fixture";
 const OPTION_NAME: &str = "carbide.proto.compiler.fixture.method_annotation";
@@ -31,6 +32,86 @@ fn compile_fixture(name: &str) -> Result<Schema, Error> {
         include_paths: vec![fixtures],
         protoc_args: Vec::new(),
     })
+}
+
+fn compile_codegen_fixtures(names: &[&str]) -> Result<Schema, Error> {
+    let fixtures = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let annotations = Path::new(env!("CARGO_MANIFEST_DIR")).join("../rpc/proto");
+    compile(&CompilerConfig {
+        proto_files: names.iter().map(|name| fixtures.join(name)).collect(),
+        include_paths: vec![fixtures, annotations],
+        protoc_args: Vec::new(),
+    })
+}
+
+fn generate_with_codegen(schema: Schema) -> tempfile::TempDir {
+    let codegen = schema.collect_codegen().expect("codegen options are valid");
+    let output = tempfile::tempdir().expect("temporary output directory is created");
+    tonic_prost_build::configure()
+        .out_dir(output.path())
+        .apply_codegen(&codegen)
+        .compile_fds(schema.file_descriptor_set)
+        .expect("fixture Rust code is generated");
+    output
+}
+
+fn parse_generated(output: &Path, package: &str) -> syn::File {
+    let generated = std::fs::read_to_string(output.join(format!("{package}.rs")))
+        .expect("generated package exists");
+    syn::parse_file(&generated).expect("generated package is valid Rust syntax")
+}
+
+fn top_level_attrs<'a>(file: &'a syn::File, name: &str) -> &'a [Attribute] {
+    file.items
+        .iter()
+        .find_map(|item| match item {
+            Item::Struct(item) if item.ident == name => Some(item.attrs.as_slice()),
+            Item::Enum(item) if item.ident == name => Some(item.attrs.as_slice()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("generated item `{name}` exists"))
+}
+
+fn nested_item_attrs<'a>(file: &'a syn::File, module: &str, name: &str) -> &'a [Attribute] {
+    let items = file
+        .items
+        .iter()
+        .find_map(|item| match item {
+            Item::Mod(item) if item.ident == module => {
+                item.content.as_ref().map(|(_, items)| items.as_slice())
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("generated module `{module}` exists"));
+    items
+        .iter()
+        .find_map(|item| match item {
+            Item::Struct(item) if item.ident == name => Some(item.attrs.as_slice()),
+            Item::Enum(item) if item.ident == name => Some(item.attrs.as_slice()),
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("generated enum `{module}::{name}` exists"))
+}
+
+fn has_derive(attrs: &[Attribute], expected: &str) -> bool {
+    attrs
+        .iter()
+        .filter(|attribute| attribute.path().is_ident("derive"))
+        .flat_map(|attribute| {
+            attribute
+                .parse_args_with(
+                    syn::punctuated::Punctuated::<syn::Path, syn::Token![,]>::parse_terminated,
+                )
+                .expect("generated derive attribute is valid")
+        })
+        .any(|path| {
+            path.segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::")
+                == expected
+        })
 }
 
 fn annotation(pool: &DescriptorPool) -> DynamicMessage {
@@ -208,4 +289,99 @@ fn prost_reencoding_drops_custom_option_values() {
 fn malformed_protobuf_returns_typed_compilation_error() {
     let error = compile_fixture("malformed.proto").expect_err("malformed fixture must fail");
     assert!(matches!(error, Error::CompileProtobuf { .. }));
+}
+
+#[test]
+fn applies_annotated_derives_to_messages_enums_and_nested_types_only() {
+    let schema = compile_codegen_fixtures(&["derives.proto"]).expect("derive fixture compiles");
+    let output = generate_with_codegen(schema);
+    let generated = parse_generated(output.path(), "carbide.proto.compiler.fixture.derives");
+
+    for attrs in [
+        top_level_attrs(&generated, "AnnotatedMessage"),
+        top_level_attrs(&generated, "AnnotatedEnum"),
+        nested_item_attrs(&generated, "annotated_message", "Payload"),
+    ] {
+        assert!(has_derive(attrs, "serde::Serialize"));
+        assert!(has_derive(attrs, "serde::Deserialize"));
+    }
+
+    for attrs in [
+        top_level_attrs(&generated, "UnannotatedMessage"),
+        top_level_attrs(&generated, "UnannotatedEnum"),
+        nested_item_attrs(&generated, "unannotated_message", "Payload"),
+    ] {
+        assert!(!has_derive(attrs, "serde::Serialize"));
+        assert!(!has_derive(attrs, "serde::Deserialize"));
+    }
+
+    assert!(has_derive(
+        top_level_attrs(&generated, "AnnotatedParentOnly"),
+        "serde::Serialize"
+    ));
+    for attrs in [
+        nested_item_attrs(&generated, "annotated_parent_only", "NestedMessage"),
+        nested_item_attrs(&generated, "annotated_parent_only", "NestedEnum"),
+        nested_item_attrs(&generated, "annotated_parent_only", "Payload"),
+    ] {
+        assert!(has_derive(attrs, "serde::Serialize"));
+    }
+}
+
+#[test]
+fn fully_qualified_matcher_does_not_match_suffix_compatible_type() {
+    let schema = compile_codegen_fixtures(&["derives.proto", "derive_suffix.proto"])
+        .expect("derive fixtures compile");
+    let output = generate_with_codegen(schema);
+    let annotated = parse_generated(output.path(), "carbide.proto.compiler.fixture.derives");
+    let suffix_compatible = parse_generated(
+        output.path(),
+        "prefix.carbide.proto.compiler.fixture.derives",
+    );
+
+    assert!(has_derive(
+        top_level_attrs(&annotated, "AnnotatedMessage"),
+        "serde::Serialize"
+    ));
+    assert!(!has_derive(
+        top_level_attrs(&suffix_compatible, "AnnotatedMessage"),
+        "serde::Serialize"
+    ));
+}
+
+#[test]
+fn missing_codegen_extension_is_reported() {
+    let schema = compile_fixture("schema.proto").expect("fixture schema compiles");
+    assert!(matches!(
+        schema.collect_codegen(),
+        Err(Error::MissingCodegenExtension(
+            "carbide.codegen.v1.message_derive"
+        ))
+    ));
+}
+
+#[test]
+fn invalid_codegen_extension_shape_is_reported() {
+    let schema = compile_codegen_fixtures(&["invalid_codegen_extension.proto"])
+        .expect("invalid extension shape is valid protobuf");
+    assert!(matches!(
+        schema.collect_codegen(),
+        Err(Error::InvalidCodegenExtension(name))
+            if name == "carbide.codegen.v1.message_derive"
+    ));
+}
+
+#[test]
+fn invalid_rust_derive_is_reported_with_its_protobuf_type() {
+    let schema = compile_codegen_fixtures(&["invalid_derive.proto"])
+        .expect("invalid Rust derive is valid protobuf");
+    assert!(matches!(
+        schema.collect_codegen(),
+        Err(Error::InvalidRustDerive {
+            protobuf_type,
+            derive,
+            ..
+        }) if protobuf_type == "carbide.proto.compiler.fixture.invalid.InvalidMessage"
+            && derive == "serde::Serialize +"
+    ));
 }

--- a/crates/proto-compiler/tests/fixtures/derive_suffix.proto
+++ b/crates/proto-compiler/tests/fixtures/derive_suffix.proto
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package prefix.carbide.proto.compiler.fixture.derives;
+
+message AnnotatedMessage {}

--- a/crates/proto-compiler/tests/fixtures/derives.proto
+++ b/crates/proto-compiler/tests/fixtures/derives.proto
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package carbide.proto.compiler.fixture.derives;
+
+import "codegen/v1/derive.proto";
+
+message AnnotatedMessage {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+
+  oneof payload {
+    string text = 1;
+    uint64 number = 2;
+  }
+}
+
+enum AnnotatedEnum {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+
+  ANNOTATED_ENUM_UNSPECIFIED = 0;
+  ANNOTATED_ENUM_ENABLED = 1;
+}
+
+message UnannotatedMessage {
+  oneof payload {
+    string text = 1;
+  }
+}
+
+enum UnannotatedEnum {
+  UNANNOTATED_ENUM_UNSPECIFIED = 0;
+}
+
+message AnnotatedParentOnly {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+
+  message NestedMessage {}
+
+  enum NestedEnum {
+    NESTED_ENUM_UNSPECIFIED = 0;
+  }
+
+  oneof payload {
+    string text = 1;
+  }
+}

--- a/crates/proto-compiler/tests/fixtures/invalid_codegen_extension.proto
+++ b/crates/proto-compiler/tests/fixtures/invalid_codegen_extension.proto
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package carbide.codegen.v1;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+  repeated int32 message_derive = 51100;
+}

--- a/crates/proto-compiler/tests/fixtures/invalid_derive.proto
+++ b/crates/proto-compiler/tests/fixtures/invalid_derive.proto
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package carbide.proto.compiler.fixture.invalid;
+
+import "codegen/v1/derive.proto";
+
+message InvalidMessage {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize +";
+}

--- a/crates/rpc/build.rs
+++ b/crates/rpc/build.rs
@@ -17,7 +17,9 @@
 use std::fs;
 use std::path::PathBuf;
 
-use carbide_proto_compiler::{CompilerConfig, ExternPaths, TonicBuilderExternPaths, compile, syn};
+use carbide_proto_compiler::{
+    CompilerConfig, ExternPaths, TonicBuilderCodegenExt, TonicBuilderExternPathsExt, compile, syn,
+};
 use tonic_client_wrapper::codegen;
 
 const PROTO_FILES: &[&str] = &[
@@ -54,6 +56,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Preserve protoc's exact bytes for reflection, including any custom
     // annotation values. No sanitization or prost_types re-encoding occurs.
     fs::write(&reflection, &schema.raw_descriptor_set)?;
+
+    let codegen = schema.collect_codegen()?;
 
     let extern_paths = ExternPaths::new(
         [
@@ -205,6 +209,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "#[cfg_attr(feature = \"test-support\", derive(carbide_prost_builder::Builder))]";
 
     let prost_builder = tonic_prost_build::configure()
+        .apply_codegen(&codegen)
         .type_attribute(
             ".google.protobuf.Timestamp",
             "#[derive(serde::Serialize, serde::Deserialize)]",
@@ -222,16 +227,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
         )
         .type_attribute(
-            ".forge.DpuMode",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
             ".forge.BmcIpAllocationType",
             "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",
-        )
-        .type_attribute(
-            ".forge.BmcIpAllocationType",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
         )
         .extern_path(".google.protobuf.Duration", "crate::Duration")
         .extern_path(".google.protobuf.Timestamp", "crate::Timestamp")
@@ -250,533 +247,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ".mlx_device",
             "#[derive(serde::Deserialize, serde::Serialize)]",
         )
-        .type_attribute(
-            "forge.AdminForceDeleteMachineRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.AdminForceDeleteMachineResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.ClientSecretBasic", "#[derive(serde::Serialize, serde::Deserialize)]")
         .type_attribute(".dns", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.FabricManagerConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.FabricManagerStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.FlatInterfaceConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.FlatInterfaceIpv6Config", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.FlatInterfaceRoutingProfile", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceInterfaceIpv6Config", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute(
-            "forge.InstanceInterfaceRoutingProfile",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceInterfaceConfig",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceInterfaceConfig.network_details",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceInterfaceVpcSelection",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceIBInterfaceConfig",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("forge.InstanceUpdateStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceNetworkConfig", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InstanceInfinibandConfig",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceSpxConfig",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceSpxAttachment",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("forge.InstanceStorageConfig", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.IpxeTemplateParameter",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.IpxeTemplateArtifact",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.IpxeTemplate",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.IpxeTemplateArtifactCacheStrategy",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("forge.TenantConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceDpuExtensionServicesConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceDpuExtensionServiceConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ManagedHostDpuExtensionServiceConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.DpuExtensionService", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceVersionInfo", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceType", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceIdList", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceCredential", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceCredential.type", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.UsernamePassword", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceStatusObservation", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceComponent", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceStatus", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceObservability", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceObservabilityConfigPrometheus", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceObservabilityConfigLogging", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceObservabilityConfig.config", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceObservabilityConfig", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.DpuExtensionServiceObservability.configs", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.InstanceSpxStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceSpxAttachmentStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceNVLinkConfig", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.InstanceNVLinkGpuConfig", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.InstanceNVLinkStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceNVLinkGpuStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkPartition", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkPartitionList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkPartitionConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkPartitionStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkPartitionGpuStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkLogicalPartition", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkLogicalPartitionList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkLogicalPartitionConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkLogicalPartitionStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkLogicalPartitionGpuStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineNVLinkGpuStatusObservation", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineNVLinkStatusObservation", "#[derive(serde::Serialize)]")
-        .type_attribute("common.NVLinkDomainId", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NvlinkNmxcEndpoint", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("forge.NvlinkNmxcEndpointList", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute(
-            "forge.DeleteNvlinkNmxcEndpointRequest",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute("common.NVLinkLogicalPartitionId", "#[derive(serde::Serialize)]")
-        .type_attribute("common.NVLinkPartitionId", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineNVLinkInfo", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLinkGpu", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineSpxStatusObservation", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineSpxAttachmentStatusObservation", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InstanceInterfaceStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceInterfaceResolvedVpcPrefixes",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceIBInterfaceStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.InstanceNetworkStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InstanceInfinibandStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.InstanceStorageStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceDpuExtensionServicesStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceDpuExtensionServiceStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceTenantStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.InstanceStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.Instance", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.Metadata",
-            "#[derive(serde::Serialize, serde::Deserialize, Eq)]",
-        )
-        .type_attribute(
-            "forge.Label",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.LifecycleStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstancePhoneHomeLastContactRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstancePhoneHomeLastContactResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.InstanceList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.Machine", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.MachineCapabilitiesSet",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesCpu",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesGpu",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesMemory",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesStorage",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesNetwork",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesInfiniband",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineCapabilityAttributesDpu",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.MachineList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineEvent", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineInterface", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InfinibandStatusObservation",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.MachineIbInterface", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineState", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineArchitecture", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineInventory", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.MachineInventorySoftwareComponent",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.HealthReportEntry", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.HealthSourceOrigin", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute(
-            "forge.ManagedHostNetworkConfig",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ManagedHostNetworkConfigResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineBootInterface",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.GetMachineBootInterfacesResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.GetMachineBootInterfacesResponse.Reconciliation",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineInterfaceBootInterface",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.PredictedBootInterface",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ExploredBootInterface",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RetainedBootInterface",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RoutingProfile",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.PrefixFilterPolicyEntry",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.AstraConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.AstraAttachment", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.AstraConfigStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.AstraAttachmentStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.AstraStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.AstraPhase", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkPrefix", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkPrefixEvent", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkSegmentConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkSegmentStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkSegment", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.AttachNetworkSegmentToVpcRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.IBPartitionConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SpxPartitionConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.IBPartitionStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.IBPartition", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.IBPartitionIdList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.IBPartitionList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SpxPartitionList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SpxPartition", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SpxPartitionIdList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.PowerOptionResponse",
-                        "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.PowerOptions",
-                        "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute(
-            "forge.InlineIpxe",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("forge.NetworkSegmentList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InstanceOperatingSystemConfig",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceOperatingSystemConfig.variant",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.OperatingSystem",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.OperatingSystemList",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.OperatingSystemType",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute("forge.InterfaceList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.NetworkSegmentStateHistory",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RackStateHistory",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.Tenant", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.TenantContent", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.TenantList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.TenantKeyset", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.TenantKeysetContent", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.TenantKeysetList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.TenantKeysetIdentifier",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.TenantPublicKey", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.TenantKeySetList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.VpcResourceState", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.MachineBootOverride", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ConnectedDevice", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkDevice", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NetworkTopologyData", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InstanceInterfaceStatusObservation",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.FabricInterfaceData", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.LinkData", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.DpuNetworkStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.LastDhcpRequest", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ResourcePool", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.DpaInterface", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.DpaInterfaceList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.Vpc", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.VpcConfig", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.VpcRoutingProfileOverrides",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.VpcEffectiveRoutingProfile",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("common.RouteTargets", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.PrefixFilterPolicyEntries",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.VpcStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.VpcList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.StorageClusterAttributes",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.VpcPrefix", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.VpcPrefixStateHistoriesRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.VpcPrefixConfig",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.VpcPrefixStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.SitePrefix", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SitePrefixConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SitePrefixStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.SitePrefixQuotaUsage",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.SitePrefixAuthority", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.SitePrefixRoutingScope",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.SitePrefixLifecycleState",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.SitePrefixIdList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SitePrefixList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.VpcPeering", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.VpcPeeringList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.StateHistoryRecord",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.StorageCluster", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.StoragePoolAttributes", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.StoragePool", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.StorageVolumeStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.StorageVolumeAttributes",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.StorageVolume", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.Switch", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SwitchConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SwitchList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.SwitchStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.DeleteStoragePoolRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ListStoragePoolRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ListStoragePoolResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.DeleteStorageVolumeRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ListStorageVolumeRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ListStorageVolumeResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.OsImageAttributes", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.OsImage", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ListOsImageRequest", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ListOsImageResponse", "#[derive(serde::Serialize)]")
-        .type_attribute("DeleteOsImageRequest", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.MachineDiscoveryInfo",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "common.UUID",
-            "#[derive(Ord, PartialOrd, serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.MachineDiscoveryInfo.discovery_data",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.DhcpDiscovery",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
         .type_attribute("forge.DhcpDiscovery", derive_prost_builder)
-        .type_attribute(
-            "forge.UserRoles",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.BMCRequestType",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.BmcInfo",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.bmc_meta_data_update_request.DataItem",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "DataItem",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "bmc_meta_data_update_request",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "BMCMetaDataUpdateRequest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "ControllerStateReason",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("ControllerStateSourceReference", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute(
-            "RuntimeConfig",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("StateSla", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "BuildInfo",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("MachineValidationResultList", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationResult", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationRunList", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationRun", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "MachineValidationRunItemList",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "MachineValidationRunItemIdList",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("MachineValidationRunItem", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "MachineValidationAttempt",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("ExpectedHostNic", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedHostNic", "#[derive(serde::Deserialize)]")
         .field_attribute(
             "ExpectedHostNic.role",
             "#[serde(default, skip_serializing_if = \"Option::is_none\", deserialize_with = \"ExpectedInterfaceRole::deserialize_optional\", serialize_with = \"ExpectedInterfaceRole::serialize_optional\")]",
@@ -785,8 +257,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "ExpectedHostNic.ip_allocation",
             "#[serde(default, skip_serializing_if = \"Option::is_none\", deserialize_with = \"ExpectedInterfaceIpAllocation::deserialize_optional\", serialize_with = \"ExpectedInterfaceIpAllocation::serialize_optional\")]",
         )
-        .type_attribute("HostLifecycleProfile", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute("ExpectedMachine", "#[derive(serde::Serialize)]")
         // `ExpectedMachine` is serialize-only here. If it gains `Deserialize`,
         // this rename also needs `alias = "host_nics"` for older payloads.
         .field_attribute(
@@ -796,106 +266,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .field_attribute(
             "ExpectedMachine.replace_host_nics",
             "#[serde(skip_serializing)]",
-        )
-        .type_attribute("ExpectedPowerShelf", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedSwitch", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedRack", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedMachineList", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedPowerShelfList", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedSwitchList", "#[derive(serde::Serialize)]")
-        .type_attribute("ExpectedRackList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "TpmCaCertDetail",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "DpfMachineState",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "TpmCaCertDetailCollection",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "TpmEkCertStatus",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "TpmEkCertStatusCollection",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "TpmCaAddedCaStatus",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "TpmCaCertId",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("MachineValidationState", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationCompleted", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationInProgress", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationStarted", "#[derive(serde::Serialize)]")
-        .type_attribute("MachineValidationStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "MachineValidationExternalConfig",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "MachineValidationTestUpdateRequest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "MachineValidationTestAddRequest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "MachineValidationTest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "MachineValidationTestsGetRequest",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "MachineValidationTestUpdateRequest.Payload",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RedfishBrowseResponse",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroup",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupStatus",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupSource",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupRuleDirection",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupRuleProtocol",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupRuleAction",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupAttributes",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupRuleAttributes",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .field_attribute(
             "forge.NetworkSecurityGroupRuleAttributes.direction",
@@ -911,135 +281,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .type_attribute(
             "forge.NetworkSecurityGroupRuleAttributes.source_net",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupRuleAttributes.source_net",
             "#[serde(rename_all=\"snake_case\")]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupRuleAttributes.destination_net",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .type_attribute(
             "forge.NetworkSecurityGroupRuleAttributes.destination_net",
             "#[serde(rename_all=\"snake_case\")]",
         )
-        .type_attribute(
-            "forge.InstanceNetworkRestrictions",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.FlatInterfaceNetworkSecurityGroupConfig",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ResolvedNetworkSecurityGroupRule",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupAttachments",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.NetworkSecurityGroupPropagationObjectStatus",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("Sku", "#[derive(serde::Serialize, serde::Deserialize)]")
         .field_attribute("Sku.schema_version", "#[serde(default)]")
         .field_attribute("Sku.associated_machine_ids", "#[serde(default)]")
-        .type_attribute("SkuList", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute(
-            "SkuComponents",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "SkuComponentChassis",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "SkuComponentCpu",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "common.SwitchId",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "SkuComponentGpu",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "SkuComponentMemory",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "SkuComponentInfinibandDevices",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "SkuComponentEthernetDevices",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "SkuComponentStorage",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
         .field_attribute("SkuComponentStorage.vendor", "#[serde(default)]")
         .field_attribute("SkuComponentStorage.capacity_mb", "#[serde(default)]")
         .field_attribute("SkuComponentStorage.min_size_mb", "#[serde(default)]")
         .field_attribute("SkuComponentStorage.max_size_mb", "#[serde(default)]")
         .field_attribute("SkuComponentStorage.pci_patterns", "#[serde(default)]")
-        .type_attribute(
-            "SkuComponentTpm",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute("SkuId", "#[derive(serde::Serialize, serde::Deserialize)]")
-        .type_attribute(
-            "SkuStatus",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute("common.RackHardwareType", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.RackCapabilitiesSet", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.RackCapabilityCompute", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.RackCapabilitySwitch", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.RackCapabilityPowerShelf", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.RackProfile", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.GetRackProfileResponse", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ConfiguredRackProfile", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.ListRackProfilesResponse", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.MachineHardwareInfoGpu",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ManagedHostQuarantineState",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ManagedHostQuarantineMode",
-            "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute("forge.AppliedRemediationIdList", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.AppliedRemediationId", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.AppliedRemediationList", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.AppliedRemediation", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.RemediationList", "#[derive(serde::Deserialize, serde::Serialize)]")
-        .type_attribute("forge.Remediation", "#[derive(serde::Deserialize, serde::Serialize)]")
         .field_attribute("machine_discovery.BlockDevice.device_type", "#[serde(default)]")
         .field_attribute("machine_discovery.NvmeDevice.serial", "#[serde(default)]")
-        .type_attribute(
-            "forge.InstanceTypeAttributes",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceType",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.InstanceTypeAllocationStats",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
         .field_attribute(
             "forge.InstanceTypeMachineCapabilityFilterAttributes.capability_type",
             "#[serde(deserialize_with = \"MachineCapabilityType::from_string\", serialize_with = \"MachineCapabilityType::serialize_from_enum_i32\")]",
@@ -1048,47 +304,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "forge.InstanceTypeMachineCapabilityFilterAttributes.device_type",
             "#[serde(deserialize_with = \"MachineCapabilityDeviceType::from_string\", serialize_with = \"MachineCapabilityDeviceType::serialize_from_enum_i32\")]",
         )
-        .type_attribute(
-            "forge.InstanceTypeMachineCapabilityFilterAttributes",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.Rack",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RackConfig",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RackList",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RackStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.PowerShelf", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.PowerShelfConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.PowerShelfList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.PowerShelfStatus", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "common.Uint32List",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
-        .type_attribute("forge.NVLPartitionConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLPartitionStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLPartition", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLPartitionList", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLLogicalPartitionConfig", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLLogicalPartitionStatus", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLLogicalPartition", "#[derive(serde::Serialize)]")
-        .type_attribute("forge.NVLLogicalPartitionList", "#[derive(serde::Serialize)]")
 
-        .type_attribute(
-            "common.PowerShelfId",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
-        )
         .type_attribute(
             ".rack_manager",
             "#[derive(serde::Deserialize, serde::Serialize)]",
@@ -1096,10 +312,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute(
             ".nmx_c",
             "#[derive(serde::Deserialize, serde::Serialize)]",
-        )
-        .type_attribute(
-            "common.RouteTarget",
-            "#[derive(serde::Deserialize,serde::Serialize)]",
         )
         .type_attribute(
             "common.MachineId",
@@ -1113,68 +325,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "common.SwitchId",
             "#[derive(Ord, PartialOrd)]",
         )
-        .type_attribute(
-            "common.RemediationId",
-            "#[derive(serde::Serialize, serde::Deserialize, Ord, PartialOrd)]",
-        )
-        .type_attribute("common.StringList", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.InstanceAllocationRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RouteServerEntries",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RouteServer",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ComputeAllocation",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.ComputeAllocationAttributes",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.GetBmcCredentialsRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.GetSwitchNvosCredentialsRequest",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute("forge.SwitchNvosInfo", "#[derive(serde::Serialize)]")
-        .type_attribute(
-            "forge.PlacementInRack",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.SpdmGetAttestationMachineResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.SpdmListAttestationMachinesResponse",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.SpdmMachineAttestationStatus",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.SpdmAttestationDetails",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "scout_firmware_upgrade.ScoutFirmwareUpgradeTask",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "scout_firmware_upgrade.FileArtifact",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
         .type_attribute("forge.VpcCreationRequest", derive_prost_builder)
         .type_attribute("forge.VpcUpdateRequest", derive_prost_builder)
         .type_attribute("forge.VpcDeletionRequest", derive_prost_builder)
@@ -1185,34 +335,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("forge.CreateComputeAllocationRequest", derive_prost_builder)
         .type_attribute("forge.UpdateComputeAllocationRequest", derive_prost_builder)
         .type_attribute("forge.DeleteComputeAllocationRequest", derive_prost_builder)
-        .type_attribute(
-            "forge.InstanceNetworkAutoConfig",
-            "#[derive(serde::Serialize)]",
-        )
-        .type_attribute(
-            "forge.RotationCredentialType",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.RotateCredentialResult",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.CredentialRotationStatusResult",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.DeviceCredentialRotationStatus",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.GetContainerRegistryCredentialRequest",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "forge.GetContainerRegistryCredentialResponse",
-            "#[derive(serde::Serialize, serde::Deserialize)]",
-        )
         .type_attribute(
             ".forge.NetworkSegmentType",
             "#[cfg_attr(feature = \"cli\", derive(clap::ValueEnum))]",

--- a/crates/rpc/proto/codegen/v1/derive.proto
+++ b/crates/rpc/proto/codegen/v1/derive.proto
@@ -14,23 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::path::PathBuf;
 
-use carbide_proto_compiler::{CompilerConfig, TonicBuilderCodegenExt, compile};
+syntax = "proto3";
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
-    let schema = compile(&CompilerConfig {
-        proto_files: vec![PathBuf::from("../rpc/proto/scout_firmware_upgrade.proto")],
-        include_paths: vec![PathBuf::from("../rpc/proto")],
-        protoc_args: Vec::new(),
-    })?;
-    let codegen = schema.collect_codegen()?;
+package carbide.codegen.v1;
 
-    tonic_prost_build::configure()
-        .out_dir(out_dir)
-        .apply_codegen(&codegen)
-        .compile_fds(schema.file_descriptor_set)?;
+import "google/protobuf/descriptor.proto";
 
-    Ok(())
+extend google.protobuf.MessageOptions {
+  // Rust derives applied to this message and all declarations nested within it.
+  // Nested derive options are additive and must not repeat inherited derives.
+  repeated string message_derive = 51100;
+}
+
+extend google.protobuf.EnumOptions {
+  // Rust derives applied to this enum in addition to derives inherited from an
+  // enclosing message.
+  repeated string enum_derive = 51101;
 }

--- a/crates/rpc/proto/common.proto
+++ b/crates/rpc/proto/common.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package common;
 
+import "codegen/v1/derive.proto";
+
 message MachineId {
   string id = 1;
 }
@@ -14,14 +16,21 @@ message MachineIdList {
 // This is different than "repeated string" since using StringList
 // allows to express a nullable/optional list
 message StringList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated string items = 1;
 }
 
 message UUID {
+  option (carbide.codegen.v1.message_derive) = "Ord";
+  option (carbide.codegen.v1.message_derive) = "PartialOrd";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string value = 1;
 }
 
 message PowerShelfId {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string id = 1;
 }
 
@@ -34,14 +43,20 @@ message RackProfileId {
 }
 
 message SwitchId {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string id = 1;
 }
 
 message Uint32List {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated uint32 items = 1;
 }
 
 message RouteTarget {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   uint32 asn = 1;
   uint32 vni = 2;
 }
@@ -49,6 +64,7 @@ message RouteTarget {
 // A list of route targets. Unlike a repeated field, this message can be optional,
 // allowing containing messages to distinguish an omitted list from an empty list.
 message RouteTargets {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated RouteTarget values = 1;
 }
 
@@ -88,18 +104,25 @@ message NetworkPrefixId {
   string value = 1;
 }
 message RemediationId {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "Ord";
+  option (carbide.codegen.v1.message_derive) = "PartialOrd";
   string value = 1;
 }
 
 message NVLinkPartitionId {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string value = 1;
 }
 
 message NVLinkLogicalPartitionId {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string value = 1;
 }
 
 message NVLinkDomainId {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string value = 1;
 }
 
@@ -121,6 +144,7 @@ message IpxeTemplateId {
 }
 
 message RackHardwareType {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string value = 1;
 }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -2,8 +2,7 @@ syntax = "proto3";
 
 package forge;
 
-// Don't forget to update build.rs to add the Serialize annotation for any new
-// message types!
+import "codegen/v1/derive.proto";
 
 import "common.proto";
 import "dns.proto";
@@ -1032,6 +1031,7 @@ service Forge {
 
 // Indicates the lifecycle state of a resource that is controlled by a state controller
 message LifecycleStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The current state of the resource
   string state = 1;
   // The state version. This version number is incremented each time the resource transitions into a new state
@@ -1050,6 +1050,7 @@ enum SpdmAttestationStatus{
 }
 
 message SpdmMachineAttestationStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineId machine_id = 1;
   SpdmAttestationStatus attestation_status = 2;
 }
@@ -1060,6 +1061,7 @@ message SpdmMachineAttestationTriggerResponse {
 }
 
 message SpdmAttestationDetails{
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineId machine_id = 1;
   string device_id = 2;
   string state = 3;
@@ -1070,6 +1072,7 @@ message SpdmAttestationDetails{
 }
 
 message SpdmGetAttestationMachineResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated SpdmAttestationDetails attestations_details = 1;
 }
 
@@ -1091,6 +1094,7 @@ message SpdmListAttestationMachinesRequest {
 }
 
 message SpdmListAttestationMachinesResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated SpdmMachineAttestationStatus statuses = 1;
 }
 
@@ -1157,6 +1161,8 @@ message TenantIdentityConfigResponse {
 // Token delegation config (per-org token exchange for machine identity).
 // The structure used when CREATING or UPDATING a secret
 message ClientSecretBasic {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string client_id = 1;
   string client_secret = 2;  // Required for input, never returned
 }
@@ -1279,15 +1285,21 @@ message MachineIngestionStateResponse{
 }
 
 message TpmCaAddedCaStatus{
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   TpmCaCertId id = 1;
   int32 matched_ek_certs = 2;
 }
 
 message TpmCaCertId{
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   int32 ca_cert_id = 1;
 }
 
 message TpmEkCertStatus{
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string serial_num = 1;
   common.MachineId machine_id = 2;
   string issuer = 3;
@@ -1295,6 +1307,8 @@ message TpmEkCertStatus{
 }
 
 message TpmEkCertStatusCollection{
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated TpmEkCertStatus tpm_ek_cert_statuses = 1;
 }
 
@@ -1304,6 +1318,8 @@ message TpmCaCert{
 }
 
 message TpmCaCertDetail{
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   int32 ca_cert_id = 1;
   string not_valid_before = 2;
   string not_valid_after = 3;
@@ -1311,6 +1327,8 @@ message TpmCaCertDetail{
 }
 
 message TpmCaCertDetailCollection{
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated TpmCaCertDetail tpm_ca_cert_details = 1;
 }
 
@@ -1389,6 +1407,8 @@ message CredentialDeletionResult {
 // CredentialType because rotation is version-addressed and operates per family,
 // not per individual vault path.
 enum RotationCredentialType {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
   // Unset sentinel. The server rejects this with InvalidArgument so a caller
   // that forgets to set the family never falls through to a destructive
   // default (proto3 zero value); rotation is too sensitive to guess a target.
@@ -1411,6 +1431,8 @@ message RotateCredentialRequest {
 }
 
 message RotateCredentialResult {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   RotationCredentialType credential_type = 1;
   // The newly published site-wide target version devices will converge to.
   uint32 target_version = 2;
@@ -1430,6 +1452,8 @@ message CredentialRotationStatusRequest {
 // Per-device convergence detail, populated on the result only when the request
 // targeted a specific device by MAC.
 message DeviceCredentialRotationStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   // The device this status describes.
   string device_mac = 1;
   // Credential version currently live on the hardware (the convergence marker).
@@ -1454,6 +1478,8 @@ message DeviceCredentialRotationStatus {
 }
 
 message CredentialRotationStatusResult {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   // Current site-wide target version for this family.
   uint32 target_version = 1;
   // Devices whose recorded version is at or beyond the target. When the request
@@ -1482,6 +1508,8 @@ message VersionRequest {
 }
 
 message BuildInfo {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string build_version = 1; // v2023.06-rc2-1-gc5c05de3
   string build_date = 2; // 2023-06-05
   string git_sha = 3; // c5c05de3
@@ -1493,6 +1521,8 @@ message BuildInfo {
 }
 
 message RuntimeConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string listen = 1;
   string metrics_endpoint = 2;
   reserved 3; // Was: string otlp_endpoint
@@ -1670,6 +1700,7 @@ message TenantSearchQuery {
 
 // A presence-aware list of prefix-filter entries.
 message PrefixFilterPolicyEntries {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated PrefixFilterPolicyEntry values = 1;
 }
 
@@ -1678,6 +1709,7 @@ message PrefixFilterPolicyEntries {
 // `internal` and `access_tier` are intentionally not exposed because allocation
 // and access controls must always come from the named base profile.
 message VpcRoutingProfileOverrides {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional common.RouteTargets route_target_imports = 1;
   optional common.RouteTargets route_targets_on_exports = 2;
   optional bool leak_default_route_from_underlay = 3;
@@ -1691,6 +1723,7 @@ message VpcRoutingProfileOverrides {
 // Unlike VpcRoutingProfileOverrides, this includes the protected properties
 // inherited from the named base profile and has no presence-aware fields.
 message VpcEffectiveRoutingProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.RouteTarget route_target_imports = 1;
   repeated common.RouteTarget route_targets_on_exports = 2;
   bool leak_default_route_from_underlay = 3;
@@ -1703,6 +1736,7 @@ message VpcEffectiveRoutingProfile {
 }
 
 message VpcConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string tenant_organization_id = 1;
   optional string tenant_keyset_id = 2;
   optional VpcVirtualizationType network_virtualization_type = 3;
@@ -1715,6 +1749,7 @@ message VpcConfig {
 }
 
 message VpcStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The actual VNI allocated to the VPC. If a VNI had been
   // explicitly requested, we'd expect this to match config.vni.
   // If not explicitly requested, we'd expect config.vni to be unset.
@@ -1726,6 +1761,7 @@ message VpcStatus {
 }
 
 message Vpc {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.VpcId id = 1;
   reserved 2;  // was: string name, replaced with metadata.name
   // Deprecated: use config.tenant_organization_id
@@ -1903,6 +1939,7 @@ message VpcDeletionResult {
 }
 
 message VpcList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Vpc vpcs = 1;
 }
 
@@ -1919,6 +1956,7 @@ enum PrefixMatchType {
 }
 
 message VpcPrefix {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.VpcPrefixId id = 1;
   string prefix = 2; // Deprecated, use config instead
   reserved 3; // was string name, replaced with metadata instead
@@ -1935,11 +1973,13 @@ message VpcPrefix {
 }
 
 message VpcPrefixConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // IPv4 or IPv6 prefix in CIDR notation
   string prefix = 1;
 }
 
 message VpcPrefixStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   uint32 total_31_segments = 1;
   uint32 available_31_segments = 2;
   uint64 total_linknet_segments = 3;
@@ -2012,10 +2052,12 @@ message VpcPrefixDeletionResult {
 }
 
 message VpcPrefixStateHistoriesRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.VpcPrefixId vpc_prefix_ids = 1;
 }
 
 message VpcPeering {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.VpcPeeringId id = 1;
   common.VpcId vpc_id = 2;
   common.VpcId peer_vpc_id = 3;
@@ -2026,6 +2068,7 @@ message VpcPeeringIdList {
 }
 
 message VpcPeeringList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated VpcPeering vpc_peerings = 1;
 }
 
@@ -2092,6 +2135,7 @@ enum TenantState {
 
 // Describe the desired configuration of an IBPartition
 message IBPartitionConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Deprecated: use Metadata instead  - the name of IBPartition.
   string name = 1;
   // The ID of tenant that IBPartition belong to
@@ -2106,6 +2150,7 @@ message IBPartitionConfig {
 
 // Describe the status and applied configuration of an IBPartition
 message IBPartitionStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Provisioning state of this partition
   TenantState state = 1;
   // The result of last state controller run - its outcome and an optional reason for that outcome
@@ -2129,6 +2174,7 @@ message IBPartitionStatus {
 
 // Describe an Infiniband based Partition configuration and status
 message IBPartition {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.IBPartitionId id = 1;
 
   IBPartitionConfig config = 2;
@@ -2140,6 +2186,7 @@ message IBPartition {
 }
 
 message IBPartitionList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated IBPartition ib_partitions = 1;
 }
 
@@ -2182,11 +2229,13 @@ message IBPartitionsByIdsRequest {
 }
 
 message IBPartitionIdList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.IBPartitionId ib_partition_ids = 1;
 }
 
 // Describe the desired configuration of a PowerShelf
 message PowerShelfConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The name of PowerShelf.
   string name = 1;
   // Power capacity in watts
@@ -2198,6 +2247,7 @@ message PowerShelfConfig {
 
 // Describe the status and applied configuration of a PowerShelf
 message PowerShelfStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The result of last state controller run - its outcome and an optional reason for that outcome
   // deprecated: Use lifecycle field
   optional ControllerStateReason state_reason = 1;
@@ -2222,6 +2272,7 @@ message PowerShelfStatus {
 
 // Describe a PowerShelf configuration and status
 message PowerShelf {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.PowerShelfId id = 1;
 
   PowerShelfConfig config = 2;
@@ -2249,6 +2300,7 @@ message PowerShelf {
 }
 
 message PowerShelfList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated PowerShelf power_shelves = 1;
 }
 
@@ -2320,6 +2372,7 @@ message PowerShelvesByIdsRequest {
 }
 
 message ExpectedPowerShelf {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string bmc_mac_address = 1;
   string bmc_username = 2;
   string bmc_password = 3;
@@ -2343,6 +2396,7 @@ message ExpectedPowerShelfRequest {
 }
 
 message ExpectedPowerShelfList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated ExpectedPowerShelf expected_power_shelves = 1;
 }
 
@@ -2361,6 +2415,7 @@ message LinkedExpectedPowerShelf {
 
 // Describe the desired configuration of a Switch
 message SwitchConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The name of Switch.
   string name = 1;
   bool enable_nmxc = 2;
@@ -2370,6 +2425,7 @@ message SwitchConfig {
 
 // Describe the desired configuration of Fabric Manager
 message FabricManagerConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   map<string, string> config_map = 1;
 }
 
@@ -2381,6 +2437,7 @@ enum FabricManagerState {
 }
 
 message FabricManagerStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   FabricManagerState fabric_manager_state = 1;
   optional string addition_info = 2;
   optional string reason = 3;
@@ -2389,6 +2446,7 @@ message FabricManagerStatus {
 
 // Describe the status and applied configuration of a Switch
 message SwitchStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The result of last state controller run - its outcome and an optional reason for that outcome
   // deprecated: Use lifecycle field
   optional ControllerStateReason state_reason = 1;
@@ -2414,12 +2472,14 @@ message SwitchStatus {
 }
 
 message PlacementInRack {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional int32 slot_number = 1;
   optional int32 tray_index = 2;
 }
 
 // Describe a Switch configuration and status
 message Switch {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.SwitchId id = 1;
 
   SwitchConfig config = 2;
@@ -2454,6 +2514,7 @@ message Switch {
 }
 
 message SwitchList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Switch switches = 1;
 }
 
@@ -2476,6 +2537,7 @@ message SwitchDeletionResult {
 
 // The state that a object/resource had at a certain point in time
 message StateHistoryRecord {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string state = 1;
   string version = 2;
   google.protobuf.Timestamp time = 3;
@@ -2518,6 +2580,7 @@ message SwitchesByIdsRequest {
 }
 
 message ExpectedSwitch {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string bmc_mac_address = 1;
   string bmc_username = 2;
   string bmc_password = 3;
@@ -2547,6 +2610,7 @@ message ExpectedSwitchRequest {
 }
 
 message ExpectedSwitchList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated ExpectedSwitch expected_switches = 1;
 }
 
@@ -2564,6 +2628,7 @@ message LinkedExpectedSwitch {
 }
 
 message ExpectedRack {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The rack identifier. Same rack_id referenced by expected machines, switches, and power shelves.
   optional common.RackId rack_id = 1;
   // The rack profile ID. Determines expected counts of compute trays, switches, and power shelves.
@@ -2579,6 +2644,7 @@ message ExpectedRackRequest {
 }
 
 message ExpectedRackList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated ExpectedRack expected_racks = 1;
 }
 
@@ -2591,6 +2657,7 @@ message IBFabricIdList {
 
 // Deprecated: use FindNetworkSegmentStateHistories RPC instead
 message NetworkSegmentStateHistory {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string state = 1;
   string version = 2;
   google.protobuf.Timestamp time = 3;
@@ -2618,6 +2685,7 @@ enum NetworkSegmentFlag {
 }
 
 message NetworkSegmentConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.VpcId vpc_id = 1;
 
   optional common.DomainId subdomain_id = 2;
@@ -2629,6 +2697,7 @@ message NetworkSegmentConfig {
 }
 
 message NetworkSegmentStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Derived from can_stretch; not accepted as user input.
   repeated NetworkSegmentFlag flags = 1;
 
@@ -2640,6 +2709,7 @@ message NetworkSegmentStatus {
 }
 
 message NetworkSegment {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.NetworkSegmentId id = 1;
 
   // Deprecated: use config.vpc_id
@@ -2702,6 +2772,7 @@ message NetworkSegmentDeletionRequest {
 }
 
 message AttachNetworkSegmentToVpcRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.NetworkSegmentId network_segment_id = 1;
   common.VpcId vpc_id = 2;
   bool allow_replace = 3;
@@ -2735,6 +2806,7 @@ message NetworkSegmentsByIdsRequest {
 }
 
 message NetworkPrefix {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.NetworkPrefixId id = 1;
   string prefix = 2;
   optional string gateway = 3;
@@ -2758,6 +2830,7 @@ message NetworkPrefix {
 }
 
 message MachineState {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string state = 1;
 }
 
@@ -2795,15 +2868,21 @@ message InstancePowerResult {
 }
 
 message InstanceList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Instance instances = 1;
 }
 
 message Label {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string key = 1;
   optional string value = 2;
 }
 
 message Metadata {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "Eq";
   string name = 1;
   string description = 2;
   repeated Label labels = 3;
@@ -2826,6 +2905,7 @@ message InstancesByIdsRequest {
 }
 
 message InstanceAllocationRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The Machine on top of which we create an Instance
   // If we go towards "we already have instances model", this would become more of a
   // AssignInstanceToTenant request, and the ID would be the instance_id
@@ -2869,12 +2949,16 @@ message BatchInstanceAllocationResponse {
 // Can be used to replace variables in iPXE templates or add parameters to kernel command line
 // Some are "well known" like 'console', others can be custom defined by users
 message IpxeTemplateParameter {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;   // Name of the parameter (used as variable in template)
   string value = 2;  // Value of the parameter
 }
 
 // Artifact cache strategy
 enum IpxeTemplateArtifactCacheStrategy {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   CACHE_AS_NEEDED = 0;   // Download and cache artifact locally if possible
   LOCAL_ONLY = 1;        // Artifact URL provided is only usable locally: site specific, no caching applicable.
   CACHED_ONLY = 2;       // Artifact URL must be cached locally or is unusable
@@ -2884,6 +2968,8 @@ enum IpxeTemplateArtifactCacheStrategy {
 // Remote artifact to be cached locally before booting
 // Examples: kernel, initrd, rootfs, qcow-imager.efi, OS image, ...
 message IpxeTemplateArtifact {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;                          // Name of the artifact (can be used as variable in template)
   string url = 2;                           // Original URL for the artifact
   optional string sha = 3;                  // Optional SHA256 checksum for the artifact
@@ -2901,6 +2987,8 @@ enum IpxeTemplateVisibility {
 
 // Template management messages
 message IpxeTemplate {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;
   string template = 2;
   repeated string required_params = 3;  // Error if these params are not provided or empty
@@ -2916,6 +3004,7 @@ message IpxeTemplate {
 // Tenant related configuration that is set once the instance is allocated
 // by a tenant
 message TenantConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Identifies the tenant that uses this instance
   string tenant_organization_id = 1;
 
@@ -2931,6 +3020,8 @@ message TenantConfig {
 }
 
 message InstanceOperatingSystemConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Contains the operating system definition based on the variant of operating system
   oneof variant {
     InlineIpxe ipxe = 1;
@@ -2968,6 +3059,8 @@ message InstanceOperatingSystemConfig {
 }
 
 message InlineIpxe {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The iPXE script which is booted into
   string ipxe_script = 1;
   // Optional user-data that is associated with the iPXE script
@@ -2977,6 +3070,7 @@ message InlineIpxe {
 
 // Desired configuration for an instance
 message InstanceConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Tenant related configuration.
   // This field can be absent if the instance has not yet been allocated by
   // a tenant. On assignment, the config changes once. Due to the one-time
@@ -3012,6 +3106,7 @@ message InstanceConfig {
 
 // Desired network configuration for an instance
 message InstanceNetworkConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Configures how instance network interfaces are set up.
   // Mutually exclusive with `auto`: when `auto` is true, this
   // MUST be empty, When `auto` is false, this lists the explicit
@@ -3040,6 +3135,7 @@ message InstanceNetworkConfig {
 }
 
 message InstanceNetworkAutoConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // For Flat zero-DPU deployments, multiple VPCs may share the same
   // HostInband network segment, so VPC ownership is carried by the
   // instance address rather than by the segment.
@@ -3048,26 +3144,34 @@ message InstanceNetworkAutoConfig {
 
 // Desired infiniband configuration for an instance
 message InstanceInfinibandConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Configures how instance infiniband interfaces are set up
   repeated InstanceIBInterfaceConfig ib_interfaces = 1;
 }
 
 message InstanceDpuExtensionServiceConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string service_id = 1;
   string version = 2;
 }
 
 // Extension services configuration for an instance
 message InstanceDpuExtensionServicesConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated InstanceDpuExtensionServiceConfig service_configs = 1;
 }
 // Desired nvlink configuration for an instance
 message InstanceNVLinkConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Configures how instance nvlink gpus are set up
   repeated InstanceNVLinkGpuConfig gpu_configs = 1;
 }
 
 message InstanceSpxConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated InstanceSpxAttachment spx_attachments = 1;
 }
 
@@ -3078,6 +3182,8 @@ enum SpxAttachmentType {
 }
 
 message InstanceSpxAttachment {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string device = 1;
   uint32 device_instance = 2;
   common.SpxPartitionId spx_partition_id = 3;
@@ -3144,6 +3250,7 @@ message InstanceConfigUpdateRequest {
 
 // Current status of an instance
 message InstanceStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Status that is related to the tenant of the instance.
   // In case no tenant has been assigned to this instance, the field would be absent.
   optional InstanceTenantStatus tenant = 1;
@@ -3178,11 +3285,13 @@ message InstanceStatus {
 }
 
 message InstanceSpxStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated InstanceSpxAttachmentStatus attachment_statuses = 1;
   SyncState configs_synced = 101;
 }
 
 message InstanceSpxAttachmentStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string mac_addr = 1;
   uint32 virtual_function_id = 2;
   optional string ip_address = 3;
@@ -3192,6 +3301,7 @@ message InstanceSpxAttachmentStatus {
 
 // State of the networking subsystem of an instance
 message InstanceNetworkStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Status for each configured interface
   //
   // For non-auto configs: each entry in this status array maps to its
@@ -3227,6 +3337,7 @@ message InstanceNetworkStatus {
 
 // State of the infiniband subsystem of an instance
 message InstanceInfinibandStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Status for each configured interface
   //
   // Each entry in this status array maps to its corresponding entry in the
@@ -3247,6 +3358,8 @@ message InstanceInfinibandStatus {
 }
 
 message DpuExtensionServiceStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   common.MachineId dpu_machine_id = 1;
   DpuExtensionServiceDeploymentStatus status = 2;
   optional string error_message = 3;
@@ -3254,6 +3367,7 @@ message DpuExtensionServiceStatus {
 }
 
 message InstanceDpuExtensionServiceStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string service_id = 1;
   string version = 2;
   DpuExtensionServiceDeploymentStatus deployment_status = 3;
@@ -3263,11 +3377,13 @@ message InstanceDpuExtensionServiceStatus {
 
 // Status of extension services subsystem of an instance
 message InstanceDpuExtensionServicesStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated InstanceDpuExtensionServiceStatus dpu_extension_services = 1;
   SyncState configs_synced = 101;
 }
 
 message InstanceNVLinkStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated InstanceNVLinkGpuStatus gpu_statuses = 1;
   SyncState configs_synced = 101;
 }
@@ -3275,6 +3391,7 @@ message InstanceNVLinkStatus {
 // Contains all information about an actively running instance
 // This entails both the instance configuration, as well as the current state of the instance
 message Instance {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Instance ID
   common.InstanceId id = 1;
   // The ID of the host machine which is utilized for this Instance (host_machine_id)
@@ -3325,6 +3442,7 @@ message Instance {
 }
 
 message InstanceUpdateStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   enum Module {
     Dpu = 0;
   }
@@ -3338,6 +3456,7 @@ message InstanceUpdateStatus {
 
 // The configuration that a customer desires for an instances network interface
 message InstanceInterfaceConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Whether the user wants to create a physical or virtual function
   InterfaceFunctionType function_type = 1;
 
@@ -3398,6 +3517,7 @@ message InstanceInterfaceConfig {
 
 // Automatic VPC-backed network selection for one instance interface.
 message InstanceInterfaceVpcSelection {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The single logical VPC this interface belongs to.
   common.VpcId vpc_id = 1;
   // The address families Core must allocate. Unspecified is invalid.
@@ -3421,6 +3541,8 @@ enum InstanceInterfaceIpFamilyMode {
 
 // IPv6 configuration for a dual-stack instance interface.
 message InstanceInterfaceIpv6Config {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   // The IPv6 VPC prefix to allocate from. The primary vpc_prefix_id creates
   // the segment, and this prefix is added to it.
   common.VpcPrefixId vpc_prefix_id = 1;
@@ -3430,6 +3552,7 @@ message InstanceInterfaceIpv6Config {
 
 // Routing-profile options API callers may narrow on an instance interface.
 message InstanceInterfaceRoutingProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // IP prefixes this interface is allowed to announce as anycast routes.
   // Every entry must be contained by an allowed_anycast_prefixes entry on the
   // owning VPC's routing profile.
@@ -3438,6 +3561,8 @@ message InstanceInterfaceRoutingProfile {
 
 // The configuration that a customer desires for an instances IB interface
 message InstanceIBInterfaceConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The name of the device that gets configured
   string device = 1;
 
@@ -3471,12 +3596,14 @@ message InstanceIBInterfaceConfig {
 
 // VPC prefixes Core resolved for an instance interface, keyed by family.
 message InstanceInterfaceResolvedVpcPrefixes {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional common.VpcPrefixId ipv4_vpc_prefix_id = 1;
   optional common.VpcPrefixId ipv6_vpc_prefix_id = 2;
 }
 
 // The actual status of a single network interface of an instance
 message InstanceInterfaceStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // If the interface is defined as a virtual function (associated
   // `InstanceInterfaceConfig.function_type == InterfaceFunctionType::VIRTUAL_FUNCTION`,
   // then this value is set and specifies the virtual function ID that is configured
@@ -3516,6 +3643,7 @@ message InstanceInterfaceStatus {
 
 // The actual status of a single IB interface of an instance
 message InstanceIBInterfaceStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The GUID of the hardware device that this interface is attached to
   optional string pf_guid = 1;
 
@@ -3539,6 +3667,7 @@ message InstanceIBInterfaceStatus {
 
 // The actual status of a single gpu of an instance
 message InstanceNVLinkGpuStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   /// fabric guid of this GPU
   optional string gpu_guid = 1;
 
@@ -3552,6 +3681,8 @@ message InstanceNVLinkGpuStatus {
 
 // The configuration that a customer desires for an instances NVLink GPUs
 message InstanceNVLinkGpuConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   uint32 device_instance = 1;
 
   // logical partition gpu is part of
@@ -3559,10 +3690,12 @@ message InstanceNVLinkGpuConfig {
 }
 
 message InstancePhoneHomeLastContactRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.InstanceId instance_id = 1;
 }
 
 message InstancePhoneHomeLastContactResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   google.protobuf.Timestamp timestamp = 1;
 }
 
@@ -3680,6 +3813,7 @@ message TenantSearchFilter {
 }
 
 message TenantList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Tenant tenants= 1;
 }
 
@@ -3688,10 +3822,12 @@ message TenantOrganizationIdList {
 }
 
 message InterfaceList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineInterface interfaces = 1;
 }
 
 message MachineList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Machine machines = 1;
 }
 
@@ -3770,6 +3906,8 @@ enum MachineType {
 }
 
 message BmcInfo {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   optional string ip = 1;
   optional string mac = 2;
   optional string version = 3;
@@ -3779,12 +3917,14 @@ message BmcInfo {
 }
 
 message SwitchNvosInfo {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string ip = 1;
   optional string mac = 2;
   optional uint32 port = 3;
 }
 
 message MachineConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Maintenance annotation set by the operator.
   optional string maintenance_reference = 1;
   optional google.protobuf.Timestamp maintenance_start_time = 2;
@@ -3804,6 +3944,7 @@ message MachineConfig {
 }
 
 message MachineStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Deprecated Machine.interfaces is superseded by this field.
   repeated MachineInterface interfaces = 1;
   optional machine_discovery.DiscoveryInfo discovery_info = 2;
@@ -3832,6 +3973,7 @@ message MachineStatus {
 }
 
 message Machine {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Uniquely identifies a Forge machine.
   // The value of this field is globally unique.
   common.MachineId id = 1;
@@ -4011,11 +4153,15 @@ message Machine {
 }
 
 message DpfMachineState {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   bool enabled = 1;
   bool used_for_ingestion = 2;
 }
 
 message InstanceNetworkRestrictions {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Describes how instances machine can connect to network segments. See [`NetworkSegmentMembershipType`] for details.
   InstanceNetworkSegmentMembershipType network_segment_membership_type = 1;
   // If network_segment_membership_type is `STATIC`, this spells out what network segment ID's are available on the
@@ -4098,10 +4244,12 @@ message DpuAgentInventoryReport {
 }
 
 message MachineInventory {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineInventorySoftwareComponent components = 1;
 }
 
 message MachineInventorySoftwareComponent {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;
   string version = 2;
   string url = 3;
@@ -4109,12 +4257,16 @@ message MachineInventorySoftwareComponent {
 
 // Summary of a health report source: its mode and source identifier.
 message HealthSourceOrigin {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   HealthReportApplyMode mode = 1;
   string source = 2;
 }
 
 // Result of last state handler invocation
 message ControllerStateReason {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Return value of last state handler invocation
   ControllerStateOutcome outcome = 1;
   // Message associated with the return value of the last state handler invocation
@@ -4133,11 +4285,14 @@ enum ControllerStateOutcome {
 
 // Location in the Source Code that lead to the specific state handling outcome
 message ControllerStateSourceReference {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string file = 1;
   int32 line = 2;
 }
 
 message StateSla {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The SLA for the current state
   // This field will be absent if there is no SLA defined for a field
   // A value of 0 (instead of absent) will indicate the `time_in_state` will always
@@ -4151,6 +4306,7 @@ message StateSla {
 
 // The most recent tenant related status
 message InstanceTenantStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The current state of the instance from the point of view of the assigned tenant
   TenantState state = 1;
   // An optional message which can contain details about the state
@@ -4165,11 +4321,13 @@ enum SyncState {
 }
 
 enum MachineArchitecture {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   ARM = 0;
   X86 = 1;
 }
 
 message MachineEvent {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   reserved 1; // previously int64 id = 1;
   reserved 2; // previously common.MachineId machine_id = 2;
 
@@ -4194,6 +4352,7 @@ enum InterfaceType {
 }
 
 message MachineInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineInterfaceId id = 1;
   optional common.MachineId attached_dpu_machine_id = 2;
   common.MachineId machine_id = 3;
@@ -4222,6 +4381,7 @@ message MachineInterface {
 
 // Infiniband interface status description
 message InfinibandStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The actual/observed state of all InfiniBand interfaces in Machine
   repeated MachineIbInterface ib_interfaces = 1;
   // When the IB status was last observed
@@ -4231,6 +4391,7 @@ message InfinibandStatusObservation {
 // Observed state of a single IB interface
 // This is the information that Carbide collects from UFM
 message MachineIbInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The GUID of the hardware device that this interface is attached to
   optional string pf_guid = 1;
 
@@ -4266,6 +4427,8 @@ message MachineIbInterface {
 }
 
 message DhcpDiscovery {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   string relay_address = 2;
   optional string vendor_string = 3;
@@ -4373,6 +4536,7 @@ message DhcpRecord {
 }
 
 message NetworkSegmentList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated NetworkSegment network_segments = 1;
 }
 
@@ -4382,6 +4546,8 @@ message SSHKeyValidationRequest {
 }
 
 enum UserRoles {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   USER = 0;
   ADMINISTRATOR = 1;
   OPERATOR = 2;
@@ -4394,10 +4560,12 @@ message SSHKeyValidationResponse {
 }
 
 message GetBmcCredentialsRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_addr = 1;
 }
 
 message GetSwitchNvosCredentialsRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.SwitchId switch_id = 1;
 }
 
@@ -4509,6 +4677,7 @@ message ManagedHostNetworkConfigRequest {
 }
 
 message ManagedHostNetworkConfigResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   reserved 1; // previously is_production_mode
 
   // ASN and DHCP servers are not versioned, they are fixed on process start
@@ -4667,6 +4836,7 @@ message ManagedHostNetworkConfigResponse {
 }
 
 message ManagedHostDpuExtensionServiceConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string service_id = 1;
   string version = 2;
   string name = 3;
@@ -4678,11 +4848,15 @@ message ManagedHostDpuExtensionServiceConfig {
 }
 
 message ManagedHostQuarantineState {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   ManagedHostQuarantineMode mode = 1;
   optional string reason = 2;
 }
 
 enum ManagedHostQuarantineMode {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   BLOCK_ALL_TRAFFIC = 0;
   // other modes may come later
 }
@@ -4720,6 +4894,7 @@ message ClearManagedHostQuarantineStateResponse {
 
 // Network configuration for a managed host (host + DPU pair) managed by Forge
 message ManagedHostNetworkConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // DPU loopback IP
   string loopback_ip = 1;
   optional ManagedHostQuarantineState quarantine_state = 2;
@@ -4728,6 +4903,7 @@ message ManagedHostNetworkConfig {
 }
 
 message FlatInterfaceConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   InterfaceFunctionType function_type = 1;
   // aka circuit_id
   uint32 vlan_id = 2;
@@ -4835,12 +5011,14 @@ message FlatInterfaceConfig {
 }
 
 message FlatInterfaceRoutingProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated PrefixFilterPolicyEntry allowed_anycast_prefixes = 1;
 }
 
 // IPv6 configuration for a dual-stack FNN interface, sent from the API to
 // the DPU agent as part of FlatInterfaceConfig.
 message FlatInterfaceIpv6Config {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Host IPv6 address (e.g. "2001:db8::1").
   string ip = 1;
   // Interface-specific prefix allocation (e.g. "2001:db8::/127").
@@ -4851,6 +5029,8 @@ message FlatInterfaceIpv6Config {
 }
 
 message FlatInterfaceNetworkSecurityGroupConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string id                                       = 1;
   string version                                  = 2;
   NetworkSecurityGroupSource source               = 3;
@@ -4895,6 +5075,7 @@ message DpuAgentUpgradePolicyResponse {
 }
 
 message AdminForceDeleteMachineRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // UUID, IP address, host name or MAC address of either the host or DPU to force delete
   string host_query = 1;
 
@@ -4916,6 +5097,7 @@ message AdminForceDeleteMachineRequest {
 // Response to AdminForceDeleteMachine call
 // Describes which resources have been released
 message AdminForceDeleteMachineResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   bool all_done = 1;
 
   string managed_host_machine_id = 11;
@@ -5042,6 +5224,8 @@ message IsInfiniteBootEnabledResponse {
 }
 
 enum BMCRequestType {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
   IPMI = 0;
   REDFISH = 1;
 }
@@ -5213,6 +5397,8 @@ enum MachineDiscoveryReporter {
 }
 
 message MachineDiscoveryInfo {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineInterfaceId machine_interface_id = 1;
   oneof discovery_data {
     machine_discovery.DiscoveryInfo info = 2;
@@ -5389,6 +5575,7 @@ enum InterfaceFunctionType {
 
 // What forge-dpu-agent reports. Will grow over time.
 message DpuNetworkStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineId dpu_machine_id = 1;
   google.protobuf.Timestamp observed_at = 2;
   // Legacy mechanism to indicate DPU health.
@@ -5416,12 +5603,15 @@ message DpuNetworkStatus {
 }
 
 message LastDhcpRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineInterfaceId host_interface_id = 1;
   string timestamp = 2;
 }
 
 // DPU extension service status
 message DpuExtensionServiceStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string service_id = 1;
   DpuExtensionServiceType service_type = 2;
   string service_name = 3;
@@ -5433,6 +5623,8 @@ message DpuExtensionServiceStatusObservation {
 }
 
 message DpuExtensionServiceComponent {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string name = 1;
   string version = 2;
   string url = 3;
@@ -5455,6 +5647,7 @@ enum HealthReportApplyMode {
 }
 
 message HealthReportEntry {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   health.HealthReport report = 1;
   HealthReportApplyMode mode = 2;
 }
@@ -5545,6 +5738,7 @@ message RemoveNVLinkDomainHealthReportRequest {
 
 // Observed status of a single network interface of an instance
 message InstanceInterfaceStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Whether the interface is a physical or virtual function
   // In the case of a virtual function the associated
   // `virtual_function_id` describes the ID of the interface
@@ -5588,6 +5782,7 @@ message InstanceInterfaceStatusObservation {
 // Describes observational data for a network interface associated with a
 // network fabric (e.g. a DPU's uplinks to the underlay network).
 message FabricInterfaceData {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string interface_name = 1;
 
   LinkData link_data = 2;
@@ -5595,6 +5790,7 @@ message FabricInterfaceData {
 
 // Link attributes from rtnetlink or equivalent.
 message LinkData {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string link_type = 1;
   optional string state = 2;
   optional bool carrier_up = 3;
@@ -5604,6 +5800,7 @@ message LinkData {
 }
 
 message Tenant {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string organization_id = 1;
   Metadata metadata = 2;
   // this string is used to verify that the client has the most updated "view" of a keyset when attempting to modify it
@@ -5649,6 +5846,7 @@ message FindTenantResponse {
 }
 
 message TenantKeysetIdentifier {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // the organization_id of the associated tenant, required to be non-null and globally unique
   string organization_id = 1;
   // the id of the key, provided by the tenant.  Must be unique within the tenant's organization.
@@ -5657,15 +5855,18 @@ message TenantKeysetIdentifier {
 }
 
 message TenantPublicKey {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string public_key = 1;
   optional string comment = 2;
 }
 
 message TenantKeysetContent {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated TenantPublicKey public_keys = 1;
 }
 
 message TenantKeyset {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   TenantKeysetIdentifier keyset_identifier = 1;
   TenantKeysetContent keyset_content = 2;
   // this version will be used to determine if a client has the most updated "view" of a tenant when attempting to modify it
@@ -5686,6 +5887,7 @@ message CreateTenantKeysetResponse {
 }
 
 message TenantKeySetList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated TenantKeyset keyset = 1;
 }
 
@@ -5749,6 +5951,7 @@ message ResourcePools {
 }
 
 message ResourcePool {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;
   string min = 2;
   string max = 3;
@@ -6051,6 +6254,7 @@ enum IpType {
 }
 
 message MachineBootOverride {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineInterfaceId machine_interface_id = 1;
   optional string custom_pxe = 2;
   optional string custom_user_data = 3;
@@ -6058,6 +6262,7 @@ message MachineBootOverride {
 
 // A connected device is described by DPU and local port.
 message ConnectedDevice {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineId id = 1;
   string local_port = 2;
   string remote_port = 3;
@@ -6092,6 +6297,7 @@ message MachineIdBmcIp {
 
 // NetworkDevice and Switch are used interchangeably.
 message NetworkDevice {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string id = 1;
   string name = 2;
   optional string description = 3;
@@ -6111,6 +6317,7 @@ message NetworkDeviceIdList {
 }
 
 message NetworkTopologyData {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated NetworkDevice network_devices = 1;
 }
 
@@ -6134,6 +6341,7 @@ message RouteServers {
 }
 
 message RouteServerEntries {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated RouteServer route_servers = 1;
 }
 
@@ -6141,6 +6349,7 @@ message RouteServerEntries {
 // code, which models a route_servers record
 // in the database.
 message RouteServer {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string address = 1;
   RouteServerSourceType source_type = 2;
 }
@@ -6202,6 +6411,7 @@ enum OsImageStatus {
 }
 
 message OsImageAttributes {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // needs to be generated by the caller (cloud) during CreateOsImage call
   common.UUID id = 1;
   string source_url = 2;
@@ -6223,6 +6433,7 @@ message OsImageAttributes {
 }
 
 message OsImage {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   OsImageAttributes attributes = 1;
   OsImageStatus status = 2;
   optional string status_message = 3;
@@ -6232,14 +6443,17 @@ message OsImage {
 }
 
 message ListOsImageRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string tenantOrganizationId = 1; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
 }
 
 message ListOsImageResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated OsImage images = 1;
 }
 
 message DeleteOsImageRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.UUID id = 1;
   string tenantOrganizationId = 2; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
 }
@@ -6262,6 +6476,8 @@ message IpxeTemplateList {
 
 
 message ExpectedHostNic {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string mac_address = 1;
   // Legacy free-form segment hint (bf3, onboard, oob, ...). Kept for backward
   // compatibility; declare `network_segment_type` instead, which wins.
@@ -6321,6 +6537,8 @@ message ExpectedHostNic {
 // comes from `[site_explorer] dpu_policy` (and falls back to `Manage` when
 // that's unset).
 enum DpuMode {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
   DPU_MODE_UNSPECIFIED = 0;
   DPU_MODE = 1;
   NIC_MODE = 2;
@@ -6343,6 +6561,8 @@ enum DpuMode {
 // replace-all, omission resets a legacy-only row to AUTO but preserves an
 // existing nested HostBmc policy that an older client cannot send.
 enum BmcIpAllocationType {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
   BMC_IP_ALLOCATION_TYPE_UNSPECIFIED = 0;
   BMC_IP_ALLOCATION_TYPE_AUTO = 1;
   BMC_IP_ALLOCATION_TYPE_DYNAMIC = 2;
@@ -6354,12 +6574,15 @@ enum BmcIpAllocationType {
 // When the outer field is unset on ExpectedMachine, the server preserves the
 // existing DB value (patch semantics).
 message HostLifecycleProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   // If true, do not lock down the server as part of host lifecycle management. If unset or false, preserve
   // the default behavior of locking down the server after configuring the BIOS.
   optional bool disable_lockdown = 1;
 }
 
 message ExpectedMachine {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string bmc_mac_address = 1;
   string bmc_username = 2;
   string bmc_password = 3;
@@ -6418,6 +6641,7 @@ message ExpectedMachineRequest {
 }
 
 message ExpectedMachineList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated ExpectedMachine expected_machines = 1;
 }
 
@@ -6502,6 +6726,7 @@ message MachineValidationCompletedResponse {
 }
 
 message MachineValidationResult {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;
   string description = 2;
   string command = 3;
@@ -6521,6 +6746,7 @@ message MachineValidationResultPostRequest {
 }
 
 message MachineValidationResultList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineValidationResult results = 1;
 }
 
@@ -6531,6 +6757,7 @@ message MachineValidationGetRequest {
 }
 
 message MachineValidationStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
 
   enum MachineValidationStarted {
     Started = 0;
@@ -6556,6 +6783,7 @@ message MachineValidationStatus {
   uint32 completed_tests = 5;
 }
 message MachineValidationRun {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.MachineValidationId validation_id = 1;
   common.MachineId machine_id = 2;
   google.protobuf.Timestamp start_time = 3;
@@ -6586,6 +6814,7 @@ message GetMachineValidationExternalConfigRequest {
   string name = 1;
 }
 message MachineValidationExternalConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;
   optional string description = 2;
   bytes config = 3;
@@ -6740,6 +6969,7 @@ message GetRedfishJobStateResponse {
 }
 
 message MachineValidationRunList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineValidationRun runs = 1;
 }
 
@@ -6753,6 +6983,7 @@ message MachineValidationRunItemSearchFilter {
 }
 
 message MachineValidationRunItemIdList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.UUID run_item_ids = 1;
 }
 
@@ -6761,10 +6992,12 @@ message MachineValidationRunItemsByIdsRequest {
 }
 
 message MachineValidationRunItemList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineValidationRunItem run_items = 1;
 }
 
 message MachineValidationRunItem {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.UUID run_item_id = 1;
   common.MachineValidationId validation_id = 2;
   string test_id = 3;
@@ -6790,6 +7023,7 @@ message MachineValidationAttemptGetRequest {
 }
 
 message MachineValidationAttempt {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.UUID attempt_id = 1;
   common.UUID run_item_id = 2;
   uint32 attempt_number = 3;
@@ -6828,6 +7062,8 @@ message BmcCredentialStatusResponse {
   bool have_credentials = 1;
 }
 message MachineValidationTestsGetRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated string supported_platforms = 1;
   repeated string contexts = 2;
   optional string test_id = 3;
@@ -6838,6 +7074,8 @@ message MachineValidationTestsGetRequest {
   optional bool verified = 8;
 }
 message MachineValidationTestUpdateRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   message Payload {
     optional string name = 1;
     optional string description = 2;
@@ -6864,6 +7102,8 @@ message MachineValidationTestUpdateRequest {
 }
 
 message MachineValidationTestAddRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name = 1;
   optional string description = 2;
   repeated string contexts = 3;
@@ -6900,6 +7140,8 @@ message MachineValidationTestVerfiedResponse {
   string message = 1;
 }
 message MachineValidationTest {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string test_id = 1;
   string name = 2;
   optional string description = 3;
@@ -6959,6 +7201,7 @@ enum MachineCapabilityDeviceType {
 }
 
 message MachineCapabilityAttributesCpu {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name               = 1;
   uint32 count              = 2;
   optional string vendor    = 3;
@@ -6968,6 +7211,7 @@ message MachineCapabilityAttributesCpu {
 }
 
 message MachineCapabilityAttributesGpu {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name                     = 1;
   uint32 count                    = 2;
   optional string vendor          = 3;
@@ -6979,6 +7223,7 @@ message MachineCapabilityAttributesGpu {
 }
 
 message MachineCapabilityAttributesMemory {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name                       = 1;
   uint32 count                      = 2;
   optional string vendor            = 3;
@@ -6986,6 +7231,7 @@ message MachineCapabilityAttributesMemory {
 }
 
 message MachineCapabilityAttributesStorage {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name                       = 1;
   uint32 count                      = 2;
   optional string vendor            = 3;
@@ -6993,6 +7239,7 @@ message MachineCapabilityAttributesStorage {
 }
 
 message MachineCapabilityAttributesNetwork {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name                                                   = 1;
   uint32 count                                                  = 2;
   optional string vendor                                        = 3;
@@ -7000,6 +7247,7 @@ message MachineCapabilityAttributesNetwork {
 }
 
 message MachineCapabilityAttributesInfiniband {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name                       = 1;
   uint32 count                      = 2;
   optional string vendor            = 3;
@@ -7014,12 +7262,14 @@ message MachineCapabilityAttributesInfiniband {
 }
 
 message MachineCapabilityAttributesDpu {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string name                       = 1;
   uint32 count                      = 2;
   optional string hardware_revision = 3;
 }
 
 message MachineCapabilitiesSet {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineCapabilityAttributesCpu cpu               = 1;
   repeated MachineCapabilityAttributesGpu gpu               = 2;
   repeated MachineCapabilityAttributesMemory memory         = 3;
@@ -7030,6 +7280,8 @@ message MachineCapabilitiesSet {
 }
 
 message InstanceTypeAttributes {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The minimum set of capabilities that a machine
   // must have before it can be link with the specified
   // instance type.
@@ -7042,6 +7294,8 @@ message InstanceTypeAttributes {
 // as a pool, and the desired capabilities of an InstanceType
 // define which machines are allowed in the pool.
 message InstanceType {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string id                                             = 1;
   InstanceTypeAttributes attributes                     = 2;
   string version                                        = 3;
@@ -7071,6 +7325,8 @@ enum MachineCapabilityType {
 // an InstanceType with that capability, the machine must also
 // have a capability that matches those properties.
 message InstanceTypeMachineCapabilityFilterAttributes {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   MachineCapabilityType capability_type                   = 1;
   optional string name                                    = 2; // Intel Xeon, Samsung SSD, etc.
   optional string frequency                               = 3; // E.g., 2.4GHz, 1024MHz, etc
@@ -7159,6 +7415,8 @@ message RedfishBrowseRequest {
 }
 
 message RedfishBrowseResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Response in JSON String
   string text = 1;
   map<string, string> headers = 2;
@@ -7242,6 +7500,8 @@ message UfmBrowseResponse {
 }
 
 message NetworkSecurityGroupAttributes {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated NetworkSecurityGroupRuleAttributes rules = 1;
 
   // Whether egress rules should be stateful.
@@ -7249,6 +7509,8 @@ message NetworkSecurityGroupAttributes {
 }
 
 message NetworkSecurityGroup {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string id                                 = 1;
   string tenant_organization_id             = 2;
   Metadata metadata                         = 3;
@@ -7309,6 +7571,8 @@ message DeleteNetworkSecurityGroupResponse {
 }
 
 enum NetworkSecurityGroupSource {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   NSG_SOURCE_INVALID  = 0; // Should be rejected.  There is no default NSG source, and the reporter should be explicit about the source.
   NSG_SOURCE_NONE     = 1; // No NSG is applied: neither VPC, Instance, nor interface has an NSG configured.
   NSG_SOURCE_VPC      = 2; // NSG sourced from NSG configured on VPC.
@@ -7316,6 +7580,8 @@ enum NetworkSecurityGroupSource {
 }
 
 message NetworkSecurityGroupStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   NetworkSecurityGroupSource source = 1;
   string id                         = 2;
   string version                    = 3;
@@ -7330,6 +7596,8 @@ enum NetworkSecurityGroupPropagationStatus {
 }
 
 message NetworkSecurityGroupPropagationObjectStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The UUID of the VPC or instance.  If we decide to allow
   // per-interface NSG application later, this _could_ be used to
   // hold the interface index number, and an optional
@@ -7385,12 +7653,16 @@ message GetNetworkSecurityGroupPropagationStatusRequest {
 }
 
 enum NetworkSecurityGroupRuleDirection {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   NSG_RULE_DIRECTION_INVALID = 0; // Must be rejected
   NSG_RULE_DIRECTION_INGRESS = 1;
   NSG_RULE_DIRECTION_EGRESS  = 2;
 }
 
 enum NetworkSecurityGroupRuleProtocol {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   NSG_RULE_PROTO_INVALID = 0; // Must be rejected
   NSG_RULE_PROTO_ANY     = 1;
   NSG_RULE_PROTO_ICMP    = 2;
@@ -7400,12 +7672,16 @@ enum NetworkSecurityGroupRuleProtocol {
 }
 
 enum NetworkSecurityGroupRuleAction {
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   NSG_RULE_ACTION_INVALID = 0; // Must be rejected
   NSG_RULE_ACTION_DENY    = 1;
   NSG_RULE_ACTION_PERMIT  = 2;
 }
 
 message NetworkSecurityGroupRuleAttributes {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
 
   // Optionally sent in; otherwise, generated on creation.
   // Facilitates metrics/logging in the future.
@@ -7437,6 +7713,8 @@ message NetworkSecurityGroupRuleAttributes {
 // with that VPC.  This is the message that is
 // actually used by the DPU to generate its NVUE config.
 message ResolvedNetworkSecurityGroupRule {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   NetworkSecurityGroupRuleAttributes rule = 1;
   repeated string src_prefixes            = 2;
   repeated string dst_prefixes            = 3;
@@ -7449,6 +7727,8 @@ message GetNetworkSecurityGroupAttachmentsRequest {
 }
 
 message NetworkSecurityGroupAttachments {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string network_security_group_id = 1;
   repeated string vpc_ids          = 2;
   repeated string instance_ids     = 3;
@@ -7472,12 +7752,16 @@ message DesiredFirmwareVersionEntry {
 }
 
 message SkuComponentChassis {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string vendor = 1;
   string model = 2;
   string architecture = 3;
 }
 
 message SkuComponentCpu {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string vendor = 1;
   string model = 2;
   uint32 thread_count = 3;
@@ -7485,6 +7769,8 @@ message SkuComponentCpu {
 }
 
 message SkuComponentGpu {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string vendor = 1;
   string model = 2;
   uint32 count = 3;
@@ -7492,6 +7778,8 @@ message SkuComponentGpu {
 }
 
 message SkuComponentEthernetDevices {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string vendor = 1;
   string model = 2;
   bool is_connected = 3;
@@ -7499,6 +7787,8 @@ message SkuComponentEthernetDevices {
 }
 
 message SkuComponentInfinibandDevices {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   // The Vendor of the InfiniBand device. E.g. `Mellanox`
   string vendor = 1;
   // The Device Name of the InfiniBand device. E.g. `MT2910 Family [ConnectX-7]`
@@ -7517,6 +7807,8 @@ message SkuComponentInfinibandDevices {
 }
 
 message SkuComponentStorage {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string vendor = 1;
   string model = 2;
   uint32 count = 3;
@@ -7533,17 +7825,23 @@ message SkuComponentStorageController {
 }
 
 message SkuComponentMemory {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string memory_type = 1;
   uint32 capacity_mb = 2;
   uint32 count = 3;
 }
 
 message SkuComponentTpm {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string vendor = 1;
   string version = 2;
 }
 
 message SkuComponents {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   SkuComponentChassis chassis = 1;
   repeated SkuComponentCpu cpus = 2;
   repeated SkuComponentGpu gpus = 3;
@@ -7555,6 +7853,8 @@ message SkuComponents {
 }
 
 message Sku {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string id = 1;
   optional string description = 2;
   optional google.protobuf.Timestamp created = 3;
@@ -7577,6 +7877,8 @@ message RemoveSkuRequest {
 }
 
 message SkuList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   repeated Sku skus = 1;
 }
 
@@ -7585,6 +7887,8 @@ message SkuIdList {
 }
 
 message SkuStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   optional google.protobuf.Timestamp verify_request_time = 1;
   optional google.protobuf.Timestamp last_match_attempt = 2;
   optional google.protobuf.Timestamp last_generate_attempt = 3;
@@ -7598,6 +7902,7 @@ message SkuSearchFilter {
 }
 
 message DpaInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.DpaInterfaceId id = 1;
   common.MachineId machine_id = 2;
   string mac_addr = 3;
@@ -7665,6 +7970,7 @@ message DpaInterfacesByIdsRequest {
 }
 
 message DpaInterfaceList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated DpaInterface interfaces = 1;
 }
 
@@ -7701,6 +8007,8 @@ message PowerOptionUpdateRequest {
 }
 
 message PowerOptions {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   PowerState desired_state = 1;
   google.protobuf.Timestamp desired_state_updated_at = 2;
   PowerState actual_state = 3;
@@ -7715,12 +8023,15 @@ message PowerOptions {
 }
 
 message PowerOptionResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated PowerOptions response = 1;
 }
 
 
 
-message ComputeAllocationAttributes {   
+message ComputeAllocationAttributes {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string instance_type_id = 1; // The source of the compute resources
   
   // The number of instances for this requested instance type allocated
@@ -7734,6 +8045,7 @@ message ComputeAllocationAttributes {
 
 
 message ComputeAllocation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.ComputeAllocationId id          = 1;
   string tenant_organization_id          = 2;
   ComputeAllocationAttributes attributes = 3;
@@ -7808,6 +8120,8 @@ message DeleteComputeAllocationResponse {
 // to include allocation stats when requested in
 // FindInstanceTypesByIdsRequest 
 message InstanceTypeAllocationStats {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The sum of all allocations for the instance type
   uint32 max_allocatable = 1;
 
@@ -7833,6 +8147,7 @@ message GetRackResponse {
 }
 
 message RackList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Rack racks = 1;
 }
 
@@ -7850,6 +8165,7 @@ message RacksByIdsRequest {
 }
 
 message Rack {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.RackId id = 1;
   // deprecated: Use status.lifecycle field
   string rack_state = 2;
@@ -7871,10 +8187,13 @@ message Rack {
 }
 
 message RackConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
 
 }
 
 message RackStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   health.HealthReport health = 7;
   repeated HealthSourceOrigin health_sources = 8;
   // Lifecycle related status
@@ -7926,6 +8245,7 @@ enum RackHardwareClass {
 }
 
 message RackCapabilityCompute {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string name = 1;
   uint32 count = 2;
   optional string vendor = 3;
@@ -7933,6 +8253,7 @@ message RackCapabilityCompute {
 }
 
 message RackCapabilitySwitch {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string name = 1;
   uint32 count = 2;
   optional string vendor = 3;
@@ -7940,6 +8261,7 @@ message RackCapabilitySwitch {
 }
 
 message RackCapabilityPowerShelf {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   optional string name = 1;
   uint32 count = 2;
   optional string vendor = 3;
@@ -7947,12 +8269,14 @@ message RackCapabilityPowerShelf {
 }
 
 message RackCapabilitiesSet {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   RackCapabilityCompute compute = 1;
   RackCapabilitySwitch switch = 2;
   RackCapabilityPowerShelf power_shelf = 3;
 }
 
 message RackProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.RackHardwareType rack_hardware_type = 1;
   RackHardwareTopology rack_hardware_topology = 2;
   RackHardwareClass rack_hardware_class = 3;
@@ -7965,17 +8289,20 @@ message GetRackProfileRequest {
 }
 
 message GetRackProfileResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.RackId rack_id = 1;
   common.RackProfileId rack_profile_id = 2;
   RackProfile profile = 3;
 }
 
 message ConfiguredRackProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.RackProfileId rack_profile_id = 1;
   RackProfile profile = 2;
 }
 
 message ListRackProfilesResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated ConfiguredRackProfile rack_profiles = 1;
 }
 
@@ -8000,6 +8327,7 @@ message RackManagerForgeResponse {
   optional string json_result = 1;
 }
 message MachineNVLinkInfo {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.NVLinkDomainId domain_uuid = 1;
   repeated NVLinkGpu gpus = 2;
   string chassis_serial = 3;
@@ -8011,11 +8339,13 @@ message UpdateMachineNvLinkInfoRequest {
 }
 
 message MachineSpxStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineSpxAttachmentStatusObservation attachment_status = 1;
   optional google.protobuf.Timestamp observed_at = 2;
 }
 
 message MachineSpxAttachmentStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   optional common.SpxPartitionId partition_id = 2;
   optional SpxAttachmentType attachment_type = 3;
@@ -8024,10 +8354,12 @@ message MachineSpxAttachmentStatusObservation {
 }
 
 message AstraConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated AstraAttachment astra_attachments = 1;
 }
 
 message AstraAttachment {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   uint32 vni = 2;
   string subnet_ipv4 = 3;
@@ -8039,10 +8371,12 @@ message AstraAttachment {
 }
 
 message AstraConfigStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated AstraAttachmentStatus astra_attachments_status = 1;
 }
 
 message AstraAttachmentStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   int32 vni = 2;
   string subnet_ipv4 = 3;
@@ -8055,6 +8389,7 @@ message AstraAttachmentStatus {
 }
 
 enum AstraPhase {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   // PHASE_UNSPECIFIED represents an unspecified phase.
   PHASE_UNSPECIFIED = 0;
   // PHASE_PENDING represents a pending phase. it means the object was created but has not been processed.
@@ -8067,12 +8402,14 @@ enum AstraPhase {
   PHASE_ERROR = 4;
 }
 message AstraStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   AstraPhase phase = 1;
   string reason = 2;
   string message = 3;
 }
 
 message NVLinkGpu {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   reserved 1;
   reserved "nmx_m_id";
   int32 tray_index = 2;
@@ -8082,10 +8419,12 @@ message NVLinkGpu {
 }
 
 message MachineNVLinkStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated MachineNVLinkGpuStatusObservation gpu_status = 1;
 }
 
 message MachineNVLinkGpuStatusObservation {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string gpu_id = 1;
   optional common.NVLinkPartitionId partition_id = 2;
   optional common.NVLinkLogicalPartitionId logical_partition_id = 3;
@@ -8130,6 +8469,7 @@ message NmxcBrowseResponse {
 
 // Describe an NVLink based Partition configuration and status
 message NVLinkPartition {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.NVLinkPartitionId id = 1;
   string name = 2;
   string nmx_m_id = 3;
@@ -8138,6 +8478,7 @@ message NVLinkPartition {
 }
 
 message NVLinkPartitionList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated NVLinkPartition partitions = 1;
 }
 
@@ -8169,6 +8510,7 @@ message NVLinkFabricSearchFilter {
 
 // Describe the desired configuration of an Logical Partition
 message NVLinkLogicalPartitionConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   Metadata metadata = 1;
   // The ID of tenant that NVLPartition belong to
   string tenant_organization_id = 2;
@@ -8176,12 +8518,14 @@ message NVLinkLogicalPartitionConfig {
 
 // Describe the status and applied configuration of an Logical Partition
 message NVLinkLogicalPartitionStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // Provisioning state of this partition
   TenantState state = 1;
 }
 
 // Describe a Logical Partition configuration and status
 message NVLinkLogicalPartition {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.NVLinkLogicalPartitionId id = 1;
   NVLinkLogicalPartitionConfig config = 2;
 
@@ -8193,6 +8537,7 @@ message NVLinkLogicalPartition {
 }
 
 message NVLinkLogicalPartitionList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated NVLinkLogicalPartition partitions = 1;
 }
 
@@ -8389,15 +8734,21 @@ message TrimTableResponse{
 }
 
 message NvlinkNmxcEndpoint {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string chassis_serial = 1;
   string endpoint = 2;
 }
 
 message NvlinkNmxcEndpointList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   repeated NvlinkNmxcEndpoint entries = 1;
 }
 
 message DeleteNvlinkNmxcEndpointRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string chassis_serial = 1;
 }
 
@@ -8414,10 +8765,14 @@ message RemediationIdList {
   repeated common.RemediationId remediation_ids = 1;
 }
 message RemediationList {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated Remediation remediations = 1;
 }
 
 message Remediation {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.RemediationId id = 1;
   Metadata metadata = 2;
   google.protobuf.Timestamp creation_time = 3;
@@ -8448,6 +8803,8 @@ message FindAppliedRemediationIdsRequest {
   optional common.MachineId dpu_machine_id = 2;
 }
 message AppliedRemediationIdList {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.RemediationId remediation_ids = 1;
   repeated common.MachineId dpu_machine_ids = 2;
 }
@@ -8456,6 +8813,8 @@ message FindAppliedRemediationsRequest {
   common.MachineId dpu_machine_id = 2;
 }
 message AppliedRemediation {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.RemediationId remediation_id = 1;
   common.MachineId dpu_machine_id = 2;
   int32 attempt = 3;
@@ -8464,6 +8823,8 @@ message AppliedRemediation {
   Metadata metadata = 6; // only the labels will be populated.
 }
 message AppliedRemediationList {
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated AppliedRemediation applied_remediations = 1;
 }
 
@@ -8507,11 +8868,15 @@ message SetPrimaryInterfaceRequest {
 
 // DPU Extension Service Types and Messages
 enum DpuExtensionServiceType {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
   KUBERNETES_POD = 0;
   // Add supported service types in the future
 }
 
 message UsernamePassword {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string username = 1;
   string password = 2;
 }
@@ -8521,6 +8886,8 @@ message SessionToken {
 }
 
 message DpuExtensionServiceCredential {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string registry_url = 1;
 
   oneof type {
@@ -8530,6 +8897,8 @@ message DpuExtensionServiceCredential {
 }
 
 message DpuExtensionServiceVersionInfo {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string version = 1;
   string data = 2;
   bool has_credential = 3;
@@ -8538,6 +8907,8 @@ message DpuExtensionServiceVersionInfo {
 }
 
 message DpuExtensionService {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string service_id = 1;
 
   DpuExtensionServiceType service_type = 2;
@@ -8619,6 +8990,8 @@ message DpuExtensionServiceSearchFilter {
 }
 
 message DpuExtensionServiceIdList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   repeated string service_ids = 1;
 }
 
@@ -8667,15 +9040,21 @@ message InstanceDpuExtensionServiceInfo {
 }
 
 message DpuExtensionServiceObservabilityConfigPrometheus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   uint32 scrape_interval_seconds = 1;
   string endpoint                = 2;
 }
 
 message DpuExtensionServiceObservabilityConfigLogging {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string path = 1;
 }
 
 message DpuExtensionServiceObservabilityConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   // The name of service being monitored OR the name of
   // the portion of the service being monitored.
   // This will default to the name of the service.
@@ -8689,6 +9068,8 @@ message DpuExtensionServiceObservabilityConfig {
 
 
 message DpuExtensionServiceObservability {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   repeated DpuExtensionServiceObservabilityConfig configs = 1;
 }
 
@@ -8848,10 +9229,12 @@ enum ScoutStreamErrorStatus {
 // We can change that with additional fields on this struct
 // if necessary in the future.
 message PrefixFilterPolicyEntry {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string prefix = 1;
 }
 
 message RoutingProfile {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.RouteTarget route_target_imports             = 1;
   repeated common.RouteTarget route_targets_on_exports         = 2;
   bool leak_default_route_from_underlay                        = 3;
@@ -9217,6 +9600,7 @@ message SpxPartitionCreationRequest {
 }
 
 message SpxPartition {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   Metadata metadata = 1;
   common.SpxPartitionId id = 2;
   uint32 vni = 3;
@@ -9224,6 +9608,7 @@ message SpxPartition {
 }
 
 message SpxPartitionIdList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.SpxPartitionId spx_partition_ids = 1;
 }
 
@@ -9241,6 +9626,7 @@ message SpxPartitionSearchFilter {
 }
 
 message SpxPartitionList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated SpxPartition spx_partitions = 1;
 }
 
@@ -9283,6 +9669,8 @@ message AdminForceDeletePowerShelfResponse {
 // Operating system definition (CRUD resource, table operating_systems).
 // Type of Operating System variant
 enum OperatingSystemType {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.enum_derive) = "serde::Deserialize";
   OS_TYPE_UNSPECIFIED = 0;
   OS_TYPE_IPXE = 1;              // Raw inline iPXE script
   OS_TYPE_TEMPLATED_IPXE = 2; // iPXE OS using an iPXE template
@@ -9338,6 +9726,8 @@ enum ExpectedInterfaceIpAllocation {
 }
 
 message OperatingSystem {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   common.OperatingSystemId id = 1;
   string name = 2;
   optional string description = 3;
@@ -9426,6 +9816,8 @@ message OperatingSystemsByIdsRequest {
 }
 
 message OperatingSystemList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   repeated OperatingSystem operating_systems = 1;
 }
 
@@ -9487,6 +9879,7 @@ message GetMachineBootInterfacesRequest {
 // captured yet still reports its MAC (the model type requires both halves,
 // which the `TryFrom` conversion enforces).
 message MachineBootInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   optional string interface_id = 2;
 }
@@ -9495,6 +9888,7 @@ message MachineBootInterface {
 // owned machine. `primary_interface` is the designation `pick_boot_interface`
 // keys on.
 message MachineInterfaceBootInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   bool primary_interface = 2;
   // Vendor-named Redfish EthernetInterface.Id, absent until site-explorer has
@@ -9510,6 +9904,7 @@ message MachineInterfaceBootInterface {
 // A `predicted_machine_interfaces` row's boot interface: the candidate a host
 // offers in the window before its first DHCP lease creates an owned row.
 message PredictedBootInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   bool primary_interface = 2;
   optional string boot_interface_id = 3;
@@ -9520,6 +9915,7 @@ message PredictedBootInterface {
 // An `explored_endpoints` row's boot interface: site-explorer's per-cycle
 // automatic pick for a BMC endpoint, used only for endpoints no machine owns.
 message ExploredBootInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // BMC endpoint address this explored default was recorded against.
   string address = 1;
   optional string boot_interface_mac = 2;
@@ -9530,12 +9926,14 @@ message ExploredBootInterface {
 // interface deletion, keyed by MAC. `recorded_at` is included so the view can
 // show stale records (ones aged past the retention window).
 message RetainedBootInterface {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   string mac_address = 1;
   string boot_interface_id = 2;
   google.protobuf.Timestamp recorded_at = 3;
 }
 
 message GetMachineBootInterfacesResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // The desired boot-interface generation, its latest persisted observation,
   // and any machine-controller work currently reconciling it.
   message Reconciliation {
@@ -9622,10 +10020,14 @@ message GetMachineBootInterfacesResponse {
 }
 
 message GetContainerRegistryCredentialRequest {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string registry = 1;
 }
 
 message GetContainerRegistryCredentialResponse {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string username = 1;
   string password = 2;
 }
@@ -9638,6 +10040,7 @@ message SetContainerRegistryCredentialRequest {
 
 // Identifies the lifecycle authority responsible for a site prefix.
 enum SitePrefixAuthority {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   option allow_alias = true;
 
   SITE_PREFIX_AUTHORITY_UNSPECIFIED = 0;
@@ -9648,12 +10051,14 @@ enum SitePrefixAuthority {
 
 // Describes where a site prefix may be routed.
 enum SitePrefixRoutingScope {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   SITE_PREFIX_ROUTING_SCOPE_UNSPECIFIED = 0;
   SITE_PREFIX_ROUTING_SCOPE_DATACENTER_ONLY = 1;
 }
 
 // Describes the current lifecycle state of a site prefix.
 enum SitePrefixLifecycleState {
+  option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
   SITE_PREFIX_LIFECYCLE_STATE_UNSPECIFIED = 0;
   SITE_PREFIX_LIFECYCLE_STATE_PROVISIONING = 1;
   SITE_PREFIX_LIFECYCLE_STATE_READY = 2;
@@ -9663,6 +10068,7 @@ enum SitePrefixLifecycleState {
 
 // A site-level prefix that may contain VPC address space.
 message SitePrefix {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   common.SitePrefixId id = 1;
   SitePrefixConfig config = 2;
   SitePrefixStatus status = 3;
@@ -9673,6 +10079,7 @@ message SitePrefix {
 }
 
 message SitePrefixConfig {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   // IPv4 or IPv6 prefix in canonical CIDR notation.
   string prefix = 1;
   // Present only for tenant-managed site prefixes.
@@ -9681,6 +10088,7 @@ message SitePrefixConfig {
 }
 
 message SitePrefixStatus {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   SitePrefixAuthority authority = 1;
   SitePrefixLifecycleState lifecycle_state = 2;
   // Tenant-wide point-in-time use for the owning tenant. Present only for
@@ -9690,6 +10098,7 @@ message SitePrefixStatus {
 }
 
 message SitePrefixQuotaUsage {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   uint32 used = 1;
   uint32 limit = 2;
 }
@@ -9749,9 +10158,11 @@ message SitePrefixesByIdsRequest {
 }
 
 message SitePrefixIdList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated common.SitePrefixId site_prefix_ids = 1;
 }
 
 message SitePrefixList {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
   repeated SitePrefix site_prefixes = 1;
 }

--- a/crates/rpc/proto/scout_firmware_upgrade.proto
+++ b/crates/rpc/proto/scout_firmware_upgrade.proto
@@ -2,7 +2,11 @@ syntax = "proto3";
 
 package scout_firmware_upgrade;
 
+import "codegen/v1/derive.proto";
+
 message ScoutFirmwareUpgradeTask {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string upgrade_task_id = 1;
   string component_type = 2;
   string target_version = 3;
@@ -13,6 +17,8 @@ message ScoutFirmwareUpgradeTask {
 }
 
 message FileArtifact {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
   string url = 1;
   string sha256 = 2;
 }

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1089,6 +1089,20 @@ mod tests {
     use super::*;
     use crate::protos::dns::{Domain, Metadata};
 
+    fn assert_serialize<T: serde::Serialize>() {}
+
+    fn assert_deserialize<T: for<'de> serde::Deserialize<'de>>() {}
+
+    #[test]
+    fn protobuf_codegen_annotations_apply_to_generated_type_kinds() {
+        assert_serialize::<forge::ClientSecretBasic>();
+        assert_deserialize::<forge::ClientSecretBasic>();
+        assert_serialize::<forge::DpuMode>();
+        assert_deserialize::<forge::DpuMode>();
+        assert_serialize::<forge::instance_interface_config::NetworkDetails>();
+        assert_serialize::<forge::get_machine_boot_interfaces_response::Reconciliation>();
+    }
+
     #[test]
     fn reflection_descriptor_contains_all_rpc_services() {
         let descriptor_set =

--- a/crates/ssh-console-mock-api-server/build.rs
+++ b/crates/ssh-console-mock-api-server/build.rs
@@ -28,6 +28,7 @@ static KEEP_RPCS: &[&str] = &[
 ];
 
 static RPC_CRATE_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../rpc");
+static RPC_PROTO_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../rpc/proto");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     carbide_version::build();
@@ -57,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "proto/machine_discovery.proto",
                 "proto/site_explorer.proto",
             ],
-            &["proto"],
+            &["proto", RPC_PROTO_DIR],
         )?;
 
     Ok(())

--- a/rest-api/proto/cmd/core-proto-fmt/main.go
+++ b/rest-api/proto/cmd/core-proto-fmt/main.go
@@ -62,6 +62,7 @@ func normalizeProtoFile(protoFile string) {
 
 	content := string(protoFileContent)
 	content = addOrReplaceLicenseHeader(content)
+	content = removeCodegenAnnotations(content)
 	content = addGoPackageOption(content)
 	content = updateImports(content)
 	content = renameCarbideReference(content)
@@ -81,6 +82,15 @@ func normalizeProtoFile(protoFile string) {
 	if err := os.WriteFile(protoFile, []byte(content), 0644); err != nil {
 		log.Err(err).Str("protoFile", protoFile).Msg("Failed to write normalized proto file")
 	}
+}
+
+// removeCodegenAnnotations removes Rust-only code generation metadata before
+// the Core protobuf snapshot is passed to Buf and the Go protobuf compiler.
+func removeCodegenAnnotations(content string) string {
+	codegenImport := regexp.MustCompile(`(?m)^[ \t]*import "codegen/v1/derive\.proto";[ \t]*\n(?:[ \t]*\n)?`)
+	content = codegenImport.ReplaceAllString(content, "")
+	codegenOption := regexp.MustCompile(`(?m)^[ \t]*option \(carbide\.codegen\.v1\.(?:message|enum)_derive\) = "[^"]+";[ \t]*\n?`)
+	return codegenOption.ReplaceAllString(content, "")
 }
 
 // addOrReplaceLicenseHeader strips any existing comment/blank-line preamble

--- a/rest-api/proto/cmd/core-proto-fmt/main_test.go
+++ b/rest-api/proto/cmd/core-proto-fmt/main_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRemoveCodegenAnnotations(t *testing.T) {
+	input := `syntax = "proto3";
+
+import "codegen/v1/derive.proto";
+
+message Example {
+  option (carbide.codegen.v1.message_derive) = "serde::Serialize";
+  option (carbide.codegen.v1.message_derive) = "serde::Deserialize";
+
+  enum State {
+    option (carbide.codegen.v1.enum_derive) = "serde::Serialize";
+    STATE_UNSPECIFIED = 0;
+  }
+
+  string value = 1;
+}
+`
+
+	output := removeCodegenAnnotations(input)
+	for _, removed := range []string{
+		"codegen/v1/derive.proto",
+		"carbide.codegen.v1.message_derive",
+		"carbide.codegen.v1.enum_derive",
+	} {
+		if strings.Contains(output, removed) {
+			t.Errorf("output still contains Rust codegen annotation %q", removed)
+		}
+	}
+	if !strings.Contains(output, "string value = 1;") {
+		t.Error("output lost protobuf schema content")
+	}
+	if strings.Contains(output, "\n\n\n") {
+		t.Error("output contains extra blank lines after removing codegen annotations")
+	}
+}

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -5,9 +5,6 @@ syntax = "proto3";
 
 package forge;
 
-// Don't forget to update build.rs to add the Serialize annotation for any new
-// message types!
-
 import "common_nico.proto";
 import "dns_nico.proto";
 import "google/protobuf/duration.proto";


### PR DESCRIPTION
Before this PR all derive type attributes were defined in build.rs file. List of mapping has become to big to manage it this way.

This PR introduces derive annotations for messages and enums. All messages that marked with these annotations will receive corresponding derive attribute in the generated code. 

## Related issues

Related to #4594 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

