### PR TITLE
feat(machine-a-tron): support IB interface live status

### DIFF
--- a/crates/bmc-mock/src/mac_address_pool.rs
+++ b/crates/bmc-mock/src/mac_address_pool.rs
@@ -90,6 +90,10 @@ impl RangesConfig {
         })
     }
 
+    pub fn base(&self) -> MacAddress {
+        self.base
+    }
+
     fn in_any_range(&self, v: MacAddress) -> bool {
         v.clear_mask_bits(self.host_bits) == self.base
     }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -50,6 +50,32 @@ pub struct HostMachineInfo {
     pub delta_psu_power: Option<Vec<bool>>,
 }
 
+trait HardwareTypeExt {
+    fn infiniband_port_count(&self) -> usize;
+}
+
+impl HardwareTypeExt for HardwareType {
+    fn infiniband_port_count(&self) -> usize {
+        match self {
+            HardwareType::WiwynnGB200Nvl => 4,
+            HardwareType::NvidiaDgxH100 => 8,
+            HardwareType::DellPowerEdgeR750
+            | HardwareType::DellPowerEdgeR760Bf4
+            | HardwareType::LenovoGB300Nvl
+            | HardwareType::NvidiaDgxGb300
+            | HardwareType::SupermicroGb300Nvl
+            | HardwareType::NvidiaDgxVr
+            | HardwareType::LiteOnPowerShelf
+            | HardwareType::DeltaPowerShelf
+            | HardwareType::NvidiaSwitchNd5200Ld
+            | HardwareType::NvidiaSwitchN5700Ld
+            | HardwareType::GenericAmi
+            | HardwareType::HpeProliantDl380aGen11
+            | HardwareType::GenericSupermicro => 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DpuMachineInfo {
     pub hw_type: HardwareType,
@@ -323,6 +349,19 @@ impl HostMachineInfo {
         self.primary_dpu()
             .map(|d| d.host_mac_address)
             .or(self.non_dpu_mac_address)
+    }
+
+    pub fn infiniband_port_guids(&self) -> Vec<String> {
+        let [b0, b1, b2, b3, b4, b5] = self.hw_mac_addr_pool.base().bytes();
+        (0..self.hw_type.infiniband_port_count())
+            .map(|interface_index| {
+                let interface_index = u16::try_from(interface_index)
+                    .expect("mock hardware models have fewer than 65536 InfiniBand interfaces");
+                let [b6, b7] = interface_index.to_be_bytes();
+                let guid = u64::from_be_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
+                format!("{guid:016x}")
+            })
+            .collect()
     }
 
     fn oem_state(&self) -> redfish::oem::State {

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -473,7 +473,9 @@ pub struct MachineATronConfig {
     /// Pool to allocate ranges of HW MAC addresses for the machines.
     /// Ranges are needed for deterministic and unique addresses but
     /// that do not participate in any associations (allocated using
-    /// just "next_mac()" manner).
+    /// just "next_mac()" manner). The normalized base also identifies
+    /// the inventory exposed by `/machines/status`, so deployments whose
+    /// inventories are aggregated must use non-overlapping ranges.
     #[serde(default)]
     pub hw_mac_address_ranges: Option<MacAddressRangesConfig>,
 }

--- a/crates/machine-a-tron/src/control_router.rs
+++ b/crates/machine-a-tron/src/control_router.rs
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use axum::body::Body;
 use axum::extract::{Path, Request, State};
@@ -22,13 +22,17 @@ use axum::http::StatusCode;
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{any, get};
 use axum::{Json, Router};
+use bmc_mock::HardwareType;
 use bmc_mock::injection::{InjectionStore, Rule, RuleId};
 use carbide_uuid::rack::RackId;
+use chrono::{SecondsFormat, Utc};
 use tower::Service;
 
 use crate::device_simulator::SimulatorLifecycle;
 use crate::simulator_registry::SimulatorRegistry;
-use crate::status::{DeviceStatusConfig, DevicesStatusResponse};
+use crate::status::{
+    DeviceKind, DeviceStatus, DeviceStatusConfig, DevicesStatusResponse, InfinibandPortStatus,
+};
 
 pub fn append(router: Router, control_state: ControlState) -> Router {
     Router::new()
@@ -55,25 +59,95 @@ pub fn append(router: Router, control_state: ControlState) -> Router {
 pub struct ControlState {
     simulators: SimulatorRegistry,
     status_config: DeviceStatusConfig,
+    inventory_version: Arc<Mutex<InventoryVersion>>,
+}
+
+#[derive(Debug)]
+struct InventoryVersion {
+    inventory_id: String,
+    epoch_id: String,
+    generation: u64,
+    snapshot: Vec<InventoryMachine>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InventoryMachine {
+    mat_id: String,
+    machine_id: Option<String>,
+    hardware_type: Option<HardwareType>,
+    infiniband_ports: Vec<InfinibandPortStatus>,
 }
 
 impl ControlState {
-    pub fn new(simulators: SimulatorRegistry, status_config: DeviceStatusConfig) -> Self {
+    pub fn new(
+        simulators: SimulatorRegistry,
+        status_config: DeviceStatusConfig,
+        inventory_id: String,
+    ) -> Self {
+        let devices = Self::collect_statuses(&simulators, &status_config);
         Self {
             simulators,
             status_config,
+            inventory_version: Arc::new(Mutex::new(InventoryVersion {
+                inventory_id,
+                epoch_id: Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true),
+                generation: 1,
+                snapshot: Self::inventory_snapshot(&devices),
+            })),
         }
     }
 
     fn devices_status(&self) -> DevicesStatusResponse {
-        DevicesStatusResponse {
-            devices: self
-                .simulators
-                .devices()
-                .iter()
-                .map(|simulator| simulator.status(&self.status_config))
-                .collect(),
+        let mut version = self
+            .inventory_version
+            .lock()
+            .expect("inventory version lock poisoned");
+        let devices = Self::collect_statuses(&self.simulators, &self.status_config);
+        let snapshot = Self::inventory_snapshot(&devices);
+        if snapshot != version.snapshot {
+            version.snapshot = snapshot;
+            version.generation = version
+                .generation
+                .checked_add(1)
+                .expect("inventory generation cannot overflow during one process epoch");
         }
+
+        DevicesStatusResponse {
+            inventory_id: version.inventory_id.clone(),
+            epoch_id: version.epoch_id.clone(),
+            generation: version.generation,
+            devices,
+        }
+    }
+
+    fn collect_statuses(
+        simulators: &SimulatorRegistry,
+        status_config: &DeviceStatusConfig,
+    ) -> Vec<DeviceStatus> {
+        simulators
+            .devices()
+            .iter()
+            .map(|simulator| simulator.status(status_config))
+            .collect()
+    }
+
+    fn inventory_snapshot(devices: &[DeviceStatus]) -> Vec<InventoryMachine> {
+        let mut machines = devices
+            .iter()
+            .filter(|device| device.device_kind == DeviceKind::Machine)
+            .map(|device| {
+                let mut infiniband_ports = device.infiniband_ports.clone().unwrap_or_default();
+                infiniband_ports.sort_by(|left, right| left.guid.cmp(&right.guid));
+                InventoryMachine {
+                    mat_id: device.mat_id.clone(),
+                    machine_id: device.machine_id.clone(),
+                    hardware_type: device.hardware_type,
+                    infiniband_ports,
+                }
+            })
+            .collect::<Vec<_>>();
+        machines.sort_by(|left, right| left.mat_id.cmp(&right.mat_id));
+        machines
     }
 
     fn device(&self, id: &str) -> Option<Arc<InjectionStore>> {
@@ -210,6 +284,7 @@ mod tests {
         ControlState::new(
             SimulatorRegistry::try_from_handles(handles).unwrap(),
             DeviceStatusConfig::new(1266),
+            "mat-06:00:00:00:00:00".to_string(),
         )
     }
 
@@ -247,6 +322,7 @@ mod tests {
                 .build()
                 .unwrap(),
             DeviceStatusConfig::new(1266),
+            "mat-06:00:00:00:00:00".to_string(),
         )
     }
 
@@ -266,7 +342,15 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        assert_eq!(&body[..], br#"{"machines":[]}"#);
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["inventory_id"], "mat-06:00:00:00:00:00");
+        assert!(
+            body["epoch_id"]
+                .as_str()
+                .is_some_and(|value| { chrono::DateTime::parse_from_rfc3339(value).is_ok() })
+        );
+        assert_eq!(body["generation"], 1);
+        assert_eq!(body["machines"], serde_json::json!([]));
     }
 
     #[tokio::test]

--- a/crates/machine-a-tron/src/device_handle.rs
+++ b/crates/machine-a-tron/src/device_handle.rs
@@ -28,6 +28,7 @@ use crate::PersistedDevice;
 use crate::api_client::ApiClient;
 use crate::dpu_machine::DpuMachineHandle;
 use crate::host_machine::MachineHandle;
+use crate::machine_state_machine::InfinibandPortState;
 use crate::power_shelf_simulator::PowerShelfHandle;
 use crate::status::{DeviceKind, DeviceStatus, DeviceStatusConfig};
 use crate::switch_simulator::SwitchHandle;
@@ -151,6 +152,19 @@ impl DeviceHandle {
             DeviceHandleInner::Machine(handle) => handle.status(config),
             DeviceHandleInner::Switch(handle) => handle.status(config),
             DeviceHandleInner::PowerShelf(handle) => handle.status(config),
+        }
+    }
+
+    pub fn set_infiniband_port_state(
+        &self,
+        guid: &str,
+        state: InfinibandPortState,
+    ) -> eyre::Result<()> {
+        match &self.0 {
+            DeviceHandleInner::Machine(handle) => handle.set_infiniband_port_state(guid, state),
+            DeviceHandleInner::Switch(_) | DeviceHandleInner::PowerShelf(_) => {
+                eyre::bail!("cannot set InfiniBand port state on {}", self.kind())
+            }
         }
     }
 

--- a/crates/machine-a-tron/src/discovery_info.rs
+++ b/crates/machine-a-tron/src/discovery_info.rs
@@ -722,20 +722,15 @@ fn gb200_gpus() -> Vec<Gpu> {
         .collect()
 }
 
-fn infiniband_guid(host: &HostMachineInfo, interface_index: usize) -> String {
-    let interface_index = u16::try_from(interface_index)
-        .expect("machine-a-tron hardware models have fewer than 65536 InfiniBand interfaces");
-    let [b0, b1, b2, b3, b4, b5] = host.hw_mac_addr_pool.base().bytes();
-    let [b6, b7] = interface_index.to_be_bytes();
-    let guid = u64::from_be_bytes([b0, b1, b2, b3, b4, b5, b6, b7]);
-    format!("{guid:016x}")
-}
-
 fn gb200_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInterface> {
+    let guids: [String; 4] = host
+        .infiniband_port_guids()
+        .try_into()
+        .expect("GB200 has four InfiniBand interfaces");
     [(0x0000, 0), (0x0002, 0), (0x0010, 1), (0x0012, 1)]
         .into_iter()
-        .enumerate()
-        .map(|(index, (domain, numa_node))| {
+        .zip(guids)
+        .map(|((domain, numa_node), guid)| {
             let device_name = if domain == 0 {
                 "ibp3s0".to_string()
             } else {
@@ -752,7 +747,7 @@ fn gb200_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInterfac
                     description: Some("MT2910 Family [ConnectX-7]".into()),
                     slot: Some(format!("{domain}:03:00.0")),
                 }),
-                guid: infiniband_guid(host, index),
+                guid,
             }
         })
         .collect()
@@ -832,6 +827,10 @@ fn cx8_network_interface(
 }
 
 fn dgx_h100_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInterface> {
+    let guids: [String; 8] = host
+        .infiniband_port_guids()
+        .try_into()
+        .expect("DGX H100 has eight InfiniBand interfaces");
     [
         (0x15, 0),
         (0x3d, 0),
@@ -843,8 +842,8 @@ fn dgx_h100_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInter
         (0xd9, 1),
     ]
     .into_iter()
-    .enumerate()
-    .map(|(index, (bus, numa_node))| {
+    .zip(guids)
+    .map(|((bus, numa_node), guid)| {
         let device_name = format!("ibp{bus}s0");
         InfinibandInterface {
             pci_properties: Some(PciDeviceProperties {
@@ -860,7 +859,7 @@ fn dgx_h100_infiniband_interfaces(host: &HostMachineInfo) -> Vec<InfinibandInter
                 description: Some("MT2910 Family [ConnectX-7]".into()),
                 slot: Some(format!("0000:{:02x}:00.0", bus + 3)),
             }),
-            guid: infiniband_guid(host, index),
+            guid,
         }
     })
     .collect()

--- a/crates/machine-a-tron/src/dpu_machine.rs
+++ b/crates/machine-a-tron/src/dpu_machine.rs
@@ -480,6 +480,7 @@ impl DpuMachineHandle {
             power_state: live_state.power_state.to_string(),
             machine_ip: live_state.machine_ip.map(|ip| ip.to_string()),
             nvos_ip: None,
+            infiniband_ports: None,
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),

--- a/crates/machine-a-tron/src/host_machine.rs
+++ b/crates/machine-a-tron/src/host_machine.rs
@@ -37,9 +37,13 @@ use crate::api_client::ApiClient;
 use crate::config::{self, MachineATronContext, MachineConfig, PersistedDevice};
 use crate::dhcp_wrapper::{DhcpRelayResult, DhcpResponseInfo, DpuDhcpRelay};
 use crate::dpu_machine::{DpuMachine, DpuMachineHandle};
-use crate::machine_state_machine::{LiveState, MachineStateMachine, PersistedMachine};
+use crate::machine_state_machine::{
+    InfinibandPortState, LiveState, MachineStateMachine, PersistedMachine,
+};
 use crate::saturating_add_duration_to_instant;
-use crate::status::{BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus};
+use crate::status::{
+    BmcStatus, DeviceKind, DeviceStatus, DeviceStatusConfig, EndpointStatus, InfinibandPortStatus,
+};
 use crate::tui::{HostDetails, UiUpdate};
 
 pub(super) struct HostMachine {
@@ -114,7 +118,6 @@ impl HostMachine {
             .into_iter()
             .map(|d| d.start(true))
             .collect::<Vec<_>>();
-
         let state_machine = MachineStateMachine::from_persisted(
             PersistedMachine::Host(persisted_device),
             MachineInfo::Host(host_info.clone()),
@@ -195,7 +198,6 @@ impl HostMachine {
             .into_iter()
             .map(|d| d.start(true))
             .collect::<Vec<_>>();
-
         let state_machine = MachineStateMachine::new(
             MachineInfo::Host(host_info.clone()),
             config,
@@ -666,8 +668,35 @@ impl MachineHandle {
         &self.0.machine_config_section
     }
 
+    pub(super) fn set_infiniband_port_state(
+        &self,
+        guid: &str,
+        state: InfinibandPortState,
+    ) -> eyre::Result<()> {
+        let mut live_state = self.0.live_state.write().unwrap();
+        let port_state = live_state
+            .infiniband_port_states
+            .get_mut(guid)
+            .ok_or_else(|| eyre::eyre!("InfiniBand port {guid} not found"))?;
+        *port_state = state;
+        Ok(())
+    }
+
     pub(super) fn status(&self, config: &DeviceStatusConfig) -> DeviceStatus {
         let live_state = self.0.live_state.read().unwrap();
+        let infiniband_ports = self
+            .0
+            .host_info
+            .infiniband_port_guids()
+            .into_iter()
+            .map(|guid| InfinibandPortStatus {
+                state: *live_state
+                    .infiniband_port_states
+                    .get(&guid)
+                    .expect("live InfiniBand state initialized from static machine info"),
+                guid,
+            })
+            .collect::<Vec<_>>();
         DeviceStatus {
             mat_id: self.0.mat_id.to_string(),
             device_kind: DeviceKind::Machine,
@@ -686,6 +715,7 @@ impl MachineHandle {
             power_state: live_state.power_state.to_string(),
             machine_ip: live_state.machine_ip.map(|ip| ip.to_string()),
             nvos_ip: None,
+            infiniband_ports: (!infiniband_ports.is_empty()).then_some(infiniband_ports),
             bmc: BmcStatus {
                 ip: live_state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -61,14 +61,16 @@ pub use device_simulator::{
 pub use dhcp_wrapper::{DhcpClient, UdpDhcpService};
 pub use dpu_machine::DpuMachineHandle;
 pub use machine_a_tron::{AppEvent, MachineATron};
-pub use machine_state_machine::BmcRegistrationMode;
+pub use machine_state_machine::{BmcRegistrationMode, InfinibandPortState};
 pub use mock_ssh_server::{
     Credentials as MockSshCredentials, MockSshServerHandle, PromptBehavior,
     spawn as spawn_mock_ssh_server,
 };
 pub use rack::{RackMemberStatus, RackStatus, RacksStatusResponse};
 pub use simulator_registry::SimulatorRegistry;
-pub use status::{DeviceKind, DeviceStatus, DeviceStatusConfig, DevicesStatusResponse};
+pub use status::{
+    DeviceKind, DeviceStatus, DeviceStatusConfig, DevicesStatusResponse, InfinibandPortStatus,
+};
 pub use tui::{Tui, UiUpdate};
 pub use tui_host_logs::TuiHostLogs;
 

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use std::borrow::Cow;
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::{Arc, RwLock};
@@ -53,6 +53,13 @@ use crate::machine_utils::{
 use crate::{PersistedDevice, PersistedDpuMachine};
 
 type DpuDhcpRelayHandle = oneshot::Sender<()>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InfinibandPortState {
+    Active,
+    Down,
+}
 
 // RFC 2131 section 4.1's Ethernet example starts at four seconds, doubles to a
 // 64-second base, and adds uniform jitter from -1 through +1 second.
@@ -253,6 +260,7 @@ pub(super) struct LiveState {
     pub(super) api_state: String,
     pub(super) tpm_ek_certificate: Option<Vec<u8>>,
     pub(super) ssh_host_key: Option<String>,
+    pub(super) infiniband_port_states: HashMap<String, InfinibandPortState>,
     /// For a DPU machine, whether its BlueField has flipped to NIC mode. Lets the
     /// owning host observe the flip through the DPU handle and converge (detach
     /// its DPU DHCP relay). Always false for a host machine.
@@ -276,12 +284,34 @@ impl Default for LiveState {
             api_state: "Unknown".to_string(),
             tpm_ek_certificate: None,
             ssh_host_key: None,
+            infiniband_port_states: HashMap::new(),
             dpu_flipped_to_nic_mode: false,
         }
     }
 }
 
 impl LiveState {
+    fn for_machine(
+        machine_info: &MachineInfo,
+        power_state: MockPowerState,
+        tpm_ek_certificate: Option<Vec<u8>>,
+    ) -> Self {
+        let infiniband_port_states = match machine_info {
+            MachineInfo::Host(host) => host
+                .infiniband_port_guids()
+                .into_iter()
+                .map(|guid| (guid, InfinibandPortState::Active))
+                .collect(),
+            MachineInfo::Dpu(_) => HashMap::new(),
+        };
+        Self {
+            power_state,
+            tpm_ek_certificate,
+            infiniband_port_states,
+            ..Default::default()
+        }
+    }
+
     pub(super) fn ui_next_boot_kind(&self) -> &'static str {
         match self.next_boot_kind {
             Some(BootOptionKind::Disk) => "Disk",
@@ -342,11 +372,11 @@ impl MachineStateMachine {
             dhcp_retry: DhcpRetryState::default(),
             machine_discovery_result: None,
             installed_os: initial_os_image,
-            live_state: Arc::new(RwLock::new(LiveState {
-                power_state: MockPowerState::On,
+            live_state: Arc::new(RwLock::new(LiveState::for_machine(
+                &machine_info,
+                MockPowerState::On,
                 tpm_ek_certificate,
-                ..Default::default()
-            })),
+            ))),
             machine_info,
             bmc_command_channel,
             config,
@@ -368,11 +398,11 @@ impl MachineStateMachine {
     ) -> MachineStateMachine {
         let (fsm, actions) = MachineFsm::init(false, Self::is_bmc_only(&machine_info, &config));
         MachineStateMachine {
-            live_state: Arc::new(RwLock::new(LiveState {
-                power_state: MockPowerState::Off,
+            live_state: Arc::new(RwLock::new(LiveState::for_machine(
+                &machine_info,
+                MockPowerState::Off,
                 tpm_ek_certificate,
-                ..Default::default()
-            })),
+            ))),
             fsm,
             actions: actions.into_iter().collect(),
             bmc_dhcp_info: None,

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -149,6 +149,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let bmc_mock_port = app_config.bmc_mock_port;
     let tui_enabled = app_config.tui_enabled;
+    let hw_mac_address_ranges = app_config
+        .hw_mac_address_ranges
+        .as_ref()
+        .map(|config| {
+            MacAddressRangesConfig::new(config.base, config.host_bits, config.range_host_bits)
+        })
+        .unwrap_or_else(|| {
+            MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 32, 8)
+        })?;
+    let inventory_id = format!(
+        "mat-{}",
+        hw_mac_address_ranges
+            .base()
+            .to_string()
+            .to_ascii_lowercase()
+    );
 
     let mac_address_pool = MacAddressPool::new(MacAddressConfig {
         pool: Some(
@@ -160,21 +176,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 24)
                 })?,
         ),
-        ranges: Some(
-            app_config
-                .hw_mac_address_ranges
-                .as_ref()
-                .map(|config| {
-                    MacAddressRangesConfig::new(
-                        config.base,
-                        config.host_bits,
-                        config.range_host_bits,
-                    )
-                })
-                .unwrap_or_else(|| {
-                    MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 32, 8)
-                })?,
-        ),
+        ranges: Some(hw_mac_address_ranges),
     });
 
     let bmc_mock_certs_dir = app_config.bmc_mock_certs_dir.clone();
@@ -217,8 +219,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Launch the control UI after the machines are created so it can report their handles. In
     // combined-BMC mode it shares the combined BMC listener. In per-IP mode it listens on the
     // loopback address at the same port, independently of the per-machine BMC listeners.
-    let control_state =
-        ControlState::new(simulators.clone(), DeviceStatusConfig::new(bmc_mock_port));
+    let control_state = ControlState::new(
+        simulators.clone(),
+        DeviceStatusConfig::new(bmc_mock_port),
+        inventory_id,
+    );
     let certs_dir = app_context
         .bmc_mock_certs_dir
         .as_ref()

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -507,6 +507,7 @@ impl PowerShelfHandle {
             power_state: state.power_state.to_string(),
             machine_ip: None,
             nvos_ip: None,
+            infiniband_ports: None,
             bmc: BmcStatus {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),

--- a/crates/machine-a-tron/src/status.rs
+++ b/crates/machine-a-tron/src/status.rs
@@ -18,6 +18,14 @@ use bmc_mock::HardwareType;
 use bmc_mock::ipmi_sim::IpmiEndpoint;
 use serde::Serialize;
 
+use crate::machine_state_machine::InfinibandPortState;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InfinibandPortStatus {
+    pub guid: String,
+    pub state: InfinibandPortState,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum DeviceKind {
@@ -65,6 +73,9 @@ impl DeviceStatusConfig {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DevicesStatusResponse {
+    pub inventory_id: String,
+    pub epoch_id: String,
+    pub generation: u64,
     #[serde(rename = "machines")]
     pub devices: Vec<DeviceStatus>,
 }
@@ -86,6 +97,8 @@ pub struct DeviceStatus {
     pub machine_ip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvos_ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub infiniband_ports: Option<Vec<InfinibandPortStatus>>,
     pub bmc: BmcStatus,
     pub dpus: Vec<DeviceStatus>,
 }

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -543,6 +543,7 @@ impl SwitchHandle {
             power_state: state.power_state.to_string(),
             machine_ip: None,
             nvos_ip: state.nvos_ip.map(|ip| ip.to_string()),
+            infiniband_ports: None,
             bmc: BmcStatus {
                 ip: state.bmc_ip.map(|ip| ip.to_string()),
                 redfish: EndpointStatus::redfish(config),


### PR DESCRIPTION
For simulation of IB and UFM interface of IB we need to  support live status of IB interfaces.
This PR adds live statuses of IB interfaces to machine-a-tron.  

In addition, it also adds unique identification of running instance of machine-a-tron using base MAC address + generation that are needed for future reconciliation process.

## Related issues

Closes #3526

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

