### PR TITLE
fix(ci): Disable REST docker build cache to reduce churn

### DIFF
--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -483,10 +483,10 @@ jobs:
 
           echo "Build completed!"
 
-      # Only main saves. Actions cache entries are ref-scoped, so concurrent pull
-      # requests starting cold each store their own byte-identical copy of this
-      # archive, crowding out main's sccache. They keep restoring main's copy
-      # through the restore-keys prefix above, so they lose nothing.
+      # Only main saves this cache. Pull requests restore main's copy through the
+      # restore-keys prefix above but cannot add one of their own: entries are
+      # ref-scoped, so concurrent pull requests starting cold each used to store
+      # a byte-identical duplicate, crowding out main's sccache.
       #
       # Saved on failure too: the packages mkosi downloaded are valid whether or
       # not the image build that followed succeeded.

--- a/.github/workflows/build-boot-artifacts.yml
+++ b/.github/workflows/build-boot-artifacts.yml
@@ -483,16 +483,13 @@ jobs:
 
           echo "Build completed!"
 
-      # Only main publishes this cache. Actions cache entries are ref-scoped: a
-      # pull request that saves writes a copy nothing else can read, so a herd of
-      # concurrent pull requests starting from a cold cache each stores its own
-      # byte-identical archive. Nine copies of this one 1.3 GB entry were live at
-      # once, 10.7 GB of duplication in the same 50 GB pool that has to hold
-      # main's sccache. Pull requests keep restoring main's copy through the
-      # restore-keys prefix above, so they lose nothing.
+      # Only main saves. Actions cache entries are ref-scoped, so concurrent pull
+      # requests starting cold each store their own byte-identical copy of this
+      # archive, crowding out main's sccache. They keep restoring main's copy
+      # through the restore-keys prefix above, so they lose nothing.
       #
