### PR TITLE
fix(ci): stop Core main secret scans at the pushed commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1356,6 +1356,7 @@ jobs:
           else
             BEFORE="${{ github.event.before }}"
             echo "base=$BEFORE" >> "$GITHUB_OUTPUT"
+            echo "head=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run TruffleHog Scan


### PR DESCRIPTION
On normal Core `main` pushes, we already gave TruffleHog `github.event.before` as the base but left `head` empty. TruffleHog treats that as an open-ended `git log --all`, so it can scan commits from unrelated fetched refs and still report green. This adds the missing `GITHUB_SHA` head so the check stops at the commit that actually landed; pull request, tag, and REST behavior stay unchanged.

- **Expected green-run effect:** No meaningful full-pipeline savings are expected. This should reduce the scanner's input, but startup time dominates the observed scan duration.
- **What it really buys us:** A green Core `main` scan is bounded to the exact push we meant to verify.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4827

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The changed branch runs only after a push lands on `main`, so the post-merge Core secret-scan job is the end-to-end check. It should log `github.event.before` as `base`, the exact pushed `GITHUB_SHA` as `head`, nonzero scan work, and no source errors.

Closes #4827
