### PR TITLE
fix: enforce unique machine interface address ownership

### DIFF
--- a/crates/api-core/src/dhcp/expire.rs
+++ b/crates/api-core/src/dhcp/expire.rs
@@ -62,7 +62,7 @@ pub(crate) async fn expire_dhcp_lease(
     // deleting a specific IP allocation would hit. Either way, both variants
     // return the interfaces whose rows were actually deleted, so we resync those
     // authoritative owners rather than a separately looked-up interface (which
-    // could differ if ownership changed or multiple rows share the address).
+    // could differ if ownership changed between the lookup and deletion).
     let resync_targets = match mac_address {
         Some(mac) => {
             db::machine_interface_address::delete_by_address_and_mac(

--- a/crates/api-core/src/dhcp/v6.rs
+++ b/crates/api-core/src/dhcp/v6.rs
@@ -95,26 +95,8 @@ pub(super) async fn observe_slaac_address(
     if let Some(address) = slaac_gua_from_eui64(prefix, mac) {
         let address = IpAddr::V6(address);
 
-        // TODO: This is a best-effort ownership check, not a complete
-        // concurrency boundary. Static assignment and preallocation do not yet
-        // share a segment lock with SLAAC observation, so they can still race
-        // between this read and insert. A future PR should route DHCP, SLAAC,
-        // and static address writes through one DB helper that locks the owning
-        // segment, checks global address ownership, applies the replacement
-        // policy, and writes the row.
-        if let Some(existing) =
-            db::machine_interface_address::find_by_address(&mut *txn, address).await?
-        {
-            if existing.id == interface_id {
-                return Ok(());
-            }
-
-            return Err(CarbideError::FailedPrecondition(format!(
-                "SLAAC address {address} is already allocated to interface {} on segment {}; refusing duplicate observation for interface {interface_id}",
-                existing.id, existing.name,
-            )));
-        }
-
+        // The shared insert is the ownership boundary for both visible and
+        // concurrent owners.
         db::machine_interface_address::insert(
             &mut *txn,
             interface_id,

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -1295,9 +1295,9 @@ async fn test_dhcp_v6_info_request_records_single_slaac_observation(
     Ok(())
 }
 
-// SLAAC observation is best-effort guarded against address ownership conflicts:
-// if the computed EUI-64 address is already held by another interface, reject
-// instead of creating a duplicate machine_interface_addresses row.
+// SLAAC observation uses the shared ownership boundary: if the computed EUI-64
+// address is already held by another interface, reject instead of creating a
+// duplicate machine_interface_addresses row.
 #[crate::sqlx_test]
 async fn test_dhcp_v6_info_request_rejects_slaac_address_owned_by_other_interface(
     pool: sqlx::PgPool,
@@ -1342,7 +1342,13 @@ async fn test_dhcp_v6_info_request_rejects_slaac_address_owned_by_other_interfac
         .await
         .expect_err("duplicate SLAAC ownership should reject");
     assert_eq!(status.code(), tonic::Code::FailedPrecondition);
-    assert!(status.message().contains("already allocated to interface"));
+    assert_eq!(
+        status.message(),
+        format!(
+            "address already in use: {duplicate_slaac} by {owner_mac} in network segment {} (interface: {owner_interface_id})",
+            env.admin_segment(),
+        )
+    );
 
     let mut txn = pool.begin().await?;
     let requester_interfaces =

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -881,31 +881,20 @@ async fn test_insecure_discovery_requires_interface_id(
 }
 
 #[crate::sqlx_test]
-async fn test_discovery_ip_lookup_rejects_missing_and_ambiguous_mappings(
+async fn test_discovery_ip_lookup_rejects_missing_mapping(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
-    let first_interface_id =
-        common::api_fixtures::dpu::dpu_discover_dhcp(&env, "02:00:00:00:10:01").await;
-    let second_interface_id =
-        common::api_fixtures::dpu::dpu_discover_dhcp(&env, "02:00:00:00:10:02").await;
-
     let mut txn = env.pool.begin().await?;
-    let missing =
-        db::machine_interface::find_for_update_by_ip(&mut txn, "203.0.113.253".parse().unwrap())
-            .await;
-    assert!(missing.is_err());
-
-    let first_interface = db::machine_interface::find_one(&mut *txn, first_interface_id).await?;
-    let first_address = first_interface.addresses[0];
-    sqlx::query("UPDATE machine_interface_addresses SET address = $1 WHERE interface_id = $2")
-        .bind(first_address)
-        .bind(second_interface_id)
-        .execute(&mut *txn)
-        .await?;
-
-    let ambiguous = db::machine_interface::find_for_update_by_ip(&mut txn, first_address).await;
-    assert!(ambiguous.is_err());
+    let missing_address = "203.0.113.253".parse().unwrap();
+    let missing = db::machine_interface::find_for_update_by_ip(&mut txn, missing_address).await;
+    assert!(matches!(
+        missing,
+        Err(db::DatabaseError::NotFoundError {
+            kind: "machine_interface for discovery IP",
+            id,
+        }) if id == missing_address.to_string()
+    ));
     Ok(())
 }
 

--- a/crates/api-db/migrations/20260810213729_machine_interface_addresses_unique.sql
+++ b/crates/api-db/migrations/20260810213729_machine_interface_addresses_unique.sql
@@ -1,0 +1,19 @@
+-- A machine-interface address identifies one interface across the site. Normalize
+-- legacy inet masks before enforcing that ownership in the database.
+-- Keep one lock across both steps so older API processes cannot insert another
+-- conflicting value in between. Existing duplicate owners intentionally stop
+-- the migration instead of letting the migration choose which owner to keep.
+LOCK TABLE public.machine_interface_addresses IN ACCESS EXCLUSIVE MODE;
+
+UPDATE public.machine_interface_addresses
+SET address = host(address)::inet
+WHERE address != host(address)::inet;
+
+ALTER TABLE public.machine_interface_addresses
+    ADD CONSTRAINT machine_interface_addresses_host_address_check
+    CHECK (address = host(address)::inet);
+
+ALTER TABLE public.machine_interface_addresses
+    ADD CONSTRAINT machine_interface_addresses_address_key UNIQUE (address);
+
+DROP INDEX public.machine_interface_addresses_address_idx;

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -1768,9 +1768,9 @@ async fn create_fast_path(
                     // Another simultaneous create got the same FQDN, try again.
                     false
                 }
-                Err(DatabaseError::TryAgain) => {
-                    // All the IP's in the batch we grabbed from the database got taken by other
-                    // concurrent calls to create_fast_path. Try again.
+                Err(DatabaseError::TryAgain | DatabaseError::AddressAlreadyInUse(_)) => {
+                    // The candidates we read were claimed before this attempt
+                    // could insert them. Roll back and select another batch.
                     false
                 }
                 Err(DatabaseError::ResourceExhausted(_)) if segments_idx < segments.len() - 1 => {
@@ -2169,7 +2169,8 @@ async fn create_inner(
     .await?;
 
     for address in allocated_addresses {
-        insert_machine_interface_address(txn, &interface_id, address, allocation_type).await?;
+        crate::machine_interface_address::insert(txn, interface_id, *address, allocation_type)
+            .await?;
     }
 
     Ok(interface_id)
@@ -2408,6 +2409,8 @@ pub async fn find_optional_for_update_by_ip(
     match interface_ids.as_slice() {
         [] => Ok(None),
         [(interface_id,)] => find_one(txn, *interface_id).await.map(Some),
+        // The address uniqueness constraint makes this unreachable on a valid schema. Keep the
+        // guard so discovery fails closed if database invariants are bypassed.
         _ => Err(DatabaseError::internal(format!(
             "multiple machine interfaces map to discovery IP {remote_ip}"
         ))),
@@ -2502,28 +2505,6 @@ async fn insert_machine_interface(
         })?;
 
     Ok(interface_id)
-}
-
-/// insert_machine_interface_address inserts a new machine interface
-/// address entry into the database. In the case of machine interfaces,
-/// this explicitly takes an `IpAddr`, since machine interfaces are
-/// always going to be a /32. It is up to the caller to ensure a possible
-/// IpNetwork returned from the IpAllocator is of the correct size.
-async fn insert_machine_interface_address(
-    txn: &mut PgConnection,
-    interface_id: &MachineInterfaceId,
-    address: &IpAddr,
-    allocation_type: model::allocation_type::AllocationType,
-) -> DatabaseResult<()> {
-    let query = "INSERT INTO machine_interface_addresses (interface_id, address, allocation_type) VALUES ($1::uuid, $2::inet, $3)";
-    sqlx::query(query)
-        .bind(interface_id)
-        .bind(address)
-        .bind(allocation_type)
-        .execute(txn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-    Ok(())
 }
 
 async fn find_by<'a, C: ColumnInfo<'a, TableType = MachineInterfaceSnapshot>>(
@@ -3542,10 +3523,10 @@ pub async fn allocate_address_for_family(
         allocated_addresses =
             allocate_v6_addresses_via_ip_allocator(&mut fast_txn, &ipv6_segment).await?;
         for address in &allocated_addresses {
-            insert_machine_interface_address(
+            crate::machine_interface_address::insert(
                 fast_txn.as_pgconn(),
-                &interface_id,
-                address,
+                interface_id,
+                *address,
                 AllocationType::Dhcp,
             )
             .await?;
@@ -3558,10 +3539,10 @@ pub async fn allocate_address_for_family(
         {
             let address = allocate_next_ip_with_retry(&mut fast_txn, segment, prefix).await?;
             allocated_addresses.push(address);
-            insert_machine_interface_address(
+            crate::machine_interface_address::insert(
                 fast_txn.as_pgconn(),
-                &interface_id,
-                &address,
+                interface_id,
+                address,
                 AllocationType::Dhcp,
             )
             .await?;

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -32,8 +32,7 @@ use crate::db_read::DbReader;
 #[cfg(test)]
 mod test_find_by_address;
 
-/// Returned by allocation paths with `AddressSelectionStrategy::StaticAddress`
-/// when the target IP is already held by some other interface.
+/// Returned when an address is already held by an interface.
 #[derive(thiserror::Error, Debug)]
 #[error("address already in use: {0} by {1} in network segment {2} (interface: {3})")]
 pub struct AddressAlreadyInUseError(
@@ -77,6 +76,7 @@ pub async fn find_by_address(
     address: IpAddr,
 ) -> Result<Option<MachineInterfaceSearchResult>, DatabaseError> {
     let query = "SELECT mi.id, mi.machine_id, mi.switch_id, mi.interface_type,
+                mi.mac_address, mi.segment_id,
                 ns.name, ns.network_segment_type, mia.allocation_type
             FROM machine_interface_addresses mia
             INNER JOIN machine_interfaces mi ON mi.id = mia.interface_id
@@ -174,22 +174,50 @@ pub async fn delete_by_interface_and_address(
         .map_err(|e| DatabaseError::query(query, e))
 }
 
-/// Insert a new address for an interface with the given allocation type.
+/// `insert` assigns an unowned address to an interface.
+///
+/// `ON CONFLICT DO NOTHING` leaves the caller's transaction usable so we can
+/// identify the current owner. Repeating the same assignment for the same
+/// interface is idempotent; a different owner or allocation type returns
+/// [`AddressAlreadyInUseError`]. Allocation callers decide whether to choose
+/// another address; this function only attempts the requested address once.
 pub async fn insert(
     txn: &mut PgConnection,
     interface_id: MachineInterfaceId,
     address: IpAddr,
     allocation_type: AllocationType,
 ) -> Result<(), DatabaseError> {
-    let query = "INSERT INTO machine_interface_addresses (interface_id, address, allocation_type) VALUES ($1::uuid, $2::inet, $3)";
-    sqlx::query(query)
+    let query = "INSERT INTO machine_interface_addresses (interface_id, address, allocation_type)
+        VALUES ($1::uuid, $2::inet, $3)
+        ON CONFLICT (address) DO NOTHING
+        RETURNING interface_id";
+
+    let inserted: Option<MachineInterfaceId> = sqlx::query_scalar(query)
         .bind(interface_id)
         .bind(address)
         .bind(allocation_type)
-        .execute(txn)
+        .fetch_optional(&mut *txn)
         .await
-        .map(|_| ())
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|e| DatabaseError::query(query, e))?;
+    if inserted.is_some() {
+        return Ok(());
+    }
+
+    let Some(existing) = find_by_address(&mut *txn, address).await? else {
+        return Err(DatabaseError::internal(format!(
+            "address {address} was reported as in use but has no owner"
+        )));
+    };
+    if existing.id == interface_id && existing.allocation_type == allocation_type {
+        return Ok(());
+    }
+    Err(AddressAlreadyInUseError(
+        address,
+        existing.mac_address,
+        existing.segment_id,
+        existing.id,
+    )
+    .into())
 }
 
 /// Assign a static address to an interface. If the interface already
@@ -226,11 +254,9 @@ pub async fn assign_static(
     Ok(result)
 }
 
-/// Delete an address allocation of the given type. Returns the interfaces that
-/// owned the deleted addresses (normally one, empty if nothing matched) so
-/// callers can resync each one's hostname rather than guessing the owner. The
-/// delete removes every matching row, so all owners are returned — not just the
-/// first — since `(address, allocation_type)` is not unique on its own.
+/// Delete an address allocation of the given type. Returns at most one owning
+/// interface in a vector so callers can share the hostname-resync path with
+/// MAC-scoped deletion.
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,
@@ -302,6 +328,8 @@ pub struct MachineInterfaceSearchResult {
     pub machine_id: Option<MachineId>,
     pub switch_id: Option<SwitchId>,
     pub interface_type: InterfaceType,
+    pub mac_address: MacAddress,
+    pub segment_id: NetworkSegmentId,
     pub name: String,
     pub network_segment_type: NetworkSegmentType,
     pub allocation_type: AllocationType,
@@ -309,7 +337,49 @@ pub struct MachineInterfaceSearchResult {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+
+    /// Creates an addressless interface for address-ownership tests.
+    async fn create_test_interface(
+        txn: &mut PgConnection,
+        segment_id: NetworkSegmentId,
+        mac_address: MacAddress,
+        hostname: &str,
+    ) -> Result<MachineInterfaceId, sqlx::Error> {
+        sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                (segment_id, mac_address, primary_interface, hostname)
+             VALUES ($1, $2, false, $3)
+             RETURNING id",
+        )
+        .bind(segment_id)
+        .bind(mac_address)
+        .bind(hostname)
+        .fetch_one(txn)
+        .await
+    }
+
+    /// Races one address insert in its own transaction.
+    async fn insert_after_barrier(
+        pool: &sqlx::PgPool,
+        barrier: Arc<tokio::sync::Barrier>,
+        interface_id: MachineInterfaceId,
+        address: IpAddr,
+        allocation_type: AllocationType,
+    ) -> Result<(), DatabaseError> {
+        barrier.wait().await;
+        let mut txn = crate::Transaction::begin(pool).await?;
+
+        match insert(txn.as_pgconn(), interface_id, address, allocation_type).await {
+            Ok(()) => txn.commit().await,
+            Err(error) => {
+                txn.rollback().await?;
+                Err(error)
+            }
+        }
+    }
 
     /// Verifies the new SLAAC allocation type survives a database round trip.
     #[crate::sqlx_test]
@@ -347,6 +417,158 @@ mod tests {
         // Verify the persisted row preserved the new allocation type.
         assert_eq!(addresses.len(), 1);
         assert_eq!(addresses[0].allocation_type, AllocationType::Slaac);
+
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    /// Verifies that concurrent inserts leave one owner and return a useful conflict.
+    #[crate::sqlx_test]
+    async fn concurrent_inserts_keep_one_address_owner(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut setup_txn = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('address-owner-race', 'V1-T0')
+             RETURNING id",
+        )
+        .fetch_one(&mut *setup_txn)
+        .await?;
+        let first_mac: MacAddress = "02:00:00:00:00:11".parse()?;
+        let second_mac: MacAddress = "02:00:00:00:00:12".parse()?;
+        let first_interface_id = create_test_interface(
+            &mut setup_txn,
+            segment_id,
+            first_mac,
+            "address-owner-race-first",
+        )
+        .await?;
+        let second_interface_id = create_test_interface(
+            &mut setup_txn,
+            segment_id,
+            second_mac,
+            "address-owner-race-second",
+        )
+        .await?;
+        setup_txn.commit().await?;
+
+        let address: IpAddr = "192.0.2.10".parse()?;
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let (first_result, second_result) = tokio::join!(
+            insert_after_barrier(
+                &pool,
+                barrier.clone(),
+                first_interface_id,
+                address,
+                AllocationType::Static,
+            ),
+            insert_after_barrier(
+                &pool,
+                barrier,
+                second_interface_id,
+                address,
+                AllocationType::Static,
+            ),
+        );
+
+        let (owner_id, owner_mac, conflict) = match (first_result, second_result) {
+            (Ok(()), Err(error)) => (first_interface_id, first_mac, error),
+            (Err(error), Ok(())) => (second_interface_id, second_mac, error),
+            results => panic!("expected one address owner and one conflict, got {results:?}"),
+        };
+        match conflict {
+            DatabaseError::AddressAlreadyInUse(AddressAlreadyInUseError(
+                conflict_address,
+                conflict_mac,
+                conflict_segment_id,
+                conflict_interface_id,
+            )) => {
+                assert_eq!(conflict_address, address);
+                assert_eq!(conflict_mac, owner_mac);
+                assert_eq!(conflict_segment_id, segment_id);
+                assert_eq!(conflict_interface_id, owner_id);
+            }
+            error => panic!("expected an address-in-use error, got {error:?}"),
+        }
+
+        let owner_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM machine_interface_addresses WHERE address = $1::inet",
+        )
+        .bind(address)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(owner_count, 1);
+
+        // Concurrent observations of the same SLAAC address for one interface
+        // are replays of the same ownership claim, so both callers succeed.
+        let slaac_address: IpAddr = "2001:db8::10".parse()?;
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let (first_result, second_result) = tokio::join!(
+            insert_after_barrier(
+                &pool,
+                barrier.clone(),
+                first_interface_id,
+                slaac_address,
+                AllocationType::Slaac,
+            ),
+            insert_after_barrier(
+                &pool,
+                barrier,
+                first_interface_id,
+                slaac_address,
+                AllocationType::Slaac,
+            ),
+        );
+        first_result?;
+        second_result?;
+
+        let slaac_owner_count: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM machine_interface_addresses WHERE address = $1::inet",
+        )
+        .bind(slaac_address)
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(slaac_owner_count, 1);
+        Ok(())
+    }
+
+    /// Verifies that masked network values cannot bypass address ownership.
+    #[crate::sqlx_test]
+    async fn machine_interface_addresses_require_host_form(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('host-addresses-only', 'V1-T0')
+             RETURNING id",
+        )
+        .fetch_one(&mut *txn)
+        .await?;
+        let interface_id = create_test_interface(
+            &mut txn,
+            segment_id,
+            "02:00:00:00:00:13".parse()?,
+            "host-addresses-only",
+        )
+        .await?;
+
+        let error = sqlx::query(
+            "INSERT INTO machine_interface_addresses (interface_id, address)
+             VALUES ($1, '192.0.2.20/24'::inet)",
+        )
+        .bind(interface_id)
+        .execute(&mut *txn)
+        .await
+        .expect_err("a machine-interface address with a network mask should be rejected");
+        match error {
+            sqlx::Error::Database(error) => assert_eq!(
+                error.constraint(),
+                Some("machine_interface_addresses_host_address_check"),
+            ),
+            error => panic!("expected a check-constraint error, got {error:?}"),
+        }
 
         txn.rollback().await?;
         Ok(())


### PR DESCRIPTION
`machine_interface_addresses` currently prevents one interface from storing the same address twice, but it does not prevent two interfaces from owning the same address. Static, DHCP, SLAAC, and manual assignment paths make independent ownership decisions, so a check performed by one path cannot close races with the others.

This change makes the database the ownership boundary. The migration normalizes legacy `inet` masks, requires host-form values, and adds `UNIQUE(address)`. Every production Rust insert now uses `machine_interface_address::insert`, which returns the existing address-in-use error when another writer wins. Fast DHCP allocation retries another candidate, and simultaneous SLAAC observations for the same interface remain idempotent.

The migration deliberately does not choose or delete an owner when existing rows conflict. It stops the upgrade so an operator can resolve the unsupported state explicitly.

## Related issues

- Closes #4150
- Part of #3491
- Depends on #4798

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Added focused SQLx coverage for concurrent address ownership and host-form storage. Updated the discovery missing-mapping test and exercised the existing SLAAC ownership test.

The following local gates pass on the rebased branch:

- `cargo make format-nightly`
- `cargo make clippy`
- `cargo make carbide-lints`
- `scripts/check-migration-filenames.sh crates/api-db/migrations/20260810213729_machine_interface_addresses_unique.sql`

## Additional Notes

Before upgrading an existing site, this query identifies both exact duplicates and masked values that would normalize to the same host address:

```sql
SELECT
    host(address)::inet AS address,
    array_agg(interface_id ORDER BY interface_id) AS interface_ids
FROM machine_interface_addresses
GROUP BY host(address)::inet
HAVING count(*) > 1;
```

Any returned address needs one explicit owner before the migration runs. The migration takes one table lock across normalization and constraint creation so an older API process cannot insert another conflict between those steps.

The existing-interface DHCP family-allocation path returns the typed conflict for a rare concurrent claim instead of retrying inside the same request. A later DHCP request sees the committed owner and selects another candidate.

#4798 should merge first because it removes the unused legacy procedure that rewrites machine-interface addresses directly.

Closes #4150