-      # Saved on failure as well, because the packages mkosi already downloaded
-      # are valid regardless of whether the image build that followed succeeded.
+      # Saved on failure too: the packages mkosi downloaded are valid whether or
+      # not the image build that followed succeeded.
       - name: Save mkosi package cache
         if: ${{ !cancelled() && inputs.build_type == 'ephemeral' && github.ref == 'refs/heads/main' && steps.mkosi-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -744,8 +744,8 @@ jobs:
       # any new commit invalidates the builder layer and the expensive cargo
       # step can never be restored. Exporting it anyway measured 7m32s on a main
       # run and bought two cached layers, while its multi-GB blobs were the bulk
-      # of what pushed the 50 GB Actions quota to its ceiling and evicted the
-      # sccache entries. sccache is what carries reuse across commits here.
+      # of what filled up the Actions quota and evicted the sccache
+      # entries.
       cache: false
       build_args: ${{ needs.prepare.outputs.release_build_args }}
       image_name: ${{ needs.prepare.outputs.image_registry }}/nvmetal-carbide
@@ -857,8 +857,8 @@ jobs:
       # Dockerfile does `COPY . .` before the cargo build, so any new commit
       # invalidates the builder layer and nothing expensive can ever be
       # restored. `mode=max` still exported the whole builder stage on every
-      # main commit, pushing `388 MB` blobs into the `50 GB` Actions cache
-      # pool that sccache depends on.
+      # main commit, pushing multi-hundred-MB blobs into the Actions cache pool
+      # that sccache depends on.
       cache: false
       build_args: >-
         ${{ format('{{"VERSION":"{0}","CI_COMMIT_SHORT_SHA":"{1}"}}',
@@ -1002,13 +1002,12 @@ jobs:
       # a run that changes no dependencies hits the primary key and skips the
       # upload rather than rewriting an equivalent entry.
       #
-      # Only main saves. This entry is ~5 GB, and the restore-keys prefix above
-      # means any pull request whose Cargo.lock differs from main's takes a
-      # prefix match rather than an exact one, so cache-hit is false and the
-      # save fires, storing a ref-scoped 5 GB copy nothing else can read. Three
-      # such copies were live at once, 15 GB of a 50 GB pool, which evicted the
-      # sccache objects the image builds read down to 3.5 GB. Pull requests keep
-      # restoring main's entry through that same prefix, so they still start warm.
+      # Only main saves. The restore-keys prefix above means a pull request whose
+      # Cargo.lock differs from main's takes a prefix match rather than an exact
+      # one, so cache-hit is false and the save fires, storing a large ref-scoped
+      # copy nothing else can read. Several were live at once, evicting the
+      # sccache objects the image builds read. Pull requests keep restoring
+      # main's entry through that same prefix, so they still start warm.
       - name: Save sccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.sccache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
@@ -1259,9 +1258,9 @@ jobs:
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-x86_64
       # No RUN steps, so there are no expensive layers worth reusing. The
-      # multi-GB blob COPY layer would also take a large bite out of the 50 GB
-      # per-repo Actions cache quota now shared with the layer and sccache
-      # caches the rest of the pipeline depends on.
+      # multi-GB blob COPY layer would also take a large bite out of the per-repo
+      # Actions cache quota shared with the layer and sccache caches the rest of
+      # the pipeline depends on.
       cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-x86_64
       image_tag: ${{ needs.prepare.outputs.version }}
@@ -1299,9 +1298,9 @@ jobs:
       target_prebuild_login: ${{ needs.prepare.outputs.bases_rebuilt == 'true' && needs.prepare.outputs.publish_images == 'true' }}
       dockerfile_path: dev/docker/Dockerfile.release-artifacts-aarch64
       # No RUN steps, so there are no expensive layers worth reusing. The
-      # multi-GB blob COPY layer would also take a large bite out of the 50 GB
-      # per-repo Actions cache quota now shared with the layer and sccache
-      # caches the rest of the pipeline depends on.
+      # multi-GB blob COPY layer would also take a large bite out of the per-repo
+      # Actions cache quota shared with the layer and sccache caches the rest of
+      # the pipeline depends on.
       cache: false
       image_name: ${{ needs.prepare.outputs.image_registry }}/boot-artifacts-aarch64
       image_tag: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1002,12 +1002,11 @@ jobs:
       # a run that changes no dependencies hits the primary key and skips the
       # upload rather than rewriting an equivalent entry.
       #
-      # Only main saves. The restore-keys prefix above means a pull request whose
-      # Cargo.lock differs from main's takes a prefix match rather than an exact
-      # one, so cache-hit is false and the save fires, storing a large ref-scoped
-      # copy nothing else can read. Several were live at once, evicting the
-      # sccache objects the image builds read. Pull requests keep restoring
-      # main's entry through that same prefix, so they still start warm.
+      # Only main saves. A pull request whose Cargo.lock differs from main's
+      # matches the restore-keys prefix rather than the exact key, so cache-hit
+      # is false and the save would otherwise fire, storing a large ref-scoped
+      # copy nothing else can read. The main-only condition blocks that, and the
+      # prefix match still leaves the pull request warm.
       - name: Save sccache
         if: ${{ !cancelled() && github.ref == 'refs/heads/main' && steps.sccache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/.github/workflows/rest-build-push-service.yml
+++ b/.github/workflows/rest-build-push-service.yml
@@ -173,13 +173,14 @@ jobs:
             VERSION=${{ steps.docker-tags.outputs.primary_tag }}
             CARBIDE_BUILD_HELM_VERSION=${{ inputs.helm_version }}
           tags: ${{ steps.docker-tags.outputs.arch_tag }}
-          cache-from: type=gha,scope=${{ inputs.service_name }}-${{ matrix.arch }}
-          # Export only from main, matching docker-build.yml. Ten services on two
-          # architectures exporting mode=max from every PR push wrote ~10 GiB of
-          # layer blobs per branch into a quota that is already over budget, and
-          # the resulting eviction was costing us the caches that actually get
-          # reused. Pull requests still read main's cache through cache-from.
-          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=max,scope={0}-{1}', inputs.service_name, matrix.arch) || '' }}
+          # No layer cache. Ten services on two architectures exporting mode=max
+          # dominated the Actions cache and held it at quota, which stopped
+          # sccache writing: the Rust builds logged a write error for every miss,
+          # discarding everything they compiled. Rebuilding Go layers costs less
+          # than that. cache-from goes too, since nothing populates the scope
+          # once main stops exporting.
+          cache-from: ''
+          cache-to: ''
           labels: |
             org.opencontainers.image.title=${{ inputs.service_name }}
             org.opencontainers.image.version=${{ inputs.semantic_version }}


### PR DESCRIPTION
REST docker build cache is not delivering meaningful hits, and using up cache write rate limits. It's also evicting Rust cache which is much more valuable. This PR disables the REST docker build cache.

It also revises the comments to not mention absolute numbers since the cache size can change.

- **Expected green-run effect:** No reliable direct savings. REST image builds may be neutral or slightly slower without layer restores, although the existing cache was not returning meaningful reuse.
- **What it really buys us:** REST image builds stop crowding useful Rust compiler objects out of the shared cache, so `sccache` can keep accepting writes across commits.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4838

Part of https://github.com/NVIDIA/infra-controller/issues/4572

## Type of Change
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)