### PR TITLE
fix: honor account URI for required password changes [ami]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.4#7772f48f934805c66dab7f1a68c5fbaf6f781295"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.46.5#c79aa49ea21a8e3e161eb9f6154f331162b79b2d"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.4" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.46.5" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.1" }
 ansi-to-html = "0.2.2"
 

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -1070,7 +1070,7 @@ mod tests {
         let sim = RedfishSim::default();
         sim.seed_user("root", "factory_pass");
         sim.seed_user("2", "factory_pass");
-        sim.set_password_change_required(true);
+        sim.set_password_change_required(true, None);
 
         sim.set_bmc_root_password(
             "127.0.0.1",
@@ -1084,6 +1084,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_bmc_root_password_ami_uses_account_uri() {
+        let sim = RedfishSim::default();
+        sim.seed_user("root", "factory_pass");
+        sim.seed_user("4", "factory_pass");
+        sim.set_password_change_required(true, Some("/redfish/v1/AccountService/Accounts/4"));
+
+        sim.set_bmc_root_password(
+            "127.0.0.1",
+            Some(443),
+            RedfishVendor::AMI,
+            Credentials::new("root", "factory_pass"),
+            "site_pass".to_string(),
+        )
+        .await
+        .expect("AMI rotation should use the account URI");
+
+        assert_eq!(sim.user_password("4").as_deref(), Some("site_pass"));
+    }
+
+    #[tokio::test]
     async fn set_bmc_root_password_ami_dispatches_to_id_two_after_password_change_required() {
         // Same factory state, but account id "2" is absent: the fallback's
         // `change_password_by_id("2")` fails with `UserNotFound("2")`, proving
@@ -1091,7 +1111,7 @@ mod tests {
         // (rather than swallowing the error or dispatching elsewhere).
         let sim = RedfishSim::default();
         sim.seed_user("root", "factory_pass");
-        sim.set_password_change_required(true);
+        sim.set_password_change_required(true, None);
 
         let err = sim
             .set_bmc_root_password(

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -409,21 +409,27 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                     .map_err(|err| redact_password(err, curr_password.as_str()))
                     .map_err(RedfishClientCreationError::RedfishError)?;
             }
-            // Vikings and Lenovo GB300s (both still detected as AMI here).
-            // Resolve the admin account by username, and fall back to the conventional
-            // id "2" only when reads are blocked by `PasswordChangeRequired` (Viking factory state).
+            // AMI-based BMCs, including Vikings and Lenovo GB300s.
+            // Resolve the admin account by username. If reads are blocked by
+            // `PasswordChangeRequired`, use its account URI or fall back to id "2".
             // Any other error propagates.
             //
             // https://docs.nvidia.com/dgx/dgxh100-user-guide/redfish-api-supp.html
-            RedfishVendor::AMI | RedfishVendor::LenovoGB300 => {
+            RedfishVendor::AMI | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300 => {
                 match client
                     .change_password(curr_user.as_str(), new_password.as_str())
                     .await
                 {
                     Ok(()) => {}
-                    Err(libredfish::RedfishError::PasswordChangeRequired) => {
+                    Err(libredfish::RedfishError::PasswordChangeRequired { account_uri }) => {
+                        // For example: /redfish/v1/AccountService/Accounts/4
+                        let account_id = account_uri
+                            .as_deref()
+                            .and_then(|uri| uri.rsplit_once('/').map(|(_, id)| id))
+                            .filter(|id| !id.is_empty())
+                            .unwrap_or("2");
                         client
-                            .change_password_by_id("2", new_password.as_str())
+                            .change_password_by_id(account_id, new_password.as_str())
                             .await
                             .map_err(|err| redact_password(err, new_password.as_str()))
                             .map_err(|err| redact_password(err, curr_password.as_str()))
@@ -437,10 +443,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                     }
                 }
             }
-            RedfishVendor::LenovoAMI
-            | RedfishVendor::Supermicro
-            | RedfishVendor::Dell
-            | RedfishVendor::Hpe => {
+            RedfishVendor::Supermicro | RedfishVendor::Dell | RedfishVendor::Hpe => {
                 client
                     .change_password(curr_user.as_str(), new_password.as_str())
                     .await
@@ -727,7 +730,7 @@ pub fn redact_passwords(
         | RfError::NoHeader
         | RfError::Lockdown
         | RfError::MissingVendor
-        | RfError::PasswordChangeRequired
+        | RfError::PasswordChangeRequired { .. }
         | RfError::FileError(_)
         | RfError::UserNotFound(_)
         | RfError::NotSupported(_)

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -885,7 +885,9 @@ impl Redfish for RedfishSimClient {
                 });
             }
             if state.password_change_required {
-                return Err(RedfishError::PasswordChangeRequired);
+                return Err(RedfishError::PasswordChangeRequired {
+                    account_uri: None,
+                });
             }
             self.authorize(&mut state, "AccountService/Accounts")?;
             if !state.users.contains_key(&s_user) {

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -885,9 +885,7 @@ impl Redfish for RedfishSimClient {
                 });
             }
             if state.password_change_required {
-                return Err(RedfishError::PasswordChangeRequired {
-                    account_uri: None,
-                });
+                return Err(RedfishError::PasswordChangeRequired { account_uri: None });
             }
             self.authorize(&mut state, "AccountService/Accounts")?;
             if !state.users.contains_key(&s_user) {

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -78,6 +78,8 @@ struct RedfishSimState {
     /// change-on-first-use has been done -- the case the `AMI`/`LenovoGB300`
     /// rotation path handles by retrying `change_password_by_id("2")`.
     password_change_required: bool,
+    /// Optional account URI returned with [`RedfishError::PasswordChangeRequired`].
+    password_change_required_account_uri: Option<String>,
     /// When set, overrides the `Vendor` field returned by `get_service_root`.
     /// Tests set it to an unrecognized value to force `probe_bmc_vendor` down
     /// the Chassis `Manufacturer` fallback path.
@@ -384,8 +386,14 @@ impl RedfishSim {
     /// [`RedfishError::PasswordChangeRequired`], modeling a factory BMC that
     /// blocks it until change-on-first-use. `change_password_by_id` still
     /// succeeds, so this exercises the `AMI`/`LenovoGB300` rotation fallback.
-    pub fn set_password_change_required(&self, required: bool) {
-        self.state.lock().unwrap().password_change_required = required;
+    pub fn set_password_change_required(&self, required: bool, account_uri: Option<&str>) {
+        let mut state = self.state.lock().unwrap();
+        state.password_change_required = required;
+        state.password_change_required_account_uri = if required {
+            account_uri.map(str::to_string)
+        } else {
+            None
+        };
     }
 
     /// Enable opt-in authentication enforcement (see [`RedfishSimState::enforce_auth`]):
@@ -885,7 +893,9 @@ impl Redfish for RedfishSimClient {
                 });
             }
             if state.password_change_required {
-                return Err(RedfishError::PasswordChangeRequired { account_uri: None });
+                return Err(RedfishError::PasswordChangeRequired {
+                    account_uri: state.password_change_required_account_uri.clone(),
+                });
             }
             self.authorize(&mut state, "AccountService/Accounts")?;
             if !state.users.contains_key(&s_user) {


### PR DESCRIPTION
This PR:

- Updates libredfish to `v0.46.5`.
- Uses the account URI from `PasswordChangeRequired` for AMI password rotation, falling back to account ID 2.
- Adds coverage for URI-based and fallback account selection.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/4724
https://github.com/NVIDIA/infra-controller/issues/4816
https://github.com/NVIDIA/infra-controller/issues/4815

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
