### PR TITLE
feat(ssh-console): ipmi reachability check

### DIFF
--- a/crates/ssh-console/src/bmc/client.rs
+++ b/crates/ssh-console/src/bmc/client.rs
@@ -16,7 +16,6 @@
  */
 use std::io;
 use std::net::SocketAddr;
-
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 

--- a/crates/ssh-console/src/bmc/client.rs
+++ b/crates/ssh-console/src/bmc/client.rs
@@ -16,7 +16,7 @@
  */
 use std::io;
 use std::net::SocketAddr;
-use std::process::Stdio;
+
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -331,20 +331,8 @@ async fn wait_until_host_is_up(
                         }
                     }
                     connection::Kind::Ipmi => {
-                        let status = tokio::process::Command::new("ping")
-                            .arg("-c")
-                            .arg("1")
-                            .arg("-W")
-                            .arg("2")
-                            .arg(addr.ip().to_string())
-                            .stdin(Stdio::null())
-                            .stdout(Stdio::null())
-                            .stderr(Stdio::null())
-                            .spawn()?
-                            .wait()
-                            .await?;
-                        if status.success() {
-                            break Ok(())
+                        if check_ipmi_reachable(addr, Duration::from_secs(2)).await {
+                            break Ok(());
                         }
                     }
                 }
@@ -571,6 +559,40 @@ impl Drop for BmcConnectionSubscription {
             -1,
             &[KeyValue::new("machine_id", self.machine_id.to_string())],
         );
+    }
+}
+
+/// Send an ASF Presence Ping (RMCP) to check if an IPMI endpoint is reachable.
+async fn check_ipmi_reachable(addr: SocketAddr, timeout: Duration) -> bool {
+    // Reference: IPMI v2.0 spec, section 13.2.3
+    const ASF_PRESENCE_PING: [u8; 12] = [
+        0x06, 0x00, 0xff, 0x06, 0x00, 0x00, 0x11, 0xbe, 0x80, 0x00, 0x00, 0x00,
+    ];
+
+    let Ok(socket) = tokio::net::UdpSocket::bind("0.0.0.0:0").await else {
+        tracing::debug!(%addr, "failed to bind UDP socket for IPMI reachability check");
+        return false;
+    };
+
+    if let Err(e) = socket.send_to(&ASF_PRESENCE_PING, addr).await {
+        tracing::debug!(%addr, error = %e, "failed to send ASF Presence Ping");
+        return false;
+    }
+
+    let mut recv_buf = [0u8; 32];
+    match tokio::time::timeout(timeout, socket.recv_from(&mut recv_buf)).await {
+        Ok(Ok((len, _))) => {
+            tracing::debug!(%addr, response_len = len, "IPMI endpoint responded to ASF Presence Ping");
+            true
+        }
+        Ok(Err(e)) => {
+            tracing::debug!(%addr, error = %e, "error receiving ASF Presence Pong");
+            false
+        }
+        Err(_) => {
+            tracing::debug!(%addr, timeout_secs = ?timeout, "ASF Presence Ping timed out");
+            false
+        }
     }
 }
 


### PR DESCRIPTION
Replace icmp ping with ASF presence ping for checking IPMI endpoint reachability. icmp ping doesn't work with Kubernetes Service ClusterIPs or if networks acls or firewalls block icmp

**Changes:**
- Remove `ping` command spawning for IPMI endpoints
- Add `check_ipmi_reachable()` function that sends ASF Presence Ping
- Add debug tracing for reachability check results
- Remove unused `Stdio` import

The ASF Presence Ping is a standard IPMI discovery mechanism (IPMI v2.0 spec, section 13.2.3) that sends a 12-byte UDP packet and expects a Presence Pong response.

## Related issues
- Closes #4860

## Type of Change
- [x] **Change** - Changes in existing functionality

## Testing
- [x] Manual testing performed
Manually tested with machine-a-tron IPMI simulation in K8s controller mode

## Additional Notes
IPMI v2 spec:
https://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf
