### PR TITLE
fix(api-model): recognize hyphenated BlueField-3 DPU models

### DIFF
--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -920,13 +920,8 @@ impl EndpointExplorationReport {
                     .filter(|chassis| is_dpu_product_chassis_id(&chassis.id))
                     .find_map(chassis_model)
             })
-            .unwrap_or("")
-            .to_string();
-        match model.to_lowercase() {
-            value if value.contains("bluefield 2") => Some(DpuModel::BlueField2),
-            value if value.contains("bluefield 3") => Some(DpuModel::BlueField3),
-            _ => Some(DpuModel::Unknown),
-        }
+            .unwrap_or("");
+        Some(DpuModel::from(model))
     }
 
     pub fn create_temporary_dmi_data(
@@ -2561,6 +2556,38 @@ mod tests {
     use super::*;
     use crate::firmware::FirmwareComponent;
     use crate::machine::machine_id::from_hardware_info;
+
+    #[test]
+    fn identify_dpu_recognizes_bluefield_model_variants() {
+        value_scenarios!(
+            run = |(system_id, model)| {
+                let report = EndpointExplorationReport {
+                    systems: vec![ComputerSystem {
+                        id: system_id.to_string(),
+                        ..Default::default()
+                    }],
+                    chassis: vec![Chassis {
+                        id: "Card1".to_string(),
+                        model: Some(model.to_string()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                };
+                let identified = report.identify_dpu();
+                if let Some(dpu_model) = &identified {
+                    assert_eq!(report.model(), Some(dpu_model.to_string()));
+                }
+                identified
+            };
+            "BlueField model identification" {
+                ("Bluefield", "NVIDIA BlueField 2 DPU") => Some(DpuModel::BlueField2),
+                ("Bluefield", "NVIDIA BlueField 3 DPU") => Some(DpuModel::BlueField3),
+                ("Bluefield", "BlueField-3 DPU") => Some(DpuModel::BlueField3),
+                ("Bluefield", "unrecognized DPU") => Some(DpuModel::Unknown),
+                ("System", "BlueField-3 DPU") => None,
+            }
+        );
+    }
 
     #[test]
     fn all_mac_addresses_combines_system_and_adapter_inventory_without_duplicates() {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -4920,9 +4920,11 @@ mod tests {
         assert_eq!(oob, "5c:25:73:9e:ac:ea".parse().unwrap());
     }
 
+    const BF3_MODEL_VARIANTS: [&str; 2] = ["NVIDIA BlueField 3 DPU", "BlueField-3 DPU"];
+
     // Minimal BlueField-3 report with a single manager eth0 interface carrying
     // `eth0_mac`. Classifies as BF3 (system id "Bluefield" + Card1 BF3 chassis).
-    fn bf3_report_with_eth0(eth0_mac: &str) -> EndpointExplorationReport {
+    fn bf3_report_with_eth0(model: &str, eth0_mac: &str) -> EndpointExplorationReport {
         use model::site_explorer::{Chassis, ComputerSystem, EthernetInterface, Manager};
         EndpointExplorationReport {
             systems: vec![ComputerSystem {
@@ -4931,7 +4933,7 @@ mod tests {
             }],
             chassis: vec![Chassis {
                 id: "Card1".to_string(),
-                model: Some("NVIDIA BlueField 3 DPU".to_string()),
+                model: Some(model.to_string()),
                 ..Default::default()
             }],
             managers: vec![Manager {
@@ -5006,23 +5008,46 @@ mod tests {
 
     #[test]
     fn is_bf4_dpu_report_does_not_match_bf3_shape() {
-        let report = bf3_report_with_eth0("5c:25:73:9e:ac:eb");
-        assert!(!is_bf4_dpu_report(&report));
+        check_values(
+            BF3_MODEL_VARIANTS.map(|model| Check {
+                scenario: model,
+                input: model,
+                expect: false,
+            }),
+            |model| is_bf4_dpu_report(&bf3_report_with_eth0(model, "5c:25:73:9e:ac:eb")),
+        );
     }
 
     #[test]
     fn bmc_eth0_offset_skips_locally_administered_mac() {
-        // Transient pre-sync MAC (locally-administered bit set) must not derive
-        // a base MAC, even though the platform classifies and an eth0 exists.
-        let transient = bf3_report_with_eth0("9a:72:d5:07:ae:7e");
-        assert_eq!(bmc_eth0_to_base_mac_offset(&transient), Some(0x25));
-        assert!(derive_base_mac_from_bmc_eth0(&transient).is_none());
-
-        // Sanity: the same report with the real (globally-unique) eth0 derives.
-        let synced = bf3_report_with_eth0("5c:25:73:9e:ac:eb");
-        assert_eq!(
-            derive_base_mac_from_bmc_eth0(&synced),
-            Some("5c:25:73:9e:ac:c6".parse().unwrap())
+        check_values(
+            [
+                Check {
+                    scenario: "space-separated BF3 model with pre-sync eth0",
+                    input: (BF3_MODEL_VARIANTS[0], "9a:72:d5:07:ae:7e"),
+                    expect: None,
+                },
+                Check {
+                    scenario: "hyphenated BF3 model with pre-sync eth0",
+                    input: (BF3_MODEL_VARIANTS[1], "9a:72:d5:07:ae:7e"),
+                    expect: None,
+                },
+                Check {
+                    scenario: "space-separated BF3 model with synced eth0",
+                    input: (BF3_MODEL_VARIANTS[0], "5c:25:73:9e:ac:eb"),
+                    expect: Some("5c:25:73:9e:ac:c6".parse().unwrap()),
+                },
+                Check {
+                    scenario: "hyphenated BF3 model with synced eth0",
+                    input: (BF3_MODEL_VARIANTS[1], "5c:25:73:9e:ac:eb"),
+                    expect: Some("5c:25:73:9e:ac:c6".parse().unwrap()),
+                },
+            ],
+            |(model, eth0_mac)| {
+                let report = bf3_report_with_eth0(model, eth0_mac);
+                assert_eq!(bmc_eth0_to_base_mac_offset(&report), Some(0x25));
+                derive_base_mac_from_bmc_eth0(&report)
+            },
         );
     }
 
@@ -5264,6 +5289,12 @@ mod tests {
             ep
         };
 
+        let bf3_with_empty_sys_image = |model| {
+            let mut ep = explored_endpoint(bf3_report_with_eth0(model, "5c:25:73:9e:ac:eb"));
+            ep.report.service = with_sys_image("").report.service;
+            ep
+        };
+
         // Drop the firmware-inventory entry whose `id` matches `inventory_id`.
         let without_inventory = |inventory_id: &str| {
             let mut ep = endpoint();
@@ -5300,6 +5331,16 @@ mod tests {
                     scenario: "legacy sys-image MAC, sanitized",
                     input: endpoint(),
                     expect: Yields("B8:3F:D2:90:95:F4".parse().unwrap()),
+                },
+                Case {
+                    scenario: "space-separated BF3 model falls back to BMC eth0",
+                    input: bf3_with_empty_sys_image(BF3_MODEL_VARIANTS[0]),
+                    expect: Yields("5c:25:73:9e:ac:c6".parse().unwrap()),
+                },
+                Case {
+                    scenario: "hyphenated BF3 model falls back to BMC eth0",
+                    input: bf3_with_empty_sys_image(BF3_MODEL_VARIANTS[1]),
+                    expect: Yields("5c:25:73:9e:ac:c6".parse().unwrap()),
                 },
                 Case {
                     scenario: "legacy sys-image MAC fails sanitization",


### PR DESCRIPTION
Redfish reports from affected BF3 cards use the chassis model `BlueField-3 DPU`. `EndpointExplorationReport::identify_dpu()` previously duplicated model parsing and only recognized the space-separated form, so these reports were classified as `Unknown`. That prevented the BF3 BMC `eth0` PF0 MAC fallback from running when the system-image MAC was unavailable.

This change reuses the shared `DpuModel` parser, which normalizes hyphens, and covers both model spellings through DPU identification, BF3/BF4 topology discrimination, and PF MAC derivation. It also changes `EndpointExplorationReport::model()` for affected reports from `unknown` to `bluefield3`.

## Related issues

Fixes #4804

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo fmt --check`
- `cargo test -p carbide-api-model identify_dpu`
- Linux with PostgreSQL: `cargo test -p carbide-api-model -p carbide-site-explorer --lib` — 424 and 59 tests passed
- Linux with PostgreSQL: `cargo test -p carbide-firmware --lib` — 23 tests passed
- `cargo clippy -p carbide-api-model --all-targets`
- Linux: `cargo clippy -p carbide-api-model -p carbide-site-explorer --all-targets`

## Additional Notes

`EndpointExplorationReport::model()` feeds firmware config lookup: site exploration stores its result on the report, and `FirmwareConfig::find_fw_info_for_host_report()` also invokes it as a fallback. That entry point has no direct unit coverage; it is exercised through preingestion-manager’s PostgreSQL-backed integration tests in CI. `FirmwareConfig::find()` independently normalizes model strings through `DpuModel::from`, so lookups already handled both spellings.

The process-local SQLx integration executable in `crates/site-explorer/tests/integration/main.rs` was not run locally. CI provides its PostgreSQL-backed integration coverage.
