### PR TITLE
fix(make): wait for the final PostgreSQL test server

### DIFF
--- a/dev/Makefile.core
+++ b/dev/Makefile.core
@@ -86,11 +86,13 @@ postgres-up: postgres-down
 		-c wal_level=minimal \
 		-c max_wal_senders=0
 
+# Probe TCP so PostgreSQL's socket-only initialization server cannot report
+# readiness before the final server starts.
 postgres-wait:
 	@ready=false; \
 	for attempt in {1..60}; do \
 		if docker exec $(POSTGRES_CONTAINER_NAME) \
-			pg_isready -U $(POSTGRES_USER) -d $(POSTGRES_DB) >/dev/null 2>&1; then \
+			pg_isready -h 127.0.0.1 -U $(POSTGRES_USER) -d $(POSTGRES_DB) >/dev/null 2>&1; then \
 			ready=true; \
 			break; \
 		fi; \


### PR DESCRIPTION
While the official PostgreSQL image initializes a fresh database, it briefly starts a socket-only server before replacing it with the final TCP server. `postgres-wait` could accept that temporary server and race its shutdown before Cargo ever started.

So, point `pg_isready` at `127.0.0.1`, which makes the helper wait for the same final TCP server the test `DATABASE_URL` uses. The existing `make core/tests` interface, image override, random host port, and exact cleanup all stay unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/4855

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

This does not change the helper's command-line interface, PostgreSQL image selection, port allocation, or container cleanup.
- Reproduced the existing readiness race in 15 of 20 fresh PostgreSQL starts.
- Verified 30 of 30 fresh starts after selecting TCP readiness.
- Ran `make core/tests POSTGRES_IMAGE=postgres:15.13-alpine TEST_ARGS='--locked -p postgres-smoke-test --test postgres_connection test_postgres_connection'`.
- Ran the same smoke test with the existing `POSTGRES_IMAGE=postgres:15` override.

Closes #4855
