### PR TITLE
fix(helm/ssh-console): add livenessProbe so a hung SSH listener restarts

### DIFF
--- a/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
+++ b/helm/charts/nico-ssh-console-rs/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               protocol: TCP
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources: {}
           volumeMounts:
             # Mount config at both paths so the binary finds it regardless of nico/carbide image variant.

--- a/helm/charts/nico-ssh-console-rs/values.yaml
+++ b/helm/charts/nico-ssh-console-rs/values.yaml
@@ -60,6 +60,16 @@ readinessProbe:
   failureThreshold: 3
   successThreshold: 1
 
+livenessProbe:
+  tcpSocket:
+    port: ssh
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  # Keep liveness more forgiving than readiness so Kubernetes drains first,
+  # then restarts only after the listener stays down.
+  failureThreshold: 6
+  successThreshold: 1
+
 ## OpenTelemetry Collector Contrib sidecar for shipping console logs to Loki.
 ## This requires a separate image from the BMM core services.
 ## Example: repository: otel/opentelemetry-collector-contrib, tag: "0.81.0"


### PR DESCRIPTION
The SSH listener can stop accepting connections while the process continues
handling BMC work. Readiness removes the pod from service, but it cannot
restart the container, leaving the Deployment unavailable indefinitely.

Add a TCP liveness probe on the named SSH port. Readiness marks the pod
unready after about 90 seconds, while liveness waits roughly three minutes
before restarting it. Using the named port keeps valid `service.port`
overrides working.

The liveness failure threshold of 6 is deliberately higher than the sibling
charts' threshold of 3. This allows readiness to remove the pod first and
restarts it only after the listener remains unavailable.

This provides automatic recovery when the listener remains down. It does not
address why the listener stopped.

## Related issues

Fixes #4817

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validated with:

- `helm lint helm/charts/nico-ssh-console-rs`
- Default `helm template` rendering
- `helm template` with `service.port=2222`, confirming liveness continues to
  use the named `ssh` port

## Additional Notes

The Kustomize path at
`deploy/nico-base/ssh-console-rs/deployment.yaml` has the same gap:
readiness only, with no liveness probe. It is intentionally out of scope here.
If that path is still used for live deployments, it likely needs the same
probe; maintainer confirmation would determine whether a follow-up is
warranted.

A Helm unittest was not added. CI's `build-validate-helm-chart` covers
umbrella-chart lint and template validation through a pinned external action;
whether that action also runs Helm unittests has not been confirmed.